### PR TITLE
Remove flaky ReadByte assert.

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
@@ -119,20 +119,6 @@ namespace System.Runtime.InteropServices.Tests
             };
 
             Assert.Equal(100, Marshal.ReadByte(structure, pointerOffset));
-
-            // The ReadByte() for object types does an explicit marshal which requires
-            // an allocation on each read. It can occur that the allocation is aligned
-            // on a byte boundary which would yield a value of 0. To mitigate the chance,
-            // marshal several times, choosing 20 as an arbitrary value. If this test
-            // fails, we should reconsider whether it is worth the flakiness.
-            int readBytes = 0;
-            for (int i = 0; i < 20; ++i)
-            {
-                readBytes += Marshal.ReadByte(structure, stringOffset);
-            }
-
-            Assert.NotEqual(0, readBytes);
-
             Assert.Equal(3, Marshal.ReadByte(structure, arrayOffset + sizeof(byte) * 2));
         }
 


### PR DESCRIPTION
We've hit the flaky assert in the Marshal.ReadByte test. I don't think that this test is worth the flaky-ness in the `Byte` case, so I'm just going to remove this assert and bring it back to how it was beforehand. Fixes #34579.

See #34445.

cc: @AaronRobinsonMSFT