### PR TITLE
Simplify ConnectHelper.ConnectAsync to just return Stream

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -139,6 +139,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\CreditManager.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\DecompressionHandler.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\EmptyReadStream.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\ExposedSocketNetworkStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2Connection.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2Stream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpAuthenticatedConnectionHandler.cs" />

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -77,7 +77,7 @@ namespace System.Net.Http
                 // Configure the socket and return a stream for it.
                 Socket socket = saea.ConnectSocket;
                 socket.NoDelay = true;
-                return new NetworkStream(socket, ownsSocket: true);
+                return new ExposedSocketNetworkStream(socket, ownsSocket: true);
             }
             catch (Exception error)
             {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -38,7 +38,7 @@ namespace System.Net.Http
             }
         }
 
-        public static async ValueTask<(Socket, Stream)> ConnectAsync(string host, int port, CancellationToken cancellationToken)
+        public static async ValueTask<Stream> ConnectAsync(string host, int port, CancellationToken cancellationToken)
         {
             // Rather than creating a new Socket and calling ConnectAsync on it, we use the static
             // Socket.ConnectAsync with a SocketAsyncEventArgs, as we can then use Socket.CancelConnectAsync
@@ -77,7 +77,7 @@ namespace System.Net.Http
                 // Configure the socket and return a stream for it.
                 Socket socket = saea.ConnectSocket;
                 socket.NoDelay = true;
-                return (socket, new NetworkStream(socket, ownsSocket: true));
+                return new NetworkStream(socket, ownsSocket: true);
             }
             catch (Exception error)
             {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ExposedSocketNetworkStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ExposedSocketNetworkStream.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Sockets
+{
+    // TODO: Delete once https://github.com/dotnet/corefx/issues/35410 is available.
+    internal sealed class ExposedSocketNetworkStream : NetworkStream
+    {
+        public ExposedSocketNetworkStream(Socket socket, bool ownsSocket) : base(socket, ownsSocket) { }
+
+        public new Socket Socket => base.Socket;
+    }
+}


### PR DESCRIPTION
SocketsHttpHandler's ConnectHelper.ConnectAsync currently returns a tuple of (Socket, Stream).  We can instead just have it return the Stream and allow the call site to fish out the Socket from the Stream if it can.  This is slightly more efficient memory-wise, in that the state machine involved will be smaller, but it also allows for a potential extensibility point that's simpler (abstracting out the ConnectAsync as a callback) and potentially allows us to in the future get a Socket in more cases, e.g. any connection helper handing back a NetworkStream.

Unfortunately, NetworkStream.Socket is protected rather than public.  Until such time that there's a public property for this, there are two options here:
1. Use reflection to create a delegate we can then use to get at the property; "Socket" is part of the exposed surface area, so the only dependency here is on documented surface area.
2. Create a custom NetworkStream-derived type that exposes the protected as a public.

I started with (2), which works fine for our own internal needs currently, but shifted to (1), as it's more flexible.

Contributes to https://github.com/dotnet/corefx/issues/35404
cc: @geoffkizer 