### PR TITLE
Bring back hooks to AddRuntimeProjectReference from buildtools

### DIFF
--- a/eng/referenceFromRuntime.targets
+++ b/eng/referenceFromRuntime.targets
@@ -9,9 +9,23 @@
       <ReferenceCopyLocalPaths Condition="'%(ReferenceFromRuntime.Private)' == 'true'" Include="@(ReferenceFromRuntime->'$(RuntimePath)%(Identity).dll')" />
     </ItemGroup>
   </Target>
+  
+  <PropertyGroup>
+    <PrepareProjectReferencesDependsOn>
+      AddRuntimeProjectReference;
+      $(PrepareProjectReferencesDependsOn);
+    </PrepareProjectReferencesDependsOn>
+    <ResolveReferencesDependsOn>
+      AddRuntimeProjectReference;
+      $(ResolveReferencesDependsOn);
+    </ResolveReferencesDependsOn>
+    <CleanDependsOn>
+      AddRuntimeProjectReference;
+      $(CleanDependsOn)
+    </CleanDependsOn>
+  </PropertyGroup>
 
   <Target Name="AddRuntimeProjectReference"
-          BeforeTargets="AddReferencesDynamically"
           Condition="'$(IsTestProject)'!='true' AND '@(ReferenceFromRuntime)' != ''">
     <Error Condition="('$(IsReferenceAssembly)' != 'true' OR '$(AllowReferenceFromRuntime)' == 'true') AND '$(RuntimeProjectFile)' == ''" Text="RuntimeProjectFile must be specified when using ReferenceFromRuntime from source projects." />
     <Error Condition="'$(IsReferenceAssembly)' == 'true' AND '$(AllowReferenceFromRuntime)' != 'true'" Text="ReferenceFromRuntime may not be used from reference assemblies." />

--- a/eng/references.targets
+++ b/eng/references.targets
@@ -34,5 +34,6 @@
       </Reference>
     </ItemGroup>
   </Target>
+
   <Target Name="AddReferencesDynamically" BeforeTargets="BeforeResolveReferences;ResolveAssemblyReferences" />
 </Project>


### PR DESCRIPTION
After the buildtools removal, the way we are hooking up AddRuntimeProjectReference is not adding the project reference to runtime.depproj before the right set of targets so that the right references are expanded. So if you try to build a project manually with /t:rebuild or /t:build, and that project has a `ReferenceFromRuntime="System.Private.Corelib"`, it would fail:

`
E:\repos\corefx3\corefx\eng\referenceFromRuntime.targets(62,5): error : Could not resolve ReferenceFromRuntime item(s) 'System.Private.CoreLib' from 'E:\repos\corefx3\corefx\\external\runtime\runtime.depproj'. [E:\repos\corefx3\corefx\src\System.Runtime\src\System.Runtime.csproj]
`