### PR TITLE
Re-enable BeginSendFile tests

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ExecutionContextFlowTest.cs
@@ -450,7 +450,6 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ActiveIssue(35493)]
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -180,7 +180,6 @@ namespace System.Net.Sockets.Tests
             File.Delete(filename);
         }
 
-        [ActiveIssue(35493)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(SendFile_MemberData))]


### PR DESCRIPTION
Fixed by https://github.com/dotnet/coreclr/pull/22871
Closes https://github.com/dotnet/corefx/issues/35493