### PR TITLE
Reduce inner and outer loop test time for S.T.Json

### DIFF
--- a/src/System.Text.Json/tests/BitStackTests.cs
+++ b/src/System.Text.Json/tests/BitStackTests.cs
@@ -84,6 +84,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
+        [OuterLoop]
         [InlineData(3_200_000)]
         [InlineData(int.MaxValue / 32 + 1)]    // 67_108_864
         public static void BitStackPushPopLarge(int bitLength)

--- a/src/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/System.Text.Json/tests/JsonTestHelper.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace System.Text.Json.Tests
@@ -155,6 +156,24 @@ namespace System.Text.Json.Tests
             Array.Copy(_dataUtf8, _dataUtf8.Length - remaining, buffers[numberOfSegments - 1], 0, remaining);
 
             return BufferFactory.Create(buffers);
+        }
+
+        public static List<ReadOnlySequence<byte>> GetSequences(ReadOnlyMemory<byte> dataMemory)
+        {
+            var sequences = new List<ReadOnlySequence<byte>>
+            {
+                new ReadOnlySequence<byte>(dataMemory)
+            };
+
+            for (int i = 0; i < dataMemory.Length; i++)
+            {
+                var firstSegment = new BufferSegment<byte>(dataMemory.Slice(0, i));
+                ReadOnlyMemory<byte> secondMem = dataMemory.Slice(i);
+                BufferSegment<byte> secondSegment = firstSegment.Append(secondMem);
+                var sequence = new ReadOnlySequence<byte>(firstSegment, 0, secondSegment, secondMem.Length);
+                sequences.Add(sequence);
+            }
+            return sequences;
         }
 
         internal static ReadOnlySequence<byte> SegmentInto(ReadOnlyMemory<byte> data, int segmentCount)
@@ -542,6 +561,21 @@ namespace System.Text.Json.Tests
         {
             double value = random.NextDouble() * (maxValue - minValue) + minValue;
             return (decimal)value;
+        }
+
+        public static string GetCompactString(string jsonString)
+        {
+            using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
+            {
+                jsonReader.FloatParseHandling = FloatParseHandling.Decimal;
+                JToken jtoken = JToken.ReadFrom(jsonReader);
+                var stringWriter = new StringWriter();
+                using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
+                {
+                    jtoken.WriteTo(jsonWriter);
+                    return stringWriter.ToString();
+                }
+            }
         }
     }
 }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -6,8 +6,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace System.Text.Json.Tests
@@ -16,23 +14,42 @@ namespace System.Text.Json.Tests
     {
         // TestCaseType is only used to give the json strings a descriptive name.
         [Theory]
-        [MemberData(nameof(TestCases))]
+        // Skipping large JSON since slicing them (O(n^2)) is too slow.
+        [MemberData(nameof(SmallTestCases))]
         public static void TestJsonReaderUtf8SegmentSizeOne(bool compactData, TestCaseType type, string jsonString)
+        {
+            ReadPartialSegmentSizeOne(compactData, type, jsonString);
+        }
+
+        // TestCaseType is only used to give the json strings a descriptive name.
+        [Theory]
+        [MemberData(nameof(LargeTestCases))]
+        public static void TestJsonReaderLargeUtf8SegmentSizeOne(bool compactData, TestCaseType type, string jsonString)
+        {
+            ReadFullySegmentSizeOne(compactData, type, jsonString);
+        }
+
+        // TestCaseType is only used to give the json strings a descriptive name.
+        [Theory]
+        [OuterLoop]
+        [MemberData(nameof(LargeTestCases))]
+        public static void TestJsonReaderLargestUtf8SegmentSizeOne(bool compactData, TestCaseType type, string jsonString)
+        {
+            // Skipping really large JSON since slicing them (O(n^2)) is too slow.
+            if (type == TestCaseType.Json40KB || type == TestCaseType.Json400KB || type == TestCaseType.ProjectLockJson)
+            {
+                return;
+            }
+
+            ReadPartialSegmentSizeOne(compactData, type, jsonString);
+        }
+
+        private static void ReadPartialSegmentSizeOne(bool compactData, TestCaseType type, string jsonString)
         {
             // Remove all formatting/indendation
             if (compactData)
             {
-                using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
-                {
-                    jsonReader.FloatParseHandling = FloatParseHandling.Decimal;
-                    JToken jtoken = JToken.ReadFrom(jsonReader);
-                    var stringWriter = new StringWriter();
-                    using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
-                    {
-                        jtoken.WriteTo(jsonWriter);
-                        jsonString = stringWriter.ToString();
-                    }
-                }
+                jsonString = JsonTestHelper.GetCompactString(jsonString);
             }
 
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
@@ -42,16 +59,6 @@ namespace System.Text.Json.Tests
             string expectedStr = JsonTestHelper.NewtonsoftReturnStringHelper(reader);
 
             ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, 1);
-
-            // Skipping really large JSON since slicing them (O(n^2)) is too slow.
-            if (type == TestCaseType.Json40KB || type == TestCaseType.Json400KB || type == TestCaseType.ProjectLockJson)
-            {
-                var utf8JsonReader = new Utf8JsonReader(sequence, isFinalBlock: true, default);
-                byte[] resultSequence = JsonTestHelper.ReaderLoop(dataUtf8.Length, out int length, ref utf8JsonReader);
-                string actualStrSequence = Encoding.UTF8.GetString(resultSequence, 0, length);
-                Assert.Equal(expectedStr, actualStrSequence);
-                return;
-            }
 
             for (int j = 0; j < dataUtf8.Length; j++)
             {
@@ -71,62 +78,72 @@ namespace System.Text.Json.Tests
             }
         }
 
