### PR TITLE
Skip test for Nano: WindowAndCursorProps/Title_Get_Windows_NoNulls

### DIFF
--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -228,14 +228,14 @@ public class WindowAndCursorProps : RemoteExecutorTestBase
         Assert.NotNull(Console.Title);
     }
 
-    [Fact]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "// NETFX does not have the fix https://github.com/dotnet/corefx/pull/28905")]
     public static void Title_Get_Windows_NoNulls()
     {
         string title = Console.Title;
         string trimmedTitle = title.TrimEnd('\0');
-        Assert.Equal(title, trimmedTitle);
+        Assert.Equal(trimmedTitle, title);
     }
 
     [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // Nano currently ignores set title


### PR DESCRIPTION
- Switch back expected vs actual in assert (got moved around because in previous PR we shortly used Assert.Contains() instead of Assert.Equal which takes the opposite order of args (expected vs actual))

Fixes #34755

cc: @danmosemsft 