### PR TITLE
Add a shared framework and host for global tools in helix submissions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -31,57 +31,57 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>224fa8e1e58b10b7fe1a5d3cfdedf2a1afbfe2e1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19081.1">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.1.0-prerelease.19074.3">
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>59e16d29c96343a15d818cd4eed57a348937ddfd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19081.1">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19081.1">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SourceRewriter" Version="1.0.0-beta.19081.1">
+    <Dependency Name="Microsoft.DotNet.SourceRewriter" Version="1.0.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19081.1">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="1.0.0-beta.19081.1">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="1.0.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="2.4.0-beta.19081.1">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="2.4.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19081.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="1.0.0-beta.19081.1">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="1.0.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19105.4">
+    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b484a0456a49578c7b768680ccf7cf96f043242a</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19081.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19081.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19112.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>0aa62fa4632a25e3a397c00c2e07a651a1169e5e</Sha>
+      <Sha>9a5da1c8a3232c6304955c7a6ffe6109a1b13d9f</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers" Version="3.0.0-beta2-final">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,16 +18,16 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19081.1</MicrosoftDotNetApiCompatPackageVersion>
-    <MicrosoftDotNetSourceRewriterPackageVersion>1.0.0-beta.19081.1</MicrosoftDotNetSourceRewriterPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19081.1</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19081.1</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19081.1</MicrosoftDotNetGenFacadesPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.0-beta.19081.1</MicrosoftDotNetXUnitExtensionsPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19081.1</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19105.4</MicrosoftDotNetCoreFxTestingPackageVersion>
-    <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19081.1</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19081.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19112.3</MicrosoftDotNetApiCompatPackageVersion>
+    <MicrosoftDotNetSourceRewriterPackageVersion>1.0.0-beta.19112.3</MicrosoftDotNetSourceRewriterPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19112.3</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19112.3</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19112.3</MicrosoftDotNetGenFacadesPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.0-beta.19112.3</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19112.3</MicrosoftDotNetBuildTasksPackagingPackageVersion>
+    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19112.3</MicrosoftDotNetCoreFxTestingPackageVersion>
+    <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19112.3</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19112.3</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNetCompilersVersion>3.0.0-beta2-final</MicrosoftNetCompilersVersion>
     <MicrosoftNETCoreCompilersVersion>$(MicrosoftNetCompilersVersion)</MicrosoftNETCoreCompilersVersion>
     <!-- Core-setup dependencies -->

--- a/eng/common/PublishToPackageFeed.proj
+++ b/eng/common/PublishToPackageFeed.proj
@@ -10,25 +10,38 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)MicrosoftDotNetBuildTasksFeedVersion.props" />
+  <Import Project="$(MSBuildThisFileDirectory)DefaultVersions.props" Condition="Exists('$(MSBuildThisFileDirectory)DefaultVersions.props')" />
+  <Import Project="$(MSBuildThisFileDirectory)Versions.props" Condition="Exists('$(MSBuildThisFileDirectory)Versions.props')" />
+  
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.build.tasks.feed\$(MicrosoftDotNetBuildTasksFeedVersion)\build\Microsoft.DotNet.Build.Tasks.Feed.targets" />
 
   <Target Name="PublishToFeed">
     <Error Condition="'$(TargetStaticFeed)' == ''" Text="TargetStaticFeed: Target feed for publishing assets wasn't provided." />
     <Error Condition="'$(AccountKeyToStaticFeed)' == ''" Text="AccountKeyToStaticFeed: Account key for target feed wasn't provided." />
-    <Error Condition="'$(FullPathAssetManifest)' == ''" Text="Full path to asset manifest wasn't provided." />
-    <Error Condition="'$(FullPathBlobBasePath)' == '' AND '$(FullPathPackageBasePath)' == ''" Text="A valid full path to BlobBasePath of PackageBasePath is required." />
+    <Error Condition="'$(ManifestsBasePath)' == ''" Text="Full path to asset manifests directory wasn't provided." />
+    <Error Condition="'$(BlobBasePath)' == '' AND '$(PackageBasePath)' == ''" Text="A valid full path to BlobBasePath of PackageBasePath is required." />
 
+    <ItemGroup>
+      <!-- Include all manifests found in the manifest folder. -->
+      <ManifestFiles Include="$(ManifestsBasePath)*.xml" />
+    </ItemGroup>
+
+    <Error Condition="'@(ManifestFiles)' == ''" Text="No manifest file was found in the provided path: $(ManifestsBasePath)" />
+	
+    <!-- Iterate publishing assets from each manifest file. -->
     <PushArtifactsInManifestToFeed
       ExpectedFeedUrl="$(TargetStaticFeed)"
       AccountKey="$(AccountKeyToStaticFeed)"
+      BARBuildId="$(BARBuildId)"
+      MaestroApiEndpoint="$(MaestroApiEndpoint)"
+      BuildAssetRegistryToken="$(BuildAssetRegistryToken)"
       Overwrite="$(OverrideAssetsWithSameName)"
       PassIfExistingItemIdentical="$(PassIfExistingItemIdentical)"
       MaxClients="$(MaxParallelUploads)"
       UploadTimeoutInMinutes="$(MaxUploadTimeoutInMinutes)"
-      AssetManifestPath="$(FullPathAssetManifest)"
-      BlobAssetsBasePath="$(FullPathBlobBasePath)"
-      PackageAssetsBasePath="$(FullPathPackageBasePath)" />
+      AssetManifestPath="%(ManifestFiles.Identity)"
+      BlobAssetsBasePath="$(BlobBasePath)"
+      PackageAssetsBasePath="$(PackageBasePath)" />
   </Target>
 
   <ItemGroup>

