### PR TITLE
Fixed Initialized misspelling on unit tests

### DIFF
--- a/src/System.Runtime/tests/System/LazyTests.cs
+++ b/src/System.Runtime/tests/System/LazyTests.cs
@@ -387,7 +387,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void EnsureInitalized_SimpleRefTypes()
+        public static void EnsureInitialized_SimpleRefTypes()
         {
             var hdcTemplate = new HasDefaultCtor();
             string strTemplate = "foo";
@@ -418,7 +418,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void EnsureInitalized_SimpleRefTypes_Invalid()
+        public static void EnsureInitialized_SimpleRefTypes_Invalid()
         {
             // Func based initialization (nulls not permitted).
             string e = null;
@@ -486,7 +486,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void EnsureInitalized_ComplexRefTypes_Invalid()
+        public static void EnsureInitialized_ComplexRefTypes_Invalid()
         {
             // Activator.CreateInstance (for a type without a default ctor).
             NoDefaultCtor ndc = null;


### PR DESCRIPTION
The System.Runtime LazyTests had a misspelling in a few of the method names.  I ran into this as I was looking through the source code for writing a blog post on how Console.Writeline works.