### PR TITLE
Label implements IEquatable<Label>

### DIFF
--- a/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
+++ b/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
@@ -56,7 +56,7 @@ namespace System.Reflection.Emit
         public virtual void ThrowException(System.Type excType) { }
         public virtual void UsingNamespace(string usingNamespace) { }
     }
-    public partial struct Label
+    public partial struct Label : IEquatable<System.Reflection.Emit.Label>
     {
         private int _dummyPrimitive;
         public override bool Equals(object obj) { throw null; }

--- a/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
+++ b/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.cs
@@ -56,7 +56,7 @@ namespace System.Reflection.Emit
         public virtual void ThrowException(System.Type excType) { }
         public virtual void UsingNamespace(string usingNamespace) { }
     }
-    public partial struct Label : IEquatable<System.Reflection.Emit.Label>
+    public partial struct Label
     {
         private int _dummyPrimitive;
         public override bool Equals(object obj) { throw null; }

--- a/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.netcore.cs
+++ b/src/System.Reflection.Emit.ILGeneration/ref/System.Reflection.Emit.ILGeneration.netcore.cs
@@ -12,4 +12,7 @@ namespace System.Reflection.Emit
     {
         public virtual void EmitCalli(System.Reflection.Emit.OpCode opcode, System.Runtime.InteropServices.CallingConvention unmanagedCallConv, Type returnType, Type[] parameterTypes) { }
     }
+
+    public partial struct Label : IEquatable<System.Reflection.Emit.Label>
+    { }
 }

--- a/src/System.Reflection.Emit.ILGeneration/tests/Label/LabelEquals.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/Label/LabelEquals.cs
@@ -14,6 +14,7 @@ namespace System.Reflection.Emit.Tests
             Label label = new Label();
             Assert.True(label.Equals(label));
             Assert.True(label.Equals((object)label));
+            Assert.True(label.Equals((IEquatable<Label>)label));
         }
 
         [Fact]
@@ -27,6 +28,7 @@ namespace System.Reflection.Emit.Tests
 
             Assert.False(label1.Equals(label2));
             Assert.False(label1.Equals((object)label2));
+            Assert.False(label1.Equals((IEquatable<Label>)label2));
         }
 
         [Theory]
@@ -48,15 +50,6 @@ namespace System.Reflection.Emit.Tests
 
             Assert.True(lb1 == lb2);
             Assert.False(lb1 != lb2);
-        }
-
-        [Fact]
-        public void Equals_IEquatable()
-        {
-            IEquatable<Label> label1 = new Label();
-            Label label2 = new Label();
-
-            Assert.True(label1.Equals(label2));
         }
     }
 }

--- a/src/System.Reflection.Emit.ILGeneration/tests/Label/LabelEquals.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/Label/LabelEquals.cs
@@ -56,7 +56,7 @@ namespace System.Reflection.Emit.Tests
             IEquatable<Label> label1 = new Label();
             Label label2 = new Label();
 
-            label1.Equals(label2);
+            Assert.True(label1.Equals(label2));
         }
     }
 }

--- a/src/System.Reflection.Emit.ILGeneration/tests/Label/LabelEquals.cs
+++ b/src/System.Reflection.Emit.ILGeneration/tests/Label/LabelEquals.cs
@@ -49,5 +49,14 @@ namespace System.Reflection.Emit.Tests
             Assert.True(lb1 == lb2);
             Assert.False(lb1 != lb2);
         }
+
+        [Fact]
+        public void Equals_IEquatable()
+        {
+            IEquatable<Label> label1 = new Label();
+            Label label2 = new Label();
+
+            label1.Equals(label2);
+        }
     }
 }


### PR DESCRIPTION
Adds an implementation of `IEquatable<Label>` to `System.Reflection.Emit.Label`.

Fixes dotnet/corefx#32959
Relies on [dotnet/corecrl/pull/22938](https://github.com/dotnet/coreclr/pull/22938)