### PR TITLE
Test more invalid values for ThreadPool.[Unsafe]RegisterWaitForSingleObject

### DIFF
--- a/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -350,9 +350,29 @@ namespace System.Threading.ThreadPools.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, (long)-2, true));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, (long)int.MaxValue + 1, true));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
                 ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, TimeSpan.FromMilliseconds(-2), true));
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 ThreadPool.RegisterWaitForSingleObject(
+                    waitHandle,
+                    callback,
+                    null,
+                    TimeSpan.FromMilliseconds((double)int.MaxValue + 1),
+                    true));
+
+            Assert.Throws<ArgumentNullException>(() => ThreadPool.UnsafeRegisterWaitForSingleObject(null, callback, null, 0, true));
+            Assert.Throws<ArgumentNullException>(() => ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, null, null, 0, true));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, -2, true));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, (long)-2, true));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, (long)int.MaxValue + 1, true));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, TimeSpan.FromMilliseconds(-2), true));
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                ThreadPool.UnsafeRegisterWaitForSingleObject(
                     waitHandle,
                     callback,
                     null,

--- a/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -349,8 +349,11 @@ namespace System.Threading.ThreadPools.Tests
                 ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, -2, true));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
                 ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, (long)-2, true));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
-                ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, (long)int.MaxValue + 1, true));
+            if (!PlatformDetection.IsFullFramework) // netfx silently overflows the timeout
+            {
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
+                    ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, (long)int.MaxValue + 1, true));
+            }
             AssertExtensions.Throws<ArgumentOutOfRangeException>("timeout", () =>
                 ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, TimeSpan.FromMilliseconds(-2), true));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("timeout", () =>
@@ -367,8 +370,11 @@ namespace System.Threading.ThreadPools.Tests
                 ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, -2, true));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
                 ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, (long)-2, true));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
-                ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, (long)int.MaxValue + 1, true));
+            if (!PlatformDetection.IsFullFramework) // netfx silently overflows the timeout
+            {
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
+                    ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, (long)int.MaxValue + 1, true));
+            }
             AssertExtensions.Throws<ArgumentOutOfRangeException>("timeout", () =>
                 ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, TimeSpan.FromMilliseconds(-2), true));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("timeout", () =>

--- a/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -345,15 +345,15 @@ namespace System.Threading.ThreadPools.Tests
             WaitOrTimerCallback callback = (state, timedOut) => { };
             Assert.Throws<ArgumentNullException>(() => ThreadPool.RegisterWaitForSingleObject(null, callback, null, 0, true));
             Assert.Throws<ArgumentNullException>(() => ThreadPool.RegisterWaitForSingleObject(waitHandle, null, null, 0, true));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
                 ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, -2, true));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
                 ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, (long)-2, true));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
                 ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, (long)int.MaxValue + 1, true));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("timeout", () =>
                 ThreadPool.RegisterWaitForSingleObject(waitHandle, callback, null, TimeSpan.FromMilliseconds(-2), true));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("timeout", () =>
                 ThreadPool.RegisterWaitForSingleObject(
                     waitHandle,
                     callback,
@@ -363,15 +363,15 @@ namespace System.Threading.ThreadPools.Tests
 
             Assert.Throws<ArgumentNullException>(() => ThreadPool.UnsafeRegisterWaitForSingleObject(null, callback, null, 0, true));
             Assert.Throws<ArgumentNullException>(() => ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, null, null, 0, true));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
                 ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, -2, true));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
                 ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, (long)-2, true));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("millisecondsTimeOutInterval", () =>
                 ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, (long)int.MaxValue + 1, true));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("timeout", () =>
                 ThreadPool.UnsafeRegisterWaitForSingleObject(waitHandle, callback, null, TimeSpan.FromMilliseconds(-2), true));
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("timeout", () =>
                 ThreadPool.UnsafeRegisterWaitForSingleObject(
                     waitHandle,
                     callback,


### PR DESCRIPTION
Unit tests for https://github.com/dotnet/corert/pull/6887.