### PR TITLE
defer sending WINDOW_UDPATE frames until a minimum threshold has been met

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -39,6 +39,7 @@ namespace System.Net.Http
         private bool _expectingSettingsAck;
         private int _initialWindowSize;
         private int _maxConcurrentStreams;
+        private int _pendingWindowUpdate;
         private int _idleSinceTickCount;
 
         private bool _disposed;
@@ -55,6 +56,7 @@ namespace System.Net.Http
         // We limit it per stream, and the user controls how many streams are created.
         // So set the connection window size to a large value.
         private const int ConnectionWindowSize = 64 * 1024 * 1024;
+        private const int ConnectionWindowThreshold = ConnectionWindowSize / 8;
 
         public Http2Connection(HttpConnectionPool pool, SslStream stream)
         {
@@ -75,6 +77,7 @@ namespace System.Net.Http
             _nextStream = 1;
             _initialWindowSize = DefaultInitialWindowSize;
             _maxConcurrentStreams = int.MaxValue;
+            _pendingWindowUpdate = 0;
         }
 
         private object SyncObject => _httpStreams;
@@ -975,12 +978,7 @@ namespace System.Net.Http
             await _writerLock.WaitAsync().ConfigureAwait(false);
             try
             {
-                // We update both the connection-level and stream-level windows at the same time
-                _outgoingBuffer.EnsureAvailableSpace((FrameHeader.Size + FrameHeader.WindowUpdateLength) * 2);
-
-                WriteFrameHeader(new FrameHeader(FrameHeader.WindowUpdateLength, FrameType.WindowUpdate, FrameFlags.None, 0));
-                BinaryPrimitives.WriteInt32BigEndian(_outgoingBuffer.AvailableSpan, amount);
-                _outgoingBuffer.Commit(FrameHeader.WindowUpdateLength);
+                _outgoingBuffer.EnsureAvailableSpace(FrameHeader.Size + FrameHeader.WindowUpdateLength);
 
                 WriteFrameHeader(new FrameHeader(FrameHeader.WindowUpdateLength, FrameType.WindowUpdate, FrameFlags.None, streamId));
                 BinaryPrimitives.WriteInt32BigEndian(_outgoingBuffer.AvailableSpan, amount);
@@ -992,6 +990,28 @@ namespace System.Net.Http
             {
                 _writerLock.Release();
             }
+        }
+
+        private void ExtendWindow(int amount)
+        {
+            Debug.Assert(amount > 0);
+
+            int windowUpdateSize;
+            lock (SyncObject)
+            {
+                Debug.Assert(_pendingWindowUpdate < ConnectionWindowThreshold);
+
+                _pendingWindowUpdate += amount;
+                if (_pendingWindowUpdate < ConnectionWindowThreshold)
+                {
+                    return;
+                }
+
+                windowUpdateSize = _pendingWindowUpdate;
+                _pendingWindowUpdate = 0;
+            }
+
+            ValueTask ignored = SendWindowUpdateAsync(0, windowUpdateSize);
         }
 
         private void WriteFrameHeader(FrameHeader frameHeader)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -56,6 +56,13 @@ namespace System.Net.Http
         // We limit it per stream, and the user controls how many streams are created.
         // So set the connection window size to a large value.
         private const int ConnectionWindowSize = 64 * 1024 * 1024;
+
+        // We hold off on sending WINDOW_UPDATE until we hit thi minimum threshold.
+        // This value is somewhat arbitrary; the intent is to ensure it is much smaller than
+        // the window size itself, or we risk stalling the server because it runs out of window space.
+        // If we want to further reduce the frequency of WINDOW_UPDATEs, it's probably better to
+        // increase the window size (and thus increase the threshold proportionally)
+        // rather than just increase the threshold.
         private const int ConnectionWindowThreshold = ConnectionWindowSize / 8;
 
         public Http2Connection(HttpConnectionPool pool, SslStream stream)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -37,6 +37,8 @@ namespace System.Net.Http
             private bool _disposed;
 
             private const int StreamWindowSize = DefaultInitialWindowSize;
+
+            // See comment on ConnectionWindowThreshold.
             private const int StreamWindowThreshold = StreamWindowSize / 8;
 
             public Http2Stream(HttpRequestMessage request, Http2Connection connection, int streamId, int initialWindowSize)
@@ -312,7 +314,8 @@ namespace System.Net.Http
                 (waitForData, bytesRead) = TryReadFromBuffer(buffer.Span);
                 if (waitForData != null)
                 {
-                    await waitForData;
+                    Debug.Assert(bytesRead == 0);
+                    await waitForData.ConfigureAwait(false);
                     (waitForData, bytesRead) = TryReadFromBuffer(buffer.Span);
                     Debug.Assert(waitForData == null);
                 }


### PR DESCRIPTION
Contributes to dotnet/runtime#1576 

Defer sending WINDOW_UPDATE frames for both connection and stream until we've hit a threshold of 1/8th of the total window size. 

Also, skip sending WINDOW_UPDATE entirely if we have already read to the end of the stream.

This shows a significant improvement on the HTTP2 perf test with concurrency == 1, about 23%.

@dotnet/ncl @stephentoub