-        [Theory]
-        [MemberData(nameof(TestCases))]
-        public static void TestPartialJsonReaderMultiSegment(bool compactData, TestCaseType type, string jsonString)
+        private static void ReadFullySegmentSizeOne(bool compactData, TestCaseType type, string jsonString)
         {
-            // Skipping really large JSON since slicing them (O(n^2)) is too slow.
-            if (type == TestCaseType.Json40KB || type == TestCaseType.Json400KB || type == TestCaseType.ProjectLockJson
-                || type == TestCaseType.DeepTree || type == TestCaseType.BroadTree || type == TestCaseType.LotsOfNumbers
-                || type == TestCaseType.LotsOfStrings || type == TestCaseType.Json4KB)
-            {
-                return;
-            }
-
             // Remove all formatting/indendation
             if (compactData)
             {
-                using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
-                {
-                    jsonReader.FloatParseHandling = FloatParseHandling.Decimal;
-                    JToken jtoken = JToken.ReadFrom(jsonReader);
-                    var stringWriter = new StringWriter();
-                    using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
-                    {
-                        jtoken.WriteTo(jsonWriter);
-                        jsonString = stringWriter.ToString();
-                    }
-                }
+                jsonString = JsonTestHelper.GetCompactString(jsonString);
+            }
+
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            Stream stream = new MemoryStream(dataUtf8);
+            TextReader reader = new StreamReader(stream, Encoding.UTF8, false, 1024, true);
+            string expectedStr = JsonTestHelper.NewtonsoftReturnStringHelper(reader);
+
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, 1);
+
+            var utf8JsonReader = new Utf8JsonReader(sequence, isFinalBlock: true, default);
+            byte[] resultSequence = JsonTestHelper.ReaderLoop(dataUtf8.Length, out int length, ref utf8JsonReader);
+            string actualStrSequence = Encoding.UTF8.GetString(resultSequence, 0, length);
+            Assert.Equal(expectedStr, actualStrSequence);
+        }
+
+        [Theory]
+        [MemberData(nameof(SmallTestCases))]
+        public static void TestPartialJsonReaderMultiSegment(bool compactData, TestCaseType type, string jsonString)
+        {
+            // Remove all formatting/indendation
+            if (compactData)
+            {
+                jsonString = JsonTestHelper.GetCompactString(jsonString);
             }
 
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
             ReadOnlyMemory<byte> dataMemory = dataUtf8;
 
-            var sequences = new List<ReadOnlySequence<byte>>
-            {
-                new ReadOnlySequence<byte>(dataMemory)
-            };
-
-            for (int i = 0; i < dataUtf8.Length; i++)
-            {
-                var firstSegment = new BufferSegment<byte>(dataMemory.Slice(0, i));
-                ReadOnlyMemory<byte> secondMem = dataMemory.Slice(i);
-                BufferSegment<byte> secondSegment = firstSegment.Append(secondMem);
-                var sequence = new ReadOnlySequence<byte>(firstSegment, 0, secondSegment, secondMem.Length);
-                sequences.Add(sequence);
-            }
+            List<ReadOnlySequence<byte>> sequences = JsonTestHelper.GetSequences(dataMemory);
 
             for (int i = 0; i < sequences.Count; i++)
             {
-                var json = new Utf8JsonReader(sequences[i], isFinalBlock: true, default);
+                ReadOnlySequence<byte> sequence = sequences[i];
+                var json = new Utf8JsonReader(sequence, isFinalBlock: true, default);
                 while (json.Read())
                     ;
-                Assert.Equal(sequences[i].Length, json.BytesConsumed);
-                Assert.Equal(sequences[i].Length, json.CurrentState.BytesConsumed);
+                Assert.Equal(sequence.Length, json.BytesConsumed);
+                Assert.Equal(sequence.Length, json.CurrentState.BytesConsumed);
 
-                Assert.True(sequences[i].Slice(json.Position).IsEmpty);
-                Assert.True(sequences[i].Slice(json.CurrentState.Position).IsEmpty);
+                Assert.True(sequence.Slice(json.Position).IsEmpty);
+                Assert.True(sequence.Slice(json.CurrentState.Position).IsEmpty);
             }
+        }
+
+        [Theory]
+        [OuterLoop]
+        [MemberData(nameof(SmallTestCases))]
+        public static void TestPartialJsonReaderSlicesMultiSegment(bool compactData, TestCaseType type, string jsonString)
+        {
+            // Remove all formatting/indendation
+            if (compactData)
+            {
+                jsonString = JsonTestHelper.GetCompactString(jsonString);
+            }
+
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            ReadOnlyMemory<byte> dataMemory = dataUtf8;
+
+            List<ReadOnlySequence<byte>> sequences = JsonTestHelper.GetSequences(dataMemory);
 
             for (int i = 0; i < sequences.Count; i++)
             {

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -158,8 +158,8 @@ namespace System.Text.Json.Tests
                     JsonReaderState jsonState = json.CurrentState;
                     byte[] consumedArray = sequence.Slice(0, consumed).ToArray();
                     Assert.Equal(consumedArray, sequence.Slice(0, json.Position).ToArray());
-                    Assert.Equal(consumedArray, sequence.Slice(0, jsonState.Position).ToArray());
-                    json = new Utf8JsonReader(sequence.Slice(consumed), isFinalBlock: true, json.CurrentState);
+                    Assert.True(json.Position.Equals(jsonState.Position));
+                    json = new Utf8JsonReader(sequence.Slice(consumed), isFinalBlock: true, jsonState);
                     while (json.Read())
                         ;
                     Assert.Equal(dataUtf8.Length - consumed, json.BytesConsumed);
@@ -355,7 +355,7 @@ namespace System.Text.Json.Tests
 
             Assert.Equal(expectedWithComments, builder.ToString());
             Assert.Equal(inputData, sequence.Slice(0, json.Position).ToArray());
-            Assert.Equal(inputData, sequence.Slice(0, json.CurrentState.Position).ToArray());
+            Assert.True(json.Position.Equals(json.CurrentState.Position));
 
             state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip });
             json = new Utf8JsonReader(sequence, isFinalBlock: true, state);
