### PR TITLE
Add GNU compiler support to build src/Native

### DIFF
--- a/src/Native/Unix/CMakeLists.txt
+++ b/src/Native/Unix/CMakeLists.txt
@@ -22,7 +22,10 @@ add_compile_options(-fPIC)
 add_compile_options(-I${CMAKE_CURRENT_SOURCE_DIR}/Common)
 add_compile_options(-I${CMAKE_CURRENT_BINARY_DIR}/Common)
 add_compile_options(-g)
-add_compile_options(-Wthread-safety)
+if(CMAKE_C_COMPILER_ID STREQUAL Clang)
+    add_compile_options(-Wthread-safety)
+    add_compile_options(-Wno-thread-safety-analysis)
+endif()
 add_compile_options(-Werror)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Emscripten)
@@ -249,7 +252,9 @@ if (NOT CLR_CMAKE_PLATFORM_WASM)
 	add_subdirectory(System.IO.Ports.Native)
 endif()
 
-add_compile_options(-Weverything)
+if(CMAKE_C_COMPILER_ID STREQUAL Clang)
+    add_compile_options(-Weverything)
+endif()
 
 add_subdirectory(System.Native)
 

--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -93,6 +93,7 @@
 #cmakedefine01 INOTIFY_RM_WATCH_WD_UNSIGNED
 #cmakedefine01 HAVE_IN_EXCL_UNLINK
 #cmakedefine01 HAVE_TCP_H_TCP_KEEPALIVE
+#cmakedefine01 HAVE_BUILTIN_MUL_OVERFLOW
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/Unix/Common/pal_safecrt.h
+++ b/src/Native/Unix/Common/pal_safecrt.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "pal_compiler.h"
+#include "pal_config.h"
 
 #include <string.h>
 #include <assert.h>
