### PR TITLE
Temporarily give System.Runtime.Extensions its own Environment.* copy

### DIFF
--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -21,15 +21,9 @@
     <Compile Include="System\CodeDom\Compiler\IndentedTextWriter.cs" />
     <Compile Include="System\Context.cs" />
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
-    <Compile Include="$(CommonPath)\CoreLib\System\Environment.cs">
-      <Link>Common\CoreLib\System\Environment.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\System\Environment.SpecialFolder.cs">
-      <Link>Common\CoreLib\System\Environment.SpecialFolder.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\System\Environment.SpecialFolderOption.cs">
-      <Link>Common\CoreLib\System\Environment.SpecialFolderOption.cs</Link>
-    </Compile>
+    <Compile Include="System\Environment.cs" />
+    <Compile Include="System\Environment.SpecialFolder.cs" />
+    <Compile Include="System\Environment.SpecialFolderOption.cs" />
     <Compile Include="System\LoaderOptimization.cs" />
     <Compile Include="System\LoaderOptimizationAttribute.cs" />
     <Compile Include="$(CommonPath)\CoreLib\System\OperatingSystem.cs">
@@ -79,17 +73,13 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uapaot' or '$(TargetGroup)' == 'uap'">
-    <Compile Include="$(CommonPath)\CoreLib\System\Environment.WinRT.cs">
-      <Link>Common\CoreLib\System\Environment.WinRT.cs</Link>
-    </Compile>
+    <Compile Include="System\Environment.WinRT.cs" />
     <Compile Include="$(CommonPath)\CoreLib\System\WinRTFolderPaths.cs">
       <Link>Common\CoreLib\System\WinRTFolderPaths.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(TargetGroup)' != 'uapaot' and '$(TargetGroup)' != 'uap'">
-    <Compile Include="$(CommonPath)\CoreLib\System\Environment.Win32.cs">
-      <Link>Common\CoreLib\System\Environment.Win32.cs</Link>
-    </Compile>
+    <Compile Include="System\Environment.Win32.cs" />
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\secur32\Interop.GetUserNameExW.cs">
       <Link>Common\Interop\Windows\secur32\Interop.GetUserNameExW.cs</Link>
     </Compile>
@@ -102,9 +92,7 @@
     <Compile Include="$(CommonPath)\CoreLib\System\PasteArguments.Windows.cs">
       <Link>Common\CoreLib\System\PasteArguments.Windows.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\System\Environment.Windows.cs">
-      <Link>Common\CoreLib\System\Environment.Windows.cs</Link>
-    </Compile>
+    <Compile Include="System\Environment.Windows.cs" />
     <Compile Include="System\Runtime\Versioning\VersioningHelper.Windows.cs" />
     <Compile Include="System\Diagnostics\Stopwatch.Windows.cs" />
     <Compile Include="$(CommonPath)\CoreLib\System\IO\Win32Marshal.cs">
@@ -191,9 +179,7 @@
   </ItemGroup>
   <!-- UNIX -->
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
-    <Compile Include="$(CommonPath)\CoreLib\System\Environment.Unix.cs">
-      <Link>Common\CoreLib\System\Environment.Unix.cs</Link>
-    </Compile>
+    <Compile Include="System\Environment.Unix.cs" />
     <Compile Include="System\Runtime\Versioning\VersioningHelper.Unix.cs" />
     <Compile Include="System\Diagnostics\Stopwatch.Unix.cs" />
     <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">

