### PR TITLE
Updating the Roslyn toolset to 3.0.0-beta4 and setting LangVersion=preview

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -312,7 +312,7 @@
   <PropertyGroup>
     <!-- default to allowing all language features -->
     <LangVersion>latest</LangVersion>
-    <LangVersion Condition="'$(Language)' == 'C#'">8.0</LangVersion>
+    <LangVersion Condition="'$(Language)' == 'C#'">preview</LangVersion>
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict</Features>
     <WarningLevel>4</WarningLevel>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -83,13 +83,13 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>cc263e38a00caf47eaad1acdcc4d2d1d55b07f92</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers" Version="3.0.0-beta3-final">
+    <Dependency Name="Microsoft.Net.Compilers" Version="3.0.0-beta4-final">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>091091276de5136e94e4413faa87e4d4ec3a7671</Sha>
+      <Sha>ec366687c8caead948e58704ad61ed644eb91b5b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Compilers" Version="3.0.0-beta3-final">
+    <Dependency Name="Microsoft.NETCore.Compilers" Version="3.0.0-beta4-final">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>091091276de5136e94e4413faa87e4d4ec3a7671</Sha>
+      <Sha>ec366687c8caead948e58704ad61ed644eb91b5b</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,7 +31,7 @@
     <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19126.3</MicrosoftDotNetCoreFxTestingPackageVersion>
     <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19126.3</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19126.3</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftNetCompilersVersion>3.0.0-beta3-final</MicrosoftNetCompilersVersion>
+    <MicrosoftNetCompilersVersion>3.0.0-beta4-final</MicrosoftNetCompilersVersion>
     <MicrosoftNETCoreCompilersVersion>$(MicrosoftNetCompilersVersion)</MicrosoftNETCoreCompilersVersion>
     <!-- Core-setup dependencies -->
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview4-27413-11</MicrosoftNETCoreAppPackageVersion>


### PR DESCRIPTION
CC. @jaredpar, @agocke, @jkotas, @danmosemsft, @eerhardt, @safern, @ericstj

The beta4 package was pushed up to NuGet today. This should hopefully be the last manual update for CoreFX, as I believe Jared is working on the appropriate Arcade changes to make this automated.