### PR TITLE
Improve handling of frames received on closed stream

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -242,7 +242,7 @@ namespace System.Net.Http
             // addition to the highest ID used by the client.
             if (streamId <= 0 || streamId >= _nextStream)
             {
-                throw new Http2ProtocolException(Http2ProtocolErrorCode.StreamClosed);
+                throw new Http2ProtocolException(Http2ProtocolErrorCode.ProtocolError);
             }
 
             lock (_syncObject)
@@ -268,7 +268,7 @@ namespace System.Net.Http
             {
                 _incomingBuffer.Discard(frameHeader.Length);
 
-                throw new Http2ProtocolException(Http2ProtocolErrorCode.ProtocolError);
+                throw new Http2ProtocolException(Http2ProtocolErrorCode.StreamClosed);
             }
 
             // TODO: Figure out how to cache this delegate.

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -242,7 +242,7 @@ namespace System.Net.Http
             // addition to the highest ID used by the client.
             if (streamId <= 0 || streamId >= _nextStream)
             {
-                throw new Http2ProtocolException(Http2ProtocolErrorCode.ProtocolError);
+                throw new Http2ProtocolException(Http2ProtocolErrorCode.StreamClosed);
             }
 
             lock (_syncObject)
@@ -344,7 +344,7 @@ namespace System.Net.Http
             {
                 _incomingBuffer.Discard(frameHeader.Length);
 
-                throw new Http2ProtocolException(Http2ProtocolErrorCode.ProtocolError);
+                throw new Http2ProtocolException(Http2ProtocolErrorCode.StreamClosed);
             }
 
             ReadOnlySpan<byte> frameData = GetFrameData(_incomingBuffer.ActiveSpan.Slice(0, frameHeader.Length), hasPad: frameHeader.PaddedFlag, hasPriority: false);

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
@@ -344,7 +344,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalFact(nameof(SupportsAlpn))]
-        public async Task CompletedResponse_FrameReceived_ResetsStream()
+        public async Task CompletedResponse_FrameReceived_ConnectionError()
         {
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
@@ -370,22 +370,14 @@ namespace System.Net.Http.Functional.Tests
                 DataFrame invalidFrame = new DataFrame(new byte[10], FrameFlags.None, 0, streamId);
                 await server.WriteFrameAsync(invalidFrame);
 
-                // Receive a RST_STREAM frame.
+                // Receive a GoAway frame, as this is a connection level error.
                 Frame receivedFrame = await server.ReadFrameAsync(TimeSpan.FromSeconds(30));
-                Assert.Equal(FrameType.RstStream, receivedFrame.Type);
-                Assert.Equal(streamId, receivedFrame.StreamId);
-
-                // Connection should still be usable.
-                sendTask = client.GetAsync(server.Address);
-                streamId = await server.ReadRequestHeaderAsync();
-                await server.SendDefaultResponseAsync(streamId);
-                response = await sendTask;
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal(FrameType.GoAway, receivedFrame.Type);
             }
         }
 
         [ConditionalFact(nameof(SupportsAlpn))]
-        public async Task EmptyResponse_FrameReceived_ResetsStream()
+        public async Task EmptyResponse_FrameReceived_ConnectionError()
         {
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
@@ -408,22 +400,14 @@ namespace System.Net.Http.Functional.Tests
                 DataFrame invalidFrame = new DataFrame(new byte[10], FrameFlags.None, 0, streamId);
                 await server.WriteFrameAsync(invalidFrame);
 
-                // Receive a RST_STREAM frame.
+                // Receive a GoAway frame, as this is a connection level error.
                 Frame receivedFrame = await server.ReadFrameAsync(TimeSpan.FromSeconds(30));
-                Assert.Equal(FrameType.RstStream, receivedFrame.Type);
-                Assert.Equal(streamId, receivedFrame.StreamId);
-
-                // Connection should still be usable.
-                sendTask = client.GetAsync(server.Address);
-                streamId = await server.ReadRequestHeaderAsync();
-                await server.SendDefaultResponseAsync(streamId);
-                response = await sendTask;
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal(FrameType.GoAway, receivedFrame.Type);
             }
         }
 
         [ConditionalFact(nameof(SupportsAlpn))]
