### PR TITLE
improve detection for ReadOnly_FileSystemHelper

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -92,7 +92,7 @@ namespace System
         public static bool IsRedHatFamily6 { get { throw null; } }
         public static bool IsRedHatFamily7 { get { throw null; } }
         public static bool IsSoundPlaySupported { get { throw null; } }
-        public static bool IsDocker { get { throw null; } }
+        public static bool IsInContainer { get { throw null; } }
         public static bool IsNotRedHatFamily6 { get { throw null; } }
         public static bool IsUap { get { throw null; } }
         public static Version ICUVersion { get { return null; } }

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -92,6 +92,7 @@ namespace System
         public static bool IsRedHatFamily6 { get { throw null; } }
         public static bool IsRedHatFamily7 { get { throw null; } }
         public static bool IsSoundPlaySupported { get { throw null; } }
+        public static bool IsDocker { get { throw null; } }
         public static bool IsNotRedHatFamily6 { get { throw null; } }
         public static bool IsUap { get { throw null; } }
         public static Version ICUVersion { get { return null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -63,6 +63,8 @@ namespace System
         public static bool IsDrawingSupported { get; } = GetGdiplusIsAvailable();
         public static bool IsSoundPlaySupported { get; } = false;
 
+        public static bool IsDocker => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists("/.dockerenv");
+
         [DllImport("libdl")]
         private static extern IntPtr dlopen(string libName, int flags);
         public const int RTLD_NOW = 0x002;

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -63,7 +63,7 @@ namespace System
         public static bool IsDrawingSupported { get; } = GetGdiplusIsAvailable();
         public static bool IsSoundPlaySupported { get; } = false;
 
-        public static bool IsDocker => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists("/.dockerenv");
+        public static bool IsInContainer => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists("/.dockerenv");
 
         [DllImport("libdl")]
         private static extern IntPtr dlopen(string libName, int flags);

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -45,6 +45,7 @@ namespace System
         public static bool IsRedHatFamily6 => false;
         public static bool IsRedHatFamily7 => false;
         public static bool IsNotRedHatFamily6 => true;
+        public static bool IsDocker => false;
 
         public static bool IsWindows10Version1607OrGreater => 
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -241,7 +241,7 @@ namespace System
             {
                 value = (string)Registry.GetValue(key, "ContainerType", defaultValue: "");
             }
-            catch ( )
+            catch
             {
             }
 

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -45,7 +45,7 @@ namespace System
         public static bool IsRedHatFamily6 => false;
         public static bool IsRedHatFamily7 => false;
         public static bool IsNotRedHatFamily6 => true;
-        public static bool IsDocker => false;
+        public static bool IsInContainer => !String.IsNullOrEmpty(GetContainerType());
 
         public static bool IsWindows10Version1607OrGreater => 
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
@@ -207,6 +207,22 @@ namespace System
         {
             Assert.True(GetProductInfo(Environment.OSVersion.Version.Major, Environment.OSVersion.Version.Minor, 0, 0, out int productType));
             return productType;
+        }
+
+        private static string GetContainerType()
+        {
+            string key = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control";
+            string value = "";
+
+            try
+            {
+                value = (string)Registry.GetValue(key, "ContainerType", defaultValue: "");
+            }
+            catch ( )
+            {
+            }
+
+            return value;
         }
 
         private const int PRODUCT_IOTUAP = 0x0000007B;

--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -11,7 +11,7 @@ namespace System.IO.Tests
 {
     public class Directory_Delete_str : FileSystemTest
     {
-        static bool IsBindMountSupported => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !PlatformDetection.IsDocker && !PlatformDetection.IsRedHatFamily6;
+        static bool IsBindMountSupported => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !PlatformDetection.IsInContainer && !PlatformDetection.IsRedHatFamily6;
 
         #region Utilities
 

--- a/src/System.IO.FileSystem/tests/Directory/Delete.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Delete.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
 using System.Text;
 using Xunit;
 using Microsoft.DotNet.XUnitExtensions;
@@ -10,6 +11,8 @@ namespace System.IO.Tests
 {
     public class Directory_Delete_str : FileSystemTest
     {
+        static bool IsBindMountSupported => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !PlatformDetection.IsDocker && !PlatformDetection.IsRedHatFamily6;
+
         #region Utilities
 
         public virtual void Delete(string path)
@@ -202,15 +205,12 @@ namespace System.IO.Tests
             Assert.False(Directory.Exists(testDir));
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsBindMountSupported))]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
         [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         public void Unix_NotFoundDirectory_ReadOnlyVolume()
         {
-            if (PlatformDetection.IsRedHatFamily6 || PlatformDetection.IsAlpine)
-                return; // [ActiveIssue(https://github.com/dotnet/corefx/issues/21920)]
-
             ReadOnly_FileSystemHelper(readOnlyDirectory =>
             {
                 Assert.Throws<DirectoryNotFoundException>(() => Delete(Path.Combine(readOnlyDirectory, "DoesNotExist")));

--- a/src/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/System.IO.FileSystem/tests/File/Delete.cs
@@ -10,7 +10,7 @@ namespace System.IO.Tests
 {
     public class File_Delete : FileSystemTest
     {
-        static bool IsBindMountSupported => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !PlatformDetection.IsDocker && !PlatformDetection.IsRedHatFamily6;
+        static bool IsBindMountSupported => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !PlatformDetection.IsInContainer && !PlatformDetection.IsRedHatFamily6;
 
         public virtual void Delete(string path)
         {

--- a/src/System.IO.FileSystem/tests/File/Delete.cs
+++ b/src/System.IO.FileSystem/tests/File/Delete.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
 using Xunit;
 using Microsoft.DotNet.XUnitExtensions;
 
@@ -9,6 +10,8 @@ namespace System.IO.Tests
 {
     public class File_Delete : FileSystemTest
     {
+        static bool IsBindMountSupported => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !PlatformDetection.IsDocker && !PlatformDetection.IsRedHatFamily6;
+
         public virtual void Delete(string path)
         {
             File.Delete(path);
@@ -113,30 +116,24 @@ namespace System.IO.Tests
 
         #region PlatformSpecific
 
-        [Fact]
+        [ConditionalFact(nameof(IsBindMountSupported))]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
         [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         public void Unix_NonExistentPath_ReadOnlyVolume()
         {
-            if (PlatformDetection.IsRedHatFamily6 || PlatformDetection.IsAlpine)
-                return; // [ActiveIssue(https://github.com/dotnet/corefx/issues/21920)]
-
             ReadOnly_FileSystemHelper(readOnlyDirectory =>
             {
                 Delete(Path.Combine(readOnlyDirectory, "DoesNotExist"));
             });
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsBindMountSupported))]
         [OuterLoop("Needs sudo access")]
         [PlatformSpecific(TestPlatforms.Linux)]
         [Trait(XunitConstants.Category, XunitConstants.RequiresElevation)]
         public void Unix_ExistingDirectory_ReadOnlyVolume()
         {
-            if (PlatformDetection.IsRedHatFamily6 || PlatformDetection.IsAlpine)
-                return; // [ActiveIssue(https://github.com/dotnet/corefx/issues/21920)]
-
             ReadOnly_FileSystemHelper(readOnlyDirectory =>
             {
                 Assert.Throws<IOException>(() => Delete(Path.Combine(readOnlyDirectory, "subdir")));


### PR DESCRIPTION
Add detection of Docker instead of blaming Alpine.
I verified that other OSes also fail when executed in Docker image. 
This also fixes currently failing tests on ARM64:
https://mc.dot.net/#/product/netcore/30/source/official~2Fdotnet~2Fcorefx~2Frefs~2Fheads~2Fmaster/type/test~2Ffunctional~2Fcli~2F/build/20190222.2/workItem/System.IO.FileSystem.Tests

Also test will now properly report skip result instead of pass.

fixes #21920  