### PR TITLE
Remove InternalsVisibleTo from S.C.C.Registration

### DIFF
--- a/src/System.ComponentModel.Composition.Registration/src/Properties/InternalsVisibleTo.cs
+++ b/src/System.ComponentModel.Composition.Registration/src/Properties/InternalsVisibleTo.cs
@@ -1,7 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("System.ComponentModel.Composition.Registration.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]

--- a/src/System.ComponentModel.Composition.Registration/src/System.ComponentModel.Composition.Registration.csproj
+++ b/src/System.ComponentModel.Composition.Registration/src/System.ComponentModel.Composition.Registration.csproj
@@ -5,9 +5,7 @@
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard'">SR.PlatformNotSupported_ComponentModel_Composition_Registration</GeneratePlatformNotSupportedAssemblyMessage>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the options -->
   <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
-    <Compile Include="Properties\InternalsVisibleTo.cs" />
     <Compile Include="System\ComponentModel\Composition\Registration\ExportBuilder.cs" />
     <Compile Include="System\ComponentModel\Composition\Registration\ImportBuilder.cs" />
     <Compile Include="System\ComponentModel\Composition\Registration\ParameterImportBuilder.cs" />

--- a/src/System.ComponentModel.Composition.Registration/tests/InternalCalls.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/InternalCalls.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace System.ComponentModel.Composition.Registration.Tests
+{
+    public static class InternalCalls
+    {
+        public static void BuildAttributes(this ExportBuilder builder, Type type, ref List<Attribute> attributes)
+        {
+            builder.GetType()
+                .GetMethod(nameof(BuildAttributes), BindingFlags.NonPublic | BindingFlags.Instance)
+                .Invoke(builder, new object[] { type, attributes });
+        }
+
+        public static void BuildAttributes(this ImportBuilder builder, Type type, ref List<Attribute> attributes)
+        {
+            builder.GetType()
+                .GetMethod(nameof(BuildAttributes), BindingFlags.NonPublic | BindingFlags.Instance)
+                .Invoke(builder, new object[] { type, attributes });
+        }
+
+        public static PartBuilder PartBuilder(Predicate<Type> selectType)
+        {
+            return (PartBuilder)typeof(PartBuilder)
+                .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(Predicate<Type>) }, null)
+                .Invoke(new object[] { selectType });
+        }
+
+        public static PartBuilder<T> PartBuilder<T>(Predicate<Type> selectType)
+        {
+            return (PartBuilder<T>)typeof(PartBuilder<T>)
+                .GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(Predicate<Type>) }, null)
+                .Invoke(new object[] { selectType });
+        }
+
+        public static IEnumerable<Attribute> BuildTypeAttributes(this PartBuilder builder, Type type)
+        {
+            return (IEnumerable<Attribute>)builder.GetType()
+                .GetMethod(nameof(BuildTypeAttributes), BindingFlags.NonPublic | BindingFlags.Instance)
+                .Invoke(builder, new object[] { type });
+        }
+
+        public static bool BuildConstructorAttributes(this PartBuilder builder, Type type, ref List<Tuple<object, List<Attribute>>> configuredMembers)
+        {
+            return (bool)builder.GetType()
+                .GetMethod(nameof(BuildConstructorAttributes), BindingFlags.NonPublic | BindingFlags.Instance)
+                .Invoke(builder, new object[] { type, configuredMembers });
+        }
+
+        public static void BuildPropertyAttributes(this PartBuilder builder, Type type, ref List<Tuple<object, List<Attribute>>> configuredMembers)
+        {
+            builder.GetType()
+                .GetMethod(nameof(BuildPropertyAttributes), BindingFlags.NonPublic | BindingFlags.Instance)
+                .Invoke(builder, new object[] { type, configuredMembers });
+        }
+
+        public static void PartBuilder_BuildDefaultConstructorAttributes(Type type, ref List<Tuple<object, List<Attribute>>> configuredMembers)
+        {
+            typeof(PartBuilder)
+                .GetMethod("BuildDefaultConstructorAttributes", BindingFlags.NonPublic | BindingFlags.Static)
+                .Invoke(null, new object[] { type, configuredMembers });
+        }
+    }
+}

