### PR TITLE
Increase timeout in Process test

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -180,7 +180,7 @@ namespace System.Diagnostics.Tests
         {
             const string expectedSignal = "Signal";
             const string successResponse = "Success";
-            const int timeout = 5 * 1000;
+            const int timeout = 30 * 1000; // 30 seconds, to allow for very slow machines
 
             Process p = CreateProcessPortable(RemotelyInvokable.WriteLineReadLine);
             p.StartInfo.RedirectStandardInput = true;


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/22110

In 5 seconds the process needs to complete startup, write one line to the console, the test must receive that  asynchronously and set an event. On a very busy machine, this may take longer.