### PR TITLE
Remove InitTools and ToolsDir

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -103,26 +103,21 @@
 
   <!-- Common repo directories -->
   <PropertyGroup>
-    <!-- Properties to remove with buildtools removal -->
-    <ProjectDir>$(RepoRoot)</ProjectDir>
-    <BinDir>$(ProjectDir)artifacts\bin\</BinDir>
-    <ToolsDir Condition="'$(ToolsDir)'==''">$(ProjectDir)Tools/</ToolsDir>
-    <BuildToolsTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(ToolsDir)net46/</BuildToolsTaskDir>
-    <BuildToolsTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(ToolsDir)</BuildToolsTaskDir>
+    <ArtifactsBinDir>$(RepoRoot)artifacts\bin\</ArtifactsBinDir>
     
     <!-- Need to try and keep the same logic as the native builds as we need this for packaging -->
-    <NativeBinDir>$(BinDir)native/$(BuildConfiguration)</NativeBinDir>
+    <NativeBinDir>$(ArtifactsBinDir)native/$(BuildConfiguration)</NativeBinDir>
 
     <!-- Use msbuild path functions as that property is used in bash scripts. -->
-    <SourceDir>$([MSBuild]::NormalizeDirectory('$(ProjectDir)', 'src'))</SourceDir>
+    <SourceDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src'))</SourceDir>
 
     <!-- Input Directories -->
     <PackagesDir>$(DotNetRestorePackagesPath)</PackagesDir>
     <PackagesDir Condition="'$(PackagesDir)'=='' AND '$(NuGetPackageRoot)' != ''">$([MSBuild]::EnsureTrailingSlash('$(NuGetPackageRoot)'))</PackagesDir>
-    <PackagesDir Condition="'$(PackagesDir)'==''">$(ProjectDir).packages/</PackagesDir>
+    <PackagesDir Condition="'$(PackagesDir)'==''">$(RepoRoot).packages/</PackagesDir>
     <!-- Respect environment variable for the .NET install directory if set; otherwise, use the current default location -->
     <DotNetRoot Condition="'$(DotNetRoot)' == ''">$(DOTNET_INSTALL_DIR)</DotNetRoot>
-    <DotNetRoot Condition="'$(DotNetRoot)' == ''">$(ProjectDir).dotnet\</DotNetRoot>
+    <DotNetRoot Condition="'$(DotNetRoot)' == ''">$(RepoRoot).dotnet\</DotNetRoot>
     <DotNetRoot Condition="!HasTrailingSlash('$(DotNetRoot)')">$(DotNetRoot)\</DotNetRoot>
     <DotnetCliPath Condition="'$(DotnetCliPath)'==''">$(DotNetRoot)</DotnetCliPath>
     <ToolHostCmd Condition="'$(ToolHostCmd)'==''">"$(DotNetRoot)dotnet"</ToolHostCmd>
@@ -201,7 +196,6 @@
 
     <!-- There are no WebAssembly tools, so treat them as Windows -->
     <ToolRuntimeRID Condition="'$(RuntimeOS)' == 'WebAssembly'">win-x64</ToolRuntimeRID>
-    <MicrosoftNetCoreIlasmPackageRuntimeId Condition="'$(MicrosoftNetCoreIlasmPackageRuntimeId)' == ''">$(ToolRuntimeRID)</MicrosoftNetCoreIlasmPackageRuntimeId>
 
     <!-- support cross-targeting by choosing a RID to restore when running on a different machine that what we're build for -->
     <_portableOS Condition="'$(OSGroup)' == 'Unix' AND '$(_runtimeOSFamily)' != 'osx' AND '$(_runtimeOSFamily)' != 'FreeBSD' AND '$(_runtimeOS)' != 'linux-musl'">linux</_portableOS>
@@ -347,11 +341,11 @@
 
     <TargetOutputRelPath Condition="'$(TargetGroup)'!=''">$(TargetGroup)/</TargetOutputRelPath>
 
-    <RuntimePath Condition="'$(RuntimePath)' == ''">$(BinDir)runtime/$(BuildConfiguration)/</RuntimePath>
-    <ShimsTargetRuntimeRoot>$(BinDir)shimsTargetRuntime/</ShimsTargetRuntimeRoot>
+    <RuntimePath Condition="'$(RuntimePath)' == ''">$(ArtifactsBinDir)runtime/$(BuildConfiguration)/</RuntimePath>
+    <ShimsTargetRuntimeRoot>$(ArtifactsBinDir)shimsTargetRuntime/</ShimsTargetRuntimeRoot>
     <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(ArtifactsBinDir)tests/</TestWorkingDir>
     <TestPath Condition="'$(TestPath)' == ''">$(TestWorkingDir)$(MSBuildProjectName)/$(BuildConfiguration)/</TestPath>
