### PR TITLE
Disable Ubuntu16.04 and 18.04 legs from PRs until they are fixed

### DIFF
--- a/buildpipeline/pipelinejobs.groovy
+++ b/buildpipeline/pipelinejobs.groovy
@@ -14,7 +14,7 @@ def branch = GithubBranchName
 // will have a trigger that can be
 // **************************
 
-def linPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/linux.groovy')
+//def linPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/linux.groovy')
 //def linArm64Pipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/linux.arm64.groovy')
 def centos6Pipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/centos.6.groovy')
 def linmuslPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/linux-musl.groovy')
@@ -22,7 +22,7 @@ def osxPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'build
 def winPipeline = Pipeline.createPipelineForGithub(this, project, branch, 'buildpipeline/windows.groovy')
 
 def configurations = [
-    ['TGroup':"netcoreapp", 'Pipeline':linPipeline, 'Name':'Linux' ,'ForPR':"Release-x64", 'Arch':['x64']],
+    //['TGroup':"netcoreapp", 'Pipeline':linPipeline, 'Name':'Linux' ,'ForPR':"Release-x64", 'Arch':['x64']],
     //['TGroup':"netcoreapp", 'Pipeline':linArm64Pipeline, 'Name':'Linux' ,'ForPR':"Release-arm64", 'Arch':['arm64']],
     ['TGroup':"netcoreapp", 'Pipeline':centos6Pipeline, 'Name':'CentOS.6' ,'ForPR':"", 'Arch':['x64']],
     ['TGroup':"netcoreapp", 'Pipeline':linmuslPipeline, 'Name':'Linux-musl' ,'ForPR':"Debug-x64", 'Arch':['x64']],

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -82,7 +82,7 @@ jobs:
           - _outerloop: true
 
         - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-          - linuxDefaultQueues: Centos.7.Amd64.Open+RedHat.7.Amd64.Open+Debian.8.Amd64.Open+Ubuntu.1604.Amd64.Open+Ubuntu.1804.Amd64.Open+OpenSuse.42.Amd64.Open #+Fedora.27.Amd64.Open
+          - linuxDefaultQueues: Centos.7.Amd64.Open+RedHat.7.Amd64.Open+Debian.8.Amd64.Open #+Ubuntu.1604.Amd64.Open+Ubuntu.1804.Amd64.Open+OpenSuse.42.Amd64.Open+Fedora.27.Amd64.Open
           - linuxArm64Queues: Ubuntu.1604.Arm64.Open
       
         - ${{ if eq(parameters.isOfficialBuild, 'true') }}:


### PR DESCRIPTION
I've opened a First Responder issue for this to be solved. However having red legs, makes developers ignore them, so we could slip some breaks in other platforms in the meantime. Since we're already loosing coverage for Ubuntu16.04 and 18.04 because they're just hanging, I think it is best to disable them.

I also remove ubuntu Jenkins leg so that we don't fill other queues. I plan to disable all other Jenkins legs tomorrow if comment triggers are fixed.

Related issues:
https://github.com/dotnet/core-eng/issues/5209
https://github.com/dotnet/corefx/issues/35220

cc: @stephentoub @danmosemsft @davidfowl 