### PR TITLE
[release/2.1] Fix the SslStream order of intermediate certificates with long chains

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -154,7 +154,11 @@ internal static partial class Interop
             Debug.Assert(chain != null, "X509Chain should not be null");
             Debug.Assert(chain.ChainElements.Count > 0, "chain.Build should have already been called");
 
-            for (int i = chain.ChainElements.Count - 2; i > 0; i--)
+            // Don't count the last item (the root)
+            int stop = chain.ChainElements.Count - 1;
+
+            // Don't include the first item (the cert whose private key we have)
+            for (int i = 1; i < stop; i++)
             {
                 SafeX509Handle dupCertHandle = Crypto.X509UpRef(chain.ChainElements[i].Certificate.Handle);
                 Crypto.CheckValidOpenSslHandle(dupCertHandle);


### PR DESCRIPTION
This is a port of #35641 to release/2.1.

Testing was done manually, because there's not an obvious/easy way of inspecting the wire cert order with the test infrastructure we have.

Fixes #35640.

#### Description

When SslStream is used on Linux with a certificate whose chain is longer than 3 elements, the middle portions of the chain are presented on the wire in the wrong order, breaking RFC compliance.

#### Customer Impact

Most certificates in use today have a 3 level chain (end-entity, intermediate, root).  Even for those who have long chains, most TLS clients will take a lax view of the presented ordering (presumably as part of alternate chain considerations).  However, the current state is in violation of the RFC and may cause compatibility problems for certain clients.

[edit] This broke an Azure partner.

#### Regression?

No

#### Packaging reviewed? 

System.Net.Security is only distributed via MIcrosoft.NETCore.App

#### Risk

Low.  Most applications won't have a 4-or-more element chain; and most clients are out-of-order-tolerant.