### PR TITLE
collect some info about SendRecvPollSync_TcpListener_Socket() test run

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/Accept.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Accept.cs
@@ -4,11 +4,14 @@
 
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
     public abstract class Accept<T> : SocketTestHelperBase<T> where T : SocketHelperBase, new()
     {
+        public Accept(ITestOutputHelper output) : base(output) { }
+
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(Loopbacks))]
@@ -288,9 +291,28 @@ namespace System.Net.Sockets.Tests
         }
     }
 
-    public sealed class AcceptSync : Accept<SocketHelperArraySync> { }
-    public sealed class AcceptSyncForceNonBlocking : Accept<SocketHelperSyncForceNonBlocking> { }
-    public sealed class AcceptApm : Accept<SocketHelperApm> { }
-    public sealed class AcceptTask : Accept<SocketHelperTask> { }
-    public sealed class AcceptEap : Accept<SocketHelperEap> { }
+    public sealed class AcceptSync : Accept<SocketHelperArraySync>
+    {
+        public AcceptSync(ITestOutputHelper output) : base(output) {}
+    }
+
+    public sealed class AcceptSyncForceNonBlocking : Accept<SocketHelperSyncForceNonBlocking>
+    {
+        public AcceptSyncForceNonBlocking(ITestOutputHelper output) : base(output) {}
+    }
+
+    public sealed class AcceptApm : Accept<SocketHelperApm>
+    {
+        public AcceptApm(ITestOutputHelper output) : base(output) {}
+    }
+
+    public sealed class AcceptTask : Accept<SocketHelperTask>
+    {
+        public AcceptTask(ITestOutputHelper output) : base(output) {}
+    }
+
+    public sealed class AcceptEap : Accept<SocketHelperEap>
+    {
+        public AcceptEap(ITestOutputHelper output) : base(output) {}
+    }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -4,11 +4,14 @@
 
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
     public abstract class Connect<T> : SocketTestHelperBase<T> where T : SocketHelperBase, new()
     {
+        public Connect(ITestOutputHelper output) : base(output) {}
+
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(Loopbacks))]
@@ -84,9 +87,28 @@ namespace System.Net.Sockets.Tests
         }
     }
 
