### PR TITLE
Add new PlatformDetection.SupportsSsl2AndSsl3 conditional for tests.

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -43,6 +43,7 @@ namespace System
         public static bool IsReflectionEmitSupported;
         public static bool SupportsAlpn { get { throw null; } }
         public static bool SupportsClientAlpn { get { throw null; } }
+        public static bool SupportsSsl2AndSsl3 { get { throw null; } }
         public static bool ClientWebSocketPartialMessagesSupported { get { throw null; } }
         public static bool HasWindowsShell { get { throw null; } }
         public static bool IsArmProcess { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -56,6 +56,8 @@ namespace System
             (OpenSslVersion.Major >= 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2)));
         public static bool SupportsClientAlpn => SupportsAlpn ||
             (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && PlatformDetection.OSXVersion > new Version(10, 12));
+        public static bool SupportsSsl2AndSsl3 => (IsWindows && !IsWindows10Version1607OrGreater) || IsOSX ||
+            (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && OpenSslVersion < new Version(1, 0, 2) && !IsDebian && !IsRedHatFamily6);
 
         // Officially, .Net Native only supports processes running in an AppContainer. However, the majority of tests still work fine
         // in a normal Win32 process and we often do so as running in an AppContainer imposes a substantial tax in debuggability

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -89,18 +89,9 @@ namespace System.Net.Http.Functional.Tests
             // These protocols are disabled by default, so we can only connect with them explicitly.
             // On certain platforms these are completely disabled and cannot be used at all.
 #pragma warning disable 0618
-            if (PlatformDetection.IsWindows ||
-                PlatformDetection.IsOSX ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
-                 PlatformDetection.OpenSslVersion < new Version(1, 0, 2) &&
-                 !PlatformDetection.IsDebian &&
-                 !PlatformDetection.IsRedHatFamily6))
+            if (PlatformDetection.SupportsSsl2AndSsl3)
             {
-                // TODO #28790: SSLv3 is supported on RHEL 6, but this test case still fails.
                 yield return new object[] { SslProtocols.Ssl3, true };
-            }
-            if (PlatformDetection.IsWindows && !PlatformDetection.IsWindows10Version1607OrGreater)
-            {
                 yield return new object[] { SslProtocols.Ssl2, true };
             }
 #pragma warning restore 0618

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -60,7 +60,7 @@ namespace System.Net.Security.Tests
         {
             // Test Ssl2 against itself.  This is a standalone test as even on versions where Windows supports Ssl2,
             // it appears to have rules around not using it when other protocols are mentioned.
-            if (!PlatformDetection.IsWindows10Version1607OrGreater)
+            if (PlatformDetection.SupportsSsl2AndSsl3)
             {
 #pragma warning disable 0618
                 await ClientAsyncSslHelper(SslProtocols.Ssl2, SslProtocols.Ssl2);
@@ -109,9 +109,12 @@ namespace System.Net.Security.Tests
         private static IEnumerable<object[]> ProtocolMismatchData()
         {
 #pragma warning disable 0618
-            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Ssl3, typeof(Exception) };
-            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls12, typeof(Exception) };
-            yield return new object[] { SslProtocols.Ssl3, SslProtocols.Tls12, typeof(Exception) };
+            if (PlatformDetection.SupportsSsl2AndSsl3)
+            {
+                yield return new object[] { SslProtocols.Ssl2, SslProtocols.Ssl3, typeof(Exception) };
+                yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls12, typeof(Exception) };
+                yield return new object[] { SslProtocols.Ssl3, SslProtocols.Tls12, typeof(Exception) };
+            }
 #pragma warning restore 0618
             yield return new object[] { SslProtocols.Tls, SslProtocols.Tls11, typeof(IOException) };
             yield return new object[] { SslProtocols.Tls, SslProtocols.Tls12, typeof(IOException) };

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -73,9 +73,12 @@ namespace System.Net.Security.Tests
         private static IEnumerable<object[]> ProtocolMismatchData()
         {
 #pragma warning disable 0618
-            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Ssl3, typeof(Exception) };
-            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls12, typeof(Exception) };
-            yield return new object[] { SslProtocols.Ssl3, SslProtocols.Tls12, typeof(Exception) };
+            if (PlatformDetection.SupportsSsl2AndSsl3)
+            {
+                yield return new object[] { SslProtocols.Ssl2, SslProtocols.Ssl3, typeof(Exception) };
+                yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls12, typeof(Exception) };
+                yield return new object[] { SslProtocols.Ssl3, SslProtocols.Tls12, typeof(Exception) };
+            }
 #pragma warning restore 0618
             yield return new object[] { SslProtocols.Tls, SslProtocols.Tls11, typeof(AuthenticationException) };
             yield return new object[] { SslProtocols.Tls, SslProtocols.Tls12, typeof(AuthenticationException) };

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -86,6 +86,14 @@ namespace System.Net.Security.Tests
         public async Task ClientAndServer_OneUsesDefault_OtherUsesLowerProtocol_Fails(
             SslProtocols? clientProtocols, SslProtocols? serverProtocols)
         {
+            if (!PlatformDetection.SupportsSsl2AndSsl3)
+            {
+#pragma warning disable 0618
+                if (clientProtocols == SslProtocols.Ssl2 || serverProtocols == SslProtocols.Ssl2)
+                    return;
+#pragma warning restore 0618
+            }
+
             using (X509Certificate2 serverCertificate = Configuration.Certificates.GetServerCertificate())
             using (X509Certificate2 clientCertificate = Configuration.Certificates.GetClientCertificate())
             {


### PR DESCRIPTION
Add conditionals for Ssl2/Ssl3 to System.Net.Http and System.Net.Security tests.

Mono does not support Ssl2/Ssl3 and this allows us to easily disable it in those tests.