### PR TITLE
Diable System.Net.Http.FunctionalTests parallel execution on UAP run

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -149,6 +149,7 @@
     <Compile Include="MultiInterfaceReadOnlyStream.cs" />
     <Compile Include="MultiInterfaceStreamContent.cs" />
     <Compile Include="PostScenarioUWPTest.cs" />
+    <Compile Include="XUnitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">

--- a/src/System.Net.Http/tests/FunctionalTests/XUnitAssemblyAttributes.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/XUnitAssemblyAttributes.cs
@@ -4,6 +4,5 @@
 
 using Xunit;
 
-// [ActiveIssue(20103)]: Disabling parallel execution of HttpListener tests
-// until all of the hangs can be addressed
+// [ActiveIssue(35002)]: Disabling parallel execution of System.Net.Http.FunctionalTests
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/System.Net.Http/tests/FunctionalTests/XUnitAssemblyAttributes.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/XUnitAssemblyAttributes.cs
@@ -4,5 +4,6 @@
 
 using Xunit;
 
-// [ActiveIssue(35002)]: Disabling parallel execution of System.Net.Http.FunctionalTests
+// [ActiveIssue(20103)]: Disabling parallel execution of HttpListener tests
+// until all of the hangs can be addressed
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/System.Net.Http/tests/FunctionalTests/XUnitAssemblyAttributes.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/XUnitAssemblyAttributes.cs
@@ -4,5 +4,5 @@
 
 using Xunit;
 
-// [ActiveIssue(35002)]: Disabling parallel execution of System.Net.Http.FunctionalTests
-[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]
+// [ActiveIssue(35002)]: Disable parallel execution of System.Net.Http.FunctionalTests on UAP test runs
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true)]

--- a/src/System.Net.HttpListener/tests/XUnitAssemblyAttributes.cs
+++ b/src/System.Net.HttpListener/tests/XUnitAssemblyAttributes.cs
@@ -4,5 +4,6 @@
 
 using Xunit;
 
-// [ActiveIssue(35002)]: Disabling parallel execution of System.Net.Http.FunctionalTests
+// [ActiveIssue(20103)]: Disabling parallel execution of HttpListener tests
+// until all of the hangs can be addressed
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]


### PR DESCRIPTION
Related: #35002 

EDIT: I want to mention that, before the change, running `System.Net.Http.FunctionalTests` test suites with Outerloop tests locally takes around 17s. After the change, it's around 58s.