### PR TITLE
Fix DispatchProxy arguments with [Out] methods

### DIFF
--- a/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -439,7 +439,7 @@ namespace System.Reflection
                 for (int i = 0; i < parameters.Length; i++)
                 {
                     // args[i] = argi;
-                    if (!parameters[i].IsOut)
+                    if (!parameters[i].IsOut || !parameters[i].ParameterType.IsByRef || parameters[i].IsIn)
                     {
                         argsArr.BeginSet(i);
                         args.Get(i);

--- a/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -439,7 +439,9 @@ namespace System.Reflection
                 for (int i = 0; i < parameters.Length; i++)
                 {
                     // args[i] = argi;
-                    if (!parameters[i].IsOut || !parameters[i].ParameterType.IsByRef || parameters[i].IsIn)
+                    bool isOutRef = parameters[i].IsOut && parameters[i].ParameterType.IsByRef && !parameters[i].IsIn;
+
+                    if (!isOutRef)
                     {
                         argsArr.BeginSet(i);
                         args.Get(i);

--- a/src/System.Reflection.DispatchProxy/tests/TestTypes.cs
+++ b/src/System.Reflection.DispatchProxy/tests/TestTypes.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 
 
@@ -14,6 +15,17 @@ using System.Text;
 public interface TestType_IHelloService
 {
     string Hello(string message);
+}
+
+public interface TestType_IOut_Ref
+{
+    void Out(out string message);
+    void Ref(ref string message);
+    void InAttribute([In] string message);
+    void OutAttribute([Out] string message);
+    void InAttribute_OutAttribute([In][Out] string message);
+    void InAttribute_OutAttribute_Ref([In][Out] ref string message);
+    void InAttribute_Ref([In] ref string message);
 }
 
 public interface TestType_IGoodbyeService


### PR DESCRIPTION
When calling a method with the [Out] argument, DispatchProxy incorrectly interprets it as a "out" method and sets the argument to null.

Fixes https://github.com/dotnet/corefx/issues/34582