### PR TITLE
Fix HttpClient EKU tests

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -163,6 +163,7 @@ namespace System.Diagnostics
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<System.Threading.Tasks.Task<int>> method, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<string, System.Threading.Tasks.Task<int>> method, string arg, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<string, string, System.Threading.Tasks.Task<int>> method, string arg1, string arg2, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
+        public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvoke(System.Func<string, string, string, System.Threading.Tasks.Task<int>> method, string arg1, string arg2, string arg3, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
         public static System.Diagnostics.RemoteExecutorTestBase.RemoteInvokeHandle RemoteInvokeRaw(System.Delegate method, string unparsedArg, System.Diagnostics.RemoteInvokeOptions options = null) { throw null; }
         public sealed partial class RemoteInvokeHandle : System.IDisposable
         {

--- a/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -150,6 +150,20 @@ namespace System.Diagnostics
 
         /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
         /// <param name="method">The method to invoke.</param>
+        /// <param name="arg1">The first argument to pass to the method.</param>
+        /// <param name="arg2">The second argument to pass to the method.</param>
+        /// <param name="arg3">The third argument to pass to the method.</param>
+        /// <param name="options">Options to use for the invocation.</param>
+        public static RemoteInvokeHandle RemoteInvoke(
+            Func<string, string, string, Task<int>> method,
+            string arg1, string arg2, string arg3,
+            RemoteInvokeOptions options = null)
+        {
+            return RemoteInvoke(GetMethodInfo(method), new[] { arg1, arg2, arg3 }, options);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
         /// <param name="arg">The argument to pass to the method.</param>
         /// <param name="options">Options to use for the invocation.</param>
         public static RemoteInvokeHandle RemoteInvoke(

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ClientCertificates.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Net.Test.Common;
@@ -106,98 +107,76 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop("Uses external server")]
-        [Fact]
-        public void Manual_SendClientCertificateWithClientAuthEKUToRemoteServer_OK()
+        public static IEnumerable<object[]> SelectClientCertificateForRemoteServer_MemberData()
         {
-            if (!CanTestClientCertificates) // can't use [Conditional*] right now as it's evaluated at the wrong time for SocketsHttpHandler
-            {
-                _output.WriteLine($"Skipping {nameof(Manual_SendClientCertificateWithClientAuthEKUToRemoteServer_OK)}()");
-                return;
-            }
-
-            // UAP HTTP stack caches connections per-process. This causes interference when these tests run in
-            // the same process as the other tests. Each test needs to be isolated to its own process.
-            // See dicussion: https://github.com/dotnet/corefx/issues/21945
-            RemoteInvoke(async useSocketsHttpHandlerString =>
-            {
-                var cert = Configuration.Certificates.GetClientCertificate();
-                HttpClientHandler handler = CreateHttpClientHandler(useSocketsHttpHandlerString);
-                handler.ClientCertificates.Add(cert);
-                using (var client = new HttpClient(handler))
-                {
-                    HttpResponseMessage response = await client.GetAsync(Configuration.Http.EchoClientCertificateRemoteServer);
-                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-                    string body = await response.Content.ReadAsStringAsync();
-                    byte[] bytes = Convert.FromBase64String(body);
-                    var receivedCert = new X509Certificate2(bytes);
-                    Assert.Equal(cert, receivedCert);
-
-                    return SuccessExitCode;
-                }
-            }, UseSocketsHttpHandler.ToString()).Dispose();
+            yield return new object[] { 1, HttpStatusCode.OK };
+            yield return new object[] { 2, HttpStatusCode.OK };
+            yield return new object[] { 3, HttpStatusCode.Forbidden };
         }
 
         [OuterLoop("Uses external server")]
-        [Fact]
-        public void Manual_SendClientCertificateWithServerAuthEKUToRemoteServer_Forbidden()
+        [Theory]
+        [MemberData(nameof(SelectClientCertificateForRemoteServer_MemberData))]
+        public void Manual_SelectClientCertificateForRemoteServer_ServerOnlyReceivesValidClientCert(
+            int certIndex, HttpStatusCode expectedStatusCode)
         {
             if (!CanTestClientCertificates) // can't use [Conditional*] right now as it's evaluated at the wrong time for SocketsHttpHandler
             {
-                _output.WriteLine($"Skipping {nameof(Manual_SendClientCertificateWithServerAuthEKUToRemoteServer_Forbidden)}()");
+                _output.WriteLine($"Skipping {nameof(Manual_SelectClientCertificateForRemoteServer_ServerOnlyReceivesValidClientCert)}()");
                 return;
             }
 
             // UAP HTTP stack caches connections per-process. This causes interference when these tests run in
             // the same process as the other tests. Each test needs to be isolated to its own process.
             // See dicussion: https://github.com/dotnet/corefx/issues/21945
-            RemoteInvoke(async useSocketsHttpHandlerString =>
+            RemoteInvoke(async (certIndexString, expectedStatusCodeString, useSocketsHttpHandlerString) =>
             {
-                var cert = Configuration.Certificates.GetServerCertificate();
+                X509Certificate2 clientCert = null;
+
+                // Get client certificate. RemoteInvoke doesn't allow easy marshaling of complex types.
+                // So we have to select the certificate at this point in the test execution.
+                if (certIndexString == "1")
+                {
+                    // This is a valid client cert since it has an EKU with a ClientAuthentication OID.
+                    clientCert = Configuration.Certificates.GetClientCertificate();
+                }
+                else if (certIndexString == "2")
+                {
+                    // This is a valid client cert since it has no EKU thus all usages are permitted.
+                    clientCert = Configuration.Certificates.GetNoEKUCertificate();
+                }
+                else if (certIndexString == "3")
+                {
+                    // This is an invalid client cert since it has an EKU but is missing ClientAuthentication OID.
+                    clientCert = Configuration.Certificates.GetServerCertificate();
+                }
+
+                Assert.NotNull(clientCert);
+
+                var statusCode = (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), expectedStatusCodeString);
                 HttpClientHandler handler = CreateHttpClientHandler(useSocketsHttpHandlerString);
-                handler.ClientCertificates.Add(cert);
+                handler.ClientCertificates.Add(clientCert);
                 using (var client = new HttpClient(handler))
                 {
-                    HttpResponseMessage response = await client.GetAsync(Configuration.Http.EchoClientCertificateRemoteServer);
-                    Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+                    var request = new HttpRequestMessage();
+                    request.RequestUri = new Uri(Configuration.Http.EchoClientCertificateRemoteServer);
+
+                    // Issue #35239. Force HTTP/1.1.
+                    request.Version = new Version(1,1);
+                    HttpResponseMessage response = await client.SendAsync(request);
+                    Assert.Equal(statusCode, response.StatusCode);
+
+                    if (statusCode == HttpStatusCode.OK)
+                    {
+                        string body = await response.Content.ReadAsStringAsync();
+                        byte[] bytes = Convert.FromBase64String(body);
+                        var receivedCert = new X509Certificate2(bytes);
+                        Assert.Equal(clientCert, receivedCert);
+                    }
 
                     return SuccessExitCode;
                 }
-            }, UseSocketsHttpHandler.ToString()).Dispose();
-        }
-
-        [OuterLoop("Uses external server")]
-        [Fact]
-        public void Manual_SendClientCertificateWithNoEKUToRemoteServer_OK()
-        {
-            if (!CanTestClientCertificates) // can't use [Conditional*] right now as it's evaluated at the wrong time for SocketsHttpHandler
-            {
-                _output.WriteLine($"Skipping {nameof(Manual_SendClientCertificateWithNoEKUToRemoteServer_OK)}()");
-                return;
-            }
-
-            // UAP HTTP stack caches connections per-process. This causes interference when these tests run in
-            // the same process as the other tests. Each test needs to be isolated to its own process.
-            // See dicussion: https://github.com/dotnet/corefx/issues/21945
-            RemoteInvoke(async useSocketsHttpHandlerString =>
-            {
-                var cert = Configuration.Certificates.GetNoEKUCertificate();
-                HttpClientHandler handler = CreateHttpClientHandler(useSocketsHttpHandlerString);
-                handler.ClientCertificates.Add(cert);
-                using (var client = new HttpClient(handler))
-                {
-                    HttpResponseMessage response = await client.GetAsync(Configuration.Http.EchoClientCertificateRemoteServer);
-                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-                    string body = await response.Content.ReadAsStringAsync();
-                    byte[] bytes = Convert.FromBase64String(body);
-                    var receivedCert = new X509Certificate2(bytes);
-                    Assert.Equal(cert, receivedCert);
-
-                    return SuccessExitCode;
-                }
-            }, UseSocketsHttpHandler.ToString()).Dispose();
+            }, certIndex.ToString(), expectedStatusCode.ToString(), UseSocketsHttpHandler.ToString()).Dispose();
         }
 
         [ActiveIssue(30056, TargetFrameworkMonikers.Uap)]


### PR DESCRIPTION
A set of HttpClient tests related to ClientCertificates were always failing on my machine:

System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_ClientCertificates_Test
* method="Manual_SendClientCertificateWithClientAuthEKUToRemoteServer_OK"
* method="Manual_SendClientCertificateWithNoEKUToRemoteServer_OK"
* method="Manual_SendClientCertificateWithServerAuthEKUToRemoteServer_Forbidden"

These tests would generate an exception:
>System.Net.Http.HttpRequestException: An error occurred while sending the request. --->
 System.IO.IOException: The remote party requested renegotiation when AllowRenegotiation was set to false.

Similar to the tests failing and fixed in PR #35225, the CI machines don't have the test
root certificate installed. So, the tests weren't running in CI and the failures weren't noticed.

The root cause of the test failures is due to using SocketsHttpHandler. It is always setting
`SslStream.AllowRenegotiation` to false when first attempting to connect via HTTP/2. This is fine
if the connection is truely HTTP/2 since HTTP/2 doesn't support TLS renegotiation. However, if the
remote endpoint doesn't support HTTP/2 and thus connects with HTTP/1.1, then the SslStream should
not have AllowRenegotiation set to false. Client certificate scenarios frequently have the server
ask for the client certificate later in the connection process. So, TLS renegotiation is used. Opened
new issue #35239 to fix this in SocketsHttpHandler (or SslStream).

As part of fixing these tests, I refactored them into a single Theory test. But I had to workaround
complications due to using RemoteInvoke. I added a new RemoteInvoke overload to handling passing
an additional parameter.