### PR TITLE
Make System.Runtime.CompilerServices.Unsafe inbox

### DIFF
--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -3721,7 +3721,8 @@
       ],
       "BaselineVersion": "4.5.1",
       "InboxOn": {
-        "uap10.0.16300": "4.0.5.0"
+        "uap10.0.16300": "4.0.5.0",
+        "netcoreapp3.0": "4.0.5.0"
       },
       "AssemblyVersionInPackageVersion": {
         "4.0.3.0": "4.4.0",

--- a/pkg/test/frameworkSettings/netcoreapp3.0/settings.targets
+++ b/pkg/test/frameworkSettings/netcoreapp3.0/settings.targets
@@ -6,4 +6,12 @@
     <!-- use the most recent MS.NETCore.App we have from upstack -->
     <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- unsafe is part of the framework but we don't yet have a MicrosoftNETCoreAppPackageVersion with that change -->
+    <IgnoredReference Include="System.Runtime.CompilerServices.Unsafe"/>
+  </ItemGroup>
+  <Target Name="CheckForWorkaroundRemoval" AfterTargets="ResolveReferences">
+    <Error Condition="'%(Reference.FileName)' == 'System.Runtime.CompilerServices.Unsafe' AND '%(Reference.NuGetPackageId)' == 'Microsoft.NETCore.App'"
+           Text="Please remove IgnoredReference workaround from pkg\test\frameworkSettings\netcoreapp3.0\settings.targets" />
+  </Target>
 </Project>

--- a/src/Common/src/CoreLib/System/Text/Rune.cs
+++ b/src/Common/src/CoreLib/System/Text/Rune.cs
@@ -477,7 +477,6 @@ namespace System.Text
         /// The <see cref="Utf8SequenceLength"/> property can be queried ahead of time to determine
         /// the required size of the <paramref name="destination"/> buffer.
         /// </remarks>
-        // ** This is public so it can be unit tested but isn't yet exposed via the reference assemblies. **
         public bool TryEncodeToUtf8Bytes(Span<byte> destination, out int bytesWritten)
         {
             // TODO: Optimize some of these writes by using BMI2 instructions.

--- a/src/System.Runtime.CompilerServices.Unsafe/Directory.Build.props
+++ b/src/System.Runtime.CompilerServices.Unsafe/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.5.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
@@ -11,7 +11,15 @@
     <!-- this package is part of the implementation closure of NETStandard.Library
          therefore it cannot reference NETStandard.Library -->
     <SuppressMetaPackage Include="NETStandard.Library" />
-    <InboxOnTargetFramework Include="uap10.0.16300" />
+
+    <!-- Since UAP and .NETCoreApp are package based we still want to enable
+         OOBing libraries that happen to overlap with their framework package.
+         This avoids us having to lock the API in our NuGet packages just 
+         to match what shipped inbox: since we can provide a new library 
+         we can update it to add API without raising the netstandard version. -->
+    <ValidatePackageSuppression Include="TreatAsOutOfBox">
+      <Value>.NETCoreApp;UAP</Value>
+    </ValidatePackageSuppression>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/src/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
+++ b/src/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
@@ -67,6 +67,7 @@
     <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Text.Encoding.Extensions" />
     <Reference Include="System.Threading" />

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterWriter.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterWriter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -86,10 +87,8 @@ namespace System.Runtime.Serialization.Formatters.Binary
             // which just returns the value of its sole Int64 dateData field.  Here, we don't
             // have access to that member (which doesn't even exist anymore, since it was only for
             // BinaryFormatter, which is now in a separate assembly).  To address that,
-            // we access the sole field directly via an unsafe cast; ideally this would
-            // just use Unsafe.As, but since we can't use that here due to not having a netcoreapp
-            // build of System.Runtime.CompilerServices.Unsafe.dll, we instead go through span.
-            long dateData = MemoryMarshal.Cast<DateTime, long>(MemoryMarshal.CreateReadOnlySpan(ref value, 1))[0];
+            // we access the sole field directly via an unsafe cast.
+            long dateData = Unsafe.As<DateTime, long>(ref value);
             WriteInt64(dateData);
         }
 

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -7709,6 +7709,7 @@ namespace System.Text
         [CLSCompliant(false)]
         public static bool TryCreate(uint value, out Rune result) { throw null; }
         public bool TryEncode(Span<char> destination, out int charsWritten) { throw null; }
+        public bool TryEncodeToUtf8Bytes(Span<byte> destination, out int bytesWritten) { throw null; }
         public static bool TryGetRuneAt(string input, int index, out Rune value) { throw null; }
         public static double GetNumericValue(Rune value) { throw null; }
         public static System.Globalization.UnicodeCategory GetUnicodeCategory(Rune value) { throw null; }

--- a/src/System.Runtime/tests/System/Text/RuneTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Text/RuneTests.netcoreapp.cs
@@ -454,14 +454,14 @@ namespace System.Text.Tests
             // First, try with a buffer that's too short
 
             Span<byte> utf8Buffer = stackalloc byte[rune.Utf8SequenceLength - 1];
-            bool success = TryEncodeToUtf8Bytes_Fn(ref rune, utf8Buffer, out int bytesWritten);
+            bool success = rune.TryEncodeToUtf8Bytes(utf8Buffer, out int bytesWritten);
             Assert.False(success);
             Assert.Equal(0, bytesWritten);
 
             // Then, try with a buffer that's appropriately sized
 
             utf8Buffer = stackalloc byte[rune.Utf8SequenceLength];
-            success = TryEncodeToUtf8Bytes_Fn(ref rune, utf8Buffer, out bytesWritten);
+            success = rune.TryEncodeToUtf8Bytes(utf8Buffer, out bytesWritten);
             Assert.True(success);
             Assert.Equal(testData.Utf8Sequence.Length, bytesWritten);
             Assert.True(utf8Buffer.SequenceEqual(testData.Utf8Sequence));
@@ -469,19 +469,10 @@ namespace System.Text.Tests
             // Finally, try with a buffer that's too long (should succeed)
 
             utf8Buffer = stackalloc byte[rune.Utf8SequenceLength + 1];
-            success = TryEncodeToUtf8Bytes_Fn(ref rune, utf8Buffer, out bytesWritten);
+            success = rune.TryEncodeToUtf8Bytes(utf8Buffer, out bytesWritten);
             Assert.True(success);
             Assert.Equal(testData.Utf8Sequence.Length, bytesWritten);
             Assert.True(utf8Buffer.Slice(0, testData.Utf8Sequence.Length).SequenceEqual(testData.Utf8Sequence));
-        }
-
-        private delegate bool TryEncodeToUtf8Bytes_Del(ref Rune rune, Span<byte> destination, out int bytesWritten);
-        private static readonly TryEncodeToUtf8Bytes_Del TryEncodeToUtf8Bytes_Fn = CreateTryEncodeToUtf8BytesDelegate();
-
-        private static TryEncodeToUtf8Bytes_Del CreateTryEncodeToUtf8BytesDelegate()
-        {
-            var methodInfo = typeof(Rune).GetMethod("TryEncodeToUtf8Bytes", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-            return (TryEncodeToUtf8Bytes_Del)methodInfo.CreateDelegate(typeof(TryEncodeToUtf8Bytes_Del));
         }
     }
 }

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -8,7 +8,7 @@
     <!-- For the inbox library (that is shipping with the product), this should always be true. -->
     <!-- BUILDING_INBOX_LIBRARY is only false when building for netstandard to validate that the sources are netstandard compatible. -->
     <!-- This is meant to help with producing a source package and not to ship a netstandard compatible binary. -->
