### PR TITLE
Collections cleanup

### DIFF
--- a/src/System.Collections.NonGeneric/src/Resources/Strings.resx
+++ b/src/System.Collections.NonGeneric/src/Resources/Strings.resx
@@ -58,23 +58,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Argument_AddingDuplicate" xml:space="preserve">
-    <value>An item with the same key has already been added. Key: {0}</value>
-  </data>
   <data name="Argument_AddingDuplicate_OldAndNewKeys " xml:space="preserve">
     <value>Item has already been added. Key in dictionary: '{0}'  Key being added: '{1}'</value>
-  </data>
-  <data name="Argument_ImplementIComparable" xml:space="preserve">
-    <value>At least one object must implement IComparable.</value>
   </data>
   <data name="Arg_ArrayPlusOffTooSmall" xml:space="preserve">
     <value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
   </data>
   <data name="Arg_RankMultiDimNotSupported" xml:space="preserve">
     <value>Only single dimensional arrays are supported for the requested action.</value>
-  </data>
-  <data name="Arg_HTCapacityOverflow" xml:space="preserve">
-    <value>Hashtable's capacity overflowed and went negative. Check load factor, capacity and the current size of the table.</value>
   </data>
   <data name="Arg_RemoveArgNotFound" xml:space="preserve">
     <value>Cannot remove the specified item because it was not found in the specified Collection.</value>

--- a/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
@@ -549,11 +549,6 @@ namespace System.Collections.Generic
                 _index = 0;
             }
 
-            private Enumerator(SerializationInfo info, StreamingContext context)
-            {
-                throw new PlatformNotSupportedException();
-            }
-
             public T Current
             {
                 get { return _current; }


### PR DESCRIPTION
I went through System.Collections.* and removed dead code as per #17905 

* [System.Collections.Concurrent](http://tempcoverage.blob.core.windows.net/report4/System.Collections.Concurrent.diff.html) ([csv](http://tempcoverage.blob.core.windows.net/report4/System.Collections.Concurrent.diff.csv)) - nothing to clean up
* [System.Collections](http://tempcoverage.blob.core.windows.net/report4/System.Collections.diff.html) ([csv](http://tempcoverage.blob.core.windows.net/report4/System.Collections.diff.csv)) - Cleaned up, as per #32654, #32676
* [System.Collections.Immutable](http://tempcoverage.blob.core.windows.net/report4/System.Collections.Immutable.diff.html) ([csv](http://tempcoverage.blob.core.windows.net/report4/System.Collections.Immutable.diff.csv)) - Nothing to clean up
* [System.Collections.NonGeneric](http://tempcoverage.blob.core.windows.net/report4/System.Collections.NonGeneric.diff.html) ([csv](http://tempcoverage.blob.core.windows.net/report4/System.Collections.NonGeneric.diff.csv)) - unused strings
* [System.Collections.Specialized](http://tempcoverage.blob.core.windows.net/report4/System.Collections.Specialized.diff.html) ([csv](http://tempcoverage.blob.core.windows.net/report4/System.Collections.Specialized.diff.csv)) - ~~cleaned up~~ nothing to remove