### PR TITLE
Make Http2Connection.SendFrameAsync return ValueTask

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -149,7 +149,7 @@ namespace System.Net.Http
             }
         }
 
-        private async Task<FrameHeader> ReadFrameAsync()
+        private async ValueTask<FrameHeader> ReadFrameAsync()
         {
             // Read frame header
             await EnsureIncomingBytesAsync(FrameHeader.Size).ConfigureAwait(false);


### PR DESCRIPTION
This method frequently completes synchronously, and in such cases we can avoid the task allocation.

Contributes to https://github.com/dotnet/corefx/issues/35309
cc: @geoffkizer 