### PR TITLE
Skip lock in GetMemory/GetSpan if memory available

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -141,9 +141,12 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.minimumSize);
             }
 
-            lock (_sync)
+            // If writing is currently active and enough space, don't need to take the lock to just set WritingActive.
+            // IsWritingActive is needed to prevent the reader releasing the writers memory when it fully consumes currently written.
+            if (!_operationState.IsWritingActive ||
+                _writingMemory.Length == 0 || _writingMemory.Length < sizeHint)
             {
-                AllocateWriteHeadUnsynchronized(sizeHint);
+                AllocateWriteHeadSynchronized(sizeHint);
             }
 
             return _writingMemory;
@@ -161,43 +164,49 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.minimumSize);
             }
 
-            lock (_sync)
+            // If writing is currently active and enough space, don't need to take the lock to just set WritingActive.
+            // IsWritingActive is needed to prevent the reader releasing the writers memory when it fully consumes currently written.
+            if (!_operationState.IsWritingActive ||
+                _writingMemory.Length == 0 || _writingMemory.Length < sizeHint)
             {
-                AllocateWriteHeadUnsynchronized(sizeHint);
+                AllocateWriteHeadSynchronized(sizeHint);
             }
 
             return _writingMemory.Span;
         }
 
-        private void AllocateWriteHeadUnsynchronized(int sizeHint)
+        private void AllocateWriteHeadSynchronized(int sizeHint)
         {
-            _operationState.BeginWrite();
-
-            if (_writingHead == null)
+            lock (_sync)
             {
-                // We need to allocate memory to write since nobody has written before
-                BufferSegment newSegment = AllocateSegment(sizeHint);
+                _operationState.BeginWrite();
 
-                // Set all the pointers
-                _writingHead = _readHead = _readTail = newSegment;
-            }
-            else
-            {
-                int bytesLeftInBuffer = _writingMemory.Length;
-
-                if (bytesLeftInBuffer == 0 || bytesLeftInBuffer < sizeHint)
+                if (_writingHead == null)
                 {
-                    if (_buffered > 0)
-                    {
-                        // Flush buffered data to the segment
-                        _writingHead.End += _buffered;
-                        _buffered = 0;
-                    }
-
+                    // We need to allocate memory to write since nobody has written before
                     BufferSegment newSegment = AllocateSegment(sizeHint);
 
-                    _writingHead.SetNext(newSegment);
-                    _writingHead = newSegment;
+                    // Set all the pointers
+                    _writingHead = _readHead = _readTail = newSegment;
+                }
+                else
+                {
+                    int bytesLeftInBuffer = _writingMemory.Length;
+
+                    if (bytesLeftInBuffer == 0 || bytesLeftInBuffer < sizeHint)
+                    {
+                        if (_buffered > 0)
+                        {
+                            // Flush buffered data to the segment
+                            _writingHead.End += _buffered;
+                            _buffered = 0;
+                        }
+
+                        BufferSegment newSegment = AllocateSegment(sizeHint);
+
+                        _writingHead.SetNext(newSegment);
+                        _writingHead = newSegment;
+                    }
                 }
             }
         }
@@ -471,6 +480,7 @@ namespace System.IO.Pipelines
                             Debug.Assert(_readHead == null);
                             Debug.Assert(_readTail == null);
                             _writingHead = null;
+                            _writingMemory = default;
                         }
 
                         returnEnd = nextBlock;


### PR DESCRIPTION
Follow up to https://github.com/dotnet/corefx/pull/35216

Mostly whitespace changes https://github.com/dotnet/corefx/pull/35234/files?w=1


```diff 
                 Method | Length | Chunks |       Mean |        Op/s |
 ---------------------- |------- |------- |-----------:|------------:|
-   Parse_ParallelAsync |    128 |      1 |   215.3 ns | 4,644,585.0 |
+   Parse_ParallelAsync |    128 |      1 |   220.6 ns | 4,533,594.4 |
-   Parse_ParallelAsync |    128 |      2 |   287.4 ns | 3,479,535.1 |
+   Parse_ParallelAsync |    128 |      2 |   278.5 ns | 3,590,931.7 |
-   Parse_ParallelAsync |    128 |      4 |   353.0 ns | 2,832,805.2 |
+   Parse_ParallelAsync |    128 |      4 |   370.3 ns | 2,700,506.4 |
-   Parse_ParallelAsync |    128 |     16 |   871.3 ns | 1,147,769.0 |
+   Parse_ParallelAsync |    128 |     16 |   740.1 ns | 1,351,178.2 |

- Parse_SequentialAsync |    128 |      1 |   388.7 ns | 2,572,948.7 |
+ Parse_SequentialAsync |    128 |      1 |   305.6 ns | 3,272,369.7 |
- Parse_SequentialAsync |    128 |      2 |   330.1 ns | 3,029,257.5 |
+ Parse_SequentialAsync |    128 |      2 |   320.9 ns | 3,116,371.4 |
- Parse_SequentialAsync |    128 |      4 |   390.2 ns | 2,563,012.9 |
+ Parse_SequentialAsync |    128 |      4 |   341.1 ns | 2,931,337.7 |
- Parse_SequentialAsync |    128 |     16 |   706.3 ns | 1,415,836.7 |
+ Parse_SequentialAsync |    128 |     16 |   520.9 ns | 1,919,708.6 |

-   Parse_ParallelAsync |   4096 |      1 |   562.7 ns | 1,777,121.4 |
+   Parse_ParallelAsync |   4096 |      1 |   594.5 ns | 1,682,215.5 |
-   Parse_ParallelAsync |   4096 |      2 |   616.0 ns | 1,623,427.8 |
+   Parse_ParallelAsync |   4096 |      2 |   664.4 ns | 1,505,151.6 |
-   Parse_ParallelAsync |   4096 |      4 |   738.3 ns | 1,354,401.6 |
+   Parse_ParallelAsync |   4096 |      4 |   692.4 ns | 1,444,246.2 |
-   Parse_ParallelAsync |   4096 |     16 | 1,156.1 ns |   864,959.1 |
+   Parse_ParallelAsync |   4096 |     16 | 1,001.6 ns |   998,373.3 |

- Parse_SequentialAsync |   4096 |      1 |   304.1 ns | 3,288,585.7 |
+ Parse_SequentialAsync |   4096 |      1 |   306.4 ns | 3,264,029.4 |
- Parse_SequentialAsync |   4096 |      2 |   330.0 ns | 3,030,397.5 |
+ Parse_SequentialAsync |   4096 |      2 |   318.5 ns | 3,140,166.6 |
- Parse_SequentialAsync |   4096 |      4 |   395.9 ns | 2,525,840.7 |
+ Parse_SequentialAsync |   4096 |      4 |   341.5 ns | 2,928,156.1 |
- Parse_SequentialAsync |   4096 |     16 |   702.8 ns | 1,422,946.7 |
+ Parse_SequentialAsync |   4096 |     16 |   485.1 ns | 2,061,508.5 |
```

@davidfowl @pakrym @jkotalik 
