### PR TITLE
skip tests failing on Windows ARM64

### DIFF
--- a/src/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
+++ b/src/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics.Tests
     internal class Helpers
     {
         public static bool IsElevatedAndCanWriteToPerfCounters { get => AdminHelpers.IsProcessElevated() && CanWriteToPerfCounters; }
-        public static bool CanWriteToPerfCounters { get => PlatformDetection.IsNotWindowsNanoServer; }
+        public static bool CanWriteToPerfCounters { get => PlatformDetection.IsNotWindowsNanoServer || (PlatformDetection.IsWindows && PlatformDetection.IsArmOrArm64Process); }
 
         public static string CreateCategory(string name, PerformanceCounterCategoryType categoryType)
         {

--- a/src/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
+++ b/src/System.Diagnostics.PerformanceCounter/tests/Helpers.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics.Tests
     internal class Helpers
     {
         public static bool IsElevatedAndCanWriteToPerfCounters { get => AdminHelpers.IsProcessElevated() && CanWriteToPerfCounters; }
-        public static bool CanWriteToPerfCounters { get => PlatformDetection.IsNotWindowsNanoServer || (PlatformDetection.IsWindows && PlatformDetection.IsArmOrArm64Process); }
+        public static bool CanWriteToPerfCounters { get => PlatformDetection.IsNotWindowsNanoServer && PlatformDetection.IsNotArmNorArm64Process; }
 
         public static string CreateCategory(string name, PerformanceCounterCategoryType categoryType)
         {


### PR DESCRIPTION
related to  #35743
This may need more investigation but for now failing tests will be skipped.
The set is conveniently same as tests skipped on Nano.