### PR TITLE
Skipping syncroot tests for uapaot due to upstream behavior chagnes

### DIFF
--- a/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
+++ b/src/Common/tests/System/Collections/ICollection.NonGeneric.Tests.cs
@@ -85,13 +85,6 @@ namespace System.Collections.Tests
         protected virtual bool ICollection_NonGeneric_HasNullSyncRoot => false;
 
         /// <summary>
-        /// Used for the ICollection_NonGeneric_SyncRootType_MatchesExcepted test. Most SyncRoots are created
-        /// using System.Threading.Interlocked.CompareExchange(ref _syncRoot, new Object(), null)
-        /// so we should test that the SyncRoot is the type we expect.
-        /// </summary>
-        protected virtual Type ICollection_NonGeneric_SyncRootType => typeof(object);
-
-        /// <summary>
         /// Used for the ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowsArgumentException tests. Some
         /// implementations throw a different exception type (e.g. ArgumentOutOfRangeException).
         /// </summary>
@@ -141,6 +134,7 @@ namespace System.Collections.Tests
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.UapAot, "Test now represents upstream behavior, and is correct in uapaot due to upstream changes: https://github.com/dotnet/coreclr/pull/21628")]
         public void ICollection_NonGeneric_SyncRoot(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
@@ -148,22 +142,6 @@ namespace System.Collections.Tests
             {
                 Assert.Equal(ICollection_NonGeneric_HasNullSyncRoot, collection.SyncRoot == null);
                 Assert.Same(collection.SyncRoot, collection.SyncRoot);
-
-                if (!ICollection_NonGeneric_HasNullSyncRoot)
-                {
-                    Assert.IsType(ICollection_NonGeneric_SyncRootType, collection.SyncRoot);
-
-                    if (ICollection_NonGeneric_SyncRootType == collection.GetType())
-                    {
-                        // If we expect the SyncRoot to be the same type as the collection, 
-                        // the SyncRoot should be the same as the collection (e.g. HybridDictionary)
-                        Assert.Same(collection, collection.SyncRoot);
-                    }
-                    else
-                    {
-                        Assert.NotSame(collection, collection.SyncRoot);
-                    }
-                }
             }
             else
             {

--- a/src/System.Collections.NonGeneric/tests/ArrayListTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ArrayListTests.cs
@@ -2548,6 +2548,8 @@ namespace System.Collections.Tests
         }
     }
 
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Changed behavior
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.UapAot, "Test now represents upstream behavior, and is correct in uapaot due to upstream changes: https://github.com/dotnet/coreclr/pull/21628")]
     public class ArrayList_SyncRootTests
     {
         private ArrayList _arrDaughter;
@@ -2576,12 +2578,12 @@ namespace System.Collections.Tests
                 _arrGrandDaughter = ArrayList.Synchronized(arrMother2);
                 _arrDaughter = ArrayList.Synchronized(arrMother2);
 
-                Assert.False(arrMother2.SyncRoot is ArrayList);
-                Assert.False(arrSon1.SyncRoot is ArrayList);
-                Assert.False(arrSon2.SyncRoot is ArrayList);
-                Assert.False(_arrDaughter.SyncRoot is ArrayList);
+                Assert.True(arrMother2.SyncRoot is ArrayList);
+                Assert.True(arrSon1.SyncRoot is ArrayList);
+                Assert.True(arrSon2.SyncRoot is ArrayList);
+                Assert.True(_arrDaughter.SyncRoot is ArrayList);
                 Assert.Equal(arrSon1.SyncRoot, arrMother2.SyncRoot);
-                Assert.False(_arrGrandDaughter.SyncRoot is ArrayList);
+                Assert.True(_arrGrandDaughter.SyncRoot is ArrayList);
 
                 arrMother2 = new ArrayList();
                 for (int i = 0; i < NumberOfElements; i++)

--- a/src/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/CollectionBaseTests.cs
@@ -288,13 +288,14 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.UapAot, "Test now represents upstream behavior, and is correct in uapaot due to upstream changes: https://github.com/dotnet/coreclr/pull/21628")]
         public static void SyncRoot()
         {
             // SyncRoot should be the reference to the underlying collection, not to MyCollection
             var collBase = new MyCollection();
             object syncRoot = collBase.SyncRoot;
-            Assert.NotEqual(syncRoot, collBase);
-            Assert.Equal(collBase.SyncRoot, collBase.SyncRoot);
+            Assert.NotNull(syncRoot);
+            Assert.Same(collBase.SyncRoot, collBase.SyncRoot);
         }
 
         [Fact]

