### PR TITLE
Expose NativeLibrary Resolver Callback

### DIFF
--- a/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -384,6 +384,7 @@ namespace System.Runtime.InteropServices
         public DllImportAttribute(string dllName) { }
         public string Value { get { throw null; } }
     }
+    public delegate System.IntPtr DllImportResolver(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath);
     [System.FlagsAttribute]
     public enum DllImportSearchPath
     {
@@ -736,6 +737,7 @@ namespace System.Runtime.InteropServices
         public static System.IntPtr GetExport(System.IntPtr handle, string name) { throw null; }
         public static System.IntPtr Load(string libraryPath) { throw null; }
         public static System.IntPtr Load(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath) { throw null; }
+        public static void SetDllImportResolver(System.Reflection.Assembly assembly, DllImportResolver resolver) { throw null; }
         public static bool TryGetExport(IntPtr handle, string name, out IntPtr address) { throw null; }
         public static bool TryLoad(string libraryPath, out System.IntPtr handle) { throw null; }
         public static bool TryLoad(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath, out System.IntPtr handle) { throw null; }

--- a/src/System.Runtime.InteropServices/src/ApiCompatBaseline.netcoreappaot.txt
+++ b/src/System.Runtime.InteropServices/src/ApiCompatBaseline.netcoreappaot.txt
@@ -1,5 +1,6 @@
 Compat issues with assembly System.Runtime.InteropServices:
 CannotRemoveBaseTypeOrInterface : Type 'System.IO.UnmanagedMemoryStream' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.DllImportResolver' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GenerateGuidForType(System.Type)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GenerateProgIdForType(System.Type)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetComObjectData(System.Object, System.Object)' does not exist in the implementation but it does exist in the contract.
@@ -17,4 +18,4 @@ MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetEndComSlot(
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.IsTypeVisibleFromCom(System.Type)' does not exist in the implementation but it does exist in the contract.
 TypeCannotChangeClassification : Type 'System.Runtime.InteropServices.HandleRef' is marked as readonly in the contract so it must also be marked readonly in the implementation.
 TypesMustExist : Type 'System.Runtime.InteropServices.NativeLibrary' does not exist in the implementation but it does exist in the contract.
-Total Issues: 16
+Total Issues: 19

--- a/src/System.Runtime.InteropServices/src/ApiCompatBaseline.uapaot.txt
+++ b/src/System.Runtime.InteropServices/src/ApiCompatBaseline.uapaot.txt
@@ -1,5 +1,6 @@
 Compat issues with assembly System.Runtime.InteropServices:
 CannotRemoveBaseTypeOrInterface : Type 'System.IO.UnmanagedMemoryStream' does not inherit from base type 'System.MarshalByRefObject' in the implementation but it does in the contract.
+TypesMustExist : Type 'System.Runtime.InteropServices.DllImportResolver' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GenerateGuidForType(System.Type)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GenerateProgIdForType(System.Type)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetComObjectData(System.Object, System.Object)' does not exist in the implementation but it does exist in the contract.
@@ -17,4 +18,4 @@ MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.GetEndComSlot(
 MembersMustExist : Member 'System.Runtime.InteropServices.Marshal.IsTypeVisibleFromCom(System.Type)' does not exist in the implementation but it does exist in the contract.
 TypeCannotChangeClassification : Type 'System.Runtime.InteropServices.HandleRef' is marked as readonly in the contract so it must also be marked readonly in the implementation.
 TypesMustExist : Type 'System.Runtime.InteropServices.NativeLibrary' does not exist in the implementation but it does exist in the contract.
-Total Issues: 18
+Total Issues: 19


### PR DESCRIPTION
Expose the APIs to set the Native Library resolver callback.

API Review:
https://github.com/dotnet/corefx/issues/32015

Implementation:
https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs

Tests:
https://github.com/dotnet/coreclr/blob/master/tests/src/Interop/NativeLibraryResolveCallback/CallbackTests.cs