### PR TITLE
WIP: Set Copyright property to match License.txt

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -251,6 +251,10 @@
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+  
+  <PropertyGroup>
+    <Copyright>© .NET Foundation and Contributors</Copyright>
+  </PropertyGroup>
 
   <!-- Set the kind of PDB to Portable and turn on SourceLink (fetching source from GitHub) -->
   <PropertyGroup>


### PR DESCRIPTION
The `Copyright` property is used by .NET SDK to emit `AssemblyCopyrightAttribute`.

The default copyright set by Arcade SDK is `© Microsoft Corporation.  All rights reserved.`