### PR TITLE
Reduce the amount of exceptions throw in Advance

### DIFF
--- a/src/System.IO.Pipelines/src/Resources/Strings.resx
+++ b/src/System.IO.Pipelines/src/Resources/Strings.resx
@@ -123,9 +123,6 @@
   <data name="BackpressureDeadlock" xml:space="preserve">
     <value>The maximum buffer limit of {0} bytes was exceeded by the writer.</value>
   </data>
-  <data name="CannotAdvancePastCurrentBufferSize" xml:space="preserve">
-    <value>Can't advance past buffer size.</value>
-  </data>
   <data name="CannotCompleteWhileReading" xml:space="preserve">
     <value>Can't complete reader while reading.</value>
   </data>
@@ -146,9 +143,6 @@
   </data>
   <data name="NoReadingOperationToComplete" xml:space="preserve">
     <value>No reading operation to complete.</value>
-  </data>
-  <data name="NoWritingOperation" xml:space="preserve">
-    <value>No writing operation. Make sure GetMemory() was called.</value>
   </data>
   <data name="ReadCanceledOnPipeReader" xml:space="preserve">
     <value>Read was canceled on underlying PipeReader.</value>

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -303,26 +303,12 @@ namespace System.IO.Pipelines
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void Advance(int bytesWritten)
         {
-            if (_writingHead == null)
-            {
-                ThrowHelper.ThrowInvalidOperationException_NotWritingNoAlloc();
-            }
-
-            if (bytesWritten >= 0)
-            {
-                Debug.Assert(_writingHead.Next == null);
-
-                if (bytesWritten > _writingMemory.Length)
-                {
-                    ThrowHelper.ThrowInvalidOperationException_AdvancingPastBufferSize();
-                }
-
-                AdvanceCore(bytesWritten);
-            }
-            else
+            if (bytesWritten < 0 || bytesWritten > _writingMemory.Length)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.bytesWritten);
             }
+
+            AdvanceCore(bytesWritten);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -303,7 +303,7 @@ namespace System.IO.Pipelines
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void Advance(int bytesWritten)
         {
-            if (bytesWritten < 0 || bytesWritten > _writingMemory.Length)
+            if ((uint)bytesWritten > (uint)_writingMemory.Length)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.bytesWritten);
             }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThrowHelper.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThrowHelper.cs
@@ -16,10 +16,6 @@ namespace System.IO.Pipelines
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Exception CreateArgumentNullException(ExceptionArgument argument) => new ArgumentNullException(argument.ToString());
 
-        public static void ThrowInvalidOperationException_NotWritingNoAlloc() { throw CreateInvalidOperationException_NotWritingNoAlloc(); }
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public static Exception CreateInvalidOperationException_NotWritingNoAlloc() => new InvalidOperationException(SR.NoWritingOperation);
-
         public static void ThrowInvalidOperationException_AlreadyReading() => throw CreateInvalidOperationException_AlreadyReading();
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static Exception CreateInvalidOperationException_AlreadyReading() => new InvalidOperationException(SR.ReadingIsInProgress);
@@ -44,10 +40,6 @@ namespace System.IO.Pipelines
         public static void ThrowInvalidOperationException_NoReadingAllowed() => throw CreateInvalidOperationException_NoReadingAllowed();
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static Exception CreateInvalidOperationException_NoReadingAllowed() => new InvalidOperationException(SR.ReadingAfterCompleted);
-
-        public static void ThrowInvalidOperationException_AdvancingPastBufferSize() => throw CreateInvalidOperationException_AdvancingPastBufferSize();
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public static Exception CreateInvalidOperationException_AdvancingPastBufferSize() => new InvalidOperationException(SR.CannotAdvancePastCurrentBufferSize);
 
         public static void ThrowInvalidOperationException_BackpressureDeadlock(long sizeLimit) => throw CreateInvalidOperationException_BackpressureDeadlock(sizeLimit);
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -176,16 +176,14 @@ namespace System.IO.Pipelines.Tests
         public void ThrowsOnAdvanceOverMemorySize()
         {
             Memory<byte> buffer = Pipe.Writer.GetMemory(1);
-            var exception = Assert.Throws<InvalidOperationException>(() => Pipe.Writer.Advance(buffer.Length + 1));
-            Assert.Equal("Can't advance past buffer size.", exception.Message);
+            Assert.Throws<ArgumentOutOfRangeException>(() => Pipe.Writer.Advance(buffer.Length + 1));
         }
 
         [Fact]
         public void ThrowsOnAdvanceWithNoMemory()
         {
             PipeWriter buffer = Pipe.Writer;
-            var exception = Assert.Throws<InvalidOperationException>(() => buffer.Advance(1));
-            Assert.Equal("No writing operation. Make sure GetMemory() was called.", exception.Message);
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Advance(1));
         }
     }
 }


### PR DESCRIPTION
- Advance checks for 3 error conditions today, no writing head (no body called GetMemory()), bytesWritten being a positive number and that Advance is called with a bytesWritten between 0 and _writingMemory.Length. Instead, just unify those into a single ArgumentOutOfRangeException.