### PR TITLE
Revisit back pressure implementation

### DIFF
--- a/src/System.IO.Pipelines/src/Resources/Strings.resx
+++ b/src/System.IO.Pipelines/src/Resources/Strings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AdvanceToInvalidCursor" xml:space="preserve">
-    <value>Pipe is already advanced past provided cursor.</value>
+    <value>The PipeReader has already advanced past the provided position.</value>
   </data>
   <data name="CannotCompleteWhileReading" xml:space="preserve">
     <value>Can't complete reader while reading.</value>

--- a/src/System.IO.Pipelines/src/Resources/Strings.resx
+++ b/src/System.IO.Pipelines/src/Resources/Strings.resx
@@ -120,9 +120,6 @@
   <data name="AdvanceToInvalidCursor" xml:space="preserve">
     <value>Pipe is already advanced past provided cursor.</value>
   </data>
-  <data name="BackpressureDeadlock" xml:space="preserve">
-    <value>The maximum buffer limit of {0} bytes was exceeded by the writer.</value>
-  </data>
   <data name="CannotCompleteWhileReading" xml:space="preserve">
     <value>Can't complete reader while reading.</value>
   </data>

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -60,7 +60,7 @@ namespace System.IO.Pipelines
         private PipeCompletion _writerCompletion;
         private PipeCompletion _readerCompletion;
 
-        // Stores the last examined position, used to calculate how much bytes were to release
+        // Stores the last examined position, used to calculate how many bytes were to release
         // for back pressure management
         private BufferSegment _lastExamined;
         private int _lastExaminedIndex;
@@ -511,6 +511,8 @@ namespace System.IO.Pipelines
                 // but only if writer is not completed yet
                 if (examinedEverything && !_writerCompletion.IsCompleted)
                 {
+                    Debug.Assert(_writerAwaitable.IsCompleted, "PipeWriter.FlushAsync is isn't completed and will deadlock");
+
                     _readerAwaitable.SetUncompleted();
                 }
 

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/ThrowHelper.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/ThrowHelper.cs
@@ -41,10 +41,6 @@ namespace System.IO.Pipelines
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static Exception CreateInvalidOperationException_NoReadingAllowed() => new InvalidOperationException(SR.ReadingAfterCompleted);
 
-        public static void ThrowInvalidOperationException_BackpressureDeadlock(long sizeLimit) => throw CreateInvalidOperationException_BackpressureDeadlock(sizeLimit);
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public static Exception CreateInvalidOperationException_BackpressureDeadlock(long sizeLimit) => new InvalidOperationException(SR.Format(SR.BackpressureDeadlock, sizeLimit));
-
         public static void ThrowInvalidOperationException_AdvanceToInvalidCursor() => throw CreateInvalidOperationException_AdvanceToInvalidCursor();
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static Exception CreateInvalidOperationException_AdvanceToInvalidCursor() => new InvalidOperationException(SR.AdvanceToInvalidCursor);

--- a/src/System.IO.Pipelines/tests/BackpressureTests.cs
+++ b/src/System.IO.Pipelines/tests/BackpressureTests.cs
@@ -30,39 +30,6 @@ namespace System.IO.Pipelines.Tests
         private readonly Pipe _pipe;
 
         [Fact]
-        public void AdvanceThrowsIfFlushActiveAndNotConsumedPastThreshold()
-        {
-            PipeWriter writableBuffer = _pipe.Writer.WriteEmpty(PauseWriterThreshold);
-            ValueTask<FlushResult> flushAsync = writableBuffer.FlushAsync();
-            Assert.False(flushAsync.IsCompleted);
-
-            ReadResult result = _pipe.Reader.ReadAsync().GetAwaiter().GetResult();
-            SequencePosition consumed = result.Buffer.GetPosition(31);
-
-            var exception = Assert.Throws<InvalidOperationException>(() => _pipe.Reader.AdvanceTo(consumed, result.Buffer.End));
-            Assert.Contains("32", exception.Message);
-
-            _pipe.Reader.AdvanceTo(result.Buffer.End, result.Buffer.End);
-        }
-
-        [Fact]
-        public async Task AdvanceThrowsIfFlushActiveAndNotConsumedPastThresholdWhenFlushIsCanceled()
-        {
-            // Write over the threshold and cancel pending flush
-            _pipe.Writer.WriteEmpty(PauseWriterThreshold);
-            var task = _pipe.Writer.FlushAsync().AsTask();
-            _pipe.Writer.CancelPendingFlush();
-
-            await task;
-
-            // Examine to the end without releasing backpressure
-            var result = await _pipe.Reader.ReadAsync();
-
-            var exception = Assert.Throws<InvalidOperationException>(() => _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.End));
-            Assert.Contains("32", exception.Message);
-        }
-
-        [Fact]
         public void FlushAsyncAwaitableCompletesWhenReaderAdvancesUnderLow()
         {
             PipeWriter writableBuffer = _pipe.Writer.WriteEmpty(PauseWriterThreshold);

--- a/src/System.IO.Pipelines/tests/BackpressureTests.cs
+++ b/src/System.IO.Pipelines/tests/BackpressureTests.cs
@@ -84,7 +84,7 @@ namespace System.IO.Pipelines.Tests
                 _pipe.Writer.Complete();
             }
 
