### PR TITLE
[WIP] Pipelines - Reduce write lock contention

### DIFF
--- a/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
@@ -47,7 +47,6 @@
     <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Tasks.Extensions" />

--- a/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Tasks.Extensions" />

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -43,9 +43,7 @@ namespace System.IO.Pipelines
         private readonly PipeScheduler _writerScheduler;
 
         private int _pooledSegmentCount;
-        private readonly BufferSegment[] _bufferSegmentPool;
-        // Temporary list to hold Segments return while being reset
-        private readonly BufferSegment[] _bufferSegmentsToReturn;
+        private readonly SegmentAsValue[] _bufferSegmentPool;
 
         private readonly DefaultPipeReader _reader;
         private readonly DefaultPipeWriter _writer;
@@ -97,8 +95,7 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.options);
             }
 
-            _bufferSegmentPool = new BufferSegment[SegmentPoolSize];
-            _bufferSegmentsToReturn = new BufferSegment[SegmentPoolSize];
+            _bufferSegmentPool = new SegmentAsValue[SegmentPoolSize];
 
             _operationState = default;
             _readerCompletion = default;
@@ -295,66 +292,6 @@ namespace System.IO.Pipelines
             // After that adjust it to fit into pools max buffer size
             var adjustedToMaximumSize = Math.Min(maxBufferSize, sizeHint);
             return adjustedToMaximumSize;
-        }
-
-        private BufferSegment CreateSegmentSynchronized()
-        {
-            BufferSegment[] segmentPool = _bufferSegmentPool;
-            lock (segmentPool)
-            {
-                int index = _pooledSegmentCount - 1;
-                if ((uint)index < (uint)segmentPool.Length)
-                {
-                    _pooledSegmentCount = index;
-                    return segmentPool[index];
-                }
-            }
-
-            return new BufferSegment();
-        }
-
-        private void ReturnSegments(BufferSegment from, BufferSegment toExclusive)
-        {
-            Debug.Assert(from != null);
-            Debug.Assert(from != toExclusive);
-
-            // Reset the Segments and return their data out of lock
-            BufferSegment[] segmentToReturn = _bufferSegmentsToReturn;
-            int count = 0;
-            do
-            {
-                BufferSegment next = from.NextSegment;
-                Debug.Assert(next != null || toExclusive == null);
-
-                from.ResetMemory();
-
-                if ((uint)count < (uint)segmentToReturn.Length)
-                {
-                    // Store in temporary list while preforming expensive resets
-                    segmentToReturn[count] = from;
-                    count++;
-                }
-
-                from = next;
-            } while (from != toExclusive);
-
-            // Add the Segments back to pool from the temporary list under lock
-            BufferSegment[] segmentPool = _bufferSegmentPool;
-            lock (segmentPool)
-            {
-                int index = _pooledSegmentCount;
-                for (int i = 0; i < count; i++)
-                {
-                    if ((uint)index < (uint)segmentPool.Length)
-                    {
-                        segmentPool[index] = segmentToReturn[i];
-                        index++;
-                    }
-                    segmentToReturn[i] = null;
-                }
-
-                _pooledSegmentCount = index;
-            }
         }
 
         internal bool CommitUnsynchronized()
@@ -1115,5 +1052,97 @@ namespace System.IO.Pipelines
                 ResetState();
             }
         }
