### PR TITLE
Introduce new, simpler to use converter test base

### DIFF
--- a/src/System.ComponentModel.TypeConverter/tests/Int16ConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Int16ConverterTests.cs
@@ -20,7 +20,17 @@ namespace System.ComponentModel.Tests
 
         public override IEnumerable<ConvertTest> ConvertFromTestData()
         {
+            yield return ConvertTest.Valid("1", (short)1);
+            yield return ConvertTest.Valid("-1  ", (short)-1);
+            yield return ConvertTest.Valid("#2", (short)2);
+            yield return ConvertTest.Valid("+7", (short)7);
+
             yield return ConvertTest.Throws<ArgumentException, Exception>("8.0");
+            yield return ConvertTest.Throws<ArgumentException, Exception>("");
+            yield return ConvertTest.Throws<ArgumentException, Exception>("bad");
+
+            yield return ConvertTest.Throws<ArgumentException, Exception>("32768");
+            yield return ConvertTest.Throws<ArgumentException, Exception>("-32769");
 
             yield return ConvertTest.CantConvert(new object());
         }

--- a/src/System.ComponentModel.TypeConverter/tests/Int16ConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Int16ConverterTests.cs
@@ -2,44 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Globalization;
-using Xunit;
 
 namespace System.ComponentModel.Tests
 {
-    public class Int16ConverterTests : ConverterTestBase
+    public class Int16ConverterTests : TypeConverterTestBase
     {
-        private static TypeConverter s_converter = new Int16Converter();
+        public override TypeConverter Converter => new Int16Converter();
 
-        [Fact]
-        public static void ConvertFrom_WithContext()
+        public override IEnumerable<ConvertTest> ConvertToTestData()
         {
-            ConvertFrom_WithContext(new object[3, 3]
-                {
-                    { "-1  ", (short)(-1), null },
-                    { "#2", (short)2, null },
-                    { "+7", (short)7, CultureInfo.InvariantCulture }
-                },
-                Int16ConverterTests.s_converter);
+            yield return ConvertTest.Valid((short)-1, "-1");
+            yield return ConvertTest.Valid((short)2, (short)2, CultureInfo.InvariantCulture);
+            yield return ConvertTest.Valid((short)3, (float)3.0);
         }
 
-        [Fact]
-        public static void ConvertFrom_WithContext_Negative()
+        public override IEnumerable<ConvertTest> ConvertFromTestData()
         {
-           AssertExtensions.Throws<ArgumentException, Exception>(
-               () => Int16ConverterTests.s_converter.ConvertFrom(TypeConverterTests.s_context, null, "8.0"));
-        }
+            yield return ConvertTest.Throws<ArgumentException, Exception>("8.0");
 
-        [Fact]
-        public static void ConvertTo_WithContext()
-        {
-            ConvertTo_WithContext(new object[3, 3]
-                {
-                    { (short)(-1), "-1", null },
-                    { (short)2, (short)2, CultureInfo.InvariantCulture },
-                    { (short)3, (float)3.0, null }
-                },
-                Int16ConverterTests.s_converter);
+            yield return ConvertTest.CantConvert(new object());
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/SampleClasses.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/SampleClasses.cs
@@ -6,6 +6,7 @@ using System.Collections;
 
 namespace System.ComponentModel.Tests
 {
+    [Serializable]
     public class MyTypeDescriptorContext : ITypeDescriptorContext
     {
         public IContainer Container => null;
@@ -59,6 +60,7 @@ namespace System.ComponentModel.Tests
         public const string Token = "Formatted class.";
     }
 
+    [Serializable]
     public class Collection1 : ICollection
     {
         public void CopyTo(Array array, int index)

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="TimeSpanConverterTests.cs" />
     <Compile Include="TypeConverterAttributeTests.cs" />
     <Compile Include="TypeConverterTests.cs" />
+    <Compile Include="TypeConverterTestBase.cs" />
     <Compile Include="TypeDescriptionProviderAttributeTests.cs" />
     <Compile Include="TypeDescriptorTests.cs" />
     <Compile Include="TypeDescriptorTests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />

--- a/src/System.ComponentModel.TypeConverter/tests/TypeConverterTestBase.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeConverterTestBase.cs
@@ -1,0 +1,325 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using Xunit;
+
+namespace System.ComponentModel.Tests
+{
+    public abstract class TypeConverterTestBase : RemoteExecutorTestBase
+    {
+        public abstract TypeConverter Converter { get; }
+        public virtual IEnumerable<ConvertTest> ConvertToTestData() => Enumerable.Empty<ConvertTest>();
+        public virtual IEnumerable<ConvertTest> ConvertFromTestData() => Enumerable.Empty<ConvertTest>();
+
+        public virtual bool PropertiesSupported { get; } = false;
+        public virtual bool StandardValuesSupported { get; } = false;
+        public virtual bool StandardValuesExclusive { get; } = false;
+
+        [Fact]
+        public void ConvertTo_DestinationType_Success()
+        {
+            Assert.All(ConvertToTestData(), convertTest =>
+            {
+                // We need to duplicate this test code as RemoteInvoke can't
+                // create "this" as the declaring type is an abstract class.
+                if (convertTest.RemoteInvokeCulture == null)
+                {
+                    Assert.Equal(convertTest.CanConvert, Converter.CanConvertTo(convertTest.Context, convertTest.DestinationType));
+
+                    if (convertTest.CanConvert)
+                    {
+                        object actual = Converter.ConvertTo(convertTest.Context, convertTest.Culture, convertTest.Source, convertTest.DestinationType);
+                        Assert.Equal(convertTest.Expected, actual);
+                    }
+                    else
+                    {
+                        Assert.Throws<NotSupportedException>(() => Converter.ConvertTo(convertTest.Context, convertTest.Culture, convertTest.Source, convertTest.DestinationType));
+                    }
+                }
+                else
+                {
+                    RemoteInvoke((typeName, testString) =>
+                    {
+                        // Deserialize the current test.
+                        TypeConverterTestBase testBase = (TypeConverterTestBase)Activator.CreateInstance(Type.GetType(typeName));
+                        ConvertTest test = ConvertTest.FromSerializedString(testString);
+
+                        CultureInfo.CurrentCulture = test.RemoteInvokeCulture;
+                        Assert.Equal(test.CanConvert, testBase.Converter.CanConvertTo(test.Context, test.DestinationType));
+
+                        if (test.CanConvert)
+                        {
+                            object actual = testBase.Converter.ConvertTo(test.Context, test.Culture, test.Source, test.DestinationType);
+                            Assert.Equal(test.Expected, actual);
+                        }
+                        else
+                        {
+                            Assert.Throws<NotSupportedException>(() => testBase.Converter.ConvertTo(test.Context, test.Culture, test.Source, test.DestinationType));
+                        }
+
+                        return SuccessExitCode;
+                    }, this.GetType().AssemblyQualifiedName, convertTest.GetSerializedString()).Dispose();
+                }
+            });
+        }
+
+        [Fact]
+        public void ConvertTo_NullDestinationType_ThrowsArgumentNullException()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("destinationType", () => Converter.ConvertTo(TypeConverterTests.s_context, null, "", null));
+        }
+
+        [Fact]
+        public void ConvertFrom_DestinationType_Success()
+        {
+            Assert.All(ConvertFromTestData(), convertTest =>
+            {
+                // We need to duplicate this test code as RemoteInvoke can't
+                // create "this" as the declaring type is an abstract class.
+                if (convertTest.RemoteInvokeCulture == null)
+                {
+                    if (convertTest.Source != null)
+                    {
+                        Assert.Equal(convertTest.CanConvert, Converter.CanConvertFrom(convertTest.Context, convertTest.Source.GetType()));
+                    }
+
+                    if (convertTest.NetCoreExceptionType == null)
+                    {
+                        object actual = Converter.ConvertFrom(convertTest.Context, convertTest.Culture, convertTest.Source);
+                        Assert.Equal(convertTest.Expected, actual);
+                    }
+                    else
+                    {
+                        AssertExtensions.Throws(convertTest.NetCoreExceptionType, convertTest.NetFrameworkExceptionType, () => Converter.ConvertFrom(convertTest.Context, convertTest.Culture, convertTest.Source));
+                    }
+                }
+                else
+                {
+                    RemoteInvoke((typeName, testString) =>
+                    {
+                        // Deserialize the current test.
+                        TypeConverterTestBase testBase = (TypeConverterTestBase)Activator.CreateInstance(Type.GetType(typeName));
+                        ConvertTest test = ConvertTest.FromSerializedString(testString);
+
+                        CultureInfo.CurrentCulture = test.RemoteInvokeCulture;
+                        if (test.Source != null)
+                        {
+                            Assert.Equal(test.CanConvert, testBase.Converter.CanConvertFrom(test.Context, test.Source.GetType()));
+                        }
+
+                        if (test.NetCoreExceptionType == null)
+                        {
+                            object actual = testBase.Converter.ConvertFrom(test.Context, test.Culture, test.Source);
+                            Assert.Equal(test.Expected, actual);
+                        }
+                        else
+                        {
+                            AssertExtensions.Throws(test.NetCoreExceptionType, test.NetFrameworkExceptionType, () => testBase.Converter.ConvertFrom(test.Context, test.Culture, test.Source));
+                        }
+
+                        return SuccessExitCode;
+                    }, this.GetType().AssemblyQualifiedName, convertTest.GetSerializedString()).Dispose();
+                }
+            });
+        }
+
+        [Fact]
+        public void GetPropertiesSupported_Invoke_ReturnsExpected()
+        {
+            TypeConverter converter = Converter;
+            Assert.Equal(PropertiesSupported, converter.GetPropertiesSupported());
+        }
+
+        [Fact]
+        public void GetStandardValuesSupported_Invoke_ReturnsExpected()
+        {
+            TypeConverter converter = Converter;
+            Assert.Equal(StandardValuesSupported, converter.GetStandardValuesSupported());
+        }
+
+        [Fact]
+        public void GetStandardValuesExclusive_Invoke_ReturnsExpected()
+        {
+            TypeConverter converter = Converter;
+            Assert.Equal(StandardValuesExclusive, converter.GetStandardValuesExclusive());
+        }
+
+        [Serializable]
+        public class ConvertTest : ISerializable
+        {
+            public object Source { get; set; }
+            public Type DestinationType { get; set; }
+            public object Expected { get; set; }
+            public CultureInfo Culture { get; set; }
+            public Type NetCoreExceptionType { get; set; }
+            public Type NetFrameworkExceptionType { get; set; }
+            public ITypeDescriptorContext Context { get; set; } = TypeConverterTests.s_context;
+            public CultureInfo RemoteInvokeCulture { get; set; }
+
+            public bool CanConvert { get; set; }
+            
+            public static ConvertTest Valid(object source, object expected, CultureInfo culture = null)
+            {
+                return new ConvertTest
+                {
+                    Source = source,
+                    DestinationType = expected?.GetType(),
+                    Expected = expected,
+                    Culture = culture,
+                    CanConvert = true,
+                };
+            }
+
+            public static ConvertTest Throws<TException>(object source, CultureInfo culture = null) where TException : Exception
+            {
+                return Throws<TException, TException>(source, culture);
+            }
+
+            public static ConvertTest Throws<TNetCoreException, TNetFrameworkException>(object source, CultureInfo culture = null) where TNetCoreException : Exception where TNetFrameworkException : Exception
+            {
+                return new ConvertTest
+                {
+                    Source = source,
+                    Culture = culture,
+                    NetCoreExceptionType = typeof(TNetCoreException),
+                    NetFrameworkExceptionType = typeof(TNetFrameworkException),
+                    CanConvert = true
+                };
+            }
+
+            public static ConvertTest CantConvert(object source, Type destinationType = null, CultureInfo culture = null)
+            {
+                return new ConvertTest
+                {
+                    Source = source,
+                    DestinationType = destinationType,
+                    Culture = culture,
+                    NetCoreExceptionType = typeof(NotSupportedException),
+                    NetFrameworkExceptionType = typeof(NotSupportedException),
+                    CanConvert = false
+                };
+            }
+
+            public ConvertTest WithContext(ITypeDescriptorContext context)
+            {
+                Context = context;
+                return this;
+            }
+
+            public ConvertTest WithRemoteInvokeCulture(CultureInfo culture)
+            {
+                RemoteInvokeCulture = culture;
+                return this;
+            }
+
+            public ConvertTest WithInvariantRemoteInvokeCulture() => WithRemoteInvokeCulture(CultureInfo.InvariantCulture);
+
+            public ConvertTest()
+            {
+            }
+  
+            protected ConvertTest(SerializationInfo info, StreamingContext context)
+            {
+                string sourceType = (string)info.GetValue("SourceType", typeof(string));
+                if (sourceType != null)
+                {
+                    Source = info.GetValue(nameof(Source), Type.GetType(sourceType));
+                }
+
+                string destinationType = (string)info.GetValue(nameof(DestinationType), typeof(string));
+                if (destinationType != null)
+                {
+                    DestinationType = Type.GetType(destinationType);
+                }
+
+                string culture = (string)info.GetValue(nameof(Culture), typeof(string));
+                if (culture != null)
+                {
+                    Culture = culture == string.Empty ? CultureInfo.InvariantCulture : new CultureInfo(culture);
+                }
+
+                string contextType = (string)info.GetValue("ContextType", typeof(string));
+                if (contextType != null)
+                {
+                    Context = (ITypeDescriptorContext)info.GetValue(nameof(Context), Type.GetType(contextType));
+                }
+
+                string expectedType = (string)info.GetValue("ExpectedType", typeof(string));
+                if (expectedType != null)
+                {
+                    Expected = info.GetValue(nameof(Expected), Type.GetType(expectedType));
+                }
+
+                string netCoreExceptionType = (string)info.GetValue(nameof(NetCoreExceptionType), typeof(string));
+                if (netCoreExceptionType != null)
+                {
+                    NetCoreExceptionType = Type.GetType(netCoreExceptionType);
+                }
+
+                string netFrameworkExceptionType = (string)info.GetValue(nameof(NetFrameworkExceptionType), typeof(string));
+                if (netFrameworkExceptionType != null)
+                {
+                    NetFrameworkExceptionType = Type.GetType(netFrameworkExceptionType);
+                }
+
+                string remoteInvokeCulture = (string)info.GetValue(nameof(RemoteInvokeCulture), typeof(string));
+                if (remoteInvokeCulture != null)
+                {
+                    RemoteInvokeCulture = culture == string.Empty ? CultureInfo.InvariantCulture : new CultureInfo(remoteInvokeCulture);
+                }
+
+                CanConvert = (bool)info.GetValue(nameof(CanConvert), typeof(bool));
+            }
+
+            public void GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                info.AddValue(nameof(Source), Source);
+                info.AddValue("SourceType", Source?.GetType()?.AssemblyQualifiedName);
+                info.AddValue(nameof(DestinationType), DestinationType?.AssemblyQualifiedName);
+                info.AddValue(nameof(Culture), Culture?.Name);
+
+                info.AddValue(nameof(Context), Context);
+                info.AddValue("ContextType", Context?.GetType()?.AssemblyQualifiedName);
+
+
+                info.AddValue(nameof(Expected), Expected);
+                info.AddValue("ExpectedType", Expected?.GetType()?.AssemblyQualifiedName);
+
+                info.AddValue(nameof(NetCoreExceptionType), NetCoreExceptionType?.AssemblyQualifiedName);
+                info.AddValue(nameof(NetFrameworkExceptionType), NetFrameworkExceptionType?.AssemblyQualifiedName);
+
+                info.AddValue(nameof(RemoteInvokeCulture), RemoteInvokeCulture?.Name);
+
+                info.AddValue(nameof(CanConvert), CanConvert);
+            }
+   
+            public static ConvertTest FromSerializedString(string s)
+            {
+                byte[] bytes = Convert.FromBase64String(s);
+                using (var stream = new MemoryStream(bytes, 0, bytes.Length))
+                {
+                    stream.Write(bytes, 0, bytes.Length);
+                    stream.Position = 0;
+                    return (ConvertTest)new BinaryFormatter().Deserialize(stream);
+                }
+            }
+
+            public string GetSerializedString()
+            {
+                using (var stream = new MemoryStream())
+                {
+                    new BinaryFormatter().Serialize(stream, this);         
+                    return Convert.ToBase64String(stream.ToArray());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently we have a bit of an odd test framework for types deriving from `TypeConverter`.
Test failures are basically impossible to diagnose and there's a pretty random distribution of `RemoteInvokes` sprinkled around the test code base

I wanted to formalise this, following the spirit of Ian's collection cleanup. Now a `TypeConverter` test set only need to derive from `TypeConverterTestBase` and override methods as appropriate. This should automatically provide lots of coverage for the converter and then can be expanded on by using things like `yield return ConvertTest.Valid("1.1").WithRemoteInvokeCulture(CultureInfo.InvariantInfo)` to add behaviour onto this

I've submitted the PR with only one change - `Int16Converter` to demonstrate this, so some of the methods in the test base are unused. However you can see example usage in the converter. If this is approved, I'll submit the others (https://github.com/hughbe/corefx/tree/type-converter-more-movement) after

I've highlighted a couple of points for discussion below