### PR TITLE
Use Environment.TickCount instead of DateTime{Offset}.UtcNow in SocketsHttpHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1657,7 +1657,7 @@ namespace System.Net.Http
 
         private static void ThrowInvalidHttpResponse(Exception innerException) => throw new HttpRequestException(SR.net_http_invalid_response, innerException);
 
-        internal override void Trace(string message, [CallerMemberName] string memberName = null) =>
+        internal sealed override void Trace(string message, [CallerMemberName] string memberName = null) =>
             NetEventSource.Log.HandlerMessage(
                 _pool?.GetHashCode() ?? 0,    // pool ID
                 GetHashCode(),                // connection ID

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -288,7 +288,7 @@ namespace System.Net.Http
         {
             // Clone the settings to get a relatively consistent view that won't change after this point.
             // (This isn't entirely complete, as some of the collections it contains aren't currently deeply cloned.)
-            HttpConnectionSettings settings = _settings.Clone();
+            HttpConnectionSettings settings = _settings.CloneAndNormalize();
 
             HttpConnectionPoolManager poolManager = new HttpConnectionPoolManager(settings);
 


### PR DESCRIPTION
We don't need the accuracy of UtcNow nor the absolute time when getting a time stamp in order to determine whether a connection should be retired; rather, we only need an approximate difference in time.  This means the resolution of TickCount is fine, and the worst that happens if a connection happens to be alive for more than its ~49 day period is we may allow the connection to then live even longer than we otherwise would.  In exchange, we get a much cheaper mechanism (~20x on Windows) mechanism for computing the connection age.

cc: @geoffkizer 