+
+        private BufferSegment CreateSegmentSynchronized()
+        {
+            SegmentAsValue[] segmentPool = _bufferSegmentPool;
+            lock (segmentPool)
+            {
+                int index = _pooledSegmentCount - 1;
+                if ((uint)index < (uint)segmentPool.Length)
+                {
+                    _pooledSegmentCount = index;
+                    return segmentPool[index];
+                }
+            }
+
+            return new BufferSegment();
+        }
+
+        private void ReturnSegments(BufferSegment from, BufferSegment toExclusive)
+        {
+            Debug.Assert(from != null);
+            Debug.Assert(from != toExclusive);
+
+            // Reset the Segments and return their data out of lock
+            ValueSegmentList segmentsToReturn = default;
+            ref var startSegment = ref segmentsToReturn.Segment00;
+            int count = 0;
+            do
+            {
+                BufferSegment next = from.NextSegment;
+                Debug.Assert(next != null || toExclusive == null);
+
+                from.ResetMemory();
+
+                if ((uint)count < (uint)SegmentPoolSize)
+                {
+                    // Store in temporary list while preforming expensive resets
+                    Unsafe.Add(ref startSegment, count) = from;
+                    count++;
+                }
+
+                from = next;
+            } while (from != toExclusive);
+
+            // Add the Segments back to pool from the temporary list under lock
+            SegmentAsValue[] segmentPool = _bufferSegmentPool;
+            lock (segmentPool)
+            {
+                int index = _pooledSegmentCount;
+                for (int i = 0; i < count; i++)
+                {
+                    if ((uint)index < (uint)segmentPool.Length)
+                    {
+                        segmentPool[index] = Unsafe.Add(ref startSegment, i);
+                        index++;
+                    }
+                }
+
+                _pooledSegmentCount = index;
+            }
+        }
+
+        // Used to avoid covariant checks on the array
+        private readonly struct SegmentAsValue
+        {
+            private readonly BufferSegment _bufferSegment;
+            public SegmentAsValue(BufferSegment bufferSegment) => _bufferSegment = bufferSegment;
+            public static implicit operator SegmentAsValue(BufferSegment b) => new SegmentAsValue(b);
+            public static implicit operator BufferSegment(SegmentAsValue s) => s._bufferSegment;
+        }
+
+        // Temporary list to hold Segments return while being reset
+#pragma warning disable CS0649
+        private ref struct ValueSegmentList
+        {
+            public BufferSegment Segment00;
+            public BufferSegment Segment01;
+            public BufferSegment Segment02;
+            public BufferSegment Segment03;
+            public BufferSegment Segment04;
+            public BufferSegment Segment05;
+            public BufferSegment Segment06;
+            public BufferSegment Segment07;
+            public BufferSegment Segment08;
+            public BufferSegment Segment09;
+            public BufferSegment Segment10;
+            public BufferSegment Segment11;
+            public BufferSegment Segment12;
+            public BufferSegment Segment13;
+            public BufferSegment Segment14;
+            public BufferSegment Segment15;
+        }
+#pragma warning enable CS0649
     }
 }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -253,6 +253,9 @@ namespace System.IO.Pipelines
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AllocateAndLinkSegment(int sizeHint = 0)
         {
+            Debug.Assert(_operationState.IsWritingActive);
+            Debug.Assert(_writingHead != null);
+
             BufferSegment newSegment = AllocateSegment(sizeHint);
             LinkWriteSegmentAndAdvance(newSegment);
             _writingMemory = newSegment.AvailableMemory;
@@ -261,6 +264,9 @@ namespace System.IO.Pipelines
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void LinkWriteSegmentAndAdvance(BufferSegment newSegment)
         {
+            Debug.Assert(_operationState.IsWritingActive);
+            Debug.Assert(_writingHead != null);
+
             _writingHead.SetNext(newSegment);
             _writingHead = newSegment;
         }
@@ -354,6 +360,9 @@ namespace System.IO.Pipelines
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void AdvanceCore(int bytesWritten)
         {
+            Debug.Assert(_operationState.IsWritingActive);
+            Debug.Assert(_writingHead != null);
+
             _currentWriteLength += bytesWritten;
             _buffered += bytesWritten;
             _writingMemory = _writingMemory.Slice(bytesWritten);

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
@@ -47,6 +47,19 @@ namespace System.IO.Pipelines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryEndRead()
+        {
+            if ((_state & State.Reading) != State.Reading &&
+                (_state & State.ReadingTentative) != State.ReadingTentative)
+            {
+                return false;
+            }
+
+            _state &= ~(State.Reading | State.ReadingTentative);
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void BeginWrite()
         {
             _state |= State.Writing;


### PR DESCRIPTION
`BufferSegment:ResetMemory()` is not an inexpensive operation (blanking 80 bytes + returning data to pool); however it doesn't need to be done under the Pipe's reader/writer sync lock.

Also the scheduling/marking of completion can happen prior to the Segments being reset and returned to the pool, allowing for lower latency.

This change resets the segments outside of lock; then uses the pool as a different lock to return the Segments to the pool (and to get them from the pool) so its a fast lock only for the pooled Segments and doesn't lock the whole Pipe.

It also reduces the scope of the lock on the write side when acquiring Memory; to only when it modifies the readHead or needs to change state to Writing (so most write Advancing will skip the lock)

Shrunk the Flush lock when writing as it can modify the write head; then acquire lock after when signalling the Reader.

/cc @davidfowl @pakrym @jkotalik