--- a/src/System.ComponentModel.Composition.Registration/tests/System.ComponentModel.Composition.Registration.Tests.csproj
+++ b/src/System.ComponentModel.Composition.Registration/tests/System.ComponentModel.Composition.Registration.Tests.csproj
@@ -5,11 +5,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Some internal types are needed, so we reference the implementation assembly, rather than the reference assembly. -->
-    <DefaultReferenceExclusions Include="System.ComponentModel.Composition.Registration" />
-    <ReferenceFromRuntime Include="System.ComponentModel.Composition.Registration" />
-  </ItemGroup>
-  <ItemGroup>
+    <Compile Include="InternalCalls.cs" />
     <Compile Include="System\ComponentModel\Composition\Registration\ExportBuilderTests.cs" />
     <Compile Include="System\ComponentModel\Composition\Registration\ExportBuilderUnitTests.cs" />
     <Compile Include="System\ComponentModel\Composition\Registration\ExportInterfacesContractExclusionTests.cs" />

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/ExportBuilderTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/ExportBuilderTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.ComponentModel.Composition.Registration.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
     public class ExportBuilderTests
     {
         interface IFoo { }

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/ExportBuilderUnitTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/ExportBuilderUnitTests.cs
@@ -68,6 +68,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void ExportInterfaceWithTypeOf1()
         {
             var ctx = new RegistrationBuilder();
@@ -83,6 +84,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void ExportInterfaceWithTypeOf2()
         {
             var ctx = new RegistrationBuilder();
@@ -98,6 +100,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void ExportInheritedInterfaceWithImplements1()
         {
             var ctx = new RegistrationBuilder();
@@ -113,6 +116,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void ExportInheritedInterfaceWithImplements2()
         {
             var ctx = new RegistrationBuilder();

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/ImportBuilderTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/ImportBuilderTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.ComponentModel.Composition.Registration.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
     public class ImportBuilderTests
     {
         interface IFoo { }

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderInheritanceTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderInheritanceTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace System.ComponentModel.Composition.Registration.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
     public class PartBuilderInheritanceTests
     {
         private abstract class BaseClass
@@ -26,7 +27,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Fact]
         public void ImportPropertyTargetingBaseClass_ShouldGenerateImportForPropertySelected()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.ImportProperties(p => p.Name == "P2"); // P2 is string
 
             IEnumerable<Attribute> typeAtts;
@@ -51,7 +52,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Fact]
         public void ImportPropertyTargetingBaseClass_ShouldGenerateImportManyForPropertySelected()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.ImportProperties(p => p.Name == "P3"); // P3 is IEnumerable<int>
 
             IEnumerable<Attribute> typeAtts;
@@ -76,7 +77,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Fact]
         public void ImportPropertyTargetingDerivedClass_ShouldGenerateImportForPropertySelected()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.ImportProperties(p => p.Name == "P4"); // P4 is string
 
             IEnumerable<Attribute> typeAtts;
@@ -101,7 +102,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Fact]
         public void ExportPropertyTargetingDerivedClass_ShouldGenerateExportForPropertySelected()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.ExportProperties(p => p.Name == "P4"); // P4 is string
 
             IEnumerable<Attribute> typeAtts;
@@ -126,7 +127,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Fact]
         public void ExportPropertyTargetingBaseClass_ShouldGenerateExportForPropertySelected()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.ExportProperties(p => p.Name == "P2"); // P2 is string
 
             IEnumerable<Attribute> typeAtts;
@@ -147,7 +148,6 @@ namespace System.ComponentModel.Composition.Registration.Tests
             Assert.Null(exportAttribute.ContractName);
             Assert.Null(exportAttribute.ContractType);
         }
-
 
         private static void GetConfiguredMembers(PartBuilder builder,
             out List<Tuple<object, List<Attribute>>> configuredMembers, out IEnumerable<Attribute> typeAtts,

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderInterfaceTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderInterfaceTests.cs
@@ -48,6 +48,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
  
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void StandardExportInterfacesShouldWork()
         {
             var builder = new RegistrationBuilder();
@@ -82,6 +83,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void StandardExportInterfacesDefaultContractShouldWork()
         {            //Same test as above only using default export builder
             var builder = new RegistrationBuilder();

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderOfTInheritanceTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderOfTInheritanceTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace System.ComponentModel.Composition.Registration.Tests
 {
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
     public class PartBuilderOfTInheritanceTests
     {
         private abstract class BaseClass
@@ -26,7 +27,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Fact]
         public void ImportPropertyTargetingBaseClass_ShouldGenerateImportForPropertySelected()
         {
-            var builder = new PartBuilder<DerClass>(t => true);
+            var builder = InternalCalls.PartBuilder<DerClass>(t => true);
             builder.ImportProperty(p => p.P2); // P2 is string
 
             IEnumerable<Attribute> typeAtts;
@@ -51,7 +52,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Fact]
         public void ImportPropertyTargetingBaseClass_ShouldGenerateImportManyForPropertySelected()
         {
-            var builder = new PartBuilder<DerClass>(t => true);
+            var builder = InternalCalls.PartBuilder<DerClass>(t => true);
             builder.ImportProperty(p => p.P3); // P3 is IEnumerable<int>
 
             IEnumerable<Attribute> typeAtts;
@@ -76,7 +77,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Fact]
         public void ImportPropertyTargetingDerivedClass_ShouldGenerateImportForPropertySelected()
         {
-            var builder = new PartBuilder<DerClass>(t => true);
+            var builder = InternalCalls.PartBuilder<DerClass>(t => true);
             builder.ImportProperty(p => p.P4); // P4 is string
 
             IEnumerable<Attribute> typeAtts;
@@ -101,7 +102,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Fact]
         public void ExportPropertyTargetingDerivedClass_ShouldGenerateExportForPropertySelected()
         {
-            var builder = new PartBuilder<DerClass>(t => true);
+            var builder = InternalCalls.PartBuilder<DerClass>(t => true);
             builder.ExportProperty(p => p.P4); // P4 is string
 
             IEnumerable<Attribute> typeAtts;
@@ -126,7 +127,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         [Fact]
         public void ExportPropertyTargetingBaseClass_ShouldGenerateExportForPropertySelected()
         {
-            var builder = new PartBuilder<DerClass>(t => true);
+            var builder = InternalCalls.PartBuilder<DerClass>(t => true);
             builder.ExportProperty(p => p.P2); // P2 is string
 
             IEnumerable<Attribute> typeAtts;

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderOfTTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderOfTTests.cs
@@ -30,9 +30,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void NoOperations_ShouldGenerateNoAttributes()
         {
-            var builder = new PartBuilder<FooImpl>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImpl>(t => true);
 
             IEnumerable<Attribute> typeAtts;
             List<Tuple<object, List<Attribute>>> configuredMembers;
@@ -43,9 +44,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ExportSelf_ShouldGenerateSingleExportAttribute()
         {
-            var builder = new PartBuilder<FooImpl>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImpl>(t => true);
             builder.Export();
 
             IEnumerable<Attribute> typeAtts;
@@ -60,9 +62,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ExportOfT_ShouldGenerateSingleExportAttributeWithContractType()
         {
-            var builder = new PartBuilder<FooImpl>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImpl>(t => true);
             builder.Export<IFoo>();
 
             IEnumerable<Attribute> typeAtts;
@@ -77,9 +80,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void AddMetadata_ShouldGeneratePartMetadataAttribute()
         {
-            var builder = new PartBuilder<FooImpl>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImpl>(t => true);
             builder.Export<IFoo>().AddMetadata("name", "value");
 
             IEnumerable<Attribute> typeAtts;
@@ -98,9 +102,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void AddMetadataWithFunc_ShouldGeneratePartMetadataAttribute()
         {
-            var builder = new PartBuilder<FooImpl>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImpl>(t => true);
             builder.Export<IFoo>().AddMetadata("name", t => t.Name);
 
             IEnumerable<Attribute> typeAtts;
@@ -119,9 +124,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ExportProperty_ShouldGenerateExportForPropertySelected()
         {
-            var builder = new PartBuilder<FooImpl>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImpl>(t => true);
             builder.ExportProperty(p => p.P1).Export<IFoo>();
 
             IEnumerable<Attribute> typeAtts;
@@ -143,9 +149,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ImportProperty_ShouldGenerateImportForPropertySelected()
         {
-            var builder = new PartBuilder<FooImpl>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImpl>(t => true);
             builder.ImportProperty(p => p.P2).Export<IFoo>(); // P2 is string
 
             IEnumerable<Attribute> typeAtts;
@@ -168,9 +175,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ImportProperty_ShouldGenerateImportForPropertySelected_And_ApplyImportMany()
         {
-            var builder = new PartBuilder<FooImpl>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImpl>(t => true);
             builder.ImportProperty(p => p.P3).Export<IFoo>(); // P3 is IEnumerable<IFoo>
 
             IEnumerable<Attribute> typeAtts;
@@ -193,9 +201,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ExportPropertyWithConfiguration_ShouldGenerateExportForPropertySelected()
         {
-            var builder = new PartBuilder<FooImpl>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImpl>(t => true);
             builder.ExportProperty(p => p.P1, c => c.AsContractName("hey"))
                 .Export<IFoo>();
 
@@ -218,9 +227,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ExportPropertyOfT_ShouldGenerateExportForPropertySelectedWithTAsContractType()
         {
-            var builder = new PartBuilder<FooImpl>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImpl>(t => true);
             builder.
                 ExportProperty<string>(p => p.P1).
                 Export<IFoo>();
@@ -244,9 +254,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ConventionSelectsConstructor_SelectsTheOneWithMostParameters()
         {
-            var builder = new PartBuilder<FooImplWithConstructors>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImplWithConstructors>(t => true);
             builder.Export<IFoo>();
 
             IEnumerable<Attribute> typeAtts;
@@ -277,9 +288,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ManuallySelectingConstructor_SelectsTheExplicitOne()
         {
-            var builder = new PartBuilder<FooImplWithConstructors>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImplWithConstructors>(t => true);
             builder.
                 SelectConstructor(param => new FooImplWithConstructors(param.Import<IEnumerable<IFoo>>())).
                 Export<IFoo>();
@@ -305,9 +317,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ManuallySelectingConstructor_SelectsTheExplicitOne_IEnumerableParameterBecomesImportMany()
         {
-            var builder = new PartBuilder<FooImplWithConstructors>(t => true);
+            var builder = InternalCalls.PartBuilder<FooImplWithConstructors>(t => true);
             builder.
                 SelectConstructor(param => new FooImplWithConstructors(param.Import<IEnumerable<IFoo>>())).
                 Export<IFoo>();
@@ -341,7 +354,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
             typeAtts = builder.BuildTypeAttributes(targetType);
             if (!builder.BuildConstructorAttributes(targetType, ref configuredMembers))
             {
-                PartBuilder.BuildDefaultConstructorAttributes(targetType, ref configuredMembers);
+                InternalCalls.PartBuilder_BuildDefaultConstructorAttributes(targetType, ref configuredMembers);
             }
             builder.BuildPropertyAttributes(targetType, ref configuredMembers);
         }

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderTests.cs
@@ -430,6 +430,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void InsideTheLambdaCallGetCustomAttributesShouldSucceed()
         {
             //Same test as above only using default export builder

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderTests.cs
@@ -53,9 +53,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void NoOperations_ShouldGenerateNoAttributes()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
 
             IEnumerable<Attribute> typeAtts;
             List<Tuple<object, List<Attribute>>> configuredMembers;
@@ -66,9 +67,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ExportSelf_ShouldGenerateSingleExportAttribute()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export();
 
             IEnumerable<Attribute> typeAtts;
@@ -83,9 +85,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ExportOfT_ShouldGenerateSingleExportAttributeWithContractType()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>();
 
             IEnumerable<Attribute> typeAtts;
@@ -100,9 +103,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void AddMetadata_ShouldGeneratePartMetadataAttribute()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>().AddMetadata("name", "value");
 
             IEnumerable<Attribute> typeAtts;
@@ -121,9 +125,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void AddMetadataWithFunc_ShouldGeneratePartMetadataAttribute()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>().AddMetadata("name", t => t.Name);
 
             IEnumerable<Attribute> typeAtts;
@@ -142,9 +147,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ExportProperty_ShouldGenerateExportForPropertySelected()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>().
                 ExportProperties(p => p.Name == "P1");
 
@@ -167,9 +173,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ImportProperty_ShouldGenerateImportForPropertySelected()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>().
                 ImportProperties(p => p.Name == "P2"); // P3 is string
 
@@ -193,9 +200,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ImportProperties_ShouldGenerateImportForPropertySelected_And_ApplyImportMany()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>().
                 ImportProperties(p => p.Name == "P3"); // P3 is IEnumerable<IFoo>
 
@@ -219,9 +227,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ExportPropertyWithConfiguration_ShouldGenerateExportForPropertySelected()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>().
                 ExportProperties(p => p.Name == "P1", (p, c) => c.AsContractName("hey"));
 
@@ -244,9 +253,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ExportPropertyOfT_ShouldGenerateExportForPropertySelectedWithTAsContractType()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>().
                 ExportProperties<string>(p => p.Name == "P1");
 
@@ -269,9 +279,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void SetCreationPolicy_ShouldGeneratePartCreationPolicyAttributeForType()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>().SetCreationPolicy(CreationPolicy.NonShared);
 
             IEnumerable<Attribute> typeAtts;
@@ -286,9 +297,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ConventionSelectsConstructor_SelectsTheOneWithMostParameters()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>();
 
             IEnumerable<Attribute> typeAtts;
@@ -319,9 +331,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ManuallySelectingConstructor_SelectsTheExplicitOne()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>().SelectConstructor((cis) => cis[1]);
 
             IEnumerable<Attribute> typeAtts;
@@ -345,9 +358,10 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "Reflection based tests")]
         public void ManuallySelectingConstructor_SelectsTheExplicitOne_IEnumerableParameterBecomesImportMany()
         {
-            var builder = new PartBuilder(t => true);
+            var builder = InternalCalls.PartBuilder(t => true);
             builder.Export<IFoo>().SelectConstructor((cis) => cis[1]);
 
             IEnumerable<Attribute> typeAtts;
@@ -379,7 +393,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
             typeAtts = builder.BuildTypeAttributes(targetType);
             if (!builder.BuildConstructorAttributes(targetType, ref configuredMembers))
             {
-                PartBuilder.BuildDefaultConstructorAttributes(targetType, ref configuredMembers);
+                InternalCalls.PartBuilder_BuildDefaultConstructorAttributes(targetType, ref configuredMembers);
             }
             builder.BuildPropertyAttributes(targetType, ref configuredMembers);
         }

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderUnitTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/PartBuilderUnitTests.cs
@@ -126,6 +126,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
     public class PartBuilderUnitTests
     {
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void ManyConstructorsControllerFindLongestConstructor_ShouldSucceed()
         {
             var ctx = new RegistrationBuilder();
@@ -154,6 +155,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void ManyConstructorsControllerFindLongestConstructorAndImportByName_ShouldSucceed()
         {
             var ctx = new RegistrationBuilder();
@@ -191,6 +193,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void LongestConstructorWithAttribute_ShouldSucceed()
         {
             var ctx = new RegistrationBuilder();
@@ -210,6 +213,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void LongestConstructorShortestWithAttribute_ShouldSucceed()
         {
             var ctx = new RegistrationBuilder();
@@ -229,6 +233,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void AmbiguousConstructorWithAttributeAppliedToOne_ShouldSucceed()
         {
             var ctx = new RegistrationBuilder();
@@ -250,6 +255,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
 
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void AmbiguousConstructor_ShouldFail()
         {
             var ctx = new RegistrationBuilder();

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderExportFuncTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderExportFuncTests.cs
@@ -22,6 +22,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void RegistrationBuilder_WithExportDelegatesShouldNotThrow()
         {
             var rb = new RegistrationBuilder();

--- a/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderTests.cs
+++ b/src/System.ComponentModel.Composition.Registration/tests/System/ComponentModel/Composition/Registration/RegistrationBuilderTests.cs
@@ -46,6 +46,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "MakeGenericType can only accept Type objects created by the runtime.")]
         public void ShouldSucceed()
         {
             var rb = new RegistrationBuilder();
@@ -175,6 +176,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ClassExportingInterface<T> : IGenericInterface<T> { }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "MakeGenericType can only accept Type objects created by the runtime.")]
         public void GenericInterfaceExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ClassExportingInterface<>));
@@ -188,6 +190,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ClassExportingBaseClass<T> : GenericBaseClass<T> { }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "MakeGenericType can only accept Type objects created by the runtime.")]
         public void GenericBaseClassExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ClassExportingBaseClass<>));
@@ -199,6 +202,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class GenericClass<T> { }
 
         [Fact]
+        [ActiveIssue(35144, TargetFrameworkMonikers.UapAot)]
         public void GenericExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(GenericClass<>));
@@ -210,6 +214,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ExplicitGenericClass<T> { }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "MakeGenericType can only accept Type objects created by the runtime.")]
         public void ExplicitGenericExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ExplicitGenericClass<>));
@@ -221,6 +226,7 @@ namespace System.ComponentModel.Composition.Registration.Tests
         private class ExplicitGenericClass<T, U> { }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "MakeGenericType can only accept Type objects created by the runtime.")]
         public void ExplicitGenericArity2ExportInRegistrationBuilder()
         {
             CompositionContainer container = CreateRegistrationBuilderContainer(typeof(ExplicitGenericClass<,>));


### PR DESCRIPTION
Allow the linker and ILC to do its work and change internal refs in tests to reflection based calls.