### PR TITLE
Disallow dangerous Unicode decompositions

### DIFF
--- a/src/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -332,7 +332,12 @@ namespace System
                 bidiStrippedHost = UriHelper.StripBidiControlCharacter(hostname, start, end - start);
                 try
                 {
-                    return s_idnMapping.GetAscii(bidiStrippedHost);
+                    string asciiForm = s_idnMapping.GetAscii(bidiStrippedHost);
+                    if (ContainsCharactersUnsafeForNormalizedHost(asciiForm))
+                    {
+                        throw new UriFormatException(SR.net_uri_BadUnicodeHostForIdn);
+                    }
+                    return asciiForm;
                 }
                 catch (ArgumentException)
                 {
@@ -535,6 +540,21 @@ namespace System
             }
 
             return false;
+        }
+
+        // The Unicode specification allows certain code points to be normalized not to
+        // punycode, but to ASCII representations that retain the same meaning. For example,
+        // the codepoint U+00BC "Vulgar Fraction One Quarter" is normalized to '1/4' rather
+        // than being punycoded.
+        //
+        // This means that a host containing Unicode characters can be normalized to contain
+        // URI reserved characters, changing the meaning of a URI only when certain properties
+        // such as IdnHost are accessed. To be safe, disallow control characters in normalized hosts.
+        private static readonly char[] s_UnsafeForNormalizedHost = { '\\', '/', '?', '@', '#', ':', '[', ']' };
+
+        internal static bool ContainsCharactersUnsafeForNormalizedHost(string host)
+        {
+            return host.IndexOfAny(s_UnsafeForNormalizedHost) != -1;
         }
     }
 }

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text;
+using System.Collections.Generic;
 using System.Common.Tests;
+using System.Linq;
+using System.Text;
 
 using Xunit;
 
@@ -566,6 +568,34 @@ namespace System.PrivateUri.Tests
             Assert.True(Uri.TryCreate(uriString, UriKind.RelativeOrAbsolute, out href));
             Assert.True(Uri.TryCreate(baseIri, href, out hrefAbsolute));
             Assert.Equal("http://www.contoso.com/%C3%A8", hrefAbsolute.AbsoluteUri);
+        }
+
+        public static IEnumerable<object[]> AllForbiddenDecompositions() =>
+            from host in new[] { "canada.c\u2100.microsoft.com", // Unicode U+2100 'Account Of' decomposes to 'a/c'
+                                 "canada.c\u2488.microsoft.com", // Unicode U+2488 'Digit One Full Stop" decomposes to '1.'
+                                 "canada.c\u2048.microsoft.com", // Unicode U+2048 'Question Exclamation Mark" decomposes to '?!'
+                                 "canada.c\uD83C\uDD00.microsoft.com" } // Unicode U+2488 'Digit Zero Full Stop" decomposes to '0.'
+            from scheme in new[] { "http", // Known scheme.
+                                   "test" } // Unknown scheme.
+            select new object[] { scheme, host };
+
+        [Theory]
+        [MemberData(nameof(AllForbiddenDecompositions))]
+        public void Iri_AllForbiddenDecompositions_IdnHostThrows(string scheme, string host)
+        {
+            Uri uri = new Uri(scheme + "://" + host);
+            Assert.Throws<UriFormatException>(() => uri.IdnHost);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllForbiddenDecompositions))]
+        public void Iri_AllForbiddenDecompositions_NonIdnPropertiesOk(string scheme, string host)
+        {
+            Uri uri = new Uri(scheme + "://" + host);
+            Assert.Equal(host, uri.Host);
+            Assert.Equal(host, uri.DnsSafeHost);
+            Assert.Equal(host, uri.Authority);
+            Assert.Equal(scheme + "://" + host + "/", uri.AbsoluteUri);
         }
     }
 }

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -581,7 +581,7 @@ namespace System.PrivateUri.Tests
 
         [Theory]
         [MemberData(nameof(AllForbiddenDecompositions))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Disable until the .NET FX CI machines get the latest patches.")]
         public void Iri_AllForbiddenDecompositions_IdnHostThrows(string scheme, string host)
         {
             Uri uri = new Uri(scheme + "://" + host);
@@ -590,7 +590,7 @@ namespace System.PrivateUri.Tests
 
         [Theory]
         [MemberData(nameof(AllForbiddenDecompositions))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Disable until the .NET FX CI machines get the latest patches.")]
         public void Iri_AllForbiddenDecompositions_NonIdnPropertiesOk(string scheme, string host)
         {
             Uri uri = new Uri(scheme + "://" + host);

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -581,6 +581,7 @@ namespace System.PrivateUri.Tests
 
         [Theory]
         [MemberData(nameof(AllForbiddenDecompositions))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void Iri_AllForbiddenDecompositions_IdnHostThrows(string scheme, string host)
         {
             Uri uri = new Uri(scheme + "://" + host);
@@ -589,6 +590,7 @@ namespace System.PrivateUri.Tests
 
         [Theory]
         [MemberData(nameof(AllForbiddenDecompositions))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void Iri_AllForbiddenDecompositions_NonIdnPropertiesOk(string scheme, string host)
         {
             Uri uri = new Uri(scheme + "://" + host);


### PR DESCRIPTION
This is a cherry pick of the commit from .NET Core 2.2, resolving the issue disclosed in [CVE-2019-0657](https://github.com/dotnet/corefx/issues/35265).

This change blocks any Unicode decompositions that change the semantics of a URI. See the comments included in the change for more details.