### PR TITLE
update test output logger so it does not break in different process

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
@@ -48,17 +48,17 @@ namespace System.Net.Sockets.Tests
                     {
                         // Invoke several tests to execute code paths while tracing is enabled
 
-                        new SendReceiveSync(_output).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
-                        new SendReceiveSync(_output).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
+                        new SendReceiveSync(null).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
+                        new SendReceiveSync(null).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
 
-                        new SendReceiveTask(_output).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
-                        new SendReceiveTask(_output).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
+                        new SendReceiveTask(null).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
+                        new SendReceiveTask(null).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
 
-                        new SendReceiveEap(_output).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
-                        new SendReceiveEap(_output).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
+                        new SendReceiveEap(null).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
+                        new SendReceiveEap(null).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
 
-                        new SendReceiveApm(_output).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
-                        new SendReceiveApm(_output).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
+                        new SendReceiveApm(null).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
+                        new SendReceiveApm(null).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
 
                         new NetworkStreamTest().CopyToAsync_AllDataCopied(4096).GetAwaiter().GetResult();
                         new NetworkStreamTest().Timeout_ValidData_Roundtrips().GetAwaiter().GetResult();

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -571,7 +571,7 @@ namespace System.Net.Sockets.Tests
                 int bytesReceived = 0;
                 var receivedChecksum = new Fletcher32();
 
-                _output.WriteLine($"{DateTime.Now} Starting listener at {listener.LocalEndpoint}");
+                _output?.WriteLine($"{DateTime.Now} Starting listener at {listener.LocalEndpoint}");
                 Task serverTask = Task.Run(async () =>
                 {
                     using (Socket remote = await listener.AcceptSocketAsync())
@@ -590,7 +590,7 @@ namespace System.Net.Sockets.Tests
                             if (received == 0)
                             {
                                 Assert.True(remote.Poll(0, SelectMode.SelectRead), "Read poll after completion should have succeeded");
-                                _output.WriteLine($"{DateTime.Now} Received 0 bytes. Stopping receiving loop after {count} iterations.");
+                                _output?.WriteLine($"{DateTime.Now} Received 0 bytes. Stopping receiving loop after {count} iterations.");
                                 break;
                             }
 
@@ -639,7 +639,7 @@ namespace System.Net.Sockets.Tests
 
                 if (bytesSent != bytesReceived)
                 {
-                    _output.WriteLine($"{DateTime.Now} Test received only {bytesReceived} bytes from {bytesSent}. Client task is {clientTask.Status}, Server task is {serverTask.Status}");
+                    _output?.WriteLine($"{DateTime.Now} Test received only {bytesReceived} bytes from {bytesSent}. Client task is {clientTask.Status}, Server task is {serverTask.Status}");
                 }
 
                 Assert.Equal(bytesSent, bytesReceived);


### PR DESCRIPTION
fixes #34839

all tests including outerloop do pass now.

```
furt@Ubuntu:~/git/wfurt-corefx2/src/System.Net.Sockets/tests/FunctionalTests$ ../../../../eng/common/msbuild.sh /t:rebuildandtest /p:outerloop=true
  RemoteExecutorConsoleApp -> /home/furt/git/wfurt-corefx2/artifacts/bin/RemoteExecutorConsoleApp/netstandard-AnyOS-Debug/RemoteExecutorConsoleApp.exe
  System.Net.Sockets.Tests -> /home/furt/git/wfurt-corefx2/artifacts/bin/System.Net.Sockets.Tests/netcoreapp-Unix-Debug/System.Net.Sockets.Tests.dll
  ----- start 07:37:53 =============== To repro directly: =====================================================
  pushd /home/furt/git/wfurt-corefx2/artifacts/bin/tests/System.Net.Sockets.Tests/netcoreapp-Linux-Debug-x64
  /home/furt/git/wfurt-corefx2/artifacts/bin/testhost/netcoreapp-Linux-Debug-x64/dotnet xunit.console.dll System.Net.Sockets.Tests.dll -xml testResults.xml -nologo -notrait category=nonnetcoreapptests -notrait category=nonlinuxtests -notrait category=failing
  popd
  ===========================================================================================================
  ~/git/wfurt-corefx2/artifacts/bin/tests/System.Net.Sockets.Tests/netcoreapp-Linux-Debug-x64 ~/git/wfurt-corefx2/src/System.Net.Sockets/tests/FunctionalTests
    Discovering: System.Net.Sockets.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.Sockets.Tests (found 959 of 1053 test cases)
    Starting:    System.Net.Sockets.Tests (parallel test collections = on, max threads = 4)
      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Success [SKIP]
        Condition(s) not met: "SupportsRawSockets"
      System.Net.Sockets.Tests.UnixDomainSocketTest.Socket_CreateUnixDomainSocket_Throws_OnWindows [SKIP]
        Condition(s) not met: "IsSubWindows10"
      System.Net.Sockets.Tests.KeepAliveTest.Socket_KeepAlive_RetryCount_Failure [SKIP]
        Condition(s) not met: "IsWindowsBelow1703"
    Finished:    System.Net.Sockets.Tests
  === TEST EXECUTION SUMMARY ===
     System.Net.Sockets.Tests  Total: 1410, Errors: 0, Failed: 0, Skipped: 3, Time: 49.323s
  ~/git/wfurt-corefx2/src/System.Net.Sockets/tests/FunctionalTests
  ----- end 07:38:43 ----- exit code 0 ----------------------------------------------------------
```