### PR TITLE
Add TypeConverterAttribute tests and fix (compat) bugs

### DIFF
--- a/src/System.ObjectModel/src/System/ComponentModel/TypeConverterAttribute.cs
+++ b/src/System.ObjectModel/src/System/ComponentModel/TypeConverterAttribute.cs
@@ -39,6 +39,11 @@ namespace System.ComponentModel
         /// </summary>
         public TypeConverterAttribute(Type type)
         {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
             ConverterTypeName = type.AssemblyQualifiedName;
         }
 
@@ -50,6 +55,11 @@ namespace System.ComponentModel
         /// </summary>
         public TypeConverterAttribute(string typeName)
         {
+            if (typeName == null)
+            {
+                throw new ArgumentNullException(nameof(typeName));
+            }
+
             ConverterTypeName = typeName;
         }
 

--- a/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -24,6 +24,7 @@
     </Compile>
     <Compile Include="ComponentModel\INotifyPropertyChangingTests.cs" />
     <Compile Include="ComponentModel\PropertyChangingEventArgsTests.cs" />
+    <Compile Include="System\ComponentModel\TypeConverterAttributeTests.cs" />
     <Compile Include="KeyedCollection\TestMethods.cs" />
     <Compile Include="KeyedCollection\ConcreteTestClasses.cs" />
     <Compile Include="KeyedCollection\Utils.cs" />

--- a/src/System.ObjectModel/tests/System/ComponentModel/TypeConverterAttributeTests.cs
+++ b/src/System.ObjectModel/tests/System/ComponentModel/TypeConverterAttributeTests.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.ComponentModel.Tests
+{
+    public class TypeConverterAttributeTests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            var attribute = new TypeConverterAttribute();
+            Assert.Empty(attribute.ConverterTypeName);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("typeName")]
+        public void Ctor_String(string typeName)
+        {
+            var attribute = new TypeConverterAttribute(typeName);
+            Assert.Equal(typeName, attribute.ConverterTypeName);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework has a bug and throws NRE because it uses the typeName in a Debug.Assert")]
+        public void Ctor_NullStringNetCore_ThrowsArgumentNullException()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("typeName", () => new TypeConverterAttribute((string)null));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, ".NET Framework has a bug and throws NRE because it uses the typeName in a Debug.Assert")]
+        public void Ctor_NullStringNetFramework_ThrowsNullReferenceException()
+        {
+            Assert.Throws<NullReferenceException>(() => new TypeConverterAttribute((string)null));
+        }
+
+        [Theory]
+        [InlineData(typeof(int))]
+        public void Ctor_Type(Type type)
+        {
+            var attribute = new TypeConverterAttribute(type);
+            Assert.Equal(type.AssemblyQualifiedName, attribute.ConverterTypeName);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework has a bug and throws NRE")]
+        public void Ctor_NullTypeNetCore_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("type", () => new TypeConverterAttribute((Type)null));
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, ".NET Framework has a bug and throws NRE")]
+        public void Ctor_NullTypeNetFramework_ThrowsNullReferenceException()
+        {
+            Assert.Throws<NullReferenceException>(() => new TypeConverterAttribute((Type)null));
+        }
+
+        [Fact]
+        public void Default_Get_ReturnsExpected()
+        {
+            Assert.Empty(TypeConverterAttribute.Default.ConverterTypeName);
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            var attribute = new TypeConverterAttribute("typeName");
+            yield return new object[] { attribute, attribute, true };
+            yield return new object[] { attribute, new TypeConverterAttribute("typeName"), true };
+            yield return new object[] { attribute, new TypeConverterAttribute("otherTypeName"), false };
+
+            yield return new object[] { new TypeConverterAttribute("typeName"), new object(), false };
+            yield return new object[] { new TypeConverterAttribute("typeName"), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public void Equal_Invoke_ReturnsExpected(TypeConverterAttribute attribute, object other, bool expected)
+        {
+            Assert.Equal(expected, attribute.Equals(other));
+        }
+
+        [Fact]
+        public void GetHashCode_Invoke_ReturnsExpected()
+        {
+            var attribute = new TypeConverterAttribute("typeName");
+            Assert.Equal("typeName".GetHashCode(), attribute.GetHashCode());
+        }
+    }
+}


### PR DESCRIPTION
.NET Framework (https://referencesource.microsoft.com/#System/compmod/system/componentmodel/TypeConverterAttribute.cs,70f7fb9a74c8db1f) has the following code

```cs
        public TypeConverterAttribute(string typeName) {
            string temp = typeName.ToUpper(CultureInfo.InvariantCulture);
            Debug.Assert(temp.IndexOf(".DLL") == -1, "Came across: " + typeName + " . Please remove the .dll extension");
            this.typeName = typeName;
        }
```

The debug assertion is obviously invalid as this is public API, but we've removed the `temp` string which would throw NRE if `typeName` was null.

This means that by removing the assertion historically, we meant that NRE doesn't throw anymore and now successfully constructs. But this means that other things like `GetHashCode` throw NRE down the line.
There are a couple fixes for this:
1. Throw NRE manually - not ideal and a bit weird
2. Throw ANE - seems good, but could break compat
3. Set `ConverterTypeName` to `string.Empty` if `typeName` is null
4. Do nothing and fix the implementation of `GetHashCode` down the line

I went with option 2, as this makes most sense because I don't think people would expect `TypeConverterAttribute.ConverterTypeName` to return null. Furthermore, this situation was blocked previously as the NRE was thrown.

I also fixed an obvious NRE that is thrown from `new TypeConverterAttribute((Type)null)` which is an obvious win