### PR TITLE
Change helix queues for package testing to be RS4

### DIFF
--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -154,9 +154,9 @@ jobs:
 
         variables:
           - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-            - allConfigurationsQueues: Windows.10.Amd64.ClientRS2.Open
+            - allConfigurationsQueues: Windows.10.Amd64.ClientRS4.Open
           - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
-            - allConfigurationsQueues: Windows.10.Amd64.ClientRS2
+            - allConfigurationsQueues: Windows.10.Amd64.ClientRS4
 
         customBuildSteps:
           - script: build.cmd


### PR DESCRIPTION
RS2 is too old and since we only use it for package testing machines go idle really often that it slows by 20-30 mins the test execution.

cc: @ericstj 