### PR TITLE
Restore IBC data and embed during Windows release builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -267,6 +267,11 @@
     <!-- Disable source link on local builds. -->
     <EnableSourceLink Condition="'$(ContinuousIntegrationBuild)' != 'true' and '$(OfficialBuildId)' == ''">false</EnableSourceLink>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- Embed IBC data on Windows release builds, if IBCMerge isn't available this will just log the commandline -->
+    <EnablePartialNgenOptimization Condition="'$(EnablePartialNgenOptimization)' == '' and '$(OS)' == 'Windows_NT' and '$(ConfigurationGroup)' == 'Release'">true</EnablePartialNgenOptimization>
+  </PropertyGroup>
 
   <!-- Set up Default symbol and optimization for Configuration -->
   <Choose>
@@ -352,6 +357,7 @@
     <NetStandard21RefPath>$(RefRootPath)netstandard2.1/</NetStandard21RefPath>
     <NetFxRefPath>$(RefRootPath)netfx/</NetFxRefPath>
     <GlobalToolsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'tools'))</GlobalToolsDir>
+    <IbcOptimizationDataDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'ibc'))</IbcOptimizationDataDir>
 
     <!-- Helix properties -->
     <OSPlatformConfig>$(OSGroup).$(Platform).$(ConfigurationGroup)</OSPlatformConfig>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" InitialTargets="CheckForBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <!--
@@ -33,14 +33,6 @@
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)versioning.targets" />
-
-  <Target Name="CheckForBuildTools">
-    <Error Condition="!Exists('$(ToolsDir)') and '$(OverrideToolsDir)'=='true'"
-           Text="The tools directory [$(ToolsDir)] does not exist. Please run build -Restore in your repo to ensure the tools are installed before attempting to build an individual project." />
-    <Error Condition="!Exists('$(ToolsDir)') and '$(OverrideToolsDir)'!='true'"
-           Text="The tools directory [$(ToolsDir)] does not exist. Please run build -InitTools in your repo to ensure the tools are installed before attempting to build an individual project." />
-  </Target>
-
   <Import Project="$(RepositoryEngineeringDir)CodeAnalysis.targets" />
 
   <!-- Corefx-specific binplacing properties -->
@@ -142,20 +134,11 @@
   </ItemGroup>
 
   <Import Project="$(RepositoryEngineeringDir)blockReflectionAttribute.targets" />
+  <Import Project="$(RepositoryEngineeringDir)codeOptimization.targets" />
   <Import Project="$(RepositoryEngineeringDir)depProj.targets" Condition="'$(MSBuildProjectExtension)' == '.depproj'" />
   <Import Project="$(RepositoryEngineeringDir)Resources.targets" />
   <Import Project="$(RepositoryEngineeringDir)references.targets" />
   <Import Project="$(RepositoryEngineeringDir)resolveContract.targets" />
-  
-  <!-- TODO: remove remaining functionality from buildtools -->
-  <PropertyGroup>
-     <!-- codeOptimization uses DnuRestoreCommand -->
-    <DnuRestoreCommand>$(DotnetTool) restore</DnuRestoreCommand>
-     <!-- optionalTooling uses DotnetToolCommand -->
-    <DotnetToolCommand>$(DotnetTool)</DotnetToolCommand>
-  </PropertyGroup>
-  <Import Project="$(ToolsDir)codeOptimization.targets" />
-  <Import Project="$(ToolsDir)OptionalTooling.targets" />
 
   <Import Project="$(ToolSetCommonDirectory)Tools.proj.nuget.g.targets" Condition="Exists('$(ToolSetCommonDirectory)Tools.proj.nuget.g.targets')" />
 

--- a/build.proj
+++ b/build.proj
@@ -27,6 +27,7 @@
       <_RestoreProjects Include="external\dir.proj" />
     </ItemGroup>
 
+    <MSBuild Projects="@(_RestoreProjects)" Properties="$(ProjectProperties);DefaultBuildAllTarget=Restore" />
     <MSBuild Projects="@(_RestoreProjects)" Properties="$(ProjectProperties)" />
   </Target>
 

--- a/build.proj
+++ b/build.proj
@@ -22,7 +22,7 @@
 
   <Import Project="Directory.Build.targets" />
 
-  <Target Name="Restore" DependsOnTargets="GenerateConfigurationProps;RestoreOptimizationDataPackage">
+  <Target Name="Restore" DependsOnTargets="GenerateConfigurationProps">
     <ItemGroup>
       <_RestoreProjects Include="external\dir.proj" />
     </ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,6 +9,7 @@
     <PreReleaseVersionLabel>preview4</PreReleaseVersionLabel>
     <!-- Opt-in repo features -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
