### PR TITLE
Publish corefx test assets

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -55,11 +55,12 @@ jobs:
     - template: ../common/templates/job/job.yml
       parameters:
         variables:
-        - group: DotNet-Blob-Feed
         - name: _dotnetFeedUrl
           value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
         - name: _targetOS
           value: ${{ parameters.targetOS }}
+        - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
+          - group: DotNet-Blob-Feed
 
         # pass along job variables
         - ${{ each variable in job.variables }}:

--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -55,6 +55,12 @@ jobs:
     - template: ../common/templates/job/job.yml
       parameters:
         variables:
+        - group: DotNet-Blob-Feed
+        - name: _dotnetFeedUrl
+          value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+        - name: _targetOS
+          value: ${{ parameters.targetOS }}
+
         # pass along job variables
         - ${{ each variable in job.variables }}:
           - ${{ if ne(variable.name, '') }}:
@@ -173,6 +179,27 @@ jobs:
             - ${{ job.customBuildSteps }}
 
           - ${{ if eq(job.submitToHelix, 'true') }}:
+            - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
+              - script: $(_msbuildCommand) eng/publish.proj
+                      /t:PublishTestAssets
+                      /p:FilesToPublishPattern=$(Build.SourcesDirectory)/artifacts/helix/**/*.zip
+                      /p:AccountKey=$(dotnetfeed-storage-access-key-1)
+                      /p:ExpectedFeedUrl=$(_dotnetFeedUrl)
+                      /p:OSGroup=$(_targetOS)
+                      /p:ArchGroup=$(_architecture)
+                      /p:ConfigurationGroup=$(_BuildConfig)
+                      /p:TargetGroup=$(_framework)
+                      /p:OfficialBuildId=$(Build.BuildNumber)
+                      /p:ContinuousIntegrationBuild=true
+                      /p:ManifestBuildId=$(Build.BuildNumber)
+                      /p:ManifestBuildData=Location=$(_dotnetFeedUrl)
+                      /p:ManifestBranch=$(Build.SourceBranchName)
+                      /p:ManifestCommit=$(Build.SourceVersion)
+                      /p:ManifestRepoUri=$(Build.Repository.Uri)
+                      ${{ job.buildExtraArguments }}
+                displayName: Publish test assets to dotnet-core feed
+                condition: and(succeeded(), ne(variables['_skipPublishTests'], 'true'))
+
             - template: /eng/pipelines/helix.yml
               parameters:
                 targetOS: ${{ parameters.targetOS }}
@@ -182,6 +209,7 @@ jobs:
                 msbuildScript: $(_msbuildCommand)
                 framework: $(_framework)
                 outerloop: $(_outerloop)
+                buildExtraArguments: ${{ job.buildExtraArguments }}
 
                 ${{ if eq(parameters.isOfficialBuild, 'true') }}:
                   isExternal: false

--- a/eng/pipelines/helix.yml
+++ b/eng/pipelines/helix.yml
@@ -12,6 +12,7 @@ parameters:
   officialBuildId: ''
   enableAzurePipelinesReporter: '' # true | false
   outerloop: '' # true | false
+  buildExtraArguments: ''
 
 steps:
   - script: ${{ parameters.msbuildScript }}
@@ -29,8 +30,10 @@ steps:
             /p:IsExternal=${{ parameters.isExternal }}
             /p:Creator=${{ parameters.creator }}
             /p:OfficialBuildId=${{ parameters.officialBuildId }}
