### PR TITLE
Use RemoteInvoke with tracing tests

### DIFF
--- a/src/System.Collections.Concurrent/tests/EtwTests.cs
+++ b/src/System.Collections.Concurrent/tests/EtwTests.cs
@@ -2,49 +2,53 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using Xunit;
 
 namespace System.Collections.Concurrent.Tests
 {
-    public class EtwTests
+    public class EtwTests : RemoteExecutorTestBase
     {
         [Fact]
         public void TestEtw()
         {
-            using (var listener = new TestEventListener("System.Collections.Concurrent.ConcurrentCollectionsEventSource", EventLevel.Verbose))
+            RemoteInvoke(() =>
             {
-                var events = new ConcurrentQueue<int>();
-
-                const int AcquiringAllLocksEventId = 3;
-                Clear(events);
-                listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () =>
+                using (var listener = new TestEventListener("System.Collections.Concurrent.ConcurrentCollectionsEventSource", EventLevel.Verbose))
                 {
-                    var cd = new ConcurrentDictionary<int, int>();
-                    cd.TryAdd(1, 1);
-                    cd.Clear();
-                });
-                Assert.True(events.Count(i => i == AcquiringAllLocksEventId) > 0);
+                    var events = new ConcurrentQueue<int>();
 
-                const int TryTakeStealsEventId = 4;
-                const int TryPeekStealsEventId = 5;
-                Clear(events);
-                listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () =>
-                {
-                    var cb = new ConcurrentBag<int>();
-                    int item;
-                    cb.TryPeek(out item);
-                    cb.TryTake(out item);
-                });
-                Assert.True(events.Count(i => i == TryPeekStealsEventId) > 0);
-                Assert.True(events.Count(i => i == TryTakeStealsEventId) > 0);
+                    const int AcquiringAllLocksEventId = 3;
+                    Clear(events);
+                    listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () =>
+                    {
+                        var cd = new ConcurrentDictionary<int, int>();
+                        cd.TryAdd(1, 1);
+                        cd.Clear();
+                    });
+                    Assert.True(events.Count(i => i == AcquiringAllLocksEventId) > 0);
 
-                // No tests for:
-                //      CONCURRENTSTACK_FASTPUSHFAILED_ID
-                //      CONCURRENTSTACK_FASTPOPFAILED_ID
-                // These require certain race condition interleavings in order to fire.
-            }
+                    const int TryTakeStealsEventId = 4;
+                    const int TryPeekStealsEventId = 5;
+                    Clear(events);
+                    listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () =>
+                    {
+                        var cb = new ConcurrentBag<int>();
+                        int item;
+                        cb.TryPeek(out item);
+                        cb.TryTake(out item);
+                    });
+                    Assert.True(events.Count(i => i == TryPeekStealsEventId) > 0);
+                    Assert.True(events.Count(i => i == TryTakeStealsEventId) > 0);
+
+                    // No tests for:
+                    //      CONCURRENTSTACK_FASTPUSHFAILED_ID
+                    //      CONCURRENTSTACK_FASTPOPFAILED_ID
+                    // These require certain race condition interleavings in order to fire.
+                }
+            }).Dispose();
         }
 
         private static void Clear<T>(ConcurrentQueue<T> queue)

--- a/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
+++ b/src/System.Collections.Concurrent/tests/System.Collections.Concurrent.Tests.csproj
@@ -105,5 +105,9 @@
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.Generic.Serialization.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.Generic.Serialization.Tests.cs</Link>
     </Compile>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/System.Data.Common/tests/System/Data/DataCommonEventSourceTest.cs
