### PR TITLE
Fix SslStream channel binding token

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/Pal.Managed/EndpointChannelBindingToken.cs
+++ b/src/System.Net.Security/src/System/Net/Security/Pal.Managed/EndpointChannelBindingToken.cs
@@ -17,7 +17,7 @@ namespace System.Net.Security
                 if (cert == null)
                     return null;
 
-                SafeChannelBindingHandle bindingHandle = new SafeChannelBindingHandle(ChannelBindingKind.Unique);
+                SafeChannelBindingHandle bindingHandle = new SafeChannelBindingHandle(ChannelBindingKind.Endpoint);
 
                 using (HashAlgorithm hashAlgo = GetHashForChannelBinding(cert))
                 {

--- a/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -49,33 +50,40 @@ namespace System.Net.Security.Tests
             var cbt2 = context.GetChannelBinding(ChannelBindingKind.Unique);
             var cbt3 = context.GetChannelBinding(ChannelBindingKind.Unknown);
 
-            CheckChannelBinding(cbt1);
-            CheckChannelBinding(cbt2);
-            CheckChannelBinding(cbt3);
+            CheckChannelBinding(ChannelBindingKind.Endpoint, cbt1);
+            CheckChannelBinding(ChannelBindingKind.Unique, cbt2);
+            CheckChannelBinding(ChannelBindingKind.Unknown, cbt3);
 
-            Assert.True(cbt1 != null, "ChannelBindingKind.Endpoint token data should be returned from SCHANNEL.");
+            Assert.True(cbt1 != null, "ChannelBindingKind.Endpoint token data should be returned.");
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                Assert.True(cbt2 == null, "ChannelBindingKind.Unique token data is not expected from SecureTransport");
+                Assert.True(cbt2 == null, "ChannelBindingKind.Unique token data is not expected on OSX platform.");
             }
             else
             {
-                Assert.True(cbt2 != null, "ChannelBindingKind.Unique token data should be returned from SCHANNEL.");
+                Assert.True(cbt2 != null, "ChannelBindingKind.Unique token data should be returned.");
             }
 
-            Assert.True(cbt3 == null, "ChannelBindingKind.Unknown token data should not be returned from SCHANNEL since it does not map to a defined context attribute.");
+            Assert.True(cbt3 == null, "ChannelBindingKind.Unknown token data should not be returned.");
         }
 
-        public void CheckChannelBinding(ChannelBinding channelBinding)
+        public void CheckChannelBinding(ChannelBindingKind kind, ChannelBinding channelBinding)
         {
             if (channelBinding != null)
             {
+                const string PrefixEndpoint = "tls-server-end-point:";
+                const string PrefixUnique = "tls-unique:";
+
                 Assert.True(!channelBinding.IsInvalid, "Channel binding token should be marked as a valid SafeHandle.");
                 Assert.True(channelBinding.Size > 0, "Number of bytes in a valid channel binding token should be greater than zero.");
                 var bytes = new byte[channelBinding.Size];
                 Marshal.Copy(channelBinding.DangerousGetHandle(), bytes, 0, channelBinding.Size);
                 Assert.Equal(channelBinding.Size, bytes.Length);
+                
+                string cbt = Encoding.ASCII.GetString(bytes);
+                string expectedPrefix = (kind == ChannelBindingKind.Endpoint) ? PrefixEndpoint : PrefixUnique;
+                Assert.Contains(expectedPrefix, cbt);
             }
         }
     }


### PR DESCRIPTION
While working on Enterprise Scenario testing I discovered a bug in how the Unix layer generates
the channel binding token.  It was using the wrong prefix for 'Endpoint' tokens.

Fixed 'Endpoint' token generation and added more detailed tests.