### PR TITLE
Add outerloop legs in new CI definitions

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -166,6 +166,7 @@ jobs:
                 helixQueues: $(_helixQueues)
                 msbuildScript: $(_msbuildCommand)
                 framework: $(_framework)
+                outerloop: $(_outerloop)
 
                 ${{ if eq(parameters.isOfficialBuild, 'true') }}:
                   isExternal: false

--- a/eng/pipelines/helix.yml
+++ b/eng/pipelines/helix.yml
@@ -11,6 +11,7 @@ parameters:
   waitForCompletion: '' # true | false
   officialBuildId: ''
   enableAzurePipelinesReporter: '' # true | false
+  outerloop: '' # true | false
 
 steps:
   - script: ${{ parameters.msbuildScript }}
@@ -19,6 +20,7 @@ steps:
             /p:ArchGroup=${{ parameters.archGroup }}
             /p:ConfigurationGroup=${{ parameters.configuration }}
             /p:OSGroup=${{ parameters.targetOS }}
+            /p:Outerloop=${{ parameters.outerloop }}
             /p:TargetGroup=${{ parameters.framework }}
             /p:HelixTargetQueues=${{ parameters.helixQueues }}
             /p:HelixBuild=$(Build.BuildNumber)

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -3,6 +3,9 @@ parameters:
   # Required: value to specify if the job is comming from an official build to run extra steps and sign binaries
   #   Default: false
   isOfficialBuild: false
+  # Required: value to specify if the build is comming from an outerloop pipeline.
+  #   Default: false
+  isOuterloopBuild: false
 
 jobs:
 
@@ -56,6 +59,8 @@ jobs:
       variables:
         - _skipTests: true
         - _outerloop: ${{ parameters.isOfficialBuild }}
+        - ${{ if eq(parameters.isOuterloopBuild, 'true') }}:
+          - _outerloop: true
 
         - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
           - linuxDefaultQueues: Centos.7.Amd64.Open+RedHat.7.Amd64.Open+Debian.8.Amd64.Open+Ubuntu.1604.Amd64.Open+Ubuntu.1804.Amd64.Open+OpenSuse.42.Amd64.Open+Fedora.27.Amd64.Open
@@ -67,35 +72,37 @@ jobs:
           - alpineQueues: Alpine.36.Amd64+Alpine.38.Amd64
 
     # Legs without helix testing
-    - job: LinuxNoTest
-      displayName: Linux
-      strategy:
-        matrix:
-          ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-            musl_x64_Debug:
-              _BuildConfig: Debug
-              _architecture: x64
+    # There is no point of running legs without outerloop tests, when in an outerloop build.
+    - ${{ if eq(parameters.isOuterloopBuild, 'false') }}:
+      - job: LinuxNoTest
+        displayName: Linux
+        strategy:
+          matrix:
+            ${{ if eq(parameters.isOfficialBuild, 'false') }}:
+              musl_x64_Debug:
+                _BuildConfig: Debug
+                _architecture: x64
+                _framework: netcoreapp
+                _dockerContainer: alpine_36_container
+                _buildScriptPrefix: ''
+                _buildExtraArguments: /p:RuntimeOS=linux-musl
+
+            arm_Release:
+              _BuildConfig: Release
+              _architecture: arm
               _framework: netcoreapp
-              _dockerContainer: alpine_36_container
-              _buildScriptPrefix: ''
-              _buildExtraArguments: /p:RuntimeOS=linux-musl
+              _buildExtraArguments: /p:RuntimeOS=ubuntu.16.04
+              _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm '
+              _dockerContainer: ubuntu_1604_arm_cross_container
 
-          arm_Release:
-            _BuildConfig: Release
-            _architecture: arm
-            _framework: netcoreapp
-            _buildExtraArguments: /p:RuntimeOS=ubuntu.16.04
-            _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm '
-            _dockerContainer: ubuntu_1604_arm_cross_container
+        pool:
+          name: Hosted Ubuntu 1604
 
-      pool:
-        name: Hosted Ubuntu 1604
+        container: $[ variables['_dockerContainer'] ]
+        buildExtraArguments: $(_buildExtraArguments)
+        buildScriptPrefix: $(_buildScriptPrefix)
+        submitToHelix: false
 
