### PR TITLE
Remove Jenkins uap and all configurations legs

### DIFF
--- a/buildpipeline/pipelinejobs.groovy
+++ b/buildpipeline/pipelinejobs.groovy
@@ -29,9 +29,9 @@ def configurations = [
     ['TGroup':"netcoreapp", 'Pipeline':osxPipeline, 'Name':'OSX', 'ForPR':"Debug-x64", 'Arch':['x64']],
     ['TGroup':"netcoreapp", 'Pipeline':winPipeline, 'Name':'Windows' , 'ForPR':"Debug-x64|Release-x86"],
     ['TGroup':"netfx",      'Pipeline':winPipeline, 'Name':'NETFX', 'ForPR':"Release-x86"],
-    ['TGroup':"uap",        'Pipeline':winPipeline, 'Name':'UWP CoreCLR', 'ForPR':"Debug-x64"],
+    //['TGroup':"uap",        'Pipeline':winPipeline, 'Name':'UWP CoreCLR', 'ForPR':"Debug-x64"],
     ['TGroup':"uapaot",     'Pipeline':winPipeline, 'Name':'UWP NETNative', 'ForPR':"Release-x86"],
-    ['TGroup':"all",        'Pipeline':winPipeline, 'Name':'Packaging All Configurations', 'ForPR':"Debug-x64"],
+    //['TGroup':"all",        'Pipeline':winPipeline, 'Name':'Packaging All Configurations', 'ForPR':"Debug-x64"],
 ]
 
 configurations.each { config ->


### PR DESCRIPTION
As we're getting closer to remove Jenkins completely, let's start progressively deleting some legs so that people start getting used to corefx-ci and using that as their validation channel. 

On this PR I propose disabling all configurations which is the slowest leg, and uap which is flaky enough that we might end up just polluting PRs with a double failure, or one pass in azure and a failure in Jenkins.

cc: @stephentoub @danmosemsft @ViktorHofer @ericstj 