--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -1194,6 +1194,7 @@ namespace System.Collections.Tests
         }
     }
 
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Changed behavior
     public class Hashtable_SyncRootTests
     {
         private Hashtable _hashDaughter;

--- a/src/System.Collections.NonGeneric/tests/QueueTests.cs
+++ b/src/System.Collections.NonGeneric/tests/QueueTests.cs
@@ -834,6 +834,8 @@ namespace System.Collections.Tests
         }
     }
 
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Changed behavior
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.UapAot, "Test now represents upstream behavior, and is correct in uapaot due to upstream changes: https://github.com/dotnet/coreclr/pull/21628")]
     public class Queue_SyncRootTests
     {
         private const int NumberOfElements = 1000;
@@ -850,7 +852,7 @@ namespace System.Collections.Tests
             {
                 queueMother.Enqueue(i);
             }
-            Assert.Equal(queueMother.SyncRoot.GetType(), typeof(object));
+            Assert.IsType<Queue>(queueMother.SyncRoot);
 
             var queueSon = Queue.Synchronized(queueMother);
             _queueGrandDaughter = Queue.Synchronized(queueSon);

--- a/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBaseTests.cs
+++ b/src/System.Collections.NonGeneric/tests/ReadOnlyCollectionBaseTests.cs
@@ -20,10 +20,12 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Changed behavior
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.UapAot, "Test now represents upstream behavior, and is correct in uapaot due to upstream changes: https://github.com/dotnet/coreclr/pull/21628")]
         public static void SyncRoot()
         {
             MyReadOnlyCollectionBase collection = CreateCollection();
-            Assert.False(collection.SyncRoot is ArrayList);
+            Assert.True(collection.SyncRoot is ArrayList);
             Assert.Same(collection.SyncRoot, collection.SyncRoot);
         }
 
@@ -33,7 +35,7 @@ namespace System.Collections.Tests
             MyReadOnlyCollectionBase collection = CreateCollection();
             Assert.Equal(100, collection.Count);
         }
-        
+
         [Fact]
         public static void CopyTo_ZeroIndex()
         {

--- a/src/System.Collections.NonGeneric/tests/StackTests.cs
+++ b/src/System.Collections.NonGeneric/tests/StackTests.cs
@@ -540,6 +540,8 @@ namespace System.Collections.Tests
         }
     }
 
+    [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Changed behavior
+    [SkipOnTargetFramework(~TargetFrameworkMonikers.UapAot, "Test now represents upstream behavior, and is correct in uapaot due to upstream changes: https://github.com/dotnet/coreclr/pull/21628")]
     public class Stack_SyncRootTests
     {
         private Stack _stackDaughter;
@@ -563,7 +565,7 @@ namespace System.Collections.Tests
                 stackMother.Push(i);
             }
 
-            Assert.Equal(typeof(object), stackMother.SyncRoot.GetType());
+            Assert.IsType<Stack>(stackMother.SyncRoot);
 
             Stack stackSon = Stack.Synchronized(stackMother);
             _stackGrandDaughter = Stack.Synchronized(stackSon);

--- a/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/HybridDictionaryTests.cs
@@ -23,8 +23,6 @@ namespace System.Collections.Specialized.Tests
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectReferenceType_ThrowType => typeof(InvalidCastException);
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfIncorrectValueType_ThrowType => typeof(InvalidCastException);
 
-        protected override Type ICollection_NonGeneric_SyncRootType => typeof(HybridDictionary);
-
         protected override object CreateTKey(int seed)
         {
             int stringLength = seed % 10 + 5;

--- a/src/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.SyncRootTests.cs
+++ b/src/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.SyncRootTests.cs
@@ -17,7 +17,7 @@ namespace System.Collections.Specialized.Tests
             Assert.False(nameObjectCollection1.IsSynchronized);
 
             Assert.Same(nameObjectCollection1.SyncRoot, nameObjectCollection1.SyncRoot);
-            Assert.NotEqual(nameObjectCollection1.SyncRoot, nameObjectCollection2.SyncRoot);
+            Assert.NotSame(nameObjectCollection1.SyncRoot, nameObjectCollection2.SyncRoot);
         }
     }
 }

