### PR TITLE
removed project-priorities link from docs readme

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -27,7 +27,6 @@ Project Docs
 
 - [Developer Guide](project-docs/developer-guide.md)
 - [Performance Testing](project-docs/performance-tests.md)
-- [Project priorities](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/project-priorities.md)
 - [Contributing to CoreFX](project-docs/contributing.md)
 - [Contributing to .NET Core](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/contributing.md)
 - [Contributing Workflow](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/contributing-workflow.md)


### PR DESCRIPTION
the link is broken and I didn't find that file in the `coreclr` or `corefx` repos