### PR TITLE
Add support for OCSP on Linux, overhaul X509Chain processing

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.Nid.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.Nid.cs
@@ -2,15 +2,42 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 
 internal static partial class Interop
 {
     internal static partial class Crypto
     {
+        private static readonly ConcurrentDictionary<string, int> s_nidLookup =
+            new ConcurrentDictionary<string, int>();
+
         internal const int NID_undef = 0;
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjSn2Nid", CharSet = CharSet.Ansi)]
         internal static extern int ObjSn2Nid(string sn);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjTxt2Nid", CharSet = CharSet.Ansi)]
+        private static extern int ObjTxt2Nid(string oid);
+
+        internal static int ResolveRequiredNid(string oid)
+        {
+            return s_nidLookup.GetOrAdd(oid, s => LookupNid(s));
+        }
+
+        private static int LookupNid(string oid)
+        {
+            int nid = ObjTxt2Nid(oid);
+
+            if (nid == NID_undef)
+            {
+                Debug.Fail($"NID Lookup for {oid} failed, only well-known types should be queried.");
+                throw new CryptographicException();
+            }
+
+            return nid;
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -109,6 +109,17 @@ internal static partial class Interop
             int second,
             [MarshalAs(UnmanagedType.Bool)] bool isDst);
 
+        [DllImport(Libraries.CryptoNative)]
+        private static extern int CryptoNative_X509StoreSetVerifyTime(
+            SafeX509StoreHandle ctx,
+            int year,
+            int month,
+            int day,
+            int hour,
+            int minute,
+            int second,
+            [MarshalAs(UnmanagedType.Bool)] bool isDst);
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CheckX509IpAddress")]
         internal static extern int CheckX509IpAddress(SafeX509Handle x509, [In]byte[] addressBytes, int addressLen, string hostname, int cchHostname);
 
@@ -150,6 +161,28 @@ internal static partial class Interop
             Debug.Assert(verifyTime.Kind != DateTimeKind.Utc, "UTC verifyTime should have been normalized to Local");
             
             int succeeded = SetX509ChainVerifyTime(
+                ctx,
+                verifyTime.Year,
+                verifyTime.Month,
+                verifyTime.Day,
+                verifyTime.Hour,
+                verifyTime.Minute,
+                verifyTime.Second,
+                verifyTime.IsDaylightSavingTime());
+
+            if (succeeded != 1)
+            {
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
+            }
+        }
+
+        internal static void X509StoreSetVerifyTime(SafeX509StoreHandle ctx, DateTime verifyTime)
+        {
+            // OpenSSL is going to convert our input time to universal, so we should be in Local or
+            // Unspecified (local-assumed).
+            Debug.Assert(verifyTime.Kind != DateTimeKind.Utc, "UTC verifyTime should have been normalized to Local");
+
+            int succeeded = CryptoNative_X509StoreSetVerifyTime(
                 ctx,
                 verifyTime.Year,
                 verifyTime.Month,

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -119,6 +120,11 @@ internal static partial class Interop
             return GetDynamicBuffer((ptr, buf, i) => GetAsn1StringBytes(ptr, buf, i), asn1);
         }
 
+        internal static ArraySegment<byte> RentAsn1StringBytes(IntPtr asn1)
+        {
+            return RentDynamicBuffer((ptr, buf, i) => GetAsn1StringBytes(ptr, buf, i), asn1);
+        }
+
         internal static byte[] GetX509Thumbprint(SafeX509Handle x509)
         {
             return GetDynamicBuffer((handle, buf, i) => GetX509Thumbprint(handle, buf, i), x509);
@@ -178,6 +184,29 @@ internal static partial class Interop
             }
 
             return bytes;
+        }
+
+        private static ArraySegment<byte> RentDynamicBuffer<THandle>(NegativeSizeReadMethod<THandle> method, THandle handle)
+        {
+            int negativeSize = method(handle, null, 0);
+
+            if (negativeSize > 0)
+            {
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
+            }
+
+            int targetSize = -negativeSize;
+            byte[] bytes = ArrayPool<byte>.Shared.Rent(targetSize);
+
+            int ret = method(handle, bytes, targetSize);
+
+            if (ret != 1)
+            {
+                ArrayPool<byte>.Shared.Return(bytes);
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
+            }
+
+            return new ArraySegment<byte>(bytes, 0, targetSize);
         }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
@@ -52,7 +52,6 @@ internal static partial class Interop
             return response;
         }
 
-
         [DllImport(Libraries.CryptoNative)]
         private static extern X509VerifyStatusCode CryptoNative_X509ChainVerifyOcsp(
             SafeX509StoreCtxHandle ctx,
@@ -92,7 +91,6 @@ internal static partial class Interop
 
             return req;
         }
-
     }
 }
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Crypto
+    {
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OcspRequestDestroy")]
+        internal static extern void OcspRequestDestroy(IntPtr ocspReq);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetOcspRequestDerSize")]
+        internal static extern int GetOcspRequestDerSize(SafeOcspRequestHandle req);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EncodeOcspRequest")]
+        internal static extern int EncodeOcspRequest(SafeOcspRequestHandle req, byte[] buf);
+
+        [DllImport(Libraries.CryptoNative)]
+        private static extern SafeOcspResponseHandle CryptoNative_DecodeOcspResponse(ref byte buf, int len);
+
+        internal static SafeOcspResponseHandle DecodeOcspResponse(ReadOnlySpan<byte> buf)
+        {
+            return CryptoNative_DecodeOcspResponse(
+                ref MemoryMarshal.GetReference(buf),
+                buf.Length);
+        }
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_OcspResponseDestroy")]
+        internal static extern void OcspResponseDestroy(IntPtr ocspReq);
+
+
+        [DllImport(Libraries.CryptoNative)]
+        private static extern X509VerifyStatusCode CryptoNative_X509ChainGetCachedOcspStatus(SafeX509StoreCtxHandle ctx, string cachePath);
+
+        internal static X509VerifyStatusCode X509ChainGetCachedOcspStatus(SafeX509StoreCtxHandle ctx, string cachePath)
+        {
+            X509VerifyStatusCode response = CryptoNative_X509ChainGetCachedOcspStatus(ctx, cachePath);
+
+            if (response < 0)
+            {
+                Debug.Fail($"Unexpected response from X509ChainGetCachedOcspSuccess: {response}");
+                throw new CryptographicException();
+            }
+
+            return response;
+        }
+
+
+        [DllImport(Libraries.CryptoNative)]
+        private static extern X509VerifyStatusCode CryptoNative_X509ChainVerifyOcsp(
+            SafeX509StoreCtxHandle ctx,
+            SafeOcspRequestHandle req,
+            SafeOcspResponseHandle resp,
+            string cachePath);
+
+        internal static X509VerifyStatusCode X509ChainVerifyOcsp(
+            SafeX509StoreCtxHandle ctx,
+            SafeOcspRequestHandle req,
+            SafeOcspResponseHandle resp,
+            string cachePath)
+        {
+            X509VerifyStatusCode response = CryptoNative_X509ChainVerifyOcsp(ctx, req, resp, cachePath);
+
+            if (response < 0)
+            {
+                Debug.Fail($"Unexpected response from X509ChainGetCachedOcspSuccess: {response}");
+                throw new CryptographicException();
+            }
+
+            return response;
+        }
+
+        [DllImport(Libraries.CryptoNative)]
+        private static extern SafeOcspRequestHandle CryptoNative_X509ChainBuildOcspRequest(SafeX509StoreCtxHandle storeCtx);
+
+        internal static SafeOcspRequestHandle X509ChainBuildOcspRequest(SafeX509StoreCtxHandle storeCtx)
+        {
+            SafeOcspRequestHandle req = CryptoNative_X509ChainBuildOcspRequest(storeCtx);
+
+            if (req.IsInvalid)
+            {
+                req.Dispose();
+                throw CreateOpenSslCryptographicException();
+            }
+
+            return req;
+        }
+
+    }
+}
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    internal class SafeOcspRequestHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public SafeOcspRequestHandle()
+            : base(true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.Crypto.OcspRequestDestroy(handle);
+            handle = IntPtr.Zero;
+            return true;
+        }
+    }
+
+    internal class SafeOcspResponseHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public SafeOcspResponseHandle()
+            : base(true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            Interop.Crypto.OcspResponseDestroy(handle);
+            handle = IntPtr.Zero;
+            return true;
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -179,7 +179,7 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetError")]
         internal static extern X509VerifyStatusCode X509StoreCtxGetError(SafeX509StoreCtxHandle ctx);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxReset")]
+        [DllImport(Libraries.CryptoNative)]
         private static extern int CryptoNative_X509StoreCtxReset(SafeX509StoreCtxHandle ctx);
 
         internal static void X509StoreCtxReset(SafeX509StoreCtxHandle ctx)
@@ -188,6 +188,21 @@ internal static partial class Interop
             {
                 throw CreateOpenSslCryptographicException();
             }
+        }
+
+        [DllImport(Libraries.CryptoNative)]
+        private static extern int CryptoNative_X509StoreCtxRebuildChain(SafeX509StoreCtxHandle ctx);
+
+        internal static bool X509StoreCtxRebuildChain(SafeX509StoreCtxHandle ctx)
+        {
+            int result = CryptoNative_X509StoreCtxRebuildChain(ctx);
+
+            if (result < 0)
+            {
+                throw CreateOpenSslCryptographicException();
+            }
+
+            return result != 0;
         }
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetErrorDepth")]

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -92,6 +92,21 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509IssuerNameHash")]
         internal static extern ulong X509IssuerNameHash(SafeX509Handle x);
 
+        [DllImport(Libraries.CryptoNative)]
+        private static extern SafeSharedAsn1OctetStringHandle CryptoNative_X509FindExtensionData(
+            SafeX509Handle x,
+            int extensionNid);
+
+        internal static SafeSharedAsn1OctetStringHandle X509FindExtensionData(SafeX509Handle x, int extensionNid)
+        {
+            CheckValidOpenSslHandle(x);
+
+            return SafeInteriorHandle.OpenInteriorHandle(
+                (handle, arg) => CryptoNative_X509FindExtensionData(handle, arg),
+                x,
+                extensionNid);
+        }
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509GetExtCount")]
         internal static extern int X509GetExtCount(SafeX509Handle x);
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Stack.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Stack.cs
@@ -35,6 +35,28 @@ internal static partial class Interop
         /// </summary>
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509StackField")]
         internal static extern IntPtr GetX509StackField(SafeSharedX509StackHandle stack, int loc);