--- a/eng/common/darc-init.ps1
+++ b/eng/common/darc-init.ps1
@@ -19,7 +19,7 @@ function InstallDarcCli ($darcVersion) {
   # Until we can anonymously query the BAR API for the latest arcade-services
   # build applied to the PROD channel, this is hardcoded.
   if (-not $darcVersion) {
-    $darcVersion = '1.1.0-beta.19057.9'
+    $darcVersion = '1.1.0-beta.19081.1'
   }
   
   $arcadeServicesSource = 'https://dotnetfeed.blob.core.windows.net/dotnet-arcade/index.json'

--- a/eng/common/internal/Directory.Build.props
+++ b/eng/common/internal/Directory.Build.props
@@ -1,0 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+<Project>
+  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+</Project>

--- a/eng/common/internal/Tools.csproj
+++ b/eng/common/internal/Tools.csproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Clear references, the SDK may add some depending on UsuingToolXxx settings, but we only want to restore the following -->
+    <PackageReference Remove="@(PackageReference)"/>
+    <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="$(MicrosoftDotNetIBCMergeVersion)" Condition="'$(UsingToolIbcOptimization)' == 'true'" />
+    <PackageReference Include="Drop.App" Version="$(DropAppVersion)" ExcludeAssets="all" Condition="'$(UsingToolVisualStudioIbcTraining)' == 'true'"/>
+  </ItemGroup>
+  <PropertyGroup>
+    <RestoreSources>
+      https://devdiv.pkgs.visualstudio.com/_packaging/8f470c7e-ac49-4afe-a6ee-cf784e438b93/nuget/v3/index.json;
+      https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json;
+    </RestoreSources>
+  </PropertyGroup>
+
+  <!-- Repository extensibility point -->
+  <Import Project="$(RepositoryEngineeringDir)InternalTools.props" Condition="Exists('$(RepositoryEngineeringDir)InternalTools.props')" />
+</Project>

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -1,48 +1,47 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
-  [string] $projects = "",
-  [string][Alias('v')]$verbosity = "minimal",
+  [string] $configuration = "Debug",
+  [string] $task,
+  [string] $verbosity = "minimal",
   [string] $msbuildEngine = $null,
-  [bool] $warnAsError = $true,
-  [switch][Alias('bl')]$binaryLog,
-  [switch][Alias('r')]$restore,
-  [switch] $ci,
+  [switch] $restore,
   [switch] $prepareMachine,
   [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
+$ci = $true
+$binaryLog = $true
+$warnAsError = $true
+
 . $PSScriptRoot\tools.ps1
 
 function Print-Usage() {
-    Write-Host "Common settings:"
-    Write-Host "  -v[erbosity] <value>    Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
-    Write-Host "  -[bl|binaryLog]         Output binary log (short: -bl)"
-    Write-Host "  -help                   Print help and exit"
-    Write-Host ""
+  Write-Host "Common settings:"
+  Write-Host "  -task <value>           Name of Arcade task (name of a project in SdkTasks directory of the Arcade SDK package)"
+  Write-Host "  -restore                Restore dependencies"
+  Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
+  Write-Host "  -help                   Print help and exit"
+  Write-Host ""
 
-    Write-Host "Advanced settings:"
-    Write-Host "  -restore                Restore dependencies (short: -r)"
-    Write-Host "  -projects <value>       Semi-colon delimited list of sln/proj's from the Arcade sdk to build. Globbing is supported (*.sln)"
-    Write-Host "  -ci                     Set when running on CI server"
-    Write-Host "  -prepareMachine         Prepare machine for CI run"
-    Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
-    Write-Host ""
-    Write-Host "Command line arguments not listed above are passed thru to msbuild."
-    Write-Host "The above arguments can be shortened as much as to be unambiguous (e.g. -co for configuration, -t for test, etc.)."
+  Write-Host "Advanced settings:"
+  Write-Host "  -prepareMachine         Prepare machine for CI run"
+  Write-Host "  -msbuildEngine <value>  Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
+  Write-Host ""
+  Write-Host "Command line arguments not listed above are passed thru to msbuild."
 }
 
-function Build {
-  $toolsetBuildProj = InitializeToolset
+function Build([string]$target) {
+  $logSuffix = if ($target -eq "Execute") { "" } else { ".$target" }
+  $log = Join-Path $LogDir "$task$logSuffix.binlog"
+  $outputPath = Join-Path $ToolsetDir "$task\\"
 
-  $toolsetBuildProj = Join-Path (Split-Path $toolsetBuildProj -Parent) "SdkTasks\SdkTask.proj"
-  $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir "SdkTask.binlog") } else { "" }
-  MSBuild $toolsetBuildProj `
-    $bl `
-    /p:Projects=$projects `
-    /p:Restore=$restore `
+  MSBuild $taskProject `
+    /bl:$log `
+    /t:$target `
+    /p:Configuration=$configuration `
     /p:RepoRoot=$RepoRoot `
-    /p:ContinuousIntegrationBuild=$ci `
+    /p:BaseIntermediateOutputPath=$outputPath `
     @properties
 }
 
@@ -52,17 +51,23 @@ try {
     exit 0
   }
 
-  if ($projects -eq "") {
-    Write-Error "Missing required parameter '-projects <value>'"
+  if ($task -eq "") {
+    Write-Host "Missing required parameter '-task <value>'" -ForegroundColor Red
     Print-Usage
     ExitWithExitCode 1
   }
 
-  if ($ci) {
-    $binaryLog = $true
+  $taskProject = GetSdkTaskProject $task
+  if (!(Test-Path $taskProject)) {
+    Write-Host "Unknown task: $task" -ForegroundColor Red
+    ExitWithExitCode 1
   }
 
-  Build
+  if ($restore) {
+    Build "Restore"
+  }
+
+  Build "Execute"
 }
 catch {
   Write-Host $_

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -41,17 +41,10 @@ parameters:
   enablePublishTestResults: false
 
   # Optional: enable sending telemetry
-  #           if 'true', these "variables" must be specified in the variables object or as part of the queue matrix
-  #             _HelixBuildConfig - differentiate between Debug, Release, other
-  #             _HelixType - Example: build/product/
-  #             _HelixSource - Example: official/dotnet/arcade/$(Build.SourceBranch)
   enableTelemetry: false
 
-  # Optional: If specified, then automatically derive "_HelixSource" variable for telemetry
+  # Optional: define the helix repo for telemeetry (example: 'dotnet/arcade')
   helixRepo: ''
-
-  # Optional: Define the type for helix telemetry (must end in '/')
-  helixType: build/product/
 
   # Required: name of the job
   name: ''
@@ -115,29 +108,20 @@ jobs:
         - name: ${{ pair.key }}
           value: ${{ pair.value }}
 
-  # Add additional variables
-  - ${{ if and(ne(parameters.helixRepo, ''), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notIn(variables['Build.Reason'], 'PullRequest')) }}:
-    - name: _HelixSource
-      value: official/${{ parameters.helixRepo }}/$(Build.SourceBranch)
-  - ${{ if and(ne(parameters.helixRepo, ''), or(ne(parameters.runAsPublic, 'false'), eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest'))) }}:
-    - name: _HelixSource
-      value: pr/${{ parameters.helixRepo }}/$(Build.SourceBranch)
-  - name: _HelixType
-    value: ${{ parameters.helixType }}
-  - name: _HelixBuildConfig
-    value: $(_BuildConfig)
-
   ${{ if ne(parameters.workspace, '') }}:
     workspace: ${{ parameters.workspace }}
 
   steps:
   - ${{ if eq(parameters.enableTelemetry, 'true') }}:
-    - template: /eng/common/templates/steps/telemetry-start.yml
-      parameters:
-        buildConfig: $(_HelixBuildConfig)
-        helixSource: $(_HelixSource)
-        helixType: $(_HelixType)
+    # Telemetry tasks are built from https://github.com/dotnet/arcade-extensions
+    - task: sendStartTelemetry@0
+      displayName: 'Send Helix Start Telemetry'
+      inputs:
+        helixRepo: ${{ parameters.helixRepo }}
+        buildConfig: $(_BuildConfig)
         runAsPublic: ${{ parameters.runAsPublic }}
+      continueOnError: ${{ parameters.continueOnError }}
+      condition: always()
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -165,11 +149,15 @@ jobs:
           TeamName: $(_TeamName)
 
   - ${{ if eq(parameters.enableTelemetry, 'true') }}:
-    - template: /eng/common/templates/steps/telemetry-end.yml
+    # Telemetry tasks are built from https://github.com/dotnet/arcade-extensions
+    - task: sendEndTelemetry@0
+      displayName: 'Send Helix End Telemetry'
+      continueOnError: ${{ parameters.continueOnError }}
+      condition: always()
 
   - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
     - task: PublishBuildArtifacts@1
-      displayName: Publish Logs to VSTS
+      displayName: Publish Logs
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
         PublishLocation: Container

--- a/eng/common/templates/job/publish-build-assets.yml
+++ b/eng/common/templates/job/publish-build-assets.yml
@@ -44,12 +44,15 @@ jobs:
         downloadPath: '$(Build.StagingDirectory)/Download'
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
-    - script: eng\common\publishbuildassets.cmd
-        /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
-        /p:BuildAssetRegistryToken=$(MaestroAccessToken)
-        /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
-        /p:Configuration=$(_BuildConfig)
+    - task: PowerShell@2
       displayName: Publish Build Assets
+      inputs:
+        filePath: eng\common\sdk-task.ps1
+        arguments: -task PublishBuildAssets -restore -msbuildEngine dotnet
+          /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
+          /p:BuildAssetRegistryToken=$(MaestroAccessToken)
+          /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+          /p:Configuration=$(_BuildConfig)
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
     - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:

--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -18,20 +18,14 @@ parameters:
   enablePublishTestResults: false
 
   # Optional: enable sending telemetry
-  #           if 'true', these "variables" must be specified in the variables object or as part of the queue matrix
-  #             _HelixBuildConfig - differentiate between Debug, Release, other
-  #             _HelixType - Example: build/product/
-  #             _HelixSource - Example: official/dotnet/arcade/$(Build.SourceBranch)
+  # if enabled then the 'helixRepo' parameter should also be specified
   enableTelemetry: false
 
   # Required: A collection of jobs to run - https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=vsts&tabs=schema#job
   jobs: []
 
-  # Optional: If specified, then automatically derive "_HelixSource" variable for telemetry
+  # Optional: define the helix repo for telemetry (example: 'dotnet/arcade')
   helixRepo: ''
-
-  # Optional: Define the type for helix telemetry (must end in '/')
-  helixType: build/product/
 
   # Optional: Override automatically derived dependsOn value for "publish build assets" job
   publishBuildAssetsDependsOn: ''

--- a/eng/common/templates/phases/publish-build-assets.yml
+++ b/eng/common/templates/phases/publish-build-assets.yml
@@ -28,12 +28,15 @@ phases:
             SecretsFilter: 'MaestroAccessToken'
           condition: ${{ parameters.condition }}
           continueOnError: ${{ parameters.continueOnError }}
-        - script: eng\common\publishbuildassets.cmd
-            /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
-            /p:BuildAssetRegistryToken=$(MaestroAccessToken)
-            /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
-            /p:Configuration=$(_BuildConfig)
+        - task: PowerShell@2
           displayName: Publish Build Assets
+          inputs:
+            filePath: eng\common\sdk-task.ps1
+            arguments: -task PublishBuildAssets -restore -msbuildEngine dotnet
+              /p:ManifestsPath='$(Build.StagingDirectory)/Download/AssetManifests'
+              /p:BuildAssetRegistryToken=$(MaestroAccessToken)
+              /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+              /p:Configuration=$(_BuildConfig)
           condition: ${{ parameters.condition }}
           continueOnError: ${{ parameters.continueOnError }}
         - task: PublishBuildArtifacts@1

--- a/eng/common/templates/steps/telemetry-end.yml
+++ b/eng/common/templates/steps/telemetry-end.yml
@@ -1,3 +1,7 @@
+parameters:
+  maxRetries: 5
+  retryDelay: 10 # in seconds
+
 steps:
 - bash: |
     if [ "$AGENT_JOBSTATUS" = "Succeeded" ] || [ "$AGENT_JOBSTATUS" = "PartiallySucceeded" ]; then
@@ -7,27 +11,41 @@ steps:
     fi
     warningCount=0
 
-    # create a temporary file for curl output
-    res=`mktemp`
-
-    curlResult=`
-      curl --verbose --output $res --write-out "%{http_code}"\
-      -H 'Content-Type: application/json' \
-      -H "X-Helix-Job-Token: $Helix_JobToken" \
-      -H 'Content-Length: 0' \
-      -X POST -G "https://helix.dot.net/api/2018-03-14/telemetry/job/build/$Helix_WorkItemId/finish" \
-      --data-urlencode "errorCount=$errorCount" \
-      --data-urlencode "warningCount=$warningCount"`
-    curlStatus=$?
-
-    if [ $curlStatus -eq 0 ]; then
-      if [ $curlResult -gt 299 ] || [ $curlResult -lt 200 ]; then
-        curlStatus=$curlResult
+    curlStatus=1
+    retryCount=0
+    # retry loop to harden against spotty telemetry connections
+    # we don't retry successes and 4xx client errors
+    until [[ $curlStatus -eq 0 || ( $curlStatus -ge 400 && $curlStatus -le 499 ) || $retryCount -ge $MaxRetries ]]
+    do
+      if [ $retryCount -gt 0 ]; then
+        echo "Failed to send telemetry to Helix; waiting $RetryDelay seconds before retrying..."
+        sleep $RetryDelay
       fi
-    fi
+
+      # create a temporary file for curl output
+      res=`mktemp`
+
+      curlResult=`
+        curl --verbose --output $res --write-out "%{http_code}"\
+        -H 'Content-Type: application/json' \
+        -H "X-Helix-Job-Token: $Helix_JobToken" \
+        -H 'Content-Length: 0' \
+        -X POST -G "https://helix.dot.net/api/2018-03-14/telemetry/job/build/$Helix_WorkItemId/finish" \
+        --data-urlencode "errorCount=$errorCount" \
+        --data-urlencode "warningCount=$warningCount"`
+      curlStatus=$?
+
+      if [ $curlStatus -eq 0 ]; then
+        if [ $curlResult -gt 299 ] || [ $curlResult -lt 200 ]; then
+          curlStatus=$curlResult
+        fi
+      fi
+
+      let retryCount++
+    done
 
     if [ $curlStatus -ne 0 ]; then
-      echo "Failed to Send Build Finish information"
+      echo "Failed to Send Build Finish information after $retryCount retries"
       vstsLogOutput="vso[task.logissue type=error;sourcepath=templates/steps/telemetry-end.yml;code=1;]Failed to Send Build Finish information: $curlStatus"
       echo "##$vstsLogOutput"
       exit 1
@@ -37,6 +55,8 @@ steps:
     # defined via VSTS variables in start-job.sh
     Helix_JobToken: $(Helix_JobToken)
     Helix_WorkItemId: $(Helix_WorkItemId)
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
   condition: and(always(), ne(variables['Agent.Os'], 'Windows_NT'))
 - powershell: |
     if (($env:Agent_JobStatus -eq 'Succeeded') -or ($env:Agent_JobStatus -eq 'PartiallySucceeded')) {
@@ -46,13 +66,30 @@ steps:
     }
     $WarningCount = 0
 
-    try {
-      Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job/build/$env:Helix_WorkItemId/finish?errorCount=$ErrorCount&warningCount=$WarningCount" -Method Post -ContentType "application/json" -Body "" `
-        -Headers @{ 'X-Helix-Job-Token'=$env:Helix_JobToken }
+    # Basic retry loop to harden against server flakiness
+    $retryCount = 0
+    while ($retryCount -lt $env:MaxRetries) {
+      try {
+        Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job/build/$env:Helix_WorkItemId/finish?errorCount=$ErrorCount&warningCount=$WarningCount" -Method Post -ContentType "application/json" -Body "" `
+          -Headers @{ 'X-Helix-Job-Token'=$env:Helix_JobToken }
+        break
+      }
+      catch {
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        if ($statusCode -ge 400 -and $statusCode -le 499) {
+          Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix (status code $statusCode); not retrying (4xx client error)"
+          Write-Host "##vso[task.logissue]error ", $_.Exception.GetType().FullName, $_.Exception.Message
+          exit 1
+        }
+        Write-Host "Failed to send telemetry to Helix (status code $statusCode); waiting $env:RetryDelay seconds before retrying..."
+        $retryCount++
+        sleep $env:RetryDelay
+        continue
+      }
     }
-    catch {
-      Write-Error $_
-      Write-Error $_.Exception
+
+    if ($retryCount -ge $env:MaxRetries) {
+      Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix after $retryCount retries."
       exit 1
     }
   displayName: Send Windows Build End Telemetry
@@ -60,4 +97,6 @@ steps:
     # defined via VSTS variables in start-job.ps1
     Helix_JobToken: $(Helix_JobToken)
     Helix_WorkItemId: $(Helix_WorkItemId)
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
   condition: and(always(),eq(variables['Agent.Os'], 'Windows_NT'))

--- a/eng/common/templates/steps/telemetry-start.yml
+++ b/eng/common/templates/steps/telemetry-start.yml
@@ -3,6 +3,8 @@ parameters:
   helixType: 'undefined_defaulted_in_telemetry.yml'
   buildConfig: ''
   runAsPublic: false
+  maxRetries: 5
+  retryDelay: 10 # in seconds
 
 steps:
 - ${{ if and(eq(parameters.runAsPublic, 'false'), not(eq(variables['System.TeamProject'], 'public'))) }}:
@@ -30,7 +32,7 @@ steps:
       }
     }
     JobListStuff
-    
+
     cat $jobInfo
 
     # create a temporary file for curl output
@@ -38,30 +40,44 @@ steps:
 
     accessTokenParameter="?access_token=$HelixApiAccessToken"
 
-    curlResult=`
-      cat $jobInfo |\
-      curl --trace - --verbose --output $res --write-out "%{http_code}" \
-      -H 'Content-Type: application/json' \
-      -X POST "https://helix.dot.net/api/2018-03-14/telemetry/job$accessTokenParameter" -d @-`
-    curlStatus=$?
-
-    if [ $curlStatus -eq 0 ]; then
-      if [ $curlResult -gt 299 ] || [ $curlResult -lt 200 ]; then
-        curlStatus=$curlResult
+    curlStatus=1
+    retryCount=0
+    # retry loop to harden against spotty telemetry connections
+    # we don't retry successes and 4xx client errors
+    until [[ $curlStatus -eq 0 || ( $curlStatus -ge 400 && $curlStatus -le 499 ) || $retryCount -ge $MaxRetries ]]
+    do
+      if [ $retryCount -gt 0 ]; then
+        echo "Failed to send telemetry to Helix; waiting $RetryDelay seconds before retrying..."
+        sleep $RetryDelay
       fi
-    fi
+
+      curlResult=`
+        cat $jobInfo |\
+        curl --trace - --verbose --output $res --write-out "%{http_code}" \
+        -H 'Content-Type: application/json' \
+        -X POST "https://helix.dot.net/api/2018-03-14/telemetry/job$accessTokenParameter" -d @-`
+      curlStatus=$?
+
+      if [ $curlStatus -eq 0 ]; then
+        if [ $curlResult -gt 299 ] || [ $curlResult -lt 200 ]; then
+          curlStatus=$curlResult
+        fi
+      fi
+
+      let retryCount++
+    done
 
     curlResult=`cat $res`
-    
+
     # validate status of curl command
     if [ $curlStatus -ne 0 ]; then
-      echo "Failed To Send Job Start information"
+      echo "Failed To Send Job Start information after $retryCount retries"
       # We have to append the ## vso prefix or vso will pick up the command when it dumps the inline script into the shell
       vstsLogOutput="vso[task.logissue type=error;sourcepath=telemetry/start-job.sh;code=1;]Failed to Send Job Start information: $curlStatus"
       echo "##$vstsLogOutput"
       exit 1
     fi
-    
+
     # Set the Helix_JobToken variable
     export Helix_JobToken=`echo $curlResult | xargs echo` # Strip Quotes
     echo "##vso[task.setvariable variable=Helix_JobToken;issecret=true;]$Helix_JobToken"
@@ -75,29 +91,44 @@ steps:
     Attempt: 1
     OperatingSystem: $(Agent.Os)
     Configuration: ${{ parameters.buildConfig }}
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
   condition: and(always(), ne(variables['Agent.Os'], 'Windows_NT'))
 - bash: |
-    res=`mktemp`
-    curlResult=`
-      curl --verbose --output $res --write-out "%{http_code}"\
-      -H 'Content-Type: application/json' \
-      -H "X-Helix-Job-Token: $Helix_JobToken" \
-      -H 'Content-Length: 0' \
-      -X POST -G "https://helix.dot.net/api/2018-03-14/telemetry/job/build" \
-      --data-urlencode "buildUri=$BuildUri"`
-    curlStatus=$?
-
-    if [ $curlStatus -eq 0 ]; then
-      if [ $curlResult -gt 299 ] || [ $curlResult -lt 200 ]; then
-        curlStatus=$curlResult
+    curlStatus=1
+    retryCount=0
+    # retry loop to harden against spotty telemetry connections
+    # we don't retry successes and 4xx client errors
+    until [[ $curlStatus -eq 0 || ( $curlStatus -ge 400 && $curlStatus -le 499 ) || $retryCount -ge $MaxRetries ]]
+    do
+      if [ $retryCount -gt 0 ]; then
+        echo "Failed to send telemetry to Helix; waiting $RetryDelay seconds before retrying..."
+        sleep $RetryDelay
       fi
-    fi
 
-    curlResult=`cat $res`
+      res=`mktemp`
+      curlResult=`
+        curl --verbose --output $res --write-out "%{http_code}"\
+        -H 'Content-Type: application/json' \
+        -H "X-Helix-Job-Token: $Helix_JobToken" \
+        -H 'Content-Length: 0' \
+        -X POST -G "https://helix.dot.net/api/2018-03-14/telemetry/job/build" \
+        --data-urlencode "buildUri=$BuildUri"`
+      curlStatus=$?
+
+      if [ $curlStatus -eq 0 ]; then
+        if [ $curlResult -gt 299 ] || [ $curlResult -lt 200 ]; then
+          curlStatus=$curlResult
+        fi
+      fi
+
+      curlResult=`cat $res`
+      let retryCount++
+    done
 
     # validate status of curl command
     if [ $curlStatus -ne 0 ]; then
-      echo "Failed to Send Build Start information"
+      echo "Failed to Send Build Start information after $retryCount retries"
       vstsLogOutput="vso[task.logissue type=error;sourcepath=telemetry/build/start.sh;code=1;]Failed to Send Build Start information: $curlStatus"
       echo "##$vstsLogOutput"
       exit 1
@@ -109,8 +140,10 @@ steps:
   env:
     BuildUri: $(System.TaskDefinitionsUri)$(System.TeamProject)/_build/index?buildId=$(Build.BuildId)&_a=summary
     Helix_JobToken: $(Helix_JobToken)
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
   condition: and(always(), ne(variables['Agent.Os'], 'Windows_NT'))
-  
+
 - powershell: |
     $jobInfo = [pscustomobject]@{
       QueueId=$env:QueueId;
@@ -120,17 +153,42 @@ steps:
       Attempt=$env:Attempt;
       Properties=[pscustomobject]@{ operatingSystem=$env:OperatingSystem; configuration=$env:Configuration };
     }
-    
+
     $jobInfoJson = $jobInfo | ConvertTo-Json
 
     if ($env:HelixApiAccessToken) {
       $accessTokenParameter="?access_token=$($env:HelixApiAccessToken)"
     }
     Write-Host "Job Info: $jobInfoJson"
-    $jobToken = Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job$($accessTokenParameter)" -Method Post -ContentType "application/json" -Body $jobInfoJson
+
+    # Basic retry loop to harden against server flakiness
+    $retryCount = 0
+    while ($retryCount -lt $env:MaxRetries) {
+      try {
+        $jobToken = Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job$($accessTokenParameter)" -Method Post -ContentType "application/json" -Body $jobInfoJson
+        break
+      }
+      catch {
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        if ($statusCode -ge 400 -and $statusCode -le 499) {
+          Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix (status code $statusCode); not retrying (4xx client error)"
+          Write-Host "##vso[task.logissue]error ", $_.Exception.GetType().FullName, $_.Exception.Message
+          exit 1
+        }
+        Write-Host "Failed to send telemetry to Helix (status code $statusCode); waiting $env:RetryDelay seconds before retrying..."
+        $retryCount++
+        sleep $env:RetryDelay
+        continue
+      }
+    }
+
+    if ($retryCount -ge $env:MaxRetries) {
+      Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix after $retryCount retries."
+      exit 1
+    }
+
     $env:Helix_JobToken = $jobToken
     Write-Host "##vso[task.setvariable variable=Helix_JobToken;issecret=true;]$env:Helix_JobToken"
-  displayName: Send Windows Job Start Telemetry
   env:
     HelixApiAccessToken: $(HelixApiAccessToken)
     Source: ${{ parameters.helixSource }}
@@ -140,15 +198,44 @@ steps:
     Attempt: 1
     OperatingSystem: $(Agent.Os)
     Configuration: ${{ parameters.buildConfig }}
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
   condition: and(always(), eq(variables['Agent.Os'], 'Windows_NT'))
+  displayName: Send Windows Job Start Telemetry
 - powershell: |
-    $workItemId = Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job/build?buildUri=$([Net.WebUtility]::UrlEncode($env:BuildUri))" -Method Post -ContentType "application/json" -Body "" `
-      -Headers @{ 'X-Helix-Job-Token'=$env:Helix_JobToken }
-  
+    # Basic retry loop to harden against server flakiness
+    $retryCount = 0
+    while ($retryCount -lt $env:MaxRetries) {
+      try {
+        $workItemId = Invoke-RestMethod -Uri "https://helix.dot.net/api/2018-03-14/telemetry/job/build?buildUri=$([Net.WebUtility]::UrlEncode($env:BuildUri))" -Method Post -ContentType "application/json" -Body "" `
+          -Headers @{ 'X-Helix-Job-Token'=$env:Helix_JobToken }
+        break
+      }
+      catch {
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        if ($statusCode -ge 400 -and $statusCode -le 499) {
+          Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix (status code $statusCode); not retrying (4xx client error)"
+          Write-Host "##vso[task.logissue]error ", $_.Exception.GetType().FullName, $_.Exception.Message
+          exit 1
+        }
+        Write-Host "Failed to send telemetry to Helix (status code $statusCode); waiting $env:RetryDelay seconds before retrying..."
+        $retryCount++
+        sleep $env:RetryDelay
+        continue
+      }
+    }
+
+    if ($retryCount -ge $env:MaxRetries) {
+      Write-Host "##vso[task.logissue]error Failed to send telemetry to Helix after $retryCount retries."
+      exit 1
+    }
+
     $env:Helix_WorkItemId = $workItemId
     Write-Host "##vso[task.setvariable variable=Helix_WorkItemId]$env:Helix_WorkItemId"
   displayName: Send Windows Build Start Telemetry
   env:
     BuildUri: $(System.TaskDefinitionsUri)$(System.TeamProject)/_build/index?buildId=$(Build.BuildId)&_a=summary
     Helix_JobToken: $(Helix_JobToken)
+    MaxRetries: ${{ parameters.maxRetries }}
+    RetryDelay: ${{ parameters.retryDelay }}
   condition: and(always(), eq(variables['Agent.Os'], 'Windows_NT'))

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -161,9 +161,10 @@ function GetDotNetInstallScript([string] $dotnetRoot) {
   return $installScript
 }
 
-function InstallDotNetSdk([string] $dotnetRoot, [string] $version) {
+function InstallDotNetSdk([string] $dotnetRoot, [string] $version, [string] $architecture = "") {
   $installScript = GetDotNetInstallScript $dotnetRoot
-  & $installScript -Version $version -InstallDir $dotnetRoot
+  $archArg = if ($architecture) { $architecture } else { "<auto>" }
+  & $installScript -Version $version -InstallDir $dotnetRoot -Architecture $archArg
   if ($lastExitCode -ne 0) {
     Write-Host "Failed to install dotnet cli (exit code '$lastExitCode')." -ForegroundColor Red
     ExitWithExitCode $lastExitCode
@@ -210,7 +211,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
     $vsMajorVersion = $vsInfo.installationVersion.Split('.')[0]
 
     InitializeVisualStudioEnvironmentVariables $vsInstallDir $vsMajorVersion
-  } elseif ($install) {
+  } else {
 
     if (Get-Member -InputObject $GlobalJson.tools -Name "xcopy-msbuild") {
       $xcopyMSBuildVersion = $GlobalJson.tools.'xcopy-msbuild'
@@ -220,9 +221,10 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
       $xcopyMSBuildVersion = "$vsMajorVersion.$($vsMinVersion.Minor).0-alpha"
     }
 
-    $vsInstallDir = InstallXCopyMSBuild $xcopyMSBuildVersion
-  } else {
-    throw "Unable to find Visual Studio that has required version and components installed"
+    $vsInstallDir = InitializeXCopyMSBuild $xcopyMSBuildVersion $install
+    if ($vsInstallDir -eq $null) {
+      throw "Unable to find Visual Studio that has required version and components installed"
+    }
   }
 
   $msbuildVersionDir = if ([int]$vsMajorVersion -lt 16) { "$vsMajorVersion.0" } else { "Current" }
@@ -240,12 +242,20 @@ function InitializeVisualStudioEnvironmentVariables([string] $vsInstallDir, [str
   }
 }
 
-function InstallXCopyMSBuild([string] $packageVersion) {
+function InstallXCopyMSBuild([string]$packageVersion) {
+  return InitializeXCopyMSBuild $packageVersion -install $true
+}
+
+function InitializeXCopyMSBuild([string]$packageVersion, [bool]$install) {
   $packageName = "RoslynTools.MSBuild"
   $packageDir = Join-Path $ToolsDir "msbuild\$packageVersion"
   $packagePath = Join-Path $packageDir "$packageName.$packageVersion.nupkg"
 
   if (!(Test-Path $packageDir)) {
+    if (!$install) {
+      return $null
+    }
+
     Create-Directory $packageDir
     Write-Host "Downloading $packageName $packageVersion"
     Invoke-WebRequest "https://dotnet.myget.org/F/roslyn-tools/api/v2/package/$packageName/$packageVersion/" -OutFile $packagePath
@@ -376,6 +386,11 @@ function GetNuGetPackageCachePath() {
   return $env:NUGET_PACKAGES
 }
 
+# Returns a full path to an Arcade SDK task project file.
+function GetSdkTaskProject([string]$taskName) {
+  return Join-Path (Split-Path (InitializeToolset) -Parent) "SdkTasks\$taskName.proj"
+}
+
 function InitializeToolset() {
   if (Test-Path variable:global:_ToolsetBuildProj) {
     return $global:_ToolsetBuildProj
@@ -394,7 +409,7 @@ function InitializeToolset() {
   }
 
   if (-not $restore) {
-    Write-Host  "Toolset version $toolsetVersion has not been restored."
+    Write-Host "Toolset version $toolsetVersion has not been restored." -ForegroundColor Red
     ExitWithExitCode 1
   }
 

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -153,7 +153,12 @@ function InstallDotNetSdk {
   GetDotNetInstallScript "$root"
   local install_script=$_GetDotNetInstallScript
 
-  bash "$install_script" --version $version --install-dir "$root" || {
+  local arch_arg=""
+  if [[ $# == 3 ]]; then
+    arch_arg="--architecture $3"
+  fi
+
+  bash "$install_script" --version $version --install-dir "$root" $arch_arg || {
     local exit_code=$?
     echo "Failed to install dotnet SDK (exit code '$exit_code')." >&2
     ExitWithExitCode $exit_code

--- a/eng/sendtohelix.proj
+++ b/eng/sendtohelix.proj
@@ -68,11 +68,15 @@
 
 
   <PropertyGroup Condition="'$(HelixCommand)' == ''">
-    <!-- For windows we need to use call, since the command is going to be called from a bat script created by Helix
-    and we exit /b at the end of RunTests.cmd, Helix runs some other commands after ours within the bat script,
-    if we don't use call, then we cause the parent script to exit, and anything after will not be executed. -->
-    <HelixCommand Condition="'$(TargetsWindows)' == 'true'">call RunTests.cmd %HELIX_CORRELATION_PAYLOAD%</HelixCommand>
-    <HelixCommand Condition="'$(TargetsWindows)' != 'true'">./RunTests.sh $HELIX_CORRELATION_PAYLOAD</HelixCommand>
+    <!--
+      For windows we need to use call, since the command is going to be called from a bat script created by Helix
+      and we exit /b at the end of RunTests.cmd, Helix runs some other commands after ours within the bat script,
+      if we don't use call, then we cause the parent script to exit, and anything after will not be executed.
+      The arguments passed in to the run script in order are the runtime directory, the dotnet root directory (for
+      helix submissions same as the runtime directory) and the global tools directory.
+    -->
+    <HelixCommand Condition="'$(TargetsWindows)' == 'true'">call RunTests.cmd %HELIX_CORRELATION_PAYLOAD% %HELIX_CORRELATION_PAYLOAD% %HELIX_CORRELATION_PAYLOAD%\tools</HelixCommand>
+    <HelixCommand Condition="'$(TargetsWindows)' != 'true'">./RunTests.sh $HELIX_CORRELATION_PAYLOAD $HELIX_CORRELATION_PAYLOAD $HELIX_CORRELATION_PAYLOAD/tools</HelixCommand>
   </PropertyGroup>
 
   <!-- We need to include all dlls in the runtime path as inputs to make it really incremental

--- a/eng/sendtohelix.proj
+++ b/eng/sendtohelix.proj
@@ -82,22 +82,32 @@
   </ItemGroup>
 
   <!-- Add global tools to runtime -->
-  <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
-    <TestArchiveRuntimeDependencies Include="$(GlobalToolsDir)**\*.*" />
+  <ItemGroup Condition="'$(UseGlobalTools)' == 'true' AND '$(TargetsNetCoreApp)' == 'true'">  
+    <TestArchiveRuntimeDependency Include="$(DotNetRoot)shared\Microsoft.NETCore.App\**\*.*" DestinationDir="shared\Microsoft.NETCore.App" />
+    <TestArchiveRuntimeDependency Include="$(DotNetRoot)host\**\*.*" DestinationDir="host" />
+    <TestArchiveRuntimeDependency Include="$(GlobalToolsDir)**\*.*" DestinationDir="tools" />
   </ItemGroup>
 
   <Target Name="CompressRuntimeDirectory"
-          Inputs="@(_RuntimeInputs);@(TestArchiveRuntimeDependencies)"
+          Inputs="@(_RuntimeInputs);@(TestArchiveRuntimeDependency)"
           Outputs="$(TestArchiveRuntimeFile)"
           Condition="'$(TargetGroup)' != 'AllConfigurations'">
 
     <!-- Copy additional test dependencies. -->
-    <Copy SourceFiles="@(TestArchiveRuntimeDependencies)"
-          DestinationFolder="$(TestHostRootPath)\%(RecursiveDir)"
+    <ItemGroup>
+      <_TestArchiveRuntimeDependency Include="@(TestArchiveRuntimeDependency)">
+        <DestinationDir>%(TestArchiveRuntimeDependency.DestinationDir)\%(RecursiveDir)</DestinationDir>
+      </_TestArchiveRuntimeDependency>
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_TestArchiveRuntimeDependency)"
+          DestinationFiles="@(_TestArchiveRuntimeDependency -> '$([MSBuild]::NormalizePath('$(TestHostRootPath)', '%(DestinationDir)', '%(Filename)%(Extension)'))')"
           SkipUnchangedFiles="true"
           OverwriteReadOnlyFiles="true"
           Retries="3"
-          RetryDelayMilliseconds="300" />
+          RetryDelayMilliseconds="300">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
 
     <MakeDir Directories="$(TestArchiveRuntimeRoot)" />
     <ZipDirectory

--- a/eng/sendtohelix.proj
+++ b/eng/sendtohelix.proj
@@ -81,8 +81,13 @@
     <_RuntimeInputs Include="$(TestHostRootPath)**/*.dll" />
   </ItemGroup>
 
+  <!-- Define which workloads require global tools. -->
+  <PropertyGroup>
+    <UseGlobalTools Condition="'$(UseGlobalTools)' == '' AND '$(Coverage)' == 'true'">true</UseGlobalTools>
+  </PropertyGroup>
+
   <!-- Add global tools to runtime -->
-  <ItemGroup Condition="'$(UseGlobalTools)' == 'true' AND '$(TargetsNetCoreApp)' == 'true'">  
+  <ItemGroup Condition="'$(UseGlobalTools)' == 'true'">
     <TestArchiveRuntimeDependency Include="$(DotNetRoot)shared\Microsoft.NETCore.App\**\*.*" DestinationDir="shared\Microsoft.NETCore.App" />
     <TestArchiveRuntimeDependency Include="$(DotNetRoot)host\**\*.*" DestinationDir="host" />
     <TestArchiveRuntimeDependency Include="$(GlobalToolsDir)**\*.*" DestinationDir="tools" />

--- a/global.json
+++ b/global.json
@@ -3,8 +3,8 @@
     "dotnet": "2.2.103"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19081.1",
-    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19081.1",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19112.3",
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19112.3",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview-27410-72"
   }
 }


### PR DESCRIPTION
Related (does not depend on it) https://github.com/dotnet/corefx/pull/35208

Changes:
- Adding the shared framework and host from the .dotnet directory to the helix submission to provide a runtime for global tools.
- Pass in additional arguments to the RunScript to set DOTNET_ROOT and GLOBAL_TOOLS_DIR.

This also allows us to use .NET Core tools on any vertical, though currently we only need them for .NET Core with code coverage.