### PR TITLE
Support building corefx in VS2019

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -5,7 +5,7 @@ Building CoreFX on Windows
 
 1. **[Visual Studio 2017](https://www.visualstudio.com/downloads/)** (Community, Professional, Enterprise) with the latest update must be installed. The Community version is completely free.
 2. **[.NET Core SDK](https://www.microsoft.com/net/download/windows)** >= v2.1.401 must be installed which will add the `dotnet` toolchain to your path.
-3. **[CMake](https://cmake.org/)** must be installed from [the CMake download page](https://cmake.org/download/#latest) and added to your path.
+3. **[CMake](https://cmake.org/)** must be installed from [the CMake download page](https://cmake.org/download/#latest) and added to your path. CMake 3.14 or later is required to build with VS 2019
 
 ### Visual Studio 2017
 

--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -3,9 +3,43 @@ Building CoreFX on Windows
 
 ## Required Software
 
-1. **[Visual Studio 2017](https://www.visualstudio.com/downloads/)** (Community, Professional, Enterprise) with the latest update must be installed. The Community version is completely free.
+1. **[Visual Studio 2017](https://www.visualstudio.com/downloads/)** or **[Visual Studio 2019](https://visualstudio.microsoft.com/vs/preview/)** (Community, Professional, Enterprise) with the latest update must be installed. The Community version is completely free.
 2. **[.NET Core SDK](https://www.microsoft.com/net/download/windows)** >= v2.1.401 must be installed which will add the `dotnet` toolchain to your path.
-3. **[CMake](https://cmake.org/)** must be installed from [the CMake download page](https://cmake.org/download/#latest) and added to your path. CMake 3.14 or later is required to build with VS 2019
+3. **[CMake](https://cmake.org/)** must be installed from [the CMake download page](https://cmake.org/download/#latest) and added to your path. CMake 3.14 or later is required to build with VS 2019.
+
+### Visual Studio 2019
+
+#### Visual Studio 2019 - 'Workloads' based install
+
+The following are the minimum requirements:
+  * .NET desktop development
+    * All Required Components
+    * .NET Framework 4.7.2 Development Tools
+  * Desktop development with C++
+    * All Required Components
+    * VC++ 2019 v142 Toolset (x86, x64)
+    * Windows 8.1 SDK and UCRT SDK
+    * VC++ 2017 v141 Toolset (x86, x64)
+  * .NET Core cross-platform development
+    * All Required Components
+
+#### Visual Studio 2019 - 'Individual components' based install
+
+The following are the minimum requirements:
+  * C# and Visual Basic Roslyn Compilers
+  * Static Analysis Tools
+  * .NET Portable Library Targeting Pack
+  * Windows 10 SDK or Windows 8.1 SDK
+  * Visual Studio C++ Core Features
+  * VC++ 2019 v142 Toolset (x86, x64)
+  * VC++ 2017 v141 Toolset (x86, x64)
+  * MSBuild
+  * .NET Framework 4.7.2 Targeting Pack
+  * Windows Universal CRT SDK
+
+To build binaries for ARM, you need the following additional indivdual components:
+* Visual C++ compilers and libraries for ARM
+* Visual C++ compilers and libraries for ARM64
 
 ### Visual Studio 2017
 

--- a/src/Native/Windows/gen-buildsys-win.bat
+++ b/src/Native/Windows/gen-buildsys-win.bat
@@ -8,29 +8,21 @@ for %%x in (%*) do Set /A argC+=1
 if NOT %argC%==3 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
-setlocal EnableDelayedExpansion
+setlocal
 set __sourceDir=%~dp0
 set __ExtraCmakeParams=
 
-:: VS 2017 is the minimum supported toolset
 if "%__VSVersion%" == "vs2019" (
-  set __VSString=16 2019
-
-  :: VS 2019 generator is not per arch, and the arch needs to be passed with -A option
-  :: x86 is the default arch selected by cmake.
   :: CMAKE 3.14 or later is required to use VS2019
-  if /i "%3" == "x64"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A x64)
-  if /i "%3" == "arm"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM)
+  set __VSString=16 2019
 ) else (
+  :: VS 2017 is the minimum supported toolset
   set __VSString=15 2017
-
-  :: VS2017 generator needs to be specified with the arch as part of its name.
-  :: x86 is the default arch selected by cmake.
-  if /i "%3" == "x64"     (set __VSString=!__VSString! Win64)
-  if /i "%3" == "arm"     (set __VSString=!__VSString! ARM)
 )
 
-:: arm64 doesn't have a specific generator so we need to pass it through -A option.
+:: x86 is the default arch selected by cmake.
+if /i "%3" == "x64"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A x64)
+if /i "%3" == "arm"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM)
 if /i "%3" == "arm64"   (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM64)
 if /i "%3" == "wasm"    (set __sourceDir=%~dp0..\Unix && goto DoGen)
 

--- a/src/Native/Windows/gen-buildsys-win.bat
+++ b/src/Native/Windows/gen-buildsys-win.bat
@@ -8,18 +8,29 @@ for %%x in (%*) do Set /A argC+=1
 if NOT %argC%==3 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
-setlocal
+setlocal EnableDelayedExpansion
 set __sourceDir=%~dp0
 set __ExtraCmakeParams=
 
-:: VS 2017 is required to build native assets,
-:: once CMake supports 2019 as the project generator we can use that if installed in the local system
-set __VSString=15 2017
+:: VS 2017 is the minimum supported toolset
+if "%__VSVersion%" == "vs2019" (
+  set __VSString=16 2019
 
-:: Set the target architecture to a format cmake understands. ANYCPU defaults to x64
-if /i "%3" == "x86"     (set __VSString=%__VSString%)
-if /i "%3" == "x64"     (set __VSString=%__VSString% Win64)
-if /i "%3" == "arm"     (set __VSString=%__VSString% ARM)
+  :: VS 2019 generator is not per arch, and the arch needs to be passed with -A option
+  :: x86 is the default arch selected by cmake.
+  :: CMAKE 3.14 or later is required to use VS2019
+  if /i "%3" == "x64"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A x64)
+  if /i "%3" == "arm"     (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM)
+) else (
+  set __VSString=15 2017
+
+  :: VS2017 generator needs to be specified with the arch as part of its name.
+  :: x86 is the default arch selected by cmake.
+  if /i "%3" == "x64"     (set __VSString=!__VSString! Win64)
+  if /i "%3" == "arm"     (set __VSString=!__VSString! ARM)
+)
+
+:: arm64 doesn't have a specific generator so we need to pass it through -A option.
 if /i "%3" == "arm64"   (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM64)
 if /i "%3" == "wasm"    (set __sourceDir=%~dp0..\Unix && goto DoGen)
 
@@ -35,7 +46,7 @@ popd
 if "%3" == "wasm" (
     emcmake cmake "-DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=1" "-DCMAKE_TOOLCHAIN_FILE=%EMSCRIPTEN%/cmake/Modules/Platform/Emscripten.cmake" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" -G "NMake Makefiles" %__sourceDir%
 ) else (
-    "%CMakePath%" %__SDKVersion% "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" -G "Visual Studio %__VSString%" -B. -H%1 %__ExtraCmakeParams% 
+    "%CMakePath%" %__SDKVersion% "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%" "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" -G "Visual Studio %__VSString%" -B. -H%1 %__ExtraCmakeParams%
 )
 endlocal
 GOTO :DONE

--- a/src/Native/build-native.cmd
+++ b/src/Native/build-native.cmd
@@ -73,7 +73,7 @@ exit /b 1
 :VS2019
 :: Setup vars for VS2019
 set __VSVersion=vs2019
-set __PlatformToolset=v141
+set __PlatformToolset=v142
 :: Set the environment for the native build
 call "%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %__VCBuildArch%
 goto :SetupDirs
@@ -120,7 +120,7 @@ echo Error: DIA SDK is missing at "%VSINSTALLDIR%DIA SDK". ^
 Make sure you selected the correct dependencies when installing Visual Studio.
 :: DIA SDK not included in Express editions
 echo Visual Studio Express does not include the DIA SDK. ^
-You need Visual Studio 2015 or 2017 (Community is free).
+You need Visual Studio 2017 or 2019 (Community is free).
 echo See: https://github.com/dotnet/corefx/blob/master/Documentation/building/windows-instructions.md#required-software
 exit /b 1
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/34613
Fixes: https://github.com/dotnet/corefx/issues/34413

CMake 3.14.0-rc1 is now out the door and can be downloaded from: https://cmake.org/download/

This version now supports the new toolset version which is `142` and now contains a VS2019 project generator. Note that since in VS2019 Preview1 the toolset version was still `141` it is required to have VS2019 Preview2 for it to work correctly.

cc: @stephentoub @ViktorHofer @danmosemsft @ahsonkhan  @ericstj 