### PR TITLE
Fix a race and inefficiency in Microsoft-Diagnostics-DiagnosticSource

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'netfx'">
     <Reference Include="System.Collections" />
+    <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Diagnostics.Tracing" />
     <Reference Include="System.Reflection" />

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -660,8 +660,7 @@ namespace System.Diagnostics
                         {
                             // _firstImplicitTransformsEntry is empty, we should fill it.  
                             // Note that it is OK that two threads may race and both call MakeImplicitTransforms on their own
-                            // (that is we don't expect exactly once initialization of _firstImplicitTransformsEntry
-                            implicitTransforms = MakeImplicitTransforms(argType);
+                            // (that is we don't expect exactly once initialization of _firstImplicitTransformsEntry)                            implicitTransforms = MakeImplicitTransforms(argType);
                             Interlocked.CompareExchange(ref _firstImplicitTransformsEntry, 
                                 new ImplicitTransformEntry() { Type = argType, Transforms = implicitTransforms }, null);
                         }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -440,7 +440,7 @@ namespace System.Diagnostics
 
                 // Points just beyond the last point in the string that has yet to be parsed.   Thus we start with the whole string.  
                 int endIdx = filterAndPayloadSpecs.Length;
-                 for (;;)
+                for (;;)
                 {
                     // Skip trailing whitespace.
                     while (0 < endIdx && char.IsWhiteSpace(filterAndPayloadSpecs[endIdx - 1]))
@@ -538,7 +538,7 @@ namespace System.Diagnostics
                 // Parse all the explicit transforms, if present
                 if (startTransformIdx < endIdx)
                 {
-                     for (;;)
+                    for (;;)
                     {
                         int specStartIdx = startTransformIdx;
                         int semiColonIdx = filterAndPayloadSpec.LastIndexOf(';', endIdx - 1, endIdx - startTransformIdx);
@@ -674,7 +674,7 @@ namespace System.Diagnostics
                         // implicitTransformas now fetched from cache or constructed, use it to Fetch all the implicit fields.  
                         if (implicitTransforms != null)
                         {
-                            for (var serializableArg = implicitTransforms; serializableArg != null; serializableArg = serializableArg.Next)
+                            for (TransformSpec serializableArg = implicitTransforms; serializableArg != null; serializableArg = serializableArg.Next)
                                 outputArgs.Add(serializableArg.Morph(args));
                         }
                     }
@@ -726,7 +726,6 @@ namespace System.Diagnostics
             private IDisposable _diagnosticsListenersSubscription; // This is our subscription that listens for new Diagnostic source to appear. 
             private Subscriptions _liveSubscriptions;              // These are the subscriptions that we are currently forwarding to the EventSource.
             private bool _noImplicitTransforms;                    // Listener can say they don't want implicit transforms.
-
             private ImplicitTransformEntry _firstImplicitTransformsEntry; // The transform for _firstImplicitFieldsType
             private ConcurrentDictionary<Type, TransformSpec> _implicitTransformsTable; // If there is more than one object type for an implicit transform, they go here.   
             private TransformSpec _explicitTransforms;             // payload to include because the user explicitly indicated how to fetch the field.  

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -660,14 +660,20 @@ namespace System.Diagnostics
                         {
                             // _firstImplicitTransformsEntry, we should fill it.  
                             implicitTransforms = MakeImplicitTransforms(argType);
-                            Interlocked.CompareExchange(ref _firstImplicitTransformsEntry, new ImplicitTransformEntry() { Type = argType, Transforms = implicitTransforms }, null);
+                            Interlocked.CompareExchange(ref _firstImplicitTransformsEntry, 
+                                new ImplicitTransformEntry() { Type = argType, Transforms = implicitTransforms }, null);
                         }
                         else
                         {
-                            // This should only happen when you are wildcarding your events (reasonably rare).   In that case you will probably need many types
-                            // Note currently we don't limit the cache size, but it is limited by the number of distinct types of objects passed to DiagnosticSource.Write.  
+                            // This should only happen when you are wildcarding your events (reasonably rare).   
+                            // In that case you will probably need many types
+                            // Note currently we don't limit the cache size, but it is limited by the number of 
+                            // distinct types of objects passed to DiagnosticSource.Write.  
                             if (_implicitTransformsTable == null)
-                                Interlocked.CompareExchange(ref _implicitTransformsTable, new ConcurrentDictionary<Type, TransformSpec>(1, 8), null);
+                            {
+                                Interlocked.CompareExchange(ref _implicitTransformsTable,
+                                    new ConcurrentDictionary<Type, TransformSpec>(1, 8), null);
+                            }
                             implicitTransforms = _implicitTransformsTable.GetOrAdd(argType, MakeImplicitTransforms);
                         }
 

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -660,7 +660,8 @@ namespace System.Diagnostics
                         {
                             // _firstImplicitTransformsEntry is empty, we should fill it.  
                             // Note that it is OK that two threads may race and both call MakeImplicitTransforms on their own
-                            // (that is we don't expect exactly once initialization of _firstImplicitTransformsEntry)                            implicitTransforms = MakeImplicitTransforms(argType);
+                            // (that is we don't expect exactly once initialization of _firstImplicitTransformsEntry)    
+                            implicitTransforms = MakeImplicitTransforms(argType);
                             Interlocked.CompareExchange(ref _firstImplicitTransformsEntry, 
                                 new ImplicitTransformEntry() { Type = argType, Transforms = implicitTransforms }, null);
                         }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -658,7 +658,9 @@ namespace System.Diagnostics
                         }
                         else if (cacheEntry == null)
                         {
-                            // _firstImplicitTransformsEntry, we should fill it.  
+                            // _firstImplicitTransformsEntry is empty, we should fill it.  
+                            // Note that it is OK that two threads may race and both call MakeImplicitTransforms on their own
+                            // (that is we don't expect exactly once initialization of _firstImplicitTransformsEntry
                             implicitTransforms = MakeImplicitTransforms(argType);
                             Interlocked.CompareExchange(ref _firstImplicitTransformsEntry, 
                                 new ImplicitTransformEntry() { Type = argType, Transforms = implicitTransforms }, null);
@@ -674,7 +676,7 @@ namespace System.Diagnostics
                                 Interlocked.CompareExchange(ref _implicitTransformsTable,
                                     new ConcurrentDictionary<Type, TransformSpec>(1, 8), null);
                             }
-                            implicitTransforms = _implicitTransformsTable.GetOrAdd(argType, MakeImplicitTransforms);
+                            implicitTransforms = _implicitTransformsTable.GetOrAdd(argType, type => MakeImplicitTransforms(type));
                         }
 
                         // implicitTransformas now fetched from cache or constructed, use it to Fetch all the implicit fields.  

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceEventSourceBridgeTests.cs
@@ -13,9 +13,10 @@ namespace System.Diagnostics.Tests
     //Complex types are not supported on EventSource for .NET 4.5
     public class DiagnosticSourceEventSourceBridgeTests : RemoteExecutorTestBase
     {
-        // For reasons I am not sure of, we run all these tests in their own sub-process using RemoteInvoke()
-        // However this makes it very inconvinient to debug the test.   By seting this #if to true you stub
-        // out RemoteInvoke and the code will run in-proc which is useful in debugging.  
+        // To avoid interactions between tests when they are run in parallel, we run all these tests in their 
+        // own sub-process using RemoteInvoke()  However this makes it very inconvinient to debug the test.   
+        // By seting this #if to true you stub out RemoteInvoke and the code will run in-proc which is useful 
+        // in debugging.
 #if false    
         class NullDispose : IDisposable
         {
@@ -118,7 +119,7 @@ namespace System.Diagnostics.Tests
         /// Test that things work properly for Linux newline conventions. 
         /// </summary>
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot,"This is linux specific test")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "This is linux specific test")]
         public void LinuxNewLineConventions()
         {
             RemoteInvoke(() =>
@@ -727,7 +728,7 @@ namespace System.Diagnostics.Tests
                             }
                             ce.Signal();
                         })
