### PR TITLE
skip SetDateTimeMax test on 32b Unix platforms

### DIFF
--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -14,7 +14,7 @@ namespace System.IO.Tests
     {
         // OSX has the limitation of setting upto 2262-04-11T23:47:16 (long.Max) date.
         // 32bit Unix has time_t up to ~ 2038.
-        private static bool OsHasMaxTime => PlatformDetection.IsWindows || (RuntimeInformation.ProcessArchitecture != Architecture.Arm && RuntimeInformation.ProcessArchitecture != Architecture.X86 && !PlatformDetection.IsOSX);
+        private static bool SupportsLongMaxDateTime => PlatformDetection.IsWindows || (RuntimeInformation.ProcessArchitecture != Architecture.Arm && RuntimeInformation.ProcessArchitecture != Architecture.X86 && !PlatformDetection.IsOSX);
 
         public override string GetExistingItem()
         {
@@ -149,7 +149,7 @@ namespace System.IO.Tests
             Assert.Equal(ticks, dateTime.Ticks);
         }
 
-        [ConditionalFact(nameof(OsHasMaxTime))]
+        [ConditionalFact(nameof(SupportsLongMaxDateTime))]
         public void SetDateTimeMax()
         {
             string file = GetTestFilePath();

--- a/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -11,6 +12,10 @@ namespace System.IO.Tests
 {
     public class File_GetSetTimes : StaticGetSetTimes
     {
+        // OSX has the limitation of setting upto 2262-04-11T23:47:16 (long.Max) date.
+        // 32bit Unix has time_t up to ~ 2038.
+        private static bool OsHasMaxTime => PlatformDetection.IsWindows || (RuntimeInformation.ProcessArchitecture != Architecture.Arm && RuntimeInformation.ProcessArchitecture != Architecture.X86 && !PlatformDetection.IsOSX);
+
         public override string GetExistingItem()
         {
             string path = GetTestFilePath();
@@ -144,8 +149,7 @@ namespace System.IO.Tests
             Assert.Equal(ticks, dateTime.Ticks);
         }
 
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.OSX)] // OSX has the limitation of setting upto 2262-04-11T23:47:16 (long.Max) date.
+        [ConditionalFact(nameof(OsHasMaxTime))]
         public void SetDateTimeMax()
         {
             string file = GetTestFilePath();


### PR DESCRIPTION
fixes #33966 

On 32 bit platforms time_t is only 32 bit (signed) and cannot hold time beyond ~ 2038. This is conceptually product bug/OS limitation,. Since we already skio  on OSX I simply extended that.

With this all tests pass (including outerloop)
```
    Finished:    System.IO.FileSystem.Tests
  === TEST EXECUTION SUMMARY ===
     System.IO.FileSystem.Tests  Total: 4192, Errors: 0, Failed: 0, Skipped: 10, Time: 130.589s
  /ssd/toweinfu/wfurt-corefx-arm/src/System.IO.FileSystem/tests
  ----- end 01:50:56 ----- exit code 0 ----------------------------------------------------------
  exit code 0 means Exited Successfully
```
