### PR TITLE
Fix issue with BufferSegment reuse

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -488,9 +488,13 @@ namespace System.IO.Pipelines
                         _readHead = nextBlock;
                         _readHeadIndex = 0;
 
-                        // The last examined index and the read head should be in sync
-                        _lastExamined = nextBlock;
-                        _lastExaminedIndex = 0;
+                        // Only update the last examined if the same as consumed
+                        if (consumedSegment == examinedSegment)
+                        {
+                            // The last examined index and the read head should be in sync
+                            _lastExamined = nextBlock;
+                            _lastExaminedIndex = 0;
+                        }
 
                         // Reset the writing head to null if it's the return block
                         // then null it out as we're about to reset that memory

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -264,6 +264,11 @@ namespace System.IO.Pipelines
 
         private void ReturnSegmentUnsynchronized(BufferSegment segment)
         {
+            Debug.Assert(segment != _readHead, "Returning _readHead segment that's in use!");
+            Debug.Assert(segment != _readTail, "Returning _readTail segment that's in use!");
+            Debug.Assert(segment != _writingHead, "Returning _writingHead segment that's in use!");
+            Debug.Assert(segment != _lastExamined, "Returning _lastExamined segment that's in use!");
+
             if (_pooledSegmentCount < _bufferSegmentPool.Length)
             {
                 _bufferSegmentPool[_pooledSegmentCount] = segment;
@@ -483,6 +488,10 @@ namespace System.IO.Pipelines
                         _readHead = nextBlock;
                         _readHeadIndex = 0;
 
+                        // The last examined index and the read head should be in sync
+                        _lastExamined = nextBlock;
+                        _lastExaminedIndex = 0;
+
                         // Reset the writing head to null if it's the return block
                         // then null it out as we're about to reset that memory
                         if (_writingHead == returnEnd)
@@ -492,10 +501,6 @@ namespace System.IO.Pipelines
                             Debug.Assert(_readTail == null);
                             _writingHead = null;
                             _writingMemory = default;
-
-                            // Anything we examined before is bogus since there are no more blocks in the linked list
-                            _lastExaminedIndex = 0;
-                            _lastExamined = null;
                         }
 
                         returnEnd = nextBlock;

--- a/src/System.IO.Pipelines/tests/PipeLengthTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeLengthTests.cs
@@ -153,6 +153,34 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        public async Task ExaminedAtSecondLastBlockWorks()
+        {
+            _pipe.Writer.WriteEmpty(_pool.MaxBufferSize);
+            _pipe.Writer.WriteEmpty(_pool.MaxBufferSize);
+            _pipe.Writer.WriteEmpty(_pool.MaxBufferSize);
+            await _pipe.Writer.FlushAsync();
+
+            ReadResult result = await _pipe.Reader.ReadAsync();
+            // This gets the end of the first block
+            SequencePosition position = result.Buffer.Slice(result.Buffer.Start, _pool.MaxBufferSize).End;
+
+            // This should return the first segment
+            _pipe.Reader.AdvanceTo(position, result.Buffer.GetPosition(_pool.MaxBufferSize * 2));
+
+            // One block remaining
+            Assert.Equal(4096, _pipe.Length);
+
+            // This should use the segment that was returned
+            _pipe.Writer.WriteEmpty(_pool.MaxBufferSize);
+            await _pipe.Writer.FlushAsync();
+
+            result = await _pipe.Reader.ReadAsync();
+            _pipe.Reader.AdvanceTo(result.Buffer.End);
+
+            Assert.Equal(0, _pipe.Length);
+        }
+
+        [Fact]
         public async Task ExaminedLessThanBeforeThrows()
         {
             _pipe.Writer.WriteEmpty(10);

--- a/src/System.IO.Pipelines/tests/PipeLengthTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeLengthTests.cs
@@ -126,6 +126,33 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        public async Task PooledSegmentsDontAffectLastExaminedSegment()
+        {
+            _pipe.Writer.WriteEmpty(_pool.MaxBufferSize);
+            _pipe.Writer.WriteEmpty(_pool.MaxBufferSize);
+            await _pipe.Writer.FlushAsync();
+
+            ReadResult result = await _pipe.Reader.ReadAsync();
+            // This gets the end of the first block
+            SequencePosition position = result.Buffer.Slice(result.Buffer.Start, _pool.MaxBufferSize).End;
+
+            // This should return the first segment
+            _pipe.Reader.AdvanceTo(position);
+
+            // One block remaining
+            Assert.Equal(4096, _pipe.Length);
+
+            // This should use the segment that was returned
+            _pipe.Writer.WriteEmpty(_pool.MaxBufferSize);
+            await _pipe.Writer.FlushAsync();
+
+            result = await _pipe.Reader.ReadAsync();
+            _pipe.Reader.AdvanceTo(result.Buffer.End);
+
+            Assert.Equal(0, _pipe.Length);
+        }
+
+        [Fact]
         public async Task ExaminedLessThanBeforeThrows()
         {
             _pipe.Writer.WriteEmpty(10);


### PR DESCRIPTION
- We stored the last examined segment to compute how many bytes we should decrement on the writer side but if that segment is returned to the segment pool, we end up in a bad state. This properly clears the state so that doesn't happen.

Found when ingesting new corefx bits into ASP.NET Core https://github.com/aspnet/AspNetCore/pull/8198