### PR TITLE
Make DEBUG builds always print chain errors

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -192,8 +192,8 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
     }
     else
     {
-#ifdef DEBUGGING_UNKNOWN_VALUE
-        printf("%s\n", CFStringGetCStringPtr(keyString, CFStringGetSystemEncoding()));
+#if defined DEBUG || defined DEBUGGING_UNKNOWN_VALUE
+        printf("Unknown Chain Status: %s\n", CFStringGetCStringPtr(keyString, CFStringGetSystemEncoding()));
 #endif
         *pStatus |= PAL_X509ChainErrorUnknownValue;
     }


### PR DESCRIPTION
To help with https://github.com/dotnet/corefx/issues/35224, but we can leave it on.

cc @stephentoub @vcsjones 