### PR TITLE
basic support for PooledConnectionLifetime for HTTP2

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -57,8 +57,6 @@ namespace System.Net.Http
         // So set the connection window size to a large value.
         private const int ConnectionWindowSize = 64 * 1024 * 1024;
 
-        private DateTimeOffset CreationTime { get; } = DateTimeOffset.UtcNow;
-
         public Http2Connection(HttpConnectionPool pool, SslStream stream)
         {
             _pool = pool;
@@ -947,18 +945,6 @@ namespace System.Net.Http
             return _disposed;
         }
 
-
-        // Check if lifetime expired on connection.
-        public bool LifetimeExpired(DateTimeOffset now, TimeSpan lifetime)
-        {
-            bool expired = lifetime != Timeout.InfiniteTimeSpan &&
-                   (lifetime == TimeSpan.Zero || CreationTime + lifetime <= now);
-
-                if (expired && NetEventSource.IsEnabled) Trace($"Connection no longer usable. Alive {now - CreationTime} > {lifetime}.");
-                return expired;
-        }
-
-
         /// <summary>Gets whether the connection exceeded any of the connection limits.</summary>
         /// <param name="now">The current time.  Passed in to amortize the cost of calling DateTime.UtcNow.</param>
         /// <param name="connectionLifetime">How long a connection can be open to be considered reusable.</param>
@@ -1308,7 +1294,7 @@ namespace System.Net.Http
 
         public sealed override string ToString() => $"{nameof(Http2Connection)}({_pool})"; // Description for diagnostic purposes
 
