### PR TITLE
Avoid NullReferenceException in BinaryObjectInfo

### DIFF
--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectInfo.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectInfo.cs
@@ -532,6 +532,11 @@ namespace System.Runtime.Serialization.Formatters.Binary
         {
             if (_isSi)
             {
+                if (_objectManager == null)
+                {
+                    throw new SerializationException(SR.Serialization_CorruptedStream);
+                }
+
                 _objectManager.RecordDelayedFixup(objectId, name, idRef);
             }
             else
@@ -539,6 +544,11 @@ namespace System.Runtime.Serialization.Formatters.Binary
                 int position = Position(name);
                 if (position != -1)
                 {
+                    if (_objectManager == null)
+                    {
+                        throw new SerializationException(SR.Serialization_CorruptedStream);
+                    }
+
                     _objectManager.RecordFixup(objectId, _cache._memberInfos[position], idRef);
                 }
             }


### PR DESCRIPTION
A corrupted BinaryFormatter stream can result in a BinaryObjectInfo getting constructed before the ObjectManager is constructed, resulting in the BinaryObjectInfo not having a reference to the ObjectManager.  Attempts to use it then hit a null reference exception.

(I've not added a unit test here.  I suggest as part of adding a wrapping exception to fix 35491, we come up with a good way of encoding fuzzed inputs; this can then have a test that piggybacks on that.)

Contributes to https://github.com/dotnet/corefx/issues/35491
cc: @danmosemsft, @ViktorHofer 