### PR TITLE
add Fact attribute instead of removed ConditionalFact

### DIFF
--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -35,6 +35,7 @@ namespace System.Net.NameResolution.PalTests
             Assert.NotNull(hostEntry.Aliases);
         }
 
+        [Fact]
         public void TryGetAddrInfo_HostName()
         {
             string hostName = NameResolutionPal.GetHostName();
@@ -45,7 +46,7 @@ namespace System.Net.NameResolution.PalTests
             SocketError error = NameResolutionPal.TryGetAddrInfo(hostName, out hostEntry, out nativeErrorCode);
             if (error == SocketError.HostNotFound && (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
             {
-                // On Unix, we are not guaranteed to be able to resove the local host. The ability to do so depends on the 
+                // On Unix, we are not guaranteed to be able to resove the local host. The ability to do so depends on the
                 // machine configurations, which varies by distro and is often inconsistent.
                 return;
             }
@@ -59,7 +60,7 @@ namespace System.Net.NameResolution.PalTests
                     throw new InvalidOperationException("Name resolution failure preventable with retry");
                 }
             }
-            
+
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(hostEntry);
             Assert.NotNull(hostEntry.HostName);
@@ -101,6 +102,7 @@ namespace System.Net.NameResolution.PalTests
             Assert.NotNull(name);
         }
 
+        [Fact]
         public void TryGetAddrInfo_HostName_TryGetNameInfo()
         {
             string hostName = NameResolutionPal.GetHostName();


### PR DESCRIPTION
follow up on #34934

@caesar1995 was right. I did run whole set with outerloop but I missed fact that the test was not executed.  This should be fixed now and verified with verbose mode:

```
furt@Ubuntu:~/git/wfurt-corefx2/src/System.Net.NameResolution/tests/PalTests$ ../../../../eng/common/msbuild.sh /t:rebuildandtest /p:outerloop=true
  System.Net.NameResolution.Pal.Tests -> /home/furt/git/wfurt-corefx2/artifacts/bin/System.Net.NameResolution.Pal.Tests/netcoreapp-Unix-Debug/System.Net.NameResolution.Pal.Tests.dll
  ----- start 12:07:35 =============== To repro directly: =====================================================
  pushd /home/furt/git/wfurt-corefx2/artifacts/bin/tests/System.Net.NameResolution.Pal.Tests/netcoreapp-Linux-Debug-x64
  /home/furt/git/wfurt-corefx2/artifacts/bin/testhost/netcoreapp-Linux-Debug-x64/dotnet xunit.console.dll System.Net.NameResolution.Pal.Tests.dll -xml testResults.xml -nologo -notrait category=nonnetcoreapptests -notrait category=nonlinuxtests -notrait category=failing -verbose -nocolor
  popd
  ===========================================================================================================
  ~/git/wfurt-corefx2/artifacts/bin/tests/System.Net.NameResolution.Pal.Tests/netcoreapp-Linux-Debug-x64 ~/git/wfurt-corefx2/src/System.Net.NameResolution/tests/PalTests
    Discovering: System.Net.NameResolution.Pal.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.NameResolution.Pal.Tests (found 11 test cases)
    Starting:    System.Net.NameResolution.Pal.Tests (parallel test collections = on, max threads = 4)
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetNameInfo_LocalHost_IPv6 [STARTING]
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetNameInfo_LocalHost_IPv6 [FINISHED] Time: 0.0063263s
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetAddrInfo_ExternalHost [STARTING]
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetAddrInfo_ExternalHost [FINISHED] Time: 0.0107417s
      System.Net.NameResolution.PalTests.NameResolutionPalTests.Exception_HostNotFound_Success [STARTING]
      System.Net.NameResolution.PalTests.NameResolutionPalTests.Exception_HostNotFound_Success [FINISHED] Time: 0.0099352s
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetAddrInfo_LocalHost_TryGetNameInfo [STARTING]
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetAddrInfo_LocalHost_TryGetNameInfo [FINISHED] Time: 0.0008799s
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetNameInfo_LocalHost_IPv4_TryGetAddrInfo [STARTING]
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetNameInfo_LocalHost_IPv4_TryGetAddrInfo [FINISHED] Time: 0.0009055s
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetAddrInfo_LocalHost [STARTING]
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetAddrInfo_LocalHost [FINISHED] Time: 0.0003098s
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetAddrInfo_HostName_TryGetNameInfo [STARTING]
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetAddrInfo_HostName_TryGetNameInfo [FINISHED] Time: 0.0010108s
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetAddrInfo_HostName [STARTING]
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetAddrInfo_HostName [FINISHED] Time: 0.0009383s
      System.Net.NameResolution.PalTests.NameResolutionPalTests.HostName_NotNull [STARTING]
      System.Net.NameResolution.PalTests.NameResolutionPalTests.HostName_NotNull [FINISHED] Time: 0.0000804s
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetNameInfo_LocalHost_IPv4 [STARTING]
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetNameInfo_LocalHost_IPv4 [FINISHED] Time: 0.0001549s
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetNameInfo_LocalHost_IPv6_TryGetAddrInfo [STARTING]
      System.Net.NameResolution.PalTests.NameResolutionPalTests.TryGetNameInfo_LocalHost_IPv6_TryGetAddrInfo [FINISHED] Time: 0.00045s
    Finished:    System.Net.NameResolution.Pal.Tests
  === TEST EXECUTION SUMMARY ===
     System.Net.NameResolution.Pal.Tests  Total: 11, Errors: 0, Failed: 0, Skipped: 0, Time: 0.138s
  ~/git/wfurt-corefx2/src/System.Net.NameResolution/tests/PalTests
  ----- end 12:07:36 ----- exit code 0 ----------------------------------------------------------
  exit code 0 means Exited Successfully
```


 