### PR TITLE
Publish build logs as artifacts and produce a binlog to publish to helix

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -130,6 +130,9 @@ jobs:
         workspace:
           clean: all
 
+        # enabling publish build artifacts, will publish all build logs under /artifacts/log/
+        enablePublishBuildArtifacts: true
+
         ${{ if ne(job.enableMicrobuild, '') }}:
           enableMicrobuild: ${{ job.enableMicrobuild }}
 

--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -82,7 +82,7 @@ jobs:
         # Windows variables
         - ${{ if eq(parameters.targetOS, 'Windows_NT') }}:
           - _buildScript: build.cmd
-          - _commonArguments: -ci -includetests
+          - _commonArguments: -ci -includetests -configuration $(_BuildConfig)
           - _msbuildCommand: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 -warnaserror:0 -ci
 
           - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
@@ -104,11 +104,10 @@ jobs:
         # Non-Windows variables
         - ${{ if ne(parameters.targetOS, 'Windows_NT') }}:
           - _buildScript: ${{ job.buildScriptPrefix }}./build.sh
-
+          - _args: --ci -includetests --configuration $(_BuildConfig)
+          - _commonArguments: $(_args)
           - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
-            - _commonArguments: --ci -includetests -stripSymbols
-          - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-            - _commonArguments: --ci -includetests
+            - _commonArguments: $(_args) -stripSymbols
 
           - _msbuildCommand: ${{ job.buildScriptPrefix }}./eng/common/msbuild.sh --warnaserror false --ci
           - _windowsOfficialBuildArguments: ''

--- a/eng/pipelines/helix.yml
+++ b/eng/pipelines/helix.yml
@@ -30,7 +30,7 @@ steps:
             /p:Creator=${{ parameters.creator }}
             /p:OfficialBuildId=${{ parameters.officialBuildId }}
             /p:EnableAzurePipelinesReporter=${{ parameters.enableAzurePipelinesReporter }}
-            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix-${{ parameters.ArchGroup }}-${{ parameters.framework }}.binlog
+            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: Send to Helix
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops

--- a/eng/pipelines/helix.yml
+++ b/eng/pipelines/helix.yml
@@ -30,6 +30,7 @@ steps:
             /p:Creator=${{ parameters.creator }}
             /p:OfficialBuildId=${{ parameters.officialBuildId }}
             /p:EnableAzurePipelinesReporter=${{ parameters.enableAzurePipelinesReporter }}
+            /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix-${{ parameters.ArchGroup }}-${{ parameters.framework }}.binlog
     displayName: Send to Helix
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -166,6 +166,7 @@ jobs:
         enableMicrobuild: ${{ parameters.isOfficialBuild }}
 
         variables:
+          - _outerloop: false
           - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
             - allConfigurationsQueues: Windows.10.Amd64.ClientRS4.Open
           - ${{ if eq(parameters.isOfficialBuild, 'true') }}:


### PR DESCRIPTION
This gives us access to binlogs from builds for easier diagnosis.

cc: @ericstj @danmosemsft @ViktorHofer 