### PR TITLE
Test to validate that TaskCompletionSource doesn't capture ExecutionContext

### DIFF
--- a/src/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
@@ -62,6 +62,44 @@ namespace System.Threading.Tasks.Tests
             GC.KeepAlive(t); // ensure the object is stored in the state machine
         }
 
+        public static IEnumerable<object[]> TaskCompletionSourceDoesntCaptureExecutionContext_MemberData()
+        {
+            yield return new object[] { new Func<TaskCompletionSource<int>>(() => new TaskCompletionSource<int>()) };
+            yield return new object[] { new Func<TaskCompletionSource<int>>(() => new TaskCompletionSource<int>(new object())) };
+            yield return new object[] { new Func<TaskCompletionSource<int>>(() => new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously)) };
+            yield return new object[] { new Func<TaskCompletionSource<int>>(() => new TaskCompletionSource<int>(new object(), TaskCreationOptions.RunContinuationsAsynchronously)) };
+        }
+
+        [Theory]
+        [MemberData(nameof(TaskCompletionSourceDoesntCaptureExecutionContext_MemberData))]
+        public static async Task TaskCompletionSourceDoesntCaptureExecutionContext(Func<TaskCompletionSource<int>> tcsFactory)
+        {
+            // Create a finalizable object that'll be referenced by captured ExecutionContext,
+            // create a TCS, and then hold on to that while forcing GCs and finalizers.
+            // We want to make sure that holding on to the resulting TCS doesn't keep
+            // that finalizable object alive.
+
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            TaskCompletionSource<int> t = null;
+            await Task.Run(delegate // avoid any issues with the stack keeping the object alive
+            {
+                var state = new InvokeActionOnFinalization { Action = () => tcs.SetResult(true) };
+                var al = new AsyncLocal<object> { Value = state }; // ensure the object is stored in ExecutionContext
+                t = tcsFactory(); // create the TCS that shouldn't capture ExecutionContext
+                al.Value = null;
+            });
+
+            for (int i = 0; i < 2; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+
+            await tcs.Task.TimeoutAfter(60_000); // finalizable object should have been collected and finalized
+            GC.KeepAlive(t); // ensure the TCS is stored in the state machine
+        }
+
         private sealed class InlineTaskScheduler : TaskScheduler
         {
             protected override void QueueTask(Task task) => TryExecuteTask(task);


### PR DESCRIPTION
Depends on https://github.com/dotnet/coreclr/pull/21981