+
+        [DllImport(Libraries.CryptoNative)]
+        private static extern int CryptoNative_X509StackAddDirectoryStore(SafeX509StackHandle stack, string storePath);
+
+        internal static void X509StackAddDirectoryStore(SafeX509StackHandle stack, string storePath)
+        {
+            if (CryptoNative_X509StackAddDirectoryStore(stack, storePath) != 1)
+            {
+                throw CreateOpenSslCryptographicException();
+            }
+        }
+
+        [DllImport(Libraries.CryptoNative)]
+        private static extern int CryptoNative_X509StackAddMultiple(SafeX509StackHandle dest, SafeX509StackHandle src);
+
+        internal static void X509StackAddMultiple(SafeX509StackHandle dest, SafeX509StackHandle src)
+        {
+            if (CryptoNative_X509StackAddMultiple(dest, src) != 1)
+            {
+                throw CreateOpenSslCryptographicException();
+            }
+        }
     }
 }
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509StoreCtx.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509StoreCtx.cs
@@ -19,6 +19,20 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetChain")]
         internal static extern SafeX509StackHandle X509StoreCtxGetChain(SafeX509StoreCtxHandle ctx);
 
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetCurrentCert")]
+        internal static extern SafeX509Handle X509StoreCtxGetCurrentCert(SafeX509StoreCtxHandle ctx);
+
+        [DllImport(Libraries.CryptoNative)]
+        private static extern int CryptoNative_X509StoreCtxCommitToChain(SafeX509StoreCtxHandle ctx);
+
+        internal static void X509StoreCtxCommitToChain(SafeX509StoreCtxHandle ctx)
+        {
+            if (CryptoNative_X509StoreCtxCommitToChain(ctx) != 1)
+            {
+                throw CreateOpenSslCryptographicException();
+            }
+        }
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetSharedUntrusted")]
         private static extern SafeSharedX509StackHandle X509StoreCtxGetSharedUntrusted_private(SafeX509StoreCtxHandle ctx);
 

--- a/src/Common/src/Microsoft/Win32/SafeHandles/Asn1SafeHandles.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/Asn1SafeHandles.Unix.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Security;
 
 namespace Microsoft.Win32.SafeHandles
 {
@@ -71,6 +70,14 @@ namespace Microsoft.Win32.SafeHandles
     internal sealed class SafeSharedAsn1IntegerHandle : SafeInteriorHandle
     {
         private SafeSharedAsn1IntegerHandle() :
+            base(IntPtr.Zero, ownsHandle: true)
+        {
+        }
+    }
+
+    internal sealed class SafeSharedAsn1OctetStringHandle : SafeInteriorHandle
+    {
+        private SafeSharedAsn1OctetStringHandle() :
             base(IntPtr.Zero, ownsHandle: true)
         {
         }

--- a/src/Common/src/System/Security/Cryptography/Oids.cs
+++ b/src/Common/src/System/Security/Cryptography/Oids.cs
@@ -42,6 +42,7 @@ namespace System.Security.Cryptography
         internal const string CertificateTemplate = "1.3.6.1.4.1.311.21.7";
         internal const string ApplicationCertPolicies = "1.3.6.1.4.1.311.21.10";
         internal const string AuthorityInformationAccess = "1.3.6.1.5.5.7.1.1";
+        internal const string OcspEndpoint = "1.3.6.1.5.5.7.48.1";
         internal const string CertificateAuthorityIssuers = "1.3.6.1.5.5.7.48.2";
         internal const string Pkcs9ExtensionRequest = "1.2.840.113549.1.9.14";
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -35,6 +35,7 @@ set(NATIVECRYPTO_SOURCES
     pal_evp_pkey_rsa.c
     pal_evp_cipher.c
     pal_hmac.c
+    pal_ocsp.c
     pal_pkcs12.c
     pal_pkcs7.c
     pal_rsa.c

--- a/src/Native/Unix/System.Security.Cryptography.Native/apibridge.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/apibridge.c
@@ -494,6 +494,11 @@ X509* local_X509_STORE_CTX_get0_cert(X509_STORE_CTX* ctx)
     return ctx ? ctx->cert : NULL;
 }
 
+X509_VERIFY_PARAM* local_X509_STORE_get0_param(X509_STORE* ctx)
+{
+    return ctx ? ctx->param: NULL;
+}
+
 int32_t local_X509_up_ref(X509* x509)
 {
     if (x509 != NULL)

--- a/src/Native/Unix/System.Security.Cryptography.Native/apibridge.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/apibridge.c
@@ -479,6 +479,11 @@ int32_t local_SSL_is_init_finished(const SSL* ssl)
     return SSL_state(ssl) == SSL_ST_OK;
 }
 
+X509Stack* local_X509_STORE_CTX_get0_chain(X509_STORE_CTX* ctx)
+{
+    return ctx ? ctx->chain : NULL;
+}
+
 X509Stack* local_X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx)
 {
     return ctx ? ctx->untrusted : NULL;

--- a/src/Native/Unix/System.Security.Cryptography.Native/apibridge.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/apibridge.c
@@ -484,6 +484,11 @@ X509Stack* local_X509_STORE_CTX_get0_chain(X509_STORE_CTX* ctx)
     return ctx ? ctx->chain : NULL;
 }
 
+X509_STORE* local_X509_STORE_CTX_get0_store(X509_STORE_CTX* ctx)
+{
+    return ctx ? ctx->ctx: NULL;
+}
+
 X509Stack* local_X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx)
 {
     return ctx ? ctx->untrusted : NULL;

--- a/src/Native/Unix/System.Security.Cryptography.Native/apibridge.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/apibridge.h
@@ -36,7 +36,8 @@ int32_t local_X509_PUBKEY_get0_param(
     ASN1_OBJECT** palgOid, const uint8_t** pkeyBytes, int* pkeyBytesLen, X509_ALGOR** palg, X509_PUBKEY* pubkey);
 STACK_OF(X509)* local_X509_STORE_CTX_get0_chain(X509_STORE_CTX* ctx);
 X509* local_X509_STORE_CTX_get0_cert(X509_STORE_CTX* ctx);
-STACK_OF(X509) * local_X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx);
+STACK_OF(X509)* local_X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx);
+X509_VERIFY_PARAM* local_X509_STORE_get0_param(X509_STORE* ctx);
 const ASN1_TIME* local_X509_get0_notAfter(const X509* x509);
 const ASN1_TIME* local_X509_get0_notBefore(const X509* x509);
 ASN1_BIT_STRING* local_X509_get0_pubkey_bitstr(const X509* x509);

--- a/src/Native/Unix/System.Security.Cryptography.Native/apibridge.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/apibridge.h
@@ -34,6 +34,7 @@ const ASN1_TIME* local_X509_CRL_get0_nextUpdate(const X509_CRL* crl);
 int32_t local_X509_NAME_get0_der(X509_NAME* x509Name, const uint8_t** pder, size_t* pderlen);
 int32_t local_X509_PUBKEY_get0_param(
     ASN1_OBJECT** palgOid, const uint8_t** pkeyBytes, int* pkeyBytesLen, X509_ALGOR** palg, X509_PUBKEY* pubkey);
+STACK_OF(X509)* local_X509_STORE_CTX_get0_chain(X509_STORE_CTX* ctx);
 X509* local_X509_STORE_CTX_get0_cert(X509_STORE_CTX* ctx);
 STACK_OF(X509) * local_X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx);
 const ASN1_TIME* local_X509_get0_notAfter(const X509* x509);

--- a/src/Native/Unix/System.Security.Cryptography.Native/apibridge.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/apibridge.h
@@ -36,6 +36,7 @@ int32_t local_X509_PUBKEY_get0_param(
     ASN1_OBJECT** palgOid, const uint8_t** pkeyBytes, int* pkeyBytesLen, X509_ALGOR** palg, X509_PUBKEY* pubkey);
 STACK_OF(X509)* local_X509_STORE_CTX_get0_chain(X509_STORE_CTX* ctx);
 X509* local_X509_STORE_CTX_get0_cert(X509_STORE_CTX* ctx);
+X509_STORE* local_X509_STORE_CTX_get0_store(X509_STORE_CTX* ctx);
 STACK_OF(X509)* local_X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx);
 X509_VERIFY_PARAM* local_X509_STORE_get0_param(X509_STORE* ctx);
 const ASN1_TIME* local_X509_get0_notAfter(const X509* x509);

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -1082,6 +1082,38 @@ int32_t CryptoNative_SetX509ChainVerifyTime(X509_STORE_CTX* ctx,
     return 1;
 }
 
