### PR TITLE
Disable used-but-marked-unused warnings in System.Security.Cryptography.Native

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_compile_options(-Wno-cast-align)
 add_compile_options(-Wno-reserved-id-macro)
 add_compile_options(-Wno-documentation)
+add_compile_options(-Wno-used-but-marked-unused)
 
 add_definitions(-DPIC=1 -DOPENSSL_API_COMPAT=0x10100000L)
 


### PR DESCRIPTION
When building in non-portable mode, some OpenSSL 1.1 function defnitions
that are marked as unused can be picked up by our build. When those
functions are called, clang reports a warning and fails the build:

    src/Native/Unix/System.Security.Cryptography.Native/openssl.c:432:12:
    error: 'sk_ASN1_OBJECT_num' was marked unused but was used [-Werror,-Wused-but-marked-unused]
          return sk_ASN1_OBJECT_num(eku);
                 ^

This 'unused' attribute was recently added to sk_* methods in OpenSSL
1.1: https://github.com/openssl/openssl/pull/8246

Fixes #35807