### PR TITLE
Fix publish.proj when pushing corefx-test-assets.xml file

### DIFF
--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -140,7 +140,7 @@
     <ItemGroup>
       <_ManifestToPush Remove="@(_ManifestToPush)" />
       <_ManifestToPush Include="$(AssetManifestFilePath)">
-        <RelativeBlobPath>$(_FileRelativePathBase)$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
+        <RelativeBlobPath>$(_FileRelativePathBase)$(AssetManifestFileName)</RelativeBlobPath>
       </_ManifestToPush>
     </ItemGroup>
 


### PR DESCRIPTION
This was hitting this msbuild bug: https://github.com/Microsoft/msbuild/issues/1053

So whenever we try to download this file we can't find it because the RelativeBlobPath is wrong. It was being set to something similar to: `<Blob Id="corefx-tests/4.6.0-preview4.19155.7/Windows_NT.x86/netcoreapp/" />`

cc: @mikem8361 