+            /p:ContinuousIntegrationBuild=true
             /p:EnableAzurePipelinesReporter=${{ parameters.enableAzurePipelinesReporter }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
+            ${{ parameters.buildExtraArguments }}
     displayName: Send to Helix
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops

--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -104,4 +104,57 @@
 
     <Message Importance="High" Text="Publishing %(SymbolPackagesToPublish.Identity) to $(SymbolServerPath)"/>
   </Target>
+
+  <Target Name="PublishTestAssets">
+    <Error Text="The ExpectedFeedUrl property wasn't supplied." Condition="'$(ExpectedFeedUrl)' == ''" />
+    <Error Text="The AccountKey property wasn't supplied." Condition="'$(AccountKey)' == ''" />
+    <Error Text="FilesToPublishPattern property wasn't supplied." Condition="'$(FilesToPublishPattern)' == ''" />
+
+    <PropertyGroup>
+      <RuntimeOS Condition="'$(RuntimeOS)' == ''">$(OSGroup)</RuntimeOS>
+      <_TestAssetVersion>$(PackageVersion)-$(VersionSuffix)</_TestAssetVersion>
+      <_FileRelativePathBase>corefx-tests/$(_TestAssetVersion)/$(RuntimeOS).$(ArchGroup).$(ConfigurationGroup)/$(TargetGroup)/</_FileRelativePathBase>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_ItemsToPush Remove="@(_ItemsToPush)" />
+      <_ItemsToPush Include="$(FilesToPublishPattern)" />
+      <_ItemsToPush>
+        <RelativeBlobPath>$(_FileRelativePathBase)$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
+      </_ItemsToPush>
+    </ItemGroup>
+
+    <Error Condition="'@(_ItemsToPush)' == ''" Text="No files to push." />
+
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(AccountKey)"
+                    ItemsToPush="@(_ItemsToPush)"
+                    PublishFlatContainer="true"
+                    ManifestBuildId="$(ManifestBuildId)"
+                    ManifestBranch="$(ManifestBranch)"
+                    ManifestCommit="$(ManifestCommit)"
+                    ManifestBuildData="$(ManifestBuildData)"
+                    ManifestRepoUri="$(ManifestRepoUri)"
+                    AssetManifestPath="$(AssetManifestFilePath)" />
+
+    <ItemGroup>
+      <_ManifestToPush Remove="@(_ManifestToPush)" />
+      <_ManifestToPush Include="$(AssetManifestFilePath)">
+        <RelativeBlobPath>$(_FileRelativePathBase)corefx-test-assets.xml</RelativeBlobPath>
+      </_ManifestToPush>
+    </ItemGroup>
+
+    <Message Importance="High" Text="PublishTestAssets: $(_FileRelativePathBase)corefx-test-assets.xml" />
+
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(AccountKey)"
+                    ItemsToPush="@(_ManifestToPush)"
+                    PublishFlatContainer="true"
+                    ManifestBuildId="$(ManifestBuildId)"
+                    ManifestBranch="$(ManifestBranch)"
+                    ManifestCommit="$(ManifestCommit)"
+                    ManifestBuildData="$(ManifestBuildData)"
+                    ManifestRepoUri="$(ManifestRepoUri)"
+                    AssetManifestPath="$(ArtifactsDir)AssetManifests\ManifestUpload.xml" />
+  </Target>
 </Project>

--- a/eng/sendtohelix.proj
+++ b/eng/sendtohelix.proj
@@ -126,19 +126,37 @@
 
   </Target>
 
-  <Target Name="BuildHelixWorkItems"
-          DependsOnTargets="CompressRuntimeDirectory">
-    <ItemGroup>
+  <PropertyGroup>
+    <TestAssetBlobFeedUrl>https://dotnetfeed.blob.core.windows.net/dotnet-core</TestAssetBlobFeedUrl>
+  </PropertyGroup>
 
+  <Target Name="GetTestAssetManifest" 
+          Outputs="$(TestAssetBlobInfos)">
+
+    <PropertyGroup>
+      <RuntimeOS Condition="'$(RuntimeOS)' == ''">$(OSGroup)</RuntimeOS>
+      <_TestAssetVersion>$(PackageVersion)-$(VersionSuffix)</_TestAssetVersion>
+      <_AssetManifestPath>$(TestAssetBlobFeedUrl)/corefx-tests/$(_TestAssetVersion)/$(RuntimeOS).$(ArchGroup).$(ConfigurationGroup)/$(TargetGroup)/corefx-test-assets.xml</_AssetManifestPath>
+    </PropertyGroup>
+
+    <ParseBuildManifest AssetManifestPath="$(_AssetManifestPath)">
+      <Output TaskParameter="BlobInfos" ItemName="TestAssetBlobInfos" />
+    </ParseBuildManifest>
+
+  </Target>
+
+  <Target Name="BuildHelixWorkItems"
+          DependsOnTargets="CompressRuntimeDirectory;GetTestAssetManifest">
+
+    <ItemGroup>
       <HelixCorrelationPayload Include="$(HelixCorrelationPayload)" />
 
-      <_WorkItem Include="$(WorkItemArchiveWildCard)" Exclude="$(HelixCorrelationPayload)" />
-
-      <HelixWorkItem Include="@(_WorkItem -> '%(FileName)')">
-        <PayloadArchive>%(Identity)</PayloadArchive>
+      <HelixWorkItem Include="@(TestAssetBlobInfos -> '%(FileName)')">
+        <PayloadUri>$(TestAssetBlobFeedUrl)/%(Identity)</PayloadUri>
         <Command>$(HelixCommand)</Command>
         <Timeout>$(_timeoutSpan)</Timeout>
       </HelixWorkItem>
     </ItemGroup>
+
   </Target>
 </Project>


### PR DESCRIPTION
So coreclr and other repos can run the corefx tests.

New step to publish the test zip files to dotnet-core blob storage.

Publishes the build manifest from above to blob storage path:

https://dotnetfeed.blob.core.windows.net/dotnet-core/corefx-tests/$(Version)/$(RuntimeOS).$(ArchGroup).$(ConfigurationGroup)/$(TargetGroup)/corefx-test-assets.xml

Uses the new Arcade ParseBuildManifest helper build task to read the above manifest and to create an ItemGroup of the test zips.

Uses the ItemGroup to send the tests to helix using the new PayloadUri metadata on the HelixWorkItem item.