-    <DefineConstants Condition="'$(TargetGroup)' != 'netstandard'">$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants>
+    <DefineConstants Condition="'$(TargetsNETStandard)' != 'true'">$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Text\Json\BitStack.cs" />
@@ -70,14 +70,15 @@
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.String.cs" />
     <Compile Include="System\Text\Json\Writer\Utf8JsonWriter.WriteValues.UnsignedNumber.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
-    <ProjectReference Include="..\..\System.Memory\src\System.Memory.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj" />
+  <ItemGroup Condition="'$(TargetsNETStandard)' != 'true'">
+    <Reference Include="System.Diagnostics.Debug" />
+    <Reference Include="System.Resources.ResourceManager" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Text.Encoding.Extensions" />
+    <Reference Include="System.Threading.Tasks" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <ItemGroup>
     <Reference Include="System.Buffers" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Numerics.Vectors" />

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -6,11 +6,7 @@ using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-#if BUILDING_INBOX_LIBRARY
-using Internal.Runtime.CompilerServices;
-#else
 using System.Runtime.CompilerServices;
-#endif
 
 namespace System.Text.Json
 {

--- a/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
@@ -7,10 +7,6 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#if BUILDING_INBOX_LIBRARY
-using Internal.Runtime.CompilerServices;
-#endif
-
 namespace System.Text.Json
 {
     internal static partial class JsonReaderHelper


### PR DESCRIPTION
Fix a couple places where we wanted to use it from other inbox assemblies but couldn't.

Unsafe remains as a package and newer versions of Unsafe will replace the inbox Version,
permitting us to add API over time.