### PR TITLE
Disable SourceLink locally

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -165,8 +165,8 @@
     <EnableDumpling>false</EnableDumpling>
     <CrashDumpFolder Condition="'$(RunningOnUnix)' != 'true'">%TMP%\CoreRunCrashDumps</CrashDumpFolder>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OfficialBuildId)' == ''">
-    <!-- Disable F5 and test explorer support for CI builds. -->
+  <!-- Disable VS support files on CI and official builds. -->
+  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(OfficialBuildId)' != ''">
     <EnableLaunchSettings>false</EnableLaunchSettings>
     <EnableVSTestReferences>false</EnableVSTestReferences>
   </PropertyGroup>
@@ -291,7 +291,8 @@
     <EnableSourceLink Condition="$(RuntimeOS.StartsWith('rhel.6')) OR '$(_runtimeOSFamily)' == 'FreeBSD'">false</EnableSourceLink>
     <!-- is is not supported on ARM platforms either. -->
     <EnableSourceLink Condition="'$(HostArch)' == 'Arm' OR '$(HostArch)' == 'Arm64'">false</EnableSourceLink>
-
+    <!-- Disable source link on local builds. -->
+    <EnableSourceLink Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(OfficialBuildId)' != ''">false</EnableSourceLink>
   </PropertyGroup>
 
   <!-- Set up Default symbol and optimization for Configuration -->


### PR DESCRIPTION
For local builds we don't need source link and disable it by default.
That behavior can be overridden by passing `/p:EnableSourceLink=true`
to the build.

This addresses the source link issue when generating coverage reports as discussed in an offline thread. We don't need to generate source link information in offline builds. I mentioned that in our last infra standup and no concerns were raised.