### PR TITLE
Add test to verify that DangerousRelease preserves Marshal.GetLastWin32Error

### DIFF
--- a/src/System.Runtime.Handles/tests/SafeHandle.cs
+++ b/src/System.Runtime.Handles/tests/SafeHandle.cs
@@ -81,4 +81,40 @@ public partial class SafeHandle_4000_Tests
         Assert.False(mch.IsInvalid);
         Assert.True(mch.IsReleased);
     }
+
+    [DllImport("Kernel32", SetLastError = true)]
+    private extern static void SetLastError(int error);
+
+    private class LastErrorSafeHandle : SafeHandle
+    {
+        internal LastErrorSafeHandle(IntPtr h)
+            : base(h, true)
+        {
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        override protected bool ReleaseHandle()
+        {
+            SetLastError(-1);
+            return true;
+        }
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public static void SafeHandle_DangerousReleasePreservesLastError()
+    {
+        LastErrorSafeHandle handle = new LastErrorSafeHandle((IntPtr)1);
+
+        bool success = false;
+        handle.DangerousAddRef(ref success);
+        handle.Dispose();
+
+        SetLastError(42);
+        handle.DangerousRelease();
+
+        int error = Marshal.GetLastWin32Error();
+        Assert.Equal(42, error);
+    }
 }

--- a/src/System.Runtime.Handles/tests/SafeHandle.cs
+++ b/src/System.Runtime.Handles/tests/SafeHandle.cs
@@ -94,7 +94,7 @@ public partial class SafeHandle_4000_Tests
 
         public override bool IsInvalid => handle == IntPtr.Zero;
 
-        override protected bool ReleaseHandle()
+        protected override bool ReleaseHandle()
         {
             SetLastError(-1);
             return true;


### PR DESCRIPTION
Regression test for https://github.com/dotnet/coreclr/pull/22871