### PR TITLE
Remove old TestCategories property

### DIFF
--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{C72FD34C-539A-4447-9796-62A229571199}</ProjectGuid>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
     <CoverageSupported>false</CoverageSupported>

--- a/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{7669C397-C21C-4C08-83F1-BE6691911E88}</ProjectGuid>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <!-- XUnit AppDomains BaseDirectory path doesn't contain a trailing slash, which impacts our tests. -->
     <XUnitNoAppdomain>true</XUnitNoAppdomain>
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>

--- a/src/System.Data.DataSetExtensions/tests/System.Data.DataSetExtensions.Tests.csproj
+++ b/src/System.Data.DataSetExtensions/tests/System.Data.DataSetExtensions.Tests.csproj
@@ -3,7 +3,6 @@
     <!-- Tests crash when running in ret mode, [ActiveIssue(23407)] -->
     <ILCBuildType>chk</ILCBuildType>
     <ProjectGuid>{2B38992F-9979-485F-B104-38C476D0B706}</ProjectGuid>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Drawing.Common/tests/Performance/System.Drawing.Common.PerformanceTests.csproj
+++ b/src/System.Drawing.Common/tests/Performance/System.Drawing.Common.PerformanceTests.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <ProjectGuid>{E66FFA55-0975-4F0D-8A18-24B2687FEDEA}</ProjectGuid>
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>

--- a/src/System.Drawing.Primitives/tests/Performance/System.Drawing.Primitives.PerformanceTests.csproj
+++ b/src/System.Drawing.Primitives/tests/Performance/System.Drawing.Primitives.PerformanceTests.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <ProjectGuid>{1BD5C9BF-D7F2-4249-AA31-43B1850A5DB3}</ProjectGuid>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>

--- a/src/System.IO.FileSystem/tests/Performance/System.IO.FileSystem.PerformanceTests.csproj
+++ b/src/System.IO.FileSystem/tests/Performance/System.IO.FileSystem.PerformanceTests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <ProjectGuid>{3C42F714-82AF-4A43-9B9C-744DE31B5C5D}</ProjectGuid>
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{F0D49126-6A1C-42D5-9428-4374C868BAF8}</ProjectGuid>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netstandard-Unix-Debug;netstandard-Unix-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>

--- a/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
+++ b/src/System.IO.IsolatedStorage/tests/System.IO.IsolatedStorage.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{BF4F9507-8FBD-45EA-81C9-3ED89C052C91}</ProjectGuid>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netstandard-Unix-Debug;netstandard-Unix-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">

--- a/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
+++ b/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{4259DCE9-3480-40BB-B08A-64A2D446264B}</ProjectGuid>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <Configurations>netfx-Debug;netfx-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->

--- a/src/System.IO/tests/Performance/System.IO.PerformanceTests.csproj
+++ b/src/System.IO/tests/Performance/System.IO.PerformanceTests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <ProjectGuid>{66AE57BA-B56C-4A1E-ACA6-7C18431D416B}</ProjectGuid>
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>

--- a/src/System.Runtime.WindowsRuntime/tests/System.Runtime.WindowsRuntime.Tests.csproj
+++ b/src/System.Runtime.WindowsRuntime/tests/System.Runtime.WindowsRuntime.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{C4854B44-ABFE-4BB5-8F89-F35FE6201338}</ProjectGuid>
-    <TestCategories>InnerLoop;OuterLoop</TestCategories>
     <Configurations>uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
     <TestRuntime>true</TestRuntime>
   </PropertyGroup>


### PR DESCRIPTION
We still have some TestCategories properties in our test projects which haven't been used for more than two years. Related https://github.com/dotnet/corefx/pull/1449

Clean.it.up.