### PR TITLE
Add target to remove binding redirect

### DIFF
--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/pkg/build/net45/System.Runtime.WindowsRuntime.UI.Xaml.targets
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/pkg/build/net45/System.Runtime.WindowsRuntime.UI.Xaml.targets
@@ -19,4 +19,13 @@
       </ItemGroup>
     </When>
   </Choose>
+  <!-- when this package is referenced as a nuget reference the binding redirect is still present, add a target to remove it -->
+  <Target Name="_RemoveWindowsRuntimeSuggestedRedirect" 
+      BeforeTargets="GenerateBindingRedirects" 
+      DependsOnTargets="ResolveAssemblyReferences"
+      Condition="'$(DoNotReferenceWinRT)' != 'true'">
+    <ItemGroup> 
+      <SuggestedBindingRedirects Remove="System.Runtime.WindowsRuntime.UI.Xaml, Culture=neutral, PublicKeyToken=b77a5c561934e089" /> 
+    </ItemGroup> 
+  </Target>
 </Project>

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/pkg/build/net45/System.Runtime.WindowsRuntime.UI.Xaml.targets
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/pkg/build/net45/System.Runtime.WindowsRuntime.UI.Xaml.targets
@@ -20,7 +20,7 @@
     </When>
   </Choose>
   <!-- when this package is referenced as a nuget reference the binding redirect is still present, add a target to remove it -->
-  <Target Name="_RemoveWindowsRuntimeSuggestedRedirect" 
+  <Target Name="_RemoveWindowsRuntimeUIXamlSuggestedRedirect" 
       BeforeTargets="GenerateBindingRedirects" 
       DependsOnTargets="ResolveAssemblyReferences"
       Condition="'$(DoNotReferenceWinRT)' != 'true'">

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/pkg/build/net461/System.Runtime.WindowsRuntime.UI.Xaml.targets
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/pkg/build/net461/System.Runtime.WindowsRuntime.UI.Xaml.targets
@@ -19,4 +19,13 @@
       </ItemGroup>
     </When>
   </Choose>
+  <!-- when this package is referenced as a nuget reference the binding redirect is still present, add a target to remove it -->
+  <Target Name="_RemoveWindowsRuntimeSuggestedRedirect" 
+      BeforeTargets="GenerateBindingRedirects" 
+      DependsOnTargets="ResolveAssemblyReferences"
+      Condition="'$(DoNotReferenceWinRT)' != 'true'">
+    <ItemGroup> 
+      <SuggestedBindingRedirects Remove="System.Runtime.WindowsRuntime.UI.Xaml, Culture=neutral, PublicKeyToken=b77a5c561934e089" /> 
+    </ItemGroup> 
+  </Target>
 </Project>

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/pkg/build/net461/System.Runtime.WindowsRuntime.UI.Xaml.targets
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/pkg/build/net461/System.Runtime.WindowsRuntime.UI.Xaml.targets
@@ -20,7 +20,7 @@
     </When>
   </Choose>
   <!-- when this package is referenced as a nuget reference the binding redirect is still present, add a target to remove it -->
-  <Target Name="_RemoveWindowsRuntimeSuggestedRedirect" 
+  <Target Name="_RemoveWindowsRuntimeUIXamlSuggestedRedirect" 
       BeforeTargets="GenerateBindingRedirects" 
       DependsOnTargets="ResolveAssemblyReferences"
       Condition="'$(DoNotReferenceWinRT)' != 'true'">

--- a/src/System.Runtime.WindowsRuntime/pkg/build/net45/System.Runtime.WindowsRuntime.targets
+++ b/src/System.Runtime.WindowsRuntime/pkg/build/net45/System.Runtime.WindowsRuntime.targets
@@ -20,4 +20,13 @@
       </ItemGroup>
     </When>
   </Choose>
+  <!-- when this package is referenced as a nuget reference the binding redirect is still present, add a target to remove it -->
+  <Target Name="_RemoveWindowsRuntimeSuggestedRedirect" 
+      BeforeTargets="GenerateBindingRedirects" 
+      DependsOnTargets="ResolveAssemblyReferences"
+      Condition="'$(DoNotReferenceWinRT)' != 'true'">
+    <ItemGroup> 
+      <SuggestedBindingRedirects Remove="System.Runtime.WindowsRuntime, Culture=neutral, PublicKeyToken=b77a5c561934e089" /> 
+    </ItemGroup> 
+  </Target>
 </Project>

--- a/src/System.Runtime.WindowsRuntime/pkg/build/net451/System.Runtime.WindowsRuntime.targets
+++ b/src/System.Runtime.WindowsRuntime/pkg/build/net451/System.Runtime.WindowsRuntime.targets
@@ -19,4 +19,13 @@
       </ItemGroup>
     </When>
   </Choose>
+  <!-- when this package is referenced as a nuget reference the binding redirect is still present, add a target to remove it -->
+  <Target Name="_RemoveWindowsRuntimeSuggestedRedirect" 
+      BeforeTargets="GenerateBindingRedirects" 
+      DependsOnTargets="ResolveAssemblyReferences"
+      Condition="'$(DoNotReferenceWinRT)' != 'true'">
+    <ItemGroup> 
+      <SuggestedBindingRedirects Remove="System.Runtime.WindowsRuntime, Culture=neutral, PublicKeyToken=b77a5c561934e089" /> 
+    </ItemGroup> 
+  </Target>
 </Project>

--- a/src/System.Runtime.WindowsRuntime/pkg/build/net461/System.Runtime.WindowsRuntime.targets
+++ b/src/System.Runtime.WindowsRuntime/pkg/build/net461/System.Runtime.WindowsRuntime.targets
@@ -19,4 +19,13 @@
       </ItemGroup>
     </When>
   </Choose>
+  <!-- when this package is referenced as a nuget reference the binding redirect is still present, add a target to remove it -->
+  <Target Name="_RemoveWindowsRuntimeSuggestedRedirect" 
+      BeforeTargets="GenerateBindingRedirects" 
+      DependsOnTargets="ResolveAssemblyReferences"
+      Condition="'$(DoNotReferenceWinRT)' != 'true'">
+    <ItemGroup> 
+      <SuggestedBindingRedirects Remove="System.Runtime.WindowsRuntime, Culture=neutral, PublicKeyToken=b77a5c561934e089" /> 
+    </ItemGroup> 
+  </Target>
 </Project>


### PR DESCRIPTION
WinRT is adding a meta package to bundle the WinRT glue assemblies, union Windows winmd, and contract assemblies.  Due to the way that the WinRT glue assemblies are referenced the existing mechanism to avoid the binding redirect for System.WindowsRuntime and System.WindowsRuntime.UI.Xaml was not sufficient.  This adds a target to remove the binding redirect, as in this scenario it is never valid.

cc @ericstj @joperezr @rido-min 