### PR TITLE
Avoid unnecessary Span to ReadOnlySpan casts

### DIFF
--- a/src/Common/src/Interop/FreeBSD/Interop.Process.cs
+++ b/src/Common/src/Interop/FreeBSD/Interop.Process.cs
@@ -225,7 +225,7 @@ internal static partial class Interop
                     throw new Win32Exception(SR.CantGetAllPids);
                 }
 
-                Span<kinfo_proc>  list = new Span<kinfo_proc>(entries, numProcesses);
+                var list = new ReadOnlySpan<kinfo_proc>(entries, numProcesses);
                 pids = new int[numProcesses];
                 idx = 0;
                 // walk through process list and skip kernel threads
@@ -357,7 +357,7 @@ internal static partial class Interop
                     throw new ArgumentOutOfRangeException(nameof(pid));
                 }
 
-                Span<kinfo_proc> process = new Span<kinfo_proc>(kinfo, count);
+                var process = new ReadOnlySpan<kinfo_proc>(kinfo, count);
 
                 // Get the process information for the specified pid
                 info = new ProcessInfo();
@@ -417,7 +417,7 @@ internal static partial class Interop
                     }
                     else
                     {
-                        Span<kinfo_proc> list = new Span<kinfo_proc>(info, count);
+                        var list = new ReadOnlySpan<kinfo_proc>(info, count);
                         for(int i = 0; i < list.Length; i++)
                         {
                             if (list[i].ki_tid == tid)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -410,7 +410,7 @@ internal static partial class Interop
             {
                 for (int i = 0; i < protocolList.Count; i++)
                 {
-                    Span<byte> clientList = new Span<byte>(inp, (int)inlen);
+                    var clientList = new Span<byte>(inp, (int)inlen);
                     while (clientList.Length > 0)
                     {
                         byte length = clientList[0];

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -62,7 +62,7 @@ internal static partial class Interop
             foreach (SslApplicationProtocol protocol in applicationProtocols)
             {
                 buffer[offset++] = (byte)(protocol.Protocol.Length);
-                protocol.Protocol.Span.CopyTo(new Span<byte>(buffer).Slice(offset));
+                protocol.Protocol.Span.CopyTo(buffer.AsSpan(offset));
                 offset += protocol.Protocol.Length;
             }
 

--- a/src/Common/src/System/Net/InteropIPAddressExtensions.Unix.cs
+++ b/src/Common/src/System/Net/InteropIPAddressExtensions.Unix.cs
@@ -35,7 +35,7 @@ namespace System.Net
             else
             {
                 return new IPAddress(
-                    new Span<byte>(nativeIPAddress.Address, Interop.Sys.IPv6AddressBytes),
+                    new ReadOnlySpan<byte>(nativeIPAddress.Address, Interop.Sys.IPv6AddressBytes),
                     (long)nativeIPAddress.ScopeId);
             }
         }

--- a/src/Common/src/System/Security/Cryptography/EccKeyFormatHelper.cs
+++ b/src/Common/src/System/Security/Cryptography/EccKeyFormatHelper.cs
@@ -225,7 +225,7 @@ namespace System.Security.Cryptography
                         keyParameters.Value.Encode(writer);
                         if (!writer.TryEncode(verify, out int written) ||
                             written != algIdParameters.Length ||
-                            !algIdParameters.SequenceEqual(verify.AsSpan(0, written)))
+                            !algIdParameters.SequenceEqual(new ReadOnlySpan<byte>(verify, 0, written)))
                         {
                             throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
                         }

--- a/src/Common/tests/Performance/Perf.Marvin.cs
+++ b/src/Common/tests/Performance/Perf.Marvin.cs
@@ -30,8 +30,8 @@ namespace System
         [MemberData(nameof(EnumerateRandomByteArrayTestCases))]
         public void Add(int iterations, byte[] data)
         {
-            Span<byte> otherData = new byte[] { 1, 2, 3 };
-            var bytes = new Span<byte>(data);
+            ReadOnlySpan<byte> otherData = new byte[] { 1, 2, 3 };
+            var bytes = new ReadOnlySpan<byte>(data);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.NetCoreApp.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDelegatedTransaction.NetCoreApp.cs
@@ -10,6 +10,6 @@ namespace System.Data.SqlClient
     {
         // Get the server-side Global Transaction Id from the PromotedDTCToken
         // Skip first 4 bytes since they contain the version
-        private Guid GetGlobalTxnIdentifierFromToken() => new Guid(_connection.PromotedDTCToken.AsSpan(_globalTransactionsTokenVersionSizeInBytes, 16));
+        private Guid GetGlobalTxnIdentifierFromToken() => new Guid(new ReadOnlySpan<byte>(_connection.PromotedDTCToken, _globalTransactionsTokenVersionSizeInBytes, 16));
     }
 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlFileStream.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlFileStream.Windows.cs
@@ -546,7 +546,7 @@ namespace System.Data.SqlTypes
 
                         // We could continue to do pointer math here, chose to use Span for convenience to 
                         // make sure we get the other members in the right place.
-                        Span<byte> data = new Span<byte>(buffer).Slice(headerSize);
+                        Span<byte> data = buffer.AsSpan(headerSize);
                         s_eaNameString.AsSpan().CopyTo(data);
                         data = data.Slice(s_eaNameString.Length);
                         transactionContext.AsSpan().CopyTo(data);

--- a/src/System.Drawing.Common/src/System/Drawing/GdiPlusStreamHelper.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiPlusStreamHelper.Unix.cs
@@ -143,7 +143,7 @@ namespace System.Drawing
             _stream.Write(buffer, 0, bufsz);
             ArrayPool<byte>.Shared.Return(buffer);
 #else
-            Span<byte> buffer = new Span<byte>(buf, bufsz);
+            var buffer = new ReadOnlySpan<byte>(buf, bufsz);
             _stream.Write(buffer);
 #endif
             return bufsz;

--- a/src/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -383,16 +383,9 @@ namespace System.Drawing
                     return;
                 }
 
-                Span<Guid> guids;
-                if (dimensions < 16)
-                {
-                    Guid* g = stackalloc Guid[dimensions];
-                    guids = new Span<Guid>(g, dimensions);
-                }
-                else
-                {
-                    guids = new Span<Guid>(new Guid[dimensions]);
-                }
+                Span<Guid> guids = dimensions < 16 ?
+                    stackalloc Guid[dimensions] :
+                    new Guid[dimensions];
 
                 fixed (Guid* g = &MemoryMarshal.GetReference(guids))
                 {

--- a/src/System.Drawing.Common/src/System/Drawing/Internal/GPStream.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Internal/GPStream.cs
@@ -217,7 +217,7 @@ namespace System.Drawing.Internal
             _dataStream.Write(buffer, 0, checked((int)cb));
             ArrayPool<byte>.Shared.Return(buffer);
 #else
-            Span<byte> buffer = new Span<byte>(pv, checked((int)cb));
+            var buffer = new ReadOnlySpan<byte>(pv, checked((int)cb));
             _dataStream.Write(buffer);
 #endif
 

--- a/src/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
+++ b/src/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
@@ -66,7 +66,7 @@ namespace System.IO.Compression
                     }
                 }
 
-                lastResult = _decoder.Decompress(_buffer.AsSpan(_bufferOffset, _bufferCount), buffer, out int bytesConsumed, out int bytesWritten);
+                lastResult = _decoder.Decompress(new ReadOnlySpan<byte>(_buffer, _bufferOffset, _bufferCount), buffer, out int bytesConsumed, out int bytesWritten);
                 if (lastResult == OperationStatus.InvalidData)
                 {
                     throw new InvalidOperationException(SR.BrotliStream_Decompress_InvalidData);
@@ -153,7 +153,7 @@ namespace System.IO.Compression
                     }
 
                     cancellationToken.ThrowIfCancellationRequested();
-                    lastResult = _decoder.Decompress(_buffer.AsSpan(_bufferOffset, _bufferCount), buffer.Span, out int bytesConsumed, out int bytesWritten);
+                    lastResult = _decoder.Decompress(new ReadOnlySpan<byte>(_buffer, _bufferOffset, _bufferCount), buffer.Span, out int bytesConsumed, out int bytesWritten);
                     if (lastResult == OperationStatus.InvalidData)
                     {
                         throw new InvalidOperationException(SR.BrotliStream_Decompress_InvalidData);

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
@@ -542,7 +542,7 @@ namespace System.Buffers
             {
                 // Negative start and negative end index == string
                 ReadOnlySpan<char> spanOfChar = ((string)startObject).AsSpan(startIndex & ReadOnlySequence.IndexBitMask, endIndex - startIndex);
-                return MemoryMarshal.CreateSpan(ref Unsafe.As<char, T>(ref MemoryMarshal.GetReference(spanOfChar)), spanOfChar.Length);
+                return MemoryMarshal.CreateReadOnlySpan(ref Unsafe.As<char, T>(ref MemoryMarshal.GetReference(spanOfChar)), spanOfChar.Length);
             }
             else
             {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/DynamicTable.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/DynamicTable.cs
@@ -38,7 +38,7 @@ namespace System.Net.Http.HPack
             }
         }
 
-        public void Insert(Span<byte> name, Span<byte> value)
+        public void Insert(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
             int entryLength = HeaderField.GetLength(name.Length, value.Length);
             EnsureAvailable(entryLength);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -282,8 +282,8 @@ namespace System.Net.Http.HPack
                         {
                             OnString(nextState: State.Ready);
 
-                            var headerNameSpan = new Span<byte>(_headerName, 0, _headerNameLength);
-                            var headerValueSpan = new Span<byte>(_headerValueOctets, 0, _headerValueLength);
+                            var headerNameSpan = new ReadOnlySpan<byte>(_headerName, 0, _headerNameLength);
+                            var headerValueSpan = new ReadOnlySpan<byte>(_headerValueOctets, 0, _headerValueLength);
 
                             onHeader(headerNameSpan, headerValueSpan);
 
@@ -328,7 +328,7 @@ namespace System.Net.Http.HPack
         private void OnIndexedHeaderField(int index, HeaderCallback onHeader)
         {
             HeaderField header = GetHeader(index);
-            onHeader(new Span<byte>(header.Name), new Span<byte>(header.Value));
+            onHeader(new ReadOnlySpan<byte>(header.Name), new ReadOnlySpan<byte>(header.Value));
             _state = State.Ready;
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HeaderField.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HeaderField.cs
@@ -9,7 +9,7 @@ namespace System.Net.Http.HPack
         // http://httpwg.org/specs/rfc7541.html#rfc.section.4.1
         public const int RfcOverhead = 32;
 
-        public HeaderField(Span<byte> name, Span<byte> value)
+        public HeaderField(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
             // TODO: We're allocating here on every new table entry.
             // That means a poorly-behaved server could cause us to allocate repeatedly.

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -356,7 +356,7 @@ namespace System.Net.Sockets
         public static unsafe IPPacketInformation GetIPPacketInformation(Interop.Winsock.ControlDataIPv6* controlBuffer)
         {
             IPAddress address = controlBuffer->length != UIntPtr.Zero ?
-                new IPAddress(new Span<byte>(controlBuffer->address, Interop.Winsock.IPv6AddressLength)) :
+                new IPAddress(new ReadOnlySpan<byte>(controlBuffer->address, Interop.Winsock.IPv6AddressLength)) :
                 IPAddress.IPv6None;
 
             return new IPPacketInformation(address, (int)controlBuffer->index);

--- a/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Tensor.cs
+++ b/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Tensor.cs
@@ -645,7 +645,7 @@ namespace System.Numerics.Tensors
                 {
                     throw new ArgumentNullException(nameof(indices));
                 }
-                var span = new Span<int>(indices);
+                var span = new ReadOnlySpan<int>(indices);
                 return this[span];
             }
 
@@ -655,7 +655,7 @@ namespace System.Numerics.Tensors
                 {
                     throw new ArgumentNullException(nameof(indices));
                 }
-                var span = new Span<int>(indices);
+                var span = new ReadOnlySpan<int>(indices);
                 this[span] = value;
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/NameTable.cs
+++ b/src/System.Private.Xml/src/System/Xml/NameTable.cs
@@ -252,7 +252,7 @@ namespace System.Xml
         }
         private static int ComputeHash32(char[] key, int start, int len)
         {
-            ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(key.AsSpan(start, len));
+            ReadOnlySpan<byte> bytes = MemoryMarshal.AsBytes(new ReadOnlySpan<char>(key, start, len));
             return Marvin.ComputeHash32(bytes, Marvin.DefaultSeed);
         }
     }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/CodeIdentifier.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Globalization;
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace System.Xml.Serialization
 {
@@ -32,11 +33,18 @@ namespace System.Xml.Serialization
         {
             identifier = MakeValid(identifier);
             if (identifier.Length <= 2)
+            {
                 return CultureInfo.InvariantCulture.TextInfo.ToUpper(identifier);
+            }
             else if (char.IsLower(identifier[0]))
-                return string.Concat(char.ToUpperInvariant(identifier[0]).ToString(), identifier.AsSpan(1));
+            {
+                char upper = char.ToUpperInvariant(identifier[0]);
+                return string.Concat(MemoryMarshal.CreateReadOnlySpan(ref upper, 1), identifier.AsSpan(1));
+            }
             else
+            {
                 return identifier;
+            }
         }
 
         /// <devdoc>
@@ -46,11 +54,18 @@ namespace System.Xml.Serialization
         {
             identifier = MakeValid(identifier);
             if (identifier.Length <= 2)
+            {
                 return CultureInfo.InvariantCulture.TextInfo.ToLower(identifier);
+            }
             else if (char.IsUpper(identifier[0]))
-                return string.Concat(char.ToLower(identifier[0]).ToString(), identifier.AsSpan(1));
+            {
+                char lower = char.ToLower(identifier[0]);
+                return string.Concat(MemoryMarshal.CreateReadOnlySpan(ref lower, 1), identifier.AsSpan(1));
+            }
             else
+            {
                 return identifier;
+            }
         }
 
         /// <devdoc>

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
@@ -391,7 +391,7 @@ namespace System.Security.Cryptography
                             continue;
                         }
 
-                        return RSAKeyFormatHelper.WritePkcs8PrivateKey(rented.AsSpan(0, pkcs1Size));
+                        return RSAKeyFormatHelper.WritePkcs8PrivateKey(new ReadOnlySpan<byte>(rented, 0, pkcs1Size));
                     }
                     finally
                     {

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Import.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Import.cs
@@ -108,7 +108,7 @@ namespace System.Security.Cryptography
             if (keyBlob == null)
                 throw new ArgumentNullException(nameof(keyBlob));
 
-            return Import(keyBlob.AsSpan(), curveName, format, provider);
+            return Import(new ReadOnlySpan<byte>(keyBlob), curveName, format, provider);
         }
 
         internal static CngKey Import(

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/X509Pal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/X509Pal.cs
@@ -87,7 +87,7 @@ namespace Internal.Cryptography.Pal
                 RSA rsa = RSA.Create();
                 try
                 {
-                    rsa.ImportRSAPublicKey(encodedKeyValue.AsSpan(), out _);
+                    rsa.ImportRSAPublicKey(new ReadOnlySpan<byte>(encodedKeyValue), out _);
                     return rsa;
                 }
                 catch (Exception)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -258,7 +258,7 @@ namespace Internal.Cryptography.Pal
             RSA rsa = new RSAOpenSsl();
             try
             {
-                rsa.ImportRSAPublicKey(encodedData.AsSpan(), out _);
+                rsa.ImportRSAPublicKey(new ReadOnlySpan<byte>(encodedData), out _);
             }
             catch (Exception)
             {


### PR DESCRIPTION
In a bunch of places we're creating a Span only to then cast it (generally implicitly) to a ReadOnlySpan.  While the JIT is generally able to do the RightThing(tm), we can avoid the unnecessary IL and pressure on the JIT by just creating a ReadOnlySpan to begin with.

Also cleaned up a few other minor span-related things as I was auditing, e.g. new Span(…).Slice(…) vs .AsSpan(…).

cc: @jkotas