### PR TITLE
Fix overflow exception in StringParsingHelpers

### DIFF
--- a/src/Common/src/System/IO/RowConfigReader.cs
+++ b/src/Common/src/System/IO/RowConfigReader.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Globalization;
 
 namespace System.IO
 {
@@ -165,13 +166,37 @@ namespace System.IO
             // PERF: We don't need to allocate a new string here, we can parse an Int32 "in-place" in the existing string.
             string value = GetNextValue(key);
             int result;
-            if (int.TryParse(value, out result))
+            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
             {
                 return result;
             }
             else
             {
                 throw new InvalidOperationException("Unable to parse value " + value + " of key " + key + " as an Int32.");
+            }
+        }
+
+        /// <summary>
+        /// Gets the next occurrence of the key in the string, and parses it as an Int64.
+        /// Throws if the key is not found in the remainder of the string, or if the key
+        /// cannot be successfully parsed into an Int64.
+        /// </summary>
+        /// <remarks>
+        /// This is mainly provided as a helper because most Linux config/info files
+        /// store integral data.
+        /// </remarks>
+        public long GetNextValueAsInt64(string key)
+        {
+            // PERF: We don't need to allocate a new string here, we can parse an Int64 "in-place" in the existing string.
+            string value = GetNextValue(key);
+            long result;
+            if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
+            {
+                return result;
+            }
+            else
+            {
+                throw new InvalidOperationException("Unable to parse value " + value + " of key " + key + " as an Int64.");
             }
         }
 

--- a/src/Common/tests/Tests/System/IO/RowConfigReaderTests.cs
+++ b/src/Common/tests/Tests/System/IO/RowConfigReaderTests.cs
@@ -16,7 +16,8 @@ namespace System.IO
         {
             RowConfigReader rcr = new RowConfigReader(data);
             Assert.Equal("stringVal", rcr.GetNextValue("stringKey"));
-            Assert.Equal(12, rcr.GetNextValueAsInt32("intKey"));
+            Assert.Equal(int.MaxValue, rcr.GetNextValueAsInt32("intKey"));
+            Assert.Equal(long.MaxValue, rcr.GetNextValueAsInt64("longKey"));
         }
 
         [MemberData(nameof(BasicTestData))]
@@ -28,6 +29,7 @@ namespace System.IO
             string unused;
             Assert.False(rcr.TryGetNextValue("stringkey", out unused));
             Assert.False(rcr.TryGetNextValue("intkey", out unused));
+            Assert.False(rcr.TryGetNextValue("longkey", out unused));
         }
 
         [MemberData(nameof(BasicTestData))]
@@ -37,7 +39,8 @@ namespace System.IO
             // Use a case-insensitive comparer and use differently-cased keys.
             RowConfigReader rcr = new RowConfigReader(data, StringComparison.OrdinalIgnoreCase);
             Assert.Equal("stringVal", rcr.GetNextValue("stringkey"));
-            Assert.Equal(12, rcr.GetNextValueAsInt32("intkey"));
+            Assert.Equal(int.MaxValue, rcr.GetNextValueAsInt32("intkey"));
+            Assert.Equal(long.MaxValue, rcr.GetNextValueAsInt64("longkey"));
         }
 
         [MemberData(nameof(BasicTestData))]
@@ -45,7 +48,8 @@ namespace System.IO
         public static void StaticHelper(string data)
         {
             Assert.Equal("stringVal", RowConfigReader.ReadFirstValueFromString(data, "stringKey"));
-            Assert.Equal("12", RowConfigReader.ReadFirstValueFromString(data, "intKey"));
+            Assert.Equal(int.MaxValue.ToString(), RowConfigReader.ReadFirstValueFromString(data, "intKey"));
+            Assert.Equal(long.MaxValue.ToString(), RowConfigReader.ReadFirstValueFromString(data, "longKey"));
         }
 
         [InlineData("key")]
@@ -107,13 +111,15 @@ namespace System.IO
             yield return new[] { BasicDataWithTabs };
         }
 
-        private static string BasicData => string.Format(
-            "stringKey stringVal{0}intKey 12{0}",
-            Environment.NewLine);
+        private static string BasicData =>
+            $"stringKey stringVal{Environment.NewLine}" +
+            $"intKey {int.MaxValue}{Environment.NewLine}" +
+            $"longKey {long.MaxValue}{Environment.NewLine}";
 
