### PR TITLE
Added tests for unsupported braces in custom format specifiers.

### DIFF
--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -892,8 +892,7 @@ namespace System.Text.Tests
 
             Assert.Throws<FormatException>(() => builder.AppendFormat("}", "")); // Format has unescaped }
             Assert.Throws<FormatException>(() => builder.AppendFormat("}a", "")); // Format has unescaped }
-
-            Assert.Throws<FormatException>(() => builder.AppendFormat("{0:}}", new string[10])); // Format has unescaped }
+            Assert.Throws<FormatException>(() => builder.AppendFormat("{0:}}", "")); // Format has unescaped }
 
             Assert.Throws<FormatException>(() => builder.AppendFormat("{\0", "")); // Format has invalid character after {
             Assert.Throws<FormatException>(() => builder.AppendFormat("{a", "")); // Format has invalid character after {

--- a/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -930,7 +930,7 @@ namespace System.Text.Tests
 
             builder.AppendFormat(formatter, "{0:}}}", 5);
             // Previously escaped brace would be passed in as the format specifier, now first brace closes the argument hole
-            Assert.False(formatter.LastFormat != null && formatter.LastFormat.Contains('}'));
+            Assert.False(formatter.LastFormat != null && formatter.LastFormat.Contains("}"));
             // Previously this would be allowed and escaped brace would be passed in, now brace is not allowed in custom format
             Assert.Throws<FormatException>(() => builder.AppendFormat("{0:{{}", new string[10])); // Format with custom format contains {
         }


### PR DESCRIPTION
Test modifications for issue #35167 with related coreclr PR for the associated StringBuilder modifications here: 

https://github.com/dotnet/coreclr/pull/23062
