### PR TITLE
Tweak ImmutableDictionary.TryGetValue to improve throughput

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/DictionaryEnumerator.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/DictionaryEnumerator.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace System.Collections.Immutable
 {
-    internal class DictionaryEnumerator<TKey, TValue> : IDictionaryEnumerator
+    internal sealed class DictionaryEnumerator<TKey, TValue> : IDictionaryEnumerator
     {
         private readonly IEnumerator<KeyValuePair<TKey, TValue>> _inner;
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.Comparers.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.Comparers.cs
@@ -19,7 +19,7 @@ namespace System.Collections.Immutable
         /// but we try to keep this an implementation detail by exposing properties that return
         /// references for these particular facilities, that are implemented as returning "this".
         /// </remarks>
-        internal class Comparers : IEqualityComparer<HashBucket>, IEqualityComparer<KeyValuePair<TKey, TValue>>
+        internal sealed class Comparers : IEqualityComparer<HashBucket>, IEqualityComparer<KeyValuePair<TKey, TValue>>
         {
             /// <summary>
             /// The default instance to use when all the comparers used are their default values.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
@@ -256,10 +256,10 @@ namespace System.Collections.Immutable
             /// Gets the value for the given key in the collection if one exists..
             /// </summary>
             /// <param name="key">The key to search for.</param>
-            /// <param name="keyOnlyComparer">The key comparer.</param>
+            /// <param name="comparers">The key comparer.</param>
             /// <param name="value">The value for the given key.</param>
             /// <returns>A value indicating whether the key was found.</returns>
-            internal bool TryGetValue(TKey key, IEqualityComparer<KeyValuePair<TKey, TValue>> keyOnlyComparer, out TValue value)
+            internal bool TryGetValue(TKey key, Comparers comparers, out TValue value)
             {
                 if (this.IsEmpty)
                 {
@@ -267,14 +267,14 @@ namespace System.Collections.Immutable
                     return false;
                 }
 
-                var kv = new KeyValuePair<TKey, TValue>(key, default(TValue));
-                if (keyOnlyComparer.Equals(_firstValue, kv))
+                if (comparers.KeyComparer.Equals(_firstValue.Key, key))
                 {
                     value = _firstValue.Value;
                     return true;
                 }
 
-                var index = _additionalElements.IndexOf(kv, keyOnlyComparer);
+                var kv = new KeyValuePair<TKey, TValue>(key, default(TValue));
+                var index = _additionalElements.IndexOf(kv, comparers.KeyOnlyComparer);
                 if (index < 0)
                 {
                     value = default(TValue);
@@ -293,7 +293,7 @@ namespace System.Collections.Immutable
             /// Searches the dictionary for a given key and returns the equal key it finds, if any.
             /// </summary>
             /// <param name="equalKey">The key to search for.</param>
-            /// <param name="keyOnlyComparer">The key comparer.</param>
+            /// <param name="comparers">The comparers.</param>
             /// <param name="actualKey">The key from the dictionary that the search found, or <paramref name="equalKey"/> if the search yielded no match.</param>
             /// <returns>A value indicating whether the search was successful.</returns>
             /// <remarks>
@@ -302,7 +302,7 @@ namespace System.Collections.Immutable
             /// the canonical value, or a value that has more complete data than the value you currently have,
             /// although their comparer functions indicate they are equal.
             /// </remarks>
-            internal bool TryGetKey(TKey equalKey, IEqualityComparer<KeyValuePair<TKey, TValue>> keyOnlyComparer, out TKey actualKey)
+            internal bool TryGetKey(TKey equalKey, Comparers comparers, out TKey actualKey)
             {
                 if (this.IsEmpty)
                 {
@@ -310,14 +310,14 @@ namespace System.Collections.Immutable
                     return false;
                 }
 
-                var kv = new KeyValuePair<TKey, TValue>(equalKey, default(TValue));
-                if (keyOnlyComparer.Equals(_firstValue, kv))
+                if (comparers.KeyComparer.Equals(_firstValue.Key, equalKey))
                 {
                     actualKey = _firstValue.Key;
                     return true;
                 }
 
-                var index = _additionalElements.IndexOf(kv, keyOnlyComparer);
+                var kv = new KeyValuePair<TKey, TValue>(equalKey, default(TValue));
+                var index = _additionalElements.IndexOf(kv, comparers.KeyOnlyComparer);
                 if (index < 0)
                 {
                     actualKey = equalKey;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.HashBucket.cs
@@ -256,7 +256,7 @@ namespace System.Collections.Immutable
             /// Gets the value for the given key in the collection if one exists..
             /// </summary>
             /// <param name="key">The key to search for.</param>
-            /// <param name="comparers">The key comparer.</param>
+            /// <param name="comparers">The comparers.</param>
             /// <param name="value">The value for the given key.</param>
             /// <returns>A value indicating whether the key was found.</returns>
             internal bool TryGetValue(TKey key, Comparers comparers, out TValue value)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.MutationInput.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.MutationInput.cs
@@ -60,6 +60,14 @@ namespace System.Collections.Immutable
             }
 
             /// <summary>
+            /// Gets the set of comparers.
+            /// </summary>
+            internal Comparers Comparers
+            {
+                get { return _comparers; }
+            }
+
+            /// <summary>
             /// Gets the key comparer.
             /// </summary>
             internal IEqualityComparer<TKey> KeyComparer

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
@@ -908,7 +908,7 @@ namespace System.Collections.Immutable
             if (origin.Root.TryGetValue(hashCode, out bucket))
             {
                 TValue value;
-                return bucket.TryGetValue(key, origin.KeyOnlyComparer, out value);
+                return bucket.TryGetValue(key, origin.Comparers, out value);
             }
 
             return false;
@@ -924,7 +924,7 @@ namespace System.Collections.Immutable
             if (origin.Root.TryGetValue(hashCode, out bucket))
             {
                 TValue value;
-                return bucket.TryGetValue(keyValuePair.Key, origin.KeyOnlyComparer, out value)
+                return bucket.TryGetValue(keyValuePair.Key, origin.Comparers, out value)
                     && origin.ValueComparer.Equals(value, keyValuePair.Value);
             }
 
@@ -940,7 +940,7 @@ namespace System.Collections.Immutable
             HashBucket bucket;
             if (origin.Root.TryGetValue(hashCode, out bucket))
             {
-                return bucket.TryGetValue(key, origin.KeyOnlyComparer, out value);
+                return bucket.TryGetValue(key, origin.Comparers, out value);
             }
 
             value = default(TValue);
@@ -956,7 +956,7 @@ namespace System.Collections.Immutable
             HashBucket bucket;
             if (origin.Root.TryGetValue(hashCode, out bucket))
             {
-                return bucket.TryGetKey(equalKey, origin.KeyOnlyComparer, out actualKey);
+                return bucket.TryGetKey(equalKey, origin.Comparers, out actualKey);
             }
 
             actualKey = equalKey;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/KeysOrValuesCollectionAccessor.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/KeysOrValuesCollectionAccessor.cs
@@ -165,7 +165,7 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A lightweight collection view over and IEnumerable of keys.
     /// </summary>
-    internal class KeysCollectionAccessor<TKey, TValue> : KeysOrValuesCollectionAccessor<TKey, TValue, TKey>
+    internal sealed class KeysCollectionAccessor<TKey, TValue> : KeysOrValuesCollectionAccessor<TKey, TValue, TKey>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="KeysCollectionAccessor{TKey, TValue}"/> class.
@@ -187,7 +187,7 @@ namespace System.Collections.Immutable
     /// <summary>
     /// A lightweight collection view over and IEnumerable of values.
     /// </summary>
-    internal class ValuesCollectionAccessor<TKey, TValue> : KeysOrValuesCollectionAccessor<TKey, TValue, TValue>
+    internal sealed class ValuesCollectionAccessor<TKey, TValue> : KeysOrValuesCollectionAccessor<TKey, TValue, TValue>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ValuesCollectionAccessor{TKey, TValue}"/> class.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
@@ -200,8 +200,28 @@ namespace System.Collections.Immutable
         [Pure]
         internal TValue GetValueOrDefault(int key)
         {
-            var match = this.Search(key);
-            return match.IsEmpty ? default(TValue) : match._value;
+            SortedInt32KeyNode<TValue> node = this;
+            while (true)
+            {
+                if (node.IsEmpty)
+                {
+                    return default(TValue);
+                }
+
+                if (key == node._key)
+                {
+                    return node._value;
+                }
+
+                if (key > node._key)
+                {
+                    node = node._right;
+                }
+                else
+                {
+                    node = node._left;
+                }
+            }
         }
 
         /// <summary>
@@ -213,16 +233,29 @@ namespace System.Collections.Immutable
         [Pure]
         internal bool TryGetValue(int key, out TValue value)
         {
-            var match = this.Search(key);
-            if (match.IsEmpty)
+            SortedInt32KeyNode<TValue> node = this;
+            while (true)
             {
-                value = default(TValue);
-                return false;
-            }
-            else
-            {
-                value = match._value;
-                return true;
+                if (node.IsEmpty)
+                {
+                    value = default(TValue);
+                    return false;
+                }
+
+                if (key == node._key)
+                {
+                    value = node._value;
+                    return true;
+                }
+
+                if (key > node._key)
+                {
+                    node = node._right;
+                }
+                else
+                {
+                    node = node._left;
+                }
             }
         }
 
@@ -546,30 +579,6 @@ namespace System.Collections.Immutable
                 _height = checked((byte)(1 + Math.Max(_left._height, _right._height)));
                 return this;
             }
-        }
-
-        /// <summary>
-        /// Searches the specified key. Callers are expected to validate arguments.
-        /// </summary>
-        /// <param name="key">The key.</param>
-        [Pure]
-        private SortedInt32KeyNode<TValue> Search(int key)
-        {
-            SortedInt32KeyNode<TValue> node = this;
-
-            while (!node.IsEmpty && key != node._key)
-            {
-                if (key > node._key)
-                {
-                    node = node._right;
-                }
-                else
-                {
-                    node = node._left;
-                }
-            }
-
-            return node;
         }
     }
 }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
@@ -555,17 +555,21 @@ namespace System.Collections.Immutable
         [Pure]
         private SortedInt32KeyNode<TValue> Search(int key)
         {
-            if (this.IsEmpty || key == _key)
+            SortedInt32KeyNode<TValue> node = this;
+
+            while (!node.IsEmpty && key != node._key)
             {
-                return this;
+                if (key > node._key)
+                {
+                    node = node._right;
+                }
+                else
+                {
+                    node = node._left;
+                }
             }
 
-            if (key > _key)
-            {
-                return _right.Search(key);
-            }
-
-            return _left.Search(key);
+            return node;
         }
     }
 }