-        private static string BasicDataWithTabs => string.Format(
-            "stringKey\t\t\tstringVal{0}intKey\t\t12{0}",
-            Environment.NewLine);
+        private static string BasicDataWithTabs =>
+            $"stringKey\t\t\tstringVal{Environment.NewLine}" +
+            $"intKey\t\t{int.MaxValue}{Environment.NewLine}" +
+            $"longKey\t\t{long.MaxValue}{Environment.NewLine}";
 
         private static IEnumerable<object[]> NewlineTestData()
         {

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -13,33 +13,33 @@ namespace System.Net.NetworkInformation
     /// </summary>
     internal struct Icmpv4StatisticsTable
     {
-        public int InMsgs;
-        public int InErrors;
-        public int InCsumErrors;
-        public int InDestUnreachs;
-        public int InTimeExcds;
-        public int InParmProbs;
-        public int InSrcQuenchs;
-        public int InRedirects;
-        public int InEchos;
-        public int InEchoReps;
-        public int InTimestamps;
-        public int InTimeStampReps;
-        public int InAddrMasks;
-        public int InAddrMaskReps;
-        public int OutMsgs;
-        public int OutErrors;
-        public int OutDestUnreachs;
-        public int OutTimeExcds;
-        public int OutParmProbs;
-        public int OutSrcQuenchs;
-        public int OutRedirects;
-        public int OutEchos;
-        public int OutEchoReps;
-        public int OutTimestamps;
-        public int OutTimestampReps;
-        public int OutAddrMasks;
-        public int OutAddrMaskReps;
+        public long InMsgs;
+        public long InErrors;
+        public long InCsumErrors;
+        public long InDestUnreachs;
+        public long InTimeExcds;
+        public long InParmProbs;
+        public long InSrcQuenchs;
+        public long InRedirects;
+        public long InEchos;
+        public long InEchoReps;
+        public long InTimestamps;
+        public long InTimeStampReps;
+        public long InAddrMasks;
+        public long InAddrMaskReps;
+        public long OutMsgs;
+        public long OutErrors;
+        public long OutDestUnreachs;
+        public long OutTimeExcds;
+        public long OutParmProbs;
+        public long OutSrcQuenchs;
+        public long OutRedirects;
+        public long OutEchos;
+        public long OutEchoReps;
+        public long OutTimestamps;
+        public long OutTimestampReps;
+        public long OutAddrMasks;
+        public long OutAddrMaskReps;
     }
 
     /// <summary>
@@ -48,68 +48,68 @@ namespace System.Net.NetworkInformation
     /// </summary>
     internal struct Icmpv6StatisticsTable
     {
-        public int InDestUnreachs;
-        public int OutDestUnreachs;
-        public int InEchoReplies;
-        public int InEchos;
-        public int OutEchoReplies;
-        public int OutEchos;
-        public int InErrors;
-        public int OutErrors;
-        public int InGroupMembQueries;
-        public int OutInGroupMembQueries;
-        public int InGroupMembReductions;
-        public int OutGroupMembReductions;
-        public int InGroupMembResponses;
-        public int OutGroupMembResponses;
-        public int InMsgs;
-        public int OutMsgs;
-        public int InNeighborAdvertisements;
-        public int OutNeighborAdvertisements;
-        public int InNeighborSolicits;
-        public int OutNeighborSolicits;
-        public int InPktTooBigs;
-        public int OutPktTooBigs;
-        public int InParmProblems;
-        public int OutParmProblems;
-        public int InRedirects;
-        public int OutRedirects;
-        public int InRouterSolicits;
-        public int OutRouterSolicits;
-        public int InRouterAdvertisements;
-        public int OutRouterAdvertisements;
-        public int InTimeExcds;
-        public int OutTimeExcds;
+        public long InDestUnreachs;
+        public long OutDestUnreachs;
+        public long InEchoReplies;
+        public long InEchos;
+        public long OutEchoReplies;
+        public long OutEchos;
+        public long InErrors;
+        public long OutErrors;
+        public long InGroupMembQueries;
+        public long OutInGroupMembQueries;
+        public long InGroupMembReductions;
+        public long OutGroupMembReductions;
+        public long InGroupMembResponses;
+        public long OutGroupMembResponses;
+        public long InMsgs;
+        public long OutMsgs;
+        public long InNeighborAdvertisements;
+        public long OutNeighborAdvertisements;
+        public long InNeighborSolicits;
+        public long OutNeighborSolicits;
+        public long InPktTooBigs;
+        public long OutPktTooBigs;
+        public long InParmProblems;
+        public long OutParmProblems;
+        public long InRedirects;
+        public long OutRedirects;
+        public long InRouterSolicits;
+        public long OutRouterSolicits;
+        public long InRouterAdvertisements;
+        public long OutRouterAdvertisements;
+        public long InTimeExcds;
+        public long OutTimeExcds;
     }
 
     internal struct TcpGlobalStatisticsTable
     {
-        public int RtoAlgorithm;
-        public int RtoMin;
-        public int RtoMax;
-        public int MaxConn;
-        public int ActiveOpens;
-        public int PassiveOpens;
-        public int AttemptFails;
-        public int EstabResets;
-        public int CurrEstab;
-        public int InSegs;
-        public int OutSegs;
-        public int RetransSegs;
-        public int InErrs;
-        public int OutRsts;
-        public int InCsumErrors;
+        public long RtoAlgorithm;
+        public long RtoMin;
+        public long RtoMax;
+        public long MaxConn;
+        public long ActiveOpens;
+        public long PassiveOpens;
+        public long AttemptFails;
+        public long EstabResets;
+        public long CurrEstab;
+        public long InSegs;
+        public long OutSegs;
+        public long RetransSegs;
+        public long InErrs;
+        public long OutRsts;
+        public long InCsumErrors;
     }
 
     internal struct UdpGlobalStatisticsTable
     {
-        public int InDatagrams;
-        public int NoPorts;
-        public int InErrors;
-        public int OutDatagrams;
-        public int RcvbufErrors;
-        public int SndbufErrors;
-        public int InCsumErrors;
+        public long InDatagrams;
+        public long NoPorts;
+        public long InErrors;
+        public long OutDatagrams;
+        public long RcvbufErrors;
+        public long SndbufErrors;
+        public long InCsumErrors;
     }
 
     /// <summary>
@@ -124,28 +124,28 @@ namespace System.Net.NetworkInformation
         // In the snmp6 file, each name is prefixed with "IP6".
 
         public bool Forwarding; // Forwarding
-        public int DefaultTtl; // DefaultTTL
+        public long DefaultTtl; // DefaultTTL
 
-        public int InReceives; // InReceives
-        public int InHeaderErrors; // InHdrErrors
-        public int InAddressErrors; // InAddrErrors
-        public int ForwardedDatagrams; // ForwDatagrams (IP6OutForwDatagrams)
-        public int InUnknownProtocols; // InUnknownProtos
-        public int InDiscards; // InDiscards
-        public int InDelivers; // InDelivers
+        public long InReceives; // InReceives
+        public long InHeaderErrors; // InHdrErrors
+        public long InAddressErrors; // InAddrErrors
+        public long ForwardedDatagrams; // ForwDatagrams (IP6OutForwDatagrams)
+        public long InUnknownProtocols; // InUnknownProtos
+        public long InDiscards; // InDiscards
+        public long InDelivers; // InDelivers
 
-        public int OutRequests; // OutRequestscat 
-        public int OutDiscards; // OutDiscards
-        public int OutNoRoutes; // OutNoRoutes
+        public long OutRequests; // OutRequestscat
+        public long OutDiscards; // OutDiscards
+        public long OutNoRoutes; // OutNoRoutes
 
-        public int ReassemblyTimeout; // ReasmTimeout
-        public int ReassemblyRequireds; // ReasmReqds
-        public int ReassemblyOKs; // ReasmOKs
-        public int ReassemblyFails; // ReasmFails
+        public long ReassemblyTimeout; // ReasmTimeout
+        public long ReassemblyRequireds; // ReasmReqds
+        public long ReassemblyOKs; // ReasmOKs
+        public long ReassemblyFails; // ReasmFails
 
-        public int FragmentOKs; // FragOKs
-        public int FragmentFails; // FragFails
-        public int FragmentCreates; // FragCreates
+        public long FragmentOKs; // FragOKs
+        public long FragmentFails; // FragFails
+        public long FragmentCreates; // FragCreates
     }
 
     internal struct IPInterfaceStatisticsTable
