### PR TITLE
Dead Code Deletions in System.IO.Compression

### DIFF
--- a/src/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/System.IO.Compression/src/Resources/Strings.resx
@@ -309,7 +309,4 @@
   <data name="Zip64EOCDNotWhereExpected" xml:space="preserve">
     <value>Zip 64 End of Central Directory Record not where indicated.</value>
   </data>
-  <data name="Argument_InvalidPathChars" xml:space="preserve">
-    <value>Illegal characters in path '{0}'.</value>
-  </data>
 </root>


### PR DESCRIPTION
As this is my first contribution to OSS,  I wanted to keep the PR small.  The three lines were removed and passed all tests.

I was unable to use the /p:TargetGroup=netfx with msbuild, so instead used /p:TargetFrameworkVersion=4.7.2,  as well as the default for tests.