### PR TITLE
Port 'Disable test on netfx' to release/2.2.

### DIFF
--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -581,6 +581,7 @@ namespace System.PrivateUri.Tests
 
         [Theory]
         [MemberData(nameof(AllForbiddenDecompositions))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Disable until the .NET FX CI machines get the latest patches.")]
         public void Iri_AllForbiddenDecompositions_IdnHostThrows(string scheme, string host)
         {
             Uri uri = new Uri(scheme + "://" + host);


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/35831 to release/2.2 (the auto-merge thing was in a weird state when this was merged to 2.1, so I'm doing this manually)

Don't merge until https://github.com/dotnet/corefx/pull/35833 goes in

CC @rmkerr 