### PR TITLE
[release/2.1] Ignore CTRequired when building an X509 chain on macOS

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.cpp
@@ -186,7 +186,8 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
         // It doesn't represent a new error code, and we're still getting the old ones, so
         // just ignore it for now.
     }
-    else if (CFEqual(keyString, CFSTR("NonEmptySubject")) || CFEqual(keyString, CFSTR("GrayListedKey")))
+    else if (CFEqual(keyString, CFSTR("NonEmptySubject")) || CFEqual(keyString, CFSTR("GrayListedKey")) ||
+             CFEqual(keyString, CFSTR("CTRequired")))
     {
         // Not a "problem" that we report.
     }


### PR DESCRIPTION
Port #35246 to release/2.1 to prevent the new "CTRequired" errors from failing X509Chain builds on macOS.

#### Description

Recent change to macOS has caused a new error code to appear during X509Chain building. Since this error code has been identified as not having impact on the .NET X509Chain class, ignore it.

#### Customer Impact

Without this fix, customers who upgrade their macOS version and build X509Chains against certificates/certificate-authorities which result in the CTRequired code will get a CryptographicException due to the unmapped error.

#### Regression?

No, reaction to OS update.

#### Packaging reviewed?

Required shim library, no packaging impact.

#### Risk

Minimal