### PR TITLE
remove instrumentation and move unreliable tests to Outerloop

### DIFF
--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -36,6 +36,7 @@ namespace System.Net.NameResolution.PalTests
         }
 
         [Fact]
+        [OuterLoop("Uses external server")]
         public void TryGetAddrInfo_HostName()
         {
             string hostName = NameResolutionPal.GetHostName();
@@ -49,16 +50,6 @@ namespace System.Net.NameResolution.PalTests
                 // On Unix, we are not guaranteed to be able to resove the local host. The ability to do so depends on the
                 // machine configurations, which varies by distro and is often inconsistent.
                 return;
-            }
-
-            // Temporary instrumentation for #32797
-            if (error == SocketError.TryAgain && Environment.OSVersion.Platform == PlatformID.Unix)
-            {
-                error = NameResolutionPal.TryGetAddrInfo(hostName, out hostEntry, out nativeErrorCode);
-                if (error != SocketError.TryAgain)
-                {
-                    throw new InvalidOperationException("Name resolution failure preventable with retry");
-                }
             }
 
             Assert.Equal(SocketError.Success, error);
@@ -103,6 +94,7 @@ namespace System.Net.NameResolution.PalTests
         }
 
         [Fact]
+        [OuterLoop("Uses external server")]
         public void TryGetAddrInfo_HostName_TryGetNameInfo()
         {
             string hostName = NameResolutionPal.GetHostName();
@@ -117,16 +109,6 @@ namespace System.Net.NameResolution.PalTests
                 // is turned off. Hence dns lookup for it's own hostname fails.
                 Assert.Equal(PlatformID.Unix, Environment.OSVersion.Platform);
                 return;
-            }
-
-            // Temporary instrumentation for #32797
-            if (error == SocketError.TryAgain && Environment.OSVersion.Platform == PlatformID.Unix)
-            {
-                error = NameResolutionPal.TryGetAddrInfo(hostName, out hostEntry, out nativeErrorCode);
-                if (error != SocketError.TryAgain)
-                {
-                    throw new InvalidOperationException("Name resolution failure preventable with retry");
-                }
             }
 
             Assert.Equal(SocketError.Success, error);


### PR DESCRIPTION
related to #32797
Removing temporary instrumentation and moving to Outerloop. 