@@ -15,7 +16,7 @@
 // Returns true if safe, false if overflows.
 inline static bool multiply_s(size_t a, size_t b, size_t* result)
 {
-#if __has_builtin(__builtin_mul_overflow)
+#if HAVE_BUILTIN_MUL_OVERFLOW
     return !__builtin_mul_overflow(a, b, result);
 #else
     if (a == 0 || b == 0)
@@ -40,7 +41,7 @@ inline static bool multiply_s(size_t a, size_t b, size_t* result)
 // Returns true if safe, false if overflows.
 inline static bool add_s(size_t a, size_t b, size_t* result)
 {
-#if __has_builtin(__builtin_add_overflow)
+#if HAVE_BUILTIN_MUL_OVERFLOW
     return !__builtin_add_overflow(a, b, result);
 #else
     if(((size_t)~((size_t)0)) - a < b)

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
@@ -160,7 +160,7 @@ uint32_t NetSecurityNative_ImportTargetName(uint32_t* minorStatus,
 
     if (isNtlmTarget)
     {
-        nameType = (gss_OID)GSS_C_NT_HOSTBASED_SERVICE;
+        nameType = GSS_C_NT_HOSTBASED_SERVICE;
     }
     else
     {

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
@@ -160,11 +160,11 @@ uint32_t NetSecurityNative_ImportTargetName(uint32_t* minorStatus,
 
     if (isNtlmTarget)
     {
-        nameType = GSS_C_NT_HOSTBASED_SERVICE;
+        nameType = (gss_OID)GSS_C_NT_HOSTBASED_SERVICE;
     }
     else
     {
-        nameType = GSS_KRB5_NT_PRINCIPAL_NAME;
+        nameType = (gss_OID)(unsigned long)GSS_KRB5_NT_PRINCIPAL_NAME;
     }
 
     GssBuffer inputNameBuffer = {.length = inputNameLen, .value = inputName};
@@ -226,7 +226,7 @@ uint32_t NetSecurityNative_InitSecContext(uint32_t* minorStatus,
     }
 
     gss_OID desiredMech = &gss_mech_OID_desc;
-    gss_OID krbMech = gss_mech_krb5;
+    gss_OID krbMech = (gss_OID)(unsigned long)gss_mech_krb5;
 #endif
 
     *isNtlmUsed = 1;

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -783,8 +783,18 @@ check_c_source_compiles(
         return x;
     }
     "
-    HAVE_TCP_H_TCP_KEEPALIVE
-)
+    HAVE_TCP_H_TCP_KEEPALIVE)
+
+check_c_source_compiles(
+    "
+    #include <unistd.h>
+    int main(void)
+    {
+        size_t result;
+        (void)__builtin_mul_overflow(0, 0, &result);
+    }
+    "
+    HAVE_BUILTIN_MUL_OVERFLOW)
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/Common/pal_config.h.in

--- a/src/Native/Unix/gen-buildsys-gcc.sh
+++ b/src/Native/Unix/gen-buildsys-gcc.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env sh
+#
+# This file invokes cmake and generates the build system for gcc.
+#
+
+if [ $# -lt 4 ]
+then
+  echo "Usage..."
+  echo "gen-buildsys-clang.sh <path to top level CMakeLists.txt> <GccMajorVersion> <GccMinorVersion> <Architecture> [build flavor] [cmakeargs]"
+  echo "Specify the path to the top level CMake file - <ProjectK>/src/NDP"
+  echo "Specify the gcc version to use, split into major and minor version"
+  echo "Specify the target architecture."
+  echo "Optionally specify the build configuration (flavor.) Defaults to DEBUG."
+  echo "Optionally pass additional arguments to CMake call."
+  exit 1
+fi
+
+# Locate gcc
+gcc_prefix=""
+
+if [ "$CROSSCOMPILE" = "1" ]; then
+  # Locate gcc
+  if [ -n "$TOOLCHAIN" ]; then
+    gcc_prefix="$TOOLCHAIN-"
+  fi
+fi
+
+# Set up the environment to be used for building with gcc.
+if command -v "${gcc_prefix}gcc-$2.$3" > /dev/null
+    then
+        desired_gcc_version="-$2.$3"
+elif command -v "${gcc_prefix}gcc$2$3" > /dev/null
+    then
+        desired_gcc_version="$2$3"
+elif command -v "${gcc_prefix}gcc-$2$3" > /dev/null
+    then
+        desired_gcc_version="-$2$3"
+elif command -v "${gcc_prefix}"gcc > /dev/null
+    then
+        desired_gcc_version=
+else
+    echo "Unable to find \"${gcc_prefix}\"gcc Compiler"
+    exit 1
+fi
+
+if [ -z "$CC" ]; then
+  CC="$(command -v "${gcc_prefix}"gcc"$desired_gcc_version")"
+  export CC
+fi
+
+build_arch="$4"
+buildtype=DEBUG
+generator="Unix Makefiles"
+__UnprocessedCMakeArgs=""
+
+ITER=-1
+for i in "$@"; do
+    ITER=$((ITER + 1))
+    if [ $ITER -lt 5 ]; then continue; fi
+    upperI="$(echo "$i" | awk '{print toupper($0)}')"
+    case $upperI in
+      # Possible build types are DEBUG, CHECKED, RELEASE, RELWITHDEBINFO, MINSIZEREL.
+      DEBUG | CHECKED | RELEASE | RELWITHDEBINFO | MINSIZEREL)
+      buildtype=$upperI
+      ;;
+      NINJA)
+      generator=Ninja
+      ;;
+      *)
+      __UnprocessedCMakeArgs="${__UnprocessedCMakeArgs}${__UnprocessedCMakeArgs:+ }$i"
+    esac
+done
+
+OS=$(uname)
+
+locate_gcc_exec() {
+  if command -v "$gcc_prefix$1$desired_gcc_version" > /dev/null 2>&1
+  then
+    command -v "$gcc_prefix$1$desired_gcc_version"
+  elif command -v "$gcc_prefix$1" > /dev/null 2>&1
+  then
+    command -v "$gcc_prefix$1"
+  else
+    exit 1
+  fi
+}
+
+if ! gcc_ar="$(locate_gcc_exec ar)"; then { echo "Unable to locate gcc-ar"; exit 1; } fi
+
+if [ -z "$NM" ]; then
+  if ! gcc_nm="$(locate_gcc_exec nm)"; then { echo "Unable to locate gcc-nm"; exit 1; } fi
+else
+  gcc_nm="$NM"
+fi
+
+if [ "$OS" = "Linux" ] || [ "$OS" = "FreeBSD" ] || [ "$OS" = "OpenBSD" ] || [ "$OS" = "NetBSD" ] || [ "$OS" = "SunOS" ]; then
+  if [ -z "$OBJDUMP" ]; then
+    if ! gcc_objdump="$(locate_gcc_exec objdump)"; then { echo "Unable to locate gcc-objdump"; exit 1; } fi
+  else
+    gcc_objdump="$OBJDUMP"
+  fi
+fi
+
+if [ -z "$OBJCOPY" ]; then
+  if ! gcc_objcopy="$(locate_gcc_exec objcopy)"; then { echo "Unable to locate gcc-objcopy"; exit 1; } fi
+else
+  gcc_objcopy="$OBJCOPY"
+fi
+
+if ! gcc_ranlib="$(locate_gcc_exec ranlib)"; then { echo "Unable to locate gcc-ranlib"; exit 1; } fi
+
+cmake_extra_defines=
+if [ -n "$LLDB_LIB_DIR" ]; then
+    cmake_extra_defines="$cmake_extra_defines -DWITH_LLDB_LIBS=$LLDB_LIB_DIR"
+fi
+if [ -n "$LLDB_INCLUDE_DIR" ]; then
+    cmake_extra_defines="$cmake_extra_defines -DWITH_LLDB_INCLUDES=$LLDB_INCLUDE_DIR"
+fi
+if [ "$CROSSCOMPILE" = "1" ]; then
+    if [ -z "$ROOTFS_DIR" ]; then
+        echo "ROOTFS_DIR not set for crosscompile"
+        exit 1
+    fi
+    if [ -z "$CONFIG_DIR" ]; then
+        CONFIG_DIR="$1/cross"
+    fi
+    export TARGET_BUILD_ARCH=$build_arch
+    cmake_extra_defines="$cmake_extra_defines -C $CONFIG_DIR/tryrun.cmake"
+    cmake_extra_defines="$cmake_extra_defines -DCMAKE_TOOLCHAIN_FILE=$CONFIG_DIR/toolchain.cmake"
+fi
+if [ "$build_arch" = "armel" ]; then
+    cmake_extra_defines="$cmake_extra_defines -DARM_SOFTFP=1"
+fi
+
+cmake \
+  -G "$generator" \
+  "-DCMAKE_AR=$gcc_ar" \
+  "-DCMAKE_NM=$gcc_nm" \
+  "-DCMAKE_RANLIB=$gcc_ranlib" \
+  "-DCMAKE_OBJCOPY=$gcc_objcopy" \
+  "-DCMAKE_OBJDUMP=$gcc_objdump" \
+  "-DCMAKE_BUILD_TYPE=$buildtype" \
+  "-DCMAKE_EXPORT_COMPILE_COMMANDS=1 " \
+  "$cmake_extra_defines" \
+  "$__UnprocessedCMakeArgs" \
+  "$1"

--- a/src/Native/build-native.sh
+++ b/src/Native/build-native.sh
@@ -7,12 +7,13 @@ usage()
     echo "If you plan to only run this script, be sure to pass those parameters."
     echo "For more information type build-native.sh -? at the root of the repo."
     echo
-    echo "Usage: $0 [runParameters][-verbose] [-clangx.y] [-cross] [-staticLibLink] [-cmakeargs] [-makeargs]"
+    echo "Usage: $0 [runParameters][-verbose] [-clangx.y] [-gccx.y] [-cross] [-staticLibLink] [-cmakeargs] [-makeargs]"
     echo "runParameters: buildArch, buildType, buildOS, -numProc <numproc value>"
     echo "BuildArch can be: -x64, -x86, -arm, -armel, -arm64"
     echo "BuildType can be: -debug, -checked, -release"
     echo "-verbose - optional argument to enable verbose build output."
     echo "-clangx.y - optional argument to build using clang version x.y."
+    echo "-gccx.y - optional argument to build using gcc version x.y."
     echo "-cross - optional argument to signify cross compilation,"
     echo "       - will use ROOTFS_DIR environment variable if set."
     echo "-staticLibLink - Optional argument to statically link any native library."
@@ -87,18 +88,28 @@ check_native_prereqs()
     # Check presence of CMake on the path
     hash cmake 2>/dev/null || { echo >&2 "Please install cmake before running this script"; exit 1; }
 
-
-    # Minimum required version of clang is version 3.9 for arm/armel cross build
-    if [[ $__CrossBuild == 1 && ("$__BuildArch" == "arm" || "$__BuildArch" == "armel") ]]; then
-        if ! [[ "$__ClangMajorVersion" -gt "3" || ( $__ClangMajorVersion == 3 && $__ClangMinorVersion == 9 ) ]]; then
-            echo "Please install clang3.9 or latest for arm/armel cross build"; exit 1;
+    if [ "$__GccBuild" = 0 ]; then
+        # Minimum required version of clang is version 3.9 for arm/armel cross build
+        if [ "$__CrossBuild" = 1 ] && { [ "$__BuildArch" = "arm" ] || [ "$__BuildArch" = "armel" ]; }; then
+            if [ "$__ClangMajorVersion" -lt 3 ] || { [ "$__ClangMajorVersion" -eq 3 ] && [ "$__ClangMinorVersion" -lt 9 ]; }; then
+                echo "Please install clang3.9 or latest for arm/armel cross build"; exit 1;
+            fi
         fi
+
+        # Check for clang
+        hash "clang-$__ClangMajorVersion.$__ClangMinorVersion" 2>/dev/null || hash "clang$__ClangMajorVersion$__ClangMinorVersion" 2>/dev/null ||  hash clang 2>/dev/null || { echo >&2 "Please install clang before running this script"; exit 1; }
+    else
+        # Minimum required version of gcc is version 5.0 for arm/armel cross build
+        if [ "$__CrossBuild" = 1 ] && { [ "$__BuildArch" = "arm" ] || [ "$__BuildArch" = "armel" ]; }; then
+            if [ "$__GccMajorVersion" -lt 5 ]; then
+                echo "Please install gcc version 5 or latest for arm/armel cross build"; exit 1;
+            fi
+        fi
+
+        # Check for gcc
+        hash "gcc-$__GccMajorVersion.$__GccMinorVersion" 2>/dev/null || hash "gcc$__GccMajorVersion$__GccMinorVersion" 2>/dev/null ||  hash gcc 2>/dev/null || { echo >&2 "Please install gcc before running this script"; exit 1; }
     fi
-
-    # Check for clang
-    hash clang-$__ClangMajorVersion.$__ClangMinorVersion 2>/dev/null ||  hash clang$__ClangMajorVersion$__ClangMinorVersion 2>/dev/null ||  hash clang 2>/dev/null || { echo >&2 "Please install clang before running this script"; exit 1; }
 }
