### PR TITLE
Use MSVC Intrinsics for TZCNT and BSF in Brotli encoder

### DIFF
--- a/src/Native/AnyOS/brotli-version.txt
+++ b/src/Native/AnyOS/brotli-version.txt
@@ -1,2 +1,6 @@
 1.0.7
 https://github.com/google/brotli/releases/tag/v1.0.7
+
+Patched to add MSVC intrinsics for TZCNT and BSR
+https://github.com/google/brotli/pull/636
+

--- a/src/Native/AnyOS/brotli-version.txt
+++ b/src/Native/AnyOS/brotli-version.txt
@@ -3,4 +3,3 @@ https://github.com/google/brotli/releases/tag/v1.0.7
 
 Patched to add MSVC intrinsics for TZCNT and BSR
 https://github.com/google/brotli/pull/636
-

--- a/src/Native/AnyOS/brotli/enc/fast_log.h
+++ b/src/Native/AnyOS/brotli/enc/fast_log.h
@@ -19,10 +19,8 @@ extern "C" {
 #endif
 
 static BROTLI_INLINE uint32_t Log2FloorNonZero(size_t n) {
-  /* TODO: generalize and move to platform.h */
-#if BROTLI_GNUC_HAS_BUILTIN(__builtin_clz, 3, 4, 0) || \
-    BROTLI_INTEL_VERSION_CHECK(16, 0, 0)
-  return 31u ^ (uint32_t)__builtin_clz((uint32_t)n);
+#if defined(BROTLI_BSR32)
+  return BROTLI_BSR32((uint32_t)n);
 #else
   uint32_t result = 0;
   while (n >>= 1) result++;

--- a/src/Native/AnyOS/brotli/enc/find_match_length.h
+++ b/src/Native/AnyOS/brotli/enc/find_match_length.h
@@ -17,8 +17,7 @@ extern "C" {
 #endif
 
 /* Separate implementation for little-endian 64-bit targets, for speed. */
-#if defined(__GNUC__) && defined(_LP64) && defined(BROTLI_LITTLE_ENDIAN)
-
+#if defined(BROTLI_TZCNT64) && BROTLI_64_BITS && BROTLI_LITTLE_ENDIAN
 static BROTLI_INLINE size_t FindMatchLengthWithLimit(const uint8_t* s1,
                                                      const uint8_t* s2,
                                                      size_t limit) {
@@ -32,7 +31,7 @@ static BROTLI_INLINE size_t FindMatchLengthWithLimit(const uint8_t* s1,
     } else {
       uint64_t x = BROTLI_UNALIGNED_LOAD64LE(s2) ^
           BROTLI_UNALIGNED_LOAD64LE(s1 + matched);
-      size_t matching_bits = (size_t)__builtin_ctzll(x);
+      size_t matching_bits = (size_t)BROTLI_TZCNT64(x);
       matched += matching_bits >> 3;
       return matched;
     }


### PR DESCRIPTION
There are 2 places in the Brotli encoder where GCC intrinsics for TZCNT and BSR are used.  I have added the MSVC equivalents so we don't incur a performance penalty compared to GCC (and compatible) builds.  I submitted a [matching PR](https://github.com/google/brotli/pull/636) over in the Google repo, which looks like it will be picked up.

I noticed a slight performance regression between 2.1 and the 3.0 previews, which had been updated to Brotli v1.0.5.  This change makes up that perf difference and more.

``` ini
BenchmarkDotNet=v0.11.3, OS=Windows 10.0.17134.556 (1803/April2018Update/Redstone4)
Intel Xeon CPU E3-1505M v6 3.00GHz, 1 CPU, 8 logical and 4 physical cores
Frequency=2929685 Hz, Resolution=341.3336 ns, Timer=TSC
.NET Core SDK=3.0.100-preview-010184
  [Host]        : .NET Core 2.1.7 (CoreCLR 4.6.27129.04, CoreFX 4.6.27129.04), 64bit RyuJIT
  2.1.7         : .NET Core 2.1.7 (CoreCLR 4.6.27129.04, CoreFX 4.6.27129.04), 64bit RyuJIT
  3.0-preview-2 : .NET Core 3.0.0-preview-27324-5 (CoreCLR 4.6.27322.0, CoreFX 4.7.19.7311), 64bit RyuJIT
  PR            : .NET Core 24973de7-9f09-4c96-a4b3-c4463fc81b91 (CoreCLR 4.6.27403.0, CoreFX 4.7.19.7311), 64bit RyuJIT

Jit=RyuJit  Platform=X64  Runtime=Core  

```
|          Method |           Job | Toolchain | Compressed Size |       Mean |     Error |    StdDev | Ratio | RatioSD |
|---------------- |-------------- |---------- |------ |-----------:|----------:|----------:|------:|--------:|
|  Alice29_q0_w12 |         2.1.7 |   Default | 78217 |   1.488 ms | 0.0237 ms | 0.0222 ms |  1.00 |    0.00 |
|  Alice29_q0_w12 | 3.0-preview-2 |   Default | 78217 |   1.499 ms | 0.0266 ms | 0.0249 ms |  1.01 |    0.00 |
|  Alice29_q0_w12 |            PR |   CoreRun | 78217 |   1.279 ms | 0.0149 ms | 0.0139 ms |  0.86 |    0.00 |
|                 |               |           |       |            |           |           |       |         |
|  Alice29_q5_w16 |         2.1.7 |   Default | 53089 |   7.308 ms | 0.0709 ms | 0.0663 ms |  1.00 |    0.00 |
|  Alice29_q5_w16 | 3.0-preview-2 |   Default | 53089 |   7.808 ms | 0.0862 ms | 0.0719 ms |  1.07 |    0.00 |
|  Alice29_q5_w16 |            PR |   CoreRun | 53089 |   6.061 ms | 0.0455 ms | 0.0404 ms |  0.83 |    0.01 |
|                 |               |           |       |            |           |           |       |         |
| Alice29_q11_w24 |         2.1.7 |   Default | 46487 | 275.866 ms | 2.6656 ms | 2.4934 ms |  1.00 |    0.00 |
| Alice29_q11_w24 | 3.0-preview-2 |   Default | 46487 | 286.640 ms | 2.5965 ms | 2.4288 ms |  1.04 |    0.00 |
| Alice29_q11_w24 |            PR |   CoreRun | 46487 | 260.619 ms | 2.2509 ms | 1.9954 ms |  0.94 |    0.00 |