-    <RefRootPath>$(BinDir)ref/</RefRootPath>
+    <RefRootPath>$(ArtifactsBinDir)ref/</RefRootPath>
     <BuildConfigurationRefPath>$(RefRootPath)$(_bc_TargetGroup)/</BuildConfigurationRefPath>
     <BuildConfigurationRefPath Condition="$(_bc_TargetGroup.EndsWith('aot'))">$(RefRootPath)$(_bc_TargetGroup.TrimEnd('aot'))/</BuildConfigurationRefPath>
     <RefPath>$(RefRootPath)$(TargetGroup)/</RefPath>
@@ -362,6 +356,7 @@
     <GlobalToolsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'tools'))</GlobalToolsDir>
     <IbcOptimizationDataDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'ibc'))</IbcOptimizationDataDir>
     <ILAsmToolPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsToolsetDir)', 'ilasm'))</ILAsmToolPath>
+    <ILLinkDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsToolsetDir)', 'ILLink'))</ILLinkDir>
 
     <!-- Helix properties -->
     <OSPlatformConfig>$(OSGroup).$(Platform).$(ConfigurationGroup)</OSPlatformConfig>
@@ -373,18 +368,18 @@
     <TestArchiveRuntimeRoot>$(TestArchiveRoot)runtime/</TestArchiveRuntimeRoot>
 
     <!-- project file to use when resolving ReferenceFromRuntime items -->
-    <RuntimeProjectFile Condition="'$(RuntimeProjectFile)' == ''">$(ProjectDir)\external\runtime\runtime.depproj</RuntimeProjectFile>
+    <RuntimeProjectFile Condition="'$(RuntimeProjectFile)' == ''">$(RepoRoot)\external\runtime\runtime.depproj</RuntimeProjectFile>
 
     <!-- Paths to binplace package content -->
-    <NETCoreAppPackageRefPath>$(BinDir)pkg\netcoreapp\ref</NETCoreAppPackageRefPath>
-    <NETCoreAppPackageRuntimePath>$(BinDir)pkg\netcoreapp\lib</NETCoreAppPackageRuntimePath>
-    <NETCoreAppAotPackageRuntimePath>$(BinDir)pkg\netcoreappaot\lib</NETCoreAppAotPackageRuntimePath>
-    <UAPPackageRefPath>$(BinDir)pkg\uap\ref</UAPPackageRefPath>
-    <UAPPackageRuntimePath>$(BinDir)pkg\uap\lib</UAPPackageRuntimePath>
-    <UAPAOTPackageRuntimePath>$(BinDir)pkg\uapaot\lib</UAPAOTPackageRuntimePath>
-    <NetFxPackageRefPath>$(BinDir)pkg\netfx\ref</NetFxPackageRefPath>
-    <NetFxPackageRuntimePath>$(BinDir)pkg\netfx\lib</NetFxPackageRuntimePath>
-    <NETStandardTestSuiteOutputPath>$(BinDir)NetStandardTestSuite\</NETStandardTestSuiteOutputPath>
+    <NETCoreAppPackageRefPath>$(ArtifactsBinDir)pkg\netcoreapp\ref</NETCoreAppPackageRefPath>
+    <NETCoreAppPackageRuntimePath>$(ArtifactsBinDir)pkg\netcoreapp\lib</NETCoreAppPackageRuntimePath>
+    <NETCoreAppAotPackageRuntimePath>$(ArtifactsBinDir)pkg\netcoreappaot\lib</NETCoreAppAotPackageRuntimePath>
+    <UAPPackageRefPath>$(ArtifactsBinDir)pkg\uap\ref</UAPPackageRefPath>
+    <UAPPackageRuntimePath>$(ArtifactsBinDir)pkg\uap\lib</UAPPackageRuntimePath>
+    <UAPAOTPackageRuntimePath>$(ArtifactsBinDir)pkg\uapaot\lib</UAPAOTPackageRuntimePath>
+    <NetFxPackageRefPath>$(ArtifactsBinDir)pkg\netfx\ref</NetFxPackageRefPath>
+    <NetFxPackageRuntimePath>$(ArtifactsBinDir)pkg\netfx\lib</NetFxPackageRuntimePath>
+    <NETStandardTestSuiteOutputPath>$(ArtifactsBinDir)NetStandardTestSuite\</NETStandardTestSuiteOutputPath>
 
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
     <BinPlaceTestSharedFramework Condition="'$(_bc_TargetGroup)' == 'netcoreapp' AND '$(BuildTests)'!='false'">true</BinPlaceTestSharedFramework>