-    public sealed class ConnectSync : Connect<SocketHelperArraySync> { }
-    public sealed class ConnectSyncForceNonBlocking : Connect<SocketHelperSyncForceNonBlocking> { }
-    public sealed class ConnectApm : Connect<SocketHelperApm> { }
-    public sealed class ConnectTask : Connect<SocketHelperTask> { }
-    public sealed class ConnectEap : Connect<SocketHelperEap> { }
+    public sealed class ConnectSync : Connect<SocketHelperArraySync>
+    {
+        public ConnectSync(ITestOutputHelper output) : base(output) {}
+    }
+
+    public sealed class ConnectSyncForceNonBlocking : Connect<SocketHelperSyncForceNonBlocking>
+    {
+        public ConnectSyncForceNonBlocking(ITestOutputHelper output) : base(output) {}
+    }
+
+    public sealed class ConnectApm : Connect<SocketHelperApm>
+    {
+        public ConnectApm(ITestOutputHelper output) : base(output) {}
+    }
+
+    public sealed class ConnectTask : Connect<SocketHelperTask>
+    {
+        public ConnectTask(ITestOutputHelper output) : base(output) {}
+    }
+
+    public sealed class ConnectEap : Connect<SocketHelperEap>
+    {
+        public ConnectEap(ITestOutputHelper output) : base(output) {}
+    }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
@@ -6,11 +6,19 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
     public class LoggingTest : RemoteExecutorTestBase
     {
+        public readonly ITestOutputHelper _output;
+
+        public LoggingTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         [ActiveIssue(20470, TargetFrameworkMonikers.UapAot)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetEventSource is only part of .NET Core.")]
@@ -40,17 +48,17 @@ namespace System.Net.Sockets.Tests
                     {
                         // Invoke several tests to execute code paths while tracing is enabled
 
-                        new SendReceiveSync().SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
-                        new SendReceiveSync().SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
+                        new SendReceiveSync(_output).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
+                        new SendReceiveSync(_output).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
 
-                        new SendReceiveTask().SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
-                        new SendReceiveTask().SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
+                        new SendReceiveTask(_output).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
+                        new SendReceiveTask(_output).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
 
-                        new SendReceiveEap().SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
-                        new SendReceiveEap().SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
+                        new SendReceiveEap(_output).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
+                        new SendReceiveEap(_output).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
 
-                        new SendReceiveApm().SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
-                        new SendReceiveApm().SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
+                        new SendReceiveApm(_output).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
+                        new SendReceiveApm(_output).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
 
                         new NetworkStreamTest().CopyToAsync_AllDataCopied(4096).GetAwaiter().GetResult();
                         new NetworkStreamTest().Timeout_ValidData_Roundtrips().GetAwaiter().GetResult();

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -8,11 +8,14 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
     public abstract class SendReceive<T> : SocketTestHelperBase<T> where T : SocketHelperBase, new()
     {
+        public SendReceive(ITestOutputHelper output) : base(output) {}
+
         [Theory]
         [InlineData(null, 0, 0)] // null array
         [InlineData(1, -1, 0)] // offset low
@@ -567,11 +570,15 @@ namespace System.Net.Sockets.Tests
             {
                 int bytesReceived = 0;
                 var receivedChecksum = new Fletcher32();
+
+                _output.WriteLine($"{DateTime.Now} Starting listener at {listener.LocalEndpoint}");
                 Task serverTask = Task.Run(async () =>
                 {
                     using (Socket remote = await listener.AcceptSocketAsync())
                     {
                         var recvBuffer = new byte[256];
+                        int count = 0;
+
                         while (true)
                         {
                             if (pollBeforeOperation)
@@ -579,9 +586,11 @@ namespace System.Net.Sockets.Tests
                                 Assert.True(remote.Poll(-1, SelectMode.SelectRead), "Read poll before completion should have succeeded");
                             }
                             int received = remote.Receive(recvBuffer, 0, recvBuffer.Length, SocketFlags.None);
+                            count++;
                             if (received == 0)
                             {
                                 Assert.True(remote.Poll(0, SelectMode.SelectRead), "Read poll after completion should have succeeded");
+                                _output.WriteLine($"{DateTime.Now} Received 0 bytes. Stopping receiving loop after {count} itterations.");
                                 break;
                             }
 
@@ -627,6 +636,11 @@ namespace System.Net.Sockets.Tests
                 });
 
                 await (new[] { serverTask, clientTask }).WhenAllOrAnyFailed(TestTimeout);
+
+                if (bytesSent != bytesReceived)
+                {
+                    _output.WriteLine($"{DateTime.Now} Test received only {bytesReceived} bytes. Client task is {clientTask.Status}, Server task is {serverTask.Status}");
+                }
 
                 Assert.Equal(bytesSent, bytesReceived);
                 Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
@@ -1357,6 +1371,8 @@ namespace System.Net.Sockets.Tests
 
     public sealed class SendReceiveSync : SendReceive<SocketHelperArraySync>
     {
+        public SendReceiveSync(ITestOutputHelper output) : base(output) { }
+
         [OuterLoop]
         [Fact]
         public void BlockingRead_DoesntRequireAnotherThreadPoolThread()
@@ -1408,8 +1424,23 @@ namespace System.Net.Sockets.Tests
         }
     }
 
-    public sealed class SendReceiveSyncForceNonBlocking : SendReceive<SocketHelperSyncForceNonBlocking> { }
-    public sealed class SendReceiveApm : SendReceive<SocketHelperApm> { }
-    public sealed class SendReceiveTask : SendReceive<SocketHelperTask> { }
-    public sealed class SendReceiveEap : SendReceive<SocketHelperEap> { }
+    public sealed class SendReceiveSyncForceNonBlocking : SendReceive<SocketHelperSyncForceNonBlocking>
+    {
+        public SendReceiveSyncForceNonBlocking(ITestOutputHelper output) : base(output) {}
+    }
+
+    public sealed class SendReceiveApm : SendReceive<SocketHelperApm>
+    {
+        public SendReceiveApm(ITestOutputHelper output) : base(output) {}
+    }
+
+    public sealed class SendReceiveTask : SendReceive<SocketHelperTask>
+    {
+        public SendReceiveTask(ITestOutputHelper output) : base(output) {}
+    }
+
+    public sealed class SendReceiveEap : SendReceive<SocketHelperEap>
+    {
+        public SendReceiveEap(ITestOutputHelper output) : base(output) {}
+    }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -590,7 +590,7 @@ namespace System.Net.Sockets.Tests
                             if (received == 0)
                             {
                                 Assert.True(remote.Poll(0, SelectMode.SelectRead), "Read poll after completion should have succeeded");
-                                _output.WriteLine($"{DateTime.Now} Received 0 bytes. Stopping receiving loop after {count} itterations.");
+                                _output.WriteLine($"{DateTime.Now} Received 0 bytes. Stopping receiving loop after {count} iterations.");
                                 break;
                             }
 
@@ -639,7 +639,7 @@ namespace System.Net.Sockets.Tests
 
                 if (bytesSent != bytesReceived)
                 {
-                    _output.WriteLine($"{DateTime.Now} Test received only {bytesReceived} bytes. Client task is {clientTask.Status}, Server task is {serverTask.Status}");
+                    _output.WriteLine($"{DateTime.Now} Test received only {bytesReceived} bytes from {bytesSent}. Client task is {clientTask.Status}, Server task is {serverTask.Status}");
                 }
 
                 Assert.Equal(bytesSent, bytesReceived);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.netcoreapp.cs
@@ -5,13 +5,24 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
-    public sealed class SendReceiveSpanSync : SendReceive<SocketHelperSpanSync> { }
-    public sealed class SendReceiveSpanSyncForceNonBlocking : SendReceive<SocketHelperSpanSyncForceNonBlocking> { }
+    public sealed class SendReceiveSpanSync : SendReceive<SocketHelperSpanSync>
+    {
+        public SendReceiveSpanSync(ITestOutputHelper output) : base(output) { }
+    }
+
+    public sealed class SendReceiveSpanSyncForceNonBlocking : SendReceive<SocketHelperSpanSyncForceNonBlocking>
+    {
+        public SendReceiveSpanSyncForceNonBlocking(ITestOutputHelper output) : base(output) { }
+    }
+
     public sealed class SendReceiveMemoryArrayTask : SendReceive<SocketHelperMemoryArrayTask>
     {
+        public SendReceiveMemoryArrayTask(ITestOutputHelper output) : base(output) { }
+
         [Fact]
         public async Task Precanceled_Throws()
         {
@@ -55,5 +66,8 @@ namespace System.Net.Sockets.Tests
             }
         }
     }
-    public sealed class SendReceiveMemoryNativeTask : SendReceive<SocketHelperMemoryNativeTask> { }
+    public sealed class SendReceiveMemoryNativeTask : SendReceive<SocketHelperMemoryNativeTask>
+    {
+        public SendReceiveMemoryNativeTask(ITestOutputHelper output) : base(output) { }
+    }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketTestHelper.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Sockets.Tests
 {
@@ -240,10 +242,12 @@ namespace System.Net.Sockets.Tests
         where T : SocketHelperBase, new()
     {
         private readonly T _socketHelper;
+        public readonly ITestOutputHelper _output;
 
-        public SocketTestHelperBase()
+        public SocketTestHelperBase(ITestOutputHelper output)
         {
             _socketHelper = new T();
+            _output = output;
         }
 
         //


### PR DESCRIPTION
related to #29862 Test System.Net.Sockets.Tests.SendReceiveMemoryNativeTask.SendRecvPollSync_TcpListener_Socket(listenAt: ::1, pollBeforeOperation: True) failed in CI.

I could not reproduce the test failure locally. 
To collect more data, this change uses ITestOutputHelper to collect more information from run. 
For now, it shows used endpoint and some basic counters with timing information. 

This is written to testResults.xml and available in test result database. 