+++ b/src/System.Data.Common/tests/System/Data/DataCommonEventSourceTest.cs
@@ -3,37 +3,41 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using Xunit;
 
 namespace System.Data.Tests
 {
-    public class DataCommonEventSourceTest
+    public class DataCommonEventSourceTest : RemoteExecutorTestBase
     {
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void InvokeCodeThatShouldFirEvents_EnsureEventsFired()
         {
-            using (var listener = new TestEventListener("System.Data.DataCommonEventSource", EventLevel.Verbose))
+            RemoteInvoke(() =>
             {
-                var events = new ConcurrentQueue<EventWrittenEventArgs>();
-                listener.RunWithCallback(events.Enqueue, () =>
+                using (var listener = new TestEventListener("System.Data.DataCommonEventSource", EventLevel.Verbose))
                 {
-                    var dt = new DataTable("Players");
-                    dt.Columns.Add(new DataColumn("Name", typeof(string)));
-                    dt.Columns.Add(new DataColumn("Weight", typeof(int)));
+                    var events = new ConcurrentQueue<EventWrittenEventArgs>();
+                    listener.RunWithCallback(events.Enqueue, () =>
+                    {
+                        var dt = new DataTable("Players");
+                        dt.Columns.Add(new DataColumn("Name", typeof(string)));
+                        dt.Columns.Add(new DataColumn("Weight", typeof(int)));
 
-                    var ds = new DataSet();
-                    ds.Tables.Add(dt);
+                        var ds = new DataSet();
+                        ds.Tables.Add(dt);
 
-                    dt.Rows.Add("John", 150);
-                    dt.Rows.Add("Jane", 120);
+                        dt.Rows.Add("John", 150);
+                        dt.Rows.Add("Jane", 120);
 
-                    DataRow[] results = dt.Select("Weight < 140");
-                    Assert.Equal(1, results.Length);
-                });
-                Assert.InRange(events.Count, 1, int.MaxValue);
-            }
+                        DataRow[] results = dt.Select("Weight < 140");
+                        Assert.Equal(1, results.Length);
+                    });
+                    Assert.InRange(events.Count, 1, int.MaxValue);
+                }
+            }).Dispose();
         }
     }
 }

--- a/src/System.Linq.Parallel/tests/EtwTests.cs
+++ b/src/System.Linq.Parallel/tests/EtwTests.cs
@@ -3,35 +3,39 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
 {
-    public static class EtwTests
+    public class EtwTests : RemoteExecutorTestBase
     {
         [Fact]
         public static void TestEtw()
         {
-            using (var listener = new TestEventListener(new Guid("159eeeec-4a14-4418-a8fe-faabcd987887"), EventLevel.Verbose))
+            RemoteInvoke(() =>
             {
-                var events = new ConcurrentQueue<int>();
-                listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () =>
+                using (var listener = new TestEventListener(new Guid("159eeeec-4a14-4418-a8fe-faabcd987887"), EventLevel.Verbose))
                 {
-                    Enumerable.Range(0, 10000).AsParallel().Select(i => i).ToArray();
-                });
+                    var events = new ConcurrentQueue<int>();
+                    listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () =>
+                    {
+                        Enumerable.Range(0, 10000).AsParallel().Select(i => i).ToArray();
+                    });
 
-                const int BeginEventId = 1;
-                Assert.Equal(expected: 1, actual: events.Count(i => i == BeginEventId));
+                    const int BeginEventId = 1;
+                    Assert.Equal(expected: 1, actual: events.Count(i => i == BeginEventId));
 
-                const int EndEventId = 2;
-                Assert.Equal(expected: 1, actual: events.Count(i => i == EndEventId));
+                    const int EndEventId = 2;
+                    Assert.Equal(expected: 1, actual: events.Count(i => i == EndEventId));
 
-                const int ForkEventId = 3;
-                const int JoinEventId = 4;
-                Assert.True(events.Count(i => i == ForkEventId) > 0);
-                Assert.Equal(events.Count(i => i == ForkEventId), events.Count(i => i == JoinEventId));
-            }
+                    const int ForkEventId = 3;
+                    const int JoinEventId = 4;
+                    Assert.True(events.Count(i => i == ForkEventId) > 0);
+                    Assert.Equal(events.Count(i => i == ForkEventId), events.Count(i => i == JoinEventId));
+                }
+            }).Dispose();
         }
     }
 }

--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -77,5 +77,9 @@
     <Compile Include="PlinqModesTests.cs" />
     <Compile Include="WithCancellationTests.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/System.Threading.Tasks.Parallel/tests/EtwTests.cs
+++ b/src/System.Threading.Tasks.Parallel/tests/EtwTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Linq;
 
