### PR TITLE
Disable appdomains for System.Linq.Parallel tests on netfx

### DIFF
--- a/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
+++ b/src/System.Linq.Parallel/tests/System.Linq.Parallel.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <ProjectGuid>{A7074928-82C3-4739-88FE-9B528977950C}</ProjectGuid>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
+    <!-- Avoid extreme slowness when running NETFX tests (ie with xunit.console.exe) -->
+    <XUnitNoAppdomain>true</XUnitNoAppdomain>
   </PropertyGroup>
   <!-- Compiled Source Files -->
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/35727

Disabling appdomains cuts the test time down from "somewhere beyond 10 minutes" to about 90 sec on my machine. The threads parameter helps a bit more.