### PR TITLE
Replace thread aborts in SoundPlayer

### DIFF
--- a/src/System.Windows.Extensions/src/System.Windows.Extensions.csproj
+++ b/src/System.Windows.Extensions/src/System.Windows.Extensions.csproj
@@ -90,6 +90,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Security.Cryptography.X509Certificates" />
     <Reference Include="System.Text.RegularExpressions" />
+    <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Threading" />
   </ItemGroup>

--- a/src/System.Windows.Extensions/tests/System/Media/SoundPlayerTests.cs
+++ b/src/System.Windows.Extensions/tests/System/Media/SoundPlayerTests.cs
@@ -3,8 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Media.Test
@@ -93,6 +98,49 @@ namespace System.Media.Test
 
             // Play.
             soundPlayer.Play();
+        }
+
+        [Theory]
+        [MemberData(nameof(Play_String_TestData))]
+        [OuterLoop]
+        public async Task LoadAsync_SourceLocationFromNetwork_Success(string sourceLocation)
+        {
+            var player = new SoundPlayer();
+
+            using (Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listener.Listen(1);
+                var ep = (IPEndPoint)listener.LocalEndPoint;
+
+                Task serverTask = Task.Run(async () =>
+                {
+                    using (Socket server = await listener.AcceptAsync())
+                    using (var serverStream = new NetworkStream(server))
+                    using (var reader = new StreamReader(new NetworkStream(server)))
+                    using (FileStream sourceStream = File.OpenRead(sourceLocation.Replace("file://", "")))
+                    {
+                        string line;
+                        while (!string.IsNullOrEmpty(line = await reader.ReadLineAsync()));
+                        byte[] header = Encoding.UTF8.GetBytes($"HTTP/1.1 200 OK\r\nContent-Length: {sourceStream.Length}\r\n\r\n");
+                        serverStream.Write(header, 0, header.Length);
+                        await sourceStream.CopyToAsync(serverStream);
+                        server.Shutdown(SocketShutdown.Both);
+                    }
+                });
+
+                var tcs = new TaskCompletionSource<AsyncCompletedEventArgs>();
+                player.LoadCompleted += (s, e) => tcs.TrySetResult(e);
+                player.SoundLocation = $"http://{ep.Address}:{ep.Port}";
+                player.LoadAsync();
+                AsyncCompletedEventArgs ea = await tcs.Task;
+                Assert.Null(ea.Error);
+                Assert.False(ea.Cancelled);
+
+                await serverTask;
+            }
+
+            player.Play();
         }
 
         [Theory]
@@ -393,6 +441,86 @@ namespace System.Media.Test
                 player.Stream = stream;
                 Assert.False(calledHandler);
             }
+        }
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "netfx aborts a worker thread and never signals operation completion")]
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public async Task LoadAsync_CancelDuringLoad_CompletesAsCanceled(int cancellationCause)
+        {
+            var tcs = new TaskCompletionSource<AsyncCompletedEventArgs>();
+            var player = new SoundPlayer();
+            player.LoadCompleted += (s, e) => tcs.SetResult(e);
+            player.Stream = new ReadAsyncBlocksUntilCanceledStream();
+            player.LoadAsync();
+
+            Assert.False(tcs.Task.IsCompleted);
+
+            switch (cancellationCause)
+            {
+                case 0:
+                    player.Stream = new MemoryStream();
+                    break;
+
+                case 1:
+                    player.LoadTimeout = 1;
+                    Assert.Throws<TimeoutException>(() => player.Load());
+                    break;
+
+                case 2:
+                    player.SoundLocation = "DoesntExistButThatDoesntMatter";
+                    break;
+            }
+
+            AsyncCompletedEventArgs ea = await tcs.Task;
+            Assert.Null(ea.Error);
+            Assert.True(ea.Cancelled);
+            Assert.Null(ea.UserState);
+        }
+
+        [Theory]
+        [MemberData(nameof(Play_String_TestData))]
+        [OuterLoop]
+        public async Task CancelDuringLoad_ThenPlay_Success(string sourceLocation)
+        {
+            using (FileStream stream = File.OpenRead(sourceLocation.Replace("file://", "")))
+            {
+                var tcs = new TaskCompletionSource<bool>();
+                AsyncCompletedEventHandler handler = (s, e) => tcs.SetResult(true);
+
+                var player = new SoundPlayer();
+                player.LoadCompleted += handler;
+                player.Stream = new ReadAsyncBlocksUntilCanceledStream();
+                player.LoadAsync();
+
+                player.Stream = stream;
+                await tcs.Task;
+                player.LoadCompleted -= handler;
+
+                player.Play();
+            }
+        }
+
+        private sealed class ReadAsyncBlocksUntilCanceledStream : Stream
+        {
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                await Task.Delay(-1, cancellationToken);
+                return 0;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+            public override void Flush() { }
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+            public override void SetLength(long value) => throw new NotSupportedException();
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/34810. This only addresses the issue of SoundPlayer using Thread.Abort, replacing it with cancellation; there are a bunch of other long-standing functional issues with this code, and I had to stop myself from spending time fixing more.

cc: @danmosemsft, @maryamariyan 