### PR TITLE
Add build badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # .NET Core Libraries (CoreFX)
 
+[![Build Status](https://dev.azure.com/dnceng/internal/_apis/build/status/dotnet/corefx/corefx-official?branchName=master)](https://dev.azure.com/dnceng/internal/_build/latest?definitionId=283&branchName=master)
+
 This repo contains the library implementation (called "CoreFX") for .NET Core. It includes System.Collections, System.IO, System.Xml, and many other components.
 The corresponding [.NET Core Runtime repo](https://github.com/dotnet/coreclr) (called "CoreCLR") contains the runtime implementation for .NET Core. It includes RyuJIT, the .NET GC, and many other components.
 Runtime-specific library code ([System.Private.CoreLib](https://github.com/dotnet/coreclr/tree/master/src/System.Private.CoreLib)) lives in the CoreCLR repo. It needs to be built and versioned in tandem with the runtime. The rest of CoreFX is agnostic of runtime-implementation and can be run on any compatible .NET runtime (e.g. [CoreRT](https://github.com/dotnet/corert)).


### PR DESCRIPTION
Note that not all the badges work because of an Azure Devops bug when there are multiple jobs with the same display name. In this case for Windows and Linux.

I don't know if this is the layout for the table that we want or if we want one table per OS. Ideas are welcome :smile:

Preview: https://github.com/safern/corefx/tree/AddBadges

Also, I moved the badges up, per Dan's request.

cc: @karelz @danmosemsft @ViktorHofer @ericstj 