### PR TITLE
Updating timeout in `SslStream_SameCertUsedForClientAndServer_Ok` test

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamCredentialCacheTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamCredentialCacheTest.cs
@@ -39,7 +39,7 @@ namespace System.Net.Security.Tests
                                             clientCertificateCollection, false);
 
 
-                await Task.WhenAll(tasks).TimeoutAfter(15 * 1000);
+                await Task.WhenAll(tasks).TimeoutAfter(TestConfiguration.PassingTestTimeoutMilliseconds);
 
                 if (!PlatformDetection.IsWindows7 ||
                     Capability.IsTrustedRootCertificateInstalled())


### PR DESCRIPTION
Updating timeout in `SslStream_SameCertUsedForClientAndServer_Ok` to match the rest of the tests in the area.

All other passing tests standardise on `TestConfiguration.PassingTestTimeoutMilliseconds`

There seems to be no reasons for `SslStream_SameCertUsedForClientAndServer_Ok` to use a hardcoded timeout.
Also the timeout is significantly shorter and occasionally leads to failures on low-spec test VMs.