### PR TITLE
Fix build warnings for System.Threading.Channels ref

### DIFF
--- a/src/System.Threading.Channels/ref/System.Threading.Channels.csproj
+++ b/src/System.Threading.Channels/ref/System.Threading.Channels.csproj
@@ -8,15 +8,15 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System.Threading.Channels.netcoreapp.cs" />
+    <Reference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Reference Include="netstandard" />
+    <Reference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3' or '$(TargetGroup)' == 'netcoreapp'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Threading.Tasks" />
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I accidentally introduced these earlier today:
```
D:\repos\corefx\.dotnet\sdk\2.1.401\Microsoft.Common.CurrentVersion.targets(2110,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Threading.Tasks". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [D:\repos\corefx\src\System.Threading.Channels\ref\System.Threading.Channels.csproj]
D:\repos\corefx\.dotnet\sdk\2.1.401\Microsoft.Common.CurrentVersion.targets(2110,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Threading.Tasks.Extensions". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [D:\repos\corefx\src\System.Threading.Channels\ref\System.Threading.Channels.csproj]
```
cc: @tarekgh 