@@ -188,33 +188,33 @@ namespace System.Net.NetworkInformation
 
             return new Icmpv4StatisticsTable()
             {
-                InMsgs = parser.ParseNextInt32(),
-                InErrors = parser.ParseNextInt32(),
-                InCsumErrors = inCsumErrorsIdx == -1 ? 0 : parser.ParseNextInt32(),
-                InDestUnreachs = parser.ParseNextInt32(),
-                InTimeExcds = parser.ParseNextInt32(),
-                InParmProbs = parser.ParseNextInt32(),
-                InSrcQuenchs = parser.ParseNextInt32(),
-                InRedirects = parser.ParseNextInt32(),
-                InEchos = parser.ParseNextInt32(),
-                InEchoReps = parser.ParseNextInt32(),
-                InTimestamps = parser.ParseNextInt32(),
-                InTimeStampReps = parser.ParseNextInt32(),
-                InAddrMasks = parser.ParseNextInt32(),
-                InAddrMaskReps = parser.ParseNextInt32(),
-                OutMsgs = parser.ParseNextInt32(),
-                OutErrors = parser.ParseNextInt32(),
-                OutDestUnreachs = parser.ParseNextInt32(),
-                OutTimeExcds = parser.ParseNextInt32(),
-                OutParmProbs = parser.ParseNextInt32(),
-                OutSrcQuenchs = parser.ParseNextInt32(),
-                OutRedirects = parser.ParseNextInt32(),
-                OutEchos = parser.ParseNextInt32(),
-                OutEchoReps = parser.ParseNextInt32(),
-                OutTimestamps = parser.ParseNextInt32(),
-                OutTimestampReps = parser.ParseNextInt32(),
-                OutAddrMasks = parser.ParseNextInt32(),
-                OutAddrMaskReps = parser.ParseNextInt32()
+                InMsgs = parser.ParseNextInt64(),
+                InErrors = parser.ParseNextInt64(),
+                InCsumErrors = inCsumErrorsIdx == -1 ? 0 : parser.ParseNextInt64(),
+                InDestUnreachs = parser.ParseNextInt64(),
+                InTimeExcds = parser.ParseNextInt64(),
+                InParmProbs = parser.ParseNextInt64(),
+                InSrcQuenchs = parser.ParseNextInt64(),
+                InRedirects = parser.ParseNextInt64(),
+                InEchos = parser.ParseNextInt64(),
+                InEchoReps = parser.ParseNextInt64(),
+                InTimestamps = parser.ParseNextInt64(),
+                InTimeStampReps = parser.ParseNextInt64(),
+                InAddrMasks = parser.ParseNextInt64(),
+                InAddrMaskReps = parser.ParseNextInt64(),
+                OutMsgs = parser.ParseNextInt64(),
+                OutErrors = parser.ParseNextInt64(),
+                OutDestUnreachs = parser.ParseNextInt64(),
+                OutTimeExcds = parser.ParseNextInt64(),
+                OutParmProbs = parser.ParseNextInt64(),
+                OutSrcQuenchs = parser.ParseNextInt64(),
+                OutRedirects = parser.ParseNextInt64(),
+                OutEchos = parser.ParseNextInt64(),
+                OutEchoReps = parser.ParseNextInt64(),
+                OutTimestamps = parser.ParseNextInt64(),
+                OutTimestampReps = parser.ParseNextInt64(),
+                OutAddrMasks = parser.ParseNextInt64(),
+                OutAddrMaskReps = parser.ParseNextInt64()
             };
         }
 
