### PR TITLE
Do not include System.IO.Ports.Native.* in NetCoreApp

### DIFF
--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -50,6 +50,7 @@
   <ItemGroup Condition="'$(IncludeNativeFiles)' == 'true'">
     <!-- Include native -->
     <ExcludeNative Include="$(NativeBinDir)/*.lib" />
+    <ExcludeNative Include="$(NativeBinDir)/System.IO.Ports.Native.*" />
     <NativeFile Include="$(NativeBinDir)/*.*" Exclude="@(ExcludeNative)" />
     <!-- force a missing file if native build is absent -->
     <NativeFile Include="$(NativeBinDir)/MISSING_NATIVE_BUILD" Condition="'@(NativeFile)' == ''" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/35358

System.IO.Ports.Native currently ships OOB so it's not needed in the framework anymore.

I believe this simple fix should remove it - not seeing .so file under runtimes/linux-x64/native on the runtime package (runtime.linux-x64.Microsoft.Private.CoreFx.NETCoreApp) produced on linux