### PR TITLE
Remove stale warning 420 pragmas

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -461,9 +461,8 @@ nameof(boundedCapacity), boundedCapacity,
                         while (_currentAdders != COMPLETE_ADDING_ON_MASK) spinner.SpinOnce();
                         throw new InvalidOperationException(SR.BlockingCollection_Completed);
                     }
-#pragma warning disable 0420 // No warning for Interlocked.xxx if compiled with new managed compiler (Roslyn)
+
                     if (Interlocked.CompareExchange(ref _currentAdders, observedAdders + 1, observedAdders) == observedAdders)
-#pragma warning restore 0420
                     {
                         Debug.Assert((observedAdders + 1) <= (~COMPLETE_ADDING_ON_MASK), "The number of concurrent adders thread exceeded the maximum limit.");
                         break;
@@ -517,9 +516,7 @@ nameof(boundedCapacity), boundedCapacity,
                 {
                     // decrement the adders count
                     Debug.Assert((_currentAdders & ~COMPLETE_ADDING_ON_MASK) > 0);
-#pragma warning disable 0420 // No warning for Interlocked.xxx if compiled with new managed compiler (Roslyn)
                     Interlocked.Decrement(ref _currentAdders);
-#pragma warning restore 0420
                 }
             }
             return waitForSemaphoreWasSuccessful;
@@ -1489,9 +1486,8 @@ nameof(boundedCapacity), boundedCapacity,
                     while (_currentAdders != COMPLETE_ADDING_ON_MASK) spinner.SpinOnce();
                     return;
                 }
-#pragma warning disable 0420 // No warning for Interlocked.xxx if compiled with new managed compiler (Roslyn)
+
                 if (Interlocked.CompareExchange(ref _currentAdders, observedAdders | COMPLETE_ADDING_ON_MASK, observedAdders) == observedAdders)
-#pragma warning restore 0420
                 {
                     spinner.Reset();
                     while (_currentAdders != COMPLETE_ADDING_ON_MASK) spinner.SpinOnce();

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -273,7 +273,6 @@ namespace System.Collections.Concurrent
             ToList().CopyTo(array, index);
         }
 
-#pragma warning disable 0420 // No warning for Interlocked.xxx if compiled with new managed compiler (Roslyn)
         /// <summary>
         /// Inserts an object at the top of the <see cref="ConcurrentStack{T}"/>.
         /// </summary>
@@ -662,7 +661,6 @@ namespace System.Collections.Concurrent
                 }
             }
         }
-#pragma warning restore 0420
 
         /// <summary>
         /// Local helper function to copy the popped elements into a given collection

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
@@ -630,7 +630,6 @@ namespace System.Collections.Concurrent
                     return ((InternalPartitionEnumerable)this).GetEnumerator();
                 }
 
-#pragma warning disable 0420 // No warning for Interlocked.xxx if compiled with new managed compiler (Roslyn)
                 ///////////////////
                 //
                 // Used by GrabChunk_Buffered()
@@ -939,8 +938,11 @@ namespace System.Collections.Concurrent
                     {
                         _localList = new KeyValuePair<long, TSource>[_maxChunkSize];
                     }
+
+#pragma warning disable 0420 // TODO: https://github.com/dotnet/corefx/issues/35022
                     // make the actual call to the enumerable that grabs a chunk
                     return _enumerable.GrabChunk(_localList, requestedChunkSize, ref _currentChunkSize.Value);
+#pragma warning restore 0420
                 }
 
                 /// <summary>
@@ -987,7 +989,6 @@ namespace System.Collections.Concurrent
                 }
             }
             #endregion
