### PR TITLE
Don't force-allocate x509ChainPolicy collections in X509Chain.Build

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -100,21 +100,32 @@ namespace Internal.Cryptography.Pal
                 systemTrusted.DisposeAll();
                 downloaded.DisposeAll();
 
-                // Candidate certs which came from extraStore should NOT be disposed, since they came
-                // from outside.
-                var extraStoreByReference = new HashSet<X509Certificate2>(
-                    ReferenceEqualityComparer<X509Certificate2>.Instance);
-
-                foreach (X509Certificate2 extraCert in extraStore)
+                if (extraStore == null || extraStore.Count == 0)
                 {
-                    extraStoreByReference.Add(extraCert);
-                }
-
-                foreach (X509Certificate2 candidate in candidates)
-                {
-                    if (!extraStoreByReference.Contains(candidate))
+                    // There were no extraStore certs, so everything can be disposed.
+                    foreach (X509Certificate2 candidate in candidates)
                     {
                         candidate.Dispose();
+                    }
+                }
+                else
+                {
+                    // Candidate certs which came from extraStore should NOT be disposed, since they came
+                    // from outside.
+                    var extraStoreByReference = new HashSet<X509Certificate2>(
+                        ReferenceEqualityComparer<X509Certificate2>.Instance);
+
+                    foreach (X509Certificate2 extraCert in extraStore)
+                    {
+                        extraStoreByReference.Add(extraCert);
+                    }
+
+                    foreach (X509Certificate2 candidate in candidates)
+                    {
+                        if (!extraStoreByReference.Contains(candidate))
+                        {
+                            candidate.Dispose();
+                        }
                     }
                 }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -418,15 +418,30 @@ namespace Internal.Cryptography.Pal
                     }
                 }
 
-                X509Certificate2Collection[] storesToCheck =
+                X509Certificate2Collection[] storesToCheck;
+                if (extraStore != null && extraStore.Count > 0)
                 {
-                    extraStore,
-                    userMyCerts,
-                    userIntermediateCerts,
-                    systemIntermediateCerts,
-                    userRootCerts,
-                    systemRootCerts,
-                };
+                    storesToCheck = new[]
+                    {
+                        extraStore,
+                        userMyCerts,
+                        userIntermediateCerts,
+                        systemIntermediateCerts,
+                        userRootCerts,
+                        systemRootCerts,
+                    };
+                }
+                else
+                {
+                    storesToCheck = new[]
+                    {
+                        userMyCerts,
+                        userIntermediateCerts,
+                        systemIntermediateCerts,
+                        userRootCerts,
+                        systemRootCerts,
+                    };
+                }
 
                 while (toProcess.Count > 0)
                 {

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
@@ -118,9 +118,9 @@ namespace System.Security.Cryptography.X509Certificates
                 _pal = ChainPal.BuildChain(
                     _useMachineContext,
                     certificate.Pal,
-                    chainPolicy.ExtraStore,
-                    chainPolicy.ApplicationPolicy,
-                    chainPolicy.CertificatePolicy,
+                    chainPolicy._extraStore,
+                    chainPolicy._applicationPolicy,
+                    chainPolicy._certificatePolicy,
                     chainPolicy.RevocationMode,
                     chainPolicy.RevocationFlag,
                     chainPolicy.VerificationTime,

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509ChainPolicy.cs
@@ -11,9 +11,9 @@ namespace System.Security.Cryptography.X509Certificates
         private X509RevocationMode _revocationMode;
         private X509RevocationFlag _revocationFlag;
         private X509VerificationFlags _verificationFlags;
-        private OidCollection _applicationPolicy;
-        private OidCollection _certificatePolicy;
-        private X509Certificate2Collection _extraStore;
+        internal OidCollection _applicationPolicy;
+        internal OidCollection _certificatePolicy;
+        internal X509Certificate2Collection _extraStore;
 
         public X509ChainPolicy()
         {


### PR DESCRIPTION
Previously X509ChainPolicy would always allocate its collections, but now it lazily allocates them.  However, X509Chain.Build is forcing them to be allocated even when they're not needed.  Stop doing that.

@bartonjs, take two.