### PR TITLE
Removing restriction of first 8 character being different from lognames

### DIFF
--- a/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
+++ b/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
@@ -307,17 +307,13 @@ namespace System.Diagnostics
                     }
 
                     logKey = eventKey.OpenSubKey(logName, true);
-                    if (logKey == null && logName.Length >= 8)
+                    if (logKey == null)
                     {
-                        string logNameFirst8 = logName.Substring(0, 8);
-                        if (string.Equals(logNameFirst8, "AppEvent", StringComparison.OrdinalIgnoreCase) ||
-                             string.Equals(logNameFirst8, "SecEvent", StringComparison.OrdinalIgnoreCase) ||
-                             string.Equals(logNameFirst8, "SysEvent", StringComparison.OrdinalIgnoreCase))
+                        if (logName.Length == 8 && (
+                            string.Equals(logName, "AppEvent", StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(logName, "SecEvent", StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(logName, "SysEvent", StringComparison.OrdinalIgnoreCase)))
                             throw new ArgumentException(SR.Format(SR.InvalidCustomerLogName, logName));
-
-                        string sameLogName = FindSame8FirstCharsLog(eventKey, logName);
-                        if (sameLogName != null)
-                            throw new ArgumentException(SR.Format(SR.DuplicateLogName, logName, sameLogName));
                     }
 
                     bool createLogKey = (logKey == null);
@@ -527,7 +523,7 @@ namespace System.Diagnostics
                 if (eventkey == null)
                     return false;
 
-                logKey = eventkey.OpenSubKey(logName, false);         // try to find log file key immediately.
+                logKey = eventkey.OpenSubKey(logName, false); // try to find log file key immediately.
                 return (logKey != null);
             }
             finally
@@ -535,23 +531,6 @@ namespace System.Diagnostics
                 eventkey?.Close();
                 logKey?.Close();
             }
-        }
-        // Try to find log file name with the same 8 first characters.
-        // Returns 'null' if no "same first 8 chars" log is found.   logName.Length must be > 7
-        private static string FindSame8FirstCharsLog(RegistryKey keyParent, string logName)
-        {
-            string logNameFirst8 = logName.Substring(0, 8);
-            string[] logNames = keyParent.GetSubKeyNames();
-
-            for (int i = 0; i < logNames.Length; i++)
-            {
-                string currentLogName = logNames[i];
-                if (currentLogName.Length >= 8 &&
-                    string.Equals(currentLogName.Substring(0, 8), logNameFirst8, StringComparison.OrdinalIgnoreCase))
-                    return currentLogName;
-            }
-
-            return null;   // not found
         }
 
         private static RegistryKey FindSourceRegistration(string source, string machineName, bool readOnly)

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -27,6 +27,65 @@ namespace System.Diagnostics.Tests
             Assert.False(EventLog.SourceExists(source));
         }
 
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void LogNameWithSame8FirstChars_NetCore()
+        {
+            string firstSource = "FirstSource_" + nameof(LogNameWithSame8FirstChars_NetCore);
+            string firstLog = "LogNameWithSame8FirstChars";
+            string secondSource = "SecondSource_" + nameof(LogNameWithSame8FirstChars_NetCore);
+            string secondLog = "LogNameWithSame8FirstCharsDuplicate";
+
+            // No Exception should be thrown.
+            try
+            {
+                EventLog.CreateEventSource(firstSource, firstLog);
+                Assert.True(EventLog.SourceExists(firstSource));
+                EventLog.CreateEventSource(secondSource, secondLog);
+                Assert.True(EventLog.SourceExists(secondSource));
+            }
+            finally
+            {
+                EventLog.DeleteEventSource(firstSource);
+                Helpers.RetryOnWin7(() => EventLog.Delete(firstLog));
+                EventLog.DeleteEventSource(secondSource);
+                Helpers.RetryOnWin7(() => EventLog.Delete(secondLog));
+            }
+        }
+
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public void LogNameWithSame8FirstChars_NetFramework()
+        {
+            string firstSource = "FirstSource_" + nameof(LogNameWithSame8FirstChars_NetFramework);
+            string firstLog = "LogNameWithSame8FirstChars";
+            string secondSource = "SecondSource_" + nameof(LogNameWithSame8FirstChars_NetFramework);
+            string secondLog = "LogNameWithSame8FirstCharsDuplicate";
+
+            try
+            {
+                EventLog.CreateEventSource(firstSource, firstLog);
+                Assert.True(EventLog.SourceExists(firstSource));
+                Assert.Throws<ArgumentException>(() => EventLog.CreateEventSource(secondSource, secondLog));
+            }
+            finally
+            {
+                EventLog.DeleteEventSource(firstSource);
+                Helpers.RetryOnWin7(() => EventLog.Delete(firstLog));
+            }
+        }
+
+        [ConditionalTheory(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
+        [InlineData("AppEvent")]
+        [InlineData("SecEvent")]
+        [InlineData("SysEvent")]
+        public void SystemLogNamesThrowException(string logName)
+        {
+            string source = "Source_" + nameof(SystemLogNamesThrowException);
+            Assert.False(EventLog.SourceExists(source));
+            Assert.Throws<ArgumentException>(() => EventLog.CreateEventSource(source, logName));         
+        }
+
         [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
         public void CheckSourceExistsArgumentNull()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/31119

I removed the first 8 same characters check. Same log Name check is not required because opensubkey will already be looking at all the subkeys, when it tries to open the subkey.

i retained the restriction of not being able to use system names such as "appevent secvent Sysevent". However i allowed them to be present as a substring.