@@ -393,7 +388,7 @@
     <BinPlaceNETFXRuntime Condition="'$(_bc_TargetGroup)' == 'netfx'">true</BinPlaceNETFXRuntime>
 
     <NETCoreAppTestSharedFxVersion>9.9.9</NETCoreAppTestSharedFxVersion>
-    <TestHostRootPath>$(BinDir)testhost/$(BuildConfiguration)/</TestHostRootPath>
+    <TestHostRootPath>$(ArtifactsBinDir)testhost/$(BuildConfiguration)/</TestHostRootPath>
     <NETCoreAppTestHostFxrPath>$(TestHostRootPath)host/fxr/$(NETCoreAppTestSharedFxVersion)/</NETCoreAppTestHostFxrPath>
     <NETCoreAppTestSharedFrameworkPath>$(TestHostRootPath)shared/Microsoft.NETCore.App/$(NETCoreAppTestSharedFxVersion)/</NETCoreAppTestSharedFrameworkPath>
     <ILCFXInputFolder>$(TestHostRootPath)ILCInputFolder</ILCFXInputFolder>

--- a/build.proj
+++ b/build.proj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <!-- remove once we no longer use maestro v1 updating -->
-  <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
+  <Import Project="$(RepositoryEngineeringDir)VersionTools.targets" />
 
   <Import Project="Directory.Build.targets" />
 

--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -1,9 +1,9 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PackageDescriptionFile>$(ProjectDir)pkg/descriptions.json</PackageDescriptionFile>
-    <PackageLicenseFile>$(ProjectDir)LICENSE.TXT</PackageLicenseFile>
-    <PackageThirdPartyNoticesFile>$(ProjectDir)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
-    <RuntimeIdGraphDefinitionFile>$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeIdGraphDefinitionFile>
+    <PackageDescriptionFile>$(RepoRoot)pkg/descriptions.json</PackageDescriptionFile>
+    <PackageLicenseFile>$(RepoRoot)LICENSE.TXT</PackageLicenseFile>
+    <PackageThirdPartyNoticesFile>$(RepoRoot)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
+    <RuntimeIdGraphDefinitionFile>$(RepoRoot)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeIdGraphDefinitionFile>
     <ReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</ReleaseNotes>
     <ProjectUrl>https://github.com/dotnet/corefx</ProjectUrl>
     <LicenseUrl>https://github.com/dotnet/corefx/blob/master/LICENSE.TXT</LicenseUrl>
@@ -15,7 +15,7 @@
     <XmlDocPackage>Microsoft.Private.Intellisense</XmlDocPackage>
     <XmlDocPackageVersion>3.0.0-preview3-190214-0</XmlDocPackageVersion>
     <XmlDocFileRoot>$(PackagesDir)$(XmlDocPackage.ToLowerInvariant())/$(XmlDocPackageVersion)/xmldocs/netcoreapp</XmlDocFileRoot>
-    <XmlDocDir>$(BinDir)docs</XmlDocDir>
+    <XmlDocDir>$(ArtifactsBinDir)docs</XmlDocDir>
 
     <!-- By default the packaging targets will package desktop facades as ref,
          but we don't use this as we now build partial-reference-facades. -->
@@ -63,7 +63,7 @@
 
     <!-- Add a marker to help the designer optimize & share .NET Core packages -->
     <File Condition="'$(IncludeDesignerMarker)' != 'false'"
-          Include="$(ProjectDir)pkg/useSharedDesignerContext.txt">
+          Include="$(RepoRoot)pkg/useSharedDesignerContext.txt">
         <SkipPackageFileCheck>true</SkipPackageFileCheck>
     </File>
   </ItemGroup>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -22,7 +22,7 @@
   <Import Project="$(MSBuildThisFileDirectory)dependencies.props" />
 
   <ItemGroup>