@@ -10,39 +11,42 @@ using Xunit;
 
 namespace System.Threading.Tasks.Tests
 {
-    public static class EtwTests
+    public class EtwTests : RemoteExecutorTestBase
     {
         [Fact]
         public static void TestEtw()
         {
-            var eventSourceName = PlatformDetection.IsFullFramework ? "System.Threading.Tasks.TplEventSource" : "System.Threading.Tasks.Parallel.EventSource";
-            using (var listener = new TestEventListener(eventSourceName, EventLevel.Verbose))
+            RemoteInvoke(() =>
             {
-                var events = new ConcurrentQueue<int>();
-                listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () => {
-                    Parallel.For(0, 10000, i => { });
+                var eventSourceName = PlatformDetection.IsFullFramework ? "System.Threading.Tasks.TplEventSource" : "System.Threading.Tasks.Parallel.EventSource";
+                using (var listener = new TestEventListener(eventSourceName, EventLevel.Verbose))
+                {
+                    var events = new ConcurrentQueue<int>();
+                    listener.RunWithCallback(ev => events.Enqueue(ev.EventId), () => {
+                        Parallel.For(0, 10000, i => { });
 
-                    var barrier = new Barrier(2);
-                    Parallel.Invoke(
-                        () => barrier.SignalAndWait(),
-                        () => barrier.SignalAndWait());
-                });
+                        var barrier = new Barrier(2);
+                        Parallel.Invoke(
+                            () => barrier.SignalAndWait(),
+                            () => barrier.SignalAndWait());
+                    });
 
-                const int BeginLoopEventId = 1;
-                const int BeginInvokeEventId = 3;
-                Assert.Equal(expected: 1, actual: events.Count(i => i == BeginLoopEventId));
-                Assert.Equal(expected: 1, actual: events.Count(i => i == BeginInvokeEventId));
+                    const int BeginLoopEventId = 1;
+                    const int BeginInvokeEventId = 3;
+                    Assert.Equal(expected: 1, actual: events.Count(i => i == BeginLoopEventId));
+                    Assert.Equal(expected: 1, actual: events.Count(i => i == BeginInvokeEventId));
 
-                const int EndLoopEventId = 2;
-                const int EndInvokeEventId = 4;
-                Assert.Equal(expected: 1, actual: events.Count(i => i == EndLoopEventId));
-                Assert.Equal(expected: 1, actual: events.Count(i => i == EndInvokeEventId));
+                    const int EndLoopEventId = 2;
+                    const int EndInvokeEventId = 4;
+                    Assert.Equal(expected: 1, actual: events.Count(i => i == EndLoopEventId));
+                    Assert.Equal(expected: 1, actual: events.Count(i => i == EndInvokeEventId));
 
-                const int ForkEventId = 5;
-                const int JoinEventId = 6;
-                Assert.True(events.Count(i => i == ForkEventId) >= 1);
-                Assert.Equal(events.Count(i => i == ForkEventId), events.Count(i => i == JoinEventId));
-            }
+                    const int ForkEventId = 5;
+                    const int JoinEventId = 6;
+                    Assert.True(events.Count(i => i == ForkEventId) >= 1);
+                    Assert.Equal(events.Count(i => i == ForkEventId), events.Count(i => i == JoinEventId));
+                }
+            }).Dispose();
         }
     }
 }

--- a/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
+++ b/src/System.Threading.Tasks.Parallel/tests/System.Threading.Tasks.Parallel.Tests.csproj
@@ -28,5 +28,9 @@
     <Compile Include="$(CommonTestPath)\System\Threading\ThreadPoolHelpers.cs">
       <Link>CommonTest\System\Threading\ThreadPoolHelpers.cs</Link>
     </Compile>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/System.Threading/tests/EtwTests.cs
