### PR TITLE
Add build batching for official builds

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -1,6 +1,12 @@
-# Disable triggers for now. TODO: add right merge triggers.
+# Setting batch to true, triggers one build at a time.
+# if there is a push while a build in progress, it will wait,
+# until the running build finishes, and produce a build with all the changes
+# that happened during the last build.
 trigger:
-- master
+  batch: true
+  branches:
+    include:
+    - master
 
 # TODO: add paths to exclude CI when modifying docs or stuff not affecting the build
 pr:


### PR DESCRIPTION
We need this if we want to have builds per commit. This helps to minimize the number of builds and allows to only have 1 build at a time build triggered automatically.

