### PR TITLE
Run ubuntu arm tests in 16.04 for official builds

### DIFF
--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -63,7 +63,7 @@ jobs:
       
         - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
           - linuxDefaultQueues: Centos.7.Amd64+RedHat.7.Amd64+Debian.8.Amd64+Debian.9.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+Ubuntu.1810.Amd64+OpenSuse.42.Amd64+SLES.12.Amd64+SLES.15.Amd64+Fedora.27.Amd64+Fedora.28.Amd64
-          - linuxArm64Queues: Ubuntu.1804.Arm64
+          - linuxArm64Queues: Ubuntu.1604.Arm64
           - alpineQueues: Alpine.36.Amd64+Alpine.38.Amd64
 
     # Legs without helix testing


### PR DESCRIPTION
In order to run in 18.04 we either need to build in 18.04, centOS or Debian. Currently we're building in 1604, causing to random failures because of missing dependencies that are tight to the dependency version in 16.04.

cc: @danmosemsft 