### PR TITLE
Channels add conditional include for ThreadPool assembly in netcoreapp

### DIFF
--- a/src/System.Threading.Channels/src/System.Threading.Channels.csproj
+++ b/src/System.Threading.Channels/src/System.Threading.Channels.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{AAADA5D3-CF64-4E9D-943C-EFDC006D6366}</ProjectGuid>
     <RootNamespace>System.Threading.Channels</RootNamespace>
@@ -39,7 +39,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
-    <Reference Include="System.Threading.ThreadPool" />
+    <Reference Include="System.Threading.ThreadPool"  Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/34178

It looks like only non-netcoreapp builds need the ThreadPool assembly reference, if it is left in the build warning

```
E:\Programming\csharp7\corefx\.dotnet\sdk\2.1.401\Microsoft.Common.CurrentVersion.targets(2110,5): warning MSB3245: Could not resolve this reference. Could not locate the assembly "System.Threading.ThreadPool". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors. [E:\Programming\csharp7\corefx\src\System.Threading.Channels\src\System.Threading.Channels.csproj]
```
is issued. Making it conditional fixes this and leaves the build (at least for me) warning and error free.

cc @tarekgh @stephentoub 