### PR TITLE
Add Location info to asset manifest

### DIFF
--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -45,6 +45,7 @@ jobs:
                 -warnaserror:0 -ci
                 /t:PublishPackagesToBlobFeed
                 /p:ManifestBuildId=$(Build.BuildNumber)
+                /p:ManifestBuildData=Location=$(_dotnetFeedUrl)
                 /p:ManifestBranch=$(Build.SourceBranchName)
                 /p:ManifestCommit=$(Build.SourceVersion)
                 /p:ManifestRepoUri=$(Build.Repository.Uri)


### PR DESCRIPTION
FYI @mmitche 

Adds ManifestBuildData (which defines "Location") to corefx publishing.

https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets#L86

I'll follow up and add this to the description in the feeds target - https://github.com/dotnet/arcade/blob/master/src/Microsoft.DotNet.Build.Tasks.Feed/build/Microsoft.DotNet.Build.Tasks.Feed.targets#L34-L39