### PR TITLE
Disable azure pipelines reporter for official builds

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -215,16 +215,13 @@ jobs:
                 msbuildScript: $(_msbuildCommand)
                 framework: $(_framework)
                 outerloop: $(_outerloop)
+                enableAzurePipelinesReporter: false
 
                 ${{ if eq(parameters.isOfficialBuild, 'true') }}:
                   isExternal: false
                   waitForCompletion: false
                   officialBuildId: $(Build.BuildNumber)
                   helixToken: $(HelixApiAccessToken)
-                  ${{ if ne(job.enableAzurePipelinesReporter, '') }}:
-                    enableAzurePipelinesReporter: ${{ job.enableAzurePipelinesReporter }}
-                  ${{ if eq(job.enableAzurePipelinesReporter, '') }}:
-                    enableAzurePipelinesReporter: true
 
                 ${{ if eq(parameters.isOfficialBuild, 'false') }}:
                   # TODO: SET Creator to the PR owner whenever Azure DevOps supports a good way to retrieve it.
@@ -232,8 +229,6 @@ jobs:
                   isExternal: true
                   waitForCompletion: true
                   helixToken: ''
-                  # TODO: Enable azure pipelines reporter for PRs once retry feature is available.
-                  enableAzurePipelinesReporter: false
 
           - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
             - task: PublishBuildArtifacts@1


### PR DESCRIPTION
In order for this to work correctly first we need to wait for our tests to finish.

cc: @MattGal 