### PR TITLE
Publish corefx test assets

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -26,6 +26,10 @@ parameters:
   #     _skipTests: true | false
   #     _outerloop: true | false
 
+  # Optional: _publishTests -> Boolean -> Publish test assets to blob storage if true.
+  # Default: false
+  #     _publishTests: true | false
+
   # Required: submitToHelix -> Boolean -> Value to know if it should submit tests payloads to helix.
   
   # Optional: buildScriptPrefix -> String -> string to append to Unix build script.
@@ -55,6 +59,11 @@ jobs:
     - template: ../common/templates/job/job.yml
       parameters:
         variables:
+        - name: _dotnetFeedUrl
+          value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+        - name: _targetOS
+          value: ${{ parameters.targetOS }}
+
         # pass along job variables
         - ${{ each variable in job.variables }}:
           - ${{ if ne(variable.name, '') }}:
@@ -78,6 +87,9 @@ jobs:
 
         - ${{ if eq(job.submitToHelix, 'true') }}:
           - group: DotNet-HelixApi-Access
+
+        - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
+          - group: DotNet-Blob-Feed
 
         # Windows variables
         - ${{ if eq(parameters.targetOS, 'Windows_NT') }}:
@@ -171,6 +183,25 @@ jobs:
 
           - ${{ if ne(job.customBuildSteps[0], '') }}:
             - ${{ job.customBuildSteps }}
+
+          - script: $(_msbuildCommand) eng/publish.proj
+                  /t:PublishTestAssets
+                  /p:FilesToPublishPattern=$(Build.SourcesDirectory)/artifacts/helix/**/*.zip
+                  /p:AccountKey=$(dotnetfeed-storage-access-key-1)
+                  /p:ExpectedFeedUrl=$(_dotnetFeedUrl)
+                  /p:OSGroup=$(_targetOS)
+                  /p:ArchGroup=$(_architecture)
+                  /p:ConfigurationGroup=$(_BuildConfig)
+                  /p:TargetGroup=$(_framework)
+                  /p:OfficialBuildId=$(Build.BuildNumber)
+                  /p:ContinuousIntegrationBuild=true
+                  /p:ManifestBuildId=$(Build.BuildNumber)
+                  /p:ManifestBuildData=Location=$(_dotnetFeedUrl)
+                  /p:ManifestBranch=$(Build.SourceBranchName)
+                  /p:ManifestCommit=$(Build.SourceVersion)
+                  /p:ManifestRepoUri=$(Build.Repository.Uri)
+            displayName: Publish test assets to dotnet-core feed
+            condition: and(succeeded(), eq(variables['_publishTests'], 'true'))
 
           - ${{ if eq(job.submitToHelix, 'true') }}:
             - template: /eng/pipelines/helix.yml

--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -59,10 +59,6 @@ jobs:
     - template: ../common/templates/job/job.yml
       parameters:
         variables:
-        - name: _dotnetFeedUrl
-          value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-        - name: _targetOS
-          value: ${{ parameters.targetOS }}
 
         # pass along job variables
         - ${{ each variable in job.variables }}:
@@ -90,6 +86,7 @@ jobs:
 
         - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
           - group: DotNet-Blob-Feed
+          - _dotnetFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
 
         # Windows variables
         - ${{ if eq(parameters.targetOS, 'Windows_NT') }}:
@@ -184,26 +181,36 @@ jobs:
           - ${{ if ne(job.customBuildSteps[0], '') }}:
             - ${{ job.customBuildSteps }}
 
