### PR TITLE
Add volatile keyword to fields used in double-checked locks

### DIFF
--- a/src/Common/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/Common/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -31,7 +31,7 @@ namespace System.Data.ProviderBase
         private readonly DbConnectionOptions _connectionOptions;
         private readonly DbConnectionPoolKey _poolKey;
         private readonly DbConnectionPoolGroupOptions _poolGroupOptions;
-        private ConcurrentDictionary<DbConnectionPoolIdentity, DbConnectionPool> _poolCollection;
+        private volatile ConcurrentDictionary<DbConnectionPoolIdentity, DbConnectionPool> _poolCollection;
 
         private int _state;          // see PoolGroupState* below
 

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerInfo.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerInfo.cs
@@ -15,7 +15,7 @@ namespace System.CodeDom.Compiler
         internal CompilerParameters _compilerParams; // This can never by null
         internal string[] _compilerLanguages; // This can never by null
         internal string[] _compilerExtensions; // This can never by null
-        private Type _type;
+        private volatile Type _type;
 
         private CompilerInfo() { } // Not createable
 

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttributeStore.cs
@@ -169,7 +169,7 @@ namespace System.ComponentModel.DataAnnotations
         {
             private readonly object _syncRoot = new object();
             private readonly Type _type;
-            private Dictionary<string, PropertyStoreItem> _propertyStoreItems;
+            private volatile Dictionary<string, PropertyStoreItem> _propertyStoreItems;
 
             internal TypeStoreItem(Type type, IEnumerable<Attribute> attributes)
                 : base(attributes)

--- a/src/System.Data.Common/src/System/Data/DataSet.cs
+++ b/src/System.Data.Common/src/System/Data/DataSet.cs
@@ -33,7 +33,7 @@ namespace System.Data
         private const string KEY_XMLSCHEMA = "XmlSchema";
         private const string KEY_XMLDIFFGRAM = "XmlDiffGram";
 
-        private DataViewManager _defaultViewManager;
+        private volatile DataViewManager _defaultViewManager;
 
         // Public Collections
         private readonly DataTableCollection _tableCollection;

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -44,7 +44,7 @@ namespace System.Diagnostics
         private ProcessStartInfo _startInfo;
 
         private bool _watchForExit;
-        private bool _watchingForExit;
+        private volatile bool _watchingForExit;
         private EventHandler _onExited;
         private bool _exited;
         private int _exitCode;
@@ -56,7 +56,7 @@ namespace System.Diagnostics
         private bool _priorityBoostEnabled;
         private bool _havePriorityBoostEnabled;
 
-        private bool _raisedOnExited;
+        private volatile bool _raisedOnExited;
         private RegisteredWaitHandle _registeredWaitHandle;
         private WaitHandle _waitHandle;
         private StreamReader _standardOutput;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -34,7 +34,7 @@ namespace System.Net.Http
 
         private bool _http2Enabled;
         private Http2Connection _http2Connection;
-        private SemaphoreSlim _http2ConnectionCreateLock;
+        private volatile SemaphoreSlim _http2ConnectionCreateLock;
 
         /// <summary>For non-proxy connection pools, this is the host name in bytes; for proxies, null.</summary>
         private readonly byte[] _hostHeaderValueBytes;

--- a/src/System.Net.Requests/src/System/Net/FileWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/FileWebRequest.cs
@@ -21,8 +21,8 @@ namespace System.Net
         private long _contentLength;
         private int _timeout = DefaultTimeoutMilliseconds;
         private bool _readPending;
-        private bool _writePending;
-        private bool _writing;
+        private volatile bool _writePending;
+        private volatile bool _writing;
         private bool _syncHint;
         private int _aborted;
 

--- a/src/System.Net.Requests/src/System/Net/FtpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/FtpWebRequest.cs
@@ -212,11 +212,11 @@ namespace System.Net
 
         private bool _enableSsl;
         private FtpControlStream _connection;
-        private Stream _stream;
+        private volatile Stream _stream;
         private RequestStage _requestStage;
         private bool _onceFailed;
         private WebHeaderCollection _ftpRequestHeaders;
-        private FtpWebResponse _ftpWebResponse;
+        private volatile FtpWebResponse _ftpWebResponse;
         private int _readWriteTimeout = 5 * 60 * 1000;  // 5 minutes.
 
         private ContextAwareResult _writeAsyncResult;

--- a/src/System.Net.Requests/src/System/Net/FtpWebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/FtpWebResponse.cs
@@ -16,7 +16,7 @@ namespace System.Net
         private Uri _responseUri;
         private FtpStatusCode _statusCode;
         private string _statusLine;
-        private WebHeaderCollection _ftpRequestHeaders;
+        private volatile WebHeaderCollection _ftpRequestHeaders;
         private DateTime _lastModified;
         private string _bannerMessage;
         private string _welcomeMessage;

--- a/src/System.Net.Requests/src/System/Net/TimerThread.cs
+++ b/src/System.Net.Requests/src/System/Net/TimerThread.cs
@@ -287,7 +287,7 @@ namespace System.Net
         /// </summary>
         private class TimerNode : Timer
         {
-            private TimerState _timerState;
+            private volatile TimerState _timerState;
             private Callback _callback;
             private object _context;
             private object _queueLock;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -31,7 +31,7 @@ namespace System.Runtime.Serialization
 
         public XmlDictionaryString[] MemberNamespaces;
 
-        private XmlDictionaryString[] _childElementNamespaces;
+        private volatile XmlDictionaryString[] _childElementNamespaces;
 
         private ClassDataContractCriticalHelper _helper;
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -144,7 +144,7 @@ namespace System.Runtime.Serialization
     {
         private XmlDictionaryString _collectionItemName;
 
-        private XmlDictionaryString _childElementNamespace;
+        private volatile XmlDictionaryString _childElementNamespace;
 
         private DataContract _itemContract;
 

--- a/src/System.Private.Xml/src/System/Xml/Dom/XmlElement.cs
+++ b/src/System.Private.Xml/src/System/Xml/Dom/XmlElement.cs
@@ -15,7 +15,7 @@ namespace System.Xml
     public class XmlElement : XmlLinkedNode
     {
         private XmlName _name;
-        private XmlAttributeCollection _attributes;
+        private volatile XmlAttributeCollection _attributes;
         private XmlLinkedNode _lastChild; // == this for empty elements otherwise it is the last child
 
         internal XmlElement(XmlName name, bool empty, XmlDocument doc) : base(doc)

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/MemoryCache.cs
@@ -28,7 +28,7 @@ namespace System.Runtime.Caching
                                                               | DefaultCacheCapabilities.CacheEntryRemovedCallback;
         private static readonly TimeSpan s_oneYear = new TimeSpan(365, 0, 0, 0);
         private static object s_initLock = new object();
-        private static MemoryCache s_defaultCache;
+        private static volatile MemoryCache s_defaultCache;
         private static CacheEntryRemovedCallback s_sentinelRemovedCallback = new CacheEntryRemovedCallback(SentinelEntry.OnCacheEntryRemovedCallback);
         private GCHandleRef<MemoryCacheStore>[] _storeRefs;
         private int _storeCount;

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -17,7 +17,7 @@ namespace Internal.Cryptography.Pal
 {
     internal sealed partial class StorePal
     {
-        private static CollectionBackedStoreProvider s_machineRootStore;
+        private static volatile CollectionBackedStoreProvider s_machineRootStore;
         private static CollectionBackedStoreProvider s_machineIntermediateStore;
         private static readonly object s_machineLoadLock = new object();
 

--- a/src/System.Transactions.Local/src/System/Transactions/Transaction.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/Transaction.cs
@@ -242,7 +242,7 @@ namespace System.Transactions
         // Internal synchronization object for transactions.  It is not safe to lock on the 
         // transaction object because it is public and users of the object may lock it for 
         // other purposes.
-        internal InternalTransaction _internalTransaction;
+        internal volatile InternalTransaction _internalTransaction;
 
         // The TransactionTraceIdentifier for the transaction instance.
         internal TransactionTraceIdentifier _traceIdentifier;


### PR DESCRIPTION
Across various projects, double-checked locks are implemented without the underlying field being `volatile`. This is correct for the Intel architecture but could fail on other architectures.

Most of these race conditions seem to be benign, but is it still correct to use the `volatile` keyword.

## How were these found
We used lgtm.com to automatically analyse this project. Alerts can be found [here](https://lgtm.com/projects/g/dotnet/corefx/alerts/?mode=tree&ruleFocus=1506088456975).

Disclaimer: I work for lgtm.com (semmle.com).