### PR TITLE
Fix ArgIterator condition

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -38,7 +38,7 @@ namespace System
         public static bool IsNotArm64Process => !IsArm64Process;
         public static bool IsArmOrArm64Process => IsArmProcess || IsArm64Process;
         public static bool IsNotArmNorArm64Process => !IsArmOrArm64Process;
-        public static bool IsArgIteratorSupported => IsWindows && IsNotArmNorArm64Process;
+        public static bool IsArgIteratorSupported => IsWindows && IsNotArmProcess;
         public static bool IsArgIteratorNotSupported => !IsArgIteratorSupported;
 
         public static bool IsNotInAppContainer => !IsInAppContainer;


### PR DESCRIPTION
When simplifying the condition on arg iterator, I misread it as "Windows not ARMxx" because it was written redundantly. It was effectively "Windows not ARM[32]". 
```c#
-        public static bool IsArgIteratorSupported => IsWindows && (IsNotArmProcess || IsArm64Process);
+        public static bool IsArgIteratorSupported => IsWindows && IsNotArmNorArm64Process;
```


https://mc.dot.net/#/product/netcore/30/source/official~2Fdotnet~2Fcorefx~2Frefs~2Fheads~2Fmaster/type/test~2Ffunctional~2Fcli~2F/build/20190303.7/workItem/System.Runtime.Tests/analysis/xunit/System.Tests.ArgIteratorTests~2FArgIterator_Throws_PlatformNotSupportedException