### PR TITLE
Add Windows ARM64 to official builds

### DIFF
--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -63,6 +63,13 @@ jobs:
               _helixQueues: $(netcoreappWindowsQueues)
               _publishTests: true
 
+            arm64_Release:
+              _BuildConfig: Release
+              _architecture: arm64
+              _framework: netcoreapp
+              _helixQueues: $(windowsArmQueue)
+              _publishTests: true
+
             NETFX_x86_Release:
               _BuildConfig: Release
               _architecture: x86
@@ -216,11 +223,6 @@ jobs:
               arm_Release:
                 _BuildConfig: Release
                 _architecture: arm
-                _framework: netcoreapp
-
-              arm64_Release:
-                _BuildConfig: Release
-                _architecture: arm64
                 _framework: netcoreapp
 
               UAPAOT_arm_Release:

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -45,6 +45,7 @@ namespace System
         public static bool IsArgIteratorNotSupported { get { throw null; } }
         public static bool IsArgIteratorSupported { get { throw null; } }
         public static bool IsArm64Process { get { throw null; } }
+        public static bool IsArmOrArm64Process { get { throw null; } }
         public static bool IsArmProcess { get { throw null; } }
         public static bool IsCentos6 { get { throw null; } }
         public static bool IsDebian { get { throw null; } }
@@ -67,6 +68,7 @@ namespace System
         public static bool IsNetNative { get { throw null; } }
         public static bool IsNonZeroLowerBoundArraySupported { get { throw null; } }
         public static bool IsNotArm64Process { get { throw null; } }
+        public static bool IsNotArmNorArm64Process { get { throw null; } }
         public static bool IsNotArmProcess { get { throw null; } }
         public static bool IsNotFedoraOrRedHatFamily { get { throw null; } }
         public static bool IsNotInAppContainer { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -36,7 +36,9 @@ namespace System
         public static bool IsNotArmProcess => !IsArmProcess;
         public static bool IsArm64Process => RuntimeInformation.ProcessArchitecture == Architecture.Arm64;
         public static bool IsNotArm64Process => !IsArm64Process;
-        public static bool IsArgIteratorSupported => IsWindows && (IsNotArmProcess || IsArm64Process);
+        public static bool IsArmOrArm64Process => IsArmProcess || IsArm64Process;
+        public static bool IsNotArmNorArm64Process => !IsArmOrArm64Process;
+        public static bool IsArgIteratorSupported => IsWindows && IsNotArmNorArm64Process;
         public static bool IsArgIteratorNotSupported => !IsArgIteratorSupported;
 
         public static bool IsNotInAppContainer => !IsInAppContainer;

--- a/src/System.Management/tests/WmiTestHelper.cs
+++ b/src/System.Management/tests/WmiTestHelper.cs
@@ -12,6 +12,7 @@ namespace System.Management.Tests
         private static readonly bool s_isElevated = AdminHelpers.IsProcessElevated();
         private static readonly bool s_isWmiSupported =
                                             PlatformDetection.IsWindows &&
+                                            PlatformDetection.IsNotArmNorArm64Process &&
                                             PlatformDetection.IsNotWindowsNanoServer &&
                                             PlatformDetection.IsNotWindowsIoTCore &&
                                             !PlatformDetection.IsUap;


### PR DESCRIPTION
@ulisesh tells me the queues are Windows.10.Arm64.Open and Windows.10.Arm64

I kicked off an official build against the private fork, with default settings. buildId=112683

@safern does this look right?