### PR TITLE
Fix several related inheritability bugs on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.SetFD.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.SetFD.cs
@@ -12,8 +12,8 @@ internal static partial class Interop
     {
         internal static partial class Fcntl
         {
-            [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlSetCloseOnExec", SetLastError=true)]
-            internal static extern int SetCloseOnExec(SafeHandle fd);
+            [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlSetFD", SetLastError=true)]
+            internal static extern int SetFD(SafeHandle fd, int flags);
         }
     }
 }

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -529,10 +529,10 @@ int32_t SystemNative_Pipe(int32_t pipeFds[2], int32_t flags)
     return result;
 }
 
-int32_t SystemNative_FcntlSetCloseOnExec(intptr_t fd)
+int32_t SystemNative_FcntlSetFD(intptr_t fd, int32_t flags)
 {
     int result;
-    while ((result = fcntl(ToFileDescriptor(fd), F_SETFD, FD_CLOEXEC)) < 0 && errno == EINTR);
+    while ((result = fcntl(ToFileDescriptor(fd), F_SETFD, ConvertOpenFlags(flags))) < 0 && errno == EINTR);
     return result;
 }
 

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -421,7 +421,7 @@ DLLEXPORT int32_t SystemNative_Pipe(int32_t pipefd[2], // [out] pipefds[0] gets 
  *
  * Returns 0 for success; -1 for failure. Sets errno for failure.
  */
-DLLEXPORT int32_t SystemNative_FcntlSetCloseOnExec(intptr_t fd);
+DLLEXPORT int32_t SystemNative_FcntlSetFD(intptr_t fd, int32_t flags);
 
 /**
  * Determines if the current platform supports getting and setting pipe capacity.

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -125,8 +125,8 @@
     <Compile Include="$(CommonPath)\CoreLib\Interop\Unix\Interop.Errors.cs">
       <Link>Common\CoreLib\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.SetCloseOnExec.cs">
-      <Link>Common\Interop\Unix\Interop.Fcntl.SetCloseOnExec.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.SetFD.cs">
+      <Link>Common\Interop\Unix\Interop.Fcntl.SetFD.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\CoreLib\Interop\Unix\Interop.IOErrors.cs">
       <Link>Common\CoreLib\Interop\Unix\Interop.IOErrors.cs</Link>

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
@@ -68,13 +68,7 @@ namespace System.IO.MemoryMappedFiles
                 if ((protections & Interop.Sys.MemoryMappedProtections.PROT_WRITE) != 0 && capacity > 0)
                 {
                     ownsFileStream = true;
-                    fileStream = CreateSharedBackingObject(protections, capacity);
-
-                    // If the MMF handle should not be inherited, mark the backing object fd as O_CLOEXEC.
-                    if (inheritability == HandleInheritability.None)
-                    {
-                        Interop.CheckIo(Interop.Sys.Fcntl.SetCloseOnExec(fileStream.SafeFileHandle));
-                    }
+                    fileStream = CreateSharedBackingObject(protections, capacity, inheritability);
                 }
             }
 
@@ -134,10 +128,10 @@ namespace System.IO.MemoryMappedFiles
                 FileAccess.Read;
         }
 
-        private static FileStream CreateSharedBackingObject(Interop.Sys.MemoryMappedProtections protections, long capacity)
+        private static FileStream CreateSharedBackingObject(Interop.Sys.MemoryMappedProtections protections, long capacity, HandleInheritability inheritability)
         {
-            return CreateSharedBackingObjectUsingMemory(protections, capacity)
-                ?? CreateSharedBackingObjectUsingFile(protections, capacity);
+            return CreateSharedBackingObjectUsingMemory(protections, capacity, inheritability)
+                ?? CreateSharedBackingObjectUsingFile(protections, capacity, inheritability);
         }
 
         // -----------------------------
@@ -145,7 +139,7 @@ namespace System.IO.MemoryMappedFiles
         // -----------------------------
 
         private static FileStream CreateSharedBackingObjectUsingMemory(
-           Interop.Sys.MemoryMappedProtections protections, long capacity)
+           Interop.Sys.MemoryMappedProtections protections, long capacity, HandleInheritability inheritability)
         {
             // The POSIX shared memory object name must begin with '/'.  After that we just want something short and unique.
             string mapName = "/corefx_map_" + Guid.NewGuid().ToString("N");
@@ -195,6 +189,13 @@ namespace System.IO.MemoryMappedFiles
                 // causing it to preemptively throw from SetLength.
                 Interop.CheckIo(Interop.Sys.FTruncate(fd, capacity));
 
+                // shm_open sets CLOEXEC implicitly.  If the inheritability requested is Inheritable, remove CLOEXEC.
+                if (inheritability == HandleInheritability.Inheritable &&
+                    Interop.Sys.Fcntl.SetFD(fd, 0) == -1)
+                {
+                    throw Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo());
+                }
+
                 // Wrap the file descriptor in a stream and return it.
                 return new FileStream(fd, TranslateProtectionsToFileAccess(protections));
             }
@@ -205,21 +206,20 @@ namespace System.IO.MemoryMappedFiles
             }
         }
 
-        private static FileStream CreateSharedBackingObjectUsingFile(Interop.Sys.MemoryMappedProtections protections, long capacity)
+        private static FileStream CreateSharedBackingObjectUsingFile(Interop.Sys.MemoryMappedProtections protections, long capacity, HandleInheritability inheritability)
         {
             // We create a temporary backing file in TMPDIR.  We don't bother putting it into subdirectories as the file exists
             // extremely briefly: it's opened/created and then immediately unlinked.
             string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
 
-            FileAccess access =
-                (protections & (Interop.Sys.MemoryMappedProtections.PROT_READ | Interop.Sys.MemoryMappedProtections.PROT_WRITE)) != 0 ? FileAccess.ReadWrite :
-                (protections & (Interop.Sys.MemoryMappedProtections.PROT_WRITE)) != 0 ? FileAccess.Write :
-                FileAccess.Read;
+            FileShare share = inheritability == HandleInheritability.None ?
+                FileShare.ReadWrite :
+                FileShare.ReadWrite | FileShare.Inheritable;
 
             // Create the backing file, then immediately unlink it so that it'll be cleaned up when no longer in use.
             // Then enlarge it to the requested capacity.
             const int DefaultBufferSize = 0x1000;
-            var fs = new FileStream(path, FileMode.CreateNew, TranslateProtectionsToFileAccess(protections), FileShare.ReadWrite, DefaultBufferSize);
+            var fs = new FileStream(path, FileMode.CreateNew, TranslateProtectionsToFileAccess(protections), share, DefaultBufferSize);
             try
             {
                 Interop.CheckIo(Interop.Sys.Unlink(path));

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -180,8 +180,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.Pipe.cs">
       <Link>Common\Interop\Unix\Interop.Fcntl.Pipe.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.SetCloseOnExec.cs">
-      <Link>Common\Interop\Unix\Interop.Fcntl.SetCloseOnExec.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.SetFD.cs">
+      <Link>Common\Interop\Unix\Interop.Fcntl.SetFD.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\CoreLib\Interop\Unix\System.Native\Interop.FLock.cs">
       <Link>Common\Interop\Unix\Interop.FLock.cs</Link>

--- a/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CrossProcess.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CrossProcess.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Threading;
 using Xunit;
 
 namespace System.IO.Pipes.Tests
@@ -16,7 +17,7 @@ namespace System.IO.Pipes.Tests
             // Then spawn another process to communicate with.
             using (var outbound = new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.Inheritable))
             using (var inbound = new AnonymousPipeServerStream(PipeDirection.In, HandleInheritability.Inheritable))
-            using (var remote = RemoteInvoke(new Func<string, string, int>(PingPong_OtherProcess), outbound.GetClientHandleAsString(), inbound.GetClientHandleAsString()))
+            using (var remote = RemoteInvoke(new Func<string, string, int>(ChildFunc), outbound.GetClientHandleAsString(), inbound.GetClientHandleAsString()))
             {
                 // Close our local copies of the handles now that we've passed them of to the other process
                 outbound.DisposeLocalCopyOfClientHandle();
@@ -30,23 +31,78 @@ namespace System.IO.Pipes.Tests
                     Assert.Equal(i, received);
                 }
             }
-        }
 
-        private static int PingPong_OtherProcess(string inHandle, string outHandle)
-        {
-            // Create the clients associated with the supplied handles
-            using (var inbound = new AnonymousPipeClientStream(PipeDirection.In, inHandle))
-            using (var outbound = new AnonymousPipeClientStream(PipeDirection.Out, outHandle))
+            int ChildFunc(string inHandle, string outHandle)
             {
-                // Repeatedly read then write a byte from and to the server
-                for (int i = 0; i < 10; i++)
+                // Create the clients associated with the supplied handles
+                using (var inbound = new AnonymousPipeClientStream(PipeDirection.In, inHandle))
+                using (var outbound = new AnonymousPipeClientStream(PipeDirection.Out, outHandle))
                 {
-                    int b = inbound.ReadByte();
-                    outbound.WriteByte((byte)b);
+                    // Repeatedly read then write a byte from and to the server
+                    for (int i = 0; i < 10; i++)
+                    {
+                        int b = inbound.ReadByte();
+                        outbound.WriteByte((byte)b);
+                    }
                 }
+                return SuccessExitCode;
             }
-            return SuccessExitCode;
         }
 
+        [Fact]
+        public void ServerClosesPipe_ClientReceivesEof()
+        {
+            using (var pipe = new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.Inheritable))
+            using (var remote = RemoteInvoke(new Func<string, int>(ChildFunc), pipe.GetClientHandleAsString()))
+            {
+                pipe.DisposeLocalCopyOfClientHandle();
+                pipe.Write(new byte[] { 1, 2, 3, 4, 5 }, 0, 5);
+
+                pipe.Dispose();
+
+                Assert.True(remote.Process.WaitForExit(30_000));
+            }
+
+            int ChildFunc(string clientHandle)
+            {
+                using (var pipe = new AnonymousPipeClientStream(PipeDirection.In, clientHandle))
+                {
+                    for (int i = 1; i <= 5; i++)
+                    {
+                        Assert.Equal(i, pipe.ReadByte());
+                    }
+                    Assert.Equal(-1, pipe.ReadByte());
+                }
+                return SuccessExitCode;
+            }
+        }
+
+        [Fact]
+        public void ClientClosesPipe_ServerReceivesEof()
+        {
+            using (var pipe = new AnonymousPipeServerStream(PipeDirection.In, HandleInheritability.Inheritable))
+            using (var remote = RemoteInvoke(new Func<string, int>(ChildFunc), pipe.GetClientHandleAsString(), new RemoteInvokeOptions { CheckExitCode = false }))
+            {
+                pipe.DisposeLocalCopyOfClientHandle();
+
+                for (int i = 1; i <= 5; i++)
+                {
+                    Assert.Equal(i, pipe.ReadByte());
+                }
+                Assert.Equal(-1, pipe.ReadByte());
+
+                remote.Process.Kill();
+            }
+
+            int ChildFunc(string clientHandle)
+            {
+                using (var pipe = new AnonymousPipeClientStream(PipeDirection.Out, clientHandle))
+                {
+                    pipe.Write(new byte[] { 1, 2, 3, 4, 5 }, 0, 5);
+                }
+                Thread.CurrentThread.Join();
+                return SuccessExitCode;
+            }
+        }
     }
 }


### PR DESCRIPTION
- AnonymousPipeServerStream accepts a HandleInheritability value.  When it's set to None, both ends of the pipe are correctly created as O_CLOEXEC to prevent them from being inherited.  However, when it's set to Inheritable, we're not marking either end of the pipe as O_CLOEXEC, which means both file descriptors are inherited by the child process.  While technically that meets the letter of the law as to what the API requires, in the 99.9% use case the server handle really isn't intended to be inherited, and rather it's only the client handle that is; by allowing the server handle to also be inherited, when the server closes its end of the pipe, the client doesn't get an EOF or broken pipe, because it still has its dup of the file descriptor open, and will for the lifetime of the process.  The fix is to always mark the server file descriptor as O_CLOEXEC even if the inheritability is set to Inheritable. (Note that this is technically a breaking change, in that the server handle is no longer inheritable when it used to be, but I think that's the better of the two options.)
- NamedPipeServer/ClientStream is built on Socket.  Previously, sockets defaulted to being inheritable, but we changed that for .NET Core 3.0, such that they're now not inherited.  But the pipe code was written expecting the default of Inheritable, and has an if block that says "if inheritability requested was not inheritable, then set O_CLOEXEC"; that now needs to be flipped to say "if inheritability was requested, clear O_CLOEXEC".
- MemoryMappedFile has a similar issue.  It tries to use shm_open to create the backing store, but shm_open defaults to having O_CLOEXEC set, and so if Inheritabile was requested, we're neglecting to clear the O_CLOEXEC flag.  However, while I've fixed this, it's unlikely to ever be a real issue for someone, since we don't expose any APIs that let you reconstruct a MemoryMappedFile from a handle.

Fixes https://github.com/dotnet/corefx/issues/34910
cc: @JeremyKuhne, @tmds, @danmosemsft 