### PR TITLE
improve Ssl3 detection

### DIFF
--- a/src/Common/tests/System/Net/SslProtocolSupport.cs
+++ b/src/Common/tests/System/Net/SslProtocolSupport.cs
@@ -23,9 +23,7 @@ namespace System.Net.Test.Common
             {
                 SslProtocols supported = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
 #pragma warning disable 0618 // SSL2/3 are deprecated
-                if (PlatformDetection.IsWindows ||
-                    PlatformDetection.IsOSX ||
-                    (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && PlatformDetection.OpenSslVersion < new Version(1, 0, 2) && !PlatformDetection.IsDebian))
+                if (PlatformDetection.SupportsSsl3)
                 {
                     supported |= SslProtocols.Ssl3;
                 }

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -43,6 +43,7 @@ namespace System
         public static bool IsReflectionEmitSupported;
         public static bool SupportsAlpn { get { throw null; } }
         public static bool SupportsClientAlpn { get { throw null; } }
+        public static bool SupportsSsl3 { get { throw null; } }
         public static bool ClientWebSocketPartialMessagesSupported { get { throw null; } }
         public static bool HasWindowsShell { get { throw null; } }
         public static bool IsArmProcess { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -62,6 +62,7 @@ namespace System
 
         public static bool IsDrawingSupported { get; } = GetGdiplusIsAvailable();
         public static bool IsSoundPlaySupported { get; } = false;
+        public static bool SupportsSsl3 => (PlatformDetection.IsOSX || (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && PlatformDetection.OpenSslVersion < new Version(1, 0, 2) && !PlatformDetection.IsDebian));
 
         [DllImport("libdl")]
         private static extern IntPtr dlopen(string libName, int flags);

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -45,6 +45,7 @@ namespace System
         public static bool IsRedHatFamily6 => false;
         public static bool IsRedHatFamily7 => false;
         public static bool IsNotRedHatFamily6 => true;
+        public static bool SupportsSsl3 => GetSsl3Support();
 
         public static bool IsWindows10Version1607OrGreater => 
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
@@ -200,6 +201,27 @@ namespace System
             }
 
             return value;
+        }
+
+        private static string GetSsl3Support()
+        {
+            string clientKey = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Client";
+            string serverKey = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server";
+            bool enabled = true;
+
+            // This may change in future but for now, missing key means protocol is enabled.
+            try
+            {
+                if ((int)Registry.GetValue(clientKey, "Enabled") == 0 || (int)Registry.GetValue(serverKey, "Enabled") == 0)
+                {
+                    enabled = false;
+                }
+            }
+            catch ( )
+            {
+            }
+
+            return enabled;
         }
 
         private static int GetWindowsProductType()

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -217,7 +217,7 @@ namespace System
                     enabled = false;
                 }
             }
-            catch (Exception e) when (e is SecurityException || e is InvalidCastException)
+            catch (Exception e) when (e is SecurityException || e is InvalidCastException || e is NullReferenceException)
             {
             }
 

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -203,7 +203,7 @@ namespace System
             return value;
         }
 
-        private static string GetSsl3Support()
+        private static bool GetSsl3Support()
         {
             string clientKey = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Client";
             string serverKey = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server";
@@ -212,12 +212,12 @@ namespace System
             // This may change in future but for now, missing key means protocol is enabled.
             try
             {
-                if ((int)Registry.GetValue(clientKey, "Enabled") == 0 || (int)Registry.GetValue(serverKey, "Enabled") == 0)
+                if ((int)Registry.GetValue(clientKey, "Enabled", 1) == 0 || (int)Registry.GetValue(serverKey, "Enabled", 1) == 0)
                 {
                     enabled = false;
                 }
             }
-            catch ( )
+            catch (Exception e) when (e is SecurityException || e is InvalidCastException)
             {
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -89,12 +89,7 @@ namespace System.Net.Http.Functional.Tests
             // These protocols are disabled by default, so we can only connect with them explicitly.
             // On certain platforms these are completely disabled and cannot be used at all.
 #pragma warning disable 0618
-            if (PlatformDetection.IsWindows ||
-                PlatformDetection.IsOSX ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
-                 PlatformDetection.OpenSslVersion < new Version(1, 0, 2) &&
-                 !PlatformDetection.IsDebian &&
-                 !PlatformDetection.IsRedHatFamily6))
+            if (PlatformDetection.SupportsSsl3)
             {
                 // TODO #28790: SSLv3 is supported on RHEL 6, but this test case still fails.
                 yield return new object[] { SslProtocols.Ssl3, true };


### PR DESCRIPTION
fixes #35537
It seems like recent Windows images have registry keys to disable SSLv3. This change updates detection to deal with is properly. It was verified on image created via reproTool. 

Note, that this does not seems directly related to discussion about defaulting SSLv3 when registry keys are missing. 
