### PR TITLE
SqlClient enhancement enable GetFieldValue<XmlReader>

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SqlTypeWorkarounds.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SqlTypeWorkarounds.cs
@@ -37,6 +37,17 @@ namespace System.Data.SqlTypes
 
             return XmlReader.Create(stream, settingsToUse);
         }
+
+        internal static XmlReader SqlXmlCreateSqlXmlReader(TextReader textReader, bool closeInput = false, bool async = false)
+        {
+            Debug.Assert(closeInput || !async, "Currently we do not have pre-created settings for !closeInput+async");
+
+            XmlReaderSettings settingsToUse = closeInput ?
+                (async ? s_defaultXmlReaderSettingsAsyncCloseInput : s_defaultXmlReaderSettingsCloseInput) :
+                s_defaultXmlReaderSettings;
+
+            return XmlReader.Create(textReader, settingsToUse);
+        }
         #endregion
 
         #region Work around inability to access SqlDateTime.ToDateTime

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -296,6 +296,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     rdr.GetFieldValue<SqlString>(15);
                     rdr.GetFieldValue<XmlReader>(14);
                     rdr.GetFieldValue<XmlReader>(15);
+                    rdr.GetFieldValueAsync<XmlReader>(14);
+                    rdr.GetFieldValueAsync<XmlReader>(15);
 
                     rdr.Read();
                     Assert.True(rdr.IsDBNullAsync(11).Result, "FAILED: IsDBNull was false for a null value");

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -294,6 +294,8 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     rdr.GetFieldValue<SqlXml>(15);
                     rdr.GetFieldValue<SqlString>(14);
                     rdr.GetFieldValue<SqlString>(15);
+                    rdr.GetFieldValue<XmlReader>(14);
+                    rdr.GetFieldValue<XmlReader>(15);
 
                     rdr.Read();
                     Assert.True(rdr.IsDBNullAsync(11).Result, "FAILED: IsDBNull was false for a null value");


### PR DESCRIPTION
Closes https://github.com/dotnet/corefx/issues/30958

To get data from an SqlDataReader instance you can use a number of approaches. One approach is to use Get[Type] overloads like `GetInt32(int)` and `GetXmlReader(int)`, another is to use the new `GetFieldValue<T>` generic version. Unfortunately while most types work with the generic function `XmlReader` does not and will throw an error. This PR changes that behaviour and adds special casing for `GetFieldValue<XmlReader>` so that the more modern api style can be used with xml without special casing in the calling method.

`GetXmlReader(int)` handles null values by returning an empty stream, it is not considered an error. `GetFieldValue` will usually throw on a null value. I have chosen to replicate the `GetXmlReader` behaviour and return an empty stream on `DBNull`. I can see an argument that it should throw on `DBNull` instead, please consider this.

As usual the standard and manual tests have been run in native mode and passed successfully (apart from those noted in https://github.com/dotnet/corefx/pull/34546). The changes are high up in the stack so native vs managed will make no difference. Tests are added to the existing DataStreamTest list.

/cc all the usual people @keeratsingh @AfsanehR @saurabh500 and requestor @bricelam 