### PR TITLE
Fix ThrowAndRethrowOtherMethod test.

### DIFF
--- a/src/System.Runtime/tests/System/ExceptionTests.cs
+++ b/src/System.Runtime/tests/System/ExceptionTests.cs
@@ -164,6 +164,7 @@ namespace System.Tests
             rethrownExceptionStackFrame = (null, null, 0);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowException()
         {
             throw new Exception("Boom!");


### PR DESCRIPTION
ThrowAndRethrowOtherMethod is sensitive to jit inlining decisions.
In particular, it fails if the jit decides to inline ThrowException.
That can happen with, e.g., random inlining policy.
In that case the stack trace doesn't have frame info for ThrowException
and VerifyCallStack skips the wrong frame.
One of the jit stress legs is failing because of that:
https://github.com/dotnet/coreclr/issues/21644 .
The fix is to ensure that ThrowException is not inlined.