-                        {  IsBackground = true }.Start();
+                        { IsBackground = true }.Start();
                     }
                     ce.Wait();
                 }
@@ -794,7 +795,7 @@ namespace System.Diagnostics.Tests
         /// </summary>
         public Predicate<DiagnosticSourceEvent> Filter;
 
-#region private 
+        #region private 
         private void UpdateLastEvent(DiagnosticSourceEvent anEvent)
         {
             if (Filter != null && !Filter(anEvent))
@@ -808,7 +809,7 @@ namespace System.Diagnostics.Tests
             EventCount++;
             LastEvent = anEvent;
         }
-#endregion
+        #endregion
     }
 
     /// <summary>
@@ -889,7 +890,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-#region private 
+        #region private 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
             bool wroteEvent = false;
@@ -941,7 +942,7 @@ namespace System.Diagnostics.Tests
         }
 
         EventSource _diagnosticSourceEventSource;
-#endregion
+        #endregion
     }
 
     internal sealed class TurnOnAllEventListener : EventListener

--- a/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -22,7 +22,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void IntPayload()
         {
-            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            using (DiagnosticListener listener = new DiagnosticListener("TestingIntPayload"))
             {
                 DiagnosticSource source = listener;
                 var result = new List<KeyValuePair<string, object>>();
@@ -48,7 +48,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void StructPayload()
         {
-            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            using (DiagnosticListener listener = new DiagnosticListener("TestingStructPayload"))
             {
                 DiagnosticSource source = listener;
                 var result = new List<KeyValuePair<string, object>>();
@@ -76,7 +76,7 @@ namespace System.Diagnostics.Tests
         {
             var result = new List<KeyValuePair<string, object>>();
             var observer = new ObserverToList<TelemData>(result);
-            var listener = new DiagnosticListener("MyListener");
+            var listener = new DiagnosticListener("TestingCompleted");
             var subscription = listener.Subscribe(observer);
 
             listener.Write("IntPayload", 5);
@@ -105,7 +105,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void BasicIsEnabled()
         {
-            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            using (DiagnosticListener listener = new DiagnosticListener("TestingBasicIsEnabled"))
             {
                 DiagnosticSource source = listener;
                 var result = new List<KeyValuePair<string, object>>();
@@ -122,7 +122,7 @@ namespace System.Diagnostics.Tests
                     return name == "StructPayload";
                 };
 
-                Assert.False(listener.IsEnabled());
+                // Assert.False(listener.IsEnabled());  Since other things might turn on all DiagnosticSources, we can't ever test that it is not enabled. 
                 using (listener.Subscribe(new ObserverToList<TelemData>(result), predicate))
                 {
                     Assert.False(source.IsEnabled("Uninteresting"));
@@ -142,7 +142,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void IsEnabledMultipleArgs()
         {
-            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            using (DiagnosticListener listener = new DiagnosticListener("TestingIsEnabledMultipleArgs"))
             {
                 DiagnosticSource source = listener;
                 var result = new List<KeyValuePair<string, object>>();
@@ -174,7 +174,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void MultiSubscriber()
         {
-            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            using (DiagnosticListener listener = new DiagnosticListener("TestingMultiSubscriber"))
             {
                 DiagnosticSource source = listener;
                 var subscriber1Result = new List<KeyValuePair<string, object>>();
@@ -545,7 +545,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void DoubleDisposeOfListener()
         {
-            var listener = new DiagnosticListener("MyListener");
+            var listener = new DiagnosticListener("TestingDoubleDisposeOfListener");
             int completionCount = 0;
 
             IDisposable subscription = listener.Subscribe(MakeObserver<KeyValuePair<string, object>>(_ => { }, () => completionCount++));
@@ -603,7 +603,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void SubscribeWithNullPredicate()
         {
-            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            using (DiagnosticListener listener = new DiagnosticListener("TestingSubscribeWithNullPredicate"))
             {
                 Predicate<string> predicate = null;
                 using (listener.Subscribe(new ObserverToList<TelemData>(new List<KeyValuePair<string, object>>()), predicate))
@@ -615,7 +615,7 @@ namespace System.Diagnostics.Tests
                 }
             }
 
-            using (DiagnosticListener listener = new DiagnosticListener("Testing"))
+            using (DiagnosticListener listener = new DiagnosticListener("TestingSubscribeWithNullPredicate"))
             {
                 DiagnosticSource source = listener;
                 Func<string, object, object, bool> predicate = null;


### PR DESCRIPTION
There is a bridge from DiagnosticSource to EventSoruce called Microsoft-Diagnostics-DiagnosticSource.
This bridge take the data object payload and derializes it int EventSource events.
There was a cache that kept  the type and it cooresponding serialization transform of the last object, which were not atomic and thus could be confused if code was executed concurrently.

In this cache is per EXPLICITLY filtered events, and works well for that case.  If however the transform is implicit, many events can share the same cache slot, and the cache becomes very ineffective.

To fix this we keep the existing one element cache, but we only set it once (which keeps things simple but avoids races and covers the explicitly filtered case), and add a lazily created ConcurrentDictionary for the 'many envent' case.

Also fixes some unrelate test issues (avoided using the same DiagnosticListner names so that tests don't interact when run concurrently),   Fixed issue were a test fails under the debugger (because the debugger turns on Microsoft-Diagnostics-DiagnosticSource which interfers with the test).

I did walk new code to insure that we at least had code coverage for the new code over our set of tests.

This fixes issue #35302 and #35303