### PR TITLE
Temporary disable FreeBSD leg

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -48,7 +48,7 @@ jobs:
     - template: /eng/pipelines/redhat6.yml
 
     # FreeBSD leg is only for official builds
-    - template: /eng/pipelines/freebsd.yml
+    # - template: /eng/pipelines/freebsd.yml
 
     # Publish step
     - template: /eng/pipelines/publish.yml
@@ -61,4 +61,4 @@ jobs:
           - LinuxNoTest
           - MacOS
           - RedHat6
-          - FreeBSD
+          # - FreeBSD


### PR DESCRIPTION
Core-Setup disabled their FreeBSD leg because the agents needed to be updated. They're now updated, however the latest Core-Setup we consumed for preview2, doesn't contain a FreeBSD runtime package. So let's disable these leg, to keep publishing to BAR and unblock official build.

We can enable this builds once core-setup does. 

cc: @danmosemsft @wfurt 