-    <PackageReference Include="$(BuildToolsPackage)" Version="$(BuildToolsPackageVersion)" />
+    <PackageReference Include="$(BuildToolsPackage)" Version="$(BuildToolsPackageVersion)" GeneratePathProperty="true" />
     <PackageReference Include="$(PublishSymbolsPackage)" Version="$(PublishSymbolsPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="$(MicrosoftDotNetApiCompatPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.SourceRewriter" Version="$(MicrosoftDotNetSourceRewriterPackageVersion)" />
@@ -71,26 +71,6 @@
 
     <Exec Command="$(DotNetCmd) restore &quot;$(OptionalToolProjectPath)&quot; --interactive --ignore-failed-sources /p:TargetGroup=$(TargetGroup)"
           WorkingDirectory="$(RepoRoot)" />
-
-  </Target>
-
-  <Target Name="InitTools" AfterTargets="Restore">
-
-    <PropertyGroup>
-      <ToolsDir Condition="'$(ToolsDir)' == ''">$(RepoRoot)Tools</ToolsDir>
-      <BuildToolsSemaphore>$([MSBuild]::NormalizePath('$(ToolsDir)', '$(BuildToolsPackageVersion).init-tools.completed'))</BuildToolsSemaphore>
-      <PackagesDir>$(NuGetPackageRoot)</PackagesDir>
-      <BuildToolsPackageDir Condition="'$(BuildToolsPackageDir)' == ''">$([MSBuild]::NormalizeDirectory('$(PackagesDir)', '$(BuildToolsPackage)', '$(BuildToolsPackageVersion)', 'lib'))</BuildToolsPackageDir>
-      <CmdExt>cmd</CmdExt>
-      <CmdExt Condition="'$(OS)' != 'Windows_NT'">sh</CmdExt>
-      <InitToolsCmdLine>"$(BuildToolsPackageDir)init-tools.$(CmdExt)" "$(RepoRoot)" $(DotNetCmd) "$(ToolsDir)" "$(PackagesDir.TrimEnd('\'))"</InitToolsCmdLine>
-    </PropertyGroup>
-
-    <Exec Condition="!Exists('$(BuildToolsSemaphore)')"
-          Command="$(InitToolsCmdLine) &gt; &quot;$(RepoRoot)init-tools.log&quot;" />
-    <Touch Files="$(BuildToolsSemaphore)"
-           AlwaysCreate="true" />
-    <OnError ExecuteTargets="DumpInitToolsLog" />
 
   </Target>
 

--- a/eng/VersionTools.targets
+++ b/eng/VersionTools.targets
@@ -1,0 +1,16 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Properties required by VersionTools which we don't wish to make avaiable broadly -->
+    <BuildToolsTaskDir Condition="'$(MSBuildRuntimeType)' != 'core'">$(PkgMicrosoft_DotNet_BuildTools)\lib\net46\</BuildToolsTaskDir>
+    <BuildToolsTaskDir Condition="'$(MSBuildRuntimeType)' == 'core'">$(PkgMicrosoft_DotNet_BuildTools)\lib\</BuildToolsTaskDir>
+    <ProjectDir>$(RepoRoot)</ProjectDir>
+  </PropertyGroup>
+  <Import Project="$(PkgMicrosoft_DotNet_BuildTools)\lib\VersionTools.targets" Condition="Exists('$(PkgMicrosoft_DotNet_BuildTools)\lib\VersionTools.targets')" />
+  <PropertyGroup>
+    <BuildToolsTaskDir />
+    <ProjectDir />
+
+    <!-- point BuildInfoCacheDir to a writable location under artifacts -->
+    <BuildInfoCacheDir>$(ToolSetCommonDirectory)BuildInfoCache/</BuildInfoCacheDir>
+  </PropertyGroup>
+</Project>

--- a/eng/dependencies.props
+++ b/eng/dependencies.props
@@ -57,7 +57,7 @@
 
   <!-- Package versions used as toolsets -->
   <PropertyGroup>
-    <BuildToolsPackage>microsoft.dotnet.buildtools</BuildToolsPackage>
+    <BuildToolsPackage>Microsoft.DotNet.BuildTools</BuildToolsPackage>
     <BuildToolsPackageVersion>3.0.0-preview1-03715-01</BuildToolsPackageVersion>
   </PropertyGroup>
 

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -10,8 +10,8 @@
 
   <!-- Inputs and outputs of ILLinkTrimAssembly -->
   <PropertyGroup>
-    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' And '$(MSBuildRuntimeType)' == 'core'">$(ToolsDir)ILLink/netcoreapp2.0/ILLink.Tasks.dll</ILLinkTasksPath>
-    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' And '$(MSBuildRuntimeType)' != 'core'">$(ToolsDir)ILLink/net46/ILLink.Tasks.dll</ILLinkTasksPath>
+    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' And '$(MSBuildRuntimeType)' == 'core'">$(ILLinkDir)netcoreapp2.0/ILLink.Tasks.dll</ILLinkTasksPath>
+    <ILLinkTasksPath Condition="'$(ILLinkTasksPath)' == '' And '$(MSBuildRuntimeType)' != 'core'">$(ILLinkDir)net46/ILLink.Tasks.dll</ILLinkTasksPath>
     <ILLinkTrimAssemblyPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</ILLinkTrimAssemblyPath>
     <ILLinkTrimAssemblySymbols>$(IntermediateOutputPath)$(TargetName).pdb</ILLinkTrimAssemblySymbols>
     <ILLinkTrimInputPath>$(IntermediateOutputPath)PreTrim/</ILLinkTrimInputPath>
@@ -36,15 +36,15 @@
   --> 
   <ItemGroup Condition="'$(BinPlaceILLinkTrimAssembly)' == 'true'">
     <BinPlaceConfiguration Include="$(BuildConfiguration)">
-      <RuntimePath>$(BinDir)ILLinkTrimAssembly/$(BuildConfiguration)/trimmed</RuntimePath>
+      <RuntimePath>$(ArtifactsBinDir)ILLinkTrimAssembly/$(BuildConfiguration)/trimmed</RuntimePath>
       <ItemName>TrimmedItem</ItemName>
     </BinPlaceConfiguration>
     <BinPlaceConfiguration Include="$(BuildConfiguration)">
-      <RuntimePath>$(BinDir)ILLinkTrimAssembly/$(BuildConfiguration)/reports</RuntimePath>
+      <RuntimePath>$(ArtifactsBinDir)ILLinkTrimAssembly/$(BuildConfiguration)/reports</RuntimePath>
       <ItemName>TrimmingReport</ItemName>
     </BinPlaceConfiguration>
     <BinPlaceConfiguration Include="$(BuildConfiguration)">
-      <RuntimePath>$(BinDir)ILLinkTrimAssembly/$(BuildConfiguration)/pretrimmed</RuntimePath>
+      <RuntimePath>$(ArtifactsBinDir)ILLinkTrimAssembly/$(BuildConfiguration)/pretrimmed</RuntimePath>
       <ItemName>PreTrimmedItem</ItemName>
     </BinPlaceConfiguration>
   </ItemGroup>

--- a/external/ILLink/ILLink.depproj
+++ b/external/ILLink/ILLink.depproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <OutputPath>$(ToolsDir)ILLink</OutputPath>
+    <OutputPath>$(ILLinkDir)</OutputPath>
     <EnableBinPlacing>false</EnableBinPlacing>
     <ILLinkTasksPackageId>illink.tasks</ILLinkTasksPackageId>
     <ILLinkTasksPackageVersion>0.1.5-preview-1461378</ILLinkTasksPackageVersion>

--- a/external/harvestPackages/harvestPackages.depproj
+++ b/external/harvestPackages/harvestPackages.depproj
@@ -6,7 +6,7 @@
 
   <Import Project="harvestPackages.props" />
 
-  <Import Project="$(ProjectDir)pkg/baseline/baseline.props" />
+  <Import Project="$(RepoRoot)pkg/baseline/baseline.props" />
 
   <!--
     Custom target to update the stable versions. Ideally we would just run this target as part of the build but

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -67,7 +67,7 @@
 
   <Target Name="IncludeFiles">
     <PropertyGroup>
-      <_projectDirLength>$(ProjectDir.Length)</_projectDirLength>
+      <_repoRootLength>$(RepoRoot.Length)</_repoRootLength>
     </PropertyGroup>
 
     <ItemGroup>
@@ -90,7 +90,7 @@
       <!-- Set targetpath for sources to be under src so that it is excluded from the lib package -->
       <File Condition="'%(File.IsSourceCodeFile)' == 'true'">
         <TargetPath>src</TargetPath>
-        <TargetPath Condition="$([System.String]::Copy('%(FullPath)').StartsWith('$(ProjectDir)'))">src/$([System.String]::Copy('%(FullPath)').Substring($(_projectDirLength)).Replace('\', '/'))</TargetPath>
+        <TargetPath Condition="$([System.String]::Copy('%(FullPath)').StartsWith('$(RepoRoot)'))">src/$([System.String]::Copy('%(FullPath)').Substring($(_repoRootLength)).Replace('\', '/'))</TargetPath>
       </File>
     </ItemGroup>
   </Target>

--- a/pkg/test/testPackages.proj
+++ b/pkg/test/testPackages.proj
@@ -28,13 +28,13 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TestDir>$(BinDir)testPkg/</TestDir>
+    <TestDir>$(ArtifactsBinDir)testPkg/</TestDir>
     <TestSupportDir>$(TestDir)support/</TestSupportDir>
     <TestProjectName>test.msbuild</TestProjectName>
     <TestProject>$(TestSupportDir)$(TestProjectName)</TestProject>
     <TestToolsDir>$(TestSupportDir)tools/</TestToolsDir>
     <TestProjectDir>$(TestDir)projects/</TestProjectDir>
-    <TestPackageDir>$(BinDir)testPackages</TestPackageDir>
+    <TestPackageDir>$(ArtifactsBinDir)testPackages</TestPackageDir>
     <TestDotNetPath>$(TestToolsDir)/dotnet</TestDotNetPath>
 
     <ProjectTemplate>project.csproj.template</ProjectTemplate>

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{E2E59C98-998F-9965-991D-99411166AF6F}</ProjectGuid>
     <ShouldWriteSigningRequired>false</ShouldWriteSigningRequired>
     <AllowReferenceFromRuntime>true</AllowReferenceFromRuntime>
-    <RuntimeProjectFile>$(ProjectDir)\external\test-runtime\XUnit.Runtime.depproj</RuntimeProjectFile>
+    <RuntimeProjectFile>$(RepoRoot)\external\test-runtime\XUnit.Runtime.depproj</RuntimeProjectFile>
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>CoreFx.Private.TestUtilities</AssemblyName>
     <ProjectGuid>{EBDB0247-CA43-4226-B7A1-8FEF21061D09}</ProjectGuid>
-    <RuntimeProjectFile>$(ProjectDir)\external\test-runtime\XUnit.Runtime.depproj</RuntimeProjectFile>
+    <RuntimeProjectFile>$(RepoRoot)\external\test-runtime\XUnit.Runtime.depproj</RuntimeProjectFile>
     <ClsCompliant>false</ClsCompliant>
     <ShouldWriteSigningRequired>false</ShouldWriteSigningRequired>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project InitialTargets="AddSkipGetTargetFrameworkToProjectReferences">
   <PropertyGroup>
-    <ErrorIfBuildToolsRestoredFromIndividualProject Condition="!Exists('$(ToolsDir)')">true</ErrorIfBuildToolsRestoredFromIndividualProject>
-
     <!-- Reset these properties back to blank, since they are defaulted by Microsoft.NET.Sdk -->
     <FileAlignment Condition="'$(FileAlignment)' == '512'"></FileAlignment>
     <ErrorReport Condition="'$(ErrorReport)' == 'prompt'"></ErrorReport>

--- a/src/Native/pkg/Directory.Build.props
+++ b/src/Native/pkg/Directory.Build.props
@@ -4,13 +4,13 @@
   <PropertyGroup>
     <!-- common properties that point to output of native build.  Can be overriden in case of 
          a coordinating build that produces all packages from OS-specific native builds -->
-    <LinuxNativePath Condition="'$(LinuxNativePath)' == ''">$(BinDir)Linux.$(PackagePlatform).$(ConfigurationGroup)\native\</LinuxNativePath>
-    <WinNativeAOTPath Condition="'$(WinNativeAOTPath)' == ''">$(BinDir)Windows_NT.$(PackagePlatform).$(ConfigurationGroup)\native_aot\</WinNativeAOTPath>
-    <WinNativePath Condition="'$(WinNativePath)' == ''">$(BinDir)Windows_NT.$(PackagePlatform).$(ConfigurationGroup)\native\</WinNativePath>
+    <LinuxNativePath Condition="'$(LinuxNativePath)' == ''">$(ArtifactsBinDir)Linux.$(PackagePlatform).$(ConfigurationGroup)\native\</LinuxNativePath>
+    <WinNativeAOTPath Condition="'$(WinNativeAOTPath)' == ''">$(ArtifactsBinDir)Windows_NT.$(PackagePlatform).$(ConfigurationGroup)\native_aot\</WinNativeAOTPath>
+    <WinNativePath Condition="'$(WinNativePath)' == ''">$(ArtifactsBinDir)Windows_NT.$(PackagePlatform).$(ConfigurationGroup)\native\</WinNativePath>
     <RHELNativePath Condition="'$(RHELNativePath)' == ''">$(LinuxNativePath)</RHELNativePath>
     <DebianNativePath Condition="'$(DebianNativePath)' == ''">$(LinuxNativePath)</DebianNativePath>
     <Fedora24NativePath Condition="'$(Fedora24NativePath)' == ''">$(LinuxNativePath)</Fedora24NativePath>
-    <OSXNativePath Condition="'$(OSXNativePath)' == ''">$(BinDir)OSX.$(PackagePlatform).$(ConfigurationGroup)\native\</OSXNativePath>
+    <OSXNativePath Condition="'$(OSXNativePath)' == ''">$(ArtifactsBinDir)OSX.$(PackagePlatform).$(ConfigurationGroup)\native\</OSXNativePath>
     <OpenSuse132NativePath Condition="'$(OpenSuse132NativePath)' == ''">$(LinuxNativePath)</OpenSuse132NativePath>
     <OpenSuse421NativePath Condition="'$(OpenSuse421NativePath)' == ''">$(LinuxNativePath)</OpenSuse421NativePath>
     <Ubuntu1404NativePath Condition="'$(Ubuntu1404NativePath)' == ''">$(LinuxNativePath)</Ubuntu1404NativePath>

--- a/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/pkg/System.Runtime.CompilerServices.Unsafe.pkgproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <ItemGroup>
-    <PackageIndex Include="$(ProjectDir)\pkg\baseline\packageBaseline.1.1.json" />
+    <PackageIndex Include="$(RepoRoot)\pkg\baseline\packageBaseline.1.1.json" />
     <ProjectReference Include="..\ref\System.Runtime.CompilerServices.Unsafe.csproj">
       <SupportedFramework>net45;netcoreapp1.0;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>

--- a/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
+++ b/src/System.Runtime.CompilerServices.Unsafe/src/System.Runtime.CompilerServices.Unsafe.ilproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <Compile Include="System.Runtime.CompilerServices.Unsafe.il" />
     <Reference Include="System.Runtime" />
-    <PackageReference Include="$(MicrosoftNetCoreIldasmPackageName)" Version="$(MicrosoftNETCoreILAsmPackageVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="AddResourcesFileToIlasm" 

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -2,10 +2,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
 
-  <PropertyGroup>
-    <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(BinDir)pkg/reports/</PackageReportDir>
-  </PropertyGroup>
-
   <ItemGroup>
     <Project Include="$(MSBuildThisFileDirectory)..\pkg\*\*.builds" Condition="'$(SkipManagedPackageBuild)' != 'true'">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
@@ -53,18 +49,6 @@
       PackageIndexFile="$(PackageIndexFile)"
       StablePackages="@(_StablePackages)" />
 
-  </Target>
-
-  <UsingTask TaskName="GenerateNetStandardSupportTable" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll" />
-  <Target Name="GenerateNETStandardDocs">
-    <Error Condition="'$(WcfPackageReportDir)' == ''"
-           Text="WcfPackageReportDir must be specified to point to the package report directory of the WCF repo.  EG: /p:WcfPackageReportDir=c:\src\wcf\bin\pkg\reports\" />
-    <ItemGroup>
-      <Reports Include="$(PackageReportDir)*.json" />
-      <Reports Include="$(WcfPackageReportDir)*.json" />
-    </ItemGroup>
-
-    <GenerateNetStandardSupportTable Reports="@(Reports)" DocFilePath="$(ProjectDir)Documentation\architecture\net-platform-standard.md" InsertIntoFile="True" />
   </Target>
 
   <!-- Generate a version text file we include in our packages -->

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllConfigurations)' == 'true'">
-    <Project Include="$(ProjectDir)pkg\test\testPackages.proj" />
+    <Project Include="$(RepoRoot)pkg\test\testPackages.proj" />
   </ItemGroup>
 
   <Target Name="BinPlaceXUnitRuntimeForNetstandardSuite"


### PR DESCRIPTION
This removes nearly the last bits of buildtools from our repo.  The only thing remaining is VersionTools.targets which I've wrapped and loaded from the package location rather than a local tools folder.