### PR TITLE
Make sure SequencePosition is saved as part of JsonReaderState

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -27,6 +27,7 @@ namespace System.Text.Json
             _buffer = jsonData.First.Span;
 
             _isFinalBlock = isFinalBlock;
+            _isInputSequence = true;
 
             // Note: We do not retain _bytesConsumed or _sequencePosition as they reset with the new input data
             _lineNumber = state._lineNumber;

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -23,6 +23,7 @@ namespace System.Text.Json
         private ReadOnlySpan<byte> _buffer;
 
         private bool _isFinalBlock;
+        private bool _isInputSequence;
 
         private long _lineNumber;
         private long _bytePositionInLine;
@@ -113,9 +114,9 @@ namespace System.Text.Json
             get
             {
                 // TODO: Cannot use Slice even though it would be faster: https://github.com/dotnet/corefx/issues/33291
-                return _currentPosition.GetObject() == null
-                    ? default
-                    : _sequence.GetPosition(BytesConsumed);
+                return _isInputSequence
+                    ? _sequence.GetPosition(BytesConsumed)
+                    : default;
             }
         }
 
@@ -140,6 +141,7 @@ namespace System.Text.Json
             _previousTokenType = _previousTokenType,
             _readerOptions = _readerOptions,
             _bitStack = _bitStack,
+            _sequencePosition = Position,
         };
 
         /// <summary>
@@ -159,6 +161,7 @@ namespace System.Text.Json
             _buffer = jsonData;
 
             _isFinalBlock = isFinalBlock;
+            _isInputSequence = false;
 
             // Note: We do not retain _bytesConsumed or _sequencePosition as they reset with the new input data
             _lineNumber = state._lineNumber;

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -124,6 +124,7 @@ namespace System.Text.Json.Tests
 
                 long consumed = json.BytesConsumed;
                 Assert.Equal(consumed, json.CurrentState.BytesConsumed);
+                Assert.Equal(default, json.Position);
 
                 // Skipping large JSON since slicing them (O(n^3)) is too slow.
                 if (type == TestCaseType.DeepTree || type == TestCaseType.BroadTree || type == TestCaseType.LotsOfNumbers
@@ -135,6 +136,8 @@ namespace System.Text.Json.Tests
                     written += length;
                     Assert.Equal(dataUtf8.Length - consumed, json.BytesConsumed);
                     Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
+                    Assert.Equal(default, json.Position);
+                    Assert.Equal(default, json.CurrentState.Position);
 
                     Assert.Equal(outputSpan.Length, written);
                     string actualStr = Encoding.UTF8.GetString(outputArray);
@@ -166,6 +169,8 @@ namespace System.Text.Json.Tests
                         written += length;
                         Assert.Equal(dataUtf8.Length - consumedInner - consumed, json.BytesConsumed);
                         Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
+                        Assert.Equal(default, json.Position);
+                        Assert.Equal(default, json.CurrentState.Position);
 
                         Assert.Equal(outputSpan.Length, written);
                         string actualStr = Encoding.UTF8.GetString(outputArray);
@@ -660,12 +665,16 @@ namespace System.Text.Json.Tests
                     ;
                 Assert.Equal(consumed, json.BytesConsumed);
                 Assert.Equal(consumed, json.CurrentState.BytesConsumed);
+                Assert.Equal(default, json.Position);
+                Assert.Equal(default, json.CurrentState.Position);
 
                 json = new Utf8JsonReader(dataUtf8.AsSpan((int)json.BytesConsumed), true, json.CurrentState);
                 while (json.Read())
                     ;
                 Assert.Equal(dataUtf8.Length - consumed, json.BytesConsumed);
                 Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
+                Assert.Equal(default, json.Position);
+                Assert.Equal(default, json.CurrentState.Position);
             }
         }
 
@@ -802,6 +811,8 @@ namespace System.Text.Json.Tests
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
                     Assert.Equal(expectedBytePosition, ex.BytePositionInLine);
+                    Assert.Equal(default, json.Position);
+                    Assert.Equal(default, json.CurrentState.Position);
                 }
             }
         }
@@ -827,6 +838,7 @@ namespace System.Text.Json.Tests
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
                     Assert.Equal(expectedBytePosition, ex.BytePositionInLine);
+                    Assert.Equal(default, json.Position);
                 }
 
                 for (int i = 0; i < dataUtf8.Length; i++)
@@ -840,6 +852,9 @@ namespace System.Text.Json.Tests
 
                         long consumed = jsonSlice.BytesConsumed;
                         Assert.Equal(consumed, jsonSlice.CurrentState.BytesConsumed);
+                        Assert.Equal(default, json.Position);
+                        Assert.Equal(default, json.CurrentState.Position);
+
                         JsonReaderState jsonState = jsonSlice.CurrentState;
 
                         jsonSlice = new Utf8JsonReader(dataUtf8.AsSpan((int)consumed), isFinalBlock: true, jsonState);
@@ -858,6 +873,8 @@ namespace System.Text.Json.Tests
                         errorMessage = $"expectedBytePosition: {expectedBytePosition} | actual: {ex.BytePositionInLine} | index: {i} | option: {commentHandling}";
                         errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
                         Assert.True(expectedBytePosition == ex.BytePositionInLine, errorMessage);
+                        Assert.Equal(default, json.Position);
+                        Assert.Equal(default, json.CurrentState.Position);
                     }
                 }
             }


### PR DESCRIPTION
The `JsonReaderState` already contained a `SequencePoisition` field. The `Utf8JsonReader` also had a `Position` property. However, we weren't storing the position in the state. Fixing that bug and addressing test gap.

cc @steveharter, @pakrym, @davidfowl 