### PR TITLE
Revert "Upgrading Roslyn to 3.0.0-beta2-final (#35134)"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -307,9 +307,7 @@
 
   <!-- Language configuration -->
   <PropertyGroup>
-    <!-- default to allowing all language features -->
-    <LangVersion>latest</LangVersion>
-    <LangVersion Condition="'$(Language)' == 'C#'">8.0</LangVersion>
+    <LangVersion>latest</LangVersion> <!-- default to allowing all language features -->
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict</Features>
     <WarningLevel>4</WarningLevel>
@@ -479,9 +477,4 @@
     <!-- Clear the init locals flag on all src projects, except those in VB, where we can't use spans. -->
     <ILLinkClearInitLocals Condition="'$(IsSourceProject)' == 'true' AND '$(Language)' != 'VB'">true</ILLinkClearInitLocals>
   </PropertyGroup>
-
-  <!-- Import the Roslyn Compiler Toolset props -->
-  <Import Project="$(PkgMicrosoft_Net_Compilers)/build/Microsoft.Net.Compilers.props" Condition="'$(MSBuildRuntimeType)' != 'Core'" />
-  <Import Project="$(PkgMicrosoft_NETCore_Compilers)/build/Microsoft.NETCore.Compilers.props" Condition="'$(MSBuildRuntimeType)' == 'Core'" />
-
 </Project>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -45,10 +45,6 @@
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
     <PackageReference Include="System.Runtime.InteropServices.Analyzers" Version="1.1.0" />
     <PackageReference Include="System.Security.Cryptography.Hashing.Algorithms.Analyzers" Version="1.1.0" />
-
-    <!-- Include the Roslyn Compilers -->
-    <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" PrivateAssets="all" ExcludeAssets="Build" GeneratePathProperty="true" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersVersion)" PrivateAssets="all" ExcludeAssets="Build" GeneratePathProperty="true" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,5 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers" Version="3.0.0-beta2-final">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>231aeb8be8357239499d45c0574e5a9a8c9174f0</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.Compilers" Version="3.0.0-beta2-final">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>231aeb8be8357239499d45c0574e5a9a8c9174f0</Sha>
-    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,8 +7,6 @@
     <!-- Always use shipping version instead of dummy version -->
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <!-- Opt-in repo features -->
-    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>
@@ -28,8 +26,6 @@
     <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19105.4</MicrosoftDotNetCoreFxTestingPackageVersion>
     <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19081.1</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19081.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftNetCompilersVersion>3.0.0-beta2-final</MicrosoftNetCompilersVersion>
-    <MicrosoftNETCoreCompilersVersion>$(MicrosoftNetCompilersVersion)</MicrosoftNETCoreCompilersVersion>
     <!-- Core-setup dependencies -->
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview-27330-4</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostPackageVersion>3.0.0-preview-27330-4</MicrosoftNETCoreDotNetHostPackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "2.2.103"
+    "dotnet": "2.1.401"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19081.1",

--- a/src/System.Threading.Channels/ref/System.Threading.Channels.csproj
+++ b/src/System.Threading.Channels/ref/System.Threading.Channels.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System.Threading.Channels.netcoreapp.cs" />
-    <ProjectReference Include="../../System.Runtime/ref/System.Runtime.csproj" />
+    <Reference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <Reference Include="netstandard" />


### PR DESCRIPTION
This slowed down our builds and a lot of CI jobs (specially AllConfigurations) are timing out.

This could be because before we where using the built-in bits of the compiler that come with the SDK and are crossgen'd and now we're using ones coming from the compiler toolset package.

We can investigate further what it needs to upgrade the compiler without impacting our builds perf and then upgrade.

cc: @stephentoub @danmosemsft @ericstj @ViktorHofer @tannergooding 