### PR DESCRIPTION
A few tweaks to ImmutableDictionary to reduce the costs of lookups:
- Changed SortedInt32KeyNode to no longer be recursive, and then inlined it into its two call sites to avoid additional indirection and duplicative branches
- Avoid wrapping and unwrapping key value pairs when comparing the first item in a HashBucket

cc: @AArnott, @agocke 

Benchmark on my machine...

| Name              | Before (us) | After (us) | Improvement | 
|-------------------|-------------|------------|-------------| 
|        Lookup1Int | 175         | 117.7      | 32.74%      | 
|      Lookup100Int | 214.3       | 172.7      | 19.41%      | 
|    Lookup10000Int | 525.6       | 507.7      | 3.41%       | 
|     Lookup1String | 563.6       | 441.9      | 21.59%      | 
|   Lookup100String | 632.3       | 530.7      | 16.07%      | 
| Lookup10000String | 1,477.10  | 1,318.00 | 10.77%      | 

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Attributes.Jobs;
using BenchmarkDotNet.Running;
using System;
using System.Collections.Immutable;
using System.Runtime.CompilerServices;

[MemoryDiagnoser]
[InProcess]
public class Benchmark
{
    private static void Main() => BenchmarkRunner.Run<Benchmark>();

    private ImmutableDictionary<int, int> _oneInt;
    private ImmutableDictionary<int, int> _hundredInts;
    private ImmutableDictionary<int, int> _tenThousandInts;