-        internal void Trace(string message, [CallerMemberName] string memberName = null) =>
+        internal override void Trace(string message, [CallerMemberName] string memberName = null) =>
             NetEventSource.Log.HandlerMessage(
                 _pool?.GetHashCode() ?? 0,    // pool ID
                 GetHashCode(),                // connection ID

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -55,6 +55,8 @@ namespace System.Net.Http
         // So set the connection window size to a large value.
         private const int ConnectionWindowSize = 64 * 1024 * 1024;
 
+        public DateTimeOffset CreationTime { get; } = DateTimeOffset.UtcNow;
+
         public Http2Connection(HttpConnectionPool pool, SslStream stream)
         {
             _pool = pool;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Net.Http.Headers;
 using System.Net.Http.HPack;
 using System.Net.Security;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,6 +40,7 @@ namespace System.Net.Http
         private bool _expectingSettingsAck;
         private int _initialWindowSize;
         private int _maxConcurrentStreams;
+        private DateTimeOffset _lastFinishedStream;
 
         private bool _disposed;
 
@@ -945,6 +947,49 @@ namespace System.Net.Http
             return _disposed;
         }
 
+        /// <summary>Gets whether the connection exceeded any of the connection limits.</summary>
+        /// <param name="now">The current time.  Passed in to amortize the cost of calling DateTime.UtcNow.</param>
+        /// <param name="pooledConnectionLifetime">How long a connection can be open to be considered reusable.</param>
+        /// <param name="pooledConnectionIdleTimeout">How long a connection can have been idle in the pool to be considered reusable.</param>
+        /// <returns>
+        /// true if we believe the connection is expired; otherwise, false.  There is an inherent race condition here,
+        /// in that the server could terminate the connection or otherwise make it unusable immediately after we check it,
+        /// but there's not much difference between that and starting to use the connection and then having the server
+        /// terminate it, which would be considered a failure, so this race condition is largely benign and inherent to
+        /// the nature of connection pooling.
+        /// </returns>
+
+        public bool IsExpired(DateTimeOffset now,
+                              TimeSpan pooledConnectionLifetime,
+                              TimeSpan pooledConnectionIdleTimeout)
+
+        {
+            if (_disposed)
+            {
+                return true;
+            }
+
+            // Check idle timeout when there are not pending requests for a while.
+            if ((_httpStreams.Count == 0) && (pooledConnectionIdleTimeout != Timeout.InfiniteTimeSpan) &&
+                    (now - _lastFinishedStream > pooledConnectionIdleTimeout))
+            {
+               if (NetEventSource.IsEnabled) Trace($"Connection no longer usable. Idle {now - _lastFinishedStream } > {pooledConnectionIdleTimeout}.");
+
+                return true;
+            }
+
+            // Lifetime can expire even with pending streams.
+            if ((pooledConnectionLifetime != Timeout.InfiniteTimeSpan) &&
+                    (pooledConnectionLifetime == TimeSpan.Zero || now - pooledConnectionLifetime > CreationTime))
+            {
+                if (NetEventSource.IsEnabled) Trace( "Connection lifetime expired.");
+
+                return true;
+            }
+
+            return false;
+        }
+
         private void AbortStreams(int lastValidStream)
         {
             lock (_syncObject)
@@ -1193,6 +1238,12 @@ namespace System.Net.Http
 
                 Debug.Assert(removed == http2Stream, "_httpStreams.TryRemove returned unexpected stream");
 
+                if (_httpStreams.Count == 0)
+                {
+                    // If this was last pending request, get timestamp so we can monitor idle time.
+                    _lastFinishedStream = DateTimeOffset.UtcNow;
+                }
+
                 if (_disposed)
                 {
                     CheckForShutdown();
@@ -1251,5 +1302,16 @@ namespace System.Net.Http
 
             return totalBytesRead;
         }
+
+        public sealed override string ToString() => $"{nameof(Http2Connection)}({_pool})"; // Description for diagnostic purposes
+
+        internal void Trace(string message, [CallerMemberName] string memberName = null) =>
+            NetEventSource.Log.HandlerMessage(
+                _pool?.GetHashCode() ?? 0,    // pool ID
+                GetHashCode(),                // connection ID
+                _stream?.GetHashCode() ?? 0,  // stream ID
+                memberName,                   // method name
+                ToString() + ": " + message); // message
+
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -201,6 +201,16 @@ namespace System.Net.Http
 
         public DateTimeOffset CreationTime { get; } = DateTimeOffset.UtcNow;
 
+        // Check if lifetime expired on connection.
+        public bool LifetimeExpired(DateTimeOffset now, TimeSpan lifetime)
+        {
+            bool expired = lifetime != Timeout.InfiniteTimeSpan &&
+                   (lifetime == TimeSpan.Zero || CreationTime + lifetime <= now);
+
+                if (expired && NetEventSource.IsEnabled) Trace($"Connection no longer usable. Alive {now - CreationTime} > {lifetime}.");
+                return expired;
+        }
+
         public TransportContext TransportContext => _transportContext;
 
         public HttpConnectionKind Kind => _pool.Kind;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -199,18 +199,6 @@ namespace System.Net.Http
             return null;
         }
 
-        public DateTimeOffset CreationTime { get; } = DateTimeOffset.UtcNow;
-
-        // Check if lifetime expired on connection.
-        public bool LifetimeExpired(DateTimeOffset now, TimeSpan lifetime)
-        {
-            bool expired = lifetime != Timeout.InfiniteTimeSpan &&
-                   (lifetime == TimeSpan.Zero || CreationTime + lifetime <= now);
-
-                if (expired && NetEventSource.IsEnabled) Trace($"Connection no longer usable. Alive {now - CreationTime} > {lifetime}.");
-                return expired;
-        }
-
         public TransportContext TransportContext => _transportContext;
 
         public HttpConnectionKind Kind => _pool.Kind;
@@ -1669,7 +1657,7 @@ namespace System.Net.Http
 
         private static void ThrowInvalidHttpResponse(Exception innerException) => throw new HttpRequestException(SR.net_http_invalid_response, innerException);
 
-        internal void Trace(string message, [CallerMemberName] string memberName = null) =>
+        internal override void Trace(string message, [CallerMemberName] string memberName = null) =>
             NetEventSource.Log.HandlerMessage(
                 _pool?.GetHashCode() ?? 0,    // pool ID
                 GetHashCode(),                // connection ID

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -10,5 +10,19 @@ namespace System.Net.Http
     internal abstract class HttpConnectionBase
     {
         public abstract Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken);
+        internal abstract void Trace(string message, string memberName = null);
+
+        public DateTimeOffset CreationTime { get; } = DateTimeOffset.UtcNow;
+
+        // Check if lifetime expired on connection.
+        public bool LifetimeExpired(DateTimeOffset now, TimeSpan lifetime)
+        {
+            bool expired = lifetime != Timeout.InfiniteTimeSpan &&
+                   (lifetime == TimeSpan.Zero || CreationTime + lifetime <= now);
+
+                if (expired && NetEventSource.IsEnabled) Trace($"Connection no longer usable. Alive {now - CreationTime} > {lifetime}.");
+                return expired;
+        }
+
     }
 }


### PR DESCRIPTION
related to #31294 

I'm not sure if we need to track expired connections. 
I originally started on that path and used HashSet to track them. But disposing Http2Conection seems to do exactly what I wanted e.g. close it when there is no pending request. 

I verified this in my setup with real HTTP2 server. 
I look at existing tests and it seems like it is not worth of fixing until #34345 lands. (or something similar)

 