### PR TITLE
Disabling the test on mac if the generated file has zero nanoseconds

### DIFF
--- a/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -43,6 +43,9 @@ namespace System.IO.Tests
 
             if (!HasNonZeroNanoseconds(fileinfo.LastWriteTime))
             {
+                if (PlatformDetection.IsOSX)
+                    return null;
+
                 DateTime dt = fileinfo.LastWriteTime;
                 dt = dt.AddTicks(1);
                 fileinfo.LastWriteTime = dt;
@@ -119,6 +122,9 @@ namespace System.IO.Tests
         public void CopyToNanosecondsPresent()
         {
             FileInfo input = GetNonZeroNanoseconds();
+            if (input == null)
+                return;
+
             FileInfo output = new FileInfo(Path.Combine(GetTestFilePath(), input.Name));
 
             output.Directory.Create();


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/34823

In our attempt to make the test deterministic we are setting the nanoseconds attribute by ourselves using Utimensat function
but it is not available on mac machines hence we cant set the nanoseconds attribute on those machines if it is zero.