--- a/src/System.Collections.Specialized/tests/OrderedDictionary/OrderedDictionaryTests.cs
+++ b/src/System.Collections.Specialized/tests/OrderedDictionary/OrderedDictionaryTests.cs
@@ -144,7 +144,7 @@ namespace System.Collections.Specialized.Tests
             ICollection keys = d.Keys;
 
             Assert.False(keys.IsSynchronized);
-            Assert.NotEqual(d, keys.SyncRoot);
+            Assert.NotSame(d, keys.SyncRoot);
             Assert.Equal(d.Count, keys.Count);
 
             foreach (var key in d.Keys)
@@ -186,16 +186,12 @@ namespace System.Collections.Specialized.Tests
             object sync1 = orderedDictionary1.SyncRoot;
             object sync2 = orderedDictionary2.SyncRoot;
 
-            // Sync root does not refer to the dictionary
-            Assert.NotEqual(sync1, orderedDictionary1);
-            Assert.NotEqual(sync2, orderedDictionary2);
-
             // Sync root objects for the same dictionaries are equivalent
-            Assert.Equal(orderedDictionary1.SyncRoot, orderedDictionary1.SyncRoot);
-            Assert.Equal(orderedDictionary2.SyncRoot, orderedDictionary2.SyncRoot);
+            Assert.Same(orderedDictionary1.SyncRoot, orderedDictionary1.SyncRoot);
+            Assert.Same(orderedDictionary2.SyncRoot, orderedDictionary2.SyncRoot);
 
             // Sync root objects for different dictionaries are not equivalent
-            Assert.NotEqual(sync1, sync2);
+            Assert.NotSame(sync1, sync2);
         }
 
         // bool System.Collections.IDictionary.IsFixedSize { get; }
@@ -274,7 +270,7 @@ namespace System.Collections.Specialized.Tests
             ICollection values = d.Values;
 
             Assert.False(values.IsSynchronized);
-            Assert.NotEqual(d, values.SyncRoot);
+            Assert.NotSame(d, values.SyncRoot);
             Assert.Equal(d.Count, values.Count);
 
             foreach (var val in values)

--- a/src/System.Collections.Specialized/tests/StringCollectionTests.cs
+++ b/src/System.Collections.Specialized/tests/StringCollectionTests.cs
@@ -635,11 +635,13 @@ namespace System.Collections.Specialized.Tests
         [Theory]
         [MemberData(nameof(StringCollection_Data))]
         [MemberData(nameof(StringCollection_Duplicates_Data))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)] // Changed behavior
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.UapAot, "Test now represents upstream behavior, and is correct in uapaot due to upstream changes: https://github.com/dotnet/coreclr/pull/21628")]
         public static void SyncRootTest(StringCollection collection, string[] data)
         {
             object syncRoot = collection.SyncRoot;
             Assert.NotNull(syncRoot);
-            Assert.IsType<object>(syncRoot);
+            Assert.IsType<ArrayList>(syncRoot);
 
             Assert.Same(syncRoot, collection.SyncRoot);
             Assert.NotSame(syncRoot, new StringCollection().SyncRoot);


### PR DESCRIPTION
Skipping syncroot tests for UapAot due to behavior changes upstream

See: 
* https://github.com/dotnet/corefx/commit/1fd3717d73da3ae7440841e8fded4adbba5b0770#diff-f45913e598f4cc114af032e9212d7e7f
* https://github.com/dotnet/coreclr/pull/21628

cc - @sergiy-k @MichalStrehovsky 