### PR TITLE
Set MaxRetryCount to 4 for both Windows and non-Windows jobs

### DIFF
--- a/eng/sendtohelix.proj
+++ b/eng/sendtohelix.proj
@@ -28,6 +28,8 @@
     <!-- This property is used to show the tests results in Azure Dev Ops. By setting this property the
     test run name will be displayed as $(BuildConfiguration)-$(HelixTargetQueue) -->
     <TestRunNamePrefix>$(BuildConfiguration)-</TestRunNamePrefix>
+
+    <MaxRetryCount Condition="'$(MaxRetryCount)' == ''">4</MaxRetryCount>
   </PropertyGroup>
 
   <!-- If mission control reports a test failure then fail the build whenever helix wait runs. -->
@@ -48,12 +50,6 @@
     <HelixType Condition="'$(TargetGroup)' == 'netfx' AND '$(OfficialBuildId)' != ''">test/functional/desktop/cli/</HelixType>
     <HelixType Condition="'$(TargetGroup)' == 'uap' AND '$(OfficialBuildId)' != ''">test/functional/uwp/</HelixType>
     <HelixType Condition="'$(TargetGroup)' == 'uapaot' AND '$(OfficialBuildId)' != ''">test/functional/ilc/</HelixType>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(MaxRetryCount)' == ''">
-    <!-- In Windows we need a higher value due to some flakyness in Nano. Can remove when helix provides new containers model -->
-    <MaxRetryCount Condition="'$(TargetsWindows)' == 'true'">9</MaxRetryCount>
-    <MaxRetryCount Condition="'$(TargetsWindows)' != 'true'">1</MaxRetryCount>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(HelixCommand)' == ''">


### PR DESCRIPTION
This to improve the ratio of failing jobs on CI since retry count was set to 1 for non-Windows.