### PR TITLE
Fix xNodeBuilder test (again)

### DIFF
--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
@@ -5057,7 +5057,7 @@ namespace CoreXml.Test.XLinq
                     w.WriteEndElement();
                     w.Dispose();
 
-                    if (!CompareReader(doc, $"<Root>{float.MaxValue}</Root>")) throw new TestException(TestResult.Failed, "");
+                    if (!CompareReader(doc, $"<Root>{float.MaxValue.ToString("R", CultureInfo.InvariantCulture)}</Root>")) throw new TestException(TestResult.Failed, "");
                 }
 
                 //[Variation(Id = 8, Desc = "WriteValue(string)", Priority = 1)]


### PR DESCRIPTION
They're failing on netfx after my previous test fix, because on netfx float.MaxValue.ToString() != float.MaxValue.ToString("R").  I've changed it to use the exact call that XmlWriter.WriteValue makes.

Fixes https://github.com/dotnet/corefx/issues/35329
cc: @tannergooding, @buyaa-n 