### PR TITLE
Removing UAPvNext Assets from OOB packages

### DIFF
--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -67,4 +67,6 @@
         <SkipPackageFileCheck>true</SkipPackageFileCheck>
     </File>
   </ItemGroup>
+
+  <Import Condition="'$(MSBuildProjectExtension)' == '.pkgproj'" Project="$(MSBuildThisFileDirectory)disableUap.targets" />
 </Project>

--- a/eng/disableUap.targets
+++ b/eng/disableUap.targets
@@ -1,0 +1,12 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="RemoveUapvNextContent"
+          Condition="'$(KeepUAPContent)' != 'true'"
+          DependsOnTargets="GetPackageReport"
+          BeforeTargets="GenerateNuSpec">
+    <ItemGroup>
+      <PackageFile Remove="@(PackageFile)" Condition="'%(PackageFile.TargetFramework)' == '$(UAPvNextTFM)'" />
+      <PackageFile Remove="@(PackageFile)" Condition="$([System.String]::new('%(PackageFile.TargetPath)').Contains('/$(UAPvNextTFM)'))" />
+      <Dependency Remove="@(Dependency)" Condition="'%(Dependency.TargetFramework)' == '$(UAPvNextTFM)'" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -12,6 +12,9 @@
     <IsFrameworkPackage>true</IsFrameworkPackage>
     <!-- Private packages need symbols -->
     <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)' == ''">true</IncludeSymbolsInPackage>
+
+    <!-- Uap assets are stripped out of other packages, but we don't want to do that for the framework package -->
+    <KeepUAPContent>true</KeepUAPContent>
   </PropertyGroup>
   <ItemGroup>
     <IgnoredReference Include="System.Private.CoreLib" />


### PR DESCRIPTION
cc: @ericstj @zamont 

Fixes #34959 

This PR will remove all uapvNext (uap10.0.16300) assets from packages except for the uap metapackage in order to make sure that netcoreapp3.0 packages (currently shipping out of master) won't leak those assets.