### PR TITLE
Debug output for assert.

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -192,7 +192,7 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
     }
     else
     {
-#ifdef DEBUGGING_UNKNOWN_VALUE
+#ifdef DEBUGGING_UNKNOWN_VALUE || DEBUG
         printf("%s\n", CFStringGetCStringPtr(keyString, CFStringGetSystemEncoding()));
 #endif
         *pStatus |= PAL_X509ChainErrorUnknownValue;


### PR DESCRIPTION
This should not be merged (yet). Using to get debug output for X509 failures from #35224.

@bartonjs @stephentoub 