### PR TITLE
Thread principal unauthenticated

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/Resources/CoreFx.Private.TestUtilities.rd.xml
+++ b/src/CoreFx.Private.TestUtilities/src/Resources/CoreFx.Private.TestUtilities.rd.xml
@@ -2,6 +2,6 @@
   <Library>
     <!-- Used in xunit conditional fact/theory -->
     <Type Name="System.PlatformDetection" Dynamic="Required Public" />
+    <Type Name="System.TestEnvironment" Dynamic="Required Public" />
   </Library>
 </Directives>
-

--- a/src/CoreFx.Private.TestUtilities/src/System/TestEnvironment.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/TestEnvironment.cs
@@ -3,11 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using Xunit;
 
 namespace System
 {
-    public static partial class TestEnvironment
+    public static class TestEnvironment
     {
         /// <summary>
         /// Check if the stress mode is enabled.

--- a/src/System.Net.Mail/tests/Functional/MailMessageTest.cs
+++ b/src/System.Net.Mail/tests/Functional/MailMessageTest.cs
@@ -146,7 +146,7 @@ namespace System.Net.Mail.Tests
         }
         
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Requires fix shipping in .NET 4.7.2")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "MailWriter is reflection blocked.")]
         public void SentSpecialLengthMailAttachment_Base64Decode_Success()
         {
             // The special length follows pattern: (3N - 1) * 0x4400 + 1

--- a/src/System.Runtime.Extensions/src/System/AppDomain.cs
+++ b/src/System.Runtime.Extensions/src/System/AppDomain.cs
@@ -398,7 +398,7 @@ namespace System
                             // Don't throw PNSE if null like for WindowsPrincipal as UnauthenticatedPrincipal should
                             // be available on all platforms.
                             Volatile.Write(ref s_getUnauthenticatedPrincipal,
-                                (Func<IPrincipal>)Delegate.CreateDelegate(typeof(Func<IPrincipal>), type, "GetDefaultInstance", ignoreCase: false, throwOnBindFailure: false));
+                                (Func<IPrincipal>)Delegate.CreateDelegate(typeof(Func<IPrincipal>), type, "GetDefaultInstance"));
                         }
 
                         principal = s_getUnauthenticatedPrincipal();

--- a/src/System.Runtime.Extensions/src/System/AppDomain.cs
+++ b/src/System.Runtime.Extensions/src/System/AppDomain.cs
@@ -395,7 +395,10 @@ namespace System
                         if (s_getUnauthenticatedPrincipal == null)
                         {
                             Type type = Type.GetType("System.Security.Principal.GenericPrincipal, System.Security.Claims", throwOnError: true);
-                            Volatile.Write(ref s_getUnauthenticatedPrincipal, (Func<IPrincipal>)Delegate.CreateDelegate(typeof(Func<IPrincipal>), type, "GetDefaultInstance"));
+                            // Don't throw PNSE if null like for WindowsPrincipal as UnauthenticatedPrincipal should
+                            // be available on all platforms.
+                            Volatile.Write(ref s_getUnauthenticatedPrincipal,
+                                (Func<IPrincipal>)Delegate.CreateDelegate(typeof(Func<IPrincipal>), type, "GetDefaultInstance", ignoreCase: false, throwOnBindFailure: false));
                         }
 
                         principal = s_getUnauthenticatedPrincipal();

--- a/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
+++ b/src/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
@@ -1247,6 +1247,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "ValueTask _obj is reflection blocked.")]
         public void NonGeneric_TornRead_DoesNotCrashOrHang()
         {
             // Validate that if we incur a torn read, we may get an exception, but we won't crash or hang.
@@ -1282,6 +1283,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "ValueTask _obj is reflection blocked.")]
         public void Generic_TornRead_DoesNotCrashOrHang()
         {
             // Validate that if we incur a torn read, we may get an exception, but we won't crash or hang.

--- a/src/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/System.Threading.Thread/tests/ThreadTests.cs
@@ -463,6 +463,8 @@ namespace System.Threading.Threads.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Mono)]
         public static void CurrentPrincipalContextFlowTest_NotFlow()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(async () =>
@@ -476,16 +478,7 @@ namespace System.Threading.Threads.Tests
 
                     task = Task.Run(() => 
                     {
-                        // Default PrincipalPolicy for netcoreapp is null
-                        if (PlatformDetection.IsNetCore)
-                        {
-                            Assert.Null(Thread.CurrentPrincipal);
-                        }
-                        else
-                        {
-                            Assert.IsType<GenericPrincipal>(Thread.CurrentPrincipal);
-                        }
-
+                        Assert.Null(Thread.CurrentPrincipal);
                         Assert.False(ExecutionContext.IsFlowSuppressed());
                     });
                 }
@@ -1141,7 +1134,7 @@ namespace System.Threading.Threads.Tests
                 AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
                 Assert.Equal(Environment.UserDomainName + @"\" + Environment.UserName, Thread.CurrentPrincipal.Identity.Name);
             }).Dispose();
-                }
+        }
 
         [Fact]
         [PlatformSpecific(TestPlatforms.AnyUnix)]

--- a/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -187,6 +187,7 @@ namespace System.Threading.ThreadPools.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Triggers an assertion failure.")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "ThreadPool.SetMinThreads and SetMaxThreads are not supported on UapAot.")]
         private static void SetMinThreadsTo0Test()
         {
             int minw, minc, maxw, maxc;


### PR DESCRIPTION
Fixing an oversight that results in an exception on uapaot in AppDomain: https://github.com/dotnet/corefx/pull/30765#discussion_r253998952. I did not add the PNSE as I don't think it is needed?

Disabling a reflection blocked test and a thread pool test where a condition for uapaot is missing.

cc @danmosemsft @jkotas @Anipik 