@@ -226,38 +226,38 @@ namespace System.Net.NetworkInformation
 
             return new Icmpv6StatisticsTable()
             {
-                InMsgs = reader.GetNextValueAsInt32("Icmp6InMsgs"),
-                InErrors = reader.GetNextValueAsInt32("Icmp6InErrors"),
-                OutMsgs = reader.GetNextValueAsInt32("Icmp6OutMsgs"),
-                OutErrors = Icmp6OutErrorsIdx == -1 ? 0 : reader.GetNextValueAsInt32("Icmp6OutErrors"),
-                InDestUnreachs = reader.GetNextValueAsInt32("Icmp6InDestUnreachs"),
-                InPktTooBigs = reader.GetNextValueAsInt32("Icmp6InPktTooBigs"),
-                InTimeExcds = reader.GetNextValueAsInt32("Icmp6InTimeExcds"),
-                InParmProblems = reader.GetNextValueAsInt32("Icmp6InParmProblems"),
-                InEchos = reader.GetNextValueAsInt32("Icmp6InEchos"),
-                InEchoReplies = reader.GetNextValueAsInt32("Icmp6InEchoReplies"),
-                InGroupMembQueries = reader.GetNextValueAsInt32("Icmp6InGroupMembQueries"),
-                InGroupMembResponses = reader.GetNextValueAsInt32("Icmp6InGroupMembResponses"),
-                InGroupMembReductions = reader.GetNextValueAsInt32("Icmp6InGroupMembReductions"),
-                InRouterSolicits = reader.GetNextValueAsInt32("Icmp6InRouterSolicits"),
-                InRouterAdvertisements = reader.GetNextValueAsInt32("Icmp6InRouterAdvertisements"),
-                InNeighborSolicits = reader.GetNextValueAsInt32("Icmp6InNeighborSolicits"),
-                InNeighborAdvertisements = reader.GetNextValueAsInt32("Icmp6InNeighborAdvertisements"),
-                InRedirects = reader.GetNextValueAsInt32("Icmp6InRedirects"),
-                OutDestUnreachs = reader.GetNextValueAsInt32("Icmp6OutDestUnreachs"),
-                OutPktTooBigs = reader.GetNextValueAsInt32("Icmp6OutPktTooBigs"),
-                OutTimeExcds = reader.GetNextValueAsInt32("Icmp6OutTimeExcds"),
-                OutParmProblems = reader.GetNextValueAsInt32("Icmp6OutParmProblems"),
-                OutEchos = reader.GetNextValueAsInt32("Icmp6OutEchos"),
-                OutEchoReplies = reader.GetNextValueAsInt32("Icmp6OutEchoReplies"),
-                OutInGroupMembQueries = reader.GetNextValueAsInt32("Icmp6OutGroupMembQueries"),
-                OutGroupMembResponses = reader.GetNextValueAsInt32("Icmp6OutGroupMembResponses"),
-                OutGroupMembReductions = reader.GetNextValueAsInt32("Icmp6OutGroupMembReductions"),
-                OutRouterSolicits = reader.GetNextValueAsInt32("Icmp6OutRouterSolicits"),
-                OutRouterAdvertisements = reader.GetNextValueAsInt32("Icmp6OutRouterAdvertisements"),
-                OutNeighborSolicits = reader.GetNextValueAsInt32("Icmp6OutNeighborSolicits"),
-                OutNeighborAdvertisements = reader.GetNextValueAsInt32("Icmp6OutNeighborAdvertisements"),
-                OutRedirects = reader.GetNextValueAsInt32("Icmp6OutRedirects")
+                InMsgs = reader.GetNextValueAsInt64("Icmp6InMsgs"),
+                InErrors = reader.GetNextValueAsInt64("Icmp6InErrors"),
+                OutMsgs = reader.GetNextValueAsInt64("Icmp6OutMsgs"),
+                OutErrors = Icmp6OutErrorsIdx == -1 ? 0 : reader.GetNextValueAsInt64("Icmp6OutErrors"),
+                InDestUnreachs = reader.GetNextValueAsInt64("Icmp6InDestUnreachs"),
+                InPktTooBigs = reader.GetNextValueAsInt64("Icmp6InPktTooBigs"),
+                InTimeExcds = reader.GetNextValueAsInt64("Icmp6InTimeExcds"),
+                InParmProblems = reader.GetNextValueAsInt64("Icmp6InParmProblems"),
+                InEchos = reader.GetNextValueAsInt64("Icmp6InEchos"),
+                InEchoReplies = reader.GetNextValueAsInt64("Icmp6InEchoReplies"),
+                InGroupMembQueries = reader.GetNextValueAsInt64("Icmp6InGroupMembQueries"),
+                InGroupMembResponses = reader.GetNextValueAsInt64("Icmp6InGroupMembResponses"),
+                InGroupMembReductions = reader.GetNextValueAsInt64("Icmp6InGroupMembReductions"),
+                InRouterSolicits = reader.GetNextValueAsInt64("Icmp6InRouterSolicits"),
+                InRouterAdvertisements = reader.GetNextValueAsInt64("Icmp6InRouterAdvertisements"),
+                InNeighborSolicits = reader.GetNextValueAsInt64("Icmp6InNeighborSolicits"),
+                InNeighborAdvertisements = reader.GetNextValueAsInt64("Icmp6InNeighborAdvertisements"),
+                InRedirects = reader.GetNextValueAsInt64("Icmp6InRedirects"),
+                OutDestUnreachs = reader.GetNextValueAsInt64("Icmp6OutDestUnreachs"),
+                OutPktTooBigs = reader.GetNextValueAsInt64("Icmp6OutPktTooBigs"),
+                OutTimeExcds = reader.GetNextValueAsInt64("Icmp6OutTimeExcds"),
+                OutParmProblems = reader.GetNextValueAsInt64("Icmp6OutParmProblems"),
+                OutEchos = reader.GetNextValueAsInt64("Icmp6OutEchos"),
+                OutEchoReplies = reader.GetNextValueAsInt64("Icmp6OutEchoReplies"),
+                OutInGroupMembQueries = reader.GetNextValueAsInt64("Icmp6OutGroupMembQueries"),
+                OutGroupMembResponses = reader.GetNextValueAsInt64("Icmp6OutGroupMembResponses"),
+                OutGroupMembReductions = reader.GetNextValueAsInt64("Icmp6OutGroupMembReductions"),
+                OutRouterSolicits = reader.GetNextValueAsInt64("Icmp6OutRouterSolicits"),
+                OutRouterAdvertisements = reader.GetNextValueAsInt64("Icmp6OutRouterAdvertisements"),
+                OutNeighborSolicits = reader.GetNextValueAsInt64("Icmp6OutNeighborSolicits"),
+                OutNeighborAdvertisements = reader.GetNextValueAsInt64("Icmp6OutNeighborAdvertisements"),
+                OutRedirects = reader.GetNextValueAsInt64("Icmp6OutRedirects")
             };
         }
 
@@ -277,24 +277,24 @@ namespace System.Net.NetworkInformation
             return new IPGlobalStatisticsTable()
             {
                 Forwarding = parser.MoveAndExtractNext() == "1",
-                DefaultTtl = parser.ParseNextInt32(),
-                InReceives = parser.ParseNextInt32(),
-                InHeaderErrors = parser.ParseNextInt32(),
-                InAddressErrors = parser.ParseNextInt32(),
-                ForwardedDatagrams = parser.ParseNextInt32(),
-                InUnknownProtocols = parser.ParseNextInt32(),
-                InDiscards = parser.ParseNextInt32(),
-                InDelivers = parser.ParseNextInt32(),
-                OutRequests = parser.ParseNextInt32(),
-                OutDiscards = parser.ParseNextInt32(),
-                OutNoRoutes = parser.ParseNextInt32(),
-                ReassemblyTimeout = parser.ParseNextInt32(),
-                ReassemblyRequireds = parser.ParseNextInt32(),
-                ReassemblyOKs = parser.ParseNextInt32(),
-                ReassemblyFails = parser.ParseNextInt32(),
-                FragmentOKs = parser.ParseNextInt32(),
-                FragmentFails = parser.ParseNextInt32(),
-                FragmentCreates = parser.ParseNextInt32(),
+                DefaultTtl = parser.ParseNextInt64(),
+                InReceives = parser.ParseNextInt64(),
+                InHeaderErrors = parser.ParseNextInt64(),
+                InAddressErrors = parser.ParseNextInt64(),
+                ForwardedDatagrams = parser.ParseNextInt64(),
+                InUnknownProtocols = parser.ParseNextInt64(),
+                InDiscards = parser.ParseNextInt64(),
+                InDelivers = parser.ParseNextInt64(),
+                OutRequests = parser.ParseNextInt64(),
+                OutDiscards = parser.ParseNextInt64(),
+                OutNoRoutes = parser.ParseNextInt64(),
+                ReassemblyTimeout = parser.ParseNextInt64(),
+                ReassemblyRequireds = parser.ParseNextInt64(),
+                ReassemblyOKs = parser.ParseNextInt64(),
+                ReassemblyFails = parser.ParseNextInt64(),
+                FragmentOKs = parser.ParseNextInt64(),
+                FragmentFails = parser.ParseNextInt64(),
+                FragmentCreates = parser.ParseNextInt64(),
             };
         }
 
