### PR TITLE
Fix UapAot runs

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,53 +26,53 @@
       <Uri>https://github.com/dotnet/coreclr</Uri>
       <Sha>b9e88989458e24fa9764e045917b141e3338eae7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SourceRewriter" Version="1.0.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.SourceRewriter" Version="1.0.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="1.0.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="1.0.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="2.4.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="2.4.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="1.0.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="1.0.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19072.5">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19074.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>044fa99d22e576fcfaf63f09ee9bba821855dddb</Sha>
+      <Sha>673cb1c9358575a722b8d9b43ccfd4222c89c0a0</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,16 +16,16 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19072.5</MicrosoftDotNetApiCompatPackageVersion>
-    <MicrosoftDotNetSourceRewriterPackageVersion>1.0.0-beta.19072.5</MicrosoftDotNetSourceRewriterPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19072.5</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19072.5</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19072.5</MicrosoftDotNetGenFacadesPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.0-beta.19072.5</MicrosoftDotNetXUnitExtensionsPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19072.5</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19072.5</MicrosoftDotNetCoreFxTestingPackageVersion>
-    <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19072.5</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19072.5</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19074.1</MicrosoftDotNetApiCompatPackageVersion>
+    <MicrosoftDotNetSourceRewriterPackageVersion>1.0.0-beta.19074.1</MicrosoftDotNetSourceRewriterPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19074.1</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19074.1</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19074.1</MicrosoftDotNetGenFacadesPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.0-beta.19074.1</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19074.1</MicrosoftDotNetBuildTasksPackagingPackageVersion>
+    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19074.1</MicrosoftDotNetCoreFxTestingPackageVersion>
+    <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19074.1</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19074.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <!-- Core-setup dependencies -->
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview-27321-5</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostPackageVersion>3.0.0-preview-27321-5</MicrosoftNETCoreDotNetHostPackageVersion>

--- a/eng/dependencies.props
+++ b/eng/dependencies.props
@@ -43,7 +43,7 @@
     <XUnitPackageVersion>2.4.1-pre.build.4059</XUnitPackageVersion>
     <XUnitPerformancePackageVersion>1.0.0-beta-build0020</XUnitPerformancePackageVersion>
     <TraceEventPackageVersion>2.0.5</TraceEventPackageVersion>
-    <UAPToolsPackageVersion>1.0.25</UAPToolsPackageVersion>
+    <MicrosoftDotNetUapTestToolsPackageVersion>1.0.30</MicrosoftDotNetUapTestToolsPackageVersion>
 
     <!-- Code coverage package version -->
     <CoverletConsolePackageVersion>1.4.0</CoverletConsolePackageVersion>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -19,6 +19,7 @@
     <XUnitAdapter Condition="'$(TargetGroup)' == 'netcoreapp'">xunit.runner.visualstudio.dotnetcore.testadapter</XUnitAdapter>
     <XUnitAdapter Condition="'$(TargetGroup)' == 'uap' OR '$(TargetGroup)' == 'uapaot'">xunit.runner.visualstudio.uwp.testadapter</XUnitAdapter>
     <XUnitAdapter Condition="'$(TargetGroup)' == 'netfx'">xunit.runner.visualstudio.testadapter</XUnitAdapter>
+    <MicrosoftDotNetUapTestToolsPackageName>microsoft.dotnet.uap.testtools</MicrosoftDotNetUapTestToolsPackageName>
     <MicrosoftNetTestSdkPackageName>microsoft.net.test.sdk</MicrosoftNetTestSdkPackageName>
     <TestPlatformHostPackageId>microsoft.testplatform.testhost</TestPlatformHostPackageId>
     <MicrosoftDiagnosticsTracingTraceEventPackageName>Microsoft.Diagnostics.Tracing.TraceEvent</MicrosoftDiagnosticsTracingTraceEventPackageName>
@@ -34,7 +35,7 @@
     <PackageReference Include="xunit" Version="$(XUnitPackageVersion)" />
     <PackageReference Include="$(MicrosoftDotNetXUnitExtensionsPackage)" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />
     <PackageReference Include="$(XUnitRunnerConsolePackageName)" Version="$(XUnitPackageVersion)" />
-    <PackageReference Condition="'$(TargetsUap)' == 'true'" Include="Microsoft.DotNet.UAP.TestTools" Version="$(UAPToolsPackageVersion)" />
+    <PackageReference Condition="'$(TargetsUap)' == 'true'" Include="$(MicrosoftDotNetUapTestToolsPackageName)" Version="$(MicrosoftDotNetUapTestToolsPackageVersion)" />
 
     <!-- for callstack line numbers -->
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.5.0" />
@@ -136,9 +137,8 @@
           AfterTargets="AfterResolveReferences">
 
     <PropertyGroup>
-      <UAPToolsPackageName>microsoft.dotnet.uap.testtools</UAPToolsPackageName>
 
