### PR TITLE
Enable tests for UAPAOT x86 and x64 official builds

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -62,9 +62,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>0d74e7a3e7c5959cbebe7302a8bf2aba98da6a4a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19078.1">
+    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19079.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0d74e7a3e7c5959cbebe7302a8bf2aba98da6a4a</Sha>
+      <Sha>f1cfa4893337c329834c42c997b1e3d8a05f9d6a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19078.1">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
     <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19078.1</MicrosoftDotNetGenFacadesPackageVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.0-beta.19078.1</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19078.1</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19078.1</MicrosoftDotNetCoreFxTestingPackageVersion>
+    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19079.3</MicrosoftDotNetCoreFxTestingPackageVersion>
     <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19078.1</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19078.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <!-- Core-setup dependencies -->

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -91,6 +91,19 @@ jobs:
               _architecture: arm
               _framework: uap
               _helixQueues: $(windowsArmQueue)
+
+            UAPAOT_x86_Release:
+              _BuildConfig: Release
+              _architecture: x86
+              _framework: uapaot
+              _helixQueues: $(uapNetfxQueues)
+
+            UAPAOT_x64_Release:
+              _BuildConfig: Release
+              _architecture: x64
+              _framework: uapaot
+              _helixQueues: $(uapNetfxQueues)
+
       pool:
         ${{ if eq(parameters.isOfficialBuild, 'true') }}:
           name: dotnet-internal-temp
@@ -208,16 +221,6 @@ jobs:
                 _BuildConfig: Release
                 _architecture: arm64
                 _framework: netcoreapp
-
-              UAPAOT_x86_Release:
-                _BuildConfig: Release
-                _architecture: x86
-                _framework: uapaot
-
-              UAPAOT_x64_Release:
-                _BuildConfig: Release
-                _architecture: x64
-                _framework: uapaot
 
               UAPAOT_arm_Release:
                 _BuildConfig: Release


### PR DESCRIPTION
Depends on consuming: https://github.com/dotnet/arcade/pull/1905

Pending: arm and arm64 that need continuation runner. Working on those already.