### PR TITLE
Publish built packages to artifacts on PRs as well

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -187,11 +187,10 @@ jobs:
                   # TODO: Enable azure pipelines reporter for PRs once retry feature is available.
                   enableAzurePipelinesReporter: false
 
-          - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
-            - task: PublishBuildArtifacts@1
-              displayName: Publish packages to artifacts container
-              inputs:
-                pathToPublish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)
-                artifactName: packages
-                artifactType: container
-              condition: and(succeeded(), ne(variables['_skipPublishPackages'], 'true'))
+          - task: PublishBuildArtifacts@1
+            displayName: Publish packages to artifacts container
+            inputs:
+              pathToPublish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)
+              artifactName: packages
+              artifactType: container
+            condition: and(succeeded(), ne(variables['_skipPublishPackages'], 'true'))

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -39,6 +39,7 @@ jobs:
               _architecture: x86
               _framework: netfx
               _helixQueues: $(uapNetfxQueues)
+              _skipPublishPackages: true # In NETFX leg we don't produce packages
 
             UWP_CoreCLR_x64_Debug:
               _BuildConfig: Debug


### PR DESCRIPTION
Per our discussion offline.

Do we want to separate artifacts per build configuration in PRs? Since in PRs we build some flavors on Debug and some on Release. 

cc: @ViktorHofer 