### PR TITLE
Reduce the time spent in System.Linq.Parallel.Tests

### DIFF
--- a/src/System.Linq.Parallel/tests/QueryOperators/JoinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/JoinTests.cs
@@ -255,7 +255,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(JoinOrderedLeftUnorderedRightData), new[] { 512, 1024 })]
+        [MemberData(nameof(JoinOrderedLeftUnorderedRightData), new[] { 256, 512 })]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve grouping of order-identical left keys through repartitioning (see https://github.com/dotnet/corefx/pull/27930#issuecomment-372084741)")]
         public static void Join_Multiple_LeftWithOrderingColisions_UnorderedRight_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
@@ -354,7 +354,7 @@ namespace System.Linq.Parallel.Tests
 
             protected override int GetExpectedSeenLeftCount(int leftCount, int rightCount)
             {
-                if (rightCount >= KeyFactor) 
+                if (rightCount >= KeyFactor)
                 {
                     return leftCount;
                 }
@@ -420,7 +420,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(JoinOrderedLeftUnorderedRightData), new[] { 512, 1024 })]
+        [MemberData(nameof(JoinOrderedLeftUnorderedRightData), new[] { 256, 512 })]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve grouping of order-identical left keys through repartitioning (see https://github.com/dotnet/corefx/pull/27930#issuecomment-372084741)")]
         public static void Join_CustomComparator_LeftWithOrderingColisions_UnorderedRight_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {


### PR DESCRIPTION
A couple of tests are failing because running for long time. The change here is to reduce the time spent there to avoid such failures in the outerloop runs