### PR TITLE
Don't rely on SslStream implementation details in ConnectHelper.

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -147,7 +147,7 @@ namespace System.Net.Http
                 Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> localFromHttpClientHandler = mapper.FromHttpClientHandler;
                 HttpRequestMessage localRequest = request;
                 sslOptions.RemoteCertificateValidationCallback = (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
-                    localFromHttpClientHandler(localRequest, certificate as X509Certificate2, chain, sslPolicyErrors);
+                    localFromHttpClientHandler(localRequest, certificate as X509Certificate2 ?? new X509Certificate2(certificate), chain, sslPolicyErrors);
             }
 
             // Create the SslStream, authenticate, and return it.


### PR DESCRIPTION
The `SslClientAuthenticationOptions.RemoteCertificateValidationCallback`
takes an `X509Certificate` argument; we shouldn't assume here that this
is in fact an instance of `X509Certificate2`.