### PR TITLE
Run Ubuntu arm tests in 1604

### DIFF
--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -59,7 +59,7 @@ jobs:
 
         - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
           - linuxDefaultQueues: Centos.7.Amd64.Open+RedHat.7.Amd64.Open+Debian.8.Amd64.Open+Ubuntu.1604.Amd64.Open+Ubuntu.1804.Amd64.Open+OpenSuse.42.Amd64.Open+Fedora.27.Amd64.Open
-          - linuxArm64Queues: Ubuntu.1804.Arm64.Open
+          - linuxArm64Queues: Ubuntu.1604.Arm64.Open
       
         - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
           - linuxDefaultQueues: Centos.7.Amd64+RedHat.7.Amd64+Debian.8.Amd64+Debian.9.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+Ubuntu.1810.Amd64+OpenSuse.42.Amd64+SLES.12.Amd64+SLES.15.Amd64+Fedora.27.Amd64+Fedora.28.Amd64


### PR DESCRIPTION
We're building in Ubuntu rather than CentOS for arm. Therefore the build is not fully portable. We need to build in a CentOS based ROOTFS container in order to be able to produce a fully portable build for arm.

Let's run  the tests in 1604 for now.

cc: @wfurt @MattGal @joperezr 