### PR TITLE
Use the array pool by default instead of going through the MemoryPool

### DIFF
--- a/src/System.IO.Pipelines/System.IO.Pipelines.sln
+++ b/src/System.IO.Pipelines/System.IO.Pipelines.sln
@@ -20,7 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E89
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO.Pipelines.Performance.Tests", "tests\Performance\System.IO.Pipelines.Performance.Tests.csproj", "{66AE57BA-B56C-4A1E-ACA6-7C18431D416B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO.Pipelines.PerformanceTests", "tests\Performance\System.IO.Pipelines.PerformanceTests.csproj", "{66AE57BA-B56C-4A1E-ACA6-7C18431D416B}"
 	ProjectSection(ProjectDependencies) = postProject
 		{1032D5F6-5AE7-4002-A0E4-FEBEADFEA977} = {1032D5F6-5AE7-4002-A0E4-FEBEADFEA977}
 	EndProjectSection

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -217,8 +217,10 @@ namespace System.IO.Pipelines
         private int GetSegmentSize(int sizeHint, int maxBufferSize = int.MaxValue)
         {
             // First we need to handle case where hint is smaller than minimum segment size
+            sizeHint = Math.Max(_minimumSegmentSize, sizeHint);
             // After that adjust it to fit into pools max buffer size
-            return Math.Clamp(sizeHint, _minimumSegmentSize, maxBufferSize);
+            var adjustedToMaximumSize = Math.Min(maxBufferSize, sizeHint);
+            return adjustedToMaximumSize;
         }
 
         private BufferSegment CreateSegmentUnsynchronized()

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
@@ -45,7 +45,7 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.resumeWriterThreshold);
             }
 
-            Pool = pool;
+            Pool = pool ?? MemoryPool<byte>.Shared;
             ReaderScheduler = readerScheduler ?? PipeScheduler.ThreadPool;
             WriterScheduler = writerScheduler ?? PipeScheduler.ThreadPool;
             PauseWriterThreshold = pauseWriterThreshold;

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
@@ -45,7 +45,7 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.resumeWriterThreshold);
             }
 
-            Pool = pool ?? MemoryPool<byte>.Shared;
+            Pool = pool;
             ReaderScheduler = readerScheduler ?? PipeScheduler.ThreadPool;
             WriterScheduler = writerScheduler ?? PipeScheduler.ThreadPool;
             PauseWriterThreshold = pauseWriterThreshold;

--- a/src/System.IO.Pipelines/tests/PipeOptionsTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeOptionsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using Xunit;
 
 namespace System.IO.Pipelines.Tests
@@ -18,6 +19,12 @@ namespace System.IO.Pipelines.Tests
         public void DefaultResumeWriterThresholdIsSet()
         {
             Assert.Equal(16384, PipeOptions.Default.ResumeWriterThreshold);
+        }
+
+        [Fact]
+        public void DefaultPoolIsSetToShared()
+        {
+            Assert.Equal(MemoryPool<byte>.Shared, PipeOptions.Default.Pool);
         }
     }
 }


### PR DESCRIPTION
The shared MemoryPool allocates an object per call to Rent. This might not be a problem in all cases but it's an unfortunate side effect of using the default implementation today. We can avoid this by leaving the default `MemoryPool<T>` null and instead using the shared ArrayPool by default (which pools the underlying array)

PS: I can't figure out how to run anything locally, so I'm just going to see what the CI tells me 😄 

Before

```
#13 ViaPipeReader
Took: 4,953 ms
Allocated: 512 kb
Peak Working Set: 16,044 kb
Gen 0 collections: 0
Gen 1 collections: 0
Gen 2 collections: 0
```

After

```
#13 ViaPipeReader
Took: 4,906 ms
Allocated: 72 kb
Peak Working Set: 15,584 kb
Gen 0 collections: 0
Gen 1 collections: 0
Gen 2 collections: 0
```
