### PR TITLE
Override WriteAsync on the DefaultPipeWriter

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.DefaultPipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.DefaultPipeWriter.cs
@@ -41,6 +41,11 @@ namespace System.IO.Pipelines
             public FlushResult GetResult(short token) => _pipe.GetFlushAsyncResult();
 
             public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags) => _pipe.OnFlushAsyncCompleted(continuation, state, flags);
+
+            public override ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+            {
+                return _pipe.WriteAsync(source, cancellationToken);
+            }
         }
     }
 }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -963,7 +963,7 @@ namespace System.IO.Pipelines
                 _writingHead.End += writable;
                 _buffered = 0;
 
-                // This is optimized to use pooled memory that's why we pass 0 instead of
+                // This is optimized to use pooled memory. That's why we pass 0 instead of
                 // source.Length
                 BufferSegment newSegment = AllocateSegment(0);
 

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -317,14 +317,20 @@ namespace System.IO.Pipelines
                     ThrowHelper.ThrowInvalidOperationException_AdvancingPastBufferSize();
                 }
 
-                _currentWriteLength += bytesWritten;
-                _buffered += bytesWritten;
-                _writingMemory = _writingMemory.Slice(bytesWritten);
+                AdvanceCore(bytesWritten);
             }
             else
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.bytesWritten);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void AdvanceCore(int bytesWritten)
+        {
+            _currentWriteLength += bytesWritten;
+            _buffered += bytesWritten;
+            _writingMemory = _writingMemory.Slice(bytesWritten);
         }
 
         internal ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken)
@@ -908,6 +914,63 @@ namespace System.IO.Pipelines
             if (_readerCompletion.IsCompletedOrThrow())
             {
                 result._resultFlags |= ResultFlags.Completed;
+            }
+        }
+
+        internal ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
+        {
+            if (_writerCompletion.IsCompleted)
+            {
+                ThrowHelper.ThrowInvalidOperationException_NoWritingAllowed();
+            }
+
+            // Allocate whatever the pool gives us so we can write, this also marks the
+            // state as writing
+            AllocateWriteHeadIfNeeded(0);
+
+            if (source.Length <= _writingMemory.Length)
+            {
+                source.CopyTo(_writingMemory);
+
+                AdvanceCore(source.Length);
+            }
+            else
+            {
+                // This is the multi segment copy
+                WriteMultiSegment(source.Span);
+            }
+
+            return FlushAsync(cancellationToken);
+        }
+
+        private void WriteMultiSegment(ReadOnlySpan<byte> source)
+        {
+            Span<byte> destination = _writingMemory.Span;
+
+            while (true)
+            {
+                int writable = Math.Min(destination.Length, source.Length);
+                source.Slice(0, writable).CopyTo(destination);
+                source = source.Slice(writable);
+                AdvanceCore(writable);
+
+                if (source.Length == 0)
+                {
+                    break;
+                }
+
+                // We filled the segment
+                _writingHead.End += writable;
+                _buffered = 0;
+
+                // This is optimized to use pooled memory that's why we pass 0 instead of
+                // source.Length
+                BufferSegment newSegment = AllocateSegment(0);
+
+                _writingHead.SetNext(newSegment);
+                _writingHead = newSegment;
+
+                destination = _writingMemory.Span;
             }
         }
 

--- a/src/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -99,7 +99,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public void CanWriteOverTheBlockLength()
+        public async Task CanWriteOverTheBlockLength()
         {
             Memory<byte> memory = Pipe.Writer.GetMemory();
             PipeWriter writer = Pipe.Writer;
@@ -107,7 +107,7 @@ namespace System.IO.Pipelines.Tests
             IEnumerable<byte> source = Enumerable.Range(0, memory.Length).Select(i => (byte)i);
             byte[] expectedBytes = source.Concat(source).Concat(source).ToArray();
 
-            writer.Write(expectedBytes);
+            await writer.WriteAsync(expectedBytes);
 
             Assert.Equal(expectedBytes, Read());
         }
@@ -149,8 +149,7 @@ namespace System.IO.Pipelines.Tests
             var data = new byte[length];
             new Random(length).NextBytes(data);
             PipeWriter output = Pipe.Writer;
-            output.Write(data);
-            await output.FlushAsync();
+            await output.WriteAsync(data);
 
             ReadResult result = await Pipe.Reader.ReadAsync();
             ReadOnlySequence<byte> input = result.Buffer;


### PR DESCRIPTION
- Today we're using an extension method on IBufferWrite<T> to implement copying the input buffer to the underlying PipeWriter. Luckily this method is virtual so we can optimize using the Pipe's internal structures directly rather than going through GetMemory and Advance