### PR TITLE
Fix outerloop JsonWriter test by creating new instance of the writer when writing invalid JSON

### DIFF
--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -855,7 +855,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [OuterLoop]
+        //[OuterLoop]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
@@ -2902,7 +2902,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [OuterLoop]
+        //[OuterLoop]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
@@ -2917,10 +2917,10 @@ namespace System.Text.Json.Tests
             value.Fill((byte)'b');
 
             var output = new ArrayBufferWriter(1024);
-            var jsonUtf8 = new Utf8JsonWriter(output, state);
 
             try
             {
+                var jsonUtf8 = new Utf8JsonWriter(output, state);
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteString(key, DateTime.Now, escape: false);
                 Assert.True(false, $"Expected ArgumentException for data too large wasn't thrown. KeyLength: {key.Length}");
@@ -2929,6 +2929,7 @@ namespace System.Text.Json.Tests
 
             try
             {
+                var jsonUtf8 = new Utf8JsonWriter(output, state);
                 jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteStringValue(value, escape: false);
                 Assert.True(false, $"Expected ArgumentException for data too large wasn't thrown. ValueLength: {value.Length}");
@@ -2939,7 +2940,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [OuterLoop]
+        //[OuterLoop]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -855,7 +855,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        //[OuterLoop]
+        [OuterLoop]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
@@ -2902,7 +2902,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        //[OuterLoop]
+        [OuterLoop]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
@@ -2940,7 +2940,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        //[OuterLoop]
+        [OuterLoop]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/34616