### PR TITLE
Disable AuthProxy__ValidCreds_ProxySendsRequestToServer test on Nano

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Proxy.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Proxy.cs
@@ -25,7 +25,7 @@ namespace System.Net.Http.Functional.Tests
         }
         
         [OuterLoop("Uses external server")]
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // Issue #32809
         [InlineData(AuthenticationSchemes.Ntlm, true, false)]
         [InlineData(AuthenticationSchemes.Negotiate, true, false)]
         [InlineData(AuthenticationSchemes.Basic, false, false)]


### PR DESCRIPTION
The System.Net.Http AuthProxy__ValidCreds_ProxySendsRequestToServer test is
frequently failing on Nano.  It is highly likely a test bug and not a product bug.

Contributes to #32809