### PR TITLE
Remove Fedora from helix test queues to unblock PRs

### DIFF
--- a/buildpipeline/linux.groovy
+++ b/buildpipeline/linux.groovy
@@ -42,11 +42,9 @@ simpleDockerNode('microsoft/dotnet-buildtools-prereqs:rhel7_prereqs_2') {
                                      'Debian.8.Amd64.Open',
                                      'Ubuntu.1604.Amd64.Open',
                                      'Ubuntu.1804.Amd64.Open',
-                                     'OpenSuse.42.Amd64.Open',
-                                     'Fedora.27.Amd64.Open',]
+                                     'OpenSuse.42.Amd64.Open']
             if (params.TestOuter) {
                 targetHelixQueues += ['Debian.9.Amd64.Open',
-                                      'Fedora.28.Amd64.Open',
                                       'Ubuntu.1810.Amd64.Open',
                                       'SLES.12.Amd64.Open',
                                       'SLES.15.Amd64.Open',]

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -82,7 +82,7 @@ jobs:
           - _outerloop: true
 
         - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-          - linuxDefaultQueues: Centos.7.Amd64.Open+RedHat.7.Amd64.Open+Debian.8.Amd64.Open+Ubuntu.1604.Amd64.Open+Ubuntu.1804.Amd64.Open+OpenSuse.42.Amd64.Open+Fedora.27.Amd64.Open
+          - linuxDefaultQueues: Centos.7.Amd64.Open+RedHat.7.Amd64.Open+Debian.8.Amd64.Open+Ubuntu.1604.Amd64.Open+Ubuntu.1804.Amd64.Open+OpenSuse.42.Amd64.Open #+Fedora.27.Amd64.Open
           - linuxArm64Queues: Ubuntu.1604.Arm64.Open
       
         - ${{ if eq(parameters.isOfficialBuild, 'true') }}:


### PR DESCRIPTION
Lets remove the fedora helix queues hitting: https://github.com/dotnet/core-eng/issues/5204 since there has been no response from the eng team and to unblock PRs until we get a response. Specially during the weekend as we don't expect a response in the meantime. 

cc: @stephentoub @danmosemsft 