-#pragma warning restore 0420
         }
         #endregion
 

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AggregateCatalog.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AggregateCatalog.cs
@@ -181,10 +181,7 @@ namespace System.ComponentModel.Composition.Hosting
             {
                 if (disposing)
                 {
-                    // NOTE : According to https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0420, the warning is bogus when used with Interlocked API.
-#pragma warning disable 420
                     if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
-#pragma warning restore 420
                     {
                         _catalogs.Dispose();
                     }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AggregateExportProvider.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AggregateExportProvider.cs
@@ -103,10 +103,7 @@ namespace System.ComponentModel.Composition.Hosting
         {
             if (disposing)
             {
-                // NOTE : According to https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0420, the warning is bogus when used with Interlocked API.
-#pragma warning disable 420
                 if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
-#pragma warning restore 420
                 {
                     foreach (ExportProvider provider in _providers)
                     {

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionScopeDefinition.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionScopeDefinition.cs
@@ -87,10 +87,7 @@ namespace System.ComponentModel.Composition.Hosting
             {
                 if (disposing)
                 {
-                    // NOTE : According to https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0420, the warning is bogus when used with Interlocked API.
-#pragma warning disable 420
                     if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
-#pragma warning restore 420
                     {
                         INotifyComposablePartCatalogChanged notifyCatalog = _catalog as INotifyComposablePartCatalogChanged;
                         if (notifyCatalog != null)

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ComposablePartCatalog.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ComposablePartCatalog.cs
@@ -60,10 +60,7 @@ namespace System.ComponentModel.Composition.Primitives
                 {
                     // Guarantee one time only set _queryableParts
                     var p = this.AsQueryable();
-                    // NOTE : According to https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0420, the warning is bogus when used with Interlocked API.
-#pragma warning disable 420
                     Interlocked.CompareExchange(ref _queryableParts, p, null);
-#pragma warning restore 420
                     if (_queryableParts == null)
                     {
                         throw new Exception(SR.Diagnostic_InternalExceptionMessage);

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/Export.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/Export.cs
@@ -205,11 +205,7 @@ namespace System.ComponentModel.Composition.Primitives
                 if (_exportedValue == Export._EmptyValue)
                 {
                     object exportedValue = GetExportedValueCore();
-
-                    // NOTE : According to https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0420, the warning is bogus when used with Interlocked API.
-#pragma warning disable 420
                     Interlocked.CompareExchange(ref _exportedValue, exportedValue, Export._EmptyValue);
-#pragma warning restore 420
                 }
 
                 return _exportedValue;

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/DisposableReflectionComposablePart.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/DisposableReflectionComposablePart.cs
@@ -35,10 +35,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
 
         void IDisposable.Dispose()
         {
-            // NOTE : According to https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0420, the warning is bogus when used with Interlocked API.
-#pragma warning disable 420
             if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
-#pragma warning restore 420
             {
                 ReleaseInstanceIfNecessary(CachedInstance);
             }

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/SafeBitVector32.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/SafeBitVector32.cs
@@ -32,10 +32,7 @@ namespace System.Configuration
                     if (value) newData = oldData | bit;
                     else newData = oldData & ~bit;
 
-#pragma warning disable 0420
                     int result = Interlocked.CompareExchange(ref _data, newData, oldData);
-#pragma warning restore 0420
-
                     if (result == oldData) break;
                 }
             }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -2796,8 +2796,6 @@ namespace System.Data.SqlClient
             }
         }
 
-#pragma warning disable 0420 // a reference to a volatile field will not be treated as volatile
-
         public void WriteAsyncCallback(PacketHandle packet, uint sniError)
         {
             WriteAsyncCallback(IntPtr.Zero, packet, sniError);
@@ -2885,8 +2883,6 @@ namespace System.Data.SqlClient
             }
         }
 
-#pragma warning restore 0420
-
         /////////////////////////////////////////
         // Network/Packet Writing & Processing //
         /////////////////////////////////////////
@@ -2923,13 +2919,11 @@ namespace System.Data.SqlClient
         internal Task WaitForAccumulatedWrites()
         {
             // Checked for stored exceptions
-#pragma warning disable 420 // A reference to a volatile field will not be treated as volatile - Disabling since the Interlocked APIs are volatile aware
             var delayedException = Interlocked.Exchange(ref _delayedWriteAsyncCallbackException, null);
             if (delayedException != null)
             {
                 throw delayedException;
             }
-#pragma warning restore 420
 
             if (_asyncWriteCount == 0)
             {
@@ -2949,13 +2943,11 @@ namespace System.Data.SqlClient
             }
 
             // Check for stored exceptions
-#pragma warning disable 420 // A reference to a volatile field will not be treated as volatile - Disabling since the Interlocked APIs are volatile aware
             delayedException = Interlocked.Exchange(ref _delayedWriteAsyncCallbackException, null);
             if (delayedException != null)
             {
                 throw delayedException;
             }
-#pragma warning restore 420
 
             // If there are no outstanding writes, see if we can shortcut and return null
             if ((_asyncWriteCount == 0) && ((!task.IsCompleted) || (task.Exception == null)))
@@ -3212,8 +3204,6 @@ namespace System.Data.SqlClient
             }
         }
 
-#pragma warning disable 0420 // a reference to a volatile field will not be treated as volatile
-
         private Task SNIWritePacket(PacketHandle packet, out uint sniError, bool canAccumulate, bool callerHasConnectionLock)
         {
             // Check for a stored exception
@@ -3350,8 +3340,6 @@ namespace System.Data.SqlClient
         internal abstract bool IsValidPacket(PacketHandle packetPointer);
 
         internal abstract uint WritePacket(PacketHandle packet, bool sync);
-
-#pragma warning restore 0420
 
         // Sends an attention signal - executing thread will consume attn.
         internal void SendAttention(bool mustTakeWriteLock = false)

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -5,12 +5,6 @@
 using System.Threading;
 using System.Collections.Generic;
 
-// TODO when we upgrade to C# V6 you can remove this.  
-// warning CS0420: 'P.x': a reference to a volatile field will not be treated as volatile
-// This happens when you pass a _subcribers (a volatile field) to interlocked operations (which are byref). 
-// This was fixed in C# V6.  
-#pragma warning disable 0420
-
 namespace System.Diagnostics
 {
     /// <summary>

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Channels/AsynchronousChannel.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Channels/AsynchronousChannel.cs
@@ -300,9 +300,7 @@ namespace System.Linq.Parallel
             // write; the CLR 2.0 memory model ensures the write won't move before the write to the
             // corresponding element, so a consumer won't see the new index but the corresponding
             // element in the array as empty.
-#pragma warning disable 0420
             Interlocked.Exchange(ref _producerBufferIndex, (bufferIndex + 1) % _buffer.Length);
-#pragma warning restore 0420
 
             // (If there is a consumer waiting, we have to ensure to signal the event. Unfortunately,
             // this requires that we issue a memory barrier: We need to guarantee that the write to
@@ -338,9 +336,7 @@ namespace System.Linq.Parallel
                 // very quickly, suddenly seeing an empty queue. This would lead to deadlock
                 // if we aren't careful. Therefore we check the empty/full state AGAIN after
                 // setting our flag to see if a real wait is warranted.
-#pragma warning disable 0420
                 Interlocked.Exchange(ref _producerIsWaiting, 1);
-#pragma warning restore 0420
 
                 // (We have to prevent the reads that go into determining whether the buffer
                 // is full from moving before the write to the producer-wait flag. Hence the CAS.)
@@ -557,9 +553,7 @@ namespace System.Linq.Parallel
                 // very quickly, suddenly seeing a full queue. This would lead to deadlock
                 // if we aren't careful. Therefore we check the empty/full state AGAIN after
                 // setting our flag to see if a real wait is warranted.
-#pragma warning disable 0420
                 Interlocked.Exchange(ref _consumerIsWaiting, 1);
-#pragma warning restore 0420
 
                 // (We have to prevent the reads that go into determining whether the buffer
                 // is full from moving before the write to the producer-wait flag. Hence the CAS.)
@@ -619,9 +613,7 @@ namespace System.Linq.Parallel
             // write; the CLR 2.0 memory model ensures the write won't move before the write to the
             // corresponding element, so a consumer won't see the new index but the corresponding
             // element in the array as empty.
-#pragma warning disable 0420
             Interlocked.Exchange(ref _consumerBufferIndex, (consumerBufferIndex + 1) % _buffer.Length);
-#pragma warning restore 0420
 
             // (Unfortunately, this whole sequence requires a memory barrier: We need to guarantee
             // that the write to _consumerBufferIndex doesn't pass the read of the wait-flags; the CLR memory

--- a/src/System.Runtime.Caching/src/System/Runtime/Caching/SafeBitVector32.cs
+++ b/src/System.Runtime.Caching/src/System/Runtime/Caching/SafeBitVector32.cs
@@ -37,10 +37,7 @@ namespace System.Runtime.Caching
                         newData = oldData & ~bit;
                     }
 
-#pragma warning disable 0420
                     int result = Interlocked.CompareExchange(ref _data, newData, oldData);
-#pragma warning restore 0420
-
                     if (result == oldData)
                     {
                         break;
@@ -69,10 +66,7 @@ namespace System.Runtime.Caching
                     return false;
                 }
 
-#pragma warning disable 0420
                 int result = Interlocked.CompareExchange(ref _data, newData, oldData);
-#pragma warning restore 0420
-
                 if (result == oldData)
                 {
                     return true;

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationAsyncResult.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationAsyncResult.cs
@@ -69,8 +69,6 @@ namespace System.IO
         }
 
 
-#pragma warning disable 420  // "a reference to a volatile field will not be treated as volatile"
-
         public WaitHandle AsyncWaitHandle
         {
             get
@@ -96,9 +94,6 @@ namespace System.IO
                 return wh;
             }
         }
-
-#pragma warning restore 420  // "a reference to a volatile field will not be treated as volatile"
-
 
         public bool CompletedSynchronously
         {

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/TaskToAsyncInfoAdapter.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/TaskToAsyncInfoAdapter.cs
@@ -21,10 +21,6 @@ namespace System.Threading.Tasks
                                                                                 where TCompletedHandler : class
                                                                                 where TProgressHandler : class
     {
-        // This class uses interlocked operations on volatile fields, and this pragma suppresses the compiler's complaint
-        // that passing a volatile by ref to a function removes the volatility. That's not necessary for interlocked.
-#pragma warning disable 0420
-
         #region Private Types, Statics and Constants
 
         // ! THIS DIAGRAM ILLUSTRATES THE CONSTANTS BELOW. UPDATE THIS IF UPDATING THE CONSTANTS BELOW!:
@@ -1023,9 +1019,6 @@ namespace System.Threading.Tasks
             }
         }
         #endregion Implementation of IAsyncInfo
-
-#pragma warning restore 0420
-
     }  // class TaskToAsyncInfoAdapter<TCompletedHandler, TProgressHandler, TResult, TProgressInfo>
 }  // namespace
 

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/ConcurrentQueue.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/ConcurrentQueue.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-#pragma warning disable 0420
-
 
 // =+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
 //

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
@@ -769,9 +769,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
 #endif
 
                 // Start the task handling scheduling exceptions
-#pragma warning disable 0420
                 Exception exception = Common.StartTaskSafe(_taskForOutputProcessing, _dataflowBlockOptions.TaskScheduler);
-#pragma warning restore 0420
                 if (exception != null)
                 {
                     // First, log the exception while the processing state is dirty which is preventing the block from completing.

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/SpscTargetCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/SpscTargetCore.cs
@@ -18,7 +18,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security;
 
-#pragma warning disable 0420 // turn off warning for passing volatiles to interlocked operations
 namespace System.Threading.Tasks.Dataflow.Internal
 {
     // SpscTargetCore provides a fast target core for use in blocks that will only have single-producer-single-consumer
@@ -313,7 +312,9 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // the exception because this method could be accessed concurrently
             // by the producer and consumer, a producer calling Fault and the 
             // processing task processing the user delegate which might throw.
+#pragma warning disable 0420
             lock (LazyInitializer.EnsureInitialized(ref _exceptions, () => new List<Exception>()))
+#pragma warning restore 0420
             {
                 _exceptions.Add(exception);
             }

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
@@ -155,8 +155,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
                 {
                     Debug.Assert(_numberOfOutstandingOperations > 0 || !storeExceptionEvenIfAlreadyCompleting,
                                 "Calls with storeExceptionEvenIfAlreadyCompleting==true may only be coming from processing task.");
-
-#pragma warning disable 0420
                     Common.AddException(ref _exceptions, exception, unwrapInnerExceptions);
                 }
 

--- a/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelLoopState.cs
+++ b/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelLoopState.cs
@@ -13,7 +13,6 @@ using System.Diagnostics;
 
 // Prevents compiler warnings/errors regarding the use of ref params in Interlocked methods
 
-#pragma warning disable 0420
 namespace System.Threading.Tasks
 {
     /// <summary>
@@ -624,5 +623,3 @@ namespace System.Threading.Tasks
         public long? LowestBreakIteration { get { return _lowestBreakIteration; } }
     }
 }
-
-#pragma warning restore 0420

--- a/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelRangeManager.cs
+++ b/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelRangeManager.cs
@@ -11,7 +11,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
-#pragma warning disable 0420
 namespace System.Threading.Tasks
 {
     /// <summary>
@@ -299,4 +298,3 @@ namespace System.Threading.Tasks
         }
     }
 }
-#pragma warning restore 0420

--- a/src/System.Threading/src/System/Threading/Barrier.cs
+++ b/src/System.Threading/src/System/Threading/Barrier.cs
@@ -267,9 +267,7 @@ namespace System.Threading
                 newCurrentTotal |= SENSE_MASK;
             }
 
-#pragma warning disable 0420
             return Interlocked.CompareExchange(ref _currentTotalCount, newCurrentTotal, currentTotal) == currentTotal;
-#pragma warning restore 0420
         }
 
         /// <summary>

--- a/src/System.Threading/src/System/Threading/CountdownEvent.cs
+++ b/src/System.Threading/src/System/Threading/CountdownEvent.cs
@@ -182,9 +182,8 @@ namespace System.Threading
             {
                 throw new InvalidOperationException(SR.CountdownEvent_Decrement_BelowZero);
             }
-#pragma warning disable 0420
+
             int newCount = Interlocked.Decrement(ref _currentCount);
-#pragma warning restore 0420
             if (newCount == 0)
             {
                 _event.Set();
@@ -237,11 +236,7 @@ namespace System.Threading
                     throw new InvalidOperationException(SR.CountdownEvent_Decrement_BelowZero);
                 }
 
-                // This disables the "CS0420: a reference to a volatile field will not be treated as volatile" warning
-                // for this statement.  This warning is clearly senseless for Interlocked operations.
-#pragma warning disable 0420
                 if (Interlocked.CompareExchange(ref _currentCount, observedCount - signalCount, observedCount) == observedCount)
-#pragma warning restore 0420
                 {
                     break;
                 }
@@ -351,11 +346,7 @@ namespace System.Threading
                     throw new InvalidOperationException(SR.CountdownEvent_Increment_AlreadyMax);
                 }
 
-                // This disables the "CS0420: a reference to a volatile field will not be treated as volatile" warning
-                // for this statement.  This warning is clearly senseless for Interlocked operations.
-#pragma warning disable 0420
                 if (Interlocked.CompareExchange(ref _currentCount, observedCount + signalCount, observedCount) == observedCount)
-#pragma warning restore 0420
                 {
                     break;
                 }


### PR DESCRIPTION
It used to be that the CS0420 warning ("a reference to a volatile field will not be treated as volatile") would fire when a volatile was used with an Interlocked.* operation.  That warning was unnecessary, as Interlocked.* would itself provide the relevant barriers, and these functions were special cased in Roslyn a long time ago.  But there are still lots of places where pragmas disabling the warning have stuck around.  I'm deleting them.