-          - script: $(_msbuildCommand) eng/publish.proj
-                  /t:PublishTestAssets
-                  /p:FilesToPublishPattern=$(Build.SourcesDirectory)/artifacts/helix/**/*.zip
-                  /p:AccountKey=$(dotnetfeed-storage-access-key-1)
-                  /p:ExpectedFeedUrl=$(_dotnetFeedUrl)
-                  /p:OSGroup=$(_targetOS)
-                  /p:ArchGroup=$(_architecture)
-                  /p:ConfigurationGroup=$(_BuildConfig)
-                  /p:TargetGroup=$(_framework)
-                  /p:OfficialBuildId=$(Build.BuildNumber)
-                  /p:ContinuousIntegrationBuild=true
-                  /p:ManifestBuildId=$(Build.BuildNumber)
-                  /p:ManifestBuildData=Location=$(_dotnetFeedUrl)
-                  /p:ManifestBranch=$(Build.SourceBranchName)
-                  /p:ManifestCommit=$(Build.SourceVersion)
-                  /p:ManifestRepoUri=$(Build.Repository.Uri)
-            displayName: Publish test assets to dotnet-core feed
-            condition: and(succeeded(), eq(variables['_publishTests'], 'true'))
-
           - ${{ if eq(job.submitToHelix, 'true') }}:
+            - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
+              - script: $(_msbuildCommand) eng/publish.proj
+                      /t:PublishTestAssets
+                      /p:FilesToPublishPattern=$(Build.SourcesDirectory)/artifacts/helix/**/*.zip
+                      /p:AccountKey=$(dotnetfeed-storage-access-key-1)
+                      /p:ExpectedFeedUrl=$(_dotnetFeedUrl)
+                      /p:OSGroup=${{ parameters.targetOS }}
+                      /p:ArchGroup=$(_architecture)
+                      /p:ConfigurationGroup=$(_BuildConfig)
+                      /p:TargetGroup=$(_framework)
+                      /p:OfficialBuildId=$(Build.BuildNumber)
+                      /p:ContinuousIntegrationBuild=true
+                      /p:AssetManifestFileName='corefx-test-assets.xml'
+                      /p:ManifestBuildId=$(Build.BuildNumber)
+                      /p:ManifestBuildData=Location=$(_dotnetFeedUrl)
+                      /p:ManifestBranch=$(Build.SourceBranchName)
+                      /p:ManifestCommit=$(Build.SourceVersion)
+                      /p:ManifestRepoUri=$(Build.Repository.Uri)
+                displayName: Publish test assets to dotnet-core feed
+                condition: and(succeeded(), eq(variables['_publishTests'], 'true'))
+
+              - task: PublishBuildArtifacts@1
+                displayName: Publish test asset manifest to artifacts container
+                inputs:
+                  pathToPublish: $(Build.SourcesDirectory)/artifacts/AssetManifests
+                  artifactName: $(Agent.Os)_$(Agent.JobName)
+                  artifactType: container
+                condition: and(succeeded(), eq(variables['_publishTests'], 'true'))
+
             - template: /eng/pipelines/helix.yml
               parameters:
                 targetOS: ${{ parameters.targetOS }}

--- a/eng/pipelines/helix.yml
+++ b/eng/pipelines/helix.yml
@@ -12,6 +12,7 @@ parameters:
   officialBuildId: ''
   enableAzurePipelinesReporter: '' # true | false
   outerloop: '' # true | false
+  buildExtraArguments: ''
 
 steps:
   - script: ${{ parameters.msbuildScript }}
@@ -29,6 +30,7 @@ steps:
             /p:IsExternal=${{ parameters.isExternal }}
             /p:Creator=${{ parameters.creator }}
             /p:OfficialBuildId=${{ parameters.officialBuildId }}
