### PR TITLE
collect system info if IPv6 loopback fails to resolve

### DIFF
--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -2,18 +2,32 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Runtime.InteropServices;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.NameResolution.PalTests
 {
     public class NameResolutionPalTests
     {
-        static NameResolutionPalTests()
+        private ITestOutputHelper _output;
+
+        public NameResolutionPalTests(ITestOutputHelper output)
         {
             NameResolutionPal.EnsureSocketsAreInitialized();
+            _output = output;
+        }
+
+        private void LogUnixInfo()
+        {
+            _output.WriteLine("--- /etc/hosts ---");
+            _output.WriteLine(File.ReadAllText("/etc/hosts"));
+            _output.WriteLine("--- /etc/resolv.conf ---");
+            _output.WriteLine(File.ReadAllText("/etc/resolv.conf"));
+            _output.WriteLine("------");
         }
 
         [Fact]
@@ -75,6 +89,10 @@ namespace System.Net.NameResolution.PalTests
             SocketError error;
             int nativeErrorCode;
             string name = NameResolutionPal.TryGetNameInfo(new IPAddress(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), out error, out nativeErrorCode);
+            if (SocketError.Success != error && Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                LogUnixInfo();
+            }
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(name);
         }
@@ -160,11 +178,20 @@ namespace System.Net.NameResolution.PalTests
             SocketError error;
             int nativeErrorCode;
             string name = NameResolutionPal.TryGetNameInfo(new IPAddress(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), out error, out nativeErrorCode);
+            if (SocketError.Success != error && Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                LogUnixInfo();
+            }
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(name);
 
             IPHostEntry hostEntry;
             error = NameResolutionPal.TryGetAddrInfo(name, out hostEntry, out nativeErrorCode);
+            if (SocketError.Success != error && Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                LogUnixInfo();
+            }
+
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(hostEntry);
         }

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -93,6 +93,7 @@ namespace System.Net.NameResolution.PalTests
             {
                 LogUnixInfo();
             }
+
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(name);
         }
@@ -182,6 +183,7 @@ namespace System.Net.NameResolution.PalTests
             {
                 LogUnixInfo();
             }
+
             Assert.Equal(SocketError.Success, error);
             Assert.NotNull(name);
 


### PR DESCRIPTION
fixes  #29293 [arm32] corefx System.Net.NameResolution.Pal.Tests fails

After investigating many DNS failures, this really seems like environmental problem.  I decided to follow @danmosemsft suggestion and collect more info on failure. 

We can reopen and investigate if this ever fails again.  

