### PR TITLE
Factor IPAddress.Loopback.MapToIPv6() into IPAddress.IsLooback

### DIFF
--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressTest.cs
@@ -191,6 +191,9 @@ namespace System.Net.Primitives.Functional.Tests
 
             ip = new IPAddress(IPAddress.IPv6Loopback.GetAddressBytes()); //IpV6 loopback
             Assert.True(IPAddress.IsLoopback(ip));
+
+            ip = new IPAddress(IPAddress.Loopback.MapToIPv6().GetAddressBytes()); // IPv4 loopback mapped to IPv6
+            Assert.Equal(!PlatformDetection.IsFullFramework, IPAddress.IsLoopback(ip)); // https://github.com/dotnet/corefx/issues/35454
         }
 
         [Fact]


### PR DESCRIPTION
Simple change to check for IPAddress.Loopback.MapToIPv6() in addition to IPAddress.Loopback and IPAddress.IPv6Loopback in IPAddress.IsLoopback.  Doing so caused a small regression in throughput for IPAddress.Equals, so I made a few other tweaks to avoid the regression.

Fixes https://github.com/dotnet/corefx/issues/35454
cc: @davidsh, @rmkerr 