@@ -306,23 +306,23 @@ namespace System.Net.NetworkInformation
 
             return new IPGlobalStatisticsTable()
             {
-                InReceives = reader.GetNextValueAsInt32("Ip6InReceives"),
-                InHeaderErrors = reader.GetNextValueAsInt32("Ip6InHdrErrors"),
-                InAddressErrors = reader.GetNextValueAsInt32("Ip6InAddrErrors"),
-                InUnknownProtocols = reader.GetNextValueAsInt32("Ip6InUnknownProtos"),
-                InDiscards = reader.GetNextValueAsInt32("Ip6InDiscards"),
-                InDelivers = reader.GetNextValueAsInt32("Ip6InDelivers"),
-                ForwardedDatagrams = reader.GetNextValueAsInt32("Ip6OutForwDatagrams"),
-                OutRequests = reader.GetNextValueAsInt32("Ip6OutRequests"),
-                OutDiscards = reader.GetNextValueAsInt32("Ip6OutDiscards"),
-                OutNoRoutes = reader.GetNextValueAsInt32("Ip6OutNoRoutes"),
-                ReassemblyTimeout = reader.GetNextValueAsInt32("Ip6ReasmTimeout"),
-                ReassemblyRequireds = reader.GetNextValueAsInt32("Ip6ReasmReqds"),
-                ReassemblyOKs = reader.GetNextValueAsInt32("Ip6ReasmOKs"),
-                ReassemblyFails = reader.GetNextValueAsInt32("Ip6ReasmFails"),
-                FragmentOKs = reader.GetNextValueAsInt32("Ip6FragOKs"),
-                FragmentFails = reader.GetNextValueAsInt32("Ip6FragFails"),
-                FragmentCreates = reader.GetNextValueAsInt32("Ip6FragCreates"),
+                InReceives = reader.GetNextValueAsInt64("Ip6InReceives"),
+                InHeaderErrors = reader.GetNextValueAsInt64("Ip6InHdrErrors"),
+                InAddressErrors = reader.GetNextValueAsInt64("Ip6InAddrErrors"),
+                InUnknownProtocols = reader.GetNextValueAsInt64("Ip6InUnknownProtos"),
+                InDiscards = reader.GetNextValueAsInt64("Ip6InDiscards"),
+                InDelivers = reader.GetNextValueAsInt64("Ip6InDelivers"),
+                ForwardedDatagrams = reader.GetNextValueAsInt64("Ip6OutForwDatagrams"),
+                OutRequests = reader.GetNextValueAsInt64("Ip6OutRequests"),
+                OutDiscards = reader.GetNextValueAsInt64("Ip6OutDiscards"),
+                OutNoRoutes = reader.GetNextValueAsInt64("Ip6OutNoRoutes"),
+                ReassemblyTimeout = reader.GetNextValueAsInt64("Ip6ReasmTimeout"),
+                ReassemblyRequireds = reader.GetNextValueAsInt64("Ip6ReasmReqds"),
+                ReassemblyOKs = reader.GetNextValueAsInt64("Ip6ReasmOKs"),
+                ReassemblyFails = reader.GetNextValueAsInt64("Ip6ReasmFails"),
+                FragmentOKs = reader.GetNextValueAsInt64("Ip6FragOKs"),
+                FragmentFails = reader.GetNextValueAsInt64("Ip6FragFails"),
+                FragmentCreates = reader.GetNextValueAsInt64("Ip6FragCreates"),
             };
         }
 
@@ -342,21 +342,21 @@ namespace System.Net.NetworkInformation
 
             return new TcpGlobalStatisticsTable()
             {
-                RtoAlgorithm = parser.ParseNextInt32(),
-                RtoMin = parser.ParseNextInt32(),
-                RtoMax = parser.ParseNextInt32(),
-                MaxConn = parser.ParseNextInt32(),
-                ActiveOpens = parser.ParseNextInt32(),
-                PassiveOpens = parser.ParseNextInt32(),
-                AttemptFails = parser.ParseNextInt32(),
-                EstabResets = parser.ParseNextInt32(),
-                CurrEstab = parser.ParseNextInt32(),
-                InSegs = parser.ParseNextInt32(),
-                OutSegs = parser.ParseNextInt32(),
-                RetransSegs = parser.ParseNextInt32(),
-                InErrs = parser.ParseNextInt32(),
-                OutRsts = parser.ParseNextInt32(),
-                InCsumErrors = inCsumErrorsIdx == -1 ? 0 : parser.ParseNextInt32()
+                RtoAlgorithm = parser.ParseNextInt64(),
+                RtoMin = parser.ParseNextInt64(),
+                RtoMax = parser.ParseNextInt64(),
+                MaxConn = parser.ParseNextInt64(),
+                ActiveOpens = parser.ParseNextInt64(),
+                PassiveOpens = parser.ParseNextInt64(),
+                AttemptFails = parser.ParseNextInt64(),
+                EstabResets = parser.ParseNextInt64(),
+                CurrEstab = parser.ParseNextInt64(),
+                InSegs = parser.ParseNextInt64(),
+                OutSegs = parser.ParseNextInt64(),
+                RetransSegs = parser.ParseNextInt64(),
+                InErrs = parser.ParseNextInt64(),
+                OutRsts = parser.ParseNextInt64(),
+                InCsumErrors = inCsumErrorsIdx == -1 ? 0 : parser.ParseNextInt64()
             };
         }
 
@@ -374,13 +374,13 @@ namespace System.Net.NetworkInformation
 
             return new UdpGlobalStatisticsTable()
             {
-                InDatagrams = parser.ParseNextInt32(),
-                NoPorts = parser.ParseNextInt32(),
-                InErrors = parser.ParseNextInt32(),
-                OutDatagrams = parser.ParseNextInt32(),
-                RcvbufErrors = parser.ParseNextInt32(),
-                SndbufErrors = parser.ParseNextInt32(),
-                InCsumErrors = inCsumErrorsIdx == -1 ? 0 : parser.ParseNextInt32()
+                InDatagrams = parser.ParseNextInt64(),
+                NoPorts = parser.ParseNextInt64(),
+                InErrors = parser.ParseNextInt64(),
+                OutDatagrams = parser.ParseNextInt64(),
+                RcvbufErrors = parser.ParseNextInt64(),
+                SndbufErrors = parser.ParseNextInt64(),
+                InCsumErrors = inCsumErrorsIdx == -1 ? 0 : parser.ParseNextInt64()
             };
         }
 