@@ -379,7 +379,7 @@ namespace System.Text.Json.Tests
 
             Assert.Equal(expectedWithoutComments, builder.ToString());
             Assert.Equal(inputData, sequence.Slice(0, json.Position).ToArray());
-            Assert.Equal(inputData, sequence.Slice(0, json.CurrentState.Position).ToArray());
+            Assert.True(json.Position.Equals(json.CurrentState.Position));
         }
 
         [Theory]
@@ -425,7 +425,7 @@ namespace System.Text.Json.Tests
 
                 Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
                 Assert.Equal(inputData, sequence.Slice(0, json.Position).ToArray());
-                Assert.Equal(inputData, sequence.Slice(0, json.CurrentState.Position).ToArray());
+                Assert.True(json.Position.Equals(json.CurrentState.Position));
             }
         }
 

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -890,7 +890,7 @@ namespace System.Text.Json.Tests
             {
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteStartArray(keyChars);
-                Assert.True(false, "Expected ArgumentException to be thrown for depth >= 1000.");
+                Assert.True(false, $"Expected ArgumentException for property too large wasn't thrown. PropertyLength: {keyChars.Length}");
             }
             catch (ArgumentException) { }
 
@@ -900,7 +900,7 @@ namespace System.Text.Json.Tests
             {
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteStartArray(key);
-                Assert.True(false, "Expected ArgumentException to be thrown for depth >= 1000.");
+                Assert.True(false, $"Expected ArgumentException for property too large wasn't thrown. PropertyLength: {key.Length}");
             }
             catch (ArgumentException) { }
 
@@ -2993,7 +2993,8 @@ namespace System.Text.Json.Tests
 
         private static void WriteTooLargeHelper(JsonWriterState state, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, bool noThrow = false)
         {
-            var output = new ArrayBufferWriter(1024);
+            // Resizing is too slow, even for outerloop tests, so initialize to a large output size up front.
+            var output = new ArrayBufferWriter(noThrow ? 40_000_000 : 1024);
             var jsonUtf8 = new Utf8JsonWriter(output, state);
 
             jsonUtf8.WriteStartObject();


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/35724

The outerloop test `WriteLargeKeyValue` now takes ~3 seconds instead of ~4 minutes.

Running all innerloop tests now take ~25 seconds instead of ~3 minutes
 - Moved the costly tests to outerloop

Running all tests (including outerloop) on my dev box takes ~4 minutes (**Edit:** With latest changes, ~3 minutes).


cc @danmosemsft, @stephentoub  