### PR TITLE
replace WaitForPipeDrain with Flush in Kill_EntireProcessTree_True_EntireTreeTerminated test

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.netcoreapp.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.netcoreapp.cs
@@ -362,7 +362,7 @@ namespace System.Diagnostics.Tests
                     using (var sw = new StreamWriter(client))
                     {
                         sw.WriteLine(message);
-                        client.WaitForPipeDrain();
+                        sw.Flush();
                     }
                 }
             }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.netcoreapp.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.netcoreapp.cs
@@ -362,7 +362,6 @@ namespace System.Diagnostics.Tests
                     using (var sw = new StreamWriter(client))
                     {
                         sw.WriteLine(message);
-                        sw.Flush();
                     }
                 }
             }


### PR DESCRIPTION
related to https://github.com/dotnet/coreclr/issues/22413

This seems like test issue as WaitForPipeDrain() is not supported on Unix and can throw.
To preserve original spirit, I added Flush() on stream and I can now pass test on x86 as well as ARM64 container.  I was running outerloop tests in loop and I did not see any Kill_EntireProcessTree_True_EntireTreeTerminated failures. 

It seems like the test fails in CI 1-2 week. I'll watch it and close the issue later if I see no failures. 

```
=== TEST EXECUTION SUMMARY ===
   System.Diagnostics.Process.Tests  Total: 272, Errors: 0, Failed: 0, Skipped: 4, Time: 20.206s
```