### PR TITLE
Set DisableImplicitFrameworkReferences for all projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -321,6 +321,8 @@
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
+    <!-- Don't reference implicit framework packages, all projects in this repo must be explicit -->
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <!-- Language configuration -->

--- a/eng/depProj.targets
+++ b/eng/depProj.targets
@@ -36,8 +36,6 @@ See the LICENSE file in the project root for more information.
   <PropertyGroup>
     <!-- Always raise runtime/lib items even for frameworks that may not use them -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <!-- Don't reference implicit framework packages, depprojs are meant to be wholy explicit -->
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <!-- We don't need the SDK to validate that we get runtime packages -->
     <EnsureRuntimePackageDependencies>false</EnsureRuntimePackageDependencies>
     <!-- don't generate netcoreapp files -->

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft.VisualBasic.Core.vbproj
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft.VisualBasic.Core.vbproj
@@ -108,8 +108,4 @@
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Thread" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsUap)' == 'true'">
-    <!-- UAP is missing default imports -->
-    <Import Include="Microsoft.VisualBasic;System;System.Collections;System.Collections.Generic;System.Diagnostics;System.Linq;System.Xml.Linq;System.Threading.Tasks" />
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/FileSystem.Windows.vb
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/FileSystem.Windows.vb
@@ -4,7 +4,9 @@
 Option Strict On
 Option Explicit On
 
+Imports System
 Imports System.ComponentModel
+Imports System.Diagnostics
 Imports System.Security
 Imports System.Runtime.Versioning
 Imports System.Text

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/FileSystem.vb
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/FileSystem.vb
@@ -3,8 +3,12 @@
 ' See the LICENSE file in the project root for more information.
 Option Strict On
 Option Explicit On
+
+Imports System
+Imports System.Collections
 Imports System.Collections.Specialized
 Imports System.ComponentModel
+Imports System.Diagnostics
 Imports System.Globalization
 Imports System.Security
 Imports System.Runtime.Versioning

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/MalformedLineException.vb
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/MalformedLineException.vb
@@ -4,6 +4,7 @@
 Option Explicit On
 Option Strict On
 
+Imports System
 Imports System.ComponentModel
 Imports System.Globalization
 Imports System.Security

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/SpecialDirectories.vb
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/SpecialDirectories.vb
@@ -3,6 +3,8 @@
 ' See the LICENSE file in the project root for more information.
 Option Strict On
 Option Explicit On
+
+Imports System
 Imports System.Environment
 Imports System.Security
 Imports Microsoft.VisualBasic.CompilerServices.Utils

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/TextFieldParser.vb
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/TextFieldParser.vb
@@ -4,7 +4,9 @@
 Option Explicit On
 Option Strict On
 
+Imports System
 Imports System.ComponentModel
+Imports System.Diagnostics
 Imports System.Globalization
 Imports System.IO
 Imports System.Text

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Helpers/NativeMethods.Windows.vb
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Helpers/NativeMethods.Windows.vb
@@ -4,6 +4,7 @@
 Option Strict On
 Option Explicit On
 
+Imports System
 Imports System.Security
 Imports System.Runtime.InteropServices
 Imports System.Runtime.Versioning

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Helpers/NativeTypes.vb
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Helpers/NativeTypes.vb
@@ -4,6 +4,8 @@
 Option Explicit On
 Option Strict On
 
+Imports System
+Imports System.Diagnostics
 Imports System.Security
 Imports System.Runtime.ConstrainedExecution
 Imports System.Runtime.InteropServices

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Helpers/UnsafeNativeMethods.vb
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/Helpers/UnsafeNativeMethods.vb
@@ -2,6 +2,7 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
+Imports System
 Imports System.Security
 Imports System.Runtime.InteropServices
 Imports System.Runtime.Versioning

--- a/src/Microsoft.VisualBasic.Core/tests/VB/FileIOTestBase.vb
+++ b/src/Microsoft.VisualBasic.Core/tests/VB/FileIOTestBase.vb
@@ -4,6 +4,7 @@
 Option Explicit On
 Option Strict On
 