+    <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
   </PropertyGroup>

--- a/eng/codeOptimization.targets
+++ b/eng/codeOptimization.targets
@@ -1,0 +1,19 @@
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Condition="'$(ApplyPartialNgenOptimization)' == ''">
+     <ApplyPartialNgenOptimization Condition="'$(IsReferenceAssembly)' == 'true'">false</ApplyPartialNgenOptimization>
+     <ApplyPartialNgenOptimization Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">false</ApplyPartialNgenOptimization>
+  </PropertyGroup>
+
+  <Target Name="SetApplyPartialNgenOptimization"
+          Condition="'$(ApplyPartialNgenOptimization)' == ''"
+          BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <_optimizationDataAssembly Include="$(IbcOptimizationDataDir)**\$(TargetFileName)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <ApplyPartialNgenOptimization Condition="'@(_optimizationDataAssembly)' != ''">true</ApplyPartialNgenOptimization>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/eng/depProj.targets
+++ b/eng/depProj.targets
@@ -100,7 +100,7 @@ See the LICENSE file in the project root for more information.
     </ItemGroup>
 
     <Error Condition="'@(NuGetDeploy)' == ''" Text="Error no assets were resolved from NuGet packages." />
-    <Message Importance="High" Text="%(FullPath) (%(NuGetPackageId).%(NuGetPackageVersion)) -&gt; @(NuGetDeploy->'$(TargetDir)%(FileName)%(Extension)')" />
+    <Message Importance="High" Text="%(FullPath) (%(NuGetPackageId).%(NuGetPackageVersion)) -&gt; @(NuGetDeploy->'$(TargetDir)%(SubFolder)%(FileName)%(Extension)')" />
 
     <!-- Include marker files if an extension has been provided -->
     <!-- internal builds use this to distinguish files which have already been signed -->

--- a/eng/dependencies.props
+++ b/eng/dependencies.props
@@ -23,6 +23,9 @@
 
     <!-- SNI runtime package -->
     <RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion>
+
+    <CoreFxOptimizationDataPackageId>optimization.windows_nt-x64.IBC.CoreFx</CoreFxOptimizationDataPackageId>
+    <CoreFxOptimizationDataPackageId Condition="'$(IBCTarget)'=='Linux'">optimization.linux-x64.IBC.CoreFx</CoreFxOptimizationDataPackageId>
   </PropertyGroup>
 
   <!-- Tests/infrastructure dependency versions. -->
@@ -45,12 +48,10 @@
     <CoverletConsolePackageVersion>1.4.0</CoverletConsolePackageVersion>
     <DotNetReportGeneratorGlobalToolPackageVersion>4.0.5</DotNetReportGeneratorGlobalToolPackageVersion>
 
-    <!-- Roslyn optimization data package version -->
     <MicrosoftDotNetIBCMergePackageVersion>4.6.0-alpha-00001</MicrosoftDotNetIBCMergePackageVersion>
     <TestILCAmd64retPackageVersion>$(ProjectNTfsTestILCPackageVersion)</TestILCAmd64retPackageVersion>
     <TestILCArmretPackageVersion>$(ProjectNTfsTestILCPackageVersion)</TestILCArmretPackageVersion>
     <TestILCX86retPackageVersion>$(ProjectNTfsTestILCPackageVersion)</TestILCX86retPackageVersion>
-    <OptimizationDataVersion>2.0.0-rc-61101-17</OptimizationDataVersion>
     <CoreFxOptimizationDataVersion>99.99.99-master-20190221.1</CoreFxOptimizationDataVersion>
   </PropertyGroup>
 

--- a/external/Directory.Build.props
+++ b/external/Directory.Build.props
@@ -5,6 +5,7 @@
     <!-- We need configuration-specific assets files. -->
     <RestoreOutputPath>$(IntermediateOutputPath)</RestoreOutputPath>
     <ProjectAssetsFile>$(RestoreOutputPath)/project.assets.json</ProjectAssetsFile>
+    <MSBuildProjectExtensionsPath>$(IntermediateOutputPath)</MSBuildProjectExtensionsPath>
     <!-- let us control the output path -->
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/external/Directory.Build.props
+++ b/external/Directory.Build.props
@@ -9,4 +9,12 @@
     <!-- let us control the output path -->
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
+  
+  <!-- don't bring in props/targets from packages, we're not consuming them we're
+       deploying them -->
+  <ItemDefinitionGroup>
+    <PackageReference>
+      <ExcludeAssets>Build</ExcludeAssets>
+    </PackageReference>
+  </ItemDefinitionGroup>
 </Project>

