### PR TITLE
Bump S.S.C.Pkcs AssemblyVersion Minor version

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -222,12 +222,6 @@
         "10.0.4.0": "10.4.0"
       }
     },
-    "Microsoft.VisualBasic.Core": {
-      "InboxOn": {
-          "netcoreapp3.0": "10.0.4.0",
-          "uap10.0.16300": "10.0.4.0"
-      }
-    },
     "Microsoft.VisualBasic.Compatibility": {
       "InboxOn": {
         "net45": "10.0.0.0"
@@ -236,6 +230,12 @@
     "Microsoft.VisualBasic.Compatibility.Data": {
       "InboxOn": {
         "net45": "10.0.0.0"
+      }
+    },
+    "Microsoft.VisualBasic.Core": {
+      "InboxOn": {
+        "netcoreapp3.0": "10.0.4.0",
+        "uap10.0.16300": "10.0.4.0"
       }
     },
     "Microsoft.VisualC": {
@@ -497,6 +497,10 @@
         "4.5.0"
       ],
       "BaselineVersion": "4.5.0",
+      "InboxOn": {}
+    },
+    "runtime.native.System.IO.Ports": {
+      "BaselineVersion": "4.6.0",
       "InboxOn": {}
     },
     "runtime.win7-x64.runtime.native.System.Data.SqlClient.sni": {
@@ -2320,10 +2324,6 @@
         "4.0.1.0": "4.6.0",
         "4.0.2.0": "4.6.0"
       }
-    },
-    "runtime.native.System.IO.Ports": {
-      "InboxOn": {},
-      "BaselineVersion": "4.6.0"
     },
     "System.IO.UnmanagedMemoryStream": {
       "StableVersions": [
@@ -4415,7 +4415,8 @@
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
         "4.0.3.0": "4.5.0",
-        "4.0.4.0": "4.6.0"
+        "4.0.4.0": "4.6.0",
+        "4.1.0.0": "4.6.0"
       }
     },
     "System.Security.Cryptography.Primitives": {

--- a/src/System.Security.Cryptography.Pkcs/Directory.Build.props
+++ b/src/System.Security.Cryptography.Pkcs/Directory.Build.props
@@ -3,7 +3,8 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <NetstandardAssemblyVersion>4.0.4.0</NetstandardAssemblyVersion>
+    <!-- Currently the netstandard build is locked to the netfx API -->
+    <AssemblyVersion Condition="'$(TargetsNetStandard)' == 'true'">4.0.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Pkcs/Directory.Build.props
+++ b/src/System.Security.Cryptography.Pkcs/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.4.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Pkcs/Directory.Build.props
+++ b/src/System.Security.Cryptography.Pkcs/Directory.Build.props
@@ -3,6 +3,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <NetstandardAssemblyVersion>4.0.4.0</NetstandardAssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -8,7 +8,6 @@
     <UsePackageTargetRuntimeDefaults Condition="'$(IsPartialFacadeAssembly)' != 'true'">true</UsePackageTargetRuntimeDefaults>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <NoWarn>$(NoWarn);CS1574;CS3016</NoWarn>
-    <AssemblyVersion Condition="'$(TargetsNetStandard)' == 'true'">$(NetstandardAssemblyVersion)</AssemblyVersion>
     <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netcoreapp-Debug;netcoreapp-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1\AsnXml.targets" />

--- a/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -8,6 +8,7 @@
     <UsePackageTargetRuntimeDefaults Condition="'$(IsPartialFacadeAssembly)' != 'true'">true</UsePackageTargetRuntimeDefaults>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <NoWarn>$(NoWarn);CS1574;CS3016</NoWarn>
+    <AssemblyVersion Condition="'$(TargetsNetStandard)' == 'true'">$(NetstandardAssemblyVersion)</AssemblyVersion>
     <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netcoreapp-Debug;netcoreapp-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1\AsnXml.targets" />


### PR DESCRIPTION
New API was added for .NET Core 3.0, so the assembly minor needs to bump.

Fixes #35160.