### PR TITLE
Use NativeLibrary.TryLoad and prefer RTLD_LAZY over RTLD_NOW

### DIFF
--- a/src/Common/src/Interop/Unix/libdl/Interop.dlopen.cs
+++ b/src/Common/src/Interop/Unix/libdl/Interop.dlopen.cs
@@ -10,7 +10,6 @@ internal partial class Interop
     internal partial class Libdl
     {
         public const int RTLD_LAZY = 0x001;
-        public const int RTLD_NOW = 0x002;
 
         [DllImport(Libraries.Libdl)]
         public static extern IntPtr dlopen(string fileName, int flag);

--- a/src/Common/src/Interop/Unix/libdl/Interop.dlopen.cs
+++ b/src/Common/src/Interop/Unix/libdl/Interop.dlopen.cs
@@ -9,6 +9,7 @@ internal partial class Interop
 {
     internal partial class Libdl
     {
+        public const int RTLD_LAZY = 0x001;
         public const int RTLD_NOW = 0x002;
 
         [DllImport(Libraries.Libdl)]

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -60,20 +60,12 @@ namespace System
         public static bool IsNetfx471OrNewer => false;
         public static bool IsNetfx472OrNewer => false;
 
-        public static bool IsDrawingSupported { get; } = GetGdiplusIsAvailable();
-        public static bool IsSoundPlaySupported { get; } = false;
+        public static bool IsDrawingSupported { get; } =
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
+                NativeLibrary.TryLoad("libgdiplus.dylib", out _) :
+                NativeLibrary.TryLoad("libgdiplus.so", out _) || NativeLibrary.TryLoad("libgdiplus.so.0", out _);
 
-        private static bool GetGdiplusIsAvailable()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return NativeLibrary.TryLoad("libgdiplus.dylib", out _);
-            }
-            else
-            {
-                return NativeLibrary.TryLoad("libgdiplus.so", out _) || NativeLibrary.TryLoad("libgdiplus.so.0", out _);
-            }
-        }
+        public static bool IsSoundPlaySupported { get; } = false;
 
         public static Version OSXVersion { get; } = ToVersion(PlatformApis.GetOSVersion());
 

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -71,7 +71,7 @@ namespace System
 
         [DllImport("libdl")]
         private static extern IntPtr dlopen(string libName, int flags);
-        public const int RTLD_LAZY = 0x001;
+        private const int RTLD_LAZY = 0x001;
 #endif
 
         public static bool IsSoundPlaySupported { get; } = false;

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -65,7 +65,7 @@ namespace System
 
         [DllImport("libdl")]
         private static extern IntPtr dlopen(string libName, int flags);
-        public const int RTLD_NOW = 0x002;
+        public const int RTLD_LAZY = 0x001;
 
         private static bool GetGdiplusIsAvailable()
         {
@@ -73,14 +73,14 @@ namespace System
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                nativeLib = dlopen("libgdiplus.dylib", RTLD_NOW);
+                nativeLib = dlopen("libgdiplus.dylib", RTLD_LAZY);
             }
             else
             {
-                nativeLib = dlopen("libgdiplus.so", RTLD_NOW);
+                nativeLib = dlopen("libgdiplus.so", RTLD_LAZY);
                 if (nativeLib == IntPtr.Zero)
                 {
-                    nativeLib = dlopen("libgdiplus.so.0", RTLD_NOW);
+                    nativeLib = dlopen("libgdiplus.so.0", RTLD_LAZY);
                 }
             }
 

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -63,28 +63,16 @@ namespace System
         public static bool IsDrawingSupported { get; } = GetGdiplusIsAvailable();
         public static bool IsSoundPlaySupported { get; } = false;
 
-        [DllImport("libdl")]
-        private static extern IntPtr dlopen(string libName, int flags);
-        public const int RTLD_LAZY = 0x001;
-
         private static bool GetGdiplusIsAvailable()
         {
-            IntPtr nativeLib;
-
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                nativeLib = dlopen("libgdiplus.dylib", RTLD_LAZY);
+                return NativeLibrary.TryLoad("libgdiplus.dylib", out _);
             }
             else
             {
-                nativeLib = dlopen("libgdiplus.so", RTLD_LAZY);
-                if (nativeLib == IntPtr.Zero)
-                {
-                    nativeLib = dlopen("libgdiplus.so.0", RTLD_LAZY);
-                }
+                return NativeLibrary.TryLoad("libgdiplus.so", out _) || NativeLibrary.TryLoad("libgdiplus.so.0", out _);
             }
-
-            return nativeLib != IntPtr.Zero;
         }
 
         public static Version OSXVersion { get; } = ToVersion(PlatformApis.GetOSVersion());

