### PR TITLE
Add Rune creation API from UTF-16 surrogate pair

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -7662,6 +7662,7 @@ namespace System.Text
     {
         private readonly int _dummyPrimitive;
         public Rune(char ch) { throw null; }
+        public Rune(char highSurrogate, char lowSurrogate) { throw null; }
         public Rune(int value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public Rune(uint value) { throw null; }
@@ -7709,6 +7710,7 @@ namespace System.Text
         public static System.Text.Rune ToUpper(System.Text.Rune value, System.Globalization.CultureInfo culture) { throw null; }
         public static System.Text.Rune ToUpperInvariant(System.Text.Rune value) { throw null; }
         public static bool TryCreate(char ch, out System.Text.Rune result) { throw null; }
+        public static bool TryCreate(char highSurrogate, char lowSurrogate, out System.Text.Rune result) { throw null; }
         public static bool TryCreate(int value, out System.Text.Rune result) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static bool TryCreate(uint value, out System.Text.Rune result) { throw null; }

--- a/src/System.Runtime/tests/System/Text/RuneTests.TestData.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/RuneTests.TestData.netcoreapp.cs
@@ -190,6 +190,24 @@ namespace System.Text.Tests
             yield return new object[] { int.MaxValue }; // too large
         }
 
+        public static IEnumerable<object[]> SurrogatePairTestData_InvalidOnly()
+        {
+            yield return new object[] { '\ud800', '\ud800' }; // two high surrogates
+            yield return new object[] { '\udfff', '\udfff' }; // two low surrogates
+            yield return new object[] { '\ude00', '\udb00' }; // low surrogate before high surrogate
+            yield return new object[] { '\ud900', '\u1234' }; // high surrogate followed by non-surrogate
+            yield return new object[] { '\ud900', '\ue000' }; // high surrogate followed by value just beyond low surrogate range
+            yield return new object[] { '\u1234', '\ude00' }; // low surrogate preceded by non-surrogate
+            yield return new object[] { '\udc00', '\ude00' }; // low surrogate preceded by value just beyond high surrogate range
+        }
+
+        public static IEnumerable<object[]> SurrogatePairTestData_ValidOnly()
+        {
+            yield return new object[] { '\ud800', '\udc00', 0x00010000 }; // lower bound for high & low surrogate
+            yield return new object[] { '\udbff', '\udfff', 0x0010FFFF }; // upper bound for high & low surrogate
+            yield return new object[] { '\ud83c', '\udfa8', 0x0001F3A8 }; // U+1F3A8 ARTIST PALETTE
+        }
+
         public class GeneralTestData
         {
             public int ScalarValue;

--- a/src/System.Runtime/tests/System/Text/RuneTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/RuneTests.netcoreapp.cs
@@ -129,6 +129,21 @@ namespace System.Text.Tests
         }
 
         [Theory]
+        [MemberData(nameof(SurrogatePairTestData_ValidOnly))]
+        public static void Ctor_SurrogatePair_Valid(char highSurrogate, char lowSurrogate, int expectedValue)
+        {
+            Assert.Equal(expectedValue, new Rune(highSurrogate, lowSurrogate).Value);
+        }
+
+        [Theory]
+        [MemberData(nameof(SurrogatePairTestData_InvalidOnly))]
+        public static void Ctor_SurrogatePair_Valid(char highSurrogate, char lowSurrogate)
+        {
+            string expectedParamName = !char.IsHighSurrogate(highSurrogate) ? nameof(highSurrogate) : nameof(lowSurrogate);
+            Assert.Throws<ArgumentOutOfRangeException>(expectedParamName, () => new Rune(highSurrogate, lowSurrogate));
+        }
+
+        [Theory]
         [InlineData('A', 'a', -1)]
         [InlineData('A', 'A', 0)]
         [InlineData('a', 'A', 1)]
@@ -363,6 +378,22 @@ namespace System.Text.Tests
         {
             Assert.False(Rune.TryCreate((char)scalarValue, out Rune result));
             Assert.Equal(0, result.Value);
+        }
+
+        [Theory]
+        [MemberData(nameof(SurrogatePairTestData_InvalidOnly))]
+        public static void TryCreate_SurrogateChars_Invalid(char highSurrogate, char lowSurrogate)
+        {
+            Assert.False(Rune.TryCreate(highSurrogate, lowSurrogate, out Rune result));
+            Assert.Equal(0, result.Value);
+        }
+
+        [Theory]
+        [MemberData(nameof(SurrogatePairTestData_ValidOnly))]
+        public static void TryCreate_SurrogateChars_Valid(char highSurrogate, char lowSurrogate, int expectedValue)
+        {
+            Assert.True(Rune.TryCreate(highSurrogate, lowSurrogate, out Rune result));
+            Assert.Equal(expectedValue, result.Value);
         }
 
         [Theory]


### PR DESCRIPTION
Resolves https://github.com/dotnet/corefx/issues/34683.

This is the ref assembly and unit tests. The unit tests will not pass until the changes in coreclr make their way over to corefx.