### PR TITLE
Fix XmlWriterTraceListenerTests handling of DateTime

### DIFF
--- a/src/System.Diagnostics.TextWriterTraceListener/tests/XmlWriterTraceListenerTests.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/XmlWriterTraceListenerTests.cs
@@ -464,6 +464,9 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
 
         private void ValidateSystemInfo(XmlDocument document, string eventId, TraceEventType eventType, DateTime date, TraceEventCache eventCache)
         {
+            // TraceEventCache uses DateTime.UtcNow, whereas XmlWriterTraceListener uses DateTime.Now.
+            date = date.ToLocalTime();
+
             XmlNode node = document.GetElementsByTagName("EventID")[0];
             Assert.Equal(eventId, node.InnerText);
 
@@ -484,7 +487,7 @@ namespace System.Diagnostics.TextWriterTraceListenerTests
 
             node = document.GetElementsByTagName("TimeCreated")[0];
             var nodeDate = DateTime.Parse(node.Attributes.GetNamedItem("SystemTime").Value);
-            Assert.Equal(date.ToString("MM-DD-YY"), nodeDate.ToString("MM-DD-YY"));
+            Assert.InRange(date - nodeDate, TimeSpan.FromHours(-1), TimeSpan.FromHours(1)); // allow some wiggle room in how close the dates need to be
 
             node = document.GetElementsByTagName("Source")[0];
             Assert.Equal("Trace", node.Attributes.GetNamedItem("Name").Value);


### PR DESCRIPTION
Some of these tests compare a textual date time from an XmlWriterTraceListener (which internally uses DateTime.Now) against a textual date time from a TraceEventCache (which internally uses DateTime.UtcNow).  This means that there's a few hour window (depending on time zone) at the transition of every month where the months end up differing and the test fails.

The tests also have a bug in that the format string used is buggy and isn't actually resulting in day and year being included, just month.  And further, even if the time zones are fixed, it's still possible but rare that taking the Now at two different moments could straddle a boundary.  So, rather than comparing ToStrings, we just compare the DateTimes, albeit with an allowed window.

(I'm assuming it's by design that XmlWriterTraceListener uses DateTime.Now rather than UtcNow, and that it would be a not-worthwhile breaking change to change it.)

cc: @danmosemsft 
Fixes https://github.com/dotnet/corefx/issues/35676