--- a/src/System.Runtime.Extensions/src/System/Environment.SpecialFolder.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.SpecialFolder.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// TODO: Delete this file. https://github.com/dotnet/coreclr/issues/21932
+
+namespace System
+{
+    public static partial class Environment
+    {
+        public enum SpecialFolder
+        {
+            ApplicationData = SpecialFolderValues.CSIDL_APPDATA,
+            CommonApplicationData = SpecialFolderValues.CSIDL_COMMON_APPDATA,
+            LocalApplicationData = SpecialFolderValues.CSIDL_LOCAL_APPDATA,
+            Cookies = SpecialFolderValues.CSIDL_COOKIES,
+            Desktop = SpecialFolderValues.CSIDL_DESKTOP,
+            Favorites = SpecialFolderValues.CSIDL_FAVORITES,
+            History = SpecialFolderValues.CSIDL_HISTORY,
+            InternetCache = SpecialFolderValues.CSIDL_INTERNET_CACHE,
+            Programs = SpecialFolderValues.CSIDL_PROGRAMS,
+            MyComputer = SpecialFolderValues.CSIDL_DRIVES,
+            MyMusic = SpecialFolderValues.CSIDL_MYMUSIC,
+            MyPictures = SpecialFolderValues.CSIDL_MYPICTURES,
+            MyVideos = SpecialFolderValues.CSIDL_MYVIDEO,
+            Recent = SpecialFolderValues.CSIDL_RECENT,
+            SendTo = SpecialFolderValues.CSIDL_SENDTO,
+            StartMenu = SpecialFolderValues.CSIDL_STARTMENU,
+            Startup = SpecialFolderValues.CSIDL_STARTUP,
+            System = SpecialFolderValues.CSIDL_SYSTEM,
+            Templates = SpecialFolderValues.CSIDL_TEMPLATES,
+            DesktopDirectory = SpecialFolderValues.CSIDL_DESKTOPDIRECTORY,
+            Personal = SpecialFolderValues.CSIDL_PERSONAL,
+            MyDocuments = SpecialFolderValues.CSIDL_PERSONAL,
+            ProgramFiles = SpecialFolderValues.CSIDL_PROGRAM_FILES,
+            CommonProgramFiles = SpecialFolderValues.CSIDL_PROGRAM_FILES_COMMON,
+            AdminTools = SpecialFolderValues.CSIDL_ADMINTOOLS,
+            CDBurning = SpecialFolderValues.CSIDL_CDBURN_AREA,
+            CommonAdminTools = SpecialFolderValues.CSIDL_COMMON_ADMINTOOLS,
+            CommonDocuments = SpecialFolderValues.CSIDL_COMMON_DOCUMENTS,
+            CommonMusic = SpecialFolderValues.CSIDL_COMMON_MUSIC,
+            CommonOemLinks = SpecialFolderValues.CSIDL_COMMON_OEM_LINKS,
+            CommonPictures = SpecialFolderValues.CSIDL_COMMON_PICTURES,
+            CommonStartMenu = SpecialFolderValues.CSIDL_COMMON_STARTMENU,
+            CommonPrograms = SpecialFolderValues.CSIDL_COMMON_PROGRAMS,
+            CommonStartup = SpecialFolderValues.CSIDL_COMMON_STARTUP,
+            CommonDesktopDirectory = SpecialFolderValues.CSIDL_COMMON_DESKTOPDIRECTORY,
+            CommonTemplates = SpecialFolderValues.CSIDL_COMMON_TEMPLATES,
+            CommonVideos = SpecialFolderValues.CSIDL_COMMON_VIDEO,
+            Fonts = SpecialFolderValues.CSIDL_FONTS,
+            NetworkShortcuts = SpecialFolderValues.CSIDL_NETHOOD,
+            PrinterShortcuts = SpecialFolderValues.CSIDL_PRINTHOOD,
+            UserProfile = SpecialFolderValues.CSIDL_PROFILE,
+            CommonProgramFilesX86 = SpecialFolderValues.CSIDL_PROGRAM_FILES_COMMONX86,
+            ProgramFilesX86 = SpecialFolderValues.CSIDL_PROGRAM_FILESX86,
+            Resources = SpecialFolderValues.CSIDL_RESOURCES,
+            LocalizedResources = SpecialFolderValues.CSIDL_RESOURCES_LOCALIZED,
+            SystemX86 = SpecialFolderValues.CSIDL_SYSTEMX86,
+            Windows = SpecialFolderValues.CSIDL_WINDOWS,
+        }
+
+        // These values are specific to Windows and are known to SHGetFolderPath, however they are
+        // also the values used in the SpecialFolder enum.  As such, we keep them as constants
+        // with their Win32 names, but keep them here rather than in Interop.Kernel32 as they're
+        // used on all platforms.
+        private static class SpecialFolderValues
+        {
+            internal const int CSIDL_APPDATA = 0x001a;
+            internal const int CSIDL_COMMON_APPDATA = 0x0023;
+            internal const int CSIDL_LOCAL_APPDATA = 0x001c;
+            internal const int CSIDL_COOKIES = 0x0021;
+            internal const int CSIDL_FAVORITES = 0x0006;
+            internal const int CSIDL_HISTORY = 0x0022;
+            internal const int CSIDL_INTERNET_CACHE = 0x0020;
+            internal const int CSIDL_PROGRAMS = 0x0002;
+            internal const int CSIDL_RECENT = 0x0008;
+            internal const int CSIDL_SENDTO = 0x0009;
+            internal const int CSIDL_STARTMENU = 0x000b;
+            internal const int CSIDL_STARTUP = 0x0007;
+            internal const int CSIDL_SYSTEM = 0x0025;
+            internal const int CSIDL_TEMPLATES = 0x0015;
+            internal const int CSIDL_DESKTOPDIRECTORY = 0x0010;
+            internal const int CSIDL_PERSONAL = 0x0005;
+            internal const int CSIDL_PROGRAM_FILES = 0x0026;
+            internal const int CSIDL_PROGRAM_FILES_COMMON = 0x002b;
+            internal const int CSIDL_DESKTOP = 0x0000;
+            internal const int CSIDL_DRIVES = 0x0011;
+            internal const int CSIDL_MYMUSIC = 0x000d;
+            internal const int CSIDL_MYPICTURES = 0x0027;
+
+            internal const int CSIDL_ADMINTOOLS = 0x0030; // <user name>\Start Menu\Programs\Administrative Tools
+            internal const int CSIDL_CDBURN_AREA = 0x003b; // USERPROFILE\Local Settings\Application Data\Microsoft\CD Burning
+            internal const int CSIDL_COMMON_ADMINTOOLS = 0x002f; // All Users\Start Menu\Programs\Administrative Tools
+            internal const int CSIDL_COMMON_DOCUMENTS = 0x002e; // All Users\Documents
+            internal const int CSIDL_COMMON_MUSIC = 0x0035; // All Users\My Music
+            internal const int CSIDL_COMMON_OEM_LINKS = 0x003a; // Links to All Users OEM specific apps
+            internal const int CSIDL_COMMON_PICTURES = 0x0036; // All Users\My Pictures
+            internal const int CSIDL_COMMON_STARTMENU = 0x0016; // All Users\Start Menu
+            internal const int CSIDL_COMMON_PROGRAMS = 0X0017; // All Users\Start Menu\Programs
+            internal const int CSIDL_COMMON_STARTUP = 0x0018; // All Users\Startup
+            internal const int CSIDL_COMMON_DESKTOPDIRECTORY = 0x0019; // All Users\Desktop
+            internal const int CSIDL_COMMON_TEMPLATES = 0x002d; // All Users\Templates
+            internal const int CSIDL_COMMON_VIDEO = 0x0037; // All Users\My Video
+            internal const int CSIDL_FONTS = 0x0014; // windows\fonts
+            internal const int CSIDL_MYVIDEO = 0x000e; // "My Videos" folder
+            internal const int CSIDL_NETHOOD = 0x0013; // %APPDATA%\Microsoft\Windows\Network Shortcuts
+            internal const int CSIDL_PRINTHOOD = 0x001b; // %APPDATA%\Microsoft\Windows\Printer Shortcuts
+            internal const int CSIDL_PROFILE = 0x0028; // %USERPROFILE% (%SystemDrive%\Users\%USERNAME%)
+            internal const int CSIDL_PROGRAM_FILES_COMMONX86 = 0x002c; // x86 Program Files\Common on RISC
+            internal const int CSIDL_PROGRAM_FILESX86 = 0x002a; // x86 C:\Program Files on RISC
+            internal const int CSIDL_RESOURCES = 0x0038; // %windir%\Resources
+            internal const int CSIDL_RESOURCES_LOCALIZED = 0x0039; // %windir%\resources\0409 (code page)
+            internal const int CSIDL_SYSTEMX86 = 0x0029; // %windir%\system32
+            internal const int CSIDL_WINDOWS = 0x0024; // GetWindowsDirectory()
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/src/System/Environment.SpecialFolderOption.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.SpecialFolderOption.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// TODO: Delete this file. https://github.com/dotnet/coreclr/issues/21932
+
+namespace System
+{
+    public static partial class Environment
+    {
+        public enum SpecialFolderOption
+        {
+            None = 0,
+            Create = SpecialFolderOptionValues.CSIDL_FLAG_CREATE,
+            DoNotVerify = SpecialFolderOptionValues.CSIDL_FLAG_DONT_VERIFY,
+        }
+
+        // These values are specific to Windows and are known to SHGetFolderPath, however they are
+        // also the values used in the SpecialFolderOption enum.  As such, we keep them as constants
+        // with their Win32 names, but keep them here rather than in Interop.Kernel32 as they're
+        // used on all platforms.
+        private static class SpecialFolderOptionValues
+        {
+            /// <summary>
+            /// Force folder creation in SHGetFolderPath. Equivalent of KF_FLAG_CREATE (0x00008000).
+            /// </summary>
+            internal const int CSIDL_FLAG_CREATE = 0x8000;
+
+            /// <summary>
+            /// Return an unverified folder path. Equivalent of KF_FLAG_DONT_VERIFY (0x00004000).
+            /// </summary>
+            internal const int CSIDL_FLAG_DONT_VERIFY = 0x4000;
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Unix.cs
@@ -1,0 +1,451 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// TODO: Delete this file. https://github.com/dotnet/coreclr/issues/21932
+
+using Internal.Runtime.Augments;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+namespace System
+{
+    public static partial class Environment
+    {
+        internal static readonly bool IsMac = Interop.Sys.GetUnixName() == "OSX";
+        private static Func<string, object> s_directoryCreateDirectory;
+
+        private static string CurrentDirectoryCore
+        {
+            get { return Interop.Sys.GetCwd(); }
+            set { Interop.CheckIo(Interop.Sys.ChDir(value), value, isDirectory: true); }
+        }
+
+        public static int ExitCode { get { return EnvironmentAugments.ExitCode; } set { EnvironmentAugments.ExitCode = value; } }
+
+        private static string ExpandEnvironmentVariablesCore(string name)
+        {
+            Span<char> initialBuffer = stackalloc char[128];
+            var result = new ValueStringBuilder(initialBuffer);
+
+            int lastPos = 0, pos;
+            while (lastPos < name.Length && (pos = name.IndexOf('%', lastPos + 1)) >= 0)
+            {
+                if (name[lastPos] == '%')
+                {
+                    string key = name.Substring(lastPos + 1, pos - lastPos - 1);
+                    string value = GetEnvironmentVariable(key);
+                    if (value != null)
+                    {
+                        result.Append(value);
+                        lastPos = pos + 1;
+                        continue;
+                    }
+                }
+                result.Append(name.AsSpan(lastPos, pos - lastPos));
+                lastPos = pos;
+            }
+            result.Append(name.AsSpan(lastPos));
+
+            return result.ToString();
+        }
+
+        private static string GetFolderPathCore(SpecialFolder folder, SpecialFolderOption option)
+        {
+            // Get the path for the SpecialFolder
+            string path = GetFolderPathCoreWithoutValidation(folder);
+            Debug.Assert(path != null);
+
+            // If we didn't get one, or if we got one but we're not supposed to verify it,
+            // or if we're supposed to verify it and it passes verification, return the path.
+            if (path.Length == 0 ||
+                option == SpecialFolderOption.DoNotVerify ||
+                Interop.Sys.Access(path, Interop.Sys.AccessMode.R_OK) == 0)
+            {
+                return path;
+            }
+
+            // Failed verification.  If None, then we're supposed to return an empty string.
+            // If Create, we're supposed to create it and then return the path.
+            if (option == SpecialFolderOption.None)
+            {
+                return string.Empty;
+            }
+            else
+            {
+                Debug.Assert(option == SpecialFolderOption.Create);
+
+                // TODO #11151: Replace with Directory.CreateDirectory once we have access to System.IO.FileSystem here.
+                Func<string, object> createDirectory = LazyInitializer.EnsureInitialized(ref s_directoryCreateDirectory, () =>
+                {
+                    Type dirType = Type.GetType("System.IO.Directory, System.IO.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", throwOnError: true);
+                    MethodInfo mi = dirType.GetTypeInfo().GetDeclaredMethod("CreateDirectory");
+                    return (Func<string, object>)mi.CreateDelegate(typeof(Func<string, object>));
+                });
+                createDirectory(path);
+
+                return path;
+            }
+        }
+
+        private static string GetFolderPathCoreWithoutValidation(SpecialFolder folder)
+        {
+            // First handle any paths that involve only static paths, avoiding the overheads of getting user-local paths.
+            // https://www.freedesktop.org/software/systemd/man/file-hierarchy.html
+            switch (folder)
+            {
+                case SpecialFolder.CommonApplicationData: return "/usr/share";
+                case SpecialFolder.CommonTemplates: return "/usr/share/templates";
+            }
+            if (IsMac)
+            {
+                switch (folder)
+                {
+                    case SpecialFolder.ProgramFiles: return "/Applications";
+                    case SpecialFolder.System: return "/System";
+                }
+            }
+
+            // All other paths are based on the XDG Base Directory Specification:
+            // https://specifications.freedesktop.org/basedir-spec/latest/
+            string home = null;
+            try
+            {
+                home = PersistedFiles.GetHomeDirectory();
+            }
+            catch (Exception exc)
+            {
+                Debug.Fail($"Unable to get home directory: {exc}");
+            }
+
+            // Fall back to '/' when we can't determine the home directory.
+            // This location isn't writable by non-root users which provides some safeguard
+            // that the application doesn't write data which is meant to be private.
+            if (string.IsNullOrEmpty(home))
+            {
+                home = "/";
+            }
+
+            // TODO: Consider caching (or precomputing and caching) all subsequent results.
+            // This would significantly improve performance for repeated access, at the expense
+            // of not being responsive to changes in the underlying environment variables,
+            // configuration files, etc.
+
+            switch (folder)
+            {
+                case SpecialFolder.UserProfile:
+                case SpecialFolder.MyDocuments: // same value as Personal
+                    return home;
+                case SpecialFolder.ApplicationData:
+                    return GetXdgConfig(home);
+                case SpecialFolder.LocalApplicationData:
+                    // "$XDG_DATA_HOME defines the base directory relative to which user specific data files should be stored."
+                    // "If $XDG_DATA_HOME is either not set or empty, a default equal to $HOME/.local/share should be used."
+                    string data = GetEnvironmentVariable("XDG_DATA_HOME");
+                    if (string.IsNullOrEmpty(data) || data[0] != '/')
+                    {
+                        data = Path.Combine(home, ".local", "share");
+                    }
+                    return data;
+
+                case SpecialFolder.Desktop:
+                case SpecialFolder.DesktopDirectory:
+                    return ReadXdgDirectory(home, "XDG_DESKTOP_DIR", "Desktop");
+                case SpecialFolder.Templates:
+                    return ReadXdgDirectory(home, "XDG_TEMPLATES_DIR", "Templates");
+                case SpecialFolder.MyVideos:
+                    return ReadXdgDirectory(home, "XDG_VIDEOS_DIR", "Videos");
+
+                case SpecialFolder.MyMusic:
+                    return IsMac ? Path.Combine(home, "Music") : ReadXdgDirectory(home, "XDG_MUSIC_DIR", "Music");
+                case SpecialFolder.MyPictures:
+                    return IsMac ? Path.Combine(home, "Pictures") : ReadXdgDirectory(home, "XDG_PICTURES_DIR", "Pictures");
+                case SpecialFolder.Fonts:
+                    return IsMac ? Path.Combine(home, "Library", "Fonts") : Path.Combine(home, ".fonts");
+
+                case SpecialFolder.Favorites:
+                    if (IsMac) return Path.Combine(home, "Library", "Favorites");
+                    break;
+                case SpecialFolder.InternetCache:
+                    if (IsMac) return Path.Combine(home, "Library", "Caches");
+                    break;
+            }
+
+            // No known path for the SpecialFolder
+            return string.Empty;
+        }
+
+        private static string GetXdgConfig(string home)
+        {
+            // "$XDG_CONFIG_HOME defines the base directory relative to which user specific configuration files should be stored."
+            // "If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used."
+            string config = GetEnvironmentVariable("XDG_CONFIG_HOME");
+            if (string.IsNullOrEmpty(config) || config[0] != '/')
+            {
+                config = Path.Combine(home, ".config");
+            }
+            return config;
+        }
+
+        private static string ReadXdgDirectory(string homeDir, string key, string fallback)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(homeDir), $"Expected non-empty homeDir");
+            Debug.Assert(!string.IsNullOrEmpty(key), $"Expected non-empty key");
+            Debug.Assert(!string.IsNullOrEmpty(fallback), $"Expected non-empty fallback");
+
+            string envPath = GetEnvironmentVariable(key);
+            if (!string.IsNullOrEmpty(envPath) && envPath[0] == '/')
+            {
+                return envPath;
+            }
+
+            // Use the user-dirs.dirs file to look up the right config.
+            // Note that the docs also highlight a list of directories in which to look for this file:
+            // "$XDG_CONFIG_DIRS defines the preference-ordered set of base directories to search for configuration files in addition
+            //  to the $XDG_CONFIG_HOME base directory. The directories in $XDG_CONFIG_DIRS should be separated with a colon ':'. If
+            //  $XDG_CONFIG_DIRS is either not set or empty, a value equal to / etc / xdg should be used."
+            // For simplicity, we don't currently do that.  We can add it if/when necessary.
+
+            string userDirsPath = Path.Combine(GetXdgConfig(homeDir), "user-dirs.dirs");
+            if (Interop.Sys.Access(userDirsPath, Interop.Sys.AccessMode.R_OK) == 0)
+            {
+                try
+                {
+                    using (var reader = new StreamReader(userDirsPath))
+                    {
+                        string line;
+                        while ((line = reader.ReadLine()) != null)
+                        {
+                            // Example lines:
+                            // XDG_DESKTOP_DIR="$HOME/Desktop"
+                            // XDG_PICTURES_DIR = "/absolute/path"
+
+                            // Skip past whitespace at beginning of line
+                            int pos = 0;
+                            SkipWhitespace(line, ref pos);
+                            if (pos >= line.Length) continue;
+
+                            // Skip past requested key name
+                            if (string.CompareOrdinal(line, pos, key, 0, key.Length) != 0) continue;
+                            pos += key.Length;
+
+                            // Skip past whitespace and past '='
+                            SkipWhitespace(line, ref pos);
+                            if (pos >= line.Length - 4 || line[pos] != '=') continue; // 4 for ="" and at least one char between quotes
+                            pos++; // skip past '='
+
+                            // Skip past whitespace and past first quote
+                            SkipWhitespace(line, ref pos);
+                            if (pos >= line.Length - 3 || line[pos] != '"') continue; // 3 for "" and at least one char between quotes
+                            pos++; // skip past opening '"'
+
+                            // Skip past relative prefix if one exists
+                            bool relativeToHome = false;
+                            const string RelativeToHomePrefix = "$HOME/";
+                            if (string.CompareOrdinal(line, pos, RelativeToHomePrefix, 0, RelativeToHomePrefix.Length) == 0)
+                            {
+                                relativeToHome = true;
+                                pos += RelativeToHomePrefix.Length;
+                            }
+                            else if (line[pos] != '/') // if not relative to home, must be absolute path
+                            {
+                                continue;
+                            }
+
+                            // Find end of path
+                            int endPos = line.IndexOf('"', pos);
+                            if (endPos <= pos) continue;
+
+                            // Got we need.  Now extract it.
+                            string path = line.Substring(pos, endPos - pos);
+                            return relativeToHome ?
+                                Path.Combine(homeDir, path) :
+                                path;
+                        }
+                    }
+                }
+                catch (Exception exc)
+                {
+                    // assembly not found, file not found, errors reading file, etc. Just eat everything.
+                    Debug.Fail($"Failed reading {userDirsPath}: {exc}");
+                }
+            }
+
+            return Path.Combine(homeDir, fallback);
+        }
+
+        private static void SkipWhitespace(string line, ref int pos)
+        {
+            while (pos < line.Length && char.IsWhiteSpace(line[pos])) pos++;
+        }
+
+        public static string[] GetLogicalDrives() => Interop.Sys.GetAllMountPoints();
+
+        private static bool Is64BitOperatingSystemWhen32BitProcess => false;
+
+        public static string MachineName
+        {
+            get
+            {
+                string hostName = Interop.Sys.GetHostName();
+                int dotPos = hostName.IndexOf('.');
+                return dotPos == -1 ? hostName : hostName.Substring(0, dotPos);
+            }
+        }
+
+        public static string NewLine => "\n";
+
+        private static readonly Lazy<OperatingSystem> s_osVersion = new Lazy<OperatingSystem>(() => GetOperatingSystem(Interop.Sys.GetUnixRelease()));
+
+        private static OperatingSystem GetOperatingSystem(string release)
+        {
+            int major = 0, minor = 0, build = 0, revision = 0;
+
+            // Parse the uname's utsname.release for the first four numbers found.
+            // This isn't perfect, but Version already doesn't map exactly to all possible release
+            // formats, e.g. 2.6.19-1.2895.fc6
+            if (release != null)
+            {
+                int i = 0;
+                major = FindAndParseNextNumber(release, ref i);
+                minor = FindAndParseNextNumber(release, ref i);
+                build = FindAndParseNextNumber(release, ref i);
+                revision = FindAndParseNextNumber(release, ref i);
+            }
+
+            // For compatibility reasons with Mono, PlatformID.Unix is returned on MacOSX. PlatformID.MacOSX
+            // is hidden from the editor and shouldn't be used.
+            return new OperatingSystem(PlatformID.Unix, new Version(major, minor, build, revision));
+        }
+
+        private static int FindAndParseNextNumber(string text, ref int pos)
+        {
+            // Move to the beginning of the number
+            for (; pos < text.Length; pos++)
+            {
+                char c = text[pos];
+                if ('0' <= c && c <= '9')
+                {
+                    break;
+                }
+            }
+
+            // Parse the number;
+            int num = 0;
+            for (; pos < text.Length; pos++)
+            {
+                char c = text[pos];
+                if ('0' > c || c > '9')
+                    break;
+
+                try
+                {
+                    num = checked((num * 10) + (c - '0'));
+                }
+                // Integer overflow can occur for example with:
+                //     Linux nelknet 4.15.0-24201807041620-generic
+                // To form a valid Version, num must be positive.
+                catch (OverflowException)
+                {
+                    return int.MaxValue;
+                }
+            }
+
+            return num;
+        }
+
+        public static string SystemDirectory => GetFolderPathCore(SpecialFolder.System, SpecialFolderOption.None);
+
+        public static int SystemPageSize => CheckedSysConf(Interop.Sys.SysConfName._SC_PAGESIZE);
+
+        public static unsafe string UserName
+        {
+            get
+            {
+                // First try with a buffer that should suffice for 99% of cases.
+                string username;
+                const int BufLen = Interop.Sys.Passwd.InitialBufferSize;
+                byte* stackBuf = stackalloc byte[BufLen];
+                if (TryGetUserNameFromPasswd(stackBuf, BufLen, out username))
+                {
+                    return username;
+                }
+
+                // Fallback to heap allocations if necessary, growing the buffer until
+                // we succeed.  TryGetUserNameFromPasswd will throw if there's an unexpected error.
+                int lastBufLen = BufLen;
+                while (true)
+                {
+                    lastBufLen *= 2;
+                    byte[] heapBuf = new byte[lastBufLen];
+                    fixed (byte* buf = &heapBuf[0])
+                    {
+                        if (TryGetUserNameFromPasswd(buf, heapBuf.Length, out username))
+                        {
+                            return username;
+                        }
+                    }
+                }
+
+            }
+        }
+
+        private static unsafe bool TryGetUserNameFromPasswd(byte* buf, int bufLen, out string path)
+        {
+            // Call getpwuid_r to get the passwd struct
+            Interop.Sys.Passwd passwd;
+            int error = Interop.Sys.GetPwUidR(Interop.Sys.GetEUid(), out passwd, buf, bufLen);
+
+            // If the call succeeds, give back the user name retrieved
+            if (error == 0)
+            {
+                Debug.Assert(passwd.Name != null);
+                path = Marshal.PtrToStringAnsi((IntPtr)passwd.Name);
+                return true;
+            }
+
+            // If the current user's entry could not be found, give back null,
+            // but still return true as false indicates the buffer was too small.
+            if (error == -1)
+            {
+                path = null;
+                return true;
+            }
+
+            var errorInfo = new Interop.ErrorInfo(error);
+
+            // If the call failed because the buffer was too small, return false to
+            // indicate the caller should try again with a larger buffer.
+            if (errorInfo.Error == Interop.Error.ERANGE)
+            {
+                path = null;
+                return false;
+            }
+
+            // Otherwise, fail.
+            throw new IOException(errorInfo.GetErrorMessage(), errorInfo.RawErrno);
+        }
+
+        public static string UserDomainName => MachineName;
+
+        /// <summary>Invoke <see cref="Interop.Sys.SysConf"/>, throwing if it fails.</summary>
+        private static int CheckedSysConf(Interop.Sys.SysConfName name)
+        {
+            long result = Interop.Sys.SysConf(name);
+            if (result == -1)
+            {
+                Interop.ErrorInfo errno = Interop.Sys.GetLastErrorInfo();
+                throw errno.Error == Interop.Error.EINVAL ?
+                    new ArgumentOutOfRangeException(nameof(name), name, errno.GetErrorMessage()) :
+                    Interop.GetIOException(errno);
+            }
+            return (int)result;
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Win32.cs
@@ -1,0 +1,286 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// TODO: Delete this file. https://github.com/dotnet/coreclr/issues/21932
+
+using System.IO;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    public static partial class Environment
+    {
+        public static string UserName
+        {
+            get
+            {
+                // 40 should be enough as we're asking for the SAM compatible name (DOMAIN\User).
+                // The max length should be 15 (domain) + 1 (separator) + 20 (name) + null. If for
+                // some reason it isn't, we'll grow the buffer.
+
+                // https://support.microsoft.com/en-us/help/909264/naming-conventions-in-active-directory-for-computers-domains-sites-and
+                // https://msdn.microsoft.com/en-us/library/ms679635.aspx
+
+                Span<char> initialBuffer = stackalloc char[40];
+                var builder = new ValueStringBuilder(initialBuffer);
+                GetUserName(ref builder);
+
+                ReadOnlySpan<char> name = builder.AsSpan();
+                int index = name.IndexOf('\\');
+                if (index != -1)
+                {
+                    // In the form of DOMAIN\User, cut off DOMAIN\
+                    name = name.Slice(index + 1);
+                }
+
+                return name.ToString();
+            }
+        }
+
+        private static void GetUserName(ref ValueStringBuilder builder)
+        {
+            uint size = 0;
+            while (Interop.Secur32.GetUserNameExW(Interop.Secur32.NameSamCompatible, ref builder.GetPinnableReference(), ref size) == Interop.BOOLEAN.FALSE)
+            {
+                if (Marshal.GetLastWin32Error() == Interop.Errors.ERROR_MORE_DATA)
+                {
+                    builder.EnsureCapacity(checked((int)size));
+                }
+                else
+                {
+                    builder.Length = 0;
+                    return;
+                }
+            }
+
+            builder.Length = (int)size;
+        }
+
+        public static string UserDomainName
+        {
+            get
+            {
+                // See the comment in UserName
+                Span<char> initialBuffer = stackalloc char[40];
+                var builder = new ValueStringBuilder(initialBuffer);
+                GetUserName(ref builder);
+
+                ReadOnlySpan<char> name = builder.AsSpan();
+                int index = name.IndexOf('\\');
+                if (index != -1)
+                {
+                    // In the form of DOMAIN\User, cut off \User and return
+                    return name.Slice(0, index).ToString();
+                }
+
+                // In theory we should never get use out of LookupAccountNameW as the above API should
+                // always return what we need. Can't find any clues in the historical sources, however.
+
+                // Domain names aren't typically long.
+                // https://support.microsoft.com/en-us/help/909264/naming-conventions-in-active-directory-for-computers-domains-sites-and
+                Span<char> initialDomainNameBuffer = stackalloc char[64];
+                var domainBuilder = new ValueStringBuilder(initialBuffer);
+                uint length = (uint)domainBuilder.Capacity;
+
+                // This API will fail to return the domain name without a buffer for the SID.
+                // SIDs are never over 68 bytes long.
+                Span<byte> sid = stackalloc byte[68];
+                uint sidLength = 68;
+
+                while (!Interop.Advapi32.LookupAccountNameW(null, ref builder.GetPinnableReference(), ref MemoryMarshal.GetReference(sid),
+                    ref sidLength, ref domainBuilder.GetPinnableReference(), ref length, out _))
+                {
+                    int error = Marshal.GetLastWin32Error();
+
+                    // The docs don't call this out clearly, but experimenting shows that the error returned is the following.
+                    if (error != Interop.Errors.ERROR_INSUFFICIENT_BUFFER)
+                    {
+                        throw new InvalidOperationException(Win32Marshal.GetMessage(error));
+                    }
+
+                    domainBuilder.EnsureCapacity((int)length);
+                }
+
+                domainBuilder.Length = (int)length;
+                return domainBuilder.ToString();
+            }
+        }
+
+        private static string GetFolderPathCore(SpecialFolder folder, SpecialFolderOption option)
+        {
+            // We're using SHGetKnownFolderPath instead of SHGetFolderPath as SHGetFolderPath is
+            // capped at MAX_PATH.
+            //
+            // Because we validate both of the input enums we shouldn't have to care about CSIDL and flag
+            // definitions we haven't mapped. If we remove or loosen the checks we'd have to account
+            // for mapping here (this includes tweaking as SHGetFolderPath would do).
+            //
+            // The only SpecialFolderOption defines we have are equivalent to KnownFolderFlags.
+
+            string folderGuid;
+
+            switch (folder)
+            {
+                case SpecialFolder.ApplicationData:
+                    folderGuid = Interop.Shell32.KnownFolders.RoamingAppData;
+                    break;
+                case SpecialFolder.CommonApplicationData:
+                    folderGuid = Interop.Shell32.KnownFolders.ProgramData;
+                    break;
+                case SpecialFolder.LocalApplicationData:
+                    folderGuid = Interop.Shell32.KnownFolders.LocalAppData;
+                    break;
+                case SpecialFolder.Cookies:
+                    folderGuid = Interop.Shell32.KnownFolders.Cookies;
+                    break;
+                case SpecialFolder.Desktop:
+                    folderGuid = Interop.Shell32.KnownFolders.Desktop;
+                    break;
+                case SpecialFolder.Favorites:
+                    folderGuid = Interop.Shell32.KnownFolders.Favorites;
+                    break;
+                case SpecialFolder.History:
+                    folderGuid = Interop.Shell32.KnownFolders.History;
+                    break;
+                case SpecialFolder.InternetCache:
+                    folderGuid = Interop.Shell32.KnownFolders.InternetCache;
+                    break;
+                case SpecialFolder.Programs:
+                    folderGuid = Interop.Shell32.KnownFolders.Programs;
+                    break;
+                case SpecialFolder.MyComputer:
+                    folderGuid = Interop.Shell32.KnownFolders.ComputerFolder;
+                    break;
+                case SpecialFolder.MyMusic:
+                    folderGuid = Interop.Shell32.KnownFolders.Music;
+                    break;
+                case SpecialFolder.MyPictures:
+                    folderGuid = Interop.Shell32.KnownFolders.Pictures;
+                    break;
+                case SpecialFolder.MyVideos:
+                    folderGuid = Interop.Shell32.KnownFolders.Videos;
+                    break;
+                case SpecialFolder.Recent:
+                    folderGuid = Interop.Shell32.KnownFolders.Recent;
+                    break;
+                case SpecialFolder.SendTo:
+                    folderGuid = Interop.Shell32.KnownFolders.SendTo;
+                    break;
+                case SpecialFolder.StartMenu:
+                    folderGuid = Interop.Shell32.KnownFolders.StartMenu;
+                    break;
+                case SpecialFolder.Startup:
+                    folderGuid = Interop.Shell32.KnownFolders.Startup;
+                    break;
+                case SpecialFolder.System:
+                    folderGuid = Interop.Shell32.KnownFolders.System;
+                    break;
+                case SpecialFolder.Templates:
+                    folderGuid = Interop.Shell32.KnownFolders.Templates;
+                    break;
+                case SpecialFolder.DesktopDirectory:
+                    folderGuid = Interop.Shell32.KnownFolders.Desktop;
+                    break;
+                case SpecialFolder.Personal:
+                    // Same as Personal
+                    // case SpecialFolder.MyDocuments:
+                    folderGuid = Interop.Shell32.KnownFolders.Documents;
+                    break;
+                case SpecialFolder.ProgramFiles:
+                    folderGuid = Interop.Shell32.KnownFolders.ProgramFiles;
+                    break;
+                case SpecialFolder.CommonProgramFiles:
+                    folderGuid = Interop.Shell32.KnownFolders.ProgramFilesCommon;
+                    break;
+                case SpecialFolder.AdminTools:
+                    folderGuid = Interop.Shell32.KnownFolders.AdminTools;
+                    break;
+                case SpecialFolder.CDBurning:
+                    folderGuid = Interop.Shell32.KnownFolders.CDBurning;
+                    break;
+                case SpecialFolder.CommonAdminTools:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonAdminTools;
+                    break;
+                case SpecialFolder.CommonDocuments:
+                    folderGuid = Interop.Shell32.KnownFolders.PublicDocuments;
+                    break;
+                case SpecialFolder.CommonMusic:
+                    folderGuid = Interop.Shell32.KnownFolders.PublicMusic;
+                    break;
+                case SpecialFolder.CommonOemLinks:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonOEMLinks;
+                    break;
+                case SpecialFolder.CommonPictures:
+                    folderGuid = Interop.Shell32.KnownFolders.PublicPictures;
+                    break;
+                case SpecialFolder.CommonStartMenu:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonStartMenu;
+                    break;
+                case SpecialFolder.CommonPrograms:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonPrograms;
+                    break;
+                case SpecialFolder.CommonStartup:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonStartup;
+                    break;
+                case SpecialFolder.CommonDesktopDirectory:
+                    folderGuid = Interop.Shell32.KnownFolders.PublicDesktop;
+                    break;
+                case SpecialFolder.CommonTemplates:
+                    folderGuid = Interop.Shell32.KnownFolders.CommonTemplates;
+                    break;
+                case SpecialFolder.CommonVideos:
+                    folderGuid = Interop.Shell32.KnownFolders.PublicVideos;
+                    break;
+                case SpecialFolder.Fonts:
+                    folderGuid = Interop.Shell32.KnownFolders.Fonts;
+                    break;
+                case SpecialFolder.NetworkShortcuts:
+                    folderGuid = Interop.Shell32.KnownFolders.NetHood;
+                    break;
+                case SpecialFolder.PrinterShortcuts:
+                    folderGuid = Interop.Shell32.KnownFolders.PrintersFolder;
+                    break;
+                case SpecialFolder.UserProfile:
+                    folderGuid = Interop.Shell32.KnownFolders.Profile;
+                    break;
+                case SpecialFolder.CommonProgramFilesX86:
+                    folderGuid = Interop.Shell32.KnownFolders.ProgramFilesCommonX86;
+                    break;
+                case SpecialFolder.ProgramFilesX86:
+                    folderGuid = Interop.Shell32.KnownFolders.ProgramFilesX86;
+                    break;
+                case SpecialFolder.Resources:
+                    folderGuid = Interop.Shell32.KnownFolders.ResourceDir;
+                    break;
+                case SpecialFolder.LocalizedResources:
+                    folderGuid = Interop.Shell32.KnownFolders.LocalizedResourcesDir;
+                    break;
+                case SpecialFolder.SystemX86:
+                    folderGuid = Interop.Shell32.KnownFolders.SystemX86;
+                    break;
+                case SpecialFolder.Windows:
+                    folderGuid = Interop.Shell32.KnownFolders.Windows;
+                    break;
+                default:
+                    return string.Empty;
+            }
+
+            return GetKnownFolderPath(folderGuid, option);
+        }
+
+        private static string GetKnownFolderPath(string folderGuid, SpecialFolderOption option)
+        {
+            Guid folderId = new Guid(folderGuid);
+
+            int hr = Interop.Shell32.SHGetKnownFolderPath(folderId, (uint)option, IntPtr.Zero, out string path);
+            if (hr != 0) // Not S_OK
+            {
+                return string.Empty;
+            }
+
+            return path;
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/src/System/Environment.WinRT.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.WinRT.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// TODO: Delete this file. https://github.com/dotnet/coreclr/issues/21932
+
+using System.IO;
+
+namespace System
+{
+    public static partial class Environment
+    {
+        public static string UserName => "Windows User";
+        public static string UserDomainName => "Windows Domain";
+        private static string GetFolderPathCore(SpecialFolder folder, SpecialFolderOption option) =>
+            WinRTFolderPaths.GetFolderPath(folder, option);
+    }
+}

--- a/src/System.Runtime.Extensions/src/System/Environment.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.Windows.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// TODO: Delete this file. https://github.com/dotnet/coreclr/issues/21932
+
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Internal.Runtime.Augments;
+
+namespace System
+{
+    public static partial class Environment
+    {
+        private static string CurrentDirectoryCore
+        {
+            get
+            {
+                Span<char> initialBuffer = stackalloc char[Interop.Kernel32.MAX_PATH];
+                var builder = new ValueStringBuilder(initialBuffer);
+
+                uint length;
+                while ((length = Interop.Kernel32.GetCurrentDirectory((uint)builder.Capacity, ref builder.GetPinnableReference())) > builder.Capacity)
+                {
+                    builder.EnsureCapacity((int)length);
+                }
+
+                if (length == 0)
+                    throw Win32Marshal.GetExceptionForLastWin32Error();
+
+                builder.Length = (int)length;
+
+                // If we have a tilde in the path, make an attempt to expand 8.3 filenames
+                return builder.AsSpan().Contains('~')
+                    ? PathHelper.TryExpandShortFileName(ref builder, null)
+                    : builder.ToString();
+            }
+            set
+            {
+                if (!Interop.Kernel32.SetCurrentDirectory(value))
+                {
+                    int errorCode = Marshal.GetLastWin32Error();
+                    throw Win32Marshal.GetExceptionForWin32Error(
+                        errorCode == Interop.Errors.ERROR_FILE_NOT_FOUND ? Interop.Errors.ERROR_PATH_NOT_FOUND : errorCode,
+                        value);
+                }
+            }
+        }
+
+        public static string[] GetLogicalDrives() => DriveInfoInternal.GetLogicalDrives();
+
+        public static string NewLine => "\r\n";
+
+        public static int SystemPageSize
+        {
+            get
+            {
+                Interop.Kernel32.GetSystemInfo(out Interop.Kernel32.SYSTEM_INFO info);
+                return info.dwPageSize;
+            }
+        }
+
+        public static int ExitCode { get { return EnvironmentAugments.ExitCode; } set { EnvironmentAugments.ExitCode = value; } }
+
+        private static string ExpandEnvironmentVariablesCore(string name)
+        {
+            Span<char> initialBuffer = stackalloc char[128];
+            var builder = new ValueStringBuilder(initialBuffer);
+
+            uint length;
+            while ((length = Interop.Kernel32.ExpandEnvironmentStringsW(name, ref builder.GetPinnableReference(), (uint)builder.Capacity)) > builder.Capacity)
+            {
+                builder.EnsureCapacity((int)length);
+            }
+
+            if (length == 0)
+                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+
+            // length includes the null terminator
+            builder.Length = (int)length - 1;
+            return builder.ToString();
+        }
+
+        private static bool Is64BitOperatingSystemWhen32BitProcess
+            => Interop.Kernel32.IsWow64Process(Interop.Kernel32.GetCurrentProcess(), out bool isWow64) && isWow64;
+
+        public static string MachineName
+        {
+            get
+            {
+                string name = Interop.Kernel32.GetComputerName();
+                if (name == null)
+                {
+                    throw new InvalidOperationException(SR.InvalidOperation_ComputerName);
+                }
+                return name;
+            }
+        }
+
+        private static readonly unsafe Lazy<OperatingSystem> s_osVersion = new Lazy<OperatingSystem>(() =>
+        {
+            var version = new Interop.Kernel32.OSVERSIONINFOEX { dwOSVersionInfoSize = sizeof(Interop.Kernel32.OSVERSIONINFOEX) };
+            if (!Interop.Kernel32.GetVersionExW(ref version))
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_GetVersion);
+            }
+
+            return new OperatingSystem(
+                PlatformID.Win32NT,
+                new Version(version.dwMajorVersion, version.dwMinorVersion, version.dwBuildNumber, (version.wServicePackMajor << 16) | version.wServicePackMinor),
+                Marshal.PtrToStringUni((IntPtr)version.szCSDVersion));
+        });
+
+        public static string SystemDirectory
+        {
+            get
+            {
+                // Normally this will be C:\Windows\System32
+                Span<char> initialBuffer = stackalloc char[32];
+                var builder = new ValueStringBuilder(initialBuffer);
+
+                uint length;
+                while ((length = Interop.Kernel32.GetSystemDirectoryW(ref builder.GetPinnableReference(), (uint)builder.Capacity)) > builder.Capacity)
+                {
+                    builder.EnsureCapacity((int)length);
+                }
+
+                if (length == 0)
+                    throw Win32Marshal.GetExceptionForLastWin32Error();
+
+                builder.Length = (int)length;
+                return builder.ToString();
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/src/System/Environment.cs
+++ b/src/System.Runtime.Extensions/src/System/Environment.cs
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// TODO: Delete this file. https://github.com/dotnet/coreclr/issues/21932
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Internal.Runtime.Augments;
+
+namespace System
+{
+    public static partial class Environment
+    {
+        public static string GetEnvironmentVariable(string variable)
+        {
+            return EnvironmentAugments.GetEnvironmentVariable(variable);
+        }
+
+        public static string GetEnvironmentVariable(string variable, EnvironmentVariableTarget target)
+        {
+            return EnvironmentAugments.GetEnvironmentVariable(variable, target);
+        }
+
+        public static IDictionary GetEnvironmentVariables()
+        {
+            // To maintain complete compatibility with prior versions we need to return a Hashtable.
+            // We did ship a prior version of Core with LowLevelDictionary, which does iterate the
+            // same (e.g. yields DictionaryEntry), but it is not a public type.
+            //
+            // While we could pass Hashtable back from CoreCLR the type is also defined here. We only
+            // want to surface the local Hashtable.
+            return EnvironmentAugments.EnumerateEnvironmentVariables().ToHashtable();
+        }
+
+        public static IDictionary GetEnvironmentVariables(EnvironmentVariableTarget target)
+        {
+            // See comments in GetEnvironmentVariables()
+            return EnvironmentAugments.EnumerateEnvironmentVariables(target).ToHashtable();
+        }
+
+        private static Hashtable ToHashtable(this IEnumerable<KeyValuePair<string, string>> pairs)
+        {
+            Hashtable hashTable = new Hashtable();
+            foreach (KeyValuePair<string, string> pair in pairs)
+            {
+                try 
+                {
+                    hashTable.Add(pair.Key, pair.Value);                 
+                }
+                catch (ArgumentException)
+                {
+                    // Throw and catch intentionally to provide non-fatal notification about corrupted environment block
+                }
+            }
+            return hashTable;
+        }
+
+        public static void SetEnvironmentVariable(string variable, string value)
+        {
+            EnvironmentAugments.SetEnvironmentVariable(variable, value);
+        }
+
+        public static void SetEnvironmentVariable(string variable, string value, EnvironmentVariableTarget target)
+        {
+            EnvironmentAugments.SetEnvironmentVariable(variable, value, target);
+        }
+
+        public static string CommandLine
+        {
+            get
+            {
+                return PasteArguments.Paste(GetCommandLineArgs(), pasteFirstArgumentUsingArgV0Rules: true);
+            }
+        }
+
+        public static string CurrentDirectory
+        {
+            get { return CurrentDirectoryCore; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                if (value.Length == 0)
+                {
+                    throw new ArgumentException(SR.Argument_PathEmpty, nameof(value));
+                }
+
+                CurrentDirectoryCore = value;
+            }
+        }
+
+        public static int CurrentManagedThreadId => EnvironmentAugments.CurrentManagedThreadId;
+
+        public static void Exit(int exitCode) => EnvironmentAugments.Exit(exitCode);
+        
+        public static void FailFast(string message) => FailFast(message, exception: null);
+
+        public static void FailFast(string message, Exception exception) => EnvironmentAugments.FailFast(message, exception);
+
+        public static string ExpandEnvironmentVariables(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (name.Length == 0)
+            {
+                return name;
+            }
+
+            return ExpandEnvironmentVariablesCore(name);
+        }
+
+        public static string[] GetCommandLineArgs() => EnvironmentAugments.GetCommandLineArgs();
+
+        public static string GetFolderPath(SpecialFolder folder) => GetFolderPath(folder, SpecialFolderOption.None);
+
+        public static string GetFolderPath(SpecialFolder folder, SpecialFolderOption option)
+        {
+            if (!Enum.IsDefined(typeof(SpecialFolder), folder))
+            {
+                throw new ArgumentOutOfRangeException(nameof(folder), folder, SR.Format(SR.Arg_EnumIllegalVal, folder));
+            }
+
+            if (option != SpecialFolderOption.None && !Enum.IsDefined(typeof(SpecialFolderOption), option))
+            {
+                throw new ArgumentOutOfRangeException(nameof(option), option, SR.Format(SR.Arg_EnumIllegalVal, option));
+            }
+
+            return GetFolderPathCore(folder, option);
+        }
+
+        public static bool HasShutdownStarted => EnvironmentAugments.HasShutdownStarted;
+
+        public static bool Is64BitProcess => IntPtr.Size == 8;
+
+        public static bool Is64BitOperatingSystem => Is64BitProcess || Is64BitOperatingSystemWhen32BitProcess;
+
+        public static OperatingSystem OSVersion => s_osVersion.Value;
+
+        public static int ProcessorCount => EnvironmentAugments.ProcessorCount;
+
+        public static string StackTrace
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)] // Prevent inlining from affecting where the stacktrace starts
+            get
+            {
+                return EnvironmentAugments.StackTrace;
+            }
+        }
+
+        public static int TickCount => EnvironmentAugments.TickCount;
+
+        public static bool UserInteractive => true;
+
+        public static Version Version
+        {
+            // Previously this represented the File version of mscorlib.dll.  Many other libraries in the framework and outside took dependencies on the first three parts of this version 
+            // remaining constant throughout 4.x.  From 4.0 to 4.5.2 this was fine since the file version only incremented the last part. Starting with 4.6 we switched to a file versioning
+            // scheme that matched the product version.  In order to preserve compatibility with existing libraries, this needs to be hard-coded.
+            get { return new Version(4, 0, 30319, 42000); }
+        }
+
+        public static long WorkingSet
+        {
+            get
+            {
+                // Use reflection to access the implementation in System.Diagnostics.Process.dll.  While far from ideal,
+                // we do this to avoid duplicating the Windows, Linux, macOS, and potentially other platform-specific implementations
+                // present in Process.  If it proves important, we could look at separating that functionality out of Process into
+                // Common files which could also be included here.
+                Type processType = Type.GetType("System.Diagnostics.Process, System.Diagnostics.Process, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", throwOnError: false);
+                IDisposable currentProcess = processType?.GetMethod("GetCurrentProcess")?.Invoke(null, BindingFlags.DoNotWrapExceptions, null, null, null) as IDisposable;
+                if (currentProcess != null)
+                {
+                    using (currentProcess)
+                    {
+                        object result = processType.GetMethod("get_WorkingSet64")?.Invoke(currentProcess, BindingFlags.DoNotWrapExceptions, null, null, null);
+                        if (result is long) return (long)result;
+                    }
+                }
+                // Could not get the current working set.
+                return 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The files were moved to shared to propagate them to coreclr.  But changes being made in coreclr are going to break System.Runtime.Extensions when the files mirror back.  As a temporary stop-gap, I'm creating local copies of the files and taking System.Runtime.Environment off of the shared copies.  Then once coreclr builds with the updates and corefx consumes the updated coreclr, we'll just delete these temporary copies and remove the relevant entries entirely from System.Runtime.Extensions.