### PR TITLE
Improve BitArray's Get, Set, SetAll and Not methods performance

### DIFF
--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -742,7 +742,7 @@ namespace System.Collections
 
         private static void ThrowArgumentOutOfRangeException(int index)
         {
-            throw new ArgumentOutOfRangeException("index", index, SR.ArgumentOutOfRange_Index);
+            throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_Index);
         }
 
         private class BitArrayEnumeratorSimple : IEnumerator, ICloneable

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
@@ -188,14 +189,8 @@ namespace System.Collections
 
         public bool this[int index]
         {
-            get
-            {
-                return Get(index);
-            }
-            set
-            {
-                Set(index, value);
-            }
+            get => Get(index);
+            set => Set(index, value);
         }
 
         /*=========================================================================
@@ -204,15 +199,13 @@ namespace System.Collections
         ** Exceptions: ArgumentOutOfRangeException if index < 0 or
         **             index >= GetLength().
         =========================================================================*/
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Get(int index)
         {
-            if ((uint)index >= (uint)Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_Index);
-            }
+            if ((uint)index >= (uint)m_length)
+                ThrowArgumentOutOfRangeException(index);
 
-            int elementIndex = Div32Rem(index, out int extraBits);
-            return (m_array[elementIndex] & (1 << extraBits)) != 0;
+            return (m_array[index >> 5] & (1 << index)) != 0;
         }
 
         /*=========================================================================
@@ -221,25 +214,23 @@ namespace System.Collections
         ** Exceptions: ArgumentOutOfRangeException if index < 0 or
         **             index >= GetLength().
         =========================================================================*/
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Set(int index, bool value)
         {
-            if ((uint)index >= (uint)Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_Index);
-            }
+            if ((uint)index >= (uint)m_length)
+                ThrowArgumentOutOfRangeException(index);
 
-            int elementIndex = Div32Rem(index, out int extraBits);
+            int bitMask = 1 << index;
+            ref int segment = ref m_array[index >> 5];
 
-            int newValue = m_array[elementIndex];
             if (value)
             {
-                newValue |= 1 << extraBits;
+                segment |= bitMask;
             }
             else
             {
-                newValue &= ~(1 << extraBits);
+                segment &= ~bitMask;
             }
-            m_array[elementIndex] = newValue;
 
             _version++;
         }
