### PR TITLE
Fix ManualResetValueTaskSource tests missing event Waits

### DIFF
--- a/src/System.Threading.Tasks.Extensions/tests/ManualResetValueTaskSourceTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/ManualResetValueTaskSourceTests.cs
@@ -258,6 +258,7 @@ namespace System.Threading.Tasks.Sources.Tests
                     i,
                     ValueTaskSourceOnCompletedFlags.None);
                 mrvts.Reset();
+                mres.Wait();
                 mres.Reset();
             }
         }
@@ -282,6 +283,7 @@ namespace System.Threading.Tasks.Sources.Tests
                     i,
                     ValueTaskSourceOnCompletedFlags.None);
                 mrvts.SetResult(42);
+                mres.Wait();
                 mrvts.Reset();
                 mres.Reset();
             }


### PR DESCRIPTION
These are sporadically failing because they're missing required .Wait() calls on an event that gets set.

cc: @kouvel, @tarekgh 