+int32_t CryptoNative_X509StoreSetVerifyTime(X509_STORE* ctx,
+                                            int32_t year,
+                                            int32_t month,
+                                            int32_t day,
+                                            int32_t hour,
+                                            int32_t minute,
+                                            int32_t second,
+                                            int32_t isDst)
+{
+    if (!ctx)
+    {
+        return 0;
+    }
+
+    time_t verifyTime = MakeTimeT(year, month, day, hour, minute, second, isDst);
+
+    if (verifyTime == (time_t)-1)
+    {
+        return 0;
+    }
+
+    X509_VERIFY_PARAM* verifyParams = X509_STORE_get0_param(ctx);
+
+    if (!verifyParams)
+    {
+        return 0;
+    }
+
+    X509_VERIFY_PARAM_set_time(verifyParams, verifyTime);
+    return 1;
+}
+
 /*
 Function:
 ReadX509AsDerFromBio

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
@@ -56,6 +56,15 @@ DLLEXPORT int32_t CryptoNative_SetX509ChainVerifyTime(X509_STORE_CTX* ctx,
                                                       int32_t second,
                                                       int32_t isDst);
 
+DLLEXPORT int32_t CryptoNative_X509StoreSetVerifyTime(X509_STORE* ctx,
+                                                      int32_t year,
+                                                      int32_t month,
+                                                      int32_t day,
+                                                      int32_t hour,
+                                                      int32_t minute,
+                                                      int32_t second,
+                                                      int32_t isDst);
+
 DLLEXPORT X509* CryptoNative_ReadX509AsDerFromBio(BIO* bio);
 
 DLLEXPORT int32_t CryptoNative_BioTell(BIO* bio);

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
@@ -132,27 +132,27 @@ struct x509_st
 
 struct x509_store_ctx_st
 {
-    void* _ignored0;
+    const void* _ignored0;
     int _ignored1;
     X509* cert;
     STACK_OF(X509*) untrusted;
-    void* _ignored2;
-    void* _ignored3;
-    void* _ignored4;
+    const void* _ignored2;
+    const void* _ignored3;
+    const void* _ignored4;
     // For comparison purposes to the 1.0.x headers:
     // BEGIN FUNCTION POINTERS
-    void* _ignored5;
-    void* _ignored6;
-    void* _ignored7;
-    void* _ignored8;
-    void* _ignored9;
-    void* _ignored10;
-    void* _ignored11;
-    void* _ignored12;
-    void* _ignored13;
-    void* _ignored14;
-    void* _ignored15;
-    void* _ignored16;
+    const void* _ignored5;
+    const void* _ignored6;
+    const void* _ignored7;
+    const void* _ignored8;
+    const void* _ignored9;
+    const void* _ignored10;
+    const void* _ignored11;
+    const void* _ignored12;
+    const void* _ignored13;
+    const void* _ignored14;
+    const void* _ignored15;
+    const void* _ignored16;
     // END FUNCTION POINTERS
     int _ignored17;
     int _ignored18;

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
@@ -132,8 +132,29 @@ struct x509_st
 
 struct x509_store_ctx_st
 {
-    const void* _ignored0;
+    X509_STORE* ctx;
     int _ignored1;
     X509* cert;
     STACK_OF(X509*) untrusted;
+    void* _ignored2;
+    void* _ignored3;
+    void* _ignored4;
+    // For comparison purposes to the 1.0.x headers:
+    // BEGIN FUNCTION POINTERS
+    void* _ignored5;
+    void* _ignored6;
+    void* _ignored7;
+    void* _ignored8;
+    void* _ignored9;
+    void* _ignored10;
+    void* _ignored11;
+    void* _ignored12;
+    void* _ignored13;
+    void* _ignored14;
+    void* _ignored15;
+    void* _ignored16;
+    // END FUNCTION POINTERS
+    int _ignored17;
+    int _ignored18;
+    STACK_OF(X509*) chain;
 };

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
@@ -158,3 +158,11 @@ struct x509_store_ctx_st
     int _ignored18;
     STACK_OF(X509*) chain;
 };
+
+struct x509_store_st
+{
+    int _ignored0;
+    const void* _ignored1;
+    const void* _ignored2;
+    X509_VERIFY_PARAM* param;
+};

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
@@ -132,7 +132,7 @@ struct x509_st
 
 struct x509_store_ctx_st
 {
-    X509_STORE* ctx;
+    void* _ignored0;
     int _ignored1;
     X509* cert;
     STACK_OF(X509*) untrusted;

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
@@ -132,7 +132,7 @@ struct x509_st
 
 struct x509_store_ctx_st
 {
-    const void* _ignored0;
+    X509_STORE* ctx;
     int _ignored1;
     X509* cert;
     STACK_OF(X509*) untrusted;

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -119,6 +119,7 @@ int OPENSSL_init_ssl(uint64_t opts, const OPENSSL_INIT_SETTINGS* settings);
 void OPENSSL_sk_free(OPENSSL_STACK*);
 OPENSSL_STACK* OPENSSL_sk_new_null(void);
 int OPENSSL_sk_num(const OPENSSL_STACK*);
+void* OPENSSL_sk_pop(OPENSSL_STACK* st);
 void OPENSSL_sk_pop_free(OPENSSL_STACK* st, void (*func)(void*));
 int OPENSSL_sk_push(OPENSSL_STACK* st, const void* data);
 void* OPENSSL_sk_value(const OPENSSL_STACK*, int);
@@ -176,11 +177,15 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
 
 #define FOR_ALL_OPENSSL_FUNCTIONS \
     REQUIRED_FUNCTION(ASN1_BIT_STRING_free) \
+    REQUIRED_FUNCTION(ASN1_d2i_bio) \
+    REQUIRED_FUNCTION(ASN1_i2d_bio) \
+    REQUIRED_FUNCTION(ASN1_GENERALIZEDTIME_free) \
     REQUIRED_FUNCTION(ASN1_INTEGER_get) \
     REQUIRED_FUNCTION(ASN1_OBJECT_free) \
     REQUIRED_FUNCTION(ASN1_OCTET_STRING_free) \
     REQUIRED_FUNCTION(ASN1_OCTET_STRING_new) \
     REQUIRED_FUNCTION(ASN1_OCTET_STRING_set) \
+    REQUIRED_FUNCTION(ASN1_STRING_dup) \
     REQUIRED_FUNCTION(ASN1_STRING_free) \
     REQUIRED_FUNCTION(ASN1_STRING_print_ex) \
     REQUIRED_FUNCTION(BASIC_CONSTRAINTS_free) \
@@ -206,8 +211,10 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(d2i_ASN1_OCTET_STRING) \
     REQUIRED_FUNCTION(d2i_BASIC_CONSTRAINTS) \
     REQUIRED_FUNCTION(d2i_EXTENDED_KEY_USAGE) \
+    REQUIRED_FUNCTION(d2i_OCSP_RESPONSE) \
     REQUIRED_FUNCTION(d2i_PKCS12) \
     REQUIRED_FUNCTION(d2i_PKCS12_bio) \
+    REQUIRED_FUNCTION(d2i_PKCS12_fp) \
     REQUIRED_FUNCTION(d2i_PKCS7) \
     REQUIRED_FUNCTION(d2i_PKCS7_bio) \
     REQUIRED_FUNCTION(d2i_RSAPublicKey) \
@@ -340,6 +347,8 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(HMAC_Update) \
     REQUIRED_FUNCTION(i2d_ASN1_INTEGER) \
     REQUIRED_FUNCTION(i2d_ASN1_TYPE) \
+    REQUIRED_FUNCTION(i2d_OCSP_REQUEST) \
+    REQUIRED_FUNCTION(i2d_OCSP_RESPONSE) \
     REQUIRED_FUNCTION(i2d_PKCS12) \
     REQUIRED_FUNCTION(i2d_PKCS7) \
     REQUIRED_FUNCTION(i2d_X509) \
@@ -353,12 +362,25 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(OBJ_sn2nid) \
     REQUIRED_FUNCTION(OBJ_txt2nid) \
     REQUIRED_FUNCTION(OBJ_txt2obj) \
+    REQUIRED_FUNCTION(OCSP_BASICRESP_free) \
+    REQUIRED_FUNCTION(OCSP_basic_verify) \
+    REQUIRED_FUNCTION(OCSP_CERTID_free) \
+    REQUIRED_FUNCTION(OCSP_cert_to_id) \
+    REQUIRED_FUNCTION(OCSP_request_add0_id) \
+    REQUIRED_FUNCTION(OCSP_request_add1_nonce) \
+    REQUIRED_FUNCTION(OCSP_REQUEST_free) \
+    REQUIRED_FUNCTION(OCSP_REQUEST_new) \
+    REQUIRED_FUNCTION(OCSP_resp_find_status) \
+    REQUIRED_FUNCTION(OCSP_response_get1_basic) \
+    REQUIRED_FUNCTION(OCSP_RESPONSE_free) \
+    REQUIRED_FUNCTION(OCSP_RESPONSE_new) \
     LEGACY_FUNCTION(OPENSSL_add_all_algorithms_conf) \
     REQUIRED_FUNCTION(OPENSSL_cleanse) \
     NEW_REQUIRED_FUNCTION(OPENSSL_init_ssl) \
     RENAMED_FUNCTION(OPENSSL_sk_free, sk_free) \
     RENAMED_FUNCTION(OPENSSL_sk_new_null, sk_new_null) \
     RENAMED_FUNCTION(OPENSSL_sk_num, sk_num) \
+    RENAMED_FUNCTION(OPENSSL_sk_pop, sk_pop) \
     RENAMED_FUNCTION(OPENSSL_sk_pop_free, sk_pop_free) \
     RENAMED_FUNCTION(OPENSSL_sk_push, sk_push) \
     RENAMED_FUNCTION(OPENSSL_sk_value, sk_value) \
@@ -442,6 +464,8 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(SSL_write) \
     REQUIRED_FUNCTION(X509_check_issued) \
     REQUIRED_FUNCTION(X509_check_purpose) \
+    REQUIRED_FUNCTION(X509_cmp_current_time) \
+    REQUIRED_FUNCTION(X509_cmp_time) \
     REQUIRED_FUNCTION(X509_CRL_free) \
     FALLBACK_FUNCTION(X509_CRL_get0_nextUpdate) \
     REQUIRED_FUNCTION(X509_digest) \
@@ -478,16 +502,20 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     FALLBACK_FUNCTION(X509_NAME_get0_der) \
     REQUIRED_FUNCTION(X509_PUBKEY_get) \
     FALLBACK_FUNCTION(X509_PUBKEY_get0_param) \
+    REQUIRED_FUNCTION(X509_subject_name_hash) \
     REQUIRED_FUNCTION(X509_STORE_add_cert) \
     REQUIRED_FUNCTION(X509_STORE_add_crl) \
+    REQUIRED_FUNCTION(X509_STORE_CTX_cleanup) \
     REQUIRED_FUNCTION(X509_STORE_CTX_free) \
-    REQUIRED_FUNCTION(X509_STORE_CTX_get0_param) \
-    FALLBACK_FUNCTION(X509_STORE_CTX_get0_chain) \
-    REQUIRED_FUNCTION(X509_STORE_CTX_get1_chain) \
+    REQUIRED_FUNCTION(X509_STORE_CTX_get_current_cert) \
     REQUIRED_FUNCTION(X509_STORE_CTX_get_error) \
     REQUIRED_FUNCTION(X509_STORE_CTX_get_error_depth) \
     FALLBACK_FUNCTION(X509_STORE_CTX_get0_cert) \
+    FALLBACK_FUNCTION(X509_STORE_CTX_get0_chain) \
+    REQUIRED_FUNCTION(X509_STORE_CTX_get0_param) \
+    REQUIRED_FUNCTION(X509_STORE_CTX_get0_store) \
     FALLBACK_FUNCTION(X509_STORE_CTX_get0_untrusted) \
+    REQUIRED_FUNCTION(X509_STORE_CTX_get1_chain) \
     REQUIRED_FUNCTION(X509_STORE_CTX_init) \
     REQUIRED_FUNCTION(X509_STORE_CTX_new) \
     REQUIRED_FUNCTION(X509_STORE_CTX_set_flags) \
@@ -524,11 +552,15 @@ FOR_ALL_OPENSSL_FUNCTIONS
 // Redefine all calls to OpenSSL functions as calls through pointers that are set
 // to the functions from the libssl.so selected by the shim.
 #define ASN1_BIT_STRING_free ASN1_BIT_STRING_free_ptr
+#define ASN1_GENERALIZEDTIME_free ASN1_GENERALIZEDTIME_free_ptr
+#define ASN1_d2i_bio ASN1_d2i_bio_ptr
+#define ASN1_i2d_bio ASN1_i2d_bio_ptr
 #define ASN1_INTEGER_get ASN1_INTEGER_get_ptr
 #define ASN1_OBJECT_free ASN1_OBJECT_free_ptr
 #define ASN1_OCTET_STRING_free ASN1_OCTET_STRING_free_ptr
 #define ASN1_OCTET_STRING_new ASN1_OCTET_STRING_new_ptr
 #define ASN1_OCTET_STRING_set ASN1_OCTET_STRING_set_ptr
+#define ASN1_STRING_dup ASN1_STRING_dup_ptr
 #define ASN1_STRING_free ASN1_STRING_free_ptr
 #define ASN1_STRING_print_ex ASN1_STRING_print_ex_ptr
 #define BASIC_CONSTRAINTS_free BASIC_CONSTRAINTS_free_ptr
@@ -554,8 +586,10 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define d2i_ASN1_OCTET_STRING d2i_ASN1_OCTET_STRING_ptr
 #define d2i_BASIC_CONSTRAINTS d2i_BASIC_CONSTRAINTS_ptr
 #define d2i_EXTENDED_KEY_USAGE d2i_EXTENDED_KEY_USAGE_ptr
+#define d2i_OCSP_RESPONSE d2i_OCSP_RESPONSE_ptr
 #define d2i_PKCS12 d2i_PKCS12_ptr
 #define d2i_PKCS12_bio d2i_PKCS12_bio_ptr
+#define d2i_PKCS12_fp d2i_PKCS12_fp_ptr
 #define d2i_PKCS7 d2i_PKCS7_ptr
 #define d2i_PKCS7_bio d2i_PKCS7_bio_ptr
 #define d2i_RSAPublicKey d2i_RSAPublicKey_ptr
@@ -688,6 +722,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define HMAC_Update HMAC_Update_ptr
 #define i2d_ASN1_INTEGER i2d_ASN1_INTEGER_ptr
 #define i2d_ASN1_TYPE i2d_ASN1_TYPE_ptr
+#define i2d_OCSP_REQUEST i2d_OCSP_REQUEST_ptr
+#define i2d_OCSP_RESPONSE i2d_OCSP_RESPONSE_ptr
 #define i2d_PKCS12 i2d_PKCS12_ptr
 #define i2d_PKCS7 i2d_PKCS7_ptr
 #define i2d_X509 i2d_X509_ptr
@@ -701,12 +737,25 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define OBJ_sn2nid OBJ_sn2nid_ptr
 #define OBJ_txt2nid OBJ_txt2nid_ptr
 #define OBJ_txt2obj OBJ_txt2obj_ptr
+#define OCSP_basic_verify OCSP_basic_verify_ptr
+#define OCSP_BASICRESP_free OCSP_BASICRESP_free_ptr
+#define OCSP_cert_to_id OCSP_cert_to_id_ptr
+#define OCSP_CERTID_free OCSP_CERTID_free_ptr
+#define OCSP_request_add0_id OCSP_request_add0_id_ptr
+#define OCSP_request_add1_nonce OCSP_request_add1_nonce_ptr
+#define OCSP_REQUEST_free OCSP_REQUEST_free_ptr
+#define OCSP_REQUEST_new OCSP_REQUEST_new_ptr
+#define OCSP_resp_find_status OCSP_resp_find_status_ptr
+#define OCSP_response_get1_basic OCSP_response_get1_basic_ptr
+#define OCSP_RESPONSE_free OCSP_RESPONSE_free_ptr
+#define OCSP_RESPONSE_new OCSP_RESPONSE_new_ptr
 #define OPENSSL_add_all_algorithms_conf OPENSSL_add_all_algorithms_conf_ptr
 #define OPENSSL_cleanse OPENSSL_cleanse_ptr
 #define OPENSSL_init_ssl OPENSSL_init_ssl_ptr
 #define OPENSSL_sk_free OPENSSL_sk_free_ptr
 #define OPENSSL_sk_new_null OPENSSL_sk_new_null_ptr
 #define OPENSSL_sk_num OPENSSL_sk_num_ptr
+#define OPENSSL_sk_pop OPENSSL_sk_pop_ptr
 #define OPENSSL_sk_pop_free OPENSSL_sk_pop_free_ptr
 #define OPENSSL_sk_push OPENSSL_sk_push_ptr
 #define OPENSSL_sk_value OPENSSL_sk_value_ptr
@@ -745,6 +794,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define sk_free OPENSSL_sk_free_ptr
 #define sk_new_null OPENSSL_sk_new_null_ptr
 #define sk_num OPENSSL_sk_num_ptr
+#define sk_pop OPENSSL_sk_pop_ptr
 #define sk_pop_free OPENSSL_sk_pop_free_ptr
 #define sk_push OPENSSL_sk_push_ptr
 #define sk_value OPENSSL_sk_value_ptr
@@ -796,6 +846,8 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define TLS_method TLS_method_ptr
 #define X509_check_issued X509_check_issued_ptr
 #define X509_check_purpose X509_check_purpose_ptr
+#define X509_cmp_current_time X509_cmp_current_time_ptr
+#define X509_cmp_time X509_cmp_time_ptr
 #define X509_CRL_free X509_CRL_free_ptr
 #define X509_CRL_get0_nextUpdate X509_CRL_get0_nextUpdate_ptr
 #define X509_digest X509_digest_ptr
@@ -832,13 +884,17 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_NAME_get_index_by_NID X509_NAME_get_index_by_NID_ptr
 #define X509_PUBKEY_get0_param X509_PUBKEY_get0_param_ptr
 #define X509_PUBKEY_get X509_PUBKEY_get_ptr
+#define X509_subject_name_hash X509_subject_name_hash_ptr
 #define X509_STORE_add_cert X509_STORE_add_cert_ptr
 #define X509_STORE_add_crl X509_STORE_add_crl_ptr
+#define X509_STORE_CTX_cleanup X509_STORE_CTX_cleanup_ptr
 #define X509_STORE_CTX_free X509_STORE_CTX_free_ptr
+#define X509_STORE_CTX_get_current_cert X509_STORE_CTX_get_current_cert_ptr
 #define X509_STORE_CTX_get0_cert X509_STORE_CTX_get0_cert_ptr
-#define X509_STORE_CTX_get0_param X509_STORE_CTX_get0_param_ptr
-#define X509_STORE_CTX_get0_untrusted X509_STORE_CTX_get0_untrusted_ptr
 #define X509_STORE_CTX_get0_chain X509_STORE_CTX_get0_chain_ptr
+#define X509_STORE_CTX_get0_param X509_STORE_CTX_get0_param_ptr
+#define X509_STORE_CTX_get0_store X509_STORE_CTX_get0_store_ptr
+#define X509_STORE_CTX_get0_untrusted X509_STORE_CTX_get0_untrusted_ptr
 #define X509_STORE_CTX_get1_chain X509_STORE_CTX_get1_chain_ptr
 #define X509_STORE_CTX_get_error X509_STORE_CTX_get_error_ptr
 #define X509_STORE_CTX_get_error_depth X509_STORE_CTX_get_error_depth_ptr
@@ -879,6 +935,9 @@ FOR_ALL_OPENSSL_FUNCTIONS
 
 // type-safe OPENSSL_sk_push
 #define sk_X509_push(stack,value) OPENSSL_sk_push((OPENSSL_STACK*)(1 ? stack : (STACK_OF(X509)*)0), (const void*)(1 ? value : (X509*)0))
+
+// type-safe OPENSSL_sk_pop
+#define sk_X509_pop(stack) OPENSSL_sk_pop((OPENSSL_STACK*)(1 ? stack : (STACK_OF(X509)*)0))
 
 // type-safe OPENSSL_sk_pop_free
 #define sk_X509_pop_free(stack, freefunc) OPENSSL_sk_pop_free((OPENSSL_STACK*)(1 ? stack : (STACK_OF(X509)*)0), (OPENSSL_sk_freefunc)(1 ? freefunc : (sk_X509_freefunc)0))
@@ -941,6 +1000,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define OPENSSL_sk_free sk_free
 #define OPENSSL_sk_new_null sk_new_null
 #define OPENSSL_sk_num sk_num
+#define OPENSSL_sk_pop sk_pop
 #define OPENSSL_sk_pop_free sk_pop_free
 #define OPENSSL_sk_push sk_push
 #define OPENSSL_sk_value sk_value

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -923,6 +923,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_1_1_0_RTM
 // type-safe OPENSSL_sk_free
 #define sk_GENERAL_NAME_free(stack) OPENSSL_sk_free((OPENSSL_STACK*)(1 ? stack : (STACK_OF(GENERAL_NAME)*)0))
+#define sk_X509_free(stack) OPENSSL_sk_free((OPENSSL_STACK*)(1 ? stack : (STACK_OF(X509)*)0))
 
 // type-safe OPENSSL_sk_num
 #define sk_ASN1_OBJECT_num(stack) OPENSSL_sk_num((const OPENSSL_STACK*)(1 ? stack : (const STACK_OF(ASN1_OBJECT)*)0))

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -366,6 +366,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(OCSP_basic_verify) \
     REQUIRED_FUNCTION(OCSP_CERTID_free) \
     REQUIRED_FUNCTION(OCSP_cert_to_id) \
+    REQUIRED_FUNCTION(OCSP_check_nonce) \
     REQUIRED_FUNCTION(OCSP_request_add0_id) \
     REQUIRED_FUNCTION(OCSP_request_add1_nonce) \
     REQUIRED_FUNCTION(OCSP_REQUEST_free) \
@@ -741,6 +742,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define OCSP_basic_verify OCSP_basic_verify_ptr
 #define OCSP_BASICRESP_free OCSP_BASICRESP_free_ptr
 #define OCSP_cert_to_id OCSP_cert_to_id_ptr
+#define OCSP_check_nonce OCSP_check_nonce_ptr
 #define OCSP_CERTID_free OCSP_CERTID_free_ptr
 #define OCSP_request_add0_id OCSP_request_add0_id_ptr
 #define OCSP_request_add1_nonce OCSP_request_add1_nonce_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -142,7 +142,8 @@ int32_t X509_NAME_get0_der(X509_NAME* x509Name, const uint8_t** pder, size_t* pd
 int32_t X509_PUBKEY_get0_param(
     ASN1_OBJECT** palgOid, const uint8_t** pkeyBytes, int* pkeyBytesLen, X509_ALGOR** palg, X509_PUBKEY* pubkey);
 X509* X509_STORE_CTX_get0_cert(X509_STORE_CTX* ctx);
-STACK_OF(X509) * X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx);
+STACK_OF(X509)* X509_STORE_CTX_get0_chain(X509_STORE_CTX* ctx);
+STACK_OF(X509)* X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx);
 const ASN1_TIME* X509_get0_notAfter(const X509* x509);
 const ASN1_TIME* X509_get0_notBefore(const X509* x509);
 ASN1_BIT_STRING* X509_get0_pubkey_bitstr(const X509* x509);

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -145,6 +145,7 @@ int32_t X509_PUBKEY_get0_param(
 X509* X509_STORE_CTX_get0_cert(X509_STORE_CTX* ctx);
 STACK_OF(X509)* X509_STORE_CTX_get0_chain(X509_STORE_CTX* ctx);
 STACK_OF(X509)* X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx);
+X509_VERIFY_PARAM* X509_STORE_get0_param(X509_STORE* ctx);
 const ASN1_TIME* X509_get0_notAfter(const X509* x509);
 const ASN1_TIME* X509_get0_notBefore(const X509* x509);
 ASN1_BIT_STRING* X509_get0_pubkey_bitstr(const X509* x509);
@@ -523,6 +524,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(X509_STORE_CTX_set_flags) \
     REQUIRED_FUNCTION(X509_STORE_CTX_set_verify_cb) \
     REQUIRED_FUNCTION(X509_STORE_free) \
+    FALLBACK_FUNCTION(X509_STORE_get0_param) \
     REQUIRED_FUNCTION(X509_STORE_new) \
     REQUIRED_FUNCTION(X509_STORE_set_flags) \
     REQUIRED_FUNCTION(X509V3_EXT_print) \
@@ -907,6 +909,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_STORE_CTX_set_flags X509_STORE_CTX_set_flags_ptr
 #define X509_STORE_CTX_set_verify_cb X509_STORE_CTX_set_verify_cb_ptr
 #define X509_STORE_free X509_STORE_free_ptr
+#define X509_STORE_get0_param X509_STORE_get0_param_ptr
 #define X509_STORE_new X509_STORE_new_ptr
 #define X509_STORE_set_flags X509_STORE_set_flags_ptr
 #define X509V3_EXT_print X509V3_EXT_print_ptr
@@ -991,6 +994,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_STORE_CTX_get0_cert local_X509_STORE_CTX_get0_cert
 #define X509_STORE_CTX_get0_chain local_X509_STORE_CTX_get0_chain
 #define X509_STORE_CTX_get0_untrusted local_X509_STORE_CTX_get0_untrusted
+#define X509_STORE_get0_param local_X509_STORE_get0_param
 #define X509_get0_notAfter local_X509_get0_notAfter
 #define X509_get0_notBefore local_X509_get0_notBefore
 #define X509_get0_pubkey_bitstr local_X509_get0_pubkey_bitstr

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -481,6 +481,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(X509_get_default_cert_file) \
     REQUIRED_FUNCTION(X509_get_default_cert_file_env) \
     REQUIRED_FUNCTION(X509_get_ext) \
+    REQUIRED_FUNCTION(X509_get_ext_by_NID) \
     REQUIRED_FUNCTION(X509_get_ext_count) \
     REQUIRED_FUNCTION(X509_get_ext_d2i) \
     REQUIRED_FUNCTION(X509_get_issuer_name) \
@@ -867,6 +868,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_get_default_cert_file X509_get_default_cert_file_ptr
 #define X509_get_default_cert_file_env X509_get_default_cert_file_env_ptr
 #define X509_get_ext X509_get_ext_ptr
+#define X509_get_ext_by_NID X509_get_ext_by_NID_ptr
 #define X509_get_ext_count X509_get_ext_count_ptr
 #define X509_get_ext_d2i X509_get_ext_d2i_ptr
 #define X509_get_issuer_name X509_get_issuer_name_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -23,6 +23,7 @@
 #include <openssl/hmac.h>
 #include <openssl/md5.h>
 #include <openssl/objects.h>
+#include <openssl/ocsp.h>
 #include <openssl/pem.h>
 #include <openssl/pkcs12.h>
 #include <openssl/pkcs7.h>
@@ -480,6 +481,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(X509_STORE_add_crl) \
     REQUIRED_FUNCTION(X509_STORE_CTX_free) \
     REQUIRED_FUNCTION(X509_STORE_CTX_get0_param) \
+    FALLBACK_FUNCTION(X509_STORE_CTX_get0_chain) \
     REQUIRED_FUNCTION(X509_STORE_CTX_get1_chain) \
     REQUIRED_FUNCTION(X509_STORE_CTX_get_error) \
     REQUIRED_FUNCTION(X509_STORE_CTX_get_error_depth) \
@@ -835,6 +837,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_STORE_CTX_get0_cert X509_STORE_CTX_get0_cert_ptr
 #define X509_STORE_CTX_get0_param X509_STORE_CTX_get0_param_ptr
 #define X509_STORE_CTX_get0_untrusted X509_STORE_CTX_get0_untrusted_ptr
+#define X509_STORE_CTX_get0_chain X509_STORE_CTX_get0_chain_ptr
 #define X509_STORE_CTX_get1_chain X509_STORE_CTX_get1_chain_ptr
 #define X509_STORE_CTX_get_error X509_STORE_CTX_get_error_ptr
 #define X509_STORE_CTX_get_error_depth X509_STORE_CTX_get_error_depth_ptr
@@ -921,6 +924,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define X509_NAME_get0_der local_X509_NAME_get0_der
 #define X509_PUBKEY_get0_param local_X509_PUBKEY_get0_param
 #define X509_STORE_CTX_get0_cert local_X509_STORE_CTX_get0_cert
+#define X509_STORE_CTX_get0_chain local_X509_STORE_CTX_get0_chain
 #define X509_STORE_CTX_get0_untrusted local_X509_STORE_CTX_get0_untrusted
 #define X509_get0_notAfter local_X509_get0_notAfter
 #define X509_get0_notBefore local_X509_get0_notBefore

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -155,6 +155,10 @@ int32_t X509_get_version(const X509* x509);
 int32_t X509_up_ref(X509* x509);
 #endif
 
+#if OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_1_0_2_RTM
+X509_STORE* X509_STORE_CTX_get0_store(X509_STORE_CTX* ctx);
+#endif
+
 #if !HAVE_OPENSSL_ALPN
 #undef HAVE_OPENSSL_ALPN
 #define HAVE_OPENSSL_ALPN 1
@@ -516,7 +520,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     FALLBACK_FUNCTION(X509_STORE_CTX_get0_cert) \
     FALLBACK_FUNCTION(X509_STORE_CTX_get0_chain) \
     REQUIRED_FUNCTION(X509_STORE_CTX_get0_param) \
-    REQUIRED_FUNCTION(X509_STORE_CTX_get0_store) \
+    FALLBACK_FUNCTION(X509_STORE_CTX_get0_store) \
     FALLBACK_FUNCTION(X509_STORE_CTX_get0_untrusted) \
     REQUIRED_FUNCTION(X509_STORE_CTX_get1_chain) \
     REQUIRED_FUNCTION(X509_STORE_CTX_init) \

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.c
@@ -44,6 +44,11 @@ int32_t CryptoNative_ObjSn2Nid(const char* sn)
     return OBJ_sn2nid(sn);
 }
 
+int32_t CryptoNative_ObjTxt2Nid(const char* sn)
+{
+    return OBJ_txt2nid(sn);
+}
+
 const ASN1_OBJECT* CryptoNative_ObjNid2Obj(int32_t nid)
 {
     return OBJ_nid2obj(nid);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.h
@@ -41,6 +41,11 @@ Direct shim to OBJ_sn2nid.
 DLLEXPORT int32_t CryptoNative_ObjSn2Nid(const char* sn);
 
 /*
+Direct shim to OBJ_txt2nid.
+*/
+DLLEXPORT int32_t CryptoNative_ObjTxt2Nid(const char* sn);
+
+/*
 Direct shim to OBJ_nid2obj.
 */
 DLLEXPORT const ASN1_OBJECT* CryptoNative_ObjNid2Obj(int32_t nid);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ocsp.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ocsp.c
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_ocsp.h"
+
+
+
+void CryptoNative_OcspRequestDestroy(OCSP_REQUEST* request)
+{
+    if (request != NULL)
+    {
+        OCSP_REQUEST_free(request);
+    }
+}
+
+int32_t CryptoNative_GetOcspRequestDerSize(OCSP_REQUEST* req)
+{
+    return i2d_OCSP_REQUEST(req, NULL);
+}
+
+int32_t CryptoNative_EncodeOcspRequest(OCSP_REQUEST* req, uint8_t* buf)
+{
+    return i2d_OCSP_REQUEST(req, &buf);
+}
+
+OCSP_RESPONSE* CryptoNative_DecodeOcspResponse(const uint8_t* buf, int32_t len)
+{
+    if (buf == NULL || len == 0)
+    {
+        return NULL;
+    }
+
+    return d2i_OCSP_RESPONSE(NULL, &buf, len);
+}
+
+void CryptoNative_OcspResponseDestroy(OCSP_RESPONSE* response)
+{
+    if (response != NULL)
+    {
+        OCSP_RESPONSE_free(response);
+    }
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ocsp.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ocsp.h
@@ -6,12 +6,27 @@
 #include "pal_compiler.h"
 #include "opensslshim.h"
 
+/*
+Direct shim to OCSP_REQUEST_free
+*/
 DLLEXPORT void CryptoNative_OcspRequestDestroy(OCSP_REQUEST* request);
 
+/*
+Returns the number of bytes required to encode an OCSP_REQUEST
+*/
 DLLEXPORT int32_t CryptoNative_GetOcspRequestDerSize(OCSP_REQUEST* req);
 
+/*
+Encodes the OCSP_REQUEST req into the destination buffer, returning the number of bytes written.
+*/
 DLLEXPORT int32_t CryptoNative_EncodeOcspRequest(OCSP_REQUEST* req, uint8_t* buf);
 
+/*
+Direct shim to d2i_OCSP_RESPONSE
+*/
 DLLEXPORT OCSP_RESPONSE* CryptoNative_DecodeOcspResponse(const uint8_t* buf, int32_t len);
 
+/*
+Direct shim to OCSP_RESPONSE_free
+*/
 DLLEXPORT void CryptoNative_OcspResponseDestroy(OCSP_RESPONSE* response);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ocsp.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ocsp.h
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_crypto_types.h"
+#include "pal_compiler.h"
+#include "opensslshim.h"
+
+DLLEXPORT void CryptoNative_OcspRequestDestroy(OCSP_REQUEST* request);
+
+DLLEXPORT int32_t CryptoNative_GetOcspRequestDerSize(OCSP_REQUEST* req);
+
+DLLEXPORT int32_t CryptoNative_EncodeOcspRequest(OCSP_REQUEST* req, uint8_t* buf);
+
+DLLEXPORT OCSP_RESPONSE* CryptoNative_DecodeOcspResponse(const uint8_t* buf, int32_t len);
+
+DLLEXPORT void CryptoNative_OcspResponseDestroy(OCSP_RESPONSE* response);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <assert.h>
 #include <dirent.h>
+#include <string.h>
 #include <unistd.h>
 
 c_static_assert(PAL_X509_V_OK == X509_V_OK);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -717,12 +717,12 @@ static X509VerifyStatusCode CheckOcsp(
             {
                 if (thisUpdate != NULL && thisupd != NULL)
                 {
-                    *thisUpdate = (ASN1_GENERALIZEDTIME*)ASN1_STRING_dup((ASN1_STRING*)thisupd);
+                    *thisUpdate = ASN1_STRING_dup(thisupd);
                 }
 
                 if (nextUpdate != NULL && nextupd != NULL)
                 {
-                    *nextUpdate = (ASN1_GENERALIZEDTIME*)ASN1_STRING_dup((ASN1_STRING*)nextupd);
+                    *nextUpdate = ASN1_STRING_dup(nextupd);
                 }
 
                 if (status == V_OCSP_CERTSTATUS_GOOD)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -167,6 +167,30 @@ int32_t CryptoNative_X509ExtensionGetCritical(X509_EXTENSION* x)
     return X509_EXTENSION_get_critical(x);
 }
 
+ASN1_OCTET_STRING* CryptoNative_X509FindExtensionData(X509* x, int32_t nid)
+{
+    if (x == NULL || nid == NID_undef)
+    {
+        return NULL;
+    }
+
+    int idx = X509_get_ext_by_NID(x, nid, -1);
+
+    if (idx < 0)
+    {
+        return NULL;
+    }
+
+    X509_EXTENSION* ext = X509_get_ext(x, idx);
+
+    if (ext == NULL)
+    {
+        return NULL;
+    }
+
+    return X509_EXTENSION_get_data(ext);
+}
+
 X509_STORE* CryptoNative_X509StoreCreate()
 {
     return X509_STORE_new();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -471,7 +471,7 @@ X509_STORE* CryptoNative_X509ChainNew(X509Stack* systemTrust, const char* userTr
         if (trustDir != NULL)
         {
             X509* cert;
-            X509Stack* tmpStack = sk_X509_new(NULL);
+            X509Stack* tmpStack = sk_X509_new_null();
 
             while ((cert = ReadNextPublicCert(trustDir, tmpStack, pathTmp, nextFileWrite)) != NULL)
             {
@@ -528,7 +528,7 @@ int32_t CryptoNative_X509StackAddDirectoryStore(X509Stack* stack, char* storePat
     if (storeDir != NULL)
     {
         X509* cert;
-        X509Stack* tmpStack = sk_X509_new(NULL);
+        X509Stack* tmpStack = sk_X509_new_null();
 
         while ((cert = ReadNextPublicCert(storeDir, tmpStack, pathTmp, nextFileWrite)) != NULL)
         {

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -313,6 +313,16 @@ int32_t CryptoNative_X509StoreCtxReset(X509_STORE_CTX* ctx)
     return CryptoNative_X509StoreCtxInit(ctx, store, leaf, untrusted);
 }
 
+int32_t CryptoNative_X509StoreCtxRebuildChain(X509_STORE_CTX* ctx)
+{
+    if (!CryptoNative_X509StoreCtxReset(ctx))
+    {
+        return -1;
+    }
+
+    return X509_verify_cert(ctx);
+}
+
 void CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback)
 {
     X509_STORE_CTX_set_verify_cb(ctx, callback);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -189,6 +189,11 @@ Shims the X509_EXTENSION_get_critical method.
 DLLEXPORT int32_t CryptoNative_X509ExtensionGetCritical(X509_EXTENSION* x);
 
 /*
+Returns the data portion of the first matched extension.
+*/
+DLLEXPORT ASN1_OCTET_STRING* CryptoNative_X509FindExtensionData(X509* x, int32_t nid);
+
+/*
 Shims the X509_STORE_new method.
 */
 DLLEXPORT X509_STORE* CryptoNative_X509StoreCreate(void);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -245,6 +245,9 @@ Shims the X509_STORE_CTX_get1_chain method.
 */
 DLLEXPORT X509Stack* CryptoNative_X509StoreCtxGetChain(X509_STORE_CTX* ctx);
 
+/*
+Shims the X509_STORE_CTX_get_current_cert function.
+*/
 DLLEXPORT X509* CryptoNative_X509StoreCtxGetCurrentCert(X509_STORE_CTX* ctx);
 
 /*
@@ -262,6 +265,10 @@ Shims the X509_STORE_CTX_get_error method.
 */
 DLLEXPORT X509VerifyStatusCode CryptoNative_X509StoreCtxGetError(X509_STORE_CTX* ctx);
 
+/*
+Resets ctx to before the chain was built, preserving the target cert, trust store, extra cert context,
+and verify parameters.
+*/
 DLLEXPORT int32_t CryptoNative_X509StoreCtxReset(X509_STORE_CTX* ctx);
 
 /*
@@ -327,14 +334,36 @@ in userTrustPath to be trusted
 */
 DLLEXPORT X509_STORE* CryptoNative_X509ChainNew(X509Stack* systemTrust, const char* userTrustPath);
 
+/*
+Adds all of the simple certificates from null-or-empty-password PFX files in storePath to stack.
+*/
 DLLEXPORT int32_t CryptoNative_X509StackAddDirectoryStore(X509Stack* stack, char* storePath);
 
+/*
+Adds all of the certificates in src to dest and increases their reference count.
+*/
 DLLEXPORT int32_t CryptoNative_X509StackAddMultiple(X509Stack* dest, X509Stack* src);
 
+/*
+Removes any untrusted/extra certificates from the unstrusted collection that are not part of
+the current chain to make chain builds after Reset faster.
+*/
 DLLEXPORT int32_t CryptoNative_X509StoreCtxCommitToChain(X509_STORE_CTX* storeCtx);
 
+/*
+Look for a cached OCSP response appropriate to the end-entity certificate using the issuer as
+determined by the chain in storeCtx.
+*/
 DLLEXPORT X509VerifyStatusCode CryptoNative_X509ChainGetCachedOcspStatus(X509_STORE_CTX* storeCtx, char* cachePath);
 
+/*
+Build an OCSP request appropriate for the end-entity certificate using the issuer (and trust) as
+determined by the chain in storeCtx.
+*/
 DLLEXPORT OCSP_REQUEST* CryptoNative_X509ChainBuildOcspRequest(X509_STORE_CTX* storeCtx);
 
+/*
+Determine if the OCSP response is acceptable, and if acceptable report the status and
+cache the result (if appropriate)
+*/
 DLLEXPORT X509VerifyStatusCode CryptoNative_X509ChainVerifyOcsp(X509_STORE_CTX* storeCtx, OCSP_REQUEST* req, OCSP_RESPONSE* resp, char* cachePath);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -240,6 +240,8 @@ Shims the X509_STORE_CTX_get1_chain method.
 */
 DLLEXPORT X509Stack* CryptoNative_X509StoreCtxGetChain(X509_STORE_CTX* ctx);
 
+DLLEXPORT X509* CryptoNative_X509StoreCtxGetCurrentCert(X509_STORE_CTX* ctx);
+
 /*
 Returns the interior pointer to the "untrusted" certificates collection for this X509_STORE_CTX
 */
@@ -254,6 +256,8 @@ DLLEXPORT X509* CryptoNative_X509StoreCtxGetTargetCert(X509_STORE_CTX* ctx);
 Shims the X509_STORE_CTX_get_error method.
 */
 DLLEXPORT X509VerifyStatusCode CryptoNative_X509StoreCtxGetError(X509_STORE_CTX* ctx);
+
+DLLEXPORT int32_t CryptoNative_X509StoreCtxReset(X509_STORE_CTX* ctx);
 
 /*
 Shims the X509_STORE_CTX_get_error_depth method.
@@ -311,3 +315,15 @@ Unlike X509Duplicate, this modifies an existing object, so no new memory is allo
 Returns the input value.
 */
 DLLEXPORT X509* CryptoNative_X509UpRef(X509* x509);
+
+/*
+Create a new X509_STORE, considering the certificates from systemTrust and any readable PFX
+in userTrustPath to be trusted
+*/
+DLLEXPORT X509_STORE* CryptoNative_X509ChainNew(X509Stack* systemTrust, const char* userTrustPath);
+
+DLLEXPORT int32_t CryptoNative_X509StackAddDirectoryStore(X509Stack* stack, char* storePath);
+
+DLLEXPORT int32_t CryptoNative_X509StackAddMultiple(X509Stack* dest, X509Stack* src);
+
+DLLEXPORT int32_t CryptoNative_X509StoreCtxCommitToChain(X509_STORE_CTX* storeCtx);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -272,6 +272,13 @@ and verify parameters.
 DLLEXPORT int32_t CryptoNative_X509StoreCtxReset(X509_STORE_CTX* ctx);
 
 /*
+Reset ctx and rebuild the chain.
+Returns -1 if CryptoNative_X509StoreCtxReset failed, otherwise returns the result of
+X509_verify_cert.
+*/
+DLLEXPORT int32_t CryptoNative_X509StoreCtxRebuildChain(X509_STORE_CTX* ctx);
+
+/*
 Shims the X509_STORE_CTX_get_error_depth method.
 */
 DLLEXPORT int32_t CryptoNative_X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -327,3 +327,9 @@ DLLEXPORT int32_t CryptoNative_X509StackAddDirectoryStore(X509Stack* stack, char
 DLLEXPORT int32_t CryptoNative_X509StackAddMultiple(X509Stack* dest, X509Stack* src);
 
 DLLEXPORT int32_t CryptoNative_X509StoreCtxCommitToChain(X509_STORE_CTX* storeCtx);
+
+DLLEXPORT X509VerifyStatusCode CryptoNative_X509ChainGetCachedOcspStatus(X509_STORE_CTX* storeCtx, char* cachePath);
+
+DLLEXPORT OCSP_REQUEST* CryptoNative_X509ChainBuildOcspRequest(X509_STORE_CTX* storeCtx);
+
+DLLEXPORT X509VerifyStatusCode CryptoNative_X509ChainVerifyOcsp(X509_STORE_CTX* storeCtx, OCSP_REQUEST* req, OCSP_RESPONSE* resp, char* cachePath);

--- a/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
+++ b/src/System.Net.Http/src/System/Net/Http/CurlHandler/CurlHandler.SslProvider.Linux.cs
@@ -378,14 +378,10 @@ namespace System.Net.Http
                         // If it succeeds in verifying the cert chain, we're done. Employing this instead of 
                         // our custom implementation will need to be revisited if we ever decide to introduce a 
                         // "disallowed" store that enables users to "untrust" certs the system trusts.
-                        int sslResult = Interop.Crypto.X509VerifyCert(storeCtx);
-                        if (sslResult == 1)
+                        if (Interop.Crypto.X509VerifyCert(storeCtx))
                         {
                             return true;
                         }
-
-                        // X509_verify_cert can return < 0 in the case of programmer error
-                        Debug.Assert(sslResult == 0, "Unexpected error from X509_verify_cert: " + sslResult);
                     }
 
                     // Either OpenSSL verification failed, or there was a server validation callback

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -87,8 +87,15 @@ namespace Internal.Cryptography.Pal
                 revocationMode = X509RevocationMode.Offline;
             }
 
-            chainPal.CommitToChain();
-            chainPal.ProcessRevocation(revocationMode, revocationFlag);
+            // In NoCheck+OK then we don't need to build the chain any more, we already
+            // know it's error-free.  So skip straight to finish.
+            if (status != Interop.Crypto.X509VerifyStatusCode.X509_V_OK ||
+                revocationMode != X509RevocationMode.NoCheck)
+            {
+                chainPal.CommitToChain();
+                chainPal.ProcessRevocation(revocationMode, revocationFlag);
+            }
+
             chainPal.Finish(applicationPolicy, certificatePolicy);
 
 #if DEBUG

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
@@ -16,6 +16,16 @@ namespace Internal.Cryptography.Pal
 {
     internal static class CrlCache
     {
+        private static readonly string s_crlDir =
+            PersistedFiles.GetUserFeatureDirectory(
+                X509Persistence.CryptographyFeatureName,
+                X509Persistence.CrlsSubFeatureName);
+
+        private static readonly string s_ocspDir =
+            PersistedFiles.GetUserFeatureDirectory(
+                X509Persistence.CryptographyFeatureName,
+                X509Persistence.OcspSubFeatureName);
+
         private const ulong X509_R_CERT_ALREADY_IN_HASH_TABLE = 0x0B07D065;
 
         public static void AddCrlForCertificate(
@@ -161,13 +171,14 @@ namespace Internal.Cryptography.Pal
                 }
             }
         }
-        
+
+        internal static string GetCachedOcspResponseDirectory()
+        {
+            return s_ocspDir;
+        }
+
         private static string GetCachedCrlPath(SafeX509Handle cert, bool mkDir=false)
         {
-            string crlDir = PersistedFiles.GetUserFeatureDirectory(
-                X509Persistence.CryptographyFeatureName,
-                X509Persistence.CrlsSubFeatureName);
-
             // X509_issuer_name_hash returns "unsigned long", which is marshalled as ulong.
             // But it only sets 32 bits worth of data, so force it down to uint just... in case.
             ulong persistentHashLong = Interop.Crypto.X509IssuerNameHash(cert);
@@ -184,10 +195,10 @@ namespace Internal.Cryptography.Pal
 
             if (mkDir)
             {
-                Directory.CreateDirectory(crlDir);
+                Directory.CreateDirectory(s_crlDir);
             }
 
-            return Path.Combine(crlDir, localFileName);
+            return Path.Combine(s_crlDir, localFileName);
         }
 
         private static string GetCdpUrl(SafeX509Handle cert)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography;
@@ -18,7 +19,7 @@ namespace Internal.Cryptography.Pal
         private const ulong X509_R_CERT_ALREADY_IN_HASH_TABLE = 0x0B07D065;
 
         public static void AddCrlForCertificate(
-            X509Certificate2 cert,
+            SafeX509Handle cert,
             SafeX509StoreHandle store,
             X509RevocationMode revocationMode,
             DateTime verificationTime,
@@ -46,7 +47,7 @@ namespace Internal.Cryptography.Pal
             DownloadAndAddCrl(cert, store, ref remainingDownloadTime);
         }
 
-        private static bool AddCachedCrl(X509Certificate2 cert, SafeX509StoreHandle store, DateTime verificationTime)
+        private static bool AddCachedCrl(SafeX509Handle cert, SafeX509StoreHandle store, DateTime verificationTime)
         {
             string crlFile = GetCachedCrlPath(cert);
 
@@ -108,7 +109,7 @@ namespace Internal.Cryptography.Pal
         }
 
         private static void DownloadAndAddCrl(
-            X509Certificate2 cert,
+            SafeX509Handle cert,
             SafeX509StoreHandle store,
             ref TimeSpan remainingDownloadTime)
         {
@@ -161,17 +162,15 @@ namespace Internal.Cryptography.Pal
             }
         }
         
-        private static string GetCachedCrlPath(X509Certificate2 cert, bool mkDir=false)
+        private static string GetCachedCrlPath(SafeX509Handle cert, bool mkDir=false)
         {
-            OpenSslX509CertificateReader pal = (OpenSslX509CertificateReader)cert.Pal;
-
             string crlDir = PersistedFiles.GetUserFeatureDirectory(
                 X509Persistence.CryptographyFeatureName,
                 X509Persistence.CrlsSubFeatureName);
 
             // X509_issuer_name_hash returns "unsigned long", which is marshalled as ulong.
             // But it only sets 32 bits worth of data, so force it down to uint just... in case.
-            ulong persistentHashLong = Interop.Crypto.X509IssuerNameHash(pal.SafeHandle);
+            ulong persistentHashLong = Interop.Crypto.X509IssuerNameHash(cert);
             if (persistentHashLong == 0)
             {
                 Interop.Crypto.ErrClearError();
@@ -191,52 +190,49 @@ namespace Internal.Cryptography.Pal
             return Path.Combine(crlDir, localFileName);
         }
 
-        private static string GetCdpUrl(X509Certificate2 cert)
+        private static string GetCdpUrl(SafeX509Handle cert)
         {
-            byte[] crlDistributionPoints = null;
+            ArraySegment<byte> crlDistributionPoints =
+                OpenSslX509CertificateReader.FindFirstExtension(cert, Oids.CrlDistributionPoints);
 
-            foreach (X509Extension extension in cert.Extensions)
-            {
-                if (StringComparer.Ordinal.Equals(extension.Oid.Value, Oids.CrlDistributionPoints))
-                {
-                    // If there's an Authority Information Access extension, it might be used for
-                    // looking up additional certificates for the chain.
-                    crlDistributionPoints = extension.RawData;
-                    break;
-                }
-            }
-
-            if (crlDistributionPoints == null)
+            if (crlDistributionPoints.Array == null)
             {
                 return null;
             }
 
-            AsnReader reader = new AsnReader(crlDistributionPoints, AsnEncodingRules.DER);
-            AsnReader sequenceReader = reader.ReadSequence();
-            reader.ThrowIfNotEmpty();
-
-            while (sequenceReader.HasData)
+            try
             {
-                DistributionPointAsn.Decode(sequenceReader, out DistributionPointAsn distributionPoint);
+                AsnReader reader = new AsnReader(crlDistributionPoints, AsnEncodingRules.DER);
+                AsnReader sequenceReader = reader.ReadSequence();
+                reader.ThrowIfNotEmpty();
 
-                // Only distributionPoint is supported
-                // Only fullName is supported, nameRelativeToCRLIssuer is for LDAP-based lookup.
-                if (distributionPoint.DistributionPoint.HasValue &&
-                    distributionPoint.DistributionPoint.Value.FullName != null)
+                while (sequenceReader.HasData)
                 {
-                    foreach (GeneralNameAsn name in distributionPoint.DistributionPoint.Value.FullName)
+                    DistributionPointAsn.Decode(sequenceReader, out DistributionPointAsn distributionPoint);
+
+                    // Only distributionPoint is supported
+                    // Only fullName is supported, nameRelativeToCRLIssuer is for LDAP-based lookup.
+                    if (distributionPoint.DistributionPoint.HasValue &&
+                        distributionPoint.DistributionPoint.Value.FullName != null)
                     {
-                        if (name.Uri != null &&
-                            Uri.TryCreate(name.Uri, UriKind.Absolute, out Uri uri) &&
-                            uri.Scheme == "http")
+                        foreach (GeneralNameAsn name in distributionPoint.DistributionPoint.Value.FullName)
                         {
-                            return name.Uri;
+                            if (name.Uri != null &&
+                                Uri.TryCreate(name.Uri, UriKind.Absolute, out Uri uri) &&
+                                uri.Scheme == "http")
+                            {
+                                return name.Uri;
+                            }
                         }
                     }
                 }
-            }
 
-            return null;
+                return null;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(crlDistributionPoints.Array);
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -292,7 +292,7 @@ namespace Internal.Cryptography.Pal
             throw new CryptographicException(SR.Cryptography_X509_StoreNoFileAvailable);
         }
 
-        private static string GetStorePath(string storeName)
+        internal static string GetStorePath(string storeName)
         {
             string directoryName = GetDirectoryName(storeName);
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -442,6 +442,32 @@ namespace Internal.Cryptography.Pal
             }
         }
 
+        internal static ArraySegment<byte> FindFirstExtension(SafeX509Handle cert, string oidValue)
+        {
+            int extensionCount = Interop.Crypto.X509GetExtCount(cert);
+
+            for (int i = 0; i < extensionCount; i++)
+            {
+                IntPtr ext = Interop.Crypto.X509GetExt(cert, i);
+                Interop.Crypto.CheckValidOpenSslHandle(ext);
+
+                IntPtr oidPtr = Interop.Crypto.X509ExtensionGetOid(ext);
+                Interop.Crypto.CheckValidOpenSslHandle(oidPtr);
+
+                string extOidValue = Interop.Crypto.GetOidValue(oidPtr);
+
+                if (oidValue == extOidValue)
+                {
+                    IntPtr dataPtr = Interop.Crypto.X509ExtensionGetData(ext);
+                    Interop.Crypto.CheckValidOpenSslHandle(dataPtr);
+
+                    return Interop.Crypto.RentAsn1StringBytes(dataPtr);
+                }
+            }
+
+            return default;
+        }
+
         internal void SetPrivateKey(SafeEvpPKeyHandle privateKey)
         {
             _privateKey = privateKey;

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -870,7 +870,7 @@ namespace Internal.Cryptography.Pal
         {
             private ErrorCollection[] _errors;
 
-            internal int LastError => _errors.Length;
+            internal int LastError => _errors?.Length ?? 0;
 
             internal ref ErrorCollection this[int idx] => ref _errors[idx];
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -99,6 +99,7 @@ namespace Internal.Cryptography.Pal
                 Interop.Crypto.X509StackAddDirectoryStore(untrusted, s_userIntermediatePath);
                 Interop.Crypto.X509StackAddDirectoryStore(untrusted, s_userPersonalPath);
                 Interop.Crypto.X509StackAddMultiple(untrusted, systemIntermediate);
+                Interop.Crypto.X509StoreSetVerifyTime(store, verificationTime);
 
                 storeCtx = Interop.Crypto.X509StoreCtxCreate();
 
@@ -106,8 +107,6 @@ namespace Internal.Cryptography.Pal
                 {
                     throw Interop.Crypto.CreateOpenSslCryptographicException();
                 }
-
-                Interop.Crypto.SetX509ChainVerifyTime(storeCtx, verificationTime);
 
                 return new OpenSslX509ChainProcessor(
                     leafHandle,
@@ -149,8 +148,6 @@ namespace Internal.Cryptography.Pal
                 }
 
                 Interop.Crypto.X509StoreCtxReset(storeCtx);
-                Interop.Crypto.SetX509ChainVerifyTime(storeCtx, _verificationTime);
-
                 Interop.Crypto.X509VerifyCert(storeCtx);
                 statusCode = Interop.Crypto.X509StoreCtxGetError(storeCtx);
             }
@@ -224,7 +221,6 @@ namespace Internal.Cryptography.Pal
                     downloadedCerts.Add(downloaded);
                     
                     Interop.Crypto.X509StoreCtxReset(storeCtx);
-                    Interop.Crypto.SetX509ChainVerifyTime(storeCtx, _verificationTime);
                     Interop.Crypto.X509VerifyCert(storeCtx);
 
                     statusCode = Interop.Crypto.X509StoreCtxGetError(storeCtx);
@@ -322,7 +318,6 @@ namespace Internal.Cryptography.Pal
 
             Interop.Crypto.X509StoreSetRevocationFlag(_store, revocationFlag);
             Interop.Crypto.X509StoreCtxReset(_storeCtx);
-            Interop.Crypto.SetX509ChainVerifyTime(_storeCtx, _verificationTime);
             Interop.Crypto.X509VerifyCert(_storeCtx);
         }
 
@@ -336,7 +331,6 @@ namespace Internal.Cryptography.Pal
                 Interop.Crypto.X509VerifyStatusCode.X509_V_OK)
             {
                 Interop.Crypto.X509StoreCtxReset(_storeCtx);
-                Interop.Crypto.SetX509ChainVerifyTime(_storeCtx, _verificationTime);
 
                 workingChain = new WorkingChain();
                 Interop.Crypto.X509StoreVerifyCallback workingCallback = workingChain.VerifyCallback;

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -147,8 +147,7 @@ namespace Internal.Cryptography.Pal
                     AddToStackAndUpRef(((OpenSslX509CertificateReader)cert.Pal).SafeHandle, untrusted);
                 }
 
-                Interop.Crypto.X509StoreCtxReset(storeCtx);
-                Interop.Crypto.X509VerifyCert(storeCtx);
+                Interop.Crypto.X509StoreCtxRebuildChain(storeCtx);
                 statusCode = Interop.Crypto.X509StoreCtxGetError(storeCtx);
             }
 
@@ -220,9 +219,7 @@ namespace Internal.Cryptography.Pal
                     AddToStackAndUpRef(downloaded.Handle, _untrustedLookup);
                     downloadedCerts.Add(downloaded);
                     
-                    Interop.Crypto.X509StoreCtxReset(storeCtx);
-                    Interop.Crypto.X509VerifyCert(storeCtx);
-
+                    Interop.Crypto.X509StoreCtxRebuildChain(storeCtx);
                     statusCode = Interop.Crypto.X509StoreCtxGetError(storeCtx);
                 }
             }
@@ -317,8 +314,7 @@ namespace Internal.Cryptography.Pal
             }
 
             Interop.Crypto.X509StoreSetRevocationFlag(_store, revocationFlag);
-            Interop.Crypto.X509StoreCtxReset(_storeCtx);
-            Interop.Crypto.X509VerifyCert(_storeCtx);
+            Interop.Crypto.X509StoreCtxRebuildChain(_storeCtx);
         }
 
         internal void Finish(OidCollection applicationPolicy, OidCollection certificatePolicy)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -140,6 +140,22 @@ namespace Internal.Cryptography.Pal
             return new ExportProvider(certificates);
         }
 
