### PR TITLE
[WIP] Fix Linux process names

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -127,12 +127,11 @@ namespace System.Diagnostics
         internal static ProcessInfo CreateProcessInfo(Interop.procfs.ParsedStat procFsStat, ReusableTextReader reusableReader)
         {
             int pid = procFsStat.pid;
-			string[] fullPathArray = Process.GetExePath(pid).Split('\\');
 
             var pi = new ProcessInfo()
             {
                 ProcessId = pid,
-                ProcessName = fullPathArray.Last(),
+                ProcessName = Path.GetFileName(Process.GetExePath(pid)),
                 BasePriority = (int)procFsStat.nice,
                 VirtualBytes = (long)procFsStat.vsize,
                 WorkingSet = procFsStat.rss * Environment.SystemPageSize,

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -128,10 +128,17 @@ namespace System.Diagnostics
         {
             int pid = procFsStat.pid;
 
+            // Get long process name if possible, otherwise use a fall back method.
+            string procName = Path.GetFileName(Process.GetExePath(pid));
+            if (String.IsNullOrEmpty(procName))
+            {
+                procName = procFsStat.comm;
+            }
+
             var pi = new ProcessInfo()
             {
                 ProcessId = pid,
-                ProcessName = Path.GetFileName(Process.GetExePath(pid)),
+                ProcessName = procName,
                 BasePriority = (int)procFsStat.nice,
                 VirtualBytes = (long)procFsStat.vsize,
                 WorkingSet = procFsStat.rss * Environment.SystemPageSize,

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -127,11 +127,12 @@ namespace System.Diagnostics
         internal static ProcessInfo CreateProcessInfo(Interop.procfs.ParsedStat procFsStat, ReusableTextReader reusableReader)
         {
             int pid = procFsStat.pid;
+			string[] fullPathArray = Process.GetExePath(pid).Split('\\');
 
             var pi = new ProcessInfo()
             {
                 ProcessId = pid,
-                ProcessName = procFsStat.comm,
+                ProcessName = fullPathArray.Last(),
                 BasePriority = (int)procFsStat.nice,
                 VirtualBytes = (long)procFsStat.vsize,
                 WorkingSet = procFsStat.rss * Environment.SystemPageSize,


### PR DESCRIPTION
Fix for Process.GetProcesses returns truncated 15 char string on Linux.

Fixes #34437 