### PR TITLE
BufferSegment Handle Memory Set/Reset better

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -27,7 +27,7 @@ namespace System.IO.Pipelines
                 Debug.Assert(value <= AvailableMemory.Length);
 
                 _end = value;
-                Memory = AvailableMemory.Slice(0, _end);
+                Memory = AvailableMemory.Slice(0, value);
             }
         }
 
@@ -66,7 +66,7 @@ namespace System.IO.Pipelines
         {
             AvailableMemory = memory;
             RunningIndex = 0;
-            End = 0;
+            _end = 0;
             NextSegment = null;
         }
 
@@ -83,6 +83,7 @@ namespace System.IO.Pipelines
 
             _memoryOwner = null;
             AvailableMemory = default;
+            Memory = default;
         }
 
         // Exposed for testing

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -209,12 +209,12 @@ namespace System.IO.Pipelines
             if (_pool is null)
             {
                 // Use the array pool
-                newSegment.SetMemory(ArrayPool<byte>.Shared.Rent(GetSegmentSize(sizeHint)));
+                newSegment.SetOwnedMemory(ArrayPool<byte>.Shared.Rent(GetSegmentSize(sizeHint)));
             }
             else if (sizeHint <= _pool.MaxBufferSize)
             {
                 // Use the specified pool if it fits
-                newSegment.SetMemory(_pool.Rent(GetSegmentSize(sizeHint, _pool.MaxBufferSize)));
+                newSegment.SetOwnedMemory(_pool.Rent(GetSegmentSize(sizeHint, _pool.MaxBufferSize)));
             }
             else
             {

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -496,9 +496,10 @@ namespace System.IO.Pipelines
 
                 while (returnStart != null && returnStart != returnEnd)
                 {
+                    BufferSegment next = returnStart.NextSegment;
                     returnStart.ResetMemory();
                     ReturnSegmentUnsynchronized(returnStart);
-                    returnStart = returnStart.NextSegment;
+                    returnStart = next;
                 }
 
                 _operationState.EndRead();


### PR DESCRIPTION
Set `Memory` to `default` on `ResetMemory()` to release the underlying reference (can now be an allocated array)

Don't slice to 0 when allocating the Memory via `SetMemory` as its already 0 length due to above.

e.g. half the calls to `set_End`; which then incurs a `.Slice` are unnecessary

![image](https://user-images.githubusercontent.com/1142958/52611667-872ad900-2e7e-11e9-9afc-93a8135d2967.png)

After

![image](https://user-images.githubusercontent.com/1142958/52643108-3ba31a00-2ed4-11e9-990b-6f88e1bf28dd.png)


/cc @davidfowl @pakrym @jkotalik 

