### PR TITLE
Update helix SDK to get fix for random RestApiExceptions

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19074.1",
-    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19074.7",
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19075.2",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview-27322-72"
   }
 }


### PR DESCRIPTION
Sometimes we where hitting a RestApiException when waiting for helix tests to finish. The issue was fixed and we need to update the SDK.
https://github.com/dotnet/arcade/issues/1837