+++ b/src/System.Threading/tests/EtwTests.cs
@@ -2,34 +2,38 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using Xunit;
 
 namespace System.Threading.Tests
 {
-    public class EtwTests
+    public class EtwTests : RemoteExecutorTestBase
     {
         [Fact]
         public void TestEtw()
         {
-            using (var listener = new TestEventListener("System.Threading.SynchronizationEventSource", EventLevel.Verbose))
+            RemoteInvoke(() =>
             {
-                const int BarrierPhaseFinishedId = 3;
-                const int ExpectedInvocations = 5;
-                int eventsRaised = 0;
-                int delegateInvocations = 0;
-                listener.RunWithCallback(ev => {
-                        Assert.Equal(expected: BarrierPhaseFinishedId, actual: ev.EventId);
-                        eventsRaised++;
-                    },
-                    () => {
-                        Barrier b = new Barrier(1, _ => delegateInvocations++);
-                        for (int i = 0; i < ExpectedInvocations; i++)
-                            b.SignalAndWait();
-                    });
-                Assert.Equal(ExpectedInvocations, delegateInvocations);
-                Assert.Equal(ExpectedInvocations, eventsRaised);
-            }
+                using (var listener = new TestEventListener("System.Threading.SynchronizationEventSource", EventLevel.Verbose))
+                {
+                    const int BarrierPhaseFinishedId = 3;
+                    const int ExpectedInvocations = 5;
+                    int eventsRaised = 0;
+                    int delegateInvocations = 0;
+                    listener.RunWithCallback(ev => {
+                            Assert.Equal(expected: BarrierPhaseFinishedId, actual: ev.EventId);
+                            eventsRaised++;
+                        },
+                        () => {
+                            Barrier b = new Barrier(1, _ => delegateInvocations++);
+                            for (int i = 0; i < ExpectedInvocations; i++)
+                                b.SignalAndWait();
+                        });
+                    Assert.Equal(ExpectedInvocations, delegateInvocations);
+                    Assert.Equal(ExpectedInvocations, eventsRaised);
+                }
+            }).Dispose();
         }
     }
 }

--- a/src/System.Transactions.Local/tests/HelperFunctions.cs
+++ b/src/System.Transactions.Local/tests/HelperFunctions.cs
@@ -5,7 +5,9 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -17,54 +19,7 @@ namespace System.Transactions.Tests
     {
         public static void PromoteTx(Transaction tx)
         {
-             TransactionInterop.GetDtcTransaction(tx);
-        }
-
-        public static void DisplaySysTxTracing(ITestOutputHelper output, ConcurrentQueue<EventWrittenEventArgs> events)
-        {
-            if (output == null)
-            {
-                return;
-            }
-
-            string outputString = null;
-            foreach (var actualevent in events)
-            {
-                switch (actualevent.Payload.Count)
-                {
-                    case 0:
-                        {
-                            outputString = actualevent.Message;
-                            break;
-                        }
-                    case 1:
-                        {
-                            outputString = string.Format(actualevent.Message, actualevent.Payload[0]);
-                            break;
-                        }
-                    case 2:
-                        {
-                            outputString = string.Format(actualevent.Message, actualevent.Payload[0], actualevent.Payload[1]);
-                            break;
-                        }
-                    case 3:
-                        {
-                            outputString = string.Format(actualevent.Message, actualevent.Payload[0], actualevent.Payload[1], actualevent.Payload[2]);
-                            break;
-                        }
-                    case 4:
-                        {
-                            outputString = string.Format(actualevent.Message, actualevent.Payload[0], actualevent.Payload[1], actualevent.Payload[2], actualevent.Payload[3]);
-                            break;
-                        }
-                    default:
-                        {
-                            outputString = string.Format(actualevent.Message, actualevent.Payload[0], actualevent.Payload[1], actualevent.Payload[2], actualevent.Payload[3], actualevent.Payload[4]);
-                            break;
-                        }
-                }
-                output.WriteLine(actualevent.Opcode + " : " + outputString);
-            }
+            TransactionInterop.GetDtcTransaction(tx);
         }
     }
 }

--- a/src/System.Transactions.Local/tests/System.Transactions.Local.Tests.csproj
+++ b/src/System.Transactions.Local/tests/System.Transactions.Local.Tests.csproj
@@ -16,6 +16,10 @@
     <Compile Include="HelperFunctions.cs" />
     <Compile Include="TestEnlistments.cs" />
     <Compile Include="TransactionTracingEventListener.cs" />
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />


### PR DESCRIPTION
Various test projects validate that EventSource data is being appropriately generated.  Since these tests can run concurrently with others in the process, they should be done as out-of-process such that they don't interfere with each other, but some test projects aren't doing that.  This fixes that, ensuring we're using RemoteInvoke everywhere we should be.

cc: @danmosemsft 
https://github.com/dotnet/coreclr/issues/21995#issuecomment-455180454