-
 
 prepare_native_build()
 {
@@ -127,8 +138,13 @@ build_native()
     cd "$__IntermediatesDir"
 
     # Regenerate the CMake solution
-    echo "Invoking cmake with arguments: \"$__nativeroot\" $__CMakeArgs $__CMakeExtraArgs"
-    "$__nativeroot/gen-buildsys-clang.sh" "$__nativeroot" $__ClangMajorVersion $__ClangMinorVersion $__BuildArch $__CMakeArgs "$__CMakeExtraArgs"
+    if [ "$__GccBuild" = 0 ]; then
+        echo "Invoking \"$__nativeroot/gen-buildsys-clang.sh\" \"$__nativeroot\" \"$__ClangMajorVersion\" \"$__ClangMinorVersion\" \"$__BuildArch\" \"$__CMakeArgs\" \"$__CMakeExtraArgs\""
+        "$__nativeroot/gen-buildsys-clang.sh" "$__nativeroot" "$__ClangMajorVersion" "$__ClangMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
+    else
+        echo "Invoking \"$__nativeroot/gen-buildsys-gcc.sh\" \"$__nativeroot\" \"$__GccMajorVersion\" \"$__GccMinorVersion\" \"$__BuildArch\" \"$__CMakeArgs\" \"$__CMakeExtraArgs\""
+        "$__nativeroot/gen-buildsys-gcc.sh" "$__nativeroot" "$__GccMajorVersion" "$__GccMinorVersion" "$__BuildArch" "$__CMakeArgs" "$__CMakeExtraArgs"
+    fi
 
     # Check that the makefiles were created.
 
@@ -162,6 +178,9 @@ __CMakeArgs=DEBUG
 __BuildOS=Linux
 __NumProc=1
 __UnprocessedBuildArgs=
+__GccBuild=0
+__GccMajorVersion=0
+__GccMinorVersion=0
 __CrossBuild=0
 __ServerGC=0
 __VerboseBuild=false
@@ -312,6 +331,31 @@ while :; do
         clang4.0|-clang4.0)
             __ClangMajorVersion=4
             __ClangMinorVersion=0
+            ;;
+        gcc5|-gcc5)
+            __GccMajorVersion=5
+            __GccMinorVersion=
+            __GccBuild=1
+            ;;
+        gcc6|-gcc6)
+            __GccMajorVersion=6
+            __GccMinorVersion=
+            __GccBuild=1
+            ;;
+        gcc7|-gcc7)
+            __GccMajorVersion=7
+            __GccMinorVersion=
+            __GccBuild=1
+            ;;
+        gcc8|-gcc8)
+            __GccMajorVersion=8
+            __GccMinorVersion=
+            __GccBuild=1
+            ;;
+        gcc|-gcc)
+            __GccMajorVersion=
+            __GccMinorVersion=
+            __GccBuild=1
             ;;
         cross|-cross)
             __CrossBuild=1


### PR DESCRIPTION
Tested with gcc v5, v6, v7 and v8 on CentOS 7, Ubuntu 18, Debian 8 and
FreeBSD 11.
`corefx/src/Native/build-native.sh x64 checked gcc`