@@ -392,13 +392,13 @@ namespace System.Net.NetworkInformation
 
             return new UdpGlobalStatisticsTable()
             {
-                InDatagrams = reader.GetNextValueAsInt32("Udp6InDatagrams"),
-                NoPorts = reader.GetNextValueAsInt32("Udp6NoPorts"),
-                InErrors = reader.GetNextValueAsInt32("Udp6InErrors"),
-                OutDatagrams = reader.GetNextValueAsInt32("Udp6OutDatagrams"),
-                RcvbufErrors = udp6ErrorsIdx == -1 ? 0 : reader.GetNextValueAsInt32("Udp6RcvbufErrors"),
-                SndbufErrors = udp6ErrorsIdx == -1 ? 0 : reader.GetNextValueAsInt32("Udp6SndbufErrors"),
-                InCsumErrors = udp6ErrorsIdx == -1 ? 0 : reader.GetNextValueAsInt32("Udp6InCsumErrors"),
+                InDatagrams = reader.GetNextValueAsInt64("Udp6InDatagrams"),
+                NoPorts = reader.GetNextValueAsInt64("Udp6NoPorts"),
+                InErrors = reader.GetNextValueAsInt64("Udp6InErrors"),
+                OutDatagrams = reader.GetNextValueAsInt64("Udp6OutDatagrams"),
+                RcvbufErrors = udp6ErrorsIdx == -1 ? 0 : reader.GetNextValueAsInt64("Udp6RcvbufErrors"),
+                SndbufErrors = udp6ErrorsIdx == -1 ? 0 : reader.GetNextValueAsInt64("Udp6SndbufErrors"),
+                InCsumErrors = udp6ErrorsIdx == -1 ? 0 : reader.GetNextValueAsInt64("Udp6InCsumErrors"),
             };
         }
 

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -124,7 +124,7 @@ namespace System.Net.NetworkInformation
         // In the snmp6 file, each name is prefixed with "IP6".
 
         public bool Forwarding; // Forwarding
-        public long DefaultTtl; // DefaultTTL
+        public int DefaultTtl; // DefaultTTL
 
         public long InReceives; // InReceives
         public long InHeaderErrors; // InHdrErrors
@@ -277,7 +277,7 @@ namespace System.Net.NetworkInformation
             return new IPGlobalStatisticsTable()
             {
                 Forwarding = parser.MoveAndExtractNext() == "1",
-                DefaultTtl = parser.ParseNextInt64(),
+                DefaultTtl = parser.ParseNextInt32(),
                 InReceives = parser.ParseNextInt64(),
                 InHeaderErrors = parser.ParseNextInt64(),
                 InAddressErrors = parser.ParseNextInt64(),

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkFiles/snmp
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkFiles/snmp
@@ -5,7 +5,7 @@ Icmp: 1 2 3 4 5 6 7 8 9 10 20 30 40 50 60 70 80 90 100 255 1024 256 9001 42 4100
 IcmpMsg: InType3 InType8 OutType0 OutType3
 IcmpMsg: 96 1 1 150
 Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
-Tcp: 1 200 120000 -1 359 28 2 53 4 21368 20642 19 0 111 0
+Tcp: 1 200 120000 -1 359 28 2 53 4 2592159585 2576867425 19 0 111 0
 Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti
 Udp: 7181 150 0 4386 0 0 1 2
 UdpLite: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
@@ -15,33 +15,33 @@ namespace System.Net.NetworkInformation.Tests
             string fileName = GetTestFilePath();
             FileUtil.NormalizeLineEndings("NetworkFiles/snmp", fileName);
             Icmpv4StatisticsTable table = StringParsingHelpers.ParseIcmpv4FromSnmpFile(fileName);
-            Assert.Equal(1, table.InMsgs);
-            Assert.Equal(2, table.InErrors);
-            Assert.Equal(3, table.InCsumErrors);
-            Assert.Equal(4, table.InDestUnreachs);
-            Assert.Equal(5, table.InTimeExcds);
-            Assert.Equal(6, table.InParmProbs);
-            Assert.Equal(7, table.InSrcQuenchs);
-            Assert.Equal(8, table.InRedirects);
-            Assert.Equal(9, table.InEchos);
-            Assert.Equal(10, table.InEchoReps);
-            Assert.Equal(20, table.InTimestamps);
-            Assert.Equal(30, table.InTimeStampReps);
-            Assert.Equal(40, table.InAddrMasks);
-            Assert.Equal(50, table.InAddrMaskReps);
-            Assert.Equal(60, table.OutMsgs);
-            Assert.Equal(70, table.OutErrors);
-            Assert.Equal(80, table.OutDestUnreachs);
-            Assert.Equal(90, table.OutTimeExcds);
-            Assert.Equal(100, table.OutParmProbs);
-            Assert.Equal(255, table.OutSrcQuenchs);
-            Assert.Equal(1024, table.OutRedirects);
-            Assert.Equal(256, table.OutEchos);
-            Assert.Equal(9001, table.OutEchoReps);
-            Assert.Equal(42, table.OutTimestamps);
-            Assert.Equal(4100414, table.OutTimestampReps);
-            Assert.Equal(2147483647, table.OutAddrMasks);
-            Assert.Equal(0, table.OutAddrMaskReps);
+            Assert.Equal(1L, table.InMsgs);
+            Assert.Equal(2L, table.InErrors);
+            Assert.Equal(3L, table.InCsumErrors);
+            Assert.Equal(4L, table.InDestUnreachs);
+            Assert.Equal(5L, table.InTimeExcds);
+            Assert.Equal(6L, table.InParmProbs);
+            Assert.Equal(7L, table.InSrcQuenchs);
+            Assert.Equal(8L, table.InRedirects);
+            Assert.Equal(9L, table.InEchos);
+            Assert.Equal(10L, table.InEchoReps);
+            Assert.Equal(20L, table.InTimestamps);
+            Assert.Equal(30L, table.InTimeStampReps);
+            Assert.Equal(40L, table.InAddrMasks);
+            Assert.Equal(50L, table.InAddrMaskReps);
+            Assert.Equal(60L, table.OutMsgs);
+            Assert.Equal(70L, table.OutErrors);
+            Assert.Equal(80L, table.OutDestUnreachs);
+            Assert.Equal(90L, table.OutTimeExcds);
+            Assert.Equal(100L, table.OutParmProbs);
+            Assert.Equal(255L, table.OutSrcQuenchs);
+            Assert.Equal(1024L, table.OutRedirects);
+            Assert.Equal(256L, table.OutEchos);
+            Assert.Equal(9001L, table.OutEchoReps);
+            Assert.Equal(42L, table.OutTimestamps);
+            Assert.Equal(4100414L, table.OutTimestampReps);
+            Assert.Equal(2147483647L, table.OutAddrMasks);
+            Assert.Equal(0L, table.OutAddrMaskReps);
         }
 
         [Fact]
@@ -50,38 +50,38 @@ namespace System.Net.NetworkInformation.Tests
             string fileName = GetTestFilePath();
             FileUtil.NormalizeLineEndings("NetworkFiles/snmp6", fileName);
             Icmpv6StatisticsTable table = StringParsingHelpers.ParseIcmpv6FromSnmp6File(fileName);
