### PR TITLE
[2.1] Disable IRI test on netfx

### DIFF
--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -581,6 +581,7 @@ namespace System.PrivateUri.Tests
 
         [Theory]
         [MemberData(nameof(AllForbiddenDecompositions))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Disable until the .NET FX CI machines get the latest patches.")]
         public void Iri_AllForbiddenDecompositions_IdnHostThrows(string scheme, string host)
         {
             Uri uri = new Uri(scheme + "://" + host);


### PR DESCRIPTION
The test disabled below won't pass until the netfx CI machines are up to date with the latest version. Once this happens we can re-enable the test. Until then, disable it to reduce noise in CI.

This test is already disabled in master.

related: #35671, #35428