### PR TITLE
fixes for ARM32

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.EasyRequest.cs
@@ -311,8 +311,8 @@ namespace System.Net.Http
 
             private void SetTimeouts()
             {
-                // Set timeout limit on the connect phase.
-                SetCurlOption(CURLoption.CURLOPT_CONNECTTIMEOUT_MS, int.MaxValue);
+                // Set timeout limit on the connect phase. curl has bug on ARM so use max - 1s.
+                SetCurlOption(CURLoption.CURLOPT_CONNECTTIMEOUT_MS, int.MaxValue - 1000);
 
                 // Override the default DNS cache timeout.  libcurl defaults to a 1 minute
                 // timeout, but we extend that to match the Windows timeout of 10 minutes.

--- a/src/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
@@ -48,13 +48,21 @@ namespace System.Net.Http.Functional.Tests
                 {
                     // Ignore.
                 }
+                catch (ObjectDisposedException)
+                {
+                    // Ignore.
+                }
+                catch (InvalidOperationException)
+                {
+                    // Ignore.
+                }
             });
         }
 
         public void Dispose()
         {
             _listener.Stop();
-            _serverTask.Wait();
+            _serverTask.Wait(TestHelper.PassingTestTimeoutMilliseconds);
         }
 
         public string BaseUrl { get; private set; }

--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -93,7 +93,7 @@ namespace System.Net.Http.Functional.Tests
 
         public static Task WhenAllCompletedOrAnyFailed(params Task[] tasks)
         {
-            return TaskTimeoutExtensions.WhenAllOrAnyFailed(tasks, PlatformDetection.IsArmProcess || PlatformDetection.IsArm64Process ? 30_000 : 10_000);
+            return TaskTimeoutExtensions.WhenAllOrAnyFailed(tasks, PlatformDetection.IsArmProcess || PlatformDetection.IsArm64Process ? PassingTestTimeoutMilliseconds * 5 : PassingTestTimeoutMilliseconds);
         }
 
         public static Task WhenAllCompletedOrAnyFailedWithTimeout(int timeoutInMilliseconds, params Task[] tasks)

--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -93,7 +93,7 @@ namespace System.Net.Http.Functional.Tests
 
         public static Task WhenAllCompletedOrAnyFailed(params Task[] tasks)
         {
-            return TaskTimeoutExtensions.WhenAllOrAnyFailed(tasks);
+            return TaskTimeoutExtensions.WhenAllOrAnyFailed(tasks, PlatformDetection.IsArmProcess || PlatformDetection.IsArm64Process ? 30_000 : 10_000);
         }
 
         public static Task WhenAllCompletedOrAnyFailedWithTimeout(int timeoutInMilliseconds, params Task[] tasks)


### PR DESCRIPTION
fixes #33991 [arm32/Linux] System.Net.Http.Functional.Tests failures on arm32 linux 

The change has three distinct parts. When I ewas investigating this on machine given to me, there were some tests always failing like this:
```
* Hostname was NOT found in DNS cache
  *   Trying 127.0.0.1...
  * TCP_NODELAY set
  * Connected to 127.0.0.1 (127.0.0.1) port 50729 (#0)
  > GET /foo HTTP/1.1
  Host: 127.0.0.1:50729
  Accept: */*
  Cookie: cookie1=value1
  Connection: close

  < HTTP/1.1 302 Found
  < Date: Wed, 09 Jan 2019 18:52:40 GMT
  < Content-Length: 0
  < Location: /bar
  < Connection: close
  <
  * Closing connection 0
  * Issue another request to this URL: 'http://127.0.0.1:50729/bar'
  * Hostname was found in DNS cache
  *   Trying 127.0.0.1...
  * TCP_NODELAY set
  * Connection timed out after -39 milliseconds
  * Closing connection 1
```
Increasing times did not help and we clearly timed out before we should. I also try same tests on same OS/Curl version on x64 and everything was working fine. I think this is bug in Curl as I verified that we pass proper values and types in debugger. I don't know if this is because `time_t` is 32bit or if this is ARM architecture but when passing in infinite (int.MaxValue) timeout value it somehow overflows. I was ready to disable offending tests but I found out that if I pass infinity - 1s it works as expected. This is clearly workaround for curl but it makes curl work fine on ARM32.

After that I was getting random timeouts when running tests in parallel. They were not specific one and the failure was always timeout. I bumped  timeout to 20s and it was OK for inner loop with occasional timeouts when running outerloop. With 30, I did no see any single failure with many runs. There may be better ways how to do that is this clearly seems to be related to host CPU performance.
But for now using the ARCH is easy and solves the problem without counting cortes  or trying to compute system computational power. 

Last part of this change is improvement to NtAuthServer. 
I have seen occasional failures on other platforms as well but on my ARM it was failing consistently.  There seems to be race condition in Dispose() when  test was skipped and we are still trying to start task. This change allows to swallow two more exception caused by  early dispose/late task start and it also increases timeout on Wait() 

With this did many successful outerloop runs on ARM32.
```
  === TEST EXECUTION SUMMARY ===
     System.Net.Http.Functional.Tests  Total: 6601, Errors: 0, Failed: 0, Skipped: 50, Time: 389.613s
  /ssd/toweinfu/wfurt-corefx-arm/src/System.Net.Http/tests/FunctionalTests
  ----- end 01:15:13 ----- exit code 0 ----------------------------------------------------------
  exit code 0 means Exited Successfully
```




  