### PR TITLE
Fix ValueStringBuilder.EnsureCapacity to call Grow correctly

### DIFF
--- a/src/Common/src/CoreLib/System/Text/ValueStringBuilder.cs
+++ b/src/Common/src/CoreLib/System/Text/ValueStringBuilder.cs
@@ -259,12 +259,21 @@ namespace System.Text
             Append(c);
         }
 
+        /// <summary>
+        /// Resize the internal buffer either by doubling current buffer size or
+        /// by adding <paramref name="additionalCapacityBeyondPos"/> to
+        /// <see cref="_pos"/> whichever is greater.
+        /// </summary>
+        /// <param name="additionalCapacityBeyondPos">
+        /// Number of chars requested beyond current position.
+        /// </param>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void Grow(int requiredAdditionalCapacity)
+        private void Grow(int additionalCapacityBeyondPos)
         {
-            Debug.Assert(requiredAdditionalCapacity > 0);
+            Debug.Assert(additionalCapacityBeyondPos > 0);
+            Debug.Assert(_pos > _chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
 
-            char[] poolArray = ArrayPool<char>.Shared.Rent(Math.Max(_pos + requiredAdditionalCapacity, _chars.Length * 2));
+            char[] poolArray = ArrayPool<char>.Shared.Rent(Math.Max(_pos + additionalCapacityBeyondPos, _chars.Length * 2));
 
             _chars.CopyTo(poolArray);
 

--- a/src/Common/src/CoreLib/System/Text/ValueStringBuilder.cs
+++ b/src/Common/src/CoreLib/System/Text/ValueStringBuilder.cs
@@ -45,7 +45,7 @@ namespace System.Text
         public void EnsureCapacity(int capacity)
         {
             if (capacity > _chars.Length)
-                Grow(capacity - _chars.Length);
+                Grow(capacity - _pos);
         }
 
         /// <summary>

--- a/src/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
+++ b/src/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
@@ -277,5 +277,42 @@ namespace System.Text.Tests
             vsb[3] = 'c';
             Assert.Equal(vsb[3], 'c');
         }
+
+        [Fact]
+        public void EnsureCapacity_IfRequestedCapacityWins()
+        {
+            // Note: constants used here may be dependent on minimal buffer size
+            // the ArrayPool is able to return.
+            Span<char> initialBuffer = stackalloc char[32];
+            var builder = new ValueStringBuilder(initialBuffer);
+
+            builder.EnsureCapacity(65);
+
+            Assert.Equal(128, builder.Capacity);
+        }
+
+        [Fact]
+        public void EnsureCapacity_IfBufferTimesTwoWins()
+        {
+            Span<char> initialBuffer = stackalloc char[32];
+            var builder = new ValueStringBuilder(initialBuffer);
+
+            builder.EnsureCapacity(33);
+
+            Assert.Equal(64, builder.Capacity);
+        }
+
+        [Fact]
+        public void EnsureCapacity_NoAllocIfNotNeeded()
+        {
+            // Note: constants used here may be dependent on minimal buffer size
+            // the ArrayPool is able to return.
+            Span<char> initialBuffer = stackalloc char[64];
+            var builder = new ValueStringBuilder(initialBuffer);
+
+            builder.EnsureCapacity(16);
+
+            Assert.Equal(64, builder.Capacity);
+        }
     }
 }


### PR DESCRIPTION
Also improved `Grow` to prevent misuse in the future.

FYI @jkotas @stephentoub 

Fixes #35746