### PR TITLE
Fix argument name in GCHandleTests

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/GCHandleTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/GCHandleTests.cs
@@ -75,7 +75,7 @@ namespace System.Runtime.InteropServices.Tests
         [MemberData(nameof(InvalidPinnedObject_TestData))]
         public void Alloc_InvalidPinnedObject_ThrowsArgumentException(object value)
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => GCHandle.Alloc(value, GCHandleType.Pinned));
+            Assert.Throws<ArgumentException>(() => GCHandle.Alloc(value, GCHandleType.Pinned));
         }
 
         [Theory]


### PR DESCRIPTION
A GCHandle test is validating that an argument exception contains a null parameter name.  That's been fixed in coreclr, so this test will start to fail when we ingest a new coreclr.  For now, just removing the null validation, as it's not useful.