+Imports System
 Imports System.Runtime.CompilerServices
 Imports Xunit
 Namespace Microsoft.VisualBasic.Tests.VB

--- a/src/Microsoft.VisualBasic.Core/tests/VB/FileIOTests.vb
+++ b/src/Microsoft.VisualBasic.Core/tests/VB/FileIOTests.vb
@@ -5,7 +5,10 @@ Option Explicit On
 Option Strict On
 
 Imports Microsoft.VisualBasic.FileIO
+Imports System
+Imports System.Collections.Generic
 Imports System.Collections.ObjectModel
+Imports System.Linq
 Imports System.Runtime.CompilerServices
 Imports System.Runtime.InteropServices
 Imports System.Text

--- a/src/Microsoft.VisualBasic.Core/tests/VB/Helpers.vb
+++ b/src/Microsoft.VisualBasic.Core/tests/VB/Helpers.vb
@@ -4,6 +4,7 @@
 Option Explicit On
 Option Strict On
 
+Imports System
 Imports System.Runtime.CompilerServices
 
 Namespace Microsoft.VisualBasic.Tests.VB

--- a/src/Microsoft.VisualBasic.Core/tests/VB/Microsoft.VisualBasic.VB.Tests.vbproj
+++ b/src/Microsoft.VisualBasic.Core/tests/VB/Microsoft.VisualBasic.VB.Tests.vbproj
@@ -11,8 +11,4 @@
     <Compile Include="FileIOTests.vb" />
     <Compile Include="TextFieldParserTests.vb" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsUap)' == 'true'">
-    <!-- UAP is missing default imports -->
-    <Import Include="Microsoft.VisualBasic;System;System.Collections;System.Collections.Generic;System.Diagnostics;System.Linq;System.Xml.Linq;System.Threading.Tasks" />
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualBasic.Core/tests/VB/SpecialDirectoriesTests.vb
+++ b/src/Microsoft.VisualBasic.Core/tests/VB/SpecialDirectoriesTests.vb
@@ -4,6 +4,7 @@
 Option Explicit On
 Option Strict On
 
+Imports System
 Imports System.Environment
 Imports Microsoft.VisualBasic.FileIO
 Imports Xunit

--- a/src/Microsoft.VisualBasic.Core/tests/VB/TextFieldParserTests.vb
+++ b/src/Microsoft.VisualBasic.Core/tests/VB/TextFieldParserTests.vb
@@ -5,6 +5,7 @@ Option Explicit On
 Option Strict On
 
 Imports Microsoft.VisualBasic.FileIO
+Imports System
 Imports Xunit
 
 Namespace Microsoft.VisualBasic.Tests.VB

--- a/src/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.csproj
+++ b/src/System.Diagnostics.EventLog/ref/System.Diagnostics.EventLog.csproj
@@ -13,6 +13,7 @@
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true'">
     <ProjectReference Include="..\..\System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj" />

--- a/src/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
+++ b/src/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard'">SR.PlatformNotSupported_EventLog</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsNetStandard)' == 'true'">SR.PlatformNotSupported_EventLog</GeneratePlatformNotSupportedAssemblyMessage>
     <!-- Although we have a netstandard configuration, we know we are not currently UAP compatible-->
     <UWPCompatible>false</UWPCompatible>
     <ProjectGuid>{432779B9-3CBD-4871-A7DC-D8A192319DBD}</ProjectGuid>
     <Configurations>net461-Debug;net461-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp2.0-Windows_NT-Debug;netcoreapp2.0-Windows_NT-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
-  <ItemGroup Condition="$(TargetGroup.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
     <Compile Include="System\Diagnostics\CompModSwitches.cs" />
     <Compile Include="System\Diagnostics\EntryWrittenEventArgs.cs" />
     <Compile Include="System\Diagnostics\EntryWrittenEventHandler.cs" />
@@ -122,6 +122,7 @@
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true'">
     <Reference Include="Microsoft.Win32.Primitives" />


### PR DESCRIPTION
The SDK added targets which require the assets file when framework reference items are set.

We can disable the implicit FrameworkReference item in order to prevent these from running.

Fixes #34765.
