### PR TITLE
Disable coverage status checks for project and patch

### DIFF
--- a/eng/codecov.yml
+++ b/eng/codecov.yml
@@ -1,10 +1,16 @@
+# https://docs.codecov.io/docs/codecov-yaml
+# https://github.com/codecov/support/wiki/Codecov-Yaml
+
 codecov:
-  branch: master
   ci:
     - dnceng.visualstudio.com
 
 coverage:
-  range: 60...90
+  status:
+    project:
+      default: false
+    patch:
+      default: false
 
 comment:
   layout: "reach, diff, files"


### PR DESCRIPTION
As discussed, I will keep the ci and reach settings for now until I'm able to test the codecov integration.