### PR TITLE
Stop blocking thread pool threads in VirtualNetwork-based tests

### DIFF
--- a/src/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
+++ b/src/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
@@ -13,9 +13,8 @@ namespace System.Net.Test.Common
         private readonly VirtualNetwork _network;
         private MemoryStream _readStream;
         private readonly bool _isServer;
-        private object _readStreamLock = new object();
+        private SemaphoreSlim _readStreamLock = new SemaphoreSlim(1, 1);
         private TaskCompletionSource<object> _flushTcs;
-        private bool _isFlushed;
 
         public VirtualNetworkStream(VirtualNetwork network, bool isServer)
         {
@@ -25,55 +24,17 @@ namespace System.Net.Test.Common
 
         public bool Disposed { get; private set; }
 
-        public override bool CanRead
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool CanRead => true;
 
-        public override bool CanSeek
-        {
-            get
-            {
-                return false;
-            }
-        }
+        public override bool CanSeek => false;
 
-        public override bool CanWrite
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public override bool CanWrite => true;
 
-        public override long Length
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
+        public override long Length => throw new NotImplementedException();
 
-        public override long Position
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
+        public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
-            set
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        public override void Flush()
-        {
-            _isFlushed = true;
-        }
+        public override void Flush() => HasBeenSyncFlushed = true;
 
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
@@ -86,7 +47,7 @@ namespace System.Net.Test.Common
             return _flushTcs.Task;
         }
 
-        public bool HasBeenSyncFlushed => _isFlushed;
+        public bool HasBeenSyncFlushed { get; private set; }
 
         public void CompleteAsyncFlush()
         {
@@ -99,52 +60,67 @@ namespace System.Net.Test.Common
             _flushTcs = null;
         }
 
-        public override void SetLength(long value)
-        {
-            throw new NotImplementedException();
-        }
+        public override void SetLength(long value) => throw new NotImplementedException();
 
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            throw new NotImplementedException();
-        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            lock (_readStreamLock)
+            _readStreamLock.Wait();
+            try
             {
                 if (_readStream == null || (_readStream.Position >= _readStream.Length))
                 {
-                    byte[] innerBuffer;
-
-                    _network.ReadFrame(_isServer, out innerBuffer);
-                    _readStream = new MemoryStream(innerBuffer);
+                    _readStream = new MemoryStream(_network.ReadFrame(_isServer));
                 }
 
                 return _readStream.Read(buffer, offset, count);
+            }
+            finally
+            {
+                _readStreamLock.Release();
+            }
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await _readStreamLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (_readStream == null || (_readStream.Position >= _readStream.Length))
+                {
+                    _readStream = new MemoryStream(await _network.ReadFrameAsync(_isServer).ConfigureAwait(false));
+                }
+
+                return await _readStream.ReadAsync(buffer, offset, count).ConfigureAwait(false);
+            }
+            finally
+            {
+                _readStreamLock.Release();
             }
         }
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            byte[] innerBuffer = new byte[count];
-
-            Buffer.BlockCopy(buffer, offset, innerBuffer, 0, count);
-            _network.WriteFrame(_isServer, innerBuffer);
-        }
-
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return cancellationToken.IsCancellationRequested ?
-                Task.FromCanceled<int>(cancellationToken) :
-                Task.Run(() => Read(buffer, offset, count));
+            _network.WriteFrame(_isServer, buffer.AsSpan(offset, count).ToArray());
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return cancellationToken.IsCancellationRequested ?
-                Task.FromCanceled<int>(cancellationToken) :
-                Task.Run(() => Write(buffer, offset, count));
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<int>(cancellationToken);
+            }
+
+            try
+            {
+                Write(buffer, offset, count);
+                return Task.CompletedTask;
+            }
+            catch (Exception exc)
+            {
+                return Task.FromException(exc);
+            }
         }
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>

--- a/src/Common/tests/Tests/System/Net/VirtualNetworkTest.cs
+++ b/src/Common/tests/Tests/System/Net/VirtualNetworkTest.cs
@@ -30,8 +30,7 @@ namespace System.Net.Test.Common
 
                 network.WriteFrame(i % 2 == 0, writeFrame);
 
-                byte [] readFrame;
-                network.ReadFrame(i % 2 == 1, out readFrame);
+                byte [] readFrame = network.ReadFrame(i % 2 == 1);
 
                 uint readChecksum = Fletcher32.Checksum(readFrame, 0, readFrame.Length);
 
@@ -66,8 +65,7 @@ namespace System.Net.Test.Common
                 int delayMilliseconds = rnd.Next(0, 1000);
                 await Task.Delay(delayMilliseconds);
 
-                byte[] readFrame;
-                network.ReadFrame(i % 2 == 1, out readFrame);
+                byte[] readFrame = network.ReadFrame(i % 2 == 1);
 
                 uint readChecksum = Fletcher32.Checksum(readFrame, 0, readFrame.Length);
 

--- a/src/System.Net.Security/tests/FunctionalTests/NotifyReadVirtualNetworkStream.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NotifyReadVirtualNetworkStream.cs
@@ -3,10 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net.Test.Common;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Security.Tests
 {
-    internal class NotifyReadVirtualNetworkStream : VirtualNetworkStream
+    internal sealed class NotifyReadVirtualNetworkStream : VirtualNetworkStream
     {
         public delegate void ReadEventHandler(byte[] buffer, int offset, int count);
         public event ReadEventHandler OnRead;
@@ -20,6 +22,12 @@ namespace System.Net.Security.Tests
         {
             OnRead?.Invoke(buffer, offset, count);
             return base.Read(buffer, offset, count);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            OnRead?.Invoke(buffer, offset, count);
+            return base.ReadAsync(buffer, offset, count, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
The SslStream tests and others use an internal VirtualNetwork helper.  Its stream's ReadAsync method currently queues a work item to the thread pool that then blocks.  This results in spurious failures and timeouts as all of the threads in the pool get blocked under load.

cc: @VSadov, @davidsh