### PR TITLE
Reclassify the test dependencies in corefx as toolset

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview-27316-72">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview-27316-72">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview-27316-72">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview-27317-6">
@@ -14,18 +26,6 @@
     <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="3.0.0-preview-27317-6">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>464f69912c1e644e1b6e3aa0184f5c7c1a690cec</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview-27316-72">
-      <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview-27316-72">
-      <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview-27316-72">
-      <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19066.1">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview-27316-72">
-      <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview-27316-72">
-      <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview-27316-72">
-      <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
-    </Dependency>
+  </ProductDependencies>
+  <ToolsetDependencies>
     <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview-27317-6">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>464f69912c1e644e1b6e3aa0184f5c7c1a690cec</Sha>
@@ -25,8 +15,18 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>464f69912c1e644e1b6e3aa0184f5c7c1a690cec</Sha>
     </Dependency>
-  </ProductDependencies>
-  <ToolsetDependencies>
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview-27316-72">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview-27316-72">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview-27316-72">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19066.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>0fb5fc58347f42121ddc9c0b361e84b8acbffb12</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview-27316-72">
-      <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview-27316-72">
-      <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview-27316-72">
-      <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview-27317-6">
@@ -26,6 +14,18 @@
     <Dependency Name="Microsoft.NETCore.DotNetHostPolicy" Version="3.0.0-preview-27317-6">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>464f69912c1e644e1b6e3aa0184f5c7c1a690cec</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview-27316-72">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview-27316-72">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview-27316-72">
+      <Uri>https://github.com/dotnet/coreclr</Uri>
+      <Sha>80720a220c340e99aa88d04ebae8118eb4fc198b</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19066.1">
       <Uri>https://github.com/dotnet/arcade</Uri>


### PR DESCRIPTION
These aren't actually repackaged/shipped, etc. so they can be made to be breaks in the graph.
It might be good to introduce a new classification (test) but for now toolset is fine.