### PR TITLE
Fix official builds to publish to BAR using new sdk-task

### DIFF
--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -61,7 +61,8 @@ jobs:
           artifactName: BuildAssetsManifest
           artifactType: container
 
-      - script: eng\common\publishbuildassets.cmd
+      - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\sdk-task.ps1
+                -task PublishBuildAssets -restore -msbuildEngine dotnet
                 /p:ManifestsPath='$(_manifestsDir)'
                 /p:BuildAssetRegistryToken=$(MaestroAccessToken)
                 /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com


### PR DESCRIPTION
Official builds are currently broken because PublishBuildAssets.cmd was deleted and now we need to use sdk-task.ps1

cc: @chcosta @danmosemsft 