    private ImmutableDictionary<string, string> _oneString;
    private ImmutableDictionary<string, string> _hundredStrings;
    private ImmutableDictionary<string, string> _tenThousandStrings;

    private string[] _strings;

    [GlobalSetup]
    public void Setup()
    {
        _strings = new string[10_000];
        for (int i = 0; i < _strings.Length; i++) _strings[i] = i.ToString();

        _oneInt = ImmutableDictionary.Create<int, int>().Add(0, 0);
        _oneString = ImmutableDictionary.Create<string, string>().Add(_strings[0], _strings[0]);

        _hundredInts = ImmutableDictionary.Create<int, int>();
        _hundredStrings = ImmutableDictionary.Create<string, string>();
        for (int i = 0; i < 100; i++)
        {
            _hundredInts = _hundredInts.Add(i, i);
            _hundredStrings = _hundredStrings.Add(_strings[i], _strings[i]);
        }

        _tenThousandInts = ImmutableDictionary.Create<int, int>();
        _tenThousandStrings = ImmutableDictionary.Create<string, string>();
        for (int i = 0; i < 10000; i++)
        {
            _tenThousandInts = _tenThousandInts.Add(i, i);
            _tenThousandStrings = _tenThousandStrings.Add(_strings[i], _strings[i]);
        }
    }