-           Task writingTask = WriteLoopAsync();
+            Task writingTask = WriteLoopAsync();
 
             while (true)
             {

--- a/src/System.IO.Pipelines/tests/PipeLengthTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeLengthTests.cs
@@ -73,7 +73,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public async Task LengthDecreasedAfterReadAdvanceConsume()
+        public async Task LengthDecreasedAfterReadAdvanceExamined()
         {
             _pipe.Writer.GetMemory(100);
             _pipe.Writer.Advance(10);
@@ -87,13 +87,13 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public async Task LengthNotChangeAfterReadAdvanceExamine()
+        public async Task LengthDoesNotChangeIfExamineDoesNotChange()
         {
             PipeWriter writableBuffer = _pipe.Writer.WriteEmpty(10);
             await writableBuffer.FlushAsync();
 
             ReadResult result = await _pipe.Reader.ReadAsync();
-            _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.End);
+            _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.Start);
 
             Assert.Equal(10, _pipe.Length);
         }

--- a/src/System.IO.Pipelines/tests/PipeLengthTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeLengthTests.cs
@@ -97,5 +97,50 @@ namespace System.IO.Pipelines.Tests
 
             Assert.Equal(10, _pipe.Length);
         }
+
+        [Fact]
+        public async Task LengthChangesIfExaminedChanges()
+        {
+            PipeWriter writableBuffer = _pipe.Writer.WriteEmpty(10);
+            await writableBuffer.FlushAsync();
+
+            ReadResult result = await _pipe.Reader.ReadAsync();
+            _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.End);
+
+            Assert.Equal(0, _pipe.Length);
+        }
+
+        [Fact]
+        public async Task LengthIsBasedOnPreviouslyExamined()
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                PipeWriter writableBuffer = _pipe.Writer.WriteEmpty(10);
+                await writableBuffer.FlushAsync();
+
+                ReadResult result = await _pipe.Reader.ReadAsync();
+                _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.End);
+
+                Assert.Equal(0, _pipe.Length);
+            }
+        }
+
+        [Fact]
+        public async Task ExaminedLessThanBeforeThrows()
+        {
+            _pipe.Writer.WriteEmpty(10);
+            await _pipe.Writer.FlushAsync();
+
+            ReadResult result = await _pipe.Reader.ReadAsync();
+            _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.End);
+
+            Assert.Equal(0, _pipe.Length);
+
+            _pipe.Writer.WriteEmpty(10);
+            await _pipe.Writer.FlushAsync();
+
+            result = await _pipe.Reader.ReadAsync();
+            Assert.Throws<InvalidOperationException>(() => _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.Start));
+        }
     }
 }

--- a/src/System.IO.Pipelines/tests/PipeLengthTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeLengthTests.cs
@@ -93,7 +93,7 @@ namespace System.IO.Pipelines.Tests
             await writableBuffer.FlushAsync();
 
             ReadResult result = await _pipe.Reader.ReadAsync();
-            _pipe.Reader.AdvanceTo(result.Buffer.Start, result.Buffer.Start);
+            _pipe.Reader.AdvanceTo(result.Buffer.Start);
 
             Assert.Equal(10, _pipe.Length);
         }


### PR DESCRIPTION
- Today when using a PipeReader from a Pipe, when the pause threshold is hit and the reader does not consume enough data to unblock the writer (enough to reduce the resume threshold) an exception is thrown. This exception is extremely hard to understand and work around since it's based on a limit set by the owner of the Pipe. It leads to people setting an extremely big limit (bigger than the biggest message) or disabling the limit completely. It's especially problematic when library authors need to expose a PipeReader but don't know what upstack protocol will be parsed and in turn doesn't know the max message size.
- The changes the back pressure mechanic to be based on examined instead of consumed. This pauses the writer if the pause threshold is hit, but lets the reader continue to buffer until a logical payoad is reached (whatever matters to the protocol).
- **This breaks software that relied on these limits to enfore a maximum buffer size and those pieces of code need to now handle their own maximum buffer size.**

Fixes #35703

cc @mgravell @benaadams @tmds