### PR TITLE
Fix typeconverter NullReferenceExceptions

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -32,7 +32,7 @@ namespace System
         public static void Throws<T>(string netCoreParamName, string netFxParamName, System.Action action) where T : System.ArgumentException { }
         public static void Throws<T>(string netCoreParamName, string netFxParamName, System.Func<object> testCode) where T : System.ArgumentException { }
         public static System.Exception Throws<TNetCoreExceptionType, TNetFxExceptionType>(System.Action action) where TNetCoreExceptionType : System.Exception where TNetFxExceptionType : System.Exception { throw null; }
-        public static void Throws<TNetCoreExceptionType, TNetFxExceptionType>(string paramName, System.Action action) where TNetCoreExceptionType : System.ArgumentException where TNetFxExceptionType : System.ArgumentException { }
+        public static void Throws<TNetCoreExceptionType, TNetFxExceptionType>(string paramName, System.Action action) where TNetCoreExceptionType : System.ArgumentException where TNetFxExceptionType : System.Exception { }
         public static void Throws<TNetCoreExceptionType, TNetFxExceptionType>(string netCoreParamName, string netFxParamName, System.Action action) where TNetCoreExceptionType : System.ArgumentException where TNetFxExceptionType : System.ArgumentException { }
     }
     public static partial class PlatformDetection

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/AttributeCollection.cs
@@ -54,7 +54,7 @@ namespace System.ComponentModel
             }
         }
 
-        protected AttributeCollection()
+        protected AttributeCollection() : this(Array.Empty<Attribute>())
         {
         }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerCollection.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerCollection.cs
@@ -37,7 +37,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public DesignerCollection(IList designers)
         {
-            _designers = designers;
+            _designers = designers ?? new ArrayList();
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContext.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContext.cs
@@ -32,6 +32,11 @@ namespace System.ComponentModel.Design
         /// </summary>
         public override void SetSavedLicenseKey(Type type, string key)
         {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
             _savedLicenseKeys[type.AssemblyQualifiedName] = key;
         }
     }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/MenuCommand.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/MenuCommand.cs
