### PR TITLE
Reduce PLINQ outerloop test execution time

### DIFF
--- a/src/System.Linq.Parallel/tests/Helpers/Sources.cs
+++ b/src/System.Linq.Parallel/tests/Helpers/Sources.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     {
         // For outerloop, we use a large count that makes it more likely we'll fill buffers and saturate
         // producers/consumers, while at the same time being cognizant of total test execution time.
-        public static readonly int OuterLoopCount = 16 * 1024 * Environment.ProcessorCount;
+        public static readonly int OuterLoopCount = 4 * 1024 * Environment.ProcessorCount;
 
         private static readonly IEnumerable<int> OuterLoopCounts = new[] { OuterLoopCount };
 

--- a/src/System.Linq.Parallel/tests/QueryOperators/JoinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/JoinTests.cs
@@ -420,7 +420,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(JoinOrderedLeftUnorderedRightData), new[] { 256, 512 })]
+        [MemberData(nameof(JoinOrderedLeftUnorderedRightData), new[] { 256 })]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve grouping of order-identical left keys through repartitioning (see https://github.com/dotnet/corefx/pull/27930#issuecomment-372084741)")]
         public static void Join_CustomComparator_LeftWithOrderingColisions_UnorderedRight_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {


### PR DESCRIPTION
Our PLINQ test suite has a ridiculously large number of test cases, in particular in outerloop (~200K), and as such it takes a long time to run.  In outerloop CI legs on some machines we're currently bumping up against time limits, causing spurious failures.  While more may be needed, these two small tweaks shrink execution time on my machine by 50%.

Fixes https://github.com/dotnet/corefx/issues/35333 (hopefully... we may need to cut more and/or increase the timeout)
cc: @tarekgh, @benaadams 