### PR TITLE
Restore the Linux X509Certificates tests to 0 SafeX509Handle finalizations

### DIFF
--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
@@ -3,21 +3,28 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeX509Handle : SafeHandle
     {
-#if DEBUG_FINALIZATIONS
-        private string _stacktrace = Environment.StackTrace;
+#if DEBUG
+        private static readonly bool s_captureTrace =
+            Environment.GetEnvironmentVariable("DEBUG_SAFEX509HANDLE_FINALIZATION") != null;
 
-        [DllImport("libc")]
-        private static extern int printf(string f, IntPtr arg0, string arg);
+        private readonly StackTrace _stacktrace =
+            s_captureTrace ? new StackTrace(fNeedFileInfo: true) : null;
 
         ~SafeX509Handle()
         {
-            printf("%p: %s\n\n", handle, _stacktrace ?? "no stacktrace...");
+            if (s_captureTrace)
+            {
+                Interop.Sys.PrintF(
+                    "%s\n\n",
+                    $"0x{handle.ToInt64():x} {_stacktrace?.ToString() ?? "no stacktrace..."}");
+            }
         }
 #endif
 

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeX509Handles.Unix.cs
@@ -3,14 +3,24 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
-using System.Security;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Win32.SafeHandles
 {
     internal sealed class SafeX509Handle : SafeHandle
     {
+#if DEBUG_FINALIZATIONS
+        private string _stacktrace = Environment.StackTrace;
+
+        [DllImport("libc")]
+        private static extern int printf(string f, IntPtr arg0, string arg);
+
+        ~SafeX509Handle()
+        {
+            printf("%p: %s\n\n", handle, _stacktrace ?? "no stacktrace...");
+        }
+#endif
+
         internal static readonly SafeX509Handle InvalidHandle = new SafeX509Handle();
 
         private SafeX509Handle() : 

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -647,6 +647,7 @@
     <Reference Include="System.IO.Compression.Brotli" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Reference Include="System.Diagnostics.StackTrace" />
     <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Encoding" />

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -222,6 +222,9 @@
     <Compile Include="$(CommonPath)\CoreLib\Interop\Unix\Interop.Errors.cs">
       <Link>Common\CoreLib\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PrintF.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.PrintF.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs</Link>
     </Compile>
@@ -411,6 +414,7 @@
     <Reference Include="System.Threading.ThreadPool" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Reference Include="System.Diagnostics.StackTrace" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.OpenSsl" />
     <Reference Include="System.Security.Cryptography.Primitives" />

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -302,6 +302,9 @@
     <Compile Include="Microsoft\Win32\SafeHandles\SafePasswordHandle.Unix.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' AND '$(TargetsOSX)' != 'true' ">
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PrintF.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.PrintF.cs</Link>
+    </Compile>
     <AsnXml Include="System\Security\Cryptography\X509Certificates\Asn1\DistributionPointAsn.xml" />
     <Compile Include="System\Security\Cryptography\X509Certificates\Asn1\DistributionPointAsn.xml.cs">
       <DependentUpon>System\Security\Cryptography\X509Certificates\Asn1\DistributionPointAsn.xml</DependentUpon>
@@ -701,6 +704,7 @@
     <Reference Include="System.Security.Cryptography.Csp" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true' AND '$(TargetsOSX)' != 'true'">
+    <Reference Include="System.Diagnostics.StackTrace" />
     <Reference Include="System.Security.Cryptography.OpenSsl" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
@@ -187,6 +187,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                     }
 
                     RunChain(chain, leafCert, true, "Chain verification");
+                    DisposeChainCerts(chain);
                 }
             }
             finally
@@ -513,6 +514,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                         chain.ChainPolicy.VerificationTime = notBefore.ToLocalTime().DateTime;
 
                         RunChain(chain, leafCert, true, "Chain build");
+                        DisposeChainCerts(chain);
                     }
                 }
                 finally

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
@@ -114,7 +114,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 "07BFD721B73DDB1751123F99D8FC0D533798C4DBD14719D5D8A85B00A144A367" +
                 "677B48891A9B56F045334811BACB7A";
 
-            Assert.Equal(expectedHex, cert.RawData.ByteArrayToHex());
+            using (cert)
+            {
+                Assert.Equal(expectedHex, cert.RawData.ByteArrayToHex());
+            }
         }
 
         [Theory]

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -177,6 +177,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chain.ChainPolicy.ExtraStore.Add(sampleCert);
                 bool valid = chain.Build(sampleCert);
                 Assert.False(valid);
+                chainHolder.DisposeChainElements();
 
                 chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
                 chain.ChainPolicy.VerificationTime = new DateTime(2015, 10, 15, 12, 01, 01, DateTimeKind.Local);
@@ -186,6 +187,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.True(valid, "Chain built validly");
 
                 Assert.Equal(1, chain.ChainElements.Count);
+                chainHolder.DisposeChainElements();
 
                 chain.Reset();
                 Assert.Equal(0, chain.ChainElements.Count);


### PR DESCRIPTION
Since the last drive down to zero finalizations (ensuring no platform-induced ones) a few have slipped back in.  This caused unnecessary distraction while investigating a different problem.

This omits a change to X509Certificate2.Verify (where the platform is actually causing finalizations) because it is already contained in #35091.