-            Assert.Equal(1, table.InMsgs);
-            Assert.Equal(2, table.InErrors);
-            Assert.Equal(3, table.OutMsgs);
-            Assert.Equal(4, table.OutErrors);
-            Assert.Equal(6, table.InDestUnreachs);
-            Assert.Equal(7, table.InPktTooBigs);
-            Assert.Equal(8, table.InTimeExcds);
-            Assert.Equal(9, table.InParmProblems);
-            Assert.Equal(10, table.InEchos);
-            Assert.Equal(11, table.InEchoReplies);
-            Assert.Equal(12, table.InGroupMembQueries);
-            Assert.Equal(13, table.InGroupMembResponses);
-            Assert.Equal(14, table.InGroupMembReductions);
-            Assert.Equal(15, table.InRouterSolicits);
-            Assert.Equal(16, table.InRouterAdvertisements);
-            Assert.Equal(17, table.InNeighborSolicits);
-            Assert.Equal(18, table.InNeighborAdvertisements);
-            Assert.Equal(19, table.InRedirects);
-            Assert.Equal(21, table.OutDestUnreachs);
-            Assert.Equal(22, table.OutPktTooBigs);
-            Assert.Equal(23, table.OutTimeExcds);
-            Assert.Equal(24, table.OutParmProblems);
-            Assert.Equal(25, table.OutEchos);
-            Assert.Equal(26, table.OutEchoReplies);
-            Assert.Equal(27, table.OutInGroupMembQueries);
-            Assert.Equal(28, table.OutGroupMembResponses);
-            Assert.Equal(29, table.OutGroupMembReductions);
-            Assert.Equal(30, table.OutRouterSolicits);
-            Assert.Equal(31, table.OutRouterAdvertisements);
-            Assert.Equal(32, table.OutNeighborSolicits);
-            Assert.Equal(33, table.OutNeighborAdvertisements);
-            Assert.Equal(34, table.OutRedirects);
+            Assert.Equal(1L, table.InMsgs);
+            Assert.Equal(2L, table.InErrors);
+            Assert.Equal(3L, table.OutMsgs);
+            Assert.Equal(4L, table.OutErrors);
+            Assert.Equal(6L, table.InDestUnreachs);
+            Assert.Equal(7L, table.InPktTooBigs);
+            Assert.Equal(8L, table.InTimeExcds);
+            Assert.Equal(9L, table.InParmProblems);
+            Assert.Equal(10L, table.InEchos);
+            Assert.Equal(11L, table.InEchoReplies);
+            Assert.Equal(12L, table.InGroupMembQueries);
+            Assert.Equal(13L, table.InGroupMembResponses);
+            Assert.Equal(14L, table.InGroupMembReductions);
+            Assert.Equal(15L, table.InRouterSolicits);
+            Assert.Equal(16L, table.InRouterAdvertisements);
+            Assert.Equal(17L, table.InNeighborSolicits);
+            Assert.Equal(18L, table.InNeighborAdvertisements);
+            Assert.Equal(19L, table.InRedirects);
+            Assert.Equal(21L, table.OutDestUnreachs);
+            Assert.Equal(22L, table.OutPktTooBigs);
+            Assert.Equal(23L, table.OutTimeExcds);
+            Assert.Equal(24L, table.OutParmProblems);
+            Assert.Equal(25L, table.OutEchos);
+            Assert.Equal(26L, table.OutEchoReplies);
+            Assert.Equal(27L, table.OutInGroupMembQueries);
+            Assert.Equal(28L, table.OutGroupMembResponses);
+            Assert.Equal(29L, table.OutGroupMembReductions);
+            Assert.Equal(30L, table.OutRouterSolicits);
+            Assert.Equal(31L, table.OutRouterAdvertisements);
+            Assert.Equal(32L, table.OutNeighborSolicits);
+            Assert.Equal(33L, table.OutNeighborAdvertisements);
+            Assert.Equal(34L, table.OutRedirects);
         }
 
         [Fact]
@@ -90,21 +90,21 @@ namespace System.Net.NetworkInformation.Tests
             string fileName = GetTestFilePath();
             FileUtil.NormalizeLineEndings("NetworkFiles/snmp", fileName);
             TcpGlobalStatisticsTable table = StringParsingHelpers.ParseTcpGlobalStatisticsFromSnmpFile(fileName);
-            Assert.Equal(1, table.RtoAlgorithm);
-            Assert.Equal(200, table.RtoMin);
-            Assert.Equal(120000, table.RtoMax);
-            Assert.Equal(-1, table.MaxConn);
-            Assert.Equal(359, table.ActiveOpens);
-            Assert.Equal(28, table.PassiveOpens);
-            Assert.Equal(2, table.AttemptFails);
-            Assert.Equal(53, table.EstabResets);
-            Assert.Equal(4, table.CurrEstab);
-            Assert.Equal(21368, table.InSegs);
-            Assert.Equal(20642, table.OutSegs);
-            Assert.Equal(19, table.RetransSegs);
-            Assert.Equal(0, table.InErrs);
-            Assert.Equal(111, table.OutRsts);
-            Assert.Equal(0, table.InCsumErrors);
+            Assert.Equal(1L, table.RtoAlgorithm);
+            Assert.Equal(200L, table.RtoMin);
+            Assert.Equal(120000L, table.RtoMax);
+            Assert.Equal(-1L, table.MaxConn);
+            Assert.Equal(359L, table.ActiveOpens);
+            Assert.Equal(28L, table.PassiveOpens);
+            Assert.Equal(2L, table.AttemptFails);
+            Assert.Equal(53L, table.EstabResets);
+            Assert.Equal(4L, table.CurrEstab);
+            Assert.Equal(2592159585L, table.InSegs);
+            Assert.Equal(2576867425L, table.OutSegs);
+            Assert.Equal(19L, table.RetransSegs);
+            Assert.Equal(0L, table.InErrs);
+            Assert.Equal(111L, table.OutRsts);
+            Assert.Equal(0L, table.InCsumErrors);
         }
 
         [Fact]
@@ -113,13 +113,13 @@ namespace System.Net.NetworkInformation.Tests
             string fileName = GetTestFilePath();
             FileUtil.NormalizeLineEndings("NetworkFiles/snmp", fileName);
             UdpGlobalStatisticsTable table = StringParsingHelpers.ParseUdpv4GlobalStatisticsFromSnmpFile(fileName);
