### PR TITLE
Remove UpdateVSConfigurations

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -2,8 +2,6 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project DefaultTargets="Build">
 
-  <UsingTask TaskName="UpdateVSConfigurations" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-
   <Import Project="Directory.Build.props" />
 
   <PropertyGroup>
@@ -89,18 +87,16 @@
   <!-- Hook that can be used to insert custom build tasks to the build process such as setup and/or cleanup tasks -->
   <Import Project="build.override.targets" Condition="Exists('build.override.targets')" />
 
-  <Target Name="UpdateVSConfigurations">
-    <Message Importance="High" Text="Updating configurations for projects ..." />
+  <!-- set up inputs for UpdateVSConfigurations in a target to avoid globbing all the time -->
+  <Target Name="_setProjectsToUpdate" BeforeTargets="UpdateVSConfigurations">
     <ItemGroup>
       <_projectsToExcludeFromUpdate Include="$(MSBuildThisFileDirectory)src/SharedFrameworkValidation/**/*.csproj" />
-      <_projectsToUpdate Include="$(MSBuildThisFileDirectory)src/**/*.*csproj" Exclude="@(_projectsToExcludeFromUpdate)" />
-      <_projectsToUpdate Include="$(MSBuildThisFileDirectory)src/**/*.*ilproj" Exclude="@(_projectsToExcludeFromUpdate)" />
-      <_projectsToUpdate Include="$(MSBuildThisFileDirectory)src/**/*.*vbproj" Exclude="@(_projectsToExcludeFromUpdate)" />
+      <ProjectsToUpdate Include="$(MSBuildThisFileDirectory)src/**/*.*csproj" Exclude="@(_projectsToExcludeFromUpdate)" />
+      <ProjectsToUpdate Include="$(MSBuildThisFileDirectory)src/**/*.*ilproj" Exclude="@(_projectsToExcludeFromUpdate)" />
+      <ProjectsToUpdate Include="$(MSBuildThisFileDirectory)src/**/*.*vbproj" Exclude="@(_projectsToExcludeFromUpdate)" />
       <_solutionsToUpdateFiles Include="$(MSBuildThisFileDirectory)src/*/Directory.Build.props" />
-      <_solutionsToUpdate Include="@(_solutionsToUpdateFiles->'%(RootDir)%(Directory)')" Exclude="@(_solutionsToExcludeFromUpdate)" />
+      <SolutionsToUpdate Include="@(_solutionsToUpdateFiles->'%(RootDir)%(Directory)')" Exclude="@(_solutionsToExcludeFromUpdate)" />
     </ItemGroup>
-    <UpdateVSConfigurations ProjectsToUpdate="@(_projectsToUpdate)" SolutionsToUpdate="@(_solutionsToUpdate)" />
-    <Message Importance="High" Text="Updating configurations for projects ... Done." />
   </Target>
 
   <!-- Define an empty Execute target for Arcade's publish to BAR finds it: https://github.com/dotnet/arcade/issues/1452 -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -66,9 +66,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>0d74e7a3e7c5959cbebe7302a8bf2aba98da6a4a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19078.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19079.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0d74e7a3e7c5959cbebe7302a8bf2aba98da6a4a</Sha>
+      <Sha>268dc10408d39b6059924989a071549371757fb1</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19078.1">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,7 @@
     <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.0-beta.19078.1</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19078.1</MicrosoftDotNetBuildTasksPackagingPackageVersion>
     <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19078.1</MicrosoftDotNetCoreFxTestingPackageVersion>
-    <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19078.1</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
+    <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19079.6</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19078.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <!-- Core-setup dependencies -->
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview-27329-4</MicrosoftNETCoreAppPackageVersion>


### PR DESCRIPTION
Pick up the UpdateVSConfigurations from latest arcade build, configuration package.

This maintains the old workflow of running /t:UpdateVSConfigurations on the root build.proj but also adds the same support for running on an individual csproj.