### PR TITLE
Change all configurations PR job to use non-hosted pool for more space in machines

### DIFF
--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -136,7 +136,7 @@ jobs:
         ${{ if eq(parameters.isOfficialBuild, 'true') }}:
           name: dotnet-internal-temp
         ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-          name: Hosted VS2017
+          name: dotnet-external-temp
 
       submitToHelix: false
       enableMicrobuild: ${{ parameters.isOfficialBuild }}


### PR DESCRIPTION
We're hitting some out of space in the disk when running the testing packages. The hosted machines are very limited in space, so let's use dotnet-external-temp which is not hosted for this leg.

https://github.com/dotnet/corefx/pull/34650#issuecomment-455337475

cc: @maryamariyan @chcosta @ericstj 