-            Assert.Equal(7181, table.InDatagrams);
-            Assert.Equal(150, table.NoPorts);
-            Assert.Equal(0, table.InErrors);
-            Assert.Equal(4386, table.OutDatagrams);
-            Assert.Equal(0, table.RcvbufErrors);
-            Assert.Equal(0, table.SndbufErrors);
-            Assert.Equal(1, table.InCsumErrors);
+            Assert.Equal(7181L, table.InDatagrams);
+            Assert.Equal(150L, table.NoPorts);
+            Assert.Equal(0L, table.InErrors);
+            Assert.Equal(4386L, table.OutDatagrams);
+            Assert.Equal(0L, table.RcvbufErrors);
+            Assert.Equal(0L, table.SndbufErrors);
+            Assert.Equal(1L, table.InCsumErrors);
         }
 
         [Fact]
@@ -128,13 +128,13 @@ namespace System.Net.NetworkInformation.Tests
             string fileName = GetTestFilePath();
             FileUtil.NormalizeLineEndings("NetworkFiles/snmp6", fileName);
             UdpGlobalStatisticsTable table = StringParsingHelpers.ParseUdpv6GlobalStatisticsFromSnmp6File(fileName);
-            Assert.Equal(19, table.InDatagrams);
-            Assert.Equal(0, table.NoPorts);
-            Assert.Equal(0, table.InErrors);
-            Assert.Equal(21, table.OutDatagrams);
-            Assert.Equal(99999, table.RcvbufErrors);
-            Assert.Equal(11011011, table.SndbufErrors);
-            Assert.Equal(0, table.InCsumErrors);
+            Assert.Equal(19L, table.InDatagrams);
+            Assert.Equal(0L, table.NoPorts);
+            Assert.Equal(0L, table.InErrors);
+            Assert.Equal(21L, table.OutDatagrams);
+            Assert.Equal(99999L, table.RcvbufErrors);
+            Assert.Equal(11011011L, table.SndbufErrors);
+            Assert.Equal(0L, table.InCsumErrors);
         }
 
         [Fact]
@@ -145,24 +145,24 @@ namespace System.Net.NetworkInformation.Tests
             IPGlobalStatisticsTable table = StringParsingHelpers.ParseIPv4GlobalStatisticsFromSnmpFile(fileName);
 
             Assert.Equal(false, table.Forwarding);
-            Assert.Equal(64, table.DefaultTtl);
-            Assert.Equal(28121, table.InReceives);
-            Assert.Equal(0, table.InHeaderErrors);
-            Assert.Equal(2, table.InAddressErrors);
-            Assert.Equal(0, table.ForwardedDatagrams);
-            Assert.Equal(0, table.InUnknownProtocols);
-            Assert.Equal(0, table.InDiscards);
-            Assert.Equal(28117, table.InDelivers);
-            Assert.Equal(24616, table.OutRequests);
-            Assert.Equal(48, table.OutDiscards);
-            Assert.Equal(0, table.OutNoRoutes);
-            Assert.Equal(0, table.ReassemblyTimeout);
-            Assert.Equal(0, table.ReassemblyRequireds);
-            Assert.Equal(1, table.ReassemblyOKs);
-            Assert.Equal(2, table.ReassemblyFails);
-            Assert.Equal(14, table.FragmentOKs);
-            Assert.Equal(0, table.FragmentFails);
-            Assert.Equal(92, table.FragmentCreates);
+            Assert.Equal(64L, table.DefaultTtl);
+            Assert.Equal(28121L, table.InReceives);
+            Assert.Equal(0L, table.InHeaderErrors);
+            Assert.Equal(2L, table.InAddressErrors);
+            Assert.Equal(0L, table.ForwardedDatagrams);
+            Assert.Equal(0L, table.InUnknownProtocols);
+            Assert.Equal(0L, table.InDiscards);
+            Assert.Equal(28117L, table.InDelivers);
+            Assert.Equal(24616L, table.OutRequests);
+            Assert.Equal(48L, table.OutDiscards);
+            Assert.Equal(0L, table.OutNoRoutes);
+            Assert.Equal(0L, table.ReassemblyTimeout);
+            Assert.Equal(0L, table.ReassemblyRequireds);
+            Assert.Equal(1L, table.ReassemblyOKs);
+            Assert.Equal(2L, table.ReassemblyFails);
+            Assert.Equal(14L, table.FragmentOKs);
+            Assert.Equal(0L, table.FragmentFails);
+            Assert.Equal(92L, table.FragmentCreates);
         }
 
         [Fact]
@@ -172,23 +172,23 @@ namespace System.Net.NetworkInformation.Tests
             FileUtil.NormalizeLineEndings("NetworkFiles/snmp6", fileName);
             IPGlobalStatisticsTable table = StringParsingHelpers.ParseIPv6GlobalStatisticsFromSnmp6File(fileName);
 
-            Assert.Equal(189, table.InReceives);
-            Assert.Equal(0, table.InHeaderErrors);
-            Assert.Equal(2000, table.InAddressErrors);
-            Assert.Equal(42, table.InUnknownProtocols);
-            Assert.Equal(0, table.InDiscards);
-            Assert.Equal(189, table.InDelivers);
-            Assert.Equal(55, table.ForwardedDatagrams);
-            Assert.Equal(199, table.OutRequests);
-            Assert.Equal(0, table.OutDiscards);
-            Assert.Equal(53, table.OutNoRoutes);
-            Assert.Equal(2121, table.ReassemblyTimeout);
-            Assert.Equal(1, table.ReassemblyRequireds);
-            Assert.Equal(2, table.ReassemblyOKs);
-            Assert.Equal(4, table.ReassemblyFails);
-            Assert.Equal(8, table.FragmentOKs);
-            Assert.Equal(16, table.FragmentFails);
-            Assert.Equal(32, table.FragmentCreates);
+            Assert.Equal(189L, table.InReceives);
+            Assert.Equal(0L, table.InHeaderErrors);
+            Assert.Equal(2000L, table.InAddressErrors);
+            Assert.Equal(42L, table.InUnknownProtocols);
+            Assert.Equal(0L, table.InDiscards);
+            Assert.Equal(189L, table.InDelivers);
+            Assert.Equal(55L, table.ForwardedDatagrams);
+            Assert.Equal(199L, table.OutRequests);
+            Assert.Equal(0L, table.OutDiscards);
+            Assert.Equal(53L, table.OutNoRoutes);
+            Assert.Equal(2121L, table.ReassemblyTimeout);
+            Assert.Equal(1L, table.ReassemblyRequireds);
+            Assert.Equal(2L, table.ReassemblyOKs);
+            Assert.Equal(4L, table.ReassemblyFails);
+            Assert.Equal(8L, table.FragmentOKs);
+            Assert.Equal(16L, table.FragmentFails);
+            Assert.Equal(32L, table.FragmentCreates);
         }
 
         [Fact]


### PR DESCRIPTION
This PR fix `System.OverflowException`-s in `StringParsingHelpers` class. Details described in #34719.