@@ -250,9 +241,11 @@ namespace System.Collections
         public void SetAll(bool value)
         {
             int fillValue = value ? -1 : 0;
-            for (int i = 0; i < m_array.Length; i++)
+            int[] array = m_array;
+
+            for (int i = 0; i < array.Length; i++)
             {
-                m_array[i] = fillValue;
+                array[i] = fillValue;
             }
 
             _version++;
@@ -403,9 +396,11 @@ namespace System.Collections
         =========================================================================*/
         public BitArray Not()
         {
-            for (int i = 0; i < m_array.Length; i++)
+            int[] array = m_array;
+
+            for (int i = 0; i < array.Length; i++)
             {
-                m_array[i] = ~m_array[i];
+                array[i] = ~array[i];
             }
 
             _version++;
@@ -743,6 +738,11 @@ namespace System.Collections
             uint quotient = (uint)number / 4;
             remainder = number & (4 - 1);   // equivalent to number % 4, since 4 is a power of 2
             return (int)quotient;
+        }
+
+        private static void ThrowArgumentOutOfRangeException(int index)
+        {
+            throw new ArgumentOutOfRangeException("index", index, SR.ArgumentOutOfRange_Index);
         }
 
         private class BitArrayEnumeratorSimple : IEnumerator, ICloneable


### PR DESCRIPTION
The generated code got smaller so I added `AggressiveInlining` to `Get` and `Set`.

**Benchmarks**:
```C#
[InProcessEmit]
public class BitArrayBenchmarks
{
    private BitArray bitArray = new BitArray(1000, true);

    [Benchmark][Arguments(100)]
    public bool Get(int index) => bitArray.Get(index);

    [Benchmark][Arguments(100, false)]
    public void Set(int index, bool value) => bitArray.Set(index, value);

    [Benchmark]
    public void SetAll() => bitArray.SetAll(false);

    [Benchmark]
    public void Not() => bitArray.Not();
}

public class InProcessEmitAttribute : JobConfigBaseAttribute
{
    public InProcessEmitAttribute() : base(new Job("InProcessEmit", new InfrastructureMode 
        { Toolchain = InProcessEmitToolchain.Instance }))
    {
    }
}
```
**Results**:
```
BenchmarkDotNet=v0.11.4, OS=Windows 10.0.17763.316 (1809/October2018Update/Redstone5)
Intel Core i7-8809G CPU 3.10GHz (Coffee Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-preview-010184
  [Host] : .NET Core ? (CoreCLR 4.6.27514.0, CoreFX 4.7.19.11501), 64bit RyuJIT

Job=InProcessEmit  Toolchain=InProcessEmitToolchain  
```

**Before**:

| Method |      Mean |     Error |    StdDev |
|------- |----------:|----------:|----------:|
|    Get |  1.008 ns | 0.0359 ns | 0.0336 ns |
|    Set |  1.811 ns | 0.0072 ns | 0.0060 ns |

**After (without AggressiveInlining)**:

| Method |       Mean |     Error |    StdDev |
|------- |-----------:|----------:|----------:|
|    Get |  0.9117 ns | 0.0482 ns | 0.0473 ns |
|    Set |  1.4892 ns | 0.0884 ns | 0.1053 ns |

**After (with AggressiveInlining)**:

| Method |      Mean |     Error |    StdDev |
|------- |----------:|----------:|----------:|
|    Get | 0.2765 ns | 0.0055 ns | 0.0052 ns |
|    Set | 0.7850 ns | 0.0267 ns | 0.0249 ns |

------
**Before**

| Method |      Mean |     Error |    StdDev |
|------- |----------:|----------:|----------:|
| SetAll | 17.822 ns | 0.0541 ns | 0.0506 ns |
|    Not | 21.032 ns | 0.1795 ns | 0.1679 ns |

**After**:

| Method |       Mean |     Error |    StdDev |
|------- |-----------:|----------:|----------:|
| SetAll | 10.2743 ns | 0.1039 ns | 0.0868 ns |
|    Not | 19.0571 ns | 0.3053 ns | 0.2706 ns |

<details><summary>Code generated BEFORE</summary><p>

```ASM
; Assembly listing for method BitArray:Get(int):bool:this
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 this         [V00,T01] (  4,  4   )     ref  ->  rcx         this class-hnd
;  V01 arg1         [V01,T00] (  6,  5   )     int  ->  rsi        
;* V02 loc0         [V02    ] (  0,  0   )     int  ->  zero-ref   
;  V03 loc1         [V03,T04] (  2,  2   )     int  ->  rsi         ld-addr-op
;  V04 OutArgs      [V04    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
;  V05 tmp1         [V05,T05] (  3,  0   )     ref  ->  rdi         class-hnd exact "Single-def Box Helper"
;  V06 tmp2         [V06,T06] (  3,  0   )     ref  ->  rsi         class-hnd exact "NewObj constructor temp"
;  V07 tmp3         [V07,T03] (  3,  3   )     int  ->  rax         "Inline stloc first use temp"
;  V08 tmp4         [V08,T07] (  2,  0   )     ref  ->  rcx         "argument with side effect"
;  V09 tmp5         [V09,T08] (  2,  0   )     ref  ->  rbx         "argument with side effect"
;  V10 tmp6         [V10,T09] (  2,  0   )     ref  ->   r9         "argument with side effect"
;  V11 tmp7         [V11,T02] (  3,  6   )     ref  ->  rcx         "arr expr"
;
; Lcl frame size = 32

G_M31143_IG01:
       57                   push     rdi
       56                   push     rsi
       53                   push     rbx
       4883EC20             sub      rsp, 32
       8BF2                 mov      esi, edx

G_M31143_IG02:
       3B7110               cmp      esi, dword ptr [rcx+16]
       732D                 jae      SHORT G_M31143_IG05

G_M31143_IG03:
       8BC6                 mov      eax, esi
       C1E805               shr      eax, 5
       83E61F               and      esi, 31
       488B4908             mov      rcx, gword ptr [rcx+8]
       3B4108               cmp      eax, dword ptr [rcx+8]
       0F838E000000         jae      G_M31143_IG06
       4863C0               movsxd   rax, eax
       8B448110             mov      eax, dword ptr [rcx+4*rax+16]
       0FA3F0               bt       eax, esi
       0F92C0               setb     al
       0FB6C0               movzx    rax, al

G_M31143_IG04:
       4883C420             add      rsp, 32
       5B                   pop      rbx
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      

G_M31143_IG05:
       48B9C8CE517CF97F0000 mov      rcx, 0x7FF97C51CEC8
       E88688B25F           call     CORINFO_HELP_NEWSFAST
       488BF8               mov      rdi, rax
       897708               mov      dword ptr [rdi+8], esi
       48B9B83A5C7CF97F0000 mov      rcx, 0x7FF97C5C3AB8
       E87188B25F           call     CORINFO_HELP_NEWSFAST
       488BF0               mov      rsi, rax
       B91D080000           mov      ecx, 0x81D
       48BA90CC5E7CF97F0000 mov      rdx, 0x7FF97C5ECC90
       E8AA1DB25F           call     CORINFO_HELP_STRCNS
       488BD8               mov      rbx, rax
       B98F050000           mov      ecx, 0x58F
       48BA90CC5E7CF97F0000 mov      rdx, 0x7FF97C5ECC90
       E8931DB25F           call     CORINFO_HELP_STRCNS
       488BC8               mov      rcx, rax
       33D2                 xor      rdx, rdx
       E8C9FBFFFF           call     SR:GetResourceString(ref,ref):ref
       4C8BC8               mov      r9, rax
       488BD3               mov      rdx, rbx
       4C8BC7               mov      r8, rdi
       488BCE               mov      rcx, rsi
       E8507EFFFF           call     ArgumentOutOfRangeException:.ctor(ref,ref,ref):this
       488BCE               mov      rcx, rsi
       E82035A25F           call     CORINFO_HELP_THROW
       CC                   int3     

G_M31143_IG06:
       E88A89C65F           call     CORINFO_HELP_RNGCHKFAIL
       CC                   int3     

; Total bytes of code 183, prolog size 7 for method BitArray:Get(int):bool:this
; ============================================================

; Assembly listing for method BitArray:Set(int,bool):this
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 this         [V00,T00] (  6,  6   )     ref  ->  rax         this class-hnd
;  V01 arg1         [V01,T01] (  6,  5   )     int  ->  rsi        
;  V02 arg2         [V02,T03] (  3,  3   )    bool  ->   r8        
;  V03 loc0         [V03,T07] (  3,  3   )     int  ->  rcx        
;  V04 loc1         [V04,T09] (  3,  2   )     int  ->  rsi         ld-addr-op
;  V05 loc2         [V05,T04] (  6,  4   )     int  ->   r9        
;  V06 OutArgs      [V06    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
;  V07 tmp1         [V07,T12] (  3,  0   )     ref  ->  rdi         class-hnd exact "Single-def Box Helper"
;  V08 tmp2         [V08,T13] (  3,  0   )     ref  ->  rsi         class-hnd exact "NewObj constructor temp"
;  V09 tmp3         [V09,T10] (  2,  2   )     int  ->  rcx         "Inline stloc first use temp"
;  V10 tmp4         [V10,T14] (  2,  0   )     ref  ->  rcx         "argument with side effect"
;  V11 tmp5         [V11,T15] (  2,  0   )     ref  ->  rbx         "argument with side effect"
;  V12 tmp6         [V12,T16] (  2,  0   )     ref  ->   r9         "argument with side effect"
;  V13 tmp7         [V13,T02] (  3,  6   )     ref  ->   r9         "arr expr"
;  V14 tmp8         [V14,T05] (  2,  4   )     ref  ->  rdx         "arr expr"
;  V15 cse0         [V15,T06] (  3,  3   )     ref  ->  rdx         "ValNumCSE"
;  V16 cse1         [V16,T11] (  2,  2   )     int  ->  r10         "ValNumCSE"
;  V17 cse2         [V17,T08] (  3,  3   )    long  ->  r10         "ValNumCSE"
;
; Lcl frame size = 32

G_M52659_IG01:
       57                   push     rdi
       56                   push     rsi
       53                   push     rbx
       4883EC20             sub      rsp, 32
       488BC1               mov      rax, rcx
       8BF2                 mov      esi, edx

G_M52659_IG02:
       3B7010               cmp      esi, dword ptr [rax+16]
       735F                 jae      SHORT G_M52659_IG07

G_M52659_IG03:
       8BCE                 mov      ecx, esi
       C1E905               shr      ecx, 5
       83E61F               and      esi, 31
       488B5008             mov      rdx, gword ptr [rax+8]
       4C8BCA               mov      r9, rdx
       458B5108             mov      r10d, dword ptr [r9+8]
       413BCA               cmp      ecx, r10d
       0F83B9000000         jae      G_M52659_IG08
       4C63D1               movsxd   r10, ecx
       478B4C9110           mov      r9d, dword ptr [r9+4*r10+16]
       4584C0               test     r8b, r8b
       7410                 je       SHORT G_M52659_IG04
       41B801000000         mov      r8d, 1
       8BCE                 mov      ecx, esi
       41D3E0               shl      r8d, cl
       450BC8               or       r9d, r8d
       EB16                 jmp      SHORT G_M52659_IG05

G_M52659_IG04:
       41B801000000         mov      r8d, 1
       8BCE                 mov      ecx, esi
       41D3E0               shl      r8d, cl
       418BC8               mov      ecx, r8d
       F7D1                 not      ecx
       4123C9               and      ecx, r9d
       448BC9               mov      r9d, ecx

G_M52659_IG05:
       46894C9210           mov      dword ptr [rdx+4*r10+16], r9d
       FF4014               inc      dword ptr [rax+20]

G_M52659_IG06:
       4883C420             add      rsp, 32
       5B                   pop      rbx
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      

G_M52659_IG07:
       48B9C8CE517CF97F0000 mov      rcx, 0x7FF97C51CEC8
       E85187B25F           call     CORINFO_HELP_NEWSFAST
       488BF8               mov      rdi, rax
       897708               mov      dword ptr [rdi+8], esi
       48B9B83A5C7CF97F0000 mov      rcx, 0x7FF97C5C3AB8
       E83C87B25F           call     CORINFO_HELP_NEWSFAST
       488BF0               mov      rsi, rax
       B91D080000           mov      ecx, 0x81D
       48BA90CC5E7CF97F0000 mov      rdx, 0x7FF97C5ECC90
       E8751CB25F           call     CORINFO_HELP_STRCNS
       488BD8               mov      rbx, rax
       B98F050000           mov      ecx, 0x58F
       48BA90CC5E7CF97F0000 mov      rdx, 0x7FF97C5ECC90
       E85E1CB25F           call     CORINFO_HELP_STRCNS
       488BC8               mov      rcx, rax
       33D2                 xor      rdx, rdx
       E894FAFFFF           call     SR:GetResourceString(ref,ref):ref
       4C8BC8               mov      r9, rax
       488BD3               mov      rdx, rbx
       4C8BC7               mov      r8, rdi
       488BCE               mov      rcx, rsi
       E81B7DFFFF           call     ArgumentOutOfRangeException:.ctor(ref,ref,ref):this
       488BCE               mov      rcx, rsi
       E8EB33A25F           call     CORINFO_HELP_THROW
       CC                   int3     

G_M52659_IG08:
       E85588C65F           call     CORINFO_HELP_RNGCHKFAIL
       CC                   int3     

; Total bytes of code 236, prolog size 7 for method BitArray:Set(int,bool):this
; ============================================================

; Assembly listing for method BitArray:SetAll(bool):this
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; fully interruptible
; Final local variable assignments
;
;  V00 this         [V00,T03] (  5,  5   )     ref  ->  rcx         this class-hnd
;  V01 arg1         [V01,T04] (  3,  3   )    bool  ->  rdx        
;  V02 loc0         [V02,T05] (  2,  5   )     int  ->  rax        
;  V03 loc1         [V03,T01] (  6, 21   )     int  ->  rdx        
;  V04 OutArgs      [V04    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
;  V05 tmp1         [V05,T06] (  3,  2   )     int  ->  rax        
;  V06 tmp2         [V06,T00] (  3, 24   )     ref  ->   r9         "arr expr"
;  V07 cse0         [V07,T02] (  4, 10   )     ref  ->   r8         "ValNumCSE"
;
; Lcl frame size = 40

G_M27665_IG01:
       4883EC28             sub      rsp, 40
       90                   nop      

G_M27665_IG02:
       84D2                 test     dl, dl
       7504                 jne      SHORT G_M27665_IG03
       33C0                 xor      eax, eax
       EB05                 jmp      SHORT G_M27665_IG04

G_M27665_IG03:
       B8FFFFFFFF           mov      eax, -1

G_M27665_IG04:
       33D2                 xor      edx, edx
       4C8B4108             mov      r8, gword ptr [rcx+8]
       4183780800           cmp      dword ptr [r8+8], 0
       7E19                 jle      SHORT G_M27665_IG06

G_M27665_IG05:
       4D8BC8               mov      r9, r8
       413B5108             cmp      edx, dword ptr [r9+8]
       7318                 jae      SHORT G_M27665_IG08
       4C63D2               movsxd   r10, edx
       4389449110           mov      dword ptr [r9+4*r10+16], eax
       FFC2                 inc      edx
       41395008             cmp      dword ptr [r8+8], edx
       7FE7                 jg       SHORT G_M27665_IG05

G_M27665_IG06:
       FF4114               inc      dword ptr [rcx+20]

G_M27665_IG07:
       4883C428             add      rsp, 40
       C3                   ret      

G_M27665_IG08:
       E8EB87C65F           call     CORINFO_HELP_RNGCHKFAIL
       CC                   int3     

; Total bytes of code 70, prolog size 5 for method BitArray:SetAll(bool):this
; ============================================================

; Assembly listing for method BitArray:Not():ref:this
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; fully interruptible
; Final local variable assignments
;
;  V00 this         [V00,T06] (  6,  6   )     ref  ->  rcx         this class-hnd
;  V01 loc0         [V01,T01] (  6, 21   )     int  ->  rax        
;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
;  V03 tmp1         [V03,T02] (  2, 16   )     ref  ->   r8         class-hnd "Strict ordering of exceptions for Array store"
;  V04 tmp2         [V04,T03] (  2, 16   )     int  ->   r9         "Strict ordering of exceptions for Array store"
;  V05 tmp3         [V05,T00] (  3, 24   )     ref  ->   r9         "arr expr"
;  V06 cse0         [V06,T04] (  5, 14   )     ref  ->  rdx         "ValNumCSE"
;  V07 cse1         [V07,T07] (  2,  8   )     int  ->  r10         "ValNumCSE"
;  V08 cse2         [V08,T05] (  3, 12   )    long  ->  r10         "ValNumCSE"
;
; Lcl frame size = 40

G_M5415_IG01:
       4883EC28             sub      rsp, 40
       90                   nop      

G_M5415_IG02:
       33C0                 xor      eax, eax
       488B5108             mov      rdx, gword ptr [rcx+8]
       837A0800             cmp      dword ptr [rdx+8], 0
       7E26                 jle      SHORT G_M5415_IG04

G_M5415_IG03:
       4C8BC2               mov      r8, rdx
       4C8BCA               mov      r9, rdx
       458B5108             mov      r10d, dword ptr [r9+8]
       413BC2               cmp      eax, r10d
       7322                 jae      SHORT G_M5415_IG06
       4C63D0               movsxd   r10, eax
       478B4C9110           mov      r9d, dword ptr [r9+4*r10+16]
       41F7D1               not      r9d
       47894C9010           mov      dword ptr [r8+4*r10+16], r9d
       FFC0                 inc      eax
       394208               cmp      dword ptr [rdx+8], eax
       7FDA                 jg       SHORT G_M5415_IG03

G_M5415_IG04:
       FF4114               inc      dword ptr [rcx+20]
       488BC1               mov      rax, rcx

G_M5415_IG05:
       4883C428             add      rsp, 40
       C3                   ret      

G_M5415_IG06:
       E88987C65F           call     CORINFO_HELP_RNGCHKFAIL
       CC                   int3     

; Total bytes of code 72, prolog size 5 for method BitArray:Not():ref:this
; ============================================================

```

</p></details>
<p>
</p>

<details><summary>Code generated AFTER. Get and Set inlined into the callers. Set was called with a constant value (true).</summary><p>

```ASM
; Assembly listing for method Program:BitArrayGet(ref,int):bool
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T01] (  4,  4   )     ref  ->  rcx         class-hnd
;  V01 arg1         [V01,T00] (  6,  5   )     int  ->  rdx        
;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
;  V03 tmp1         [V03,T02] (  3,  6   )     ref  ->  rax         "arr expr"
;  V04 cse0         [V04,T03] (  3,  3   )     int  ->  rcx         "ValNumCSE"
;
; Lcl frame size = 40

G_M64820_IG01:
       4883EC28             sub      rsp, 40
       90                   nop      

G_M64820_IG02:
       3B5110               cmp      edx, dword ptr [rcx+16]
       7323                 jae      SHORT G_M64820_IG05

G_M64820_IG03:
       488B4108             mov      rax, gword ptr [rcx+8]
       8BCA                 mov      ecx, edx
       C1F905               sar      ecx, 5
       3B4808               cmp      ecx, dword ptr [rax+8]
       731D                 jae      SHORT G_M64820_IG06
       4863C9               movsxd   rcx, ecx
       8B448810             mov      eax, dword ptr [rax+4*rcx+16]
       0FA3D0               bt       eax, edx
       0F92C0               setb     al
       0FB6C0               movzx    rax, al

G_M64820_IG04:
       4883C428             add      rsp, 40
       C3                   ret      

G_M64820_IG05:
       8BCA                 mov      ecx, edx
       E874F8FFFF           call     BitArray:ThrowIndexOutOfRange(int)
       CC                   int3     

G_M64820_IG06:
       E8368AC65F           call     CORINFO_HELP_RNGCHKFAIL
       CC                   int3     

; Total bytes of code 59, prolog size 5 for method Program:BitArrayGet(ref,int):bool
; ============================================================

; Assembly listing for method Program:BitArraySet(ref,int)
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  6,  6   )     ref  ->  rax         class-hnd
;  V01 arg1         [V01,T01] (  6,  5   )     int  ->  rdx        
;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
;  V03 tmp1         [V03,T05] (  2,  2   )     int  ->   r8         "Inline stloc first use temp"
;  V04 tmp2         [V04,T03] (  3,  3   )   byref  ->  rcx         "Inline stloc first use temp"
;  V05 tmp3         [V05,T02] (  3,  6   )     ref  ->  rcx         "arr expr"
;  V06 cse0         [V06,T04] (  3,  3   )     int  ->  rdx         "ValNumCSE"
;
; Lcl frame size = 40

G_M45352_IG01:
       4883EC28             sub      rsp, 40
       90                   nop      
       488BC1               mov      rax, rcx

G_M45352_IG02:
       3B5010               cmp      edx, dword ptr [rax+16]
       732A                 jae      SHORT G_M45352_IG05

G_M45352_IG03:
       41B801000000         mov      r8d, 1
       8BCA                 mov      ecx, edx
       41D3E0               shl      r8d, cl
       488B4808             mov      rcx, gword ptr [rax+8]
       C1FA05               sar      edx, 5
       3B5108               cmp      edx, dword ptr [rcx+8]
       731B                 jae      SHORT G_M45352_IG06
       4863D2               movsxd   rdx, edx
       488D4C9110           lea      rcx, bword ptr [rcx+4*rdx+16]
       440901               or       dword ptr [rcx], r8d
       FF4014               inc      dword ptr [rax+20]

G_M45352_IG04:
       4883C428             add      rsp, 40
       C3                   ret      

G_M45352_IG05:
       8BCA                 mov      ecx, edx
       E81AF8FFFF           call     BitArray:ThrowIndexOutOfRange(int)
       CC                   int3     

G_M45352_IG06:
       E8DC89C65F           call     CORINFO_HELP_RNGCHKFAIL
       CC                   int3     

; Total bytes of code 69, prolog size 5 for method Program:BitArraySet(ref,int)
; ============================================================

; Assembly listing for method BitArray:SetAll(bool):this
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; fully interruptible
; Final local variable assignments
;
;  V00 this         [V00,T01] (  5,  5   )     ref  ->  rcx         this class-hnd
;  V01 arg1         [V01,T04] (  3,  3   )    bool  ->  rdx        
;  V02 loc0         [V02,T05] (  2,  5   )     int  ->  rax        
;  V03 loc1         [V03,T02] (  3,  6   )     ref  ->  rdx         class-hnd
;  V04 loc2         [V04,T00] (  5, 17   )     int  ->   r8        
;# V05 OutArgs      [V05    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;  V06 tmp1         [V06,T06] (  3,  2   )     int  ->  rax        
;  V07 cse0         [V07,T03] (  3,  6   )     int  ->   r9         "ValNumCSE"
;
; Lcl frame size = 0

G_M27665_IG01:
       0F1F440000           nop      

G_M27665_IG02:
       84D2                 test     dl, dl
       7504                 jne      SHORT G_M27665_IG03
       33C0                 xor      eax, eax
       EB05                 jmp      SHORT G_M27665_IG04

G_M27665_IG03:
       B8FFFFFFFF           mov      eax, -1

G_M27665_IG04:
       488B5108             mov      rdx, gword ptr [rcx+8]
       4533C0               xor      r8d, r8d
       448B4A08             mov      r9d, dword ptr [rdx+8]
       4585C9               test     r9d, r9d
       7E10                 jle      SHORT G_M27665_IG06

G_M27665_IG05:
       4D63D0               movsxd   r10, r8d
       4289449210           mov      dword ptr [rdx+4*r10+16], eax
       41FFC0               inc      r8d
       453BC8               cmp      r9d, r8d
       7FF0                 jg       SHORT G_M27665_IG05

G_M27665_IG06:
       FF4114               inc      dword ptr [rcx+20]

G_M27665_IG07:
       C3                   ret      

; Total bytes of code 54, prolog size 5 for method BitArray:SetAll(bool):this
; ============================================================

; Assembly listing for method BitArray:Not():ref:this
; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
; optimized code
; rsp based frame
; fully interruptible
; Final local variable assignments
;
;  V00 this         [V00,T04] (  6,  6   )     ref  ->  rcx         this class-hnd
;  V01 loc0         [V01,T03] (  4, 10   )     ref  ->  rax         class-hnd
;  V02 loc1         [V02,T00] (  5, 17   )     int  ->  rdx        
;# V03 OutArgs      [V03    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
;  V04 tmp1         [V04,T01] (  2, 16   )     int  ->  r10         "Strict ordering of exceptions for Array store"
;  V05 cse0         [V05,T05] (  3,  6   )     int  ->   r8         "ValNumCSE"
;  V06 cse1         [V06,T02] (  3, 12   )    long  ->   r9         "ValNumCSE"
;
; Lcl frame size = 0

G_M5415_IG01:
       0F1F440000           nop      

G_M5415_IG02:
       488B4108             mov      rax, gword ptr [rcx+8]
       33D2                 xor      edx, edx
       448B4008             mov      r8d, dword ptr [rax+8]
       4585C0               test     r8d, r8d
       7E17                 jle      SHORT G_M5415_IG04

G_M5415_IG03:
       4C63CA               movsxd   r9, edx
       468B548810           mov      r10d, dword ptr [rax+4*r9+16]
       41F7D2               not      r10d
       4689548810           mov      dword ptr [rax+4*r9+16], r10d
       FFC2                 inc      edx
       443BC2               cmp      r8d, edx
       7FE9                 jg       SHORT G_M5415_IG03

G_M5415_IG04:
       FF4114               inc      dword ptr [rcx+20]
       488BC1               mov      rax, rcx

G_M5415_IG05:
       C3                   ret      

; Total bytes of code 50, prolog size 5 for method BitArray:Not():ref:this
; ============================================================
```

</p></details>
<p>
</p>