-      container: $[ variables['_dockerContainer'] ]
-      buildExtraArguments: $(_buildExtraArguments)
-      buildScriptPrefix: $(_buildScriptPrefix)
-      submitToHelix: false
-
-      variables:
-        - _skipTests: true
-        - _outerloop: ${{ parameters.isOfficialBuild }}
+        variables:
+          - _skipTests: true
+          - _outerloop: ${{ parameters.isOfficialBuild }}

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -37,6 +37,25 @@ jobs:
             _dockerContainer: ubuntu_1604_arm64_cross_container
             _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
             _buildExtraArguments: ''
+
+          ${{ if eq(parameters.isOuterloopBuild, 'true') }}:
+            x64_Debug:
+              _BuildConfig: Debug
+              _architecture: x64
+              _framework: netcoreapp
+              _helixQueues: $(linuxDefaultQueues)
+              _dockerContainer: rhel7_container
+              _buildScriptPrefix: ''
+              _buildExtraArguments: ''
+
+            arm64_Debug:
+              _BuildConfig: Debug
+              _architecture: arm64
+              _framework: netcoreapp
+              _helixQueues: $(linuxArm64Queues)
+              _dockerContainer: ubuntu_1604_arm64_cross_container
+              _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
+              _buildExtraArguments: ''
           
           ${{ if eq(parameters.isOfficialBuild, 'true') }}:
             musl_x64_Release:

--- a/eng/pipelines/macos.yml
+++ b/eng/pipelines/macos.yml
@@ -3,6 +3,9 @@ parameters:
   # Required: value to specify if the job is comming from an official build to run extra steps and sign binaries
   #   Default: false
   isOfficialBuild: false
+  # Required: value to specify if the build is comming from an outerloop pipeline.
+  #   Default: false
+  isOuterloopBuild: false
 
 jobs:
 
@@ -47,6 +50,8 @@ jobs:
       variables:
         - _skipTests: true
         - _outerloop: ${{ parameters.isOfficialBuild }}
+        - ${{ if eq(parameters.isOuterloopBuild, 'true') }}:
+          - _outerloop: true
 
         - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
           - macOSQueues: OSX.1012.Amd64.Open+OSX.1013.Amd64.Open

--- a/eng/pipelines/outerloop.yml
+++ b/eng/pipelines/outerloop.yml
@@ -1,0 +1,28 @@
+trigger: none
+
+resources:
+  containers:
+  - container: rhel7_container
+    image: microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2
+
+  - container: ubuntu_1604_arm64_cross_container
+    image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921
+
+jobs:
+  # Windows outerloop legs
+  - ${{ if endsWith(variables['Build.DefinitionName'], 'windows') }}:
+    - template: /eng/pipelines/windows.yml
+      parameters:
+        isOuterloopBuild: true
+
+  # Linux outerloop legs
+  - ${{ if endsWith(variables['Build.DefinitionName'], 'linux') }}:
+    - template: /eng/pipelines/linux.yml
+      parameters:
+        isOuterloopBuild: true
+
+  # MacOS outerloop legs
+  - ${{ if endsWith(variables['Build.DefinitionName'], 'osx') }}:
+    - template: /eng/pipelines/macos.yml
+      parameters:
+        isOuterloopBuild: true

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -3,6 +3,9 @@ parameters:
   # Required: value to specify if the job is comming from an official build to run extra steps and sign binaries
   #   Default: false
   isOfficialBuild: false
+  # Required: value to specify if the build is comming from an outerloop pipeline.
+  #   Default: false
+  isOuterloopBuild: false
 
 jobs:
 
@@ -101,6 +104,8 @@ jobs:
       variables:
         - _skipTests: true
         - _outerloop: ${{ parameters.isOfficialBuild }}
+        - ${{ if eq(parameters.isOuterloopBuild, 'true') }}:
+          - _outerloop: true
 
         - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
           - netcoreappWindowsQueues: Windows.7.Amd64.Open+Windows.81.Amd64.Open+Windows.10.Amd64.ClientRS4.ES.Open
@@ -113,125 +118,127 @@ jobs:
           - uapNetfxQueues: Windows.10.Amd64.ClientRS4
           - windowsArmQueue: Windows.10.Arm64
 
