### PR TITLE
Allow CreateRelationship to work with FileAccess.Write

### DIFF
--- a/src/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
@@ -448,9 +448,6 @@ namespace System.IO.Packaging
             else
                 ValidateUniqueRelationshipId(id);
 
-            //Ensure the relationship part
-            EnsureRelationshipPart();
-
             // create and add
             PackageRelationship relationship = new PackageRelationship(_package, _sourcePart, targetUri, targetMode, relationshipType, id);
             _relationships.Add(relationship);
@@ -471,7 +468,10 @@ namespace System.IO.Packaging
             using (Stream partStream = part.GetStream())
             using (IgnoreFlushAndCloseStream s = new IgnoreFlushAndCloseStream(partStream))
             {
-                s.SetLength(0);    // truncate to resolve PS 954048
+                if (_package.FileOpenAccess != FileAccess.Write)
+                {
+                    s.SetLength(0);    // truncate to resolve PS 954048
+                }
 
                 // use UTF-8 encoding by default
                 using (XmlWriter writer = XmlWriter.Create(s, new XmlWriterSettings { Encoding = System.Text.Encoding.UTF8 }))

--- a/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
@@ -283,7 +283,14 @@ namespace System.IO.Packaging
         /// <exception cref="ArgumentException">If partUri parameter does not conform to the valid partUri syntax</exception>
         public virtual bool PartExists(Uri partUri)
         {
-            return (GetPartHelper(partUri) != null);
+            ThrowIfObjectDisposed();
+
+            if (partUri == null)
+                throw new ArgumentNullException(nameof(partUri));
+
+            PackUriHelper.ValidatedPartUri validatePartUri = PackUriHelper.ValidatePartUri(partUri);
+
+            return _partList.ContainsKey(validatePartUri);
         }
 
 
@@ -1048,7 +1055,7 @@ namespace System.IO.Packaging
                 //
                 //     _partList.Keys.CopyTo(keys, 0);
 
-                for (int i = 0; i < _partList.Keys.Count; i++)
+                for (int i = 0; i < partKeys.Length; i++)
                 {
                     // Some of these may disappear during above close because the list contains "relationship parts"
                     // and these are removed if their parts' relationship collection is empty


### PR DESCRIPTION
When adding a relationship InternalRelationshipCollection was creating a part
but not writing anything to it.  This caused an empty entry to be created in
the zip archive which later needed to be rewritten.  That's disallowed with
FileAccess.Write.  Instead, avoid creating the entry until it's content is
written.

When writing a relationship file InternalRelationshipCollection was attempting
to truncate any existing content.  This throws when the package is open  with
FileAccess.Write since the part stream is not seekable.  Don't do the seek
when package is open for FileAccess.Write since no pre-existing content is
possible.

In Package.PartExists don't attempt to get the part.  PartExists on .NETCore
only needs to query its local list of parts.  Since it isn't returning a
mutable part, it doesn't need to throw for packages opened with FileAccess.Write.

Avoid out of bounds exception when enumerating part keys. The fix that delays
creating the relationship part until its content exposed an issue in
DoOperationOnEachPart.  This was creating a copy of the part keys, but then
enumerating over the length of original list instead of the copy.  Since I
delayed the creating of a part until it was flushed this made the length change
while iterating the loop.  Since this code was using its copied list of keys
it should have never been using the original bounds.

/cc @pensivebrian @twsouthwick 

Related #24457.  My previous fix enabled FileAccess.Write for creating Packages with large files but creation of relationships still wasn't working with FileAccess.Write.  This enables CreateRelationship.