+            /p:ContinuousIntegrationBuild=true
             /p:EnableAzurePipelinesReporter=${{ parameters.enableAzurePipelinesReporter }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: Send to Helix

--- a/eng/pipelines/helix.yml
+++ b/eng/pipelines/helix.yml
@@ -12,7 +12,6 @@ parameters:
   officialBuildId: ''
   enableAzurePipelinesReporter: '' # true | false
   outerloop: '' # true | false
-  buildExtraArguments: ''
 
 steps:
   - script: ${{ parameters.msbuildScript }}
@@ -30,7 +29,6 @@ steps:
             /p:IsExternal=${{ parameters.isExternal }}
             /p:Creator=${{ parameters.creator }}
             /p:OfficialBuildId=${{ parameters.officialBuildId }}
-            /p:ContinuousIntegrationBuild=true
             /p:EnableAzurePipelinesReporter=${{ parameters.enableAzurePipelinesReporter }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: Send to Helix

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -28,6 +28,7 @@ jobs:
             _dockerContainer: rhel7_container
             _buildScriptPrefix: ''
             _buildExtraArguments: ''
+            _publishTests: true
 
           arm64_Release:
             _BuildConfig: Release

--- a/eng/pipelines/macos.yml
+++ b/eng/pipelines/macos.yml
@@ -33,6 +33,7 @@ jobs:
               _architecture: x64
               _framework: netcoreapp
               _helixQueues: $(macOSQueues)
+              _publishTests: true
 
       pool:
         name: Hosted Mac Internal Sierra

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -48,12 +48,14 @@ jobs:
               _architecture: x64
               _framework: netcoreapp
               _helixQueues: $(netcoreappWindowsQueues)+$(nanoQueues)
+              _publishTests: true
 
             x86_Release:
               _BuildConfig: Release
               _architecture: x86
               _framework: netcoreapp
               _helixQueues: $(netcoreappWindowsQueues)
+              _publishTests: true
 
             NETFX_x86_Release:
               _BuildConfig: Release

--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -10,7 +10,8 @@
     <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">corefx</GitHubRepositoryName>
     <AssetManifestFileName Condition="'$(AssetManifestFileName)' == '' AND '$(ManifestBuildId)' != ''">$(GitHubRepositoryName)-$(ManifestBuildId)</AssetManifestFileName>
     <AssetManifestFileName Condition="'$(AssetManifestFileName)' == ''">$(GitHubRepositoryName)</AssetManifestFileName>
-    <AssetManifestFilePath>$(ArtifactsDir)AssetManifests\$(AssetManifestFileName).xml</AssetManifestFilePath>
+    <AssetManifestDir>$(ArtifactsDir)AssetManifests\</AssetManifestDir>
+    <AssetManifestFilePath>$(AssetManifestDir)$(AssetManifestFileName).xml</AssetManifestFilePath>
 
     <PackageOutputRoot Condition="'$(PackagesOutputRoot)' == ''">$(ArtifactsDir)/packages/</PackageOutputRoot>
     <FinalPublishPattern>$(PackageOutputRoot)*.nupkg</FinalPublishPattern>
@@ -139,7 +140,7 @@
     <ItemGroup>
       <_ManifestToPush Remove="@(_ManifestToPush)" />
       <_ManifestToPush Include="$(AssetManifestFilePath)">
-        <RelativeBlobPath>$(_FileRelativePathBase)corefx-test-assets.xml</RelativeBlobPath>
+        <RelativeBlobPath>$(_FileRelativePathBase)$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
       </_ManifestToPush>
     </ItemGroup>
 
@@ -154,6 +155,6 @@
                     ManifestCommit="$(ManifestCommit)"
                     ManifestBuildData="$(ManifestBuildData)"
                     ManifestRepoUri="$(ManifestRepoUri)"
-                    AssetManifestPath="$(ArtifactsDir)AssetManifests\ManifestUpload.xml" />
+                    AssetManifestPath="$(AssetManifestDir)ManifestUpload.xml" />
   </Target>
 </Project>

--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -8,10 +8,10 @@
 
   <PropertyGroup>
     <GitHubRepositoryName Condition="'$(GitHubRepositoryName)' == ''">corefx</GitHubRepositoryName>
-    <AssetManifestFileName Condition="'$(AssetManifestFileName)' == '' AND '$(ManifestBuildId)' != ''">$(GitHubRepositoryName)-$(ManifestBuildId)</AssetManifestFileName>
-    <AssetManifestFileName Condition="'$(AssetManifestFileName)' == ''">$(GitHubRepositoryName)</AssetManifestFileName>
+    <AssetManifestFileName Condition="'$(AssetManifestFileName)' == '' AND '$(ManifestBuildId)' != ''">$(GitHubRepositoryName)-$(ManifestBuildId).xml</AssetManifestFileName>
+    <AssetManifestFileName Condition="'$(AssetManifestFileName)' == ''">$(GitHubRepositoryName).xml</AssetManifestFileName>
     <AssetManifestDir>$(ArtifactsDir)AssetManifests\</AssetManifestDir>
-    <AssetManifestFilePath>$(AssetManifestDir)$(AssetManifestFileName).xml</AssetManifestFilePath>
+    <AssetManifestFilePath>$(AssetManifestDir)$(AssetManifestFileName)</AssetManifestFilePath>
 
     <PackageOutputRoot Condition="'$(PackagesOutputRoot)' == ''">$(ArtifactsDir)/packages/</PackageOutputRoot>
     <FinalPublishPattern>$(PackageOutputRoot)*.nupkg</FinalPublishPattern>

--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -104,4 +104,56 @@
 
     <Message Importance="High" Text="Publishing %(SymbolPackagesToPublish.Identity) to $(SymbolServerPath)"/>
   </Target>
+
+  <Target Name="PublishTestAssets">
+    <Error Text="The ExpectedFeedUrl property wasn't supplied." Condition="'$(ExpectedFeedUrl)' == ''" />
+    <Error Text="The AccountKey property wasn't supplied." Condition="'$(AccountKey)' == ''" />
+    <Error Text="FilesToPublishPattern property wasn't supplied." Condition="'$(FilesToPublishPattern)' == ''" />
+
+    <PropertyGroup>
+      <_TestAssetVersion>$(PackageVersion)-$(VersionSuffix)</_TestAssetVersion>
+      <_FileRelativePathBase>corefx-tests/$(_TestAssetVersion)/$(OSGroup).$(ArchGroup)/$(TargetGroup)/</_FileRelativePathBase>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_ItemsToPush Remove="@(_ItemsToPush)" />
+      <_ItemsToPush Include="$(FilesToPublishPattern)" />
+      <_ItemsToPush>
+        <RelativeBlobPath>$(_FileRelativePathBase)$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
+      </_ItemsToPush>
+    </ItemGroup>
+
+    <Error Condition="'@(_ItemsToPush)' == ''" Text="No files to push." />
+
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(AccountKey)"
+                    ItemsToPush="@(_ItemsToPush)"
+                    PublishFlatContainer="true"
+                    ManifestBuildId="$(ManifestBuildId)"
+                    ManifestBranch="$(ManifestBranch)"
+                    ManifestCommit="$(ManifestCommit)"
+                    ManifestBuildData="$(ManifestBuildData)"
+                    ManifestRepoUri="$(ManifestRepoUri)"
+                    AssetManifestPath="$(AssetManifestFilePath)" />
+
+    <ItemGroup>
+      <_ManifestToPush Remove="@(_ManifestToPush)" />
+      <_ManifestToPush Include="$(AssetManifestFilePath)">
+        <RelativeBlobPath>$(_FileRelativePathBase)corefx-test-assets.xml</RelativeBlobPath>
+      </_ManifestToPush>
+    </ItemGroup>
+
+    <Message Importance="High" Text="PublishTestAssets: $(_FileRelativePathBase)corefx-test-assets.xml" />
+
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(AccountKey)"
+                    ItemsToPush="@(_ManifestToPush)"
+                    PublishFlatContainer="true"
+                    ManifestBuildId="$(ManifestBuildId)"
+                    ManifestBranch="$(ManifestBranch)"
+                    ManifestCommit="$(ManifestCommit)"
+                    ManifestBuildData="$(ManifestBuildData)"
+                    ManifestRepoUri="$(ManifestRepoUri)"
+                    AssetManifestPath="$(ArtifactsDir)AssetManifests\ManifestUpload.xml" />
+  </Target>
 </Project>


### PR DESCRIPTION
So coreclr and other repos can run the corefx tests.

New step to publish the test zip files to dotnet-core blob storage.

Publishes the build manifest from above to blob storage path:

https://dotnetfeed.blob.core.windows.net/dotnet-core/corefx-tests/$(Version)/$(TargetOS).$(ArchGroup)/$(TargetGroup)/corefx-test-assets.xml

Declare DotNet-Blob-Feed only in official builds