@@ -165,7 +165,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public override string ToString()
         {
-            string str = CommandID.ToString() + " : ";
+            string str = (CommandID?.ToString() ?? "") + " : ";
             if ((_status & SUPPORTED) != 0)
             {
                 str += "Supported";

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/DesignerSerializerAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/DesignerSerializerAttribute.cs
@@ -19,6 +19,15 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public DesignerSerializerAttribute(Type serializerType, Type baseSerializerType)
         {
+            if (serializerType == null)
+            {
+                throw new ArgumentNullException(nameof(serializerType));
+            }
+            if (baseSerializerType == null)
+            {
+                throw new ArgumentNullException(nameof(baseSerializerType));
+            }
+
             SerializerTypeName = serializerType.AssemblyQualifiedName;
             SerializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
         }
@@ -28,6 +37,11 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public DesignerSerializerAttribute(string serializerTypeName, Type baseSerializerType)
         {
+            if (baseSerializerType == null)
+            {
+                throw new ArgumentNullException(nameof(baseSerializerType));
+            }
+
             SerializerTypeName = serializerTypeName;
             SerializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
         }
@@ -64,7 +78,7 @@ namespace System.ComponentModel.Design.Serialization
             {
                 if (_typeId == null)
                 {
-                    string baseType = SerializerBaseTypeName;
+                    string baseType = SerializerBaseTypeName ?? string.Empty;
                     int comma = baseType.IndexOf(',');
                     if (comma != -1)
                     {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/RootDesignerSerializerAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/Serialization/RootDesignerSerializerAttribute.cs
@@ -20,6 +20,15 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public RootDesignerSerializerAttribute(Type serializerType, Type baseSerializerType, bool reloadable)
         {
+            if (serializerType == null)
+            {
+                throw new ArgumentNullException(nameof(serializerType));
+            }
+            if (baseSerializerType == null)
+            {
+                throw new ArgumentNullException(nameof(baseSerializerType));
+            }
+
             SerializerTypeName = serializerType.AssemblyQualifiedName;
             SerializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
             Reloadable = reloadable;
@@ -30,6 +39,11 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public RootDesignerSerializerAttribute(string serializerTypeName, Type baseSerializerType, bool reloadable)
         {
+            if (baseSerializerType == null)
+            {
+                throw new ArgumentNullException(nameof(baseSerializerType));
+            }
+
             SerializerTypeName = serializerTypeName;
             SerializerBaseTypeName = baseSerializerType.AssemblyQualifiedName;
             Reloadable = reloadable;
@@ -75,7 +89,7 @@ namespace System.ComponentModel.Design.Serialization
             {
                 if (_typeId == null)
                 {
-                    string baseType = SerializerBaseTypeName;
+                    string baseType = SerializerBaseTypeName ?? string.Empty;
                     int comma = baseType.IndexOf(',');
                     if (comma != -1)
                     {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DesignerAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DesignerAttribute.cs
@@ -30,6 +30,11 @@ namespace System.ComponentModel
         /// </summary>
         public DesignerAttribute(Type designerType)
         {
+            if (designerType == null)
+            {
+                throw new ArgumentNullException(nameof(designerType));
+            }
+
             DesignerTypeName = designerType.AssemblyQualifiedName;
             DesignerBaseTypeName = typeof(IDesigner).FullName;
         }
@@ -50,7 +55,16 @@ namespace System.ComponentModel
         /// </summary>
         public DesignerAttribute(string designerTypeName, Type designerBaseType)
         {
-            DesignerTypeName = designerTypeName ?? throw new ArgumentNullException(nameof(designerTypeName));
+            if (designerTypeName == null)
+            {
+                throw new ArgumentNullException(nameof(designerTypeName));
+            }
+            if (designerBaseType == null)
+            {
+                throw new ArgumentNullException(nameof(designerBaseType));
+            }
+
+            DesignerTypeName = designerTypeName;
             DesignerBaseTypeName = designerBaseType.AssemblyQualifiedName;
         }
 
@@ -60,6 +74,15 @@ namespace System.ComponentModel
         /// </summary>
         public DesignerAttribute(Type designerType, Type designerBaseType)
         {
+            if (designerType == null)
+            {
+                throw new ArgumentNullException(nameof(designerType));
+            }
+            if (designerBaseType == null)
+            {
+                throw new ArgumentNullException(nameof(designerBaseType));
+            }
+
             DesignerTypeName = designerType.AssemblyQualifiedName;
             DesignerBaseTypeName = designerBaseType.AssemblyQualifiedName;
         }
@@ -87,7 +110,7 @@ namespace System.ComponentModel
             {
                 if (_typeId == null)
                 {
-                    string baseType = DesignerBaseTypeName;
+                    string baseType = DesignerBaseTypeName ?? string.Empty;
                     int comma = baseType.IndexOf(',');
                     if (comma != -1)
                     {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EditorAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/EditorAttribute.cs
@@ -37,7 +37,16 @@ namespace System.ComponentModel
         /// </summary>
         public EditorAttribute(string typeName, Type baseType)
         {
-            EditorTypeName = typeName ?? throw new ArgumentNullException(nameof(typeName));
+            if (typeName == null)
+            {
+                throw new ArgumentNullException(nameof(typeName));
+            }
+            if (baseType == null)
+            {
+                throw new ArgumentNullException(nameof(baseType));
+            }
+
+            EditorTypeName = typeName;
             EditorBaseTypeName = baseType.AssemblyQualifiedName;
         }
 
@@ -46,6 +55,15 @@ namespace System.ComponentModel
         /// </summary>
         public EditorAttribute(Type type, Type baseType)
         {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+            if (baseType == null)
+            {
+                throw new ArgumentNullException(nameof(baseType));
+            }
+
             EditorTypeName = type.AssemblyQualifiedName;
             EditorBaseTypeName = baseType.AssemblyQualifiedName;
         }
@@ -73,7 +91,7 @@ namespace System.ComponentModel
             {
                 if (_typeId == null)
                 {
-                    string baseType = EditorBaseTypeName;
+                    string baseType = EditorBaseTypeName ?? string.Empty;
                     int comma = baseType.IndexOf(',');
                     if (comma != -1)
                     {

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtenderProvidedPropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtenderProvidedPropertyAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System.ComponentModel
 {
     /// <summary>
@@ -57,9 +59,19 @@ namespace System.ComponentModel
                 return false;
             }
 
-            if (other.IsDefaultAttribute())
+            // ExtenderProperty is null if the attribute is created with
+            // the default constructor. In this case, all the properties
+            // are null (and are immutable), so we only need to check the
+            // nullability of one property to know about the nullability
+            // of the rest.
+            if (other.ExtenderProperty == null)
             {
-                return IsDefaultAttribute();
+                Debug.Assert(other.Provider == null);
+                Debug.Assert(other.ReceiverType == null);
+                Debug.Assert(Provider == null);
+                Debug.Assert(ReceiverType == null);
+
+                return ExtenderProperty == null;
             }
 
             return other.ExtenderProperty.Equals(ExtenderProperty)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtenderProvidedPropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtenderProvidedPropertyAttribute.cs
@@ -52,9 +52,17 @@ namespace System.ComponentModel
             {
                 return true;
             }
+            if (!(obj is ExtenderProvidedPropertyAttribute other))
+            {
+                return false;
+            }
 
-            return obj is ExtenderProvidedPropertyAttribute other
-                && other.ExtenderProperty.Equals(ExtenderProperty)
+            if (other.IsDefaultAttribute())
+            {
+                return IsDefaultAttribute();
+            }
+
+            return other.ExtenderProperty.Equals(ExtenderProperty)
                 && other.Provider.Equals(Provider)
                 && other.ReceiverType.Equals(ReceiverType);
         }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/InstallerTypeAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/InstallerTypeAttribute.cs
@@ -21,6 +21,11 @@ namespace System.ComponentModel
         /// </summary>
         public InstallerTypeAttribute(Type installerType)
         {
+            if (installerType == null)
+            {
+                throw new ArgumentNullException(nameof(installerType));
+            }
+
             _typeName = installerType.AssemblyQualifiedName;
         }
 

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseException.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseException.cs
@@ -24,14 +24,14 @@ namespace System.ComponentModel
         /// Initializes a new instance of the <see cref='System.ComponentModel.LicenseException'/> class for the 
         /// specified type.
         /// </summary>
-        public LicenseException(Type type) : this(type, null, SR.Format(SR.LicExceptionTypeOnly, type.FullName))
+        public LicenseException(Type type) : this(type, null, SR.Format(SR.LicExceptionTypeOnly, type?.FullName))
         {
         }
         /// <summary>
         /// Initializes a new instance of the <see cref='System.ComponentModel.LicenseException'/> class for the 
         /// specified type and instance.
         /// </summary>
-        public LicenseException(Type type, object instance) : this(type, null, SR.Format(SR.LicExceptionTypeAndInstance, type.FullName, instance.GetType().FullName))
+        public LicenseException(Type type, object instance) : this(type, null, SR.Format(SR.LicExceptionTypeAndInstance, type?.FullName, instance?.GetType().FullName))
         {
         }
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ProvidePropertyAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ProvidePropertyAttribute.cs
@@ -15,6 +15,11 @@ namespace System.ComponentModel
         /// </summary>
         public ProvidePropertyAttribute(string propertyName, Type receiverType)
         {
+            if (receiverType == null)
+            {
+                throw new ArgumentNullException(nameof(receiverType));
+            }
+
             PropertyName = propertyName;
             ReceiverTypeName = receiverType.AssemblyQualifiedName;
         }
@@ -50,7 +55,10 @@ namespace System.ComponentModel
                 && other.ReceiverTypeName == ReceiverTypeName;
         }
 
-        public override int GetHashCode() => PropertyName.GetHashCode() ^ ReceiverTypeName.GetHashCode();
+        public override int GetHashCode()
+        {
+            return (PropertyName?.GetHashCode() ?? 0) ^ (ReceiverTypeName?.GetHashCode() ?? 0);
+        }
 
         public override object TypeId => GetType().FullName + PropertyName;
     }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RefreshEventArgs.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/RefreshEventArgs.cs
@@ -16,7 +16,7 @@ namespace System.ComponentModel
         public RefreshEventArgs(object componentChanged)
         {
             ComponentChanged = componentChanged;
-            TypeChanged = componentChanged.GetType();
+            TypeChanged = componentChanged?.GetType();
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemAttribute.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemAttribute.cs
@@ -57,6 +57,11 @@ namespace System.ComponentModel
         /// </summary>
         public ToolboxItemAttribute(Type toolboxItemType)
         {
+            if (toolboxItemType == null)
+            {
+                throw new ArgumentNullException(nameof(toolboxItemType));
+            }
+
             _toolboxItemType = toolboxItemType;
             _toolboxItemTypeName = toolboxItemType.AssemblyQualifiedName;
         }

--- a/src/System.ComponentModel.TypeConverter/tests/Design/DesignerCollectionTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Design/DesignerCollectionTests.cs
@@ -13,11 +13,16 @@ namespace System.ComponentModel.Design.Tests
     {
         public static IEnumerable<object[]> Ctor_TestData()
         {
+            // [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core fixed a NRE bug.")]
+            if (!PlatformDetection.IsFullFramework)
+            {
+                yield return new object[] { null };
+            }
+
             yield return new object[] { new IDesignerHost[] { new TestDesignerHost(), null, new TestDesignerHost() } };
         }
 
         [Theory]
-        [InlineData(null)]
         [MemberData(nameof(Ctor_TestData))]
         public void Ctor_DesignersArray(IDesignerHost[] designers)
         {
@@ -31,17 +36,8 @@ namespace System.ComponentModel.Design.Tests
         public void Ctor_DesignersIList(IDesignerHost[] designers)
         {
             var collection = new DesignerCollection((IList)designers);
-            Assert.Equal(designers.Length, collection.Count);
-            Assert.Equal(designers, collection.Cast<IDesignerHost>());
-        }
-
-        [Fact]
-        public void Ctor_NullDesignersIList_Success()
-        {
-            var collection = new DesignerCollection((IList)null);
-            Assert.Throws<NullReferenceException>(() => collection.Count);
-            Assert.Throws<NullReferenceException>(() => collection.GetEnumerator());
-            Assert.Throws<NullReferenceException>(() => collection[0]);
+            Assert.Equal(designers?.Length ?? 0, collection.Count);
+            Assert.Equal(designers ?? Enumerable.Empty<IDesignerHost>(), collection.Cast<IDesignerHost>());
         }
 
         [Fact]
@@ -73,6 +69,16 @@ namespace System.ComponentModel.Design.Tests
             collection.CopyTo(destination, 1);
 
             Assert.Equal(new IDesignerHost[] { null, designers[0], designers[1], null }, destination);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core fixed a NRE bug.")]
+        public void CopyTo_NullIList_Nop()
+        {
+            ICollection collection = new DesignerCollection((IList)null);
+            var array = new object[] { 1, 2, 3 };
+            collection.CopyTo(array, 1);
+            Assert.Equal(new object[] { 1, 2, 3}, array);
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/Design/DesigntimeLicenseContextTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Design/DesigntimeLicenseContextTests.cs
@@ -42,7 +42,7 @@ namespace System.ComponentModel.Design.Tests
         public void SetSavedLicenseKey_NullType_ThrowsNullReferenceException()
         {
             var context = new DesigntimeLicenseContext();
-            Assert.Throws<NullReferenceException>(() => context.SetSavedLicenseKey(null, "Key"));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("type", () => context.SetSavedLicenseKey(null, "Key"));
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/Design/MenuCommandTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Design/MenuCommandTests.cs
@@ -108,10 +108,17 @@ namespace System.ComponentModel.Design.Tests
         }
 
         [Fact]
-        public void ToString_NullCommandId_ThrowsNullReferenceException()
+        public void ToString_NullCommandI_ReturnsExpected()
         {
             var command = new MenuCommand(new EventHandler(EventHandler), null);
-            Assert.Throws<NullReferenceException>(() => command.ToString());
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.Equal(" : Supported|Enabled|Visible", command.ToString());
+            }
+            else
+            {
+                Assert.Throws<NullReferenceException>(() => command.ToString());
+            }
         }
 
         [Fact]

--- a/src/System.ComponentModel.TypeConverter/tests/Design/Serialization/DesignerSerializerAttributeTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Design/Serialization/DesignerSerializerAttributeTests.cs
@@ -19,16 +19,16 @@ namespace System.ComponentModel.Design.Serialization.Tests
         }
 
         [Fact]
-        public void Ctor_NullSerializerType_ThrowsNullReferenceException()
+        public void Ctor_NullSerializerType_ThrowsArgumentNullException()
         {
-            Assert.Throws<NullReferenceException>(() => new DesignerSerializerAttribute((Type)null, typeof(int)));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>(() => new DesignerSerializerAttribute((Type)null, typeof(int)));
         }
 
         [Fact]
-        public void Ctor_NullBaseSerializerType_ThrowsNullReferenceException()
+        public void Ctor_NullBaseSerializerType_ThrowsArgumentNullException()
         {
-            Assert.Throws<NullReferenceException>(() => new DesignerSerializerAttribute(typeof(int), (Type)null));
-            Assert.Throws<NullReferenceException>(() => new DesignerSerializerAttribute("int", (Type)null));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("baseSerializerType", () => new DesignerSerializerAttribute(typeof(int), (Type)null));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("baseSerializerType", () => new DesignerSerializerAttribute("int", (Type)null));
         }
 
         [Theory]
@@ -65,7 +65,14 @@ namespace System.ComponentModel.Design.Serialization.Tests
         public void TypeId_NullBaseSerializerTypeName_ThrowsNullReferenceException()
         {
             var attribute = new DesignerSerializerAttribute("SerializerType", (string)null);
-            Assert.Throws<NullReferenceException>(() => attribute.TypeId);
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.Equal("System.ComponentModel.Design.Serialization.DesignerSerializerAttribute", attribute.TypeId);
+            }
+            else
+            {
+                Assert.Throws<NullReferenceException>(() => attribute.TypeId);
+            }
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/Design/Serialization/RootDesignerSerializerAttributeTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Design/Serialization/RootDesignerSerializerAttributeTests.cs
@@ -23,14 +23,14 @@ namespace System.ComponentModel.Design.Serialization.Tests
         [Fact]
         public void Ctor_NullSerializerType_ThrowsNullReferenceException()
         {
-            Assert.Throws<NullReferenceException>(() => new RootDesignerSerializerAttribute((Type)null, typeof(int), false));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("serializerType", () => new RootDesignerSerializerAttribute((Type)null, typeof(int), false));
         }
 
         [Fact]
         public void Ctor_NullBaseSerializerType_ThrowsNullReferenceException()
         {
-            Assert.Throws<NullReferenceException>(() => new RootDesignerSerializerAttribute(typeof(int), (Type)null, false));
-            Assert.Throws<NullReferenceException>(() => new RootDesignerSerializerAttribute("int", (Type)null, false));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("baseSerializerType", () => new RootDesignerSerializerAttribute(typeof(int), (Type)null, false));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("baseSerializerType", () => new RootDesignerSerializerAttribute("int", (Type)null, false));
         }
 
         [Theory]
@@ -66,10 +66,17 @@ namespace System.ComponentModel.Design.Serialization.Tests
         }
 
         [Fact]
-        public void TypeId_NullBaseSerializerTypeName_ThrowsNullReferenceException()
+        public void TypeId_NullBaseSerializerTypeName_ReturnsExpected()
         {
             var attribute = new RootDesignerSerializerAttribute("SerializerType", (string)null, reloadable: true);
-            Assert.Throws<NullReferenceException>(() => attribute.TypeId);
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.Equal("System.ComponentModel.Design.Serialization.RootDesignerSerializerAttribute", attribute.TypeId);
+            }
+            else
+            {
+                Assert.Throws<NullReferenceException>(() => attribute.TypeId);
+            }
         }
     }
 #pragma warning restore 0618

--- a/src/System.ComponentModel.TypeConverter/tests/DesignerAttributeTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DesignerAttributeTests.cs
@@ -66,7 +66,7 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public void Ctor_NullDesignerTypeName_ThrowsArgumentNullExceptionException()
+        public void Ctor_NullDesignerTypeName_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException, NullReferenceException>(() => new DesignerAttribute((string)null));
             AssertExtensions.Throws<ArgumentNullException, NullReferenceException>(() => new DesignerAttribute(null, "designerBaseTypeName"));
@@ -74,17 +74,17 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public void Ctor_NullDesignerType_ThrowsNullReferenceException()
+        public void Ctor_NullDesignerType_ThrowsArgumentNullException()
         {
-            Assert.Throws<NullReferenceException>(() => new DesignerAttribute((Type)null));
-            Assert.Throws<NullReferenceException>(() => new DesignerAttribute((Type)null, typeof(int)));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("designerType", () => new DesignerAttribute((Type)null));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("designerType", () => new DesignerAttribute((Type)null, typeof(int)));
         }
 
         [Fact]
-        public void Ctor_NullDesignerBaseType_ThrowsNullReferenceException()
+        public void Ctor_NullDesignerBaseType_ThrowsArgumentNullException()
         {
-            Assert.Throws<NullReferenceException>(() => new DesignerAttribute("designerTypeName", (Type)null));
-            Assert.Throws<NullReferenceException>(() => new DesignerAttribute(typeof(int), null));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("designerBaseType", () => new DesignerAttribute("designerTypeName", (Type)null));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("designerBaseType", () => new DesignerAttribute(typeof(int), null));
         }
 
         [Theory]
@@ -101,7 +101,14 @@ namespace System.ComponentModel.Tests
         public void TypeId_NullDesignerDesignerTypeName_ThrowsNullReferenceException()
         {
             var attribute = new DesignerAttribute("DesignerType", (string)null);
-            Assert.Throws<NullReferenceException>(() => attribute.TypeId);
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.Equal("System.ComponentModel.DesignerAttribute", attribute.TypeId);
+            }
+            else
+            {
+                Assert.Throws<NullReferenceException>(() => attribute.TypeId);
+            }
         }
 
         public static IEnumerable<object[]> Equals_TestData()

--- a/src/System.ComponentModel.TypeConverter/tests/EditorAttributeTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/EditorAttributeTests.cs
@@ -52,23 +52,23 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public void Ctor_NullEditorTypeName_ThrowsArgumentNullException()
+        public void Ctor_NullTypeName_ThrowsArgumentNullException()
         {
-            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>(() => new EditorAttribute(null, "baseTypeName"));
-            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>(() => new EditorAttribute((string)null, typeof(int)));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("typeName", () => new EditorAttribute(null, "baseTypeName"));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("typeName", () => new EditorAttribute((string)null, typeof(int)));
         }
 
         [Fact]
-        public void Ctor_NullType_ThrowsNullReferenceException()
+        public void Ctor_NullType_ThrowsArgumentNullException()
         {
-            Assert.Throws<NullReferenceException>(() => new EditorAttribute((Type)null, typeof(int)));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("type", () => new EditorAttribute((Type)null, typeof(int)));
         }
 
         [Fact]
-        public void Ctor_NullEditorBaseType_ThrowsNullReferenceException()
+        public void Ctor_NullBaseType_ThrowsArgumentNullException()
         {
-            Assert.Throws<NullReferenceException>(() => new EditorAttribute("typeName", (Type)null));
-            Assert.Throws<NullReferenceException>(() => new EditorAttribute(typeof(int), null));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("baseType", () => new EditorAttribute("typeName", (Type)null));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("baseType", () => new EditorAttribute(typeof(int), null));
         }
 
         [Theory]
@@ -82,10 +82,17 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public void TypeId_NullBaseTypeName_ThrowsNullReferenceException()
+        public void TypeId_NullBaseTypeName_ReturnsExpected()
         {
             var attribute = new EditorAttribute("Type", (string)null);
-            Assert.Throws<NullReferenceException>(() => attribute.TypeId);
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.Equal("System.ComponentModel.EditorAttribute", attribute.TypeId);
+            }
+            else
+            {
+                Assert.Throws<NullReferenceException>(() => attribute.TypeId);
+            }
         }
 
         public static IEnumerable<object[]> Equals_TestData()

--- a/src/System.ComponentModel.TypeConverter/tests/ExtenderProvidedPropertyAttributeTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/ExtenderProvidedPropertyAttributeTests.cs
@@ -43,7 +43,14 @@ namespace System.ComponentModel.Tests
         public void Equals_NullProperties_ThrowsNullReferenceException()
         {
             var attribute = new ExtenderProvidedPropertyAttribute();
-            Assert.Throws<NullReferenceException>(() => attribute.Equals(new ExtenderProvidedPropertyAttribute()));
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.True(attribute.Equals(new ExtenderProvidedPropertyAttribute()));
+            }
+            else
+            {
+                Assert.Throws<NullReferenceException>(() => attribute.Equals(new ExtenderProvidedPropertyAttribute()));
+            }
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/InstallerTypeAttributeTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/InstallerTypeAttributeTests.cs
@@ -12,16 +12,16 @@ namespace System.ComponentModel.Tests
         [Theory]
         [InlineData(typeof(int))]
         [InlineData(typeof(InstallerTypeAttribute))]
-        public void Ctor_InheritanceLevel(Type installerType)
+        public void Ctor_Type(Type installerType)
         {
             var attribute = new InstallerTypeAttribute(installerType);
             Assert.Equal(installerType, attribute.InstallerType);
         }
 
         [Fact]
-        public void Ctor_NullInstallerType_ThrowsNullReferenceException()
+        public void Ctor_NullInstallerType_ThrowsArgumentNullException()
         {
-            Assert.Throws<NullReferenceException>(() => new InstallerTypeAttribute((Type)null));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("installerType", () => new InstallerTypeAttribute((Type)null));
         }
 
         [Theory]

--- a/src/System.ComponentModel.TypeConverter/tests/LicenseExceptionTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/LicenseExceptionTests.cs
@@ -11,8 +11,18 @@ namespace System.ComponentModel.Tests
 {
     public class LicenseExceptionTests
     {
+        public static IEnumerable<object[]> Ctor_Type_TestData()
+        {
+            if (!PlatformDetection.IsFullFramework)
+            {
+                yield return new object[] { null };
+            }
+
+            yield return new object[] { typeof(int) };
+        }
+
         [Theory]
-        [InlineData(typeof(int))]
+        [MemberData(nameof(Ctor_Type_TestData))]
         public void Ctor_Type(Type type)
         {
             var exception = new LicenseException(type);
@@ -22,8 +32,18 @@ namespace System.ComponentModel.Tests
             Assert.NotEmpty(exception.Message);
         }
 
+        public static IEnumerable<object[]> Ctor_Type_Object_TestData()
+        {
+            if (!PlatformDetection.IsFullFramework)
+            {
+                yield return new object[] { null, null };
+            }
+
+            yield return new object[] { typeof(int), "instance" };
+        }
+
         [Theory]
-        [InlineData(typeof(int), "instance")]
+        [MemberData(nameof(Ctor_Type_Object_TestData))]
         public void Ctor_Type_Object(Type type, object instance)
         {
             var exception = new LicenseException(type, instance);
@@ -60,19 +80,6 @@ namespace System.ComponentModel.Tests
             Assert.Equal(-2146232063, exception.HResult);
             Assert.Equal(type, exception.LicensedType);
             Assert.Equal(message, exception.Message);
-        }
-
-        [Fact]
-        public void Ctor_NullType_ThrowsNullReferenceException()
-        {
-            Assert.Throws<NullReferenceException>(() => new LicenseException(null));
-            Assert.Throws<NullReferenceException>(() => new LicenseException(null, new object()));
-        }
-
-        [Fact]
-        public void Ctor_NullInstance_ThrowsNullReferenceException()
-        {
-            Assert.Throws<NullReferenceException>(() => new LicenseException(typeof(int), null));
         }
 
         [Fact]

--- a/src/System.ComponentModel.TypeConverter/tests/ProvidePropertyAttributeTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/ProvidePropertyAttributeTests.cs
@@ -35,7 +35,7 @@ namespace System.ComponentModel
         [Fact]
         public void Ctor_NullReceiverType_ThrowsNullReferenceException()
         {
-            Assert.Throws<NullReferenceException>(() => new ProvidePropertyAttribute("propertyName", (Type)null));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("receiverType", () => new ProvidePropertyAttribute("propertyName", (Type)null));
         }
 
         public static IEnumerable<object[]> Equals_TestData()
@@ -72,17 +72,32 @@ namespace System.ComponentModel
         }
 
         [Fact]
-        public void GetHashCode_NullPropertyName_ThrowsNullReferenceException()
+        public void GetHashCode_NullPropertyName_ReturnsEqual()
         {
             var attribute = new ProvidePropertyAttribute(null, "receiverTypeName");
-            Assert.Throws<NullReferenceException>(() => attribute.GetHashCode());
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.Equal(attribute.GetHashCode(), attribute.GetHashCode());
+            }
+            else
+            {
+                Assert.Throws<NullReferenceException>(() => attribute.GetHashCode());
+            }
         }
 
         [Fact]
-        public void GetHashCode_NullReceiverTypeName_ThrowsNullReferenceException()
+        public void GetHashCode_NullReceiverTypeName_ReturnsEqual()
         {
             var attribute = new ProvidePropertyAttribute("propertyName", (string)null);
-            Assert.Throws<NullReferenceException>(() => attribute.GetHashCode());
+
+            if (!PlatformDetection.IsFullFramework)
+            {
+                Assert.Equal(attribute.GetHashCode(), attribute.GetHashCode());
+            }
+            else
+            {
+                Assert.Throws<NullReferenceException>(() => attribute.GetHashCode());
+            }
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/RefreshEventArgsTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/RefreshEventArgsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.ComponentModel.Tests
@@ -18,19 +19,23 @@ namespace System.ComponentModel.Tests
             Assert.Same(typeChanged, args.TypeChanged);
         }
 
-        [Fact]
-        public void Ctor_Object()
+        public static IEnumerable<object[]> Ctor_Object_TestData()
         {
-            object componentChanged = "componentChanged";
-            var args = new RefreshEventArgs(componentChanged);
-            Assert.Same(componentChanged, args.ComponentChanged);
-            Assert.Equal(typeof(string), args.TypeChanged);
+            if (!PlatformDetection.IsFullFramework)
+            {
+                yield return new object[] { null, null };
+            }
+
+                yield return new object[] { "componentChanged", typeof(string) };
         }
 
-        [Fact]
-        public void Ctor_NullComponentChanged_ThrowsNullReferenceException()
+        [Theory]
+        [MemberData(nameof(Ctor_Object_TestData))]
+        public void Ctor_Object(object componentChanged, Type expectedTypeChanged)
         {
-            Assert.Throws<NullReferenceException>(() => new RefreshEventArgs((object)null));
+            var args = new RefreshEventArgs(componentChanged);
+            Assert.Same(componentChanged, args.ComponentChanged);
+            Assert.Equal(expectedTypeChanged, args.TypeChanged);
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/ToolboxItemAttributeTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/ToolboxItemAttributeTests.cs
@@ -80,7 +80,7 @@ namespace System.ComponentModel
         [Fact]
         public void Ctor_NullToolboxItemType_ThrowsNullReferenceException()
         {
-            Assert.Throws<NullReferenceException>(() => new ToolboxItemAttribute((Type)null));
+            AssertExtensions.Throws<ArgumentNullException, NullReferenceException>("toolboxItemType", () => new ToolboxItemAttribute((Type)null));
         }
 
         [Fact]


### PR DESCRIPTION
In some cases, added argument validation. In others, simply `nop` or set a default value