### PR TITLE
Fix ImageCharacteristics of PEHeaderBuilder when initialized by CreateLibraryHeader

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEHeaderBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEHeaderBuilder.cs
@@ -103,7 +103,7 @@ namespace System.Reflection.PortableExecutable
 
         public static PEHeaderBuilder CreateLibraryHeader()
         {
-            return new PEHeaderBuilder(imageCharacteristics: Characteristics.Dll);
+            return new PEHeaderBuilder(imageCharacteristics: Characteristics.ExecutableImage | Characteristics.Dll);
         }
 
         internal bool Is32Bit => Machine != Machine.Amd64 && Machine != Machine.IA64 && Machine != Machine.Arm64;

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/PEHeaderBuilderTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/PEHeaderBuilderTests.cs
@@ -21,5 +21,18 @@ namespace System.Reflection.PortableExecutable.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => new PEHeaderBuilder(fileAlignment: int.MaxValue));
             Assert.Throws<ArgumentOutOfRangeException>(() => new PEHeaderBuilder(fileAlignment: int.MinValue));
         }
+
+        [Fact]
+        public void ValidateFactoryMethods()
+        {
+            var peHeaderExe = PEHeaderBuilder.CreateExecutableHeader();
+            Assert.NotNull(peHeaderExe);
+            Assert.True((peHeaderExe.ImageCharacteristics & Characteristics.ExecutableImage) != 0);
+
+            var peHeaderLib = PEHeaderBuilder.CreateLibraryHeader();
+            Assert.NotNull(peHeaderLib);
+            Assert.True((peHeaderLib.ImageCharacteristics & Characteristics.ExecutableImage) != 0);
+            Assert.True((peHeaderLib.ImageCharacteristics & Characteristics.Dll) != 0);
+        }
     }
 }


### PR DESCRIPTION
When `PEHeaderBuilder` is initialized with `CreateLibraryHeader` method and it's used to serialize an assembly, .NET Core runtime refuses to load this assembly. This pull request fixes by setting `Characteristics.ExecutableImage` bit of `ImageCharacteristics` property when `PEHeaderBuilder` is initialized with `CreateLibraryHeader` method.

Fixes: #35758