### PR TITLE
Adding some tests for double/float roundtripping.

### DIFF
--- a/src/System.Runtime/tests/System/DoubleTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/DoubleTests.netcoreapp.cs
@@ -189,5 +189,40 @@ namespace System.Tests
                 return SuccessExitCode;
             }).Dispose();
         }
+
+        public static IEnumerable<object[]> ToStringRoundtrip_TestData()
+        {
+            yield return new object[] { double.NegativeInfinity };
+            yield return new object[] { double.MinValue };
+            yield return new object[] { -Math.PI };
+            yield return new object[] { -Math.E };
+            yield return new object[] { -double.Epsilon };
+            yield return new object[] { -0.84551240822557006 };
+            yield return new object[] { -0.0 };
+            yield return new object[] { double.NaN };
+            yield return new object[] { 0.0 };
+            yield return new object[] { 0.84551240822557006 };
+            yield return new object[] { double.Epsilon };
+            yield return new object[] { Math.E };
+            yield return new object[] { Math.PI };
+            yield return new object[] { double.MaxValue };
+            yield return new object[] { double.PositiveInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToStringRoundtrip_TestData))]
+        public static void ToStringRoundtrip(double value)
+        {
+            double result = double.Parse(value.ToString());
+            Assert.Equal(BitConverter.DoubleToInt64Bits(value), BitConverter.DoubleToInt64Bits(result));
+        }
+
+        [Theory]
+        [MemberData(nameof(ToStringRoundtrip_TestData))]
+        public static void ToStringRoundtrip_R(double value)
+        {
+            double result = double.Parse(value.ToString("R"));
+            Assert.Equal(BitConverter.DoubleToInt64Bits(value), BitConverter.DoubleToInt64Bits(result));
+        }
     }
 }

--- a/src/System.Runtime/tests/System/SingleTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/SingleTests.netcoreapp.cs
@@ -192,5 +192,40 @@ namespace System.Tests
                 return SuccessExitCode;
             }).Dispose();
         }
+
+        public static IEnumerable<object[]> ToStringRoundtrip_TestData()
+        {
+            yield return new object[] { float.NegativeInfinity };
+            yield return new object[] { float.MinValue };
+            yield return new object[] { -MathF.PI };
+            yield return new object[] { -MathF.E };
+            yield return new object[] { -float.Epsilon };
+            yield return new object[] { -0.845512408f };
+            yield return new object[] { -0.0f };
+            yield return new object[] { float.NaN };
+            yield return new object[] { 0.0f };
+            yield return new object[] { 0.845512408f };
+            yield return new object[] { float.Epsilon };
+            yield return new object[] { MathF.E };
+            yield return new object[] { MathF.PI };
+            yield return new object[] { float.MaxValue };
+            yield return new object[] { float.PositiveInfinity };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToStringRoundtrip_TestData))]
+        public static void ToStringRoundtrip(float value)
+        {
+            float result = float.Parse(value.ToString());
+            Assert.Equal(BitConverter.SingleToInt32Bits(value), BitConverter.SingleToInt32Bits(result));
+        }
+
+        [Theory]
+        [MemberData(nameof(ToStringRoundtrip_TestData))]
+        public static void ToStringRoundtrip_R(float value)
+        {
+            float result = float.Parse(value.ToString("R"));
+            Assert.Equal(BitConverter.SingleToInt32Bits(value), BitConverter.SingleToInt32Bits(result));
+        }
     }
 }


### PR DESCRIPTION
This just adds tests to validate the new roundtripping behavior for double/floats. We are explicitly testing some edge values and values which were known to previously be incorrect.

This resolves https://github.com/dotnet/coreclr/issues/13615
This resolves https://github.com/dotnet/coreclr/issues/3313