### PR TITLE
Fix failing xNodeBuilder tests

### DIFF
--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
@@ -5057,7 +5057,7 @@ namespace CoreXml.Test.XLinq
                     w.WriteEndElement();
                     w.Dispose();
 
-                    if (!CompareReader(doc, "<Root>3.40282347E+38</Root>")) throw new TestException(TestResult.Failed, "");
+                    if (!CompareReader(doc, $"<Root>{float.MaxValue}</Root>")) throw new TestException(TestResult.Failed, "");
                 }
 
                 //[Variation(Id = 8, Desc = "WriteValue(string)", Priority = 1)]

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/Configurations.props
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/Configurations.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+      netcoreapp;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/WriterSettings.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/WriterSettings.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using Microsoft.Test.ModuleCore;
@@ -21,7 +22,7 @@ namespace CoreXml.Test.XLinq
                     XDocument d = new XDocument();
                     XmlWriter w = d.CreateWriter();
 
-                    TestLog.Equals(w.Settings.Encoding.ToString(), "System.Text.UTF8Encoding", "Incorrect default value of Encoding");
+                    TestLog.Compare(w.Settings.Encoding is UTF8Encoding, "Incorrect default value of Encoding");
                     TestLog.Equals(w.Settings.OmitXmlDeclaration, false, "Incorrect default value of OmitXmlDeclaration");
                     TestLog.Equals(w.Settings.NewLineHandling, NewLineHandling.Replace, "Incorrect default value of NewLineHandling");
                     TestLog.Equals(w.Settings.NewLineChars, Environment.NewLine, "Incorrect default value of NewLineChars");
@@ -40,7 +41,7 @@ namespace CoreXml.Test.XLinq
                     XElement d = new XElement("a");
                     XmlWriter w = d.CreateWriter();
 
-                    TestLog.Equals(w.Settings.Encoding.ToString(), "System.Text.UTF8Encoding", "Incorrect default value of Encoding");
+                    TestLog.Compare(w.Settings.Encoding is UTF8Encoding, "Incorrect default value of Encoding");
                     TestLog.Equals(w.Settings.OmitXmlDeclaration, false, "Incorrect default value of OmitXmlDeclaration");
                     TestLog.Equals(w.Settings.NewLineHandling, NewLineHandling.Replace, "Incorrect default value of NewLineHandling");
                     TestLog.Equals(w.Settings.NewLineChars, Environment.NewLine, "Incorrect default value of NewLineChars");
@@ -59,7 +60,7 @@ namespace CoreXml.Test.XLinq
                     XDocument d = new XDocument();
                     XmlWriter w = d.CreateWriter();
                     w.Dispose();
-                    TestLog.Equals(w.Settings.Encoding.ToString(), "System.Text.UTF8Encoding", "Incorrect default value of Encoding");
+                    TestLog.Compare(w.Settings.Encoding is UTF8Encoding, "Incorrect default value of Encoding");
                     TestLog.Equals(w.Settings.OmitXmlDeclaration, false, "Incorrect default value of OmitXmlDeclaration");
                     TestLog.Equals(w.Settings.NewLineHandling, NewLineHandling.Replace, "Incorrect default value of NewLineHandling");
                     TestLog.Equals(w.Settings.NewLineChars, Environment.NewLine, "Incorrect default value of NewLineChars");
@@ -77,7 +78,7 @@ namespace CoreXml.Test.XLinq
                     XElement d = new XElement("a");
                     XmlWriter w = d.CreateWriter();
                     w.Dispose();
-                    TestLog.Equals(w.Settings.Encoding.ToString(), "System.Text.UTF8Encoding", "Incorrect default value of Encoding");
+                    TestLog.Compare(w.Settings.Encoding is UTF8Encoding, "Incorrect default value of Encoding");
                     TestLog.Equals(w.Settings.OmitXmlDeclaration, false, "Incorrect default value of OmitXmlDeclaration");
                     TestLog.Equals(w.Settings.NewLineHandling, NewLineHandling.Replace, "Incorrect default value of NewLineHandling");
                     TestLog.Equals(w.Settings.NewLineChars, Environment.NewLine, "Incorrect default value of NewLineChars");


### PR DESCRIPTION
1 of the tests is failing because float.MaxValue.ToString() changed and it had hardcoded the previous value.

4 of the tests failed because it was doing a string comparison on the type name of Encoding.UTF8, which a while ago changed to be a sealed derived type and thus is no longer exactly "System.Text.UTF8Encoding".  My only explanation for why these just started failing is that we weren't previously running them?  Might have something to do with the lack of a Configurations.props file, which I had to add in order to run the tests locally.

Fixes https://github.com/dotnet/corefx/issues/35090
cc: @danmosemsft, @rmkerr, @tannergooding 