+        internal static CollectionBackedStoreProvider GetMachineRoot()
+        {
+            return (CollectionBackedStoreProvider)FromSystemStore(
+                X509Store.RootStoreName,
+                StoreLocation.LocalMachine,
+                OpenFlags.ReadOnly);
+        }
+
+        internal static CollectionBackedStoreProvider GetMachineIntermediate()
+        {
+            return (CollectionBackedStoreProvider)FromSystemStore(
+                X509Store.IntermediateCAStoreName,
+                StoreLocation.LocalMachine,
+                OpenFlags.ReadOnly);
+        }
+
         public static IStorePal FromSystemStore(string storeName, StoreLocation storeLocation, OpenFlags openFlags)
         {
             if (storeLocation == StoreLocation.CurrentUser)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X509Persistence.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X509Persistence.cs
@@ -9,5 +9,6 @@ namespace Internal.Cryptography.Pal
         internal const string CryptographyFeatureName = "cryptography";
         internal const string X509StoresSubFeatureName = "x509stores";
         internal const string CrlsSubFeatureName = "crls";
+        internal const string OcspSubFeatureName = "ocsp";
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -348,6 +348,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.GetIntegerBytes.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.GetIntegerBytes.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Nid.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.Nid.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Bignum.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Bignum.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -363,6 +363,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.OCSP.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OCSP.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Pkcs12.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Pkcs12.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Store.cs
@@ -13,6 +13,7 @@ namespace System.Security.Cryptography.X509Certificates
         internal const string RootStoreName = "Root";
         internal const string IntermediateCAStoreName = "CA";
         internal const string DisallowedStoreName = "Disallowed";
+        internal const string MyStoreName = "My";
 
         private IStorePal _storePal;
 
@@ -56,7 +57,7 @@ namespace System.Security.Cryptography.X509Certificates
                     Name = DisallowedStoreName;
                     break;
                 case StoreName.My:
-                    Name = "My";
+                    Name = MyStoreName;
                     break;
                 case StoreName.Root:
                     Name = RootStoreName;

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -559,6 +559,19 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                     for (int j = 0; j < onlineChain.ChainElements.Count; j++)
                     {
+                        X509ChainStatusFlags chainFlags = onlineChain.ChainStatus.Aggregate(
+                            X509ChainStatusFlags.NoError,
+                            (cur, status) => cur | status.Status);
+
+                        const X509ChainStatusFlags WontCheck =
+                            X509ChainStatusFlags.RevocationStatusUnknown | X509ChainStatusFlags.UntrustedRoot;
+
+                        if (chainFlags == WontCheck)
+                        {
+                            Console.WriteLine($"{nameof(VerifyWithRevocation)}: online chain failed with {{{chainFlags}}}, skipping");
+                            return;
+                        }
+
                         X509ChainElement chainElement = onlineChain.ChainElements[j];
 
                         // Since `NoError` gets mapped as the empty array, just look for non-empty arrays


### PR DESCRIPTION
The primary motivator for this change is to enable support for validating certificates with the On-line Certificate Status Protocol (OCSP) in addition to Certificate Revocation Lists (CRLs).

OCSP requests can't be done speculatively, as the issuer public key is used as part of the request payload; so the chain building can't just be done as a big data dump.

While tinkering with the chain building, move a lot of the processing to the native side to cut down on the number of P/Invokes that are required.  In particular, loading CurrentUser\My no longer has 3 P/Invokes per entry (File.Open, interpret the contents, add to the chain build context), but just one call for the whole store (the fopen/interpret/add are all done in the same iterated function).

Additionally, move some allocating things to rent from the array pool, or do one-time lookups and save the result in statics.

Fixes #3034.