### PR TITLE
[WIP] Enable CoreLib coverage hits

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,8 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Use IL version of System.Private.CoreLib and link to the testhost folder to probe additional assemblies. -->
-    <CoverageProbePath Include="shared\Microsoft.NETCore.App\9.9.9\il" />
     <CoverageProbePath Include="shared\Microsoft.NETCore.App\9.9.9" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Enable CoreLib coverage

@ericstj I need to replace the System.Private.CoreLib.dll in the testhost folder with the one in the testhost/il folder (for netcoreapp). I know that the runtime restore is happening in external/runtime.depproj but I'm not entirely sure where I should plug in because of the additional binplacing from the runtime to the testhost directory. I will ping you offline to unblock this PR.