### PR TITLE
Reduce overhead of ReadOnlySequence<T>.CopyTo

### DIFF
--- a/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
+++ b/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
@@ -63,12 +63,12 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CopyTo<T>(in this ReadOnlySequence<T> source, Span<T> destination)
         {
-            if (source.Length > destination.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.destination);
-
             if (source.IsSingleSegment)
             {
-                source.First.Span.CopyTo(destination);
+                ReadOnlySpan<T> span = source.First.Span;
+                if (span.Length > destination.Length)
+                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.destination);
+                span.CopyTo(destination);
             }
             else
             {
@@ -78,6 +78,9 @@ namespace System.Buffers
 
         private static void CopyToMultiSegment<T>(in ReadOnlySequence<T> sequence, Span<T> destination)
         {
+            if (sequence.Length > destination.Length)
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.destination);
+
             SequencePosition position = sequence.Start;
             while (sequence.TryGet(ref position, out ReadOnlyMemory<T> memory))
             {


### PR DESCRIPTION
`ReadOnlySequence<T>.Length` isn't as small or fast as `ReadOnlySpan<T>.Length`, which is just a field access.  Since we need the span anyway for the single element case, just get the span first and then compare with its length.

Before:
```
      Method |     Mean |     Error |    StdDev | Allocated |
------------ |---------:|----------:|----------:|----------:|
    CopyTo_1 | 23.05 ns | 0.4898 ns | 1.0955 ns |       0 B |
   CopyTo_10 | 21.22 ns | 0.5399 ns | 0.5050 ns |       0 B |
  CopyTo_100 | 23.22 ns | 0.5186 ns | 0.8805 ns |       0 B |
```

After:
```
      Method |     Mean |     Error |    StdDev | Allocated |
------------ |---------:|----------:|----------:|----------:|
    CopyTo_1 | 20.07 ns | 0.1141 ns | 0.1068 ns |       0 B |
   CopyTo_10 | 19.60 ns | 0.4029 ns | 0.3957 ns |       0 B |
  CopyTo_100 | 20.91 ns | 0.1305 ns | 0.1090 ns |       0 B |
```

Benchmark:
```C#
private ReadOnlySequence<byte> _1Byte = new ReadOnlySequence<byte>(new byte[1]);
private ReadOnlySequence<byte> _10Bytes = new ReadOnlySequence<byte>(new byte[10]);
private ReadOnlySequence<byte> _100Bytes = new ReadOnlySequence<byte>(new byte[100]);

private byte[] _dest = new byte[1000];

[Benchmark] public void CopyTo_1() => _1Byte.CopyTo(_dest);
[Benchmark] public void CopyTo_10() => _10Bytes.CopyTo(_dest);
[Benchmark] public void CopyTo_100() => _100Bytes.CopyTo(_dest);
```

cc: @ahsonkhan, @pakrym 