### PR TITLE
Don't force-allocate x509ChainPolicy collections in X509Chain.Build

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
@@ -118,9 +118,9 @@ namespace System.Security.Cryptography.X509Certificates
                 _pal = ChainPal.BuildChain(
                     _useMachineContext,
                     certificate.Pal,
-                    chainPolicy.ExtraStore,
-                    chainPolicy.ApplicationPolicy,
-                    chainPolicy.CertificatePolicy,
+                    chainPolicy._extraStore,
+                    chainPolicy._applicationPolicy,
+                    chainPolicy._certificatePolicy,
                     chainPolicy.RevocationMode,
                     chainPolicy.RevocationFlag,
                     chainPolicy.VerificationTime,

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
@@ -11,9 +11,9 @@ namespace System.Security.Cryptography.X509Certificates
         private X509RevocationMode _revocationMode;
         private X509RevocationFlag _revocationFlag;
         private X509VerificationFlags _verificationFlags;
-        private OidCollection _applicationPolicy;
-        private OidCollection _certificatePolicy;
-        private X509Certificate2Collection _extraStore;
+        internal OidCollection _applicationPolicy;
+        internal OidCollection _certificatePolicy;
+        internal X509Certificate2Collection _extraStore;
 
         public X509ChainPolicy()
         {


### PR DESCRIPTION
Previously X509ChainPolicy would always allocate its collections, but now it lazily allocates them.  However, X509Chain.Build is forcing them to be allocated even when they're not needed.  Stop doing that.

cc: @bartonjs 