    [Benchmark]
    public int Lookup1Int()
    {
        int count = 0;
        for (int i = 0; i < 10000; i++)
        {
            for (int j = 0; j < 1; j++)
            {
                if (_oneInt.TryGetValue(j, out _))
                {
                    count++;
                }
            }
        }
        return count;
    }

    [Benchmark]
    public int Lookup100Int()
    {
        int count = 0;
        {
            for (int i = 0; i < 100; i++)
            {
                for (int j = 0; j < 100; j++)
                {
                    if (_hundredInts.TryGetValue(j, out _))
                    {
                        count++;
                    }
                }
            }
        }
        return count;
    }

    [Benchmark]
    public int Lookup10000Int()
    {
        int count = 0;
        for (int i = 0; i < 1; i++)
        {
            for (int j = 0; j < 10000; j++)
            {
                if (_tenThousandInts.TryGetValue(j, out _))
                {
                    count++;
                }
            }
        }
        return count;
    }

    [Benchmark]
    public int Lookup1String()
    {
        string[] strings = _strings;

        int count = 0;
        {
            for (int i = 0; i < 10000; i++)
            {
                for (int j = 0; j < 1; j++)
                {
                    if (_oneString.TryGetValue(strings[j], out _))
                    {
                        count++;
                    }
                }
            }
        }
        return count;
    }

    [Benchmark]
    public int Lookup100String()
    {
        string[] strings = _strings;

        int count = 0;
        for (int i = 0; i < 100; i++)
        {
            for (int j = 0; j < 100; j++)
            {
                if (_hundredStrings.TryGetValue(strings[j], out _))
                {
                    count++;
                }
            }
        }
        return count;
    }

    [Benchmark]
    public int Lookup10000String()
    {
        string[] strings = _strings;

        int count = 0;
        for (int i = 0; i < 1; i++)
        {
            for (int j = 0; j < 10000; j++)
            {
                if (_tenThousandStrings.TryGetValue(strings[j], out _))
                {
                    count++;
                }
            }
        }
        return count;
    }
}
```