-    # Packaging all configurations
-    - job: AllConfigurations
-      displayName: Packaging All Configurations
-      strategy:
-        matrix:
-          # PR Validation Matrix
-          ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-            x64_Debug:
-              _BuildConfig: Debug
-              _architecture: x64
-              _framework: allConfigurations
-              _helixQueues: $(allConfigurationsQueues)
+    # There is no point of running legs without outerloop tests, when in an outerloop build.
+    - ${{ if eq(parameters.isOuterloopBuild, 'false') }}:
+      # Packaging all configurations
+      - job: AllConfigurations
+        displayName: Packaging All Configurations
+        strategy:
+          matrix:
+            # PR Validation Matrix
+            ${{ if eq(parameters.isOfficialBuild, 'false') }}:
+              x64_Debug:
+                _BuildConfig: Debug
+                _architecture: x64
+                _framework: allConfigurations
+                _helixQueues: $(allConfigurationsQueues)
 
-          # Official Build Matrix
+            # Official Build Matrix
+            ${{ if eq(parameters.isOfficialBuild, 'true') }}:
+              x64_Release:
+                _BuildConfig: Release
+                _architecture: x64
+                _framework: allConfigurations
+                _helixQueues: $(allConfigurationsQueues)
+
+        pool:
           ${{ if eq(parameters.isOfficialBuild, 'true') }}:
-            x64_Release:
-              _BuildConfig: Release
-              _architecture: x64
-              _framework: allConfigurations
-              _helixQueues: $(allConfigurationsQueues)
+            name: dotnet-internal-temp
+          ${{ if eq(parameters.isOfficialBuild, 'false') }}:
+            name: Hosted VS2017
 
-      pool:
-        ${{ if eq(parameters.isOfficialBuild, 'true') }}:
-          name: dotnet-internal-temp
-        ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-          name: Hosted VS2017
+        submitToHelix: true
+        # azure pipelines reporter only supports xunit results based tests.
+        enableAzurePipelinesReporter: false
+        enableMicrobuild: ${{ parameters.isOfficialBuild }}
 
-      submitToHelix: true
-      # azure pipelines reporter only supports xunit results based tests.
-      enableAzurePipelinesReporter: false
-      enableMicrobuild: ${{ parameters.isOfficialBuild }}
+        variables:
+          - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
+            - allConfigurationsQueues: Windows.10.Amd64.ClientRS2.Open
+          - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
+            - allConfigurationsQueues: Windows.10.Amd64.ClientRS2
 
-      variables:
-        - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-          - allConfigurationsQueues: Windows.10.Amd64.ClientRS2.Open
-        - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
-          - allConfigurationsQueues: Windows.10.Amd64.ClientRS2
-
-      customBuildSteps:
-        - script: build.cmd
-                  -ci
-                  -$(_framework)
-                  /p:ArchGroup=$(_architecture)
-                  /p:ConfigurationGroup=$(_BuildConfig)
-                  /p:RuntimeOS=win10
-                  $(_windowsOfficialBuildArguments)
-                  $(_msbuildCommonParameters)
-          displayName: Build Packages
-        - script: build.cmd
-                  -ci
-                  -test
-                  -$(_framework)
-                  /p:ArchGroup=$(_architecture)
-                  /p:ConfigurationGroup=$(_BuildConfig)
-                  /p:ArchiveTests=true
-          displayName: Build test projects
-        - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
+        customBuildSteps:
+          - script: build.cmd
+                    -ci
+                    -$(_framework)
+                    /p:ArchGroup=$(_architecture)
+                    /p:ConfigurationGroup=$(_BuildConfig)
+                    /p:RuntimeOS=win10
+                    $(_windowsOfficialBuildArguments)
+                    $(_msbuildCommonParameters)
+            displayName: Build Packages
           - script: build.cmd
                     -ci
                     -test
-                    /p:TargetGroup=netstandard
+                    -$(_framework)
                     /p:ArchGroup=$(_architecture)
                     /p:ConfigurationGroup=$(_BuildConfig)
-                    /p:SkipTests=true
-            displayName: Build Netstandard Test Suite
+                    /p:ArchiveTests=true
+            displayName: Build test projects
+          - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
+            - script: build.cmd
+                      -ci
+                      -test
+                      /p:TargetGroup=netstandard
+                      /p:ArchGroup=$(_architecture)
+                      /p:ConfigurationGroup=$(_BuildConfig)
+                      /p:SkipTests=true
+              displayName: Build Netstandard Test Suite
 
