### PR TITLE
Update calls in Json tests from GetStringValue to GetString

### DIFF
--- a/src/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/System.Text.Json/tests/JsonTestHelper.cs
@@ -216,7 +216,7 @@ namespace System.Text.Json.Tests
                 if (json.HasValueSequence)
                 {
                     Assert.True(json.ValueSpan == default);
-                    if ((tokenType != JsonTokenType.String && tokenType != JsonTokenType.PropertyName) || json.GetStringValue().Length != 0)
+                    if ((tokenType != JsonTokenType.String && tokenType != JsonTokenType.PropertyName) || json.GetString().Length != 0)
                     {
                         // Empty strings could still make this true, i.e. ""
                         Assert.False(json.ValueSequence.IsEmpty);
@@ -225,7 +225,7 @@ namespace System.Text.Json.Tests
                 else
                 {
                     Assert.True(json.ValueSequence.IsEmpty);
-                    if ((tokenType != JsonTokenType.String && tokenType != JsonTokenType.PropertyName) || json.GetStringValue().Length != 0)
+                    if ((tokenType != JsonTokenType.String && tokenType != JsonTokenType.PropertyName) || json.GetString().Length != 0)
                     {
                         // Empty strings could still make this true, i.e. ""
                         Assert.False(json.ValueSpan == default);

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -674,11 +674,11 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    actualValues.Add(json.GetStringValue());
+                    actualValues.Add(json.GetString());
                 }
                 else if (json.TokenType == JsonTokenType.PropertyName)
                 {
-                    actualPropertyNames.Add(json.GetStringValue());
+                    actualPropertyNames.Add(json.GetString());
                 }
             }
 
@@ -721,7 +721,7 @@ namespace System.Text.Json.Tests
                 Assert.Equal(JsonTokenType.String, json.TokenType);
                 try
                 {
-                    string val = json.GetStringValue();
+                    string val = json.GetString();
                     Assert.True(false, "Expected InvalidOperationException when trying to get string value for invalid UTF-16 JSON text.");
                 }
                 catch (InvalidOperationException) { }
@@ -754,7 +754,7 @@ namespace System.Text.Json.Tests
                     {
                         try
                         {
-                            string val = json.GetStringValue();
+                            string val = json.GetString();
                             Assert.True(false, "Expected InvalidOperationException when trying to get string value for invalid UTF-8 JSON text.");
                         }
                         catch (InvalidOperationException ex)


### PR DESCRIPTION
Fixes the build breaks (for example those seen in https://github.com/dotnet/corefx/pull/34693) introduced by conflicting PRs merged in recently (there was no merge conflict, and CI was green, but CI needed to be reset after https://github.com/dotnet/corefx/pull/34667 and https://github.com/dotnet/corefx/pull/34636 were merged to catch the API change failing the build in https://github.com/dotnet/corefx/pull/34604).

cc @ViktorHofer, @jkotas 