### PR TITLE
Update helix sdk that fixes test retry

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19074.1",
-    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19074.1",
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19074.7",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview-27322-72"
   }
 }


### PR DESCRIPTION
Even though I set MaxRetryCount to 4, tests where not retrying because xunit's exit code was getting overridden by some helix sdk post commands to parse test results. Fixed that in: https://github.com/dotnet/arcade/pull/1882 so with this PR we should get test retry in the new CI leg. Hopefully this will get it green 🤞

cc: @stephentoub @danmosemsft @ViktorHofer 