-      <UAPToolsFolder Condition="'$(UAPToolsFolder)'==''">$(PackagesDir)$(UAPToolsPackageName)\$(UAPToolsPackageVersion)\Tools\$(ArchGroup)</UAPToolsFolder>
+      <UAPToolsFolder Condition="'$(UAPToolsFolder)'==''">$(PackagesDir)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion)\Tools\$(ArchGroup)</UAPToolsFolder>
       <UAPToolsFolder>$(UAPToolsFolder.Replace('/', '\'))</UAPToolsFolder>
     </PropertyGroup>
 
@@ -252,8 +252,8 @@
           Condition="'$(TargetGroup)' == 'uap' OR '$(TargetGroup)' == 'uapaot'"
           BeforeTargets="ResolveReferences">
 
-    <Error Condition="'$(TargetGroup)' == 'uapaot' AND !Exists('$(PackagesDir)$(XUnitRunnerConsolePackageName)\$(XUnitPackageVersion)\tools\netcoreapp2.0\$(XUnitRunner).dll')"
-            Text="Error: looks the package $(PackagesDir)$(XUnitRunnerConsolePackageName)\$(XUnitPackageVersion) not restored or missing $(XUnitRunner).dll."
+    <Error Condition="'$(TargetGroup)' == 'uapaot' AND !Exists('$(PackagesDir)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion)\lib\netcoreapp2.0\$(XUnitRunner).dll')"
+            Text="Error: looks the package $(PackagesDir)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion) not restored or missing $(XUnitRunner).dll."
     />
     <Error Condition="'$(EnableVSTestReferences)' == 'true' AND !Exists('$(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\uap10.0\$(XUnitAdapter).dll')"
             Text="Error: looks the package $(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion) not restored or missing $(XUnitAdapter).dll."
@@ -263,9 +263,14 @@
     />
 
     <ItemGroup>
-      <ReferenceCopyLocalPaths Condition="'$(TargetGroup)' == 'uapaot'" Include="$(PackagesDir)$(XUnitRunnerConsolePackageName)\$(XUnitPackageVersion)\tools\netcoreapp2.0\*.*">
+      <ReferenceCopyLocalPaths Condition="'$(TargetGroup)' == 'uapaot'" Include="$(PackagesDir)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion)\lib\netcoreapp2.0\*.dll">
         <Private>false</Private>
-        <NuGetPackageId>$(XUnitRunnerConsolePackageName)</NuGetPackageId>
+        <NuGetPackageId>$(MicrosoftDotNetUapTestToolsPackageName)</NuGetPackageId>
+        <NuGetPackageVersion>$(MicrosoftDotNetUapTestToolsPackageVersion)</NuGetPackageVersion>
+      </ReferenceCopyLocalPaths>
+      <ReferenceCopyLocalPaths Condition="'$(TargetGroup)' == 'uapaot'" Include="$(PackagesDir)xunit.runner.utility\$(XUnitPackageVersion)\lib\netcoreapp1.0\*.dll">
+        <Private>false</Private>
+        <NuGetPackageId>xunit.runner.utility</NuGetPackageId>
         <NuGetPackageVersion>$(XUnitPackageVersion)</NuGetPackageVersion>
       </ReferenceCopyLocalPaths>
       <ReferenceCopyLocalPaths Condition="'$(EnableVSTestReferences)' == 'true'" Include="$(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\uap10.0\*.dll">

--- a/global.json
+++ b/global.json
@@ -3,8 +3,8 @@
     "dotnet": "2.1.401"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19072.5",
-    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19072.5",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19074.1",
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19074.1",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview-27322-72"
   }
 }

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.aot.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.aot.cs
@@ -10,9 +10,9 @@ namespace System.Diagnostics
     /// <summary>Base class used for all tests that need to spawn a remote process.</summary>
     public abstract partial class RemoteExecutorTestBase : FileCleanupTestBase
     {
-        protected static readonly string HostRunnerName = PlatformDetection.IsWindows ? "dotnet.exe" : "dotnet";
+        protected static readonly string HostRunnerName = "xunit.console.exe";
         protected static readonly string HostRunner = Process.GetCurrentProcess().MainModule.FileName;
 
-        private static readonly string ExtraParameter = TestConsoleApp;
+        private static readonly string ExtraParameter = "remote";
     }
 }


### PR DESCRIPTION
Depends on https://github.com/dotnet/arcade/pull/1627
Fixes https://github.com/dotnet/corefx/issues/30423

Using the xunit.console runner fork compiled with `/p:DefineConstants=WINDOWS_UWP` for uapaot.

Additional changes:
- Improve test run time by removing one ilc invocation for the RemoteExecutorConsoleApp which is part of the runner itself, same as on uap.
- Update UWP runner to .NET Core 2.2 and streamline cod with the added fork so that only one code base remains.
- Minor code cleanup in the CoreFxTesting package.

cc @danmosemsft @MichalStrehovsky @Lxiamail @joshfree @MattGal 