### PR TITLE
Reduce the amount of slicing in GetMemory/GetSpan/Advance

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -92,15 +92,6 @@ namespace System.IO.Pipelines
 
         public int Length => End;
 
-        /// <summary>
-        /// The amount of writable bytes in this segment. It is the amount of bytes between Length and End
-        /// </summary>
-        public int WritableBytes
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => AvailableMemory.Length - End;
-        }
-
         public void SetNext(BufferSegment segment)
         {
             Debug.Assert(segment != null);

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -70,6 +70,8 @@ namespace System.IO.Pipelines
 
         // The write head which is the extent of the IPipelineWriter's written bytes
         private BufferSegment _writingHead;
+        private Memory<byte> _writingMemory;
+        private int _buffered;
 
         private PipeOperationState _operationState;
 
@@ -144,11 +146,7 @@ namespace System.IO.Pipelines
                 AllocateWriteHeadUnsynchronized(sizeHint);
             }
 
-            // Slice the AvailableMemory to the WritableBytes size
-            int end = _writingHead.End;
-            Memory<byte> availableMemory = _writingHead.AvailableMemory;
-            availableMemory = availableMemory.Slice(end);
-            return availableMemory;
+            return _writingMemory;
         }
 
         internal Span<byte> GetSpan(int sizeHint)
@@ -168,16 +166,13 @@ namespace System.IO.Pipelines
                 AllocateWriteHeadUnsynchronized(sizeHint);
             }
 
-            // Slice the AvailableMemory to the WritableBytes size
-            int end = _writingHead.End;
-            Span<byte> availableSpan = _writingHead.AvailableMemory.Span;
-            availableSpan = availableSpan.Slice(end);
-            return availableSpan;
+            return _writingMemory.Span;
         }
 
         private void AllocateWriteHeadUnsynchronized(int sizeHint)
         {
             _operationState.BeginWrite();
+
             if (_writingHead == null)
             {
                 // We need to allocate memory to write since nobody has written before
@@ -188,10 +183,17 @@ namespace System.IO.Pipelines
             }
             else
             {
-                int bytesLeftInBuffer = _writingHead.WritableBytes;
+                int bytesLeftInBuffer = _writingMemory.Length;
 
                 if (bytesLeftInBuffer == 0 || bytesLeftInBuffer < sizeHint)
                 {
+                    if (_buffered > 0)
+                    {
+                        // Flush buffered data to the segment
+                        _writingHead.End += _buffered;
+                        _buffered = 0;
+                    }
+
                     BufferSegment newSegment = AllocateSegment(sizeHint);
 
                     _writingHead.SetNext(newSegment);
@@ -219,6 +221,8 @@ namespace System.IO.Pipelines
                 // We can't use the pool so allocate an array
                 newSegment.SetUnownedMemory(new byte[sizeHint]);
             }
+
+            _writingMemory = newSegment.AvailableMemory;
 
             return newSegment;
         }
@@ -262,6 +266,9 @@ namespace System.IO.Pipelines
                 return true;
             }
 
+            // Update the writing head
+            _writingHead.End += _buffered;
+
             // Always move the read tail to the write head
             _readTail = _writingHead;
             _readTailIndex = _writingHead.End;
@@ -279,6 +286,7 @@ namespace System.IO.Pipelines
             }
 
             _currentWriteLength = 0;
+            _buffered = 0;
 
             return false;
         }
@@ -295,16 +303,14 @@ namespace System.IO.Pipelines
             {
                 Debug.Assert(_writingHead.Next == null);
 
-                Memory<byte> buffer = _writingHead.AvailableMemory;
-
-                if (_writingHead.End > buffer.Length - bytesWritten)
+                if (bytesWritten > _writingMemory.Length)
                 {
                     ThrowHelper.ThrowInvalidOperationException_AdvancingPastBufferSize();
                 }
 
-                // if bytesWritten is zero, these do nothing
-                _writingHead.End += bytesWritten;
                 _currentWriteLength += bytesWritten;
+                _buffered += bytesWritten;
+                _writingMemory = _writingMemory.Slice(bytesWritten);
             }
             else
             {


### PR DESCRIPTION
- Avoid setting End on the writing segment until commit or until
we're moving to the next segment.
- This ends up making the pipe a little bigger but makes writing faster.

PS: This is another take on what I was trying to do with https://github.com/dotnet/corefx/pull/33948 (inspired by https://github.com/aspnet/AspNetCore/pull/7432)

This is the benchmark https://github.com/aspnet/AspNetCore/blob/c1ce7b9a7764f7ee742da7abb29c1b498f1e2594/src/Servers/Kestrel/perf/Kestrel.Performance/PipeThroughputBenchmark.cs but using the default pool instead of the Kestrel memory pool.

## Released version
```
                  Method |     Mean |     Error |    StdDev |   Median |      Op/s | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
------------------------ |---------:|----------:|----------:|---------:|----------:|------------:|------------:|------------:|--------------------:|
 ParseLiveAspNetTwoTasks | 1.002 us | 0.0815 us | 0.2379 us | 1.077 us | 998,447.5 |           - |           - |           - |                 1 B |
   ParseLiveAspNetInline | 1.113 us | 0.0839 us | 0.2448 us | 1.060 us | 898,460.3 |           - |           - |           - |                24 B |
```

## Before changes

```
                  Method |       Mean |     Error |   StdDev |        Op/s | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
------------------------ |-----------:|----------:|---------:|------------:|------------:|------------:|------------:|--------------------:|
 ParseLiveAspNetTwoTasks |   951.5 ns |  90.71 ns | 263.2 ns | 1,050,924.4 |           - |           - |           - |                 1 B |
   ParseLiveAspNetInline | 1,060.2 ns | 109.24 ns | 315.2 ns |   943,226.1 |           - |           - |           - |                   - |
```

## After changes
```
                  Method |     Mean |    Error |   StdDev |        Op/s | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
------------------------ |---------:|---------:|---------:|------------:|------------:|------------:|------------:|--------------------:|
 ParseLiveAspNetTwoTasks | 894.1 ns | 87.71 ns | 255.8 ns | 1,118,447.7 |           - |           - |           - |                 1 B |
   ParseLiveAspNetInline | 991.6 ns | 67.47 ns | 190.3 ns | 1,008,508.4 |           - |           - |           - |                   - |
```