--- a/src/System.Data.Odbc/tests/Helpers.cs
+++ b/src/System.Data.Odbc/tests/Helpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
 
 namespace System.Data.Odbc.Tests
 {

--- a/src/System.Data.Odbc/tests/Helpers.cs
+++ b/src/System.Data.Odbc/tests/Helpers.cs
@@ -16,7 +16,7 @@ namespace System.Data.Odbc.Tests
 #if TargetsWindows
                 !PlatformDetection.IsWindowsNanoServer && (!PlatformDetection.IsWindowsServerCore || Environment.Is64BitProcess);
 #else
-                Interop.Libdl.dlopen(Interop.Libraries.Odbc32, Interop.Libdl.RTLD_NOW) != IntPtr.Zero;
+                NativeLibrary.TryLoad(Interop.Libraries.Odbc32, out _);
 #endif
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Unix.cs
@@ -32,7 +32,7 @@ namespace System.Drawing
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     libraryName = "libgdiplus.dylib";
-                    lib = Interop.Libdl.dlopen(libraryName, Interop.Libdl.RTLD_NOW);
+                    lib = Interop.Libdl.dlopen(libraryName, Interop.Libdl.RTLD_LAZY);
                 }
                 else
                 {
@@ -41,10 +41,10 @@ namespace System.Drawing
                     // a global configuration setting. We prefer the "unversioned" shared object name, and fallback to
                     // the name suffixed with ".0".
                     libraryName = "libgdiplus.so";
-                    lib = Interop.Libdl.dlopen(libraryName, Interop.Libdl.RTLD_NOW);
+                    lib = Interop.Libdl.dlopen(libraryName, Interop.Libdl.RTLD_LAZY);
                     if (lib == IntPtr.Zero)
                     {
-                        lib = Interop.Libdl.dlopen("libgdiplus.so.0", Interop.Libdl.RTLD_NOW);
+                        lib = Interop.Libdl.dlopen("libgdiplus.so.0", Interop.Libdl.RTLD_LAZY);
                     }
                 }
 
@@ -58,7 +58,7 @@ namespace System.Drawing
                     {
                         var searchPath = Path.Combine(searchDirectory, libraryName);
 
-                        lib = Interop.Libdl.dlopen(searchPath, Interop.Libdl.RTLD_NOW);
+                        lib = Interop.Libdl.dlopen(searchPath, Interop.Libdl.RTLD_LAZY);
 
                         if (lib != IntPtr.Zero)
                         {

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/LibcupsNative.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/LibcupsNative.cs
@@ -15,10 +15,10 @@ namespace System.Drawing.Printing
         private static IntPtr LoadLibcups()
         {
             // We allow both "libcups.so" and "libcups.so.2" to be loaded.
-            IntPtr lib = Interop.Libdl.dlopen("libcups.so", Interop.Libdl.RTLD_NOW);
+            IntPtr lib = Interop.Libdl.dlopen("libcups.so", Interop.Libdl.RTLD_LAZY);
             if (lib == IntPtr.Zero)
             {
-                lib = Interop.Libdl.dlopen("libcups.so.2", Interop.Libdl.RTLD_NOW);
+                lib = Interop.Libdl.dlopen("libcups.so.2", Interop.Libdl.RTLD_LAZY);
             }
 
             return lib;


### PR DESCRIPTION
Use:
* `NativeLibrary.TryLoad` in few test helpers
* `RTLD_LAZY` instead of `RTLD_NOW`

Related to: #34633