### PR TITLE
Fix advance for single length delimiter

### DIFF
--- a/src/System.Memory/src/System/Buffers/SequenceReader.Search.cs
+++ b/src/System.Memory/src/System/Buffers/SequenceReader.Search.cs
@@ -434,6 +434,10 @@ namespace System.Buffers
 
                 if (delimiter.Length == 1)
                 {
+                    if (advancePastDelimiter)
+                    {
+                        Advance(1);
+                    }
                     return true;
                 }
 

--- a/src/System.Memory/tests/SequenceReader/ReadTo.cs
+++ b/src/System.Memory/tests/SequenceReader/ReadTo.cs
@@ -186,7 +186,7 @@ namespace System.Memory.Tests.SequenceReader
 
             Span<byte> delimiter = new byte[] { 1 };
 
-            for (int i = 1; i < 6; i += 2)
+            for (int i = 1; i < 6; i += 1)
             {
                 delimiter[0] = (byte)i;
                 Assert.True(reader.TryReadTo(out ReadOnlySequence<byte> sequence, delimiter, advancePastDelimiter: true));

--- a/src/System.Memory/tests/SequenceReader/ReadTo.cs
+++ b/src/System.Memory/tests/SequenceReader/ReadTo.cs
@@ -183,14 +183,18 @@ namespace System.Memory.Tests.SequenceReader
             });
 
             SequenceReader<byte> reader = new SequenceReader<byte>(bytes);
-
             Span<byte> delimiter = new byte[] { 1 };
 
             for (int i = 1; i < 6; i += 1)
             {
+                // Also check scanning from the start.
+                SequenceReader<byte> resetReader = new SequenceReader<byte>(bytes);
                 delimiter[0] = (byte)i;
                 Assert.True(reader.TryReadTo(out ReadOnlySequence<byte> sequence, delimiter, advancePastDelimiter: true));
+                Assert.True(resetReader.TryReadTo(out sequence, delimiter, advancePastDelimiter: true));
                 Assert.True(reader.TryPeek(out byte value));
+                Assert.Equal(i + 1, value);
+                Assert.True(resetReader.TryPeek(out value));
                 Assert.Equal(i + 1, value);
             }
         }

--- a/src/System.Memory/tests/SequenceReader/ReadTo.cs
+++ b/src/System.Memory/tests/SequenceReader/ReadTo.cs
@@ -173,5 +173,26 @@ namespace System.Memory.Tests.SequenceReader
             reader.Advance(4);
             Assert.False(reader.TryReadTo(out ReadOnlySequence<byte> span, 255, 0, advancePastDelimiter));
         }
+
+        [Fact]
+        public void TryReadTo_SingleDelimiter()
+        {
+            ReadOnlySequence<byte> bytes = SequenceFactory.Create(new byte[][] {
+                new byte[] { 1 },
+                new byte[] { 2, 3, 4, 5, 6 }
+            });
+
+            SequenceReader<byte> reader = new SequenceReader<byte>(bytes);
+
+            Span<byte> delimiter = new byte[] { 1 };
+
+            for (int i = 1; i < 6; i += 2)
+            {
+                delimiter[0] = (byte)i;
+                Assert.True(reader.TryReadTo(out ReadOnlySequence<byte> sequence, delimiter, advancePastDelimiter: true));
+                Assert.True(reader.TryPeek(out byte value));
+                Assert.Equal(i + 1, value);
+            }
+        }
     }
 }


### PR DESCRIPTION
If the delimiter span for TryReadTo was only one character long we weren't advancing past the delimiter if requested. Add regression test.

cc: @jkotalik 