### PR TITLE
System.Runtime added to known test list in BasicEventSourceTest

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestUtilities.cs
@@ -38,7 +38,8 @@ namespace BasicEventSourceTests
                     eventSource.Name != "System.Threading.SynchronizationEventSource" &&
                     eventSource.Name != "System.Runtime.InteropServices.InteropEventProvider" &&
                     eventSource.Name != "System.Reflection.Runtime.Tracing" &&
-                    eventSource.Name != "Microsoft-Windows-DotNETRuntime"
+                    eventSource.Name != "Microsoft-Windows-DotNETRuntime" && 
+                    eventSource.Name != "System.Runtime"
                     )
                 {
                     eventSourceNames += eventSource.Name + " ";


### PR DESCRIPTION
https://github.com/dotnet/coreclr/pull/22515 adds a new EventSource to the runtime (System.Runtime). Adding this to the list of known event source.