### PR TITLE
fix ssl3 failing tests in release/2.1

### DIFF
--- a/src/Common/tests/System/Net/SslProtocolSupport.cs
+++ b/src/Common/tests/System/Net/SslProtocolSupport.cs
@@ -19,9 +19,7 @@ namespace System.Net.Test.Common
             {
                 SslProtocols supported = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
 #pragma warning disable 0618 // SSL2/3 are deprecated
-                if (PlatformDetection.IsWindows ||
-                    PlatformDetection.IsOSX ||
-                    (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && PlatformDetection.OpenSslVersion < new Version(1, 0, 2) && !PlatformDetection.IsDebian))
+                if (PlatformDetection.SupportsSsl3)
                 {
                     supported |= SslProtocols.Ssl3;
                 }

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -39,6 +39,7 @@ namespace System
     public static partial class PlatformDetection
     {
         public static bool IsReflectionEmitSupported;
+        public static bool SupportsSsl3 { get { throw null; } }
         public static bool ClientWebSocketPartialMessagesSupported { get { throw null; } }
         public static bool HasWindowsShell { get { throw null; } }
         public static bool IsArmProcess { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -50,6 +50,8 @@ namespace System
         public static bool IsRedHatFamily7 => IsRedHatFamilyAndVersion(7);
         public static bool IsNotFedoraOrRedHatFamily => !IsFedora && !IsRedHatFamily;
 
+        public static bool SupportsSsl3 => (PlatformDetection.IsOSX || (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && PlatformDetection.OpenSslVersion < new Version(1, 0, 2) && !PlatformDetection.IsDebian));
+
         public static Version OSXVersion { get; } = ToVersion(Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.OperatingSystemVersion);
 
         public static Version OpenSslVersion => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? Interop.OpenSsl.OpenSslVersion : throw new PlatformNotSupportedException();

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Windows.cs
@@ -42,6 +42,7 @@ namespace System
         public static bool IsRedHatFamily6 => false;
         public static bool IsRedHatFamily7 => false;
         public static bool IsNotRedHatFamily6 => true;
+        public static bool SupportsSsl3 => GetSsl3Support();
 
         public static bool IsWindows10Version1607OrGreater => 
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 14393;
@@ -184,6 +185,27 @@ namespace System
             }
 
             return value;
+        }
+
+        private static bool GetSsl3Support()
+        {
+            string clientKey = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Client";
+            string serverKey = @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server";
+            bool enabled = true;
+
+            // This may change in future but for now, missing key means protocol is enabled.
+            try
+            {
+                if ((int)Registry.GetValue(clientKey, "Enabled", 1) == 0 || (int)Registry.GetValue(serverKey, "Enabled", 1) == 0)
+                {
+                    enabled = false;
+                }
+            }
+            catch (Exception e) when (e is SecurityException || e is InvalidCastException || e is NullReferenceException)
+            {
+            }
+
+            return enabled;
         }
 
         private static int GetWindowsProductType()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.SslProtocols.cs
@@ -83,12 +83,7 @@ namespace System.Net.Http.Functional.Tests
             // These protocols are disabled by default, so we can only connect with them explicitly.
             // On certain platforms these are completely disabled and cannot be used at all.
 #pragma warning disable 0618
-            if (PlatformDetection.IsWindows ||
-                PlatformDetection.IsOSX ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
-                 PlatformDetection.OpenSslVersion < new Version(1, 0, 2) &&
-                 !PlatformDetection.IsDebian &&
-                 !PlatformDetection.IsRedHatFamily6))
+            if (PlatformDetection.SupportsSsl3)
             {
                 // TODO #28790: SSLv3 is supported on RHEL 6, but this test case still fails.
                 yield return new object[] { SslProtocols.Ssl3, true };
@@ -110,11 +105,13 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            if (UseSocketsHttpHandler)
+#pragma warning disable 0618
+            if (UseSocketsHttpHandler  || (IsCurlHandler && PlatformDetection.IsRedHatFamily6 && acceptedProtocol == SslProtocols.Ssl3))
             {
                 // TODO #26186: SocketsHttpHandler is failing on some OSes.
                 return;
             }
+#pragma warning restore 0618
 
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (var client = new HttpClient(handler))


### PR DESCRIPTION
TEST ONLY

port back changes from #35574 and #35605 to make some sslv3 conditional as OSes drop support. 

related to #35671

