### PR TITLE
disable AllSubscriberStress test on ARM64 

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -501,7 +501,7 @@ namespace System.Diagnostics.Tests
         /// Stresses the AllListeners by having many threads be adding and removing.
         /// </summary>
         [OuterLoop]
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(35539)]
         [InlineData(100, 100)] // run multiple times to stress it further
         [InlineData(100, 100)]
         [InlineData(100, 100)]


### PR DESCRIPTION
related to #35539

It seems like it takes very long time to run it with current container configuration. This change disables this test so we can get complete runs.  