### PR TITLE
fix ping TTL option for OSX

### DIFF
--- a/src/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -84,10 +84,17 @@ namespace System.Net.NetworkInformation
 
             if (ttl > 0)
             {
-                if (!ipv4 && s_isBSD)
+                if (s_isBSD)
                 {
-                    // OSX and FreeBSD use -h to set hop limit for IPv6
-                    sb.Append(" -h ");
+                    // OSX and FreeBSD use -h to set hop limit for IPv6 and -m ttl for IPv4
+                    if (ipv4)
+                    {
+                        sb.Append(" -m ");
+                    }
+                    else
+                    {
+                        sb.Append(" -h ");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
This got missed because my machine defaults to IPv6 and that worked as expected when resolving name. 
CI machines do not have global IPv6 configured and test fail. I was able to reproduce the failure when forcibly disabling IPv4 on my system.  