-    # TODO: UAPAOT official builds should send to helix using continuation runner.
-    # Legs without HELIX testing
-    - job: WindowsNoTest
-      displayName: Windows
-      strategy:
-        matrix:
-          ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-            UWP_NETNative_x86_Release:
-              _BuildConfig: Release
-              _architecture: x86
-              _framework: uapaot
+      # TODO: UAPAOT official builds should send to helix using continuation runner.
+      # Legs without HELIX testing
+      - job: WindowsNoTest
+        displayName: Windows
+        strategy:
+          matrix:
+            ${{ if eq(parameters.isOfficialBuild, 'false') }}:
+              UWP_NETNative_x86_Release:
+                _BuildConfig: Release
+                _architecture: x86
+                _framework: uapaot
 
+            ${{ if eq(parameters.isOfficialBuild, 'true') }}:
+              arm_Release:
+                _BuildConfig: Release
+                _architecture: arm
+                _framework: netcoreapp
+
+              arm64_Release:
+                _BuildConfig: Release
+                _architecture: arm64
+                _framework: netcoreapp
+
+              UAPAOT_x86_Release:
+                _BuildConfig: Release
+                _architecture: x86
+                _framework: uapaot
+
+              UAPAOT_x64_Release:
+                _BuildConfig: Release
+                _architecture: x64
+                _framework: uapaot
+
+              UAPAOT_arm_Release:
+                _BuildConfig: Release
+                _architecture: arm
+                _framework: uapaot
+
+              UAPAOT_arm64_Release:
+                _BuildConfig: Release
+                _architecture: arm64
+                _framework: uapaot
+
+        pool:
           ${{ if eq(parameters.isOfficialBuild, 'true') }}:
-            arm_Release:
-              _BuildConfig: Release
-              _architecture: arm
-              _framework: netcoreapp
+            name: dotnet-internal-temp
+          ${{ if eq(parameters.isOfficialBuild, 'false') }}:
+            name: Hosted VS2017
 
-            arm64_Release:
-              _BuildConfig: Release
-              _architecture: arm64
-              _framework: netcoreapp
+        submitToHelix: false
+        enableMicrobuild: ${{ parameters.isOfficialBuild }}
+        buildExtraArguments: /p:RuntimeOS=win10
 
-            UAPAOT_x86_Release:
-              _BuildConfig: Release
-              _architecture: x86
-              _framework: uapaot
-
-            UAPAOT_x64_Release:
-              _BuildConfig: Release
-              _architecture: x64
-              _framework: uapaot
-
-            UAPAOT_arm_Release:
-              _BuildConfig: Release
-              _architecture: arm
-              _framework: uapaot
-
-            UAPAOT_arm64_Release:
-              _BuildConfig: Release
-              _architecture: arm64
-              _framework: uapaot
-
-      pool:
-        ${{ if eq(parameters.isOfficialBuild, 'true') }}:
-          name: dotnet-internal-temp
-        ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-          name: Hosted VS2017
-
-      submitToHelix: false
-      enableMicrobuild: ${{ parameters.isOfficialBuild }}
-      buildExtraArguments: /p:RuntimeOS=win10
-
-      variables:
-        - _skipTests: true
-        - _outerloop: ${{ parameters.isOfficialBuild }}
+        variables:
+          - _skipTests: true
+          - _outerloop: ${{ parameters.isOfficialBuild }}

--- a/eng/sendtohelix.proj
+++ b/eng/sendtohelix.proj
@@ -50,6 +50,7 @@
   <PropertyGroup Condition="'$(HelixType)' == ''">
     <!-- For PRs we want helixtype to be the same for all frameworks except package testing-->
     <HelixType>test/functional/cli/</HelixType>
+    <HelixType Condition="'$(Outerloop)' == 'true' AND '$(OfficialBuildId)' == ''">$(HelixType)/outerloop/</HelixType>
     <HelixType Condition="'$(TargetGroup)' == 'AllConfigurations'">test/functional/packaging/</HelixType>
     <HelixType Condition="'$(TargetGroup)' == 'netfx' AND '$(OfficialBuildId)' != ''">test/functional/desktop/cli/</HelixType>
     <HelixType Condition="'$(TargetGroup)' == 'uap' AND '$(OfficialBuildId)' != ''">test/functional/uwp/</HelixType>


### PR DESCRIPTION
This enables three new optional legs that are only executed when requested by a comment. Options available are the following:

/AzurePipelines run corefx-outerloop-linux
/AzurePipelines run corefx-outerloop-osx
/AzurePipelines run corefx-outerloop-windows

Plus we can also do:
/AzurePipelines run all (will run all 3 above, and re-trigger corefx-ci.)

FYI: @ahsonkhan @davidsh @ericstj @ViktorHofer @stephentoub @danmosemsft 