-        public async Task ResetResponseStream_FrameReceived_ResetsStream()
+        public async Task ResetResponseStream_FrameReceived_ConnectionError()
         {
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
@@ -446,17 +430,9 @@ namespace System.Net.Http.Functional.Tests
                 DataFrame invalidFrame = new DataFrame(new byte[10], FrameFlags.None, 0, streamId);
                 await server.WriteFrameAsync(invalidFrame);
 
-                // Receive a RST_STREAM frame.
+                // Receive a GoAway frame, as this is a connection level error.
                 Frame receivedFrame = await server.ReadFrameAsync(TimeSpan.FromSeconds(30));
-                Assert.Equal(FrameType.RstStream, receivedFrame.Type);
-                Assert.Equal(streamId, receivedFrame.StreamId);
-
-                // Connection should still be usable.
-                sendTask = client.GetAsync(server.Address);
-                streamId = await server.ReadRequestHeaderAsync();
-                await server.SendDefaultResponseAsync(streamId);
-                HttpResponseMessage response = await sendTask;
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal(FrameType.GoAway, receivedFrame.Type);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
@@ -370,7 +370,7 @@ namespace System.Net.Http.Functional.Tests
                 DataFrame invalidFrame = new DataFrame(new byte[10], FrameFlags.None, 0, streamId);
                 await server.WriteFrameAsync(invalidFrame);
 
-                // The server should close the connection, as this is a fatal connection level error.
+                // The server should close the connection as this is a fatal connection level error.
                 Exception ex = await Assert.ThrowsAsync<Exception>(async () => await server.ReadFrameAsync(TimeSpan.FromSeconds(30)));
                 Assert.Equal("Connection stream closed while attempting to read frame header.", ex.Message);
 
@@ -401,7 +401,7 @@ namespace System.Net.Http.Functional.Tests
                 DataFrame invalidFrame = new DataFrame(new byte[10], FrameFlags.None, 0, streamId);
                 await server.WriteFrameAsync(invalidFrame);
 
-                // The server should close the connection, as this is a fatal connection level error.
+                // The server should close the connection as this is a fatal connection level error.
                 Exception ex = await Assert.ThrowsAsync<Exception>(async () => await server.ReadFrameAsync(TimeSpan.FromSeconds(30)));
                 Assert.Equal("Connection stream closed while attempting to read frame header.", ex.Message);
             }
@@ -431,7 +431,7 @@ namespace System.Net.Http.Functional.Tests
                 DataFrame invalidFrame = new DataFrame(new byte[10], FrameFlags.None, 0, streamId);
                 await server.WriteFrameAsync(invalidFrame);
 
-                // The server should close the connection, as this is a fatal connection level error.
+                // The server should close the connection as this is a fatal connection level error.
                 Exception ex = await Assert.ThrowsAsync<Exception>(async () => await server.ReadFrameAsync(TimeSpan.FromSeconds(30)));
                 Assert.Equal("Connection stream closed while attempting to read frame header.", ex.Message);
             }

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.Http2.cs
@@ -370,9 +370,10 @@ namespace System.Net.Http.Functional.Tests
                 DataFrame invalidFrame = new DataFrame(new byte[10], FrameFlags.None, 0, streamId);
                 await server.WriteFrameAsync(invalidFrame);
 
-                // Receive a GoAway frame, as this is a connection level error.
-                Frame receivedFrame = await server.ReadFrameAsync(TimeSpan.FromSeconds(30));
-                Assert.Equal(FrameType.GoAway, receivedFrame.Type);
+                // The server should close the connection, as this is a fatal connection level error.
+                Exception ex = await Assert.ThrowsAsync<Exception>(async () => await server.ReadFrameAsync(TimeSpan.FromSeconds(30)));
+                Assert.Equal("Connection stream closed while attempting to read frame header.", ex.Message);
+
             }
         }
 
@@ -400,9 +401,9 @@ namespace System.Net.Http.Functional.Tests
                 DataFrame invalidFrame = new DataFrame(new byte[10], FrameFlags.None, 0, streamId);
                 await server.WriteFrameAsync(invalidFrame);
 
-                // Receive a GoAway frame, as this is a connection level error.
-                Frame receivedFrame = await server.ReadFrameAsync(TimeSpan.FromSeconds(30));
-                Assert.Equal(FrameType.GoAway, receivedFrame.Type);
+                // The server should close the connection, as this is a fatal connection level error.
+                Exception ex = await Assert.ThrowsAsync<Exception>(async () => await server.ReadFrameAsync(TimeSpan.FromSeconds(30)));
+                Assert.Equal("Connection stream closed while attempting to read frame header.", ex.Message);
             }
         }
 
@@ -430,9 +431,9 @@ namespace System.Net.Http.Functional.Tests
                 DataFrame invalidFrame = new DataFrame(new byte[10], FrameFlags.None, 0, streamId);
                 await server.WriteFrameAsync(invalidFrame);
 
-                // Receive a GoAway frame, as this is a connection level error.
-                Frame receivedFrame = await server.ReadFrameAsync(TimeSpan.FromSeconds(30));
-                Assert.Equal(FrameType.GoAway, receivedFrame.Type);
+                // The server should close the connection, as this is a fatal connection level error.
+                Exception ex = await Assert.ThrowsAsync<Exception>(async () => await server.ReadFrameAsync(TimeSpan.FromSeconds(30)));
+                Assert.Equal("Connection stream closed while attempting to read frame header.", ex.Message);
             }
         }
 


### PR DESCRIPTION
This PR adds basic support for GoAway frames in HTTP/2, and modifies our error handling in order to send them when we receive a frame on a completed stream.

This change isn't ready to merge yet, as it is at least nominally in violation of the spec. See the discussion on #34461 for more details.

We should also decide whether or not GoAway frames are useful enough (as a tool for debugging) that they are worth including. If not we can remove `SendGoAwayAsync` and leave the rest of the code as-is.