### PR TITLE
Reduce memory allocation in Http2Stream

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -46,7 +46,7 @@ namespace System.Net.Http
 
         private static readonly byte[] s_http2ConnectionPreface = Encoding.ASCII.GetBytes("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
 
-        private const int InitialBufferSize = 4096;
+        private const int InitialConnectionBufferSize = 4096;
 
         private const int DefaultInitialWindowSize = 65535;
 
@@ -60,9 +60,9 @@ namespace System.Net.Http
             _pool = pool;
             _stream = stream;
             _syncObject = new object();
-            _incomingBuffer = new ArrayBuffer(InitialBufferSize);
-            _outgoingBuffer = new ArrayBuffer(InitialBufferSize);
-            _headerBuffer = new ArrayBuffer(InitialBufferSize);
+            _incomingBuffer = new ArrayBuffer(InitialConnectionBufferSize);
+            _outgoingBuffer = new ArrayBuffer(InitialConnectionBufferSize);
+            _headerBuffer = new ArrayBuffer(InitialConnectionBufferSize);
 
             _hpackDecoder = new HPackDecoder();
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http.Headers;
-using System.Net.Http.HPack;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,24 +13,26 @@ namespace System.Net.Http
 {
     internal sealed partial class Http2Connection 
     {
-        // TODO: ISSUE 31301: Should we pool Http2Stream objects?
-        sealed class Http2Stream : IDisposable
+        private sealed class Http2Stream : IDisposable
         {
+            private const int InitialStreamBufferSize =
+#if DEBUG
+                10;
+#else
+                1024;
+#endif
+
             private readonly Http2Connection _connection;
             private readonly int _streamId;
-            private readonly object _syncObject;
-
+            private readonly CreditManager _streamWindow;
+            private readonly HttpRequestMessage _request;
+            private readonly HttpResponseMessage _response;
             private readonly TaskCompletionSource<bool> _responseHeadersAvailable;
-            private ArrayBuffer _responseBuffer;
+
+            private ArrayBuffer _responseBuffer; // mutable struct, do not make this readonly
             private TaskCompletionSource<bool> _responseDataAvailable;
             private bool _responseComplete;
             private bool _responseAborted;
-
-            private readonly CreditManager _streamWindow;
-
-            private readonly HttpRequestMessage _request;
-            private readonly HttpResponseMessage _response;
-            private readonly HttpConnectionResponseContent _responseContent;
             private bool _disposed;
 
             public Http2Stream(HttpRequestMessage request, Http2Connection connection, int streamId, int initialWindowSize)
@@ -41,13 +41,16 @@ namespace System.Net.Http
                 _streamId = streamId;
 
                 _request = request;
-                _responseContent = new HttpConnectionResponseContent();
-                _response = new HttpResponseMessage() { Version = HttpVersion.Version20, RequestMessage = request, Content = _responseContent };
+                _response = new HttpResponseMessage()
+                {
+                    Version = HttpVersion.Version20,
+                    RequestMessage = request,
+                    Content = new HttpConnectionResponseContent()
+                };
 
-                _syncObject = new object();
                 _disposed = false;
 
-                _responseBuffer = new ArrayBuffer(InitialBufferSize);
+                _responseBuffer = new ArrayBuffer(InitialStreamBufferSize);
 
                 _streamWindow = new CreditManager(initialWindowSize);
 
@@ -57,6 +60,8 @@ namespace System.Net.Http
                 // See: https://github.com/dotnet/corefx/blob/master/src/Common/tests/System/Threading/Tasks/Sources/ManualResetValueTaskSource.cs
                 _responseDataAvailable = null;
             }
+
+            private object SyncObject => _streamWindow;
 
             public int StreamId => _streamId;
             public HttpRequestMessage Request => _request;
@@ -85,14 +90,9 @@ namespace System.Net.Http
                 bool emptyResponse = await _responseHeadersAvailable.Task.ConfigureAwait(false);
 
                 // Start to process the response body.
-                if (emptyResponse)
-                {
-                    _responseContent.SetStream(EmptyReadStream.Instance);
-                }
-                else
-                {
-                    _responseContent.SetStream(new Http2ReadStream(this));
-                }
+                ((HttpConnectionResponseContent)_response.Content).SetStream(emptyResponse ?
+                    EmptyReadStream.Instance :
+                    (Stream)new Http2ReadStream(this));
 
                 // Process Set-Cookie headers.
                 if (_connection._pool.Settings._useCookies)
@@ -162,7 +162,7 @@ namespace System.Net.Http
             {
                 TaskCompletionSource<bool> readDataAvailable = null;
 
-                lock (_syncObject)
+                lock (SyncObject)
                 {
                     if (_disposed)
                     {
@@ -201,7 +201,7 @@ namespace System.Net.Http
 
             public void OnResponseAbort()
             {
-                lock (_syncObject)
+                lock (SyncObject)
                 {
                     if (_disposed)
                     {
@@ -248,23 +248,6 @@ namespace System.Net.Http
                 return bytesToRead;
             }
 
-            public async ValueTask<int> ReadDataAsyncCore(Task onDataAvailable, Memory<byte> buffer)
-            {
-                await onDataAvailable.ConfigureAwait(false);
-
-                lock (_syncObject)
-                {
-                    if (_responseBuffer.ActiveSpan.Length > 0)
-                    {
-                        return ReadFromBuffer(buffer.Span);
-                    }
-
-                    // If no data was made available, we must be at the end of the stream
-                    Debug.Assert(_responseComplete);
-                    return 0;
-                }
-            }
-
             // TODO: ISSUE 31310: Cancellation support
 
             public ValueTask<int> ReadDataAsync(Memory<byte> buffer, CancellationToken cancellationToken)
@@ -275,8 +258,13 @@ namespace System.Net.Http
                 }
 
                 Task onDataAvailable;
-                lock (_syncObject)
+                lock (SyncObject)
                 {
+                    if (_disposed)
+                    {
+                        return new ValueTask<int>(Task.FromException<int>(new ObjectDisposedException(nameof(Http2Stream))));
+                    }
+
                     if (_responseBuffer.ActiveSpan.Length > 0)
                     {
                         return new ValueTask<int>(ReadFromBuffer(buffer.Span));
@@ -299,6 +287,23 @@ namespace System.Net.Http
                 }
 
                 return ReadDataAsyncCore(onDataAvailable, buffer);
+
+                async ValueTask<int> ReadDataAsyncCore(Task onDataAvailable, Memory<byte> buffer)
+                {
+                    await onDataAvailable.ConfigureAwait(false);
+
+                    lock (SyncObject)
+                    {
+                        if (!_disposed && _responseBuffer.ActiveSpan.Length > 0)
+                        {
+                            return ReadFromBuffer(buffer.Span);
+                        }
+
+                        // If no data was made available, we must be at the end of the stream
+                        Debug.Assert(_responseComplete);
+                        return 0;
+                    }
+                }
             }
 
             private async ValueTask SendDataAsync(ReadOnlyMemory<byte> buffer)
@@ -318,13 +323,14 @@ namespace System.Net.Http
 
             public void Dispose()
             {
-                lock (_syncObject)
+                lock (SyncObject)
                 {
                     if (!_disposed)
                     {
                         _disposed = true;
 
                         _streamWindow.Dispose();
+                        _responseBuffer.Dispose();
 
                         // TODO: ISSUE 31310: If the stream is not complete, we should send RST_STREAM
                     }
@@ -333,8 +339,7 @@ namespace System.Net.Http
 
             private sealed class Http2ReadStream : BaseAsyncStream
             {
-                private readonly Http2Stream _http2Stream;
-                private int _disposed; // 0==no, 1==yes
+                private Http2Stream _http2Stream;
 
                 public Http2ReadStream(Http2Stream http2Stream)
                 {
@@ -344,15 +349,15 @@ namespace System.Net.Http
 
                 protected override void Dispose(bool disposing)
                 {
-                    if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                    Http2Stream stream = Interlocked.Exchange(ref _http2Stream, null);
+                    if (stream == null)
                     {
                         return;
                     }
 
                     if (disposing)
                     {
-                        Debug.Assert(_http2Stream != null);
-                        _http2Stream.Dispose();
+                        stream.Dispose();
                     }
 
                     base.Dispose(disposing);
@@ -363,7 +368,7 @@ namespace System.Net.Http
 
                 public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
                 {
-                    return _http2Stream.ReadDataAsync(destination, cancellationToken);
+                    return _http2Stream?.ReadDataAsync(destination, cancellationToken) ?? new ValueTask<int>(0);
                 }
 
                 public override ValueTask WriteAsync(ReadOnlyMemory<byte> destination, CancellationToken cancellationToken) => throw new NotSupportedException();
@@ -374,8 +379,7 @@ namespace System.Net.Http
 
             private sealed class Http2WriteStream : BaseAsyncStream
             {
-                private readonly Http2Stream _http2Stream;
-                private int _disposed; // 0==no, 1==yes
+                private Http2Stream _http2Stream;
 
                 public Http2WriteStream(Http2Stream http2Stream)
                 {
@@ -385,13 +389,14 @@ namespace System.Net.Http
 
                 protected override void Dispose(bool disposing)
                 {
-                    if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                    Http2Stream stream = Interlocked.Exchange(ref _http2Stream, null);
+                    if (stream == null)
                     {
                         return;
                     }
 
                     // Don't wait for completion, which could happen asynchronously.
-                    ValueTask ignored = _http2Stream._connection.SendEndStreamAsync(_http2Stream.StreamId);
+                    ValueTask ignored = stream._connection.SendEndStreamAsync(stream.StreamId);
 
                     base.Dispose(disposing);
                 }
@@ -403,7 +408,7 @@ namespace System.Net.Http
 
                 public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
                 {
-                    return _http2Stream.SendDataAsync(buffer);
+                    return _http2Stream?.SendDataAsync(buffer) ?? default(ValueTask);
                 }
 
                 public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionResponseContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionResponseContent.cs
@@ -12,26 +12,25 @@ namespace System.Net.Http
     internal sealed class HttpConnectionResponseContent : HttpContent
     {
         private Stream _stream;
-        private bool _consumedStream;
 
         public void SetStream(Stream stream)
         {
             Debug.Assert(stream != null);
             Debug.Assert(stream.CanRead);
-            Debug.Assert(!_consumedStream);
 
             _stream = stream;
         }
 
         private Stream ConsumeStream()
         {
-            if (_consumedStream || _stream == null)
+            Stream stream = _stream;
+            if (stream == null)
             {
                 throw new InvalidOperationException(SR.net_http_content_stream_already_read);
             }
-            _consumedStream = true;
 
-            return _stream;
+            _stream = null;
+            return stream;
         }
 
         protected sealed override Task SerializeToStreamAsync(Stream stream, TransportContext context) =>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionResponseContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionResponseContent.cs
@@ -12,25 +12,26 @@ namespace System.Net.Http
     internal sealed class HttpConnectionResponseContent : HttpContent
     {
         private Stream _stream;
+        private bool _consumedStream; // separate from _stream so that Dispose can drain _stream
 
         public void SetStream(Stream stream)
         {
             Debug.Assert(stream != null);
             Debug.Assert(stream.CanRead);
+            Debug.Assert(!_consumedStream);
 
             _stream = stream;
         }
 
         private Stream ConsumeStream()
         {
-            Stream stream = _stream;
-            if (stream == null)
+            if (_consumedStream || _stream == null)
             {
                 throw new InvalidOperationException(SR.net_http_content_stream_already_read);
             }
+            _consumedStream = true;
 
-            _stream = null;
-            return stream;
+            return _stream;
         }
 
         protected sealed override Task SerializeToStreamAsync(Stream stream, TransportContext context) =>


### PR DESCRIPTION
- Pool response buffers via ArrayPool
- Don't allocate a separate sync object
- Shrink the size of a few types

This (in particular the buffers, the rest were just really low hanging fruit I noticed along the way) has a very measurable impact on the amount of allocation happening, though we're still aways away from where we are for HTTP/1.1.

Below is a C# test app, which I'm running against a localhost server created just by doing `dotnet new web` with .NET Core 3.0 Preview 2; the only tweak I made to it was to remove the logging configuration from the generated json file.  The test app as written below just makes 50K GET requests (all serialized one after the other) to https://localhost:5001/, which outputs "hello world" in a response body.

Here's example run on my machine when using HTTP/1.1:
```
00:00:07.1380364: 24 / 2 / 0
00:00:07.0321134: 25 / 3 / 0
00:00:07.1096999: 24 / 3 / 0
00:00:07.1130195: 25 / 4 / 0
00:00:07.1667388: 24 / 5 / 0
00:00:07.1335548: 25 / 5 / 0
00:00:07.0896373: 24 / 6 / 0
```
The output is execution time followed by gen0, gen1, and gen2 GCs.

Now here's HTTP/2 prior to this change:
```
00:00:07.7105986: 89 / 3 / 0
00:00:07.7240805: 89 / 4 / 0
00:00:07.7693986: 89 / 4 / 0
00:00:07.6759160: 88 / 5 / 0
00:00:07.7105327: 89 / 6 / 0
00:00:07.6869135: 89 / 7 / 0
00:00:07.7373724: 88 / 7 / 0
```
and after this change:
```
00:00:07.7463253: 35 / 3 / 0
00:00:07.9400427: 34 / 3 / 0
00:00:07.8681804: 35 / 4 / 0
00:00:07.7955239: 35 / 5 / 0
00:00:07.7796479: 34 / 6 / 0
00:00:07.6910270: 35 / 7 / 0
00:00:07.7161377: 34 / 7 / 0
```
so a marked improvement, but still much more than HTTP/1.1.

Unfortunately the difference increases in both time and memory when requests start happening in parallel.  Tweaking the concurrency level in the test from 1 to Environment.ProcessorCount, such that on my 8-core I end up making 400K requests, I get these results for HTTP/1.1:
```
00:00:08.7074793: 204 / 2 / 1
00:00:08.8334615: 204 / 3 / 0
00:00:08.7282221: 203 / 4 / 0
00:00:08.5498555: 205 / 5 / 0
00:00:08.4470234: 204 / 6 / 0
00:00:08.6309900: 203 / 7 / 0
00:00:08.7555510: 204 / 7 / 0
```
these for HTTP/2 prior to my change:
```
00:00:20.4351018: 837 / 2 / 0
00:00:20.3068919: 828 / 5 / 1
00:00:20.5228177: 828 / 7 / 0
00:00:20.4031636: 827 / 9 / 0
00:00:19.8560855: 829 / 16 / 0
00:00:19.9637692: 830 / 19 / 0
00:00:20.2521657: 830 / 22 / 1
```
and these for HTTP/2 with my change:
```
00:00:16.8593566: 332 / 2 / 0
00:00:16.7375893: 329 / 4 / 1
00:00:16.4571576: 327 / 5 / 0
00:00:16.3972835: 326 / 7 / 0
00:00:16.6289501: 327 / 9 / 0
00:00:16.1113589: 329 / 10 / 0
00:00:16.2596736: 328 / 12 / 0
```
Again, the change helps significantly, but it still a long ways behind 1.1, especially now in throughput, which suggests the HTTP/2 implementation currently has some synchronization bottleneck that's throttling throughput.  That'll need to be investigated separately.

One other interesting thing I note which I don't yet have a good explanation for is while the number of gen0 and gen2 GCs remains fairly stable across all of these versions, the number of gen1 GCs gently climbs, and trend that seems to continue without end (for at least a few minutes, which is all I gave it).  We should investigate that, as well.

Finally, note that all of this is running on one machine, both client and the ASP.NET Core server, so everything should be taken with grains of salt.

C# code:
```C#
using System;
using System.Diagnostics;
using System.Linq;
using System.IO;
using System.Net.Http;
using System.Security.Cryptography.X509Certificates;
using System.Threading.Tasks;

class Test
{
    public static async Task Main(string[] args)
    {
        if (args.Length >= 1 && args[0] == "2")
        {
            Environment.SetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_HTTP2SUPPORT", "true");
        }

        int concurrentRequests = 1; //Environment.ProcessorCount;
        var invoker = new HttpMessageInvoker(new SocketsHttpHandler());
        var message = new HttpRequestMessage(HttpMethod.Get, $"https://localhost:5001/");

        var sw = new Stopwatch();
        while (true)
        {
            int gen0 = GC.CollectionCount(0), gen1 = GC.CollectionCount(1), gen2 = GC.CollectionCount(2);
            sw.Restart();
            await Task.WhenAll(Enumerable.Range(0, concurrentRequests).Select(_ => Task.Run(async () =>
            {
                for (int i = 0; i < 50_000; i++)
                {
                    using (HttpResponseMessage r = await invoker.SendAsync(message, default))
                    using (Stream s = await r.Content.ReadAsStreamAsync())
                    {
                        await s.CopyToAsync(Stream.Null);
                    }
                }
            })));
            sw.Stop();
            Console.WriteLine($"{sw.Elapsed}: {GC.CollectionCount(0) - gen0} / {GC.CollectionCount(1)} / {GC.CollectionCount(2) - gen2}");
        }
    }

    private static X509Certificate2 GetServerCertificate()
    {
        var certCollection = new X509Certificate2Collection();
        certCollection.Import(s_testCertBytes, "testcertificate", X509KeyStorageFlags.DefaultKeySet);
        return certCollection.Cast<X509Certificate2>().First(c => c.HasPrivateKey);
    }

    private static readonly byte[] s_testCertBytes = Convert.FromBase64String(@"MIIVBAIBAzCCFMAGCSqGSIb3DQEHAaCCFLEEghStMIIUqTCCCooGCSqGSIb3DQEHAaCCCnsEggp3MIIKczCCCm8GCyqGSIb3DQEMCgECoIIJfjCCCXowHAYKKoZIhvcNAQwBAzAOBAhCAauyUWggWwICB9AEgglYefzzX/jx0b+BLU/TkAVj1KBpojf0o6qdTXV42drqIGhX/k1WwF1ypVYdHeeuDfhH2eXHImwPTw+0bACY0dSiIHKptm0sb/MskoGI8nlOtHWLi+QBirJ9LSUZcBNOLwoMeYLSFEWWBT69k/sWrc6/SpDoVumkfG4pZ02D9bQgs1+k8fpZjZGoZp1jput8CQXPE3JpCsrkdSdiAbWdbNNnYAy4C9Ej/vdyXJVdBTEsKzPYajAzo6Phj/oS/J3hMxxbReMtj2Z0QkoBBVMc70d+DpAK5OY3et872D5bZjvxhjAYh5JoVTCLTLjbtPRn1g7qh2dQsIpfQ5KrdgqdImshHvxgL92ooC1eQVqQffMnZ0/LchWNb2rMDa89K9CtAefEIF4ve2bOUZUNFqQ6dvd90SgKq6jNfwQf/1u70WKE86+vChXMMcHFeKso6hTE9+/zuUPNVmbRefYAtDd7ng996S15FNVdxqyVLlmfcihX1jGhTLi//WuMEaOfXJ9KiwYUyxdUnMp5QJqO8X/tiwnsuhlFe3NKMXY77jUe8F7I+dv5cjb9iKXAT+q8oYx1LcWu2mj1ER9/b2omnotp2FIaJDwI40Tts6t4QVH3bUNE9gFIfTMK+WMgKBz/JAGvC1vbPSdFsWIqwhl7mEYWx83HJp/+Uqp5f+d8m4phSan2rkHEeDjkUaoifLWHWDmL94SZBrgU6yGVK9dU82kr7jCSUTrnga8qDYsHwpQ22QZtu0aOJGepSwZU7NZNMiyX6QR2hI0CNMjvTK2VusHFB+qnvw+19DzaDT6P0KNPxwBwp07KMQm3HWTRNt9u6gKUmo5FHngoGte+TZdY66dAwCl0Pt+p1v18XlOB2KOQZKLXnhgikjOwYQxFr3oTb2MjsP6YqnSF9EpYpmiNySXiYmrYxVinHmK+5JBqoQCN2C3N24slZkYq+AYUTnNST7Ib2We3bBICOFdVUgtFITRW40T+0XZnIv8G1Kbaq/1avfWI/ieKKxyiYp/ZNXaxc+ycgpsSsAJEuhb83bUkSBpGg9PvFEF0DXm4ah67Ja1SSTmvrCnrOsWZXIpciexMWRGoKrdvd7Yzj9E8hiu+CGTC4T6+7FxVXJrjCg9zU9G2U6g7uxzoyjGj1wqkhxgvl9pPbz6/KqDRLOHCEwRF4qlWXhsJy4levxGtifFt6n7DWaNSsOUf8Nwpi+d4fd7LQ7B5tW/y+/vVZziORueruCWO4LnfPhpJ70g18uyN7KyzrWy29rpE46rfjZGGt0WDZYahObPbw6HjcqSOuzwRoJMxamQb2qsuQnaBS6Bhb5PAnY4SEA045odf/u9uC7mLom2KGNHHz6HrgEPas2UHoJLuxYvY1pza/29akuVQZQUvMA5yMFHHGYZLtTKtCGdVGwX0+QS6ovpV93xux4I/5TrD5U8z9RmTdAx03R3MUhkHF7Zbv5egDNsVar+41YWG4VkV1ZXtsZRKJf0hvKNvrpH0e7fVKBdXljm5PXOSg2VdtkhhOpnKKSMcv6MbGWVi/svWLnc7Qim4A4MDaz+bFVZmh3oGJ7WHvRQhWIcHUL+YJx+064+4IKXZJ/2a/+b2o7C8mJ3GGSBx831ADogg6MRWZx3UY19OZ8YMvpzmZEBRZZnm4KgNpj+SQnf6pGzD2cmnRhzG60LSNPb17iKbdoUAEMkgt2tlMKXpnt1r7qwsIoTt407cAdCEsUH7OU/AjfFmSkKJZ7vC5HweqZPnhgJgZ6LYHlfiRzUR1xeDg8JG0nb0vb7LUE4nGPy39/TxIGos7WNwGpG1QVL/8pKjFdjwREaR8e5CSTlQ7gxHV+G3FFvFGpA1p8cRFzlgE6khDLrSJIUkhkHMA3oFwwAzBNIKVXjToyxCogDqxWya0E1Hw5rVCS/zOCS1De2XQbXs//g46TW0wTJwvgNbs0xLShf3XB+23meeEsMTCR0+igtMMMsh5K/vBUGcJA27ru/KM9qEBcseb/tqCkhhsdj1dnH0HDmpgFf5DfVrjm+P6ickcF2b+Ojr9t7XHgFszap3COpEPGmeJqNOUTuU53tu/O774IBgqINMWvvG65yQwsEO06jRrFPRUGb0eH6UM4vC7wbKajnfDuI/EXSgvuOSZ9wE8DeoeK/5We4pN7MSWoDl39gI/LBoNDKFYEYuAw/bhGp8nOwDKki4a16aYcBGRClpN3ymrdurWsi7TjyFHXfgW8fZe4jXLuKRIk19lmL1gWyD+3bT3mkI2cU2OaY2C0fVHhtiBVaYbxBV8+kjK8q0Q70zf0r+xMHnewk9APFqUjguPguTdpCoH0VAQST9Mmriv/J12+Y+fL6H+jrtDY2zHPxTF85pA4bBBnLA7Qt9TKCe6uuWu5yBqxOV3w2Oa4Pockv1gJzFbVnwlEUWnIjbWVIyo9vo4LBd03uJHPPIQbUp9kCP/Zw+Zblo42/ifyY+a+scwl1q1dZ7Y0L92yJCKm9Qf6Q+1PBK+uU9pcuVTg/Imqcg5T7jFO5QCi88uwcorgQp+qoeFi0F9tnUecfDl6d0PSgAPnX9XA0ny3bPwSiWOA8+uW73gesxnGTsNrtc1j85tail8N6m6S2tHXwOmM65J4XRZlzzeM4D/Rzzh13xpRA9kzm9T2cSHsXEYmSW1X7WovrmYhdOh9K3DPwSyG4tD58cvC7X79UbOB+d17ieo7ZCj+NSLVQO1BqTK0QfErdoVHGKfQG8Lc/ERQRqj132Mhi2/r5Ca7AWdqD7/3wgRdQTJSFXt/akpM44xu5DMTCISEFOLWiseSOBtzT6ssaq2Q35dCkXp5wVbWxkXAD7Gm34FFXXyZrJWAx45Y40wj/0KDJoEzXCuS4Cyiskx1EtYNNOtfDC5wngywmINFUnnW0NkdKSxmDJvrT6HkRKN8ftik7tP4ZvTaTS28Z0fDmWJ+RjvZW+vtF6mrIzYgGOgdpZwG0ZOSKrXKrY3xpMO16fXyawFfBosLzCty7uA57niPS76UXdbplgPanIGFyceTg1MsNDsd8vszXd4KezN2VMaxvw+93s0Uk/3Mc+5MAj+UhXPi5UguXMhNo/CU7erzyxYreOlAI7ZzGhPk+oT9g/MqWa5RpA2IBUaK/wgaNaHChfCcDj/J1qEl6YQQboixxp1IjQxiV9bRQzgwf31Cu2m/FuHTTkPCdxDK156pyFdhcgTpTNy7RPLDGB3TATBgkqhkiG9w0BCRUxBgQEAQAAADBdBgkrBgEEAYI3EQExUB5OAE0AaQBjAHIAbwBzAG8AZgB0ACAAUwB0AHIAbwBuAGcAIABDAHIAeQBwAHQAbwBnAHIAYQBwAGgAaQBjACAAUAByAG8AdgBpAGQAZQByMGcGCSqGSIb3DQEJFDFaHlgAQwBlAHIAdABSAGUAcQAtADcAOQA4AGUANQA4AGIANQAtAGMAOQA2ADQALQA0ADcAZQA2AC0AYQAzADIAOQAtADAAMQBjAGEAZABmADcANgAyAGEANgA5MIIKFwYJKoZIhvcNAQcGoIIKCDCCCgQCAQAwggn9BgkqhkiG9w0BBwEwHAYKKoZIhvcNAQwBBjAOBAh+t0PMVhyoagICB9CAggnQwKPcfNq8ETOrNesDKNNYJVXnWoZ9Qjgj9RSpj+pUN5I3B67iFpXClvnglKbeNarNCzN4hXD0I+ce+u+Q3iy9AAthG7uyYYNBRjCWcBy25iS8htFUm9VoV9lH8TUnS63Wb/KZnowew2HVd8QI/AwQkRn8MJ200IxR/cFD4GuVO/Q76aqvmFb1BBHItTerUz7t9izjhL46BLabJKx6Csqixle7EoDOsTCA3H1Vmy2/Hw3FUtSUER23jnRgpRTA48M6/nhlnfjsjmegcnVBoyCgGaUadGE5OY42FDDUW7wT9VT6vQEiIfKSZ7fyqtZ6n4+xD2rVySVGQB9+ROm0mywZz9PufsYptZeB7AfNOunOAd2k1F5y3qT0cjCJ+l4eXr9KRd2lHOGZVoGq+e08ylBQU5HB+Tgm6mZaEO2QgzXOAt1ilS0lDii490DsST62+v58l2R45ItbRiorG/US7+HZHjHUY7EsDUZ+gn3ZZNqh1lAoli5bC1xcjEjNdqq0knyCAUaNMG59UhCWoB6lJpRfVEeQOm+TjgyGw6t3Fx/6ulNPc1V/wcascmahH3kgHL146iJi1p2c2yIJtEB+4zrbYv7xH73c8qXVh/VeuD80I/+QfD+GaW0MllIMyhCHcduFoUznHcDYr5GhJBhU62t6sNnSjtEU1bcd20oHrBwrpkA7g3/Mmny33IVrqooWFe876lvQVq7GtFu8ijVyzanZUs/Cr7k5xX3zjh6yUMAbPiSnTHCl+SEdttkR936fA6de8vIRRGj6eAKqboRxgC1zgsJrj7ZVI7h0QlJbodwY2jzyzcC5khn3tKYjlYeK08iQnzeK5c9JVgQAHyB4uOyfbE50oBCYJE7npjyV7LEN2f7a3GHX4ZWI3pTgbUv+Q1t8BZozQ4pcFQUE+upYucVL3Fr2T8f7HF4G4KbDE4aoLiVrYjy0dUs7rCgjeKu21UPA/BKx4ebjG+TZjUSGf8TXqrJak1PQOG4tExNBYxLtvBdFoOAsYsKjTOfMYpPXp4vObfktFKPcD1dVdlXYXvS5Dtz3qEkwmruA9fPQ6FYi+OFjw0Pkwkr5Tz+0hRMGgb1JRgVo8SVlW/NZZIEbKJdW5ZVLyMzdd1dC0ogNDZLPcPR/HENe2UXtq+0qQw0ekZ+aC2/RvfAMr5XICX8lHtYmQlAFGRhFNuOysHj7V2AJTuOx2wCXtGzrTPc6eyslsWyJign8bD1r+gkejx/qKBwwTvZF1aSmiQmFnmMm0jLj7n8v7v6zHCFTuKF1bHZ44eIwMaUDl6MAgHDdvkPl56rYgq/TM3dKuXnu47GLiRei0EXTT9OMCKcI6XYICsge81ET3k15VfLyI1LNufgqAsafnwl31yqntscXW0NsxW6SkmyXaW1mndxejLBQRjik3civBGTgxgKQbZaO9ZGOrjsSogcCSne+s0zLDxEFjmaYYtpIaU8SFWDja5jyo0jvM3OHUwvElvndZJgreFGG5cKHgwgGKdkYgx6YAvucrgQwqKE/+nxuhkKWtV9D4h9qFAqZbWc9jOPtWx9h3U3gX3NTLY/4Z4iy/FXR9KnKUtCmD1MSRRIOiMca1sNTga3mP/+qSS5u+pyon5c4c/jLdEW0GapDz/yvQcc0MP/21vSoeIkUN+w/RzUBvxrawhHGx+FeLlI249+LBKNBQu4Fbw6G9AYpPJf3PdNc0GRMnantA4B7Rm2NsSGdqqrEMuCw1XxzR6ki4jbLC/ASbcVMr54YsBw+45sggenFshRrYm0QXoUM5XoqEtesby6YfPAjBldyB/QcuULV6QyAeL44YmxOnKD5E5qQwgfcZUxN01eBgbeSS7bZI3zpFwAMdMQ+dtwHXMuhVXuUGLmNTvNe9DupfPGKbaM8louY1Xw4fmg4PaY7MP2mdYQlEXvSg2geICJVuGRBirH+Xv8VPr7lccN++LXv2NmggoUo/d18gvhY8XtOrOMon1QGANPh7SzBjR3v19JD170Z6GuZCLtMh681YkKwW/+Em5rOtexoNQRTjZLNSTthtMyLfAqLk6lZnbbh+7VdCWVfzZoOzUNV+fVwwvyR9ouIzrvDoZ5iGRZU8rEuntap6rBrf9F3FMsz4mvPlCAMp15sovLFpVI8t+8OmKmqQH3LOwd03s6iMJ+0YEWrCaTQYu3kEKoOWC3uhGE8XLSjZBqc3kwVIlzVzOBr97SGjG88JYVDW2FrjQbIv+1yTzOYzMnCDUW3T8GMtfYEQbN6ZtBaD9i4ZeZlQCdkfGuNC6OYO98L7fU4frgff8nNfeka8kHtvNMn4CosFKBRXA5y+kqEE0Qk5feZhfM8NX9x3O0CJobm4HC57VxJ3c0jTe2SA0gAfB4g0keghmDzYgjQAuIY/o1LMKFiBNue4fnXlhU1L402Zlx/lzKDera6o3Xgh9IXj3ZqyFlXa9bkyKDtek0ephTZulLc3NLeb1a3KZxId8OmplR8OcZsHluEu+Z3Der0j8Ro7X7kOnNkUxuTV2blqZ4V8DsYKATeKv4ffc1Ub8MLBd9hMs8ehjmC5jkYApM5HvXl4411mPN6MrF8f2hPVgqrd3p/M80c8wNWjvWIvPLr9Tjqk71hKBq3+Hu0oI1zuoTY2BOhBLyvpjM+mvRd8UlrFJTLGTyCAXvAhIDRIVyrGuscO5Y0sfDc+82Bvrua4FyhZkjb1r8GrGciH0V5HHKjg5dewWnr21qf4q96yf2/ZjoldFFvKiCd8wum9ZV1OaTbjjg46oSpIyBzxl4qpfrgT1ZX1MvGW4uAJ7WQHjSAex7VGr1Sl+ghe5PQBbURyFiu9PnBRMOMjGYkI2lngd3bdehc+i2fPnNe5LgdsBbmUKmEJH96rlkFT8Co+NYBWKBUsBXyfC+kwXDRyNrt2r7VafWWz/cwK0/AJ/Ucq4vz8E0mzy03Gs+ePW+tP9JOHP6leF0TLhbItvQl3DJy0gj6TyrO9S077EVyukFCXeH1/yp04lmq4G0urU+pUf2wamP4BVNcVsikPMYo/e75UI330inXG4+SbJ40q/MQIfYnXydhVmWVCUXkfRFNbcCu7JclIrzS1WO26q6BOgs2GhA3nEan8CKxa85h/oCaDPPMGhkQtCU75vBqQV9Hk2+W5zMSSj7R9RiH34MkCxETtY8IwKa+kiRAeMle8ePAmT6HfcBOdTsVGNoRHQAOZewwUycrIOYJ/54WOmcy9JZW9/clcgxHGXZq44tJ3BDHQQ4qBgVd5jc9Qy9/fGS3YxvsZJ3iN7IMs4Jt3GWdfvwNpJaCBJjiiUntJPwdXMjAeUEZ16Tmxdb1l42rjFSCptMJS2N2EPSNb36+staNgzflctLLpmyEK4wyqjA7MB8wBwYFKw4DAhoEFIM7fHJcmsN6HkU8HxypGcoifg5MBBRXe8XL349R6ZDmsMhpyXbXENCljwICB9A=");
}
```

cc: @geoffkizer, @rmkerr, @wfurt, @davidsh, @caesar1995 
Fixes https://github.com/dotnet/corefx/issues/31301.  That issue is specifically about Http2Stream, but at the moment the life span around Http2Stream isn't entirely clear, and the buffers represent the bulk of it.  We can revisit pooling Http2Stream later, in particular if/when we've moved to use reusable IValueTaskSource implementations for the response header/data TCS instances; at that point, we would be able to pool the Http2Stream, its credit manager, those TCS instances, and any other objects that end up being a part of this instance.