### PR TITLE
Removing assertion not true for all events

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
@@ -60,7 +60,7 @@ namespace System.Diagnostics.Tests
                                 }
                             }
                             Assert.Contains("EventLogMessages.dll", providerMetadata.MessageFilePath);
-                            Assert.Contains("EventLogMessages.dll", providerMetadata.HelpLink.ToString());
+                            Assert.Contains("EventLogMessages.dll", providerMetadata.HelpLink?.ToString());
                         }
                         else
                         {

--- a/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
@@ -60,6 +60,10 @@ namespace System.Diagnostics.Tests
                                 }
                             }
                             Assert.Contains("EventLogMessages.dll", providerMetadata.MessageFilePath);
+                            if (providerMetadata.HelpLink != null)
+                            {
+                                Assert.Contains("EventLogMessages.dll", providerMetadata.HelpLink.ToString());
+                            }
                         }
                         else
                         {

--- a/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/System/Diagnostics/Reader/ProviderMetadataTests.cs
@@ -60,7 +60,6 @@ namespace System.Diagnostics.Tests
                                 }
                             }
                             Assert.Contains("EventLogMessages.dll", providerMetadata.MessageFilePath);
-                            Assert.Contains("EventLogMessages.dll", providerMetadata.HelpLink?.ToString());
                         }
                         else
                         {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/coreclr/issues/22024

Looking at the test this was the only line that could throw NullReferenceException. If that threw and because it doesn't always fail on all machines, it means this assertion won't hold true for all events.

cc: @danmosemsft 