--- a/external/dir.proj
+++ b/external/dir.proj
@@ -17,6 +17,7 @@
     <Project Include="harvestPackages/harvestPackages.depproj" />
     <Project Include="binplacePackages/binplacePackages.depproj" />
     <Project Include="docs/docs.depproj" Condition="'$(DotNetBuildFromSource)' != 'true'" />
+    <Project Include="optimizationData/optimizationData.depproj" Condition="'$(EnablePartialNgenOptimization)' == 'true' AND '$(DotNetBuildFromSource)' != 'true'" />
     <Project Condition="'$(ILLinkTrimAssembly)' != 'false'" Include="ILLink/ILLink.depproj" />
   </ItemGroup>
 

--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NETStandard.Library" ExcludeAssets="Build">
+    <PackageReference Include="NETStandard.Library">
       <Version>$(NETStandardLibraryPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>

--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NETStandard.Library">
+    <PackageReference Include="NETStandard.Library" ExcludeAssets="Build">
       <Version>$(NETStandardLibraryPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>

--- a/external/optimizationData/Configurations.props
+++ b/external/optimizationData/Configurations.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildConfigurations>
+      netstandard;
+    </BuildConfigurations>
+  </PropertyGroup>
+</Project>

--- a/external/optimizationData/optimizationData.depproj
+++ b/external/optimizationData/optimizationData.depproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RestoreSources>
+      https://dotnet.myget.org/F/dotnet-core-optimization-data/api/v3/index.json;
+      $(RestoreSources);
+    </RestoreSources>
+    <!-- Copy to IBC directory -->
+    <OutputPath>$(IbcOptimizationDataDir)</OutputPath>
+    <EnableBinPlacing>false</EnableBinPlacing>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- IBC data -->
+    <IBCPackage Include="$(CoreFxOptimizationDataPackageId)" Version="$(CoreFxOptimizationDataVersion)" AddDirectory="true" />
+    <PackageReference Include="@(IBCPackage)" GeneratePathProperty="true" />
+  </ItemGroup>
+  
+  <!-- IBC data packages don't follow NuGet conventions, so grab the contents
+       using the NuGet-generated-property that points to the restored package.  -->
+  <Target Name="GetIBCData"
+          Inputs="%(IBCPackage.Identity)"
+          Outputs="unused"
+          AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <IBCPackage>
+        <!-- Assign metadata using the nuget convention for property naming -->
+        <PropertyName>Pkg$([System.String]::new('%(IBCPackage.Identity)').Replace('.', '_'))</PropertyName>
+      </IBCPackage>
+    </ItemGroup>
+    <PropertyGroup>
+      <!-- evaluate the package property -->
+      <_ibcPkgSrc>$(%(IBCPackage.PropertyName))</_ibcPkgSrc>
+      <_ibcPkgDest>%(IBCPackage.Identity)</_ibcPkgDest>
+      <_includeFileDir>%(IBCPackage.AddDirectory)</_includeFileDir>
+    </PropertyGroup>
+
+    <Error Condition="!Exists('$(_ibcPkgSrc)')" Text="Package '%(IBCPackage.Identity)' was not restored!" />
+
+    <ItemGroup>
+      <_optimizationDataSourceFile Include="$(_ibcPkgSrc)\**\*.dll;$(_ibcPkgSrc)\**\*.ibc" 
+                                   NuGetPackageId="%(IBCPackage.Identity)"
+                                   NuGetPackageVersion="%(IBCPackage.Version)" />
+      <_optimizationDataSourceFile SubFolder="$(_ibcPkgDest)\%(RecursiveDir)" />
+      <_optimizationDataSourceFile Condition="'$(_includeFileDir)' == 'true'" SubFolder="%(SubFolder)%(FileName).dll\" />
+      <ReferenceCopyLocalPaths Include="@(_optimizationDataSourceFile)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/pkg/Directory.Build.targets
+++ b/pkg/Directory.Build.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" InitialTargets="CheckForBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Condition="'$(IsFrameworkPackage)' == 'true'" Project="frameworkPackage.targets" />
 


### PR DESCRIPTION
See the following docs.
https://github.com/dotnet/arcade/blob/bac85242024ba867b6204b90c1522793093f5e31/Documentation/ArcadeSdk.md#ibc-optimization-data-embedding

We are using IBC data produced by our perf team and embedding into all builds of a DLL;
currently we don't distinguish cross-compiles of the same DLL, nor does arcade define any
conventions to do so.  I've disabled it for references and not-supported assemblies.