### PR TITLE
Make ReadToEnd static helper resilient against stream.Length changes.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
@@ -180,11 +180,11 @@ namespace System.Text.Json
 
             try
             {
-                long expectedLength = 0;
-
                 if (stream.CanSeek)
                 {
-                    expectedLength = Math.Max(1L, stream.Length - stream.Position);
+                    // Ask for 1 more than the length to avoid resizing later,
+                    // which is unnecessary in the common case where the stream length doesn't change.
+                    long expectedLength = Math.Max(0, stream.Length - stream.Position) + 1;
                     rented = ArrayPool<byte>.Shared.Rent(checked((int)expectedLength));
                 }
                 else
@@ -196,7 +196,7 @@ namespace System.Text.Json
 
                 do
                 {
-                    if (expectedLength == 0 && rented.Length == written)
+                    if (rented.Length == written)
                     {
                         byte[] toReturn = rented;
                         rented = ArrayPool<byte>.Shared.Rent(checked(toReturn.Length * 2));
@@ -239,11 +239,11 @@ namespace System.Text.Json
 
             try
             {
-                long expectedLength = 0;
-
                 if (stream.CanSeek)
                 {
-                    expectedLength = Math.Max(1L, stream.Length - stream.Position);
+                    // Ask for 1 more than the length to avoid resizing later,
+                    // which is unnecessary in the common case where the stream length doesn't change.
+                    long expectedLength = Math.Max(0, stream.Length - stream.Position) + 1;
                     rented = ArrayPool<byte>.Shared.Rent(checked((int)expectedLength));
                 }
                 else
@@ -255,7 +255,7 @@ namespace System.Text.Json
 
                 do
                 {
-                    if (expectedLength == 0 && rented.Length == written)
+                    if (rented.Length == written)
                     {
                         byte[] toReturn = rented;
                         rented = ArrayPool<byte>.Shared.Rent(toReturn.Length * 2);


### PR DESCRIPTION
Applying feedback from https://github.com/dotnet/core-setup/pull/5009#discussion_r250294649 where we  were using the ReadToEnd static helper from corefx.

Do you have any suggestions on how to test this? I was trying to get one thread to read from the stream while another changes its length but couldn't get the test to fail since it relies on the timing of the get and set length. Any ideas on how to deterministically test the race condition?

cc @bartonjs, @stephentoub 