### PR TITLE
Seed the AsnReader/AsnWriter changes from corefxlab

### DIFF
--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/Asn1Tag.Accelerators.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/Asn1Tag.Accelerators.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial struct Asn1Tag
+    {
+        /// <summary>
+        ///   Represents the End-of-Contents meta-tag.
+        /// </summary>
+        public static readonly Asn1Tag EndOfContents = new Asn1Tag(0, (int)UniversalTagNumber.EndOfContents);
+
+        /// <summary>
+        ///   Represents the universal class tag for a Boolean value.
+        /// </summary>
+        public static readonly Asn1Tag Boolean = new Asn1Tag(0, (int)UniversalTagNumber.Boolean);
+
+        /// <summary>
+        ///   Represents the universal class tag for an Integer value.
+        /// </summary>
+        public static readonly Asn1Tag Integer = new Asn1Tag(0, (int)UniversalTagNumber.Integer);
+
+        /// <summary>
+        ///   Represents the universal class tag for a Bit String value under a primitive encoding.
+        /// </summary>
+        public static readonly Asn1Tag PrimitiveBitString = new Asn1Tag(0, (int)UniversalTagNumber.BitString);
+
+        /// <summary>
+        ///   Represents the universal class tag for a Bit String value under a constructed encoding.
+        /// </summary>
+        public static readonly Asn1Tag ConstructedBitString =
+            new Asn1Tag(ConstructedMask, (int)UniversalTagNumber.BitString);
+
+        /// <summary>
+        ///   Represents the universal class tag for an Octet String value under a primitive encoding.
+        /// </summary>
+        public static readonly Asn1Tag PrimitiveOctetString = new Asn1Tag(0, (int)UniversalTagNumber.OctetString);
+
+        /// <summary>
+        ///   Represents the universal class tag for a Octet String value under a constructed encoding.
+        /// </summary>
+        public static readonly Asn1Tag ConstructedOctetString =
+            new Asn1Tag(ConstructedMask, (int)UniversalTagNumber.OctetString);
+
+        /// <summary>
+        ///   Represents the universal class tag for a Null value.
+        /// </summary>
+        public static readonly Asn1Tag Null = new Asn1Tag(0, (int)UniversalTagNumber.Null);
+
+        /// <summary>
+        ///   Represents the universal class tag for an Object Identifier value.
+        /// </summary>
+        public static readonly Asn1Tag ObjectIdentifier = new Asn1Tag(0, (int)UniversalTagNumber.ObjectIdentifier);
+
+        /// <summary>
+        ///   Represents the universal class tag for an Enumerated value.
+        /// </summary>
+        public static readonly Asn1Tag Enumerated = new Asn1Tag(0, (int)UniversalTagNumber.Enumerated);
+
+        /// <summary>
+        ///   Represents the universal class tag for a Sequence value (always a constructed encoding).
+        /// </summary>
+        public static readonly Asn1Tag Sequence = new Asn1Tag(ConstructedMask, (int)UniversalTagNumber.Sequence);
+
+        /// <summary>
+        ///   Represents the universal class tag for a SetOf value (always a constructed encoding).
+        /// </summary>
+        public static readonly Asn1Tag SetOf = new Asn1Tag(ConstructedMask, (int)UniversalTagNumber.SetOf);
+
+        /// <summary>
+        ///   Represents the universal class tag for a UtcTime value.
+        /// </summary>
+        public static readonly Asn1Tag UtcTime = new Asn1Tag(0, (int)UniversalTagNumber.UtcTime);
+
+        /// <summary>
+        ///   Represents the universal class tag for a GeneralizedTime value.
+        /// </summary>
+        public static readonly Asn1Tag GeneralizedTime = new Asn1Tag(0, (int)UniversalTagNumber.GeneralizedTime);
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/Asn1Tag.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/Asn1Tag.cs
@@ -1,0 +1,503 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    /// <summary>
+    ///   This type represents an ASN.1 tag, as described in ITU-T Recommendation X.680.
+    /// </summary>
+    // T-REC-X.690-201508 sec 8.1.2
+    public partial struct Asn1Tag : IEquatable<Asn1Tag>
+    {
+        private const byte ClassMask = 0b1100_0000;
+        private const byte ConstructedMask = 0b0010_0000;
+        private const byte ControlMask = ClassMask | ConstructedMask;
+        private const byte TagNumberMask = 0b0001_1111;
+
+        private readonly byte _controlFlags;
+
+        /// <summary>
+        ///   The tag class to which this tag belongs.
+        /// </summary>
+        public TagClass TagClass => (TagClass)(_controlFlags & ClassMask);
+
+        /// <summary>
+        ///   Indicates if the tag represents a constructed encoding (<c>true</c>), or
+        ///   a primitive encoding (<c>false</c>).
+        /// </summary>
+        public bool IsConstructed => (_controlFlags & ConstructedMask) != 0;
+
+        /// <summary>
+        ///   The numeric value for this tag.
+        /// </summary>
+        /// <remarks>
+        ///   If <see cref="TagClass"/> is <see cref="Asn1.TagClass.Universal"/>, this value can
+        ///   be interpreted as a <see cref="UniversalTagNumber"/>.
+        /// </remarks>
+        public int TagValue { get; private set; }
+
+        private Asn1Tag(byte controlFlags, int tagValue)
+        {
+            _controlFlags = (byte)(controlFlags & ControlMask);
+            TagValue = tagValue;
+        }
+
+        /// <summary>
+        ///   Create an <see cref="Asn1Tag"/> for a tag from the UNIVERSAL class.
+        /// </summary>
+        /// <param name="universalTagNumber">
+        ///   The <see cref="UniversalTagNumber"/> value to represent as a tag.
+        /// </param>
+        /// <param name="isConstructed">
+        ///   <c>true</c> for a constructed tag, <c>false</c> for a primitive tag.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="universalTagNumber"/> is not a known value.
+        /// </exception>
+        public Asn1Tag(UniversalTagNumber universalTagNumber, bool isConstructed = false)
+            : this(isConstructed ? ConstructedMask : (byte)0, (int)universalTagNumber)
+        {
+            // T-REC-X.680-201508 sec 8.6 (Table 1)
+            const UniversalTagNumber ReservedIndex = (UniversalTagNumber)15;
+
+            if (universalTagNumber < UniversalTagNumber.EndOfContents ||
+                universalTagNumber > UniversalTagNumber.RelativeObjectIdentifierIRI ||
+                universalTagNumber == ReservedIndex)
+            {
+                throw new ArgumentOutOfRangeException(nameof(universalTagNumber));
+            }
+        }
+
+        /// <summary>
+        ///   Create an <see cref="Asn1Tag"/> for a specified value within a specified tag class.
+        /// </summary>
+        /// <param name="tagClass">
+        ///   The <see cref="TagClass"/> for this tag.
+        /// </param>
+        /// <param name="tagValue">
+        ///   The numeric value for this tag.
+        /// </param>
+        /// <param name="isConstructed">
+        ///   <c>true</c> for a constructed tag, <c>false</c> for a primitive tag.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="tagClass"/> is not a known value --OR--
+        ///   <paramref name="tagValue" /> is negative.
+        /// </exception>
+        /// <remarks>
+        ///   This constructor allows for the creation undefined UNIVERSAL class tags.
+        /// </remarks>
+        public Asn1Tag(TagClass tagClass, int tagValue, bool isConstructed = false)
+            : this((byte)((byte)tagClass | (isConstructed ? ConstructedMask : 0)), tagValue)
+        {
+            if (tagClass < TagClass.Universal || tagClass > TagClass.Private)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tagClass));
+            }
+
+            if (tagValue < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tagValue));
+            }
+        }
+
+        /// <summary>
+        ///   Produce an <see cref="Asn1Tag"/> with the same <seealso cref="TagClass"/> and
+        ///   <seealso cref="TagValue"/> values, but whose <seealso cref="IsConstructed"/> is <c>true</c>.
+        /// </summary>
+        /// <returns>
+        ///   An <see cref="Asn1Tag"/> with the same <seealso cref="TagClass"/> and <seealso cref="TagValue"/>
+        ///   values, but whose <seealso cref="IsConstructed"/> is <c>true</c>.
+        /// </returns>
+        public Asn1Tag AsConstructed()
+        {
+            return new Asn1Tag((byte)(_controlFlags | ConstructedMask), TagValue);
+        }
+
+        /// <summary>
+        ///   Produce an <see cref="Asn1Tag"/> with the same <seealso cref="TagClass"/> and
+        ///   <seealso cref="TagValue"/> values, but whose <seealso cref="IsConstructed"/> is <c>false</c>.
+        /// </summary>
+        /// <returns>
+        ///   An <see cref="Asn1Tag"/> with the same <seealso cref="TagClass"/> and <seealso cref="TagValue"/>
+        ///   values, but whose <seealso cref="IsConstructed"/> is <c>false</c>.
+        /// </returns>
+        public Asn1Tag AsPrimitive()
+        {
+            return new Asn1Tag((byte)(_controlFlags & ~ConstructedMask), TagValue);
+        }
+
+        /// <summary>
+        ///   Read a BER-encoded tag which starts at <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">
+        ///   The read only byte sequence from which to read.
+        /// </param>
+        /// <param name="tag">
+        ///   The decoded <see cref="Asn1Tag"/>.
+        /// </param>
+        /// <param name="bytesConsumed"></param>
+        /// <returns>
+        ///   <c>true</c> if a tag was correctly decoded, <c>false</c> otherwise.
+        /// </returns>
+        public static bool TryDecode(ArraySegment<byte> source, out Asn1Tag tag, out int bytesConsumed)
+        {
+            return TryDecode(source.AsSpan(), out tag, out bytesConsumed);
+        }
+
+        /// <summary>
+        ///   Read a BER-encoded tag which starts at <paramref name="source"/>.
+        /// </summary>
+        /// <param name="source">
+        ///   The read only byte sequence whose beginning is a BER-encoded tag.
+        /// </param>
+        /// <param name="tag">
+        ///   The decoded <see cref="Asn1Tag"/>.
+        /// </param>
+        /// <param name="bytesConsumed"></param>
+        /// <returns>
+        ///   <c>true</c> if a tag was correctly decoded, <c>false</c> otherwise.
+        /// </returns>
+        public static bool TryDecode(ReadOnlySpan<byte> source, out Asn1Tag tag, out int bytesConsumed)
+        {
+            tag = default(Asn1Tag);
+            bytesConsumed = 0;
+
+            if (source.IsEmpty)
+            {
+                return false;
+            }
+
+            byte first = source[bytesConsumed];
+            bytesConsumed++;
+            uint tagValue = (uint)(first & TagNumberMask);
+
+            if (tagValue == TagNumberMask)
+            {
+                // Multi-byte encoding
+                // T-REC-X.690-201508 sec 8.1.2.4
+                const byte ContinuationFlag = 0x80;
+                const byte ValueMask = ContinuationFlag - 1;
+
+                tagValue = 0;
+                byte current;
+
+                do
+                {
+                    if (source.Length <= bytesConsumed)
+                    {
+                        bytesConsumed = 0;
+                        return false;
+                    }
+
+                    current = source[bytesConsumed];
+                    byte currentValue = (byte)(current & ValueMask);
+                    bytesConsumed++;
+
+                    // If TooBigToShift is shifted left 7, the content bit shifts out.
+                    // So any value greater than or equal to this cannot be shifted without loss.
+                    const int TooBigToShift = 0b00000010_00000000_00000000_00000000;
+
+                    if (tagValue >= TooBigToShift)
+                    {
+                        bytesConsumed = 0;
+                        return false;
+                    }
+
+                    tagValue <<= 7;
+                    tagValue |= currentValue;
+
+                    // The first byte cannot have the value 0 (T-REC-X.690-201508 sec 8.1.2.4.2.c)
+                    if (tagValue == 0)
+                    {
+                        bytesConsumed = 0;
+                        return false;
+                    }
+                }
+                while ((current & ContinuationFlag) == ContinuationFlag);
+
+                // This encoding is only valid for tag values greater than 30.
+                // (T-REC-X.690-201508 sec 8.1.2.3, 8.1.2.4)
+                if (tagValue <= 30)
+                {
+                    bytesConsumed = 0;
+                    return false;
+                }
+
+                // There's not really any ambiguity, but prevent negative numbers from showing up.
+                if (tagValue > int.MaxValue)
+                {
+                    bytesConsumed = 0;
+                    return false;
+                }
+            }
+
+            Debug.Assert(bytesConsumed > 0);
+            tag = new Asn1Tag(first, (int)tagValue);
+            return true;
+        }
+
+        /// <summary>
+        ///   Report the number of bytes required for the BER-encoding of this tag.
+        /// </summary>
+        /// <returns>
+        ///   The number of bytes required for the BER-encoding of this tag.
+        /// </returns>
+        /// <seealso cref="TryEncode(Span{byte},out int)"/>
+        public int CalculateEncodedSize()
+        {
+            const int SevenBits = 0b0111_1111;
+            const int FourteenBits = 0b0011_1111_1111_1111;
+            const int TwentyOneBits = 0b0001_1111_1111_1111_1111_1111;
+            const int TwentyEightBits = 0b0000_1111_1111_1111_1111_1111_1111_1111;
+
+            if (TagValue < TagNumberMask)
+                return 1;
+            if (TagValue <= SevenBits)
+                return 2;
+            if (TagValue <= FourteenBits)
+                return 3;
+            if (TagValue <= TwentyOneBits)
+                return 4;
+            if (TagValue <= TwentyEightBits)
+                return 5;
+
+            return 6;
+        }
+
+        /// <summary>
+        ///   Write the BER-encoded form of this tag to <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">
+        ///   The start of where the encoded tag should be written.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   Receives the value from <see cref="CalculateEncodedSize"/> on success, 0 on failure.
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> if <paramref name="destination"/>.<see cref="Span{T}.Length"/> &lt;
+        ///   <see cref="CalculateEncodedSize"/>(), <c>true</c> otherwise.
+        /// </returns>
+        public bool TryEncode(Span<byte> destination, out int bytesWritten)
+        {
+            int spaceRequired = CalculateEncodedSize();
+
+            if (destination.Length < spaceRequired)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            if (spaceRequired == 1)
+            {
+                byte value = (byte)(_controlFlags | TagValue);
+                destination[0] = value;
+                bytesWritten = 1;
+                return true;
+            }
+
+            byte firstByte = (byte)(_controlFlags | TagNumberMask);
+            destination[0] = firstByte;
+
+            int remaining = TagValue;
+            int idx = spaceRequired - 1;
+
+            while (remaining > 0)
+            {
+                int segment = remaining & 0x7F;
+
+                // The last byte doesn't get the marker, which we write first.
+                if (remaining != TagValue)
+                {
+                    segment |= 0x80;
+                }
+
+                Debug.Assert(segment <= byte.MaxValue);
+                destination[idx] = (byte)segment;
+                remaining >>= 7;
+                idx--;
+            }
+
+            Debug.Assert(idx == 0);
+            bytesWritten = spaceRequired;
+            return true;
+        }
+
+        /// <summary>
+        ///   Write the BER-encoded form of this tag to <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">
+        ///   The start of where the encoded tag should be written.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   Receives the value from <see cref="CalculateEncodedSize"/> on success, 0 on failure.
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> if <paramref name="destination"/>.<see cref="ArraySegment{T}.Count"/> &lt;
+        ///   <see cref="CalculateEncodedSize"/>(), <c>true</c> otherwise.
+        /// </returns>
+        public bool TryEncode(ArraySegment<byte> destination, out int bytesWritten)
+        {
+            return TryEncode(destination.AsSpan(), out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Write the BER-encoded form of this tag to <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">
+        ///   The start of where the encoded tag should be written.
+        /// </param>
+        /// <returns>
+        ///   The number of bytes written to <paramref name="destination"/>.
+        /// </returns>
+        /// <seealso cref="CalculateEncodedSize"/>
+        /// <exception cref="CryptographicException">
+        ///   <paramref name="destination"/>.<see cref="Span{T}.Length"/> &lt; <see cref="CalculateEncodedSize"/>.
+        /// </exception>
+        public int Encode(Span<byte> destination)
+        {
+            if (TryEncode(destination, out int bytesWritten))
+            {
+                return bytesWritten;
+            }
+
+            throw new CryptographicException(SR.Argument_EncodeDestinationTooSmall);
+        }
+
+        /// <summary>
+        ///   Write the BER-encoded form of this tag to <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">
+        ///   The start of where the encoded tag should be written.
+        /// </param>
+        /// <returns>
+        ///   The number of bytes written to <paramref name="destination"/>.
+        /// </returns>
+        /// <seealso cref="CalculateEncodedSize"/>
+        /// <exception cref="CryptographicException">
+        ///   <paramref name="destination"/>.<see cref="ArraySegment{T}.Count"/> &lt; <see cref="CalculateEncodedSize"/>.
+        /// </exception>
+        public int Encode(ArraySegment<byte> destination)
+        {
+            return Encode(destination.AsSpan());
+        }
+
+        /// <summary>
+        ///   Tests if <paramref name="other"/> has the same encoding as this tag.
+        /// </summary>
+        /// <param name="other">
+        ///   Tag to test for equality.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> if <paramref name="other"/> has the same values for
+        ///   <see cref="TagClass"/>, <see cref="TagValue"/>, and <see cref="IsConstructed"/>;
+        ///   <c>false</c> otherwise.
+        /// </returns>
+        public bool Equals(Asn1Tag other)
+        {
+            return _controlFlags == other._controlFlags && TagValue == other.TagValue;
+        }
+
+        /// <summary>
+        ///   Tests if <paramref name="obj"/> is an <see cref="Asn1Tag"/> with the same
+        ///   encoding as this tag.
+        /// </summary>
+        /// <param name="obj">Object to test for value equality</param>
+        /// <returns>
+        ///   <c>false</c> if <paramref name="obj"/> is not an <see cref="Asn1Tag"/>,
+        ///   <see cref="Equals(System.Security.Cryptography.Asn1.Asn1Tag)"/> otherwise.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            return obj is Asn1Tag tag && Equals(tag);
+        }
+
+        /// <summary>
+        ///   Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>
+        ///   A 32-bit signed integer hash code.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            // Most TagValue values will be in the 0-30 range,
+            // the GetHashCode value only has collisions when TagValue is
+            // between 2^29 and uint.MaxValue
+            return (_controlFlags << 24) ^ TagValue;
+        }
+
+        /// <summary>
+        ///   Tests if two <see cref="Asn1Tag"/> values have the same BER encoding.
+        /// </summary>
+        /// <param name="left">The first value to compare.</param>
+        /// <param name="right">The second value to compare.</param>
+        /// <returns>
+        ///   <c>true</c> if <paramref name="left"/> and <paramref name="right"/> have the same
+        ///   BER encoding, <c>false</c> otherwise.
+        /// </returns>
+        public static bool operator ==(Asn1Tag left, Asn1Tag right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        ///   Tests if two <see cref="Asn1Tag"/> values have a different BER encoding.
+        /// </summary>
+        /// <param name="left">The first value to compare.</param>
+        /// <param name="right">The second value to compare.</param>
+        /// <returns>
+        ///   <c>true</c> if <paramref name="left"/> and <paramref name="right"/> have a different
+        ///   BER encoding, <c>false</c> otherwise.
+        /// </returns>
+        public static bool operator !=(Asn1Tag left, Asn1Tag right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        ///   Tests if <paramref name="other"/> has the same <see cref="TagClass"/> and <see cref="TagValue"/>
+        ///   values as this tag, and does not compare <see cref="IsConstructed"/>.
+        /// </summary>
+        /// <param name="other">Tag to test for concept equality.</param>
+        /// <returns>
+        ///   <c>true</c> if <paramref name="other"/> has the same <see cref="TagClass"/> and <see cref="TagValue"/>
+        ///   as this tag, <c>false</c> otherwise.
+        /// </returns>
+        public bool HasSameClassAndValue(Asn1Tag other)
+        {
+            return TagValue == other.TagValue && TagClass == other.TagClass;
+        }
+
+        /// <summary>
+        ///   Provides a text representation of this tag suitable for debugging.
+        /// </summary>
+        /// <returns>
+        ///   A text representation of this tag suitable for debugging.
+        /// </returns>
+        public override string ToString()
+        {
+            const string ConstructedPrefix = "Constructed ";
+            string classAndValue;
+
+            if (TagClass == TagClass.Universal)
+            {
+                classAndValue = ((UniversalTagNumber)TagValue).ToString();
+            }
+            else
+            {
+                classAndValue = TagClass + "-" + TagValue;
+            }
+
+            if (IsConstructed)
+            {
+                return ConstructedPrefix + classAndValue;
+            }
+
+            return classAndValue;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnCharacterStringEncodings.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnCharacterStringEncodings.cs
@@ -1,0 +1,489 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace System.Security.Cryptography.Asn1
+{
+    internal static class AsnCharacterStringEncodings
+    {
+        private static readonly Text.Encoding s_utf8Encoding = new UTF8Encoding(false, throwOnInvalidBytes: true);
+        private static readonly Text.Encoding s_bmpEncoding = new BMPEncoding();
+        private static readonly Text.Encoding s_ia5Encoding = new IA5Encoding();
+        private static readonly Text.Encoding s_visibleStringEncoding = new VisibleStringEncoding();
+        private static readonly Text.Encoding s_printableStringEncoding = new PrintableStringEncoding();
+        private static readonly Text.Encoding s_t61Encoding = new T61Encoding();
+
+        internal static Text.Encoding GetEncoding(UniversalTagNumber encodingType)
+        {
+            switch (encodingType)
+            {
+                case UniversalTagNumber.UTF8String:
+                    return s_utf8Encoding;
+                case UniversalTagNumber.PrintableString:
+                    return s_printableStringEncoding;
+                case UniversalTagNumber.IA5String:
+                    return s_ia5Encoding;
+                case UniversalTagNumber.VisibleString:
+                    return s_visibleStringEncoding;
+                case UniversalTagNumber.BMPString:
+                    return s_bmpEncoding;
+                case UniversalTagNumber.T61String:
+                    return s_t61Encoding;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(encodingType), encodingType, null);
+            }
+        }
+    }
+
+    internal abstract class SpanBasedEncoding : Text.Encoding
+    {
+        protected SpanBasedEncoding()
+            : base(0, EncoderFallback.ExceptionFallback, DecoderFallback.ExceptionFallback)
+        {
+        }
+
+        protected abstract int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes, bool write);
+        protected abstract int GetChars(ReadOnlySpan<byte> bytes, Span<char> chars, bool write);
+
+        public override int GetByteCount(char[] chars, int index, int count)
+        {
+            return GetByteCount(new ReadOnlySpan<char>(chars, index, count));
+        }
+
+        public override unsafe int GetByteCount(char* chars, int count)
+        {
+            return GetByteCount(new ReadOnlySpan<char>(chars, count));
+        }
+
+        public override int GetByteCount(string s)
+        {
+            return GetByteCount(s.AsSpan());
+        }
+
+        public
+#if netcoreapp || uap || NETCOREAPP
+            override
+#endif
+        int GetByteCount(ReadOnlySpan<char> chars)
+        {
+            return GetBytes(chars, Span<byte>.Empty, write: false);
+        }
+
+        public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
+        {
+            return GetBytes(
+                new ReadOnlySpan<char>(chars, charIndex, charCount),
+                new Span<byte>(bytes, byteIndex, bytes.Length - byteIndex),
+                write: true);
+        }
+
+        public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
+        {
+            return GetBytes(
+                new ReadOnlySpan<char>(chars, charCount),
+                new Span<byte>(bytes, byteCount),
+                write: true);
+        }
+
+        public override int GetCharCount(byte[] bytes, int index, int count)
+        {
+            return GetCharCount(new ReadOnlySpan<byte>(bytes, index, count));
+        }
+
+        public override unsafe int GetCharCount(byte* bytes, int count)
+        {
+            return GetCharCount(new ReadOnlySpan<byte>(bytes, count));
+        }
+
+        public
+#if netcoreapp || uap || NETCOREAPP
+            override
+#endif
+        int GetCharCount(ReadOnlySpan<byte> bytes)
+        {
+            return GetChars(bytes, Span<char>.Empty, write: false);
+        }
+
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+        {
+            return GetChars(
+                new ReadOnlySpan<byte>(bytes, byteIndex, byteCount),
+                new Span<char>(chars, charIndex, chars.Length - charIndex),
+                write: true);
+        }
+
+        public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
+        {
+            return GetChars(
+                new ReadOnlySpan<byte>(bytes, byteCount),
+                new Span<char>(chars, charCount),
+                write: true);
+        }
+    }
+
+    internal class IA5Encoding : RestrictedAsciiStringEncoding
+    {
+        // T-REC-X.680-201508 sec 41, Table 8.
+        // ISO International Register of Coded Character Sets to be used with Escape Sequences 001
+        //   is ASCII 0x00 - 0x1F
+        // ISO International Register of Coded Character Sets to be used with Escape Sequences 006
+        //   is ASCII 0x21 - 0x7E
+        // Space is ASCII 0x20, delete is ASCII 0x7F.
+        //
+        // The net result is all of 7-bit ASCII
+        internal IA5Encoding()
+            : base(0x00, 0x7F)
+        {
+        }
+    }
+
+    internal class VisibleStringEncoding : RestrictedAsciiStringEncoding
+    {
+        // T-REC-X.680-201508 sec 41, Table 8.
+        // ISO International Register of Coded Character Sets to be used with Escape Sequences 006
+        //   is ASCII 0x21 - 0x7E
+        // Space is ASCII 0x20.
+        internal VisibleStringEncoding()
+            : base(0x20, 0x7E)
+        {
+        }
+    }
+
+    internal class PrintableStringEncoding : RestrictedAsciiStringEncoding
+    {
+        // T-REC-X.680-201508 sec 41.4
+        internal PrintableStringEncoding()
+            : base("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 '()+,-./:=?")
+        {
+        }
+    }
+
+    internal abstract class RestrictedAsciiStringEncoding : SpanBasedEncoding
+    {
+        private readonly bool[] _isAllowed;
+
+        protected RestrictedAsciiStringEncoding(byte minCharAllowed, byte maxCharAllowed)
+        {
+            Debug.Assert(minCharAllowed <= maxCharAllowed);
+            Debug.Assert(maxCharAllowed <= 0x7F);
+
+            bool[] isAllowed = new bool[0x80];
+
+            for (byte charCode = minCharAllowed; charCode <= maxCharAllowed; charCode++)
+            {
+                isAllowed[charCode] = true;
+            }
+
+            _isAllowed = isAllowed;
+        }
+
+        protected RestrictedAsciiStringEncoding(IEnumerable<char> allowedChars)
+        {
+            bool[] isAllowed = new bool[0x7F];
+
+            foreach (char c in allowedChars)
+            {
+                if (c >= isAllowed.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(allowedChars));
+                }
+
+                Debug.Assert(isAllowed[c] == false);
+                isAllowed[c] = true;
+            }
+
+            _isAllowed = isAllowed;
+        }
+
+        public override int GetMaxByteCount(int charCount)
+        {
+            return charCount;
+        }
+
+        public override int GetMaxCharCount(int byteCount)
+        {
+            return byteCount;
+        }
+
+        protected override int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes, bool write)
+        {
+            if (chars.IsEmpty)
+            {
+                return 0;
+            }
+
+            for (int i = 0; i < chars.Length; i++)
+            {
+                char c = chars[i];
+
+                if ((uint)c >= (uint)_isAllowed.Length || !_isAllowed[c])
+                {
+                    EncoderFallback.CreateFallbackBuffer().Fallback(c, i);
+
+                    Debug.Fail("Fallback should have thrown");
+                    throw new CryptographicException();
+                }
+
+                if (write)
+                {
+                    bytes[i] = (byte)c;
+                }
+            }
+
+            return chars.Length;
+        }
+
+        protected override int GetChars(ReadOnlySpan<byte> bytes, Span<char> chars, bool write)
+        {
+            if (bytes.IsEmpty)
+            {
+                return 0;
+            }
+
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                byte b = bytes[i];
+
+                if ((uint)b >= (uint)_isAllowed.Length || !_isAllowed[b])
+                {
+                    DecoderFallback.CreateFallbackBuffer().Fallback(
+                        new[] { b },
+                        i);
+
+                    Debug.Fail("Fallback should have thrown");
+                    throw new CryptographicException();
+                }
+
+                if (write)
+                {
+                    chars[i] = (char)b;
+                }
+            }
+
+            return bytes.Length;
+        }
+    }
+
+    /// <summary>
+    ///   Big-Endian UCS-2 encoding (the same as UTF-16BE, but disallowing surrogate pairs to leave plane 0)
+    /// </summary>
+    // T-REC-X.690-201508 sec 8.23.8 says to see ISO/IEC 10646:2003 section 13.1.
+    // ISO/IEC 10646:2003 sec 13.1 says each character is represented by "two octets".
+    // ISO/IEC 10646:2003 sec 6.3 says that when serialized as octets to use big endian.
+    internal class BMPEncoding : SpanBasedEncoding
+    {
+        protected override int GetBytes(ReadOnlySpan<char> chars, Span<byte> bytes, bool write)
+        {
+            if (chars.IsEmpty)
+            {
+                return 0;
+            }
+
+            int writeIdx = 0;
+
+            for (int i = 0; i < chars.Length; i++)
+            {
+                char c = chars[i];
+
+                if (char.IsSurrogate(c))
+                {
+                    EncoderFallback.CreateFallbackBuffer().Fallback(c, i);
+
+                    Debug.Fail("Fallback should have thrown");
+                    throw new CryptographicException();
+                }
+
+                ushort val16 = c;
+
+                if (write)
+                {
+                    bytes[writeIdx + 1] = (byte)val16;
+                    bytes[writeIdx] = (byte)(val16 >> 8);
+                }
+
+                writeIdx += 2;
+            }
+
+            return writeIdx;
+        }
+
+        protected override int GetChars(ReadOnlySpan<byte> bytes, Span<char> chars, bool write)
+        {
+            if (bytes.IsEmpty)
+            {
+                return 0;
+            }
+
+            if (bytes.Length % 2 != 0)
+            {
+                DecoderFallback.CreateFallbackBuffer().Fallback(
+                    bytes.Slice(bytes.Length - 1).ToArray(),
+                    bytes.Length - 1);
+
+                Debug.Fail("Fallback should have thrown");
+                throw new CryptographicException();
+            }
+
+            int writeIdx = 0;
+
+            for (int i = 0; i < bytes.Length; i += 2)
+            {
+                int val = bytes[i] << 8 | bytes[i + 1];
+                char c = (char)val;
+
+                if (char.IsSurrogate(c))
+                {
+                    DecoderFallback.CreateFallbackBuffer().Fallback(
+                        bytes.Slice(i, 2).ToArray(),
+                        i);
+
+                    Debug.Fail("Fallback should have thrown");
+                    throw new CryptographicException();
+                }
+
+                if (write)
+                {
+                    chars[writeIdx] = c;
+                }
+
+                writeIdx++;
+            }
+
+            return writeIdx;
+        }
+
+        public override int GetMaxByteCount(int charCount)
+        {
+            checked
+            {
+                return charCount * 2;
+            }
+        }
+
+        public override int GetMaxCharCount(int byteCount)
+        {
+            return byteCount / 2;
+        }
+    }
+
+    /// <summary>
+    /// Compatibility encoding for T61Strings. Interprets the characters as UTF-8 or
+    /// ISO-8859-1 as a fallback.
+    /// </summary>
+    internal class T61Encoding : Text.Encoding
+    {
+        private static readonly Text.Encoding s_utf8Encoding = new UTF8Encoding(false, throwOnInvalidBytes: true);
+        private static readonly Text.Encoding s_latin1Encoding = System.Text.Encoding.GetEncoding("iso-8859-1");
+
+        public override int GetByteCount(char[] chars, int index, int count)
+        {
+            return s_utf8Encoding.GetByteCount(chars, index, count);
+        }
+
+        public override unsafe int GetByteCount(char* chars, int count)
+        {
+            return s_utf8Encoding.GetByteCount(chars, count);
+        }
+
+        public override int GetByteCount(string s)
+        {
+            return s_utf8Encoding.GetByteCount(s);
+        }
+
+#if netcoreapp || uap || NETCOREAPP
+        public override int GetByteCount(ReadOnlySpan<char> chars)
+        {
+            return s_utf8Encoding.GetByteCount(chars);
+        }
+#endif
+
+        public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
+        {
+            return s_utf8Encoding.GetBytes(chars, charIndex, charCount, bytes, byteIndex);
+        }
+
+        public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
+        {
+            return s_utf8Encoding.GetBytes(chars, charCount, bytes, byteCount);
+        }
+
+        public override int GetCharCount(byte[] bytes, int index, int count)
+        {
+            try
+            {
+                return s_utf8Encoding.GetCharCount(bytes, index, count);
+            }
+            catch (DecoderFallbackException)
+            {
+                return s_latin1Encoding.GetCharCount(bytes, index, count);
+            }
+        }
+
+        public override unsafe int GetCharCount(byte* bytes, int count)
+        {
+            try
+            {
+                return s_utf8Encoding.GetCharCount(bytes, count);
+            }
+            catch (DecoderFallbackException)
+            {
+                return s_latin1Encoding.GetCharCount(bytes, count);
+            }
+        }
+
+#if netcoreapp || uap || NETCOREAPP
+        public override int GetCharCount(ReadOnlySpan<byte> bytes)
+        {
+            try
+            {
+                return s_utf8Encoding.GetCharCount(bytes);
+            }
+            catch (DecoderFallbackException)
+            {
+                return s_latin1Encoding.GetCharCount(bytes);
+            }
+        }
+#endif
+
+        public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
+        {
+            try
+            {
+                return s_utf8Encoding.GetChars(bytes, byteIndex, byteCount, chars, charIndex);
+            }
+            catch (DecoderFallbackException)
+            {
+                return s_latin1Encoding.GetChars(bytes, byteIndex, byteCount, chars, charIndex);
+            }
+        }
+
+        public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
+        {
+            try
+            {
+                return s_utf8Encoding.GetChars(bytes, byteCount, chars, charCount);
+            }
+            catch (DecoderFallbackException)
+            {
+                return s_latin1Encoding.GetChars(bytes, byteCount, chars, charCount);
+            }
+        }
+
+        public override int GetMaxByteCount(int charCount)
+        {
+            return s_utf8Encoding.GetMaxByteCount(charCount);
+        }
+
+        public override int GetMaxCharCount(int byteCount)
+        {
+            // Latin-1 is single byte encoding, so byteCount == charCount
+            // UTF-8 is multi-byte encoding, so byteCount >= charCount
+            // We want to return the maximum of those two, which happens to be byteCount.
+            return byteCount;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnEncodingRules.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnEncodingRules.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    /// <summary>
+    ///   The encoding ruleset for an <see cref="AsnReader"/> or <see cref="AsnWriter"/>.
+    /// </summary>
+    // ITU-T-REC.X.680-201508 sec 4.
+    public enum AsnEncodingRules
+    {
+        /// <summary>
+        /// ITU-T X.690 Basic Encoding Rules
+        /// </summary>
+        BER,
+
+        /// <summary>
+        /// ITU-T X.690 Canonical Encoding Rules
+        /// </summary>
+        CER,
+
+        /// <summary>
+        /// ITU-T X.690 Distinguished Encoding Rules
+        /// </summary>
+        DER,
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.BitString.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.BitString.cs
@@ -1,0 +1,703 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a BIT STRING with tag UNIVERSAL 3, returning the contents
+        ///   as a <see cref="ReadOnlyMemory{T}"/> over the original data.
+        /// </summary>
+        /// <param name="unusedBitCount">
+        ///   On success, receives the number of bits in the last byte which were reported as
+        ///   "unused" by the writer.
+        /// </param>
+        /// <param name="value">
+        ///   On success, receives a <see cref="ReadOnlyMemory{T}"/> over the original data
+        ///   corresponding to the value of the BIT STRING.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if the BIT STRING value had a primitive encoding,
+        ///   <c>false</c> and does not advance the reader if it had a constructed encoding.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="TryCopyBitStringBytes(Span{byte},out int,out int)"/>
+        public bool TryReadPrimitiveBitStringValue(out int unusedBitCount, out ReadOnlyMemory<byte> value)
+            => TryReadPrimitiveBitStringValue(Asn1Tag.PrimitiveBitString, out unusedBitCount, out value);
+
+        /// <summary>
+        ///   Reads the next value as a BIT STRING with a specified tag, returning the contents
+        ///   as a <see cref="ReadOnlyMemory{T}"/> over the original data.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="unusedBitCount">
+        ///   On success, receives the number of bits in the last byte which were reported as
+        ///   "unused" by the writer.
+        /// </param>
+        /// <param name="value">
+        ///   On success, receives a <see cref="ReadOnlyMemory{T}"/> over the original data
+        ///   corresponding to the value of the BIT STRING.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if the BIT STRING value had a primitive encoding,
+        ///   <c>false</c> and does not advance the reader if it had a constructed encoding.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <seealso cref="TryCopyBitStringBytes(Asn1Tag,Span{byte},out int,out int)"/>
+        public bool TryReadPrimitiveBitStringValue(
+            Asn1Tag expectedTag,
+            out int unusedBitCount,
+            out ReadOnlyMemory<byte> value)
+        {
+            bool isPrimitive = TryReadPrimitiveBitStringValue(
+                expectedTag,
+                out Asn1Tag actualTag,
+                out int? contentsLength,
+                out int headerLength,
+                out unusedBitCount,
+                out value,
+                out byte normalizedLastByte);
+
+            if (isPrimitive)
+            {
+                // A BER reader which encountered a situation where an "unused" bit was not
+                // set to 0.
+                if (value.Length != 0 && normalizedLastByte != value.Span[value.Length - 1])
+                {
+                    unusedBitCount = 0;
+                    value = default(ReadOnlyMemory<byte>);
+                    return false;
+                }
+
+                // Skip the tag+length (header) and the unused bit count byte (1) and the contents.
+                _data = _data.Slice(headerLength + value.Length + 1);
+            }
+
+            return isPrimitive;
+        }
+
+        /// <summary>
+        ///   Reads the next value as a BIT STRING with tag UNIVERSAL 3, copying the value
+        ///   into a provided destination buffer.
+        /// </summary>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="unusedBitCount">
+        ///   On success, receives the number of bits in the last byte which were reported as
+        ///   "unused" by the writer.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveBitStringValue(out int,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadBitString(out int)"/>
+        public bool TryCopyBitStringBytes(
+            Span<byte> destination,
+            out int unusedBitCount,
+            out int bytesWritten)
+        {
+            return TryCopyBitStringBytes(
+                Asn1Tag.PrimitiveBitString,
+                destination,
+                out unusedBitCount,
+                out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as a BIT STRING with a specified tag, copying the value
+        ///   into a provided destination buffer.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="unusedBitCount">
+        ///   On success, receives the number of bits in the last byte which were reported as
+        ///   "unused" by the writer.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveBitStringValue(Asn1Tag,out int,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadBitString(Asn1Tag,out int)"/>
+        public bool TryCopyBitStringBytes(
+            Asn1Tag expectedTag,
+            Span<byte> destination,
+            out int unusedBitCount,
+            out int bytesWritten)
+        {
+            if (TryReadPrimitiveBitStringValue(
+                expectedTag,
+                out Asn1Tag actualTag,
+                out int? contentsLength,
+                out int headerLength,
+                out unusedBitCount,
+                out ReadOnlyMemory<byte> value,
+                out byte normalizedLastByte))
+            {
+                if (value.Length > destination.Length)
+                {
+                    bytesWritten = 0;
+                    unusedBitCount = 0;
+                    return false;
+                }
+
+                CopyBitStringValue(value, normalizedLastByte, destination);
+
+                bytesWritten = value.Length;
+                // contents doesn't include the unusedBitCount value, so add one byte for that.
+                _data = _data.Slice(headerLength + value.Length + 1);
+                return true;
+            }
+
+            Debug.Assert(actualTag.IsConstructed);
+
+            bool read = TryCopyConstructedBitStringValue(
+                Slice(_data, headerLength, contentsLength),
+                destination,
+                contentsLength == null,
+                out unusedBitCount,
+                out int bytesRead,
+                out bytesWritten);
+
+            if (read)
+            {
+                _data = _data.Slice(headerLength + bytesRead);
+            }
+
+            return read;
+        }
+
+        /// <summary>
+        ///   Reads the next value as a BIT STRING with tag UNIVERSAL 3, copying the value
+        ///   into a provided destination buffer.
+        /// </summary>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="unusedBitCount">
+        ///   On success, receives the number of bits in the last byte which were reported as
+        ///   "unused" by the writer.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveBitStringValue(out int,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadBitString(out int)"/>
+        public bool TryCopyBitStringBytes(
+            ArraySegment<byte> destination,
+            out int unusedBitCount,
+            out int bytesWritten)
+        {
+            return TryCopyBitStringBytes(
+                Asn1Tag.PrimitiveBitString,
+                destination.AsSpan(),
+                out unusedBitCount,
+                out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as a BIT STRING with a specified tag, copying the value
+        ///   into a provided destination buffer.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="unusedBitCount">
+        ///   On success, receives the number of bits in the last byte which were reported as
+        ///   "unused" by the writer.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveBitStringValue(Asn1Tag,out int,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadBitString(Asn1Tag,out int)"/>
+        public bool TryCopyBitStringBytes(
+            Asn1Tag expectedTag,
+            ArraySegment<byte> destination,
+            out int unusedBitCount,
+            out int bytesWritten)
+        {
+            return TryCopyBitStringBytes(
+                expectedTag,
+                destination.AsSpan(),
+                out unusedBitCount,
+                out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as a BIT STRING with tag UNIVERSAL 3, returning the value
+        ///   in a byte array.
+        /// </summary>
+        /// <param name="unusedBitCount">
+        ///   On success, receives the number of bits in the last byte which were reported as
+        ///   "unused" by the writer.
+        /// </param>
+        /// <returns>
+        ///   a copy of the value in a newly allocated, precisely sized, array.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveBitStringValue(out int,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="TryCopyBitStringBytes(Span{byte},out int,out int)"/>
+        public byte[] ReadBitString(out int unusedBitCount)
+        {
+            return ReadBitString(Asn1Tag.PrimitiveBitString, out unusedBitCount);
+        }
+
+        /// <summary>
+        ///   Reads the next value as a BIT STRING with tag UNIVERSAL 3, returning the value
+        ///   in a byte array.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="unusedBitCount">
+        ///   On success, receives the number of bits in the last byte which were reported as
+        ///   "unused" by the writer.
+        /// </param>
+        /// <returns>
+        ///   a copy of the value in a newly allocated, precisely sized, array.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveBitStringValue(Asn1Tag,out int,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="TryCopyBitStringBytes(Asn1Tag,Span{byte},out int,out int)"/>
+        public byte[] ReadBitString(Asn1Tag expectedTag, out int unusedBitCount)
+        {
+            ReadOnlyMemory<byte> memory;
+
+            if (TryReadPrimitiveBitStringValue(expectedTag, out unusedBitCount, out memory))
+            {
+                return memory.ToArray();
+            }
+
+            memory = PeekEncodedValue();
+
+            // Guaranteed long enough
+            byte[] rented = ArrayPool<byte>.Shared.Rent(memory.Length);
+            int dataLength = 0;
+
+            try
+            {
+                if (!TryCopyBitStringBytes(expectedTag, rented, out unusedBitCount, out dataLength))
+                {
+                    Debug.Fail("TryCopyBitStringBytes failed with a pre-allocated buffer");
+                    throw new CryptographicException();
+                }
+
+                byte[] alloc = new byte[dataLength];
+                rented.AsSpan(0, dataLength).CopyTo(alloc);
+                return alloc;
+            }
+            finally
+            {
+                rented.AsSpan(0, dataLength).Clear();
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        private void ParsePrimitiveBitStringContents(
+            ReadOnlyMemory<byte> source,
+            out int unusedBitCount,
+            out ReadOnlyMemory<byte> value,
+            out byte normalizedLastByte)
+        {
+            // T-REC-X.690-201508 sec 9.2
+            if (RuleSet == AsnEncodingRules.CER && source.Length > MaxCERSegmentSize)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            // T-REC-X.690-201508 sec 8.6.2.3
+            if (source.Length == 0)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            ReadOnlySpan<byte> sourceSpan = source.Span;
+            unusedBitCount = sourceSpan[0];
+
+            // T-REC-X.690-201508 sec 8.6.2.2
+            if (unusedBitCount > 7)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            if (source.Length == 1)
+            {
+                // T-REC-X.690-201508 sec 8.6.2.4
+                if (unusedBitCount > 0)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                Debug.Assert(unusedBitCount == 0);
+                value = ReadOnlyMemory<byte>.Empty;
+                normalizedLastByte = 0;
+                return;
+            }
+
+            // Build a mask for the bits that are used so the normalized value can be computed
+            //
+            // If 3 bits are "unused" then build a mask for them to check for 0.
+            // -1 << 3 => 0b1111_1111 << 3 => 0b1111_1000
+            int mask = -1 << unusedBitCount;
+            byte lastByte = sourceSpan[sourceSpan.Length - 1];
+            byte maskedByte = (byte)(lastByte & mask);
+
+            if (maskedByte != lastByte)
+            {
+                // T-REC-X.690-201508 sec 11.2.1
+                if (RuleSet == AsnEncodingRules.DER || RuleSet == AsnEncodingRules.CER)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+            }
+
+            normalizedLastByte = maskedByte;
+            value = source.Slice(1);
+        }
+
+        private delegate void BitStringCopyAction(
+            ReadOnlyMemory<byte> value,
+            byte normalizedLastByte,
+            Span<byte> destination);
+
+        private static void CopyBitStringValue(
+            ReadOnlyMemory<byte> value,
+            byte normalizedLastByte,
+            Span<byte> destination)
+        {
+            if (value.Length == 0)
+            {
+                return;
+            }
+
+            value.Span.CopyTo(destination);
+            // Replace the last byte with the normalized answer.
+            destination[value.Length - 1] = normalizedLastByte;
+        }
+
+        private int CountConstructedBitString(ReadOnlyMemory<byte> source, bool isIndefinite)
+        {
+            Span<byte> destination = Span<byte>.Empty;
+
+            return ProcessConstructedBitString(
+                source,
+                destination,
+                null,
+                isIndefinite,
+                out _,
+                out _);
+        }
+
+        private void CopyConstructedBitString(
+            ReadOnlyMemory<byte> source,
+            Span<byte> destination,
+            bool isIndefinite,
+            out int unusedBitCount,
+            out int bytesRead,
+            out int bytesWritten)
+        {
+            Span<byte> tmpDest = destination;
+
+            bytesWritten = ProcessConstructedBitString(
+                source,
+                tmpDest,
+                (value, lastByte, dest) => CopyBitStringValue(value, lastByte, dest),
+                isIndefinite,
+                out unusedBitCount,
+                out bytesRead);
+        }
+
+        private int ProcessConstructedBitString(
+            ReadOnlyMemory<byte> source,
+            Span<byte> destination,
+            BitStringCopyAction copyAction,
+            bool isIndefinite,
+            out int lastUnusedBitCount,
+            out int bytesRead)
+        {
+            lastUnusedBitCount = 0;
+            bytesRead = 0;
+            int lastSegmentLength = MaxCERSegmentSize;
+
+            AsnReader tmpReader = new AsnReader(source, RuleSet);
+            Stack<(AsnReader, bool, int)> readerStack = null;
+            int totalLength = 0;
+            Asn1Tag tag = Asn1Tag.ConstructedBitString;
+            Span<byte> curDest = destination;
+
+            do
+            {
+                while (tmpReader.HasData)
+                {
+                    tag = tmpReader.ReadTagAndLength(out int? length, out int headerLength);
+
+                    if (tag == Asn1Tag.PrimitiveBitString)
+                    {
+                        if (lastUnusedBitCount != 0)
+                        {
+                            // T-REC-X.690-201508 sec 8.6.4, only the last segment may have
+                            // a number of bits not a multiple of 8.
+                            throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                        }
+
+                        if (RuleSet == AsnEncodingRules.CER && lastSegmentLength != MaxCERSegmentSize)
+                        {
+                            // T-REC-X.690-201508 sec 9.2
+                            throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                        }
+
+                        Debug.Assert(length != null);
+                        ReadOnlyMemory<byte> encodedValue = Slice(tmpReader._data, headerLength, length.Value);
+
+                        ParsePrimitiveBitStringContents(
+                            encodedValue,
+                            out lastUnusedBitCount,
+                            out ReadOnlyMemory<byte> contents,
+                            out byte normalizedLastByte);
+
+                        int localLen = headerLength + encodedValue.Length;
+                        tmpReader._data = tmpReader._data.Slice(localLen);
+
+                        bytesRead += localLen;
+                        totalLength += contents.Length;
+                        lastSegmentLength = encodedValue.Length;
+
+                        if (copyAction != null)
+                        {
+                            copyAction(contents, normalizedLastByte, curDest);
+                            curDest = curDest.Slice(contents.Length);
+                        }
+                    }
+                    else if (tag == Asn1Tag.EndOfContents && isIndefinite)
+                    {
+                        ValidateEndOfContents(tag, length, headerLength);
+
+                        bytesRead += headerLength;
+
+                        if (readerStack?.Count > 0)
+                        {
+                            (AsnReader topReader, bool wasIndefinite, int pushedBytesRead) = readerStack.Pop();
+                            topReader._data = topReader._data.Slice(bytesRead);
+
+                            bytesRead += pushedBytesRead;
+                            isIndefinite = wasIndefinite;
+                            tmpReader = topReader;
+                        }
+                        else
+                        {
+                            // We have matched the EndOfContents that brought us here.
+                            break;
+                        }
+                    }
+                    else if (tag == Asn1Tag.ConstructedBitString)
+                    {
+                        if (RuleSet == AsnEncodingRules.CER)
+                        {
+                            // T-REC-X.690-201508 sec 9.2
+                            throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                        }
+
+                        if (readerStack == null)
+                        {
+                            readerStack = new Stack<(AsnReader, bool, int)>();
+                        }
+
+                        readerStack.Push((tmpReader, isIndefinite, bytesRead));
+
+                        tmpReader = new AsnReader(
+                            Slice(tmpReader._data, headerLength, length),
+                            RuleSet);
+
+                        bytesRead = headerLength;
+                        isIndefinite = (length == null);
+                    }
+                    else
+                    {
+                        // T-REC-X.690-201508 sec 8.6.4.1 (in particular, Note 2)
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+                }
+
+                if (isIndefinite && tag != Asn1Tag.EndOfContents)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                if (readerStack?.Count > 0)
+                {
+                    (AsnReader topReader, bool wasIndefinite, int pushedBytesRead) = readerStack.Pop();
+
+                    tmpReader = topReader;
+                    tmpReader._data = tmpReader._data.Slice(bytesRead);
+
+                    isIndefinite = wasIndefinite;
+                    bytesRead += pushedBytesRead;
+                }
+                else
+                {
+                    tmpReader = null;
+                }
+            } while (tmpReader != null);
+
+            return totalLength;
+        }
+
+        private bool TryCopyConstructedBitStringValue(
+            ReadOnlyMemory<byte> source,
+            Span<byte> dest,
+            bool isIndefinite,
+            out int unusedBitCount,
+            out int bytesRead,
+            out int bytesWritten)
+        {
+            // Call CountConstructedBitString to get the required byte and to verify that the
+            // data is well-formed before copying into dest.
+            int contentLength = CountConstructedBitString(source, isIndefinite);
+
+            // Since the unused bits byte from the segments don't count, only one segment
+            // returns 999 (or less), the second segment bumps the count to 1000, and is legal.
+            //
+            // T-REC-X.690-201508 sec 9.2
+            if (RuleSet == AsnEncodingRules.CER && contentLength < MaxCERSegmentSize)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            if (dest.Length < contentLength)
+            {
+                unusedBitCount = 0;
+                bytesRead = 0;
+                bytesWritten = 0;
+                return false;
+            }
+
+            CopyConstructedBitString(
+                source,
+                dest,
+                isIndefinite,
+                out unusedBitCount,
+                out bytesRead,
+                out bytesWritten);
+
+            Debug.Assert(bytesWritten == contentLength);
+            return true;
+        }
+
+        private bool TryReadPrimitiveBitStringValue(
+            Asn1Tag expectedTag,
+            out Asn1Tag actualTag,
+            out int? contentsLength,
+            out int headerLength,
+            out int unusedBitCount,
+            out ReadOnlyMemory<byte> value,
+            out byte normalizedLastByte)
+        {
+            actualTag = ReadTagAndLength(out contentsLength, out headerLength);
+            CheckExpectedTag(actualTag, expectedTag, UniversalTagNumber.BitString);
+
+            if (actualTag.IsConstructed)
+            {
+                if (RuleSet == AsnEncodingRules.DER)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                unusedBitCount = 0;
+                value = default(ReadOnlyMemory<byte>);
+                normalizedLastByte = 0;
+                return false;
+            }
+
+            Debug.Assert(contentsLength.HasValue);
+            ReadOnlyMemory<byte> encodedValue = Slice(_data, headerLength, contentsLength.Value);
+
+            ParsePrimitiveBitStringContents(
+                encodedValue,
+                out unusedBitCount,
+                out value,
+                out normalizedLastByte);
+
+            return true;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Boolean.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Boolean.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a Boolean with tag UNIVERSAL 1.
+        /// </summary>
+        /// <returns>The next value as a Boolean.</returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public bool ReadBoolean() => ReadBoolean(Asn1Tag.Boolean);
+
+        /// <summary>
+        ///   Reads the next value as a Boolean with a specified tag.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <returns>The next value as a Boolean.</returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public bool ReadBoolean(Asn1Tag expectedTag)
+        {
+            Asn1Tag tag = ReadTagAndLength(out int? length, out int headerLength);
+            CheckExpectedTag(tag, expectedTag, UniversalTagNumber.Boolean);
+
+            // T-REC-X.690-201508 sec 8.2.1
+            if (tag.IsConstructed)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            bool value = ReadBooleanValue(
+                Slice(_data, headerLength, length.Value).Span,
+                RuleSet);
+
+            _data = _data.Slice(headerLength + length.Value);
+            return value;
+        }
+
+        private static bool ReadBooleanValue(
+            ReadOnlySpan<byte> source,
+            AsnEncodingRules ruleSet)
+        {
+            // T-REC-X.690-201508 sec 8.2.1
+            if (source.Length != 1)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            byte val = source[0];
+
+            // T-REC-X.690-201508 sec 8.2.2
+            if (val == 0)
+            {
+                return false;
+            }
+
+            // T-REC-X.690-201508 sec 11.1
+            if (val != 0xFF && (ruleSet == AsnEncodingRules.DER || ruleSet == AsnEncodingRules.CER))
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Enumerated.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Enumerated.cs
@@ -1,0 +1,225 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as an Enumerated value with tag UNIVERSAL 10,
+        ///   returning the contents as a <see cref="ReadOnlyMemory{T}"/> over the original data.
+        /// </summary>
+        /// <returns>
+        ///   The bytes of the Enumerated value, in signed big-endian form.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="ReadEnumeratedValue{TEnum}()"/>
+        public ReadOnlyMemory<byte> ReadEnumeratedBytes() =>
+            ReadEnumeratedBytes(Asn1Tag.Enumerated);
+
+        /// <summary>
+        ///   Reads the next value as a Enumerated with a specified tag, returning the contents
+        ///   as a <see cref="ReadOnlyMemory{T}"/> over the original data.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <returns>
+        ///   The bytes of the Enumerated value, in signed big-endian form.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <seealso cref="ReadEnumeratedValue{TEnum}(Asn1Tag)"/>
+        public ReadOnlyMemory<byte> ReadEnumeratedBytes(Asn1Tag expectedTag)
+        {
+            // T-REC-X.690-201508 sec 8.4 says the contents are the same as for integers.
+            ReadOnlyMemory<byte> contents =
+                GetIntegerContents(expectedTag, UniversalTagNumber.Enumerated, out int headerLength);
+
+            _data = _data.Slice(headerLength + contents.Length);
+            return contents;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Enumerated value with tag UNIVERSAL 10, converting it to
+        ///   the non-[<see cref="FlagsAttribute"/>] enum specfied by <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <typeparam name="TEnum">Destination enum type</typeparam>
+        /// <returns>
+        ///   the Enumerated value converted to a <typeparamref name="TEnum"/>.
+        /// </returns>
+        /// <remarks>
+        ///   This method does not validate that the return value is defined within
+        ///   <typeparamref name="TEnum"/>.
+        /// </remarks>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the encoded value is too big to fit in a <typeparamref name="TEnum"/> value
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <typeparamref name="TEnum"/> is not an enum type --OR--
+        ///   <typeparamref name="TEnum"/> was declared with <see cref="FlagsAttribute"/>
+        /// </exception>
+        /// <seealso cref="ReadEnumeratedValue{TEnum}(Asn1Tag)"/>
+        public TEnum ReadEnumeratedValue<TEnum>() where TEnum : struct
+        {
+            Type tEnum = typeof(TEnum);
+
+            return (TEnum)Enum.ToObject(tEnum, ReadEnumeratedValue(tEnum));
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Enumerated with tag UNIVERSAL 10, converting it to the
+        ///   non-[<see cref="FlagsAttribute"/>] enum specfied by <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <typeparam name="TEnum">Destination enum type</typeparam>
+        /// <returns>
+        ///   the Enumerated value converted to a <typeparamref name="TEnum"/>.
+        /// </returns>
+        /// <remarks>
+        ///   This method does not validate that the return value is defined within
+        ///   <typeparamref name="TEnum"/>.
+        /// </remarks>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the encoded value is too big to fit in a <typeparamref name="TEnum"/> value
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <typeparamref name="TEnum"/> is not an enum type --OR--
+        ///   <typeparamref name="TEnum"/> was declared with <see cref="FlagsAttribute"/>
+        ///   --OR--
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public TEnum ReadEnumeratedValue<TEnum>(Asn1Tag expectedTag) where TEnum : struct
+        {
+            Type tEnum = typeof(TEnum);
+
+            return (TEnum)Enum.ToObject(tEnum, ReadEnumeratedValue(expectedTag, tEnum));
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Enumerated value with tag UNIVERSAL 10, converting it to
+        ///   the non-[<see cref="FlagsAttribute"/>] enum specfied by <paramref name="tEnum"/>.
+        /// </summary>
+        /// <param name="tEnum">Type object representing the destination type.</param>
+        /// <returns>
+        ///   the Enumerated value converted to a <paramref name="tEnum"/>.
+        /// </returns>
+        /// <remarks>
+        ///   This method does not validate that the return value is defined within
+        ///   <paramref name="tEnum"/>.
+        /// </remarks>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the encoded value is too big to fit in a <paramref name="tEnum"/> value
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tEnum"/> is not an enum type --OR--
+        ///   <paramref name="tEnum"/> was declared with <see cref="FlagsAttribute"/>
+        /// </exception>
+        /// <seealso cref="ReadEnumeratedValue(Asn1Tag, Type)"/>
+        public Enum ReadEnumeratedValue(Type tEnum) =>
+            ReadEnumeratedValue(Asn1Tag.Enumerated, tEnum);
+
+        /// <summary>
+        ///   Reads the next value as an Enumerated with tag UNIVERSAL 10, converting it to the
+        ///   non-[<see cref="FlagsAttribute"/>] enum specfied by <paramref name="tEnum"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="tEnum">Type object representing the destination type.</param>
+        /// <returns>
+        ///   the Enumerated value converted to a <paramref name="tEnum"/>.
+        /// </returns>
+        /// <remarks>
+        ///   This method does not validate that the return value is defined within
+        ///   <paramref name="tEnum"/>.
+        /// </remarks>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the encoded value is too big to fit in a <paramref name="tEnum"/> value
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tEnum"/> is not an enum type --OR--
+        ///   <paramref name="tEnum"/> was declared with <see cref="FlagsAttribute"/>
+        ///   --OR--
+        ///   <paramref name="tEnum"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tEnum"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public Enum ReadEnumeratedValue(Asn1Tag expectedTag, Type tEnum)
+        {
+            const UniversalTagNumber tagNumber = UniversalTagNumber.Enumerated;
+
+            // This will throw an ArgumentException if TEnum isn't an enum type,
+            // so we don't need to validate it.
+            Type backingType = tEnum.GetEnumUnderlyingType();
+
+            if (tEnum.IsDefined(typeof(FlagsAttribute), false))
+            {
+                throw new ArgumentException(
+                    SR.Cryptography_Asn_EnumeratedValueRequiresNonFlagsEnum,
+                    nameof(tEnum));
+            }
+
+            // T-REC-X.690-201508 sec 8.4 says the contents are the same as for integers.
+            int sizeLimit = Marshal.SizeOf(backingType);
+
+            if (backingType == typeof(int) ||
+                backingType == typeof(long) ||
+                backingType == typeof(short) ||
+                backingType == typeof(sbyte))
+            {
+                if (!TryReadSignedInteger(sizeLimit, expectedTag, tagNumber, out long value))
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                return (Enum)Enum.ToObject(tEnum, value);
+            }
+
+            if (backingType == typeof(uint) ||
+                backingType == typeof(ulong) ||
+                backingType == typeof(ushort) ||
+                backingType == typeof(byte))
+            {
+                if (!TryReadUnsignedInteger(sizeLimit, expectedTag, tagNumber, out ulong value))
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                return (Enum)Enum.ToObject(tEnum, value);
+            }
+
+            Debug.Fail($"No handler for type {backingType.Name}");
+            throw new CryptographicException();
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.GeneralizedTime.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.GeneralizedTime.cs
@@ -1,0 +1,404 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a GeneralizedTime with tag UNIVERSAL 24.
+        /// </summary>
+        /// <param name="disallowFractions">
+        ///   <c>true</c> to cause a <see cref="CryptographicException"/> to be thrown if a
+        ///   fractional second is encountered, such as the restriction on the PKCS#7 Signing
+        ///   Time attribute. 
+        /// </param>
+        /// <returns>
+        ///   a DateTimeOffset representing the value encoded in the GeneralizedTime.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public DateTimeOffset ReadGeneralizedTime(bool disallowFractions = false) =>
+            ReadGeneralizedTime(Asn1Tag.GeneralizedTime, disallowFractions);
+
+        /// <summary>
+        ///   Reads the next value as a GeneralizedTime with a specified tag.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="disallowFractions">
+        ///   <c>true</c> to cause a <see cref="CryptographicException"/> to be thrown if a
+        ///   fractional second is encountered, such as the restriction on the PKCS#7 Signing
+        ///   Time attribute. 
+        /// </param>
+        /// <returns>
+        ///   a DateTimeOffset representing the value encoded in the GeneralizedTime.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public DateTimeOffset ReadGeneralizedTime(Asn1Tag expectedTag, bool disallowFractions = false)
+        {
+            byte[] rented = null;
+
+            ReadOnlySpan<byte> contents = GetOctetStringContents(
+                expectedTag,
+                UniversalTagNumber.GeneralizedTime,
+                out int bytesRead,
+                ref rented);
+
+            DateTimeOffset value = ParseGeneralizedTime(RuleSet, contents, disallowFractions);
+
+            if (rented != null)
+            {
+                Array.Clear(rented, 0, contents.Length);
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+
+            _data = _data.Slice(bytesRead);
+            return value;
+        }
+
+        private static DateTimeOffset ParseGeneralizedTime(
+            AsnEncodingRules ruleSet,
+            ReadOnlySpan<byte> contentOctets,
+            bool disallowFractions)
+        {
+            // T-REC-X.680-201510 sec 46 defines a lot of formats for GeneralizedTime.
+            //
+            // All formats start with yyyyMMdd.
+            //
+            // "Local time" formats are
+            //   [date]HH.fractionOfAnHourToAnArbitraryPrecision
+            //   [date]HHmm.fractionOfAMinuteToAnArbitraryPrecision
+            //   [date]HHmmss.fractionOfASecondToAnArbitraryPrecision
+            //
+            // "UTC time" formats are the local formats suffixed with 'Z'
+            //
+            // "UTC offset time" formats are the local formats suffixed with
+            //  +HH
+            //  +HHmm
+            //  -HH
+            //  -HHmm
+            //
+            // Since T-REC-X.680-201510 46.3(a)(1) and 46.3(a)(2) both specify the ISO 8601:2004
+            // Basic format, we shall presume that 46.3(a)(3) also meant only the Basic format,
+            // and therefore [+/-]HH:mm (with the colon) are prohibited. (based on ISO 8601:201x-DIS)
+
+            // Since DateTimeOffset doesn't have a notion of
+            // "I'm a local time, but with an unknown offset", the computer's current offset will
+            // be used.
+
+            // T-REC-X.690-201510 sec 11.7 binds CER and DER to a much smaller set of inputs:
+            //  * Only the UTC/Z format can be used.
+            //  * HHmmss must always be used
+            //  * If fractions are present they will be separated by period, never comma.
+            //  * If fractions are present the last digit mustn't be 0.
+
+            bool strict = ruleSet == AsnEncodingRules.DER || ruleSet == AsnEncodingRules.CER;
+            if (strict && contentOctets.Length < 15)
+            {
+                // yyyyMMddHHmmssZ
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+            else if (contentOctets.Length < 10)
+            {
+                // yyyyMMddHH
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            ReadOnlySpan<byte> contents = contentOctets;
+
+            int year = ParseNonNegativeIntAndSlice(ref contents, 4);
+            int month = ParseNonNegativeIntAndSlice(ref contents, 2);
+            int day = ParseNonNegativeIntAndSlice(ref contents, 2);
+            int hour = ParseNonNegativeIntAndSlice(ref contents, 2);
+            int? minute = null;
+            int? second = null;
+            ulong fraction = 0;
+            ulong fractionScale = 1;
+            byte lastFracDigit = 0xFF;
+            TimeSpan? timeOffset = null;
+            bool isZulu = false;
+
+            const byte HmsState = 0;
+            const byte FracState = 1;
+            const byte SuffixState = 2;
+            byte state = HmsState;
+
+            byte? GetNextState(byte octet)
+            {
+                if (octet == 'Z' || octet == '-' || octet == '+')
+                {
+                    return SuffixState;
+                }
+
+                if (octet == '.' || octet == ',')
+                {
+                    return FracState;
+                }
+
+                return null;
+            }
+
+            // This while loop could be rewritten to include the FracState and Suffix
+            // processing steps.  But since there's a forward flow to the state machine
+            // the loop body then needs to account for that.
+            while (state == HmsState && contents.Length != 0)
+            {
+                byte? nextState = GetNextState(contents[0]);
+
+                if (nextState == null)
+                {
+                    if (minute == null)
+                    {
+                        minute = ParseNonNegativeIntAndSlice(ref contents, 2);
+                    }
+                    else if (second == null)
+                    {
+                        second = ParseNonNegativeIntAndSlice(ref contents, 2);
+                    }
+                    else
+                    {
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+                }
+                else
+                {
+                    state = nextState.Value;
+                }
+            }
+
+            if (state == FracState)
+            {
+                if (disallowFractions)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                Debug.Assert(!contents.IsEmpty);
+                byte octet = contents[0];
+                Debug.Assert(state == GetNextState(octet));
+
+                if (octet == '.')
+                {
+                    // Always valid
+                }
+                else if (octet == ',')
+                {
+                    // Valid for BER, but not CER or DER.
+                    // T-REC-X.690-201510 sec 11.7.4
+                    if (strict)
+                    {
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+                }
+                else
+                {
+                    Debug.Fail($"Unhandled value '{octet:X2}' in {nameof(FracState)}");
+                    throw new CryptographicException();
+                }
+
+                contents = contents.Slice(1);
+
+                if (contents.IsEmpty)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                // There are 36,000,000,000 ticks per hour, and hour is our largest scale.
+                // In case the double -> Ticks conversion allows for rounding up we can allow
+                // for a 12th digit.
+
+                if (!Utf8Parser.TryParse(SliceAtMost(contents, 12), out fraction, out int fracLength) ||
+                    fracLength == 0)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                lastFracDigit = (byte)(fraction % 10);
+
+                for (int i = 0; i < fracLength; i++)
+                {
+                    fractionScale *= 10;
+                }
+
+                contents = contents.Slice(fracLength);
+
+                // Drain off any remaining digits.
+                // The unsigned parsers will not accept + or - as a leading character, so
+                // they won't eat timezone suffix.
+                // But Utf8Parser.TryParse reports false on overflow, so limit it to 9 digits at a time.
+                while (Utf8Parser.TryParse(SliceAtMost(contents, 9), out uint nonSemantic, out fracLength))
+                {
+                    contents = contents.Slice(fracLength);
+                    lastFracDigit = (byte)(nonSemantic % 10);
+                }
+
+                if (contents.Length != 0)
+                {
+                    byte? nextState = GetNextState(contents[0]);
+
+                    if (nextState == null)
+                    {
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+
+                    // If this produces FracState we'll finish with a non-empty contents, and still throw.
+                    state = nextState.Value;
+                }
+            }
+
+            if (state == SuffixState)
+            {
+                Debug.Assert(!contents.IsEmpty);
+                byte octet = contents[0];
+                Debug.Assert(state == GetNextState(octet));
+                contents = contents.Slice(1);
+
+                if (octet == 'Z')
+                {
+                    timeOffset = TimeSpan.Zero;
+                    isZulu = true;
+                }
+                else
+                {
+                    bool isMinus;
+
+                    if (octet == '+')
+                    {
+                        isMinus = false;
+                    }
+                    else if (octet == '-')
+                    {
+                        isMinus = true;
+                    }
+                    else
+                    {
+                        Debug.Fail($"Unhandled value '{octet:X2}' in {nameof(SuffixState)}");
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+
+                    if (contents.IsEmpty)
+                    {
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+
+                    int offsetHour = ParseNonNegativeIntAndSlice(ref contents, 2);
+                    int offsetMinute = 0;
+
+                    if (contents.Length != 0)
+                    {
+                        offsetMinute = ParseNonNegativeIntAndSlice(ref contents, 2);
+                    }
+
+                    // ISO 8601:2004 4.2.1 restricts a "minute" value to [00,59].
+                    // The "hour" value is effectively bound to [00,23] by the same section, but
+                    // is bound to [00,14] by DateTimeOffset, so no additional check is required here.
+                    if (offsetMinute > 59)
+                    {
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+
+                    TimeSpan tmp = new TimeSpan(offsetHour, offsetMinute, 0);
+
+                    if (isMinus)
+                    {
+                        tmp = -tmp;
+                    }
+
+                    timeOffset = tmp;
+                }
+            }
+
+            // Was there data after a suffix, or fracstate went re-entrant?
+            if (!contents.IsEmpty)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            // T-REC-X.690-201510 sec 11.7
+            if (strict)
+            {
+                if (!isZulu || !second.HasValue)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                if (lastFracDigit == 0)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+            }
+
+            double frac = (double)fraction / fractionScale;
+            TimeSpan fractionSpan = TimeSpan.Zero;
+
+            if (!minute.HasValue)
+            {
+                minute = 0;
+                second = 0;
+
+                if (fraction != 0)
+                {
+                    // No minutes means this is fractions of an hour
+                    fractionSpan = new TimeSpan((long)(frac * TimeSpan.TicksPerHour));
+                }
+            }
+            else if (!second.HasValue)
+            {
+                second = 0;
+
+                if (fraction != 0)
+                {
+                    // No seconds means this is fractions of a minute
+                    fractionSpan = new TimeSpan((long)(frac * TimeSpan.TicksPerMinute));
+                }
+            }
+            else if (fraction != 0)
+            {
+                // Both minutes and seconds means fractions of a second.
+                fractionSpan = new TimeSpan((long)(frac * TimeSpan.TicksPerSecond));
+            }
+
+            DateTimeOffset value;
+
+            try
+            {
+                if (timeOffset == null)
+                {
+                    // Use the local timezone offset since there's no information in the contents.
+                    // T-REC-X.680-201510 sec 46.2(a).
+                    value = new DateTimeOffset(new DateTime(year, month, day, hour, minute.Value, second.Value));
+                }
+                else
+                {
+                    // T-REC-X.680-201510 sec 46.2(b) or 46.2(c).
+                    value = new DateTimeOffset(year, month, day, hour, minute.Value, second.Value, timeOffset.Value);
+                }
+
+                value += fractionSpan;
+                return value;
+            }
+            catch (Exception e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Integer.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Integer.cs
@@ -1,0 +1,665 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Numerics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as an Integer with tag UNIVERSAL 2, returning the contents
+        ///   as a <see cref="ReadOnlyMemory{T}"/> over the original data.
+        /// </summary>
+        /// <returns>
+        ///   The bytes of the Integer value, in signed big-endian form.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public ReadOnlyMemory<byte> ReadIntegerBytes() =>
+            ReadIntegerBytes(Asn1Tag.Integer);
+
+        /// <summary>
+        ///   Reads the next value as a Integer with a specified tag, returning the contents
+        ///   as a <see cref="ReadOnlyMemory{T}"/> over the original data.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <returns>
+        ///   The bytes of the Integer value, in signed big-endian form.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public ReadOnlyMemory<byte> ReadIntegerBytes(Asn1Tag expectedTag)
+        {
+            ReadOnlyMemory<byte> contents =
+                GetIntegerContents(expectedTag, UniversalTagNumber.Integer, out int headerLength);
+
+            _data = _data.Slice(headerLength + contents.Length);
+            return contents;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Integer with tag UNIVERSAL 2, returning the contents
+        ///   as a <see cref="BigInteger"/>.
+        /// </summary>
+        /// <returns>
+        ///   The bytes of the Integer value, in signed big-endian form.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public BigInteger ReadInteger() => ReadInteger(Asn1Tag.Integer);
+
+        /// <summary>
+        ///   Reads the next value as a Integer with a specified tag, returning the contents
+        ///   as a <see cref="BigInteger"/> over the original data.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <returns>
+        ///   The bytes of the Integer value, in signed big-endian form.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public BigInteger ReadInteger(Asn1Tag expectedTag)
+        {
+            ReadOnlyMemory<byte> contents =
+                GetIntegerContents(expectedTag, UniversalTagNumber.Integer, out int headerLength);
+
+            // TODO: Split this for netcoreapp/netstandard to use the Big-Endian BigInteger parsing
+            byte[] tmp = ArrayPool<byte>.Shared.Rent(contents.Length);
+            BigInteger value;
+
+            try
+            {
+                byte fill = (contents.Span[0] & 0x80) == 0 ? (byte)0 : (byte)0xFF;
+                // Fill the unused portions of tmp with positive or negative padding.
+                new Span<byte>(tmp, contents.Length, tmp.Length - contents.Length).Fill(fill);
+                contents.CopyTo(tmp);
+                // Convert to Little-Endian.
+                AsnWriter.Reverse(new Span<byte>(tmp, 0, contents.Length));
+                value = new BigInteger(tmp);
+            }
+            finally
+            {
+                // Clear the whole tmp so that not even the sign bit is returned to the array pool.
+                Array.Clear(tmp, 0, tmp.Length);
+                ArrayPool<byte>.Shared.Return(tmp);
+            }
+
+            _data = _data.Slice(headerLength + contents.Length);
+            return value;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Integer with tag UNIVERSAL 2, interpreting the contents
+        ///   as an <see cref="int"/>.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the <see cref="int"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="int.MinValue"/> and <see cref="int.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public bool TryReadInt32(out int value) =>
+            TryReadInt32(Asn1Tag.Integer, out value);
+
+        /// <summary>
+        ///   Reads the next value as a Integer with a specified tag, interpreting the contents
+        ///   as an <see cref="int"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="value">
+        ///   On success, receives the <see cref="int"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="int.MinValue"/> and <see cref="int.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public bool TryReadInt32(Asn1Tag expectedTag, out int value)
+        {
+            if (TryReadSignedInteger(sizeof(int), expectedTag, UniversalTagNumber.Integer, out long longValue))
+            {
+                value = (int)longValue;
+                return true;
+            }
+
+            value = 0;
+            return false;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Integer with tag UNIVERSAL 2, interpreting the contents
+        ///   as a <see cref="uint"/>.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the <see cref="uint"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="uint.MinValue"/> and <see cref="uint.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public bool TryReadUInt32(out uint value) =>
+            TryReadUInt32(Asn1Tag.Integer, out value);
+
+        /// <summary>
+        ///   Reads the next value as a Integer with a specified tag, interpreting the contents
+        ///   as a <see cref="uint"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="value">
+        ///   On success, receives the <see cref="uint"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="uint.MinValue"/> and <see cref="uint.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public bool TryReadUInt32(Asn1Tag expectedTag, out uint value)
+        {
+            if (TryReadUnsignedInteger(sizeof(uint), expectedTag, UniversalTagNumber.Integer, out ulong ulongValue))
+            {
+                value = (uint)ulongValue;
+                return true;
+            }
+
+            value = 0;
+            return false;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Integer with tag UNIVERSAL 2, interpreting the contents
+        ///   as a <see cref="long"/>.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the <see cref="long"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="long.MinValue"/> and <see cref="long.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public bool TryReadInt64(out long value) =>
+            TryReadInt64(Asn1Tag.Integer, out value);
+
+        /// <summary>
+        ///   Reads the next value as a Integer with a specified tag, interpreting the contents
+        ///   as an <see cref="long"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="value">
+        ///   On success, receives the <see cref="long"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="long.MinValue"/> and <see cref="long.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public bool TryReadInt64(Asn1Tag expectedTag, out long value)
+        {
+            return TryReadSignedInteger(sizeof(long), expectedTag, UniversalTagNumber.Integer, out value);
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Integer with tag UNIVERSAL 2, interpreting the contents
+        ///   as a <see cref="ulong"/>.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the <see cref="ulong"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="ulong.MinValue"/> and <see cref="ulong.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public bool TryReadUInt64(out ulong value) =>
+            TryReadUInt64(Asn1Tag.Integer, out value);
+
+        /// <summary>
+        ///   Reads the next value as a Integer with a specified tag, interpreting the contents
+        ///   as a <see cref="ulong"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="value">
+        ///   On success, receives the <see cref="ulong"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="ulong.MinValue"/> and <see cref="ulong.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public bool TryReadUInt64(Asn1Tag expectedTag, out ulong value)
+        {
+            return TryReadUnsignedInteger(sizeof(ulong), expectedTag, UniversalTagNumber.Integer, out value);
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Integer with tag UNIVERSAL 2, interpreting the contents
+        ///   as a <see cref="short"/>.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the <see cref="short"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="short.MinValue"/> and <see cref="short.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public bool TryReadInt16(out short value) =>
+            TryReadInt16(Asn1Tag.Integer, out value);
+
+        /// <summary>
+        ///   Reads the next value as a Integer with a specified tag, interpreting the contents
+        ///   as an <see cref="short"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="value">
+        ///   On success, receives the <see cref="short"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="short.MinValue"/> and <see cref="short.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public bool TryReadInt16(Asn1Tag expectedTag, out short value)
+        {
+            if (TryReadSignedInteger(sizeof(short), expectedTag, UniversalTagNumber.Integer, out long longValue))
+            {
+                value = (short)longValue;
+                return true;
+            }
+
+            value = 0;
+            return false;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Integer with tag UNIVERSAL 2, interpreting the contents
+        ///   as a <see cref="ushort"/>.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the <see cref="ushort"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="ushort.MinValue"/> and <see cref="ushort.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public bool TryReadUInt16(out ushort value) =>
+            TryReadUInt16(Asn1Tag.Integer, out value);
+
+        /// <summary>
+        ///   Reads the next value as a Integer with a specified tag, interpreting the contents
+        ///   as a <see cref="ushort"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="value">
+        ///   On success, receives the <see cref="ushort"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="ushort.MinValue"/> and <see cref="ushort.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public bool TryReadUInt16(Asn1Tag expectedTag, out ushort value)
+        {
+            if (TryReadUnsignedInteger(sizeof(ushort), expectedTag, UniversalTagNumber.Integer, out ulong ulongValue))
+            {
+                value = (ushort)ulongValue;
+                return true;
+            }
+
+            value = 0;
+            return false;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Integer with tag UNIVERSAL 2, interpreting the contents
+        ///   as an <see cref="sbyte"/>.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the <see cref="sbyte"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="sbyte.MinValue"/> and <see cref="sbyte.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public bool TryReadInt8(out sbyte value) =>
+            TryReadInt8(Asn1Tag.Integer, out value);
+
+        /// <summary>
+        ///   Reads the next value as a Integer with a specified tag, interpreting the contents
+        ///   as an <see cref="sbyte"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="value">
+        ///   On success, receives the <see cref="sbyte"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="sbyte.MinValue"/> and <see cref="sbyte.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the Integer value is not valid
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public bool TryReadInt8(Asn1Tag expectedTag, out sbyte value)
+        {
+            if (TryReadSignedInteger(sizeof(sbyte), expectedTag, UniversalTagNumber.Integer, out long longValue))
+            {
+                value = (sbyte)longValue;
+                return true;
+            }
+
+            value = 0;
+            return false;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Integer with tag UNIVERSAL 2, interpreting the contents
+        ///   as a <see cref="byte"/>.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the <see cref="byte"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="byte.MinValue"/> and <see cref="byte.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public bool TryReadUInt8(out byte value) =>
+            TryReadUInt8(Asn1Tag.Integer, out value);
+
+        /// <summary>
+        ///   Reads the next value as a Integer with a specified tag, interpreting the contents
+        ///   as a <see cref="byte"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="value">
+        ///   On success, receives the <see cref="byte"/> value represented
+        /// </param>
+        /// <returns>
+        ///   <c>false</c> and does not advance the reader if the value is not between
+        ///   <see cref="byte.MinValue"/> and <see cref="byte.MaxValue"/>, inclusive; otherwise
+        ///   <c>true</c> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public bool TryReadUInt8(Asn1Tag expectedTag, out byte value)
+        {
+            if (TryReadUnsignedInteger(sizeof(byte), expectedTag, UniversalTagNumber.Integer, out ulong ulongValue))
+            {
+                value = (byte)ulongValue;
+                return true;
+            }
+
+            value = 0;
+            return false;
+        }
+
+        private ReadOnlyMemory<byte> GetIntegerContents(
+            Asn1Tag expectedTag,
+            UniversalTagNumber tagNumber,
+            out int headerLength)
+        {
+            Asn1Tag tag = ReadTagAndLength(out int? length, out headerLength);
+            CheckExpectedTag(tag, expectedTag, tagNumber);
+
+            // T-REC-X.690-201508 sec 8.3.1
+            if (tag.IsConstructed || length < 1)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            // Slice first so that an out of bounds value triggers a CryptographicException.
+            ReadOnlyMemory<byte> contents = Slice(_data, headerLength, length.Value);
+            ReadOnlySpan<byte> contentSpan = contents.Span;
+
+            // T-REC-X.690-201508 sec 8.3.2
+            if (contents.Length > 1)
+            {
+                ushort bigEndianValue = (ushort)(contentSpan[0] << 8 | contentSpan[1]);
+                const ushort RedundancyMask = 0b1111_1111_1000_0000;
+                ushort masked = (ushort)(bigEndianValue & RedundancyMask);
+
+                // If the first 9 bits are all 0 or are all 1, the value is invalid.
+                if (masked == 0 || masked == RedundancyMask)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+            }
+
+            return contents;
+        }
+
+        private bool TryReadSignedInteger(
+            int sizeLimit,
+            Asn1Tag expectedTag,
+            UniversalTagNumber tagNumber,
+            out long value)
+        {
+            Debug.Assert(sizeLimit <= sizeof(long));
+
+            ReadOnlyMemory<byte> contents = GetIntegerContents(expectedTag, tagNumber, out int headerLength);
+
+            if (contents.Length > sizeLimit)
+            {
+                value = 0;
+                return false;
+            }
+
+            ReadOnlySpan<byte> contentSpan = contents.Span;
+
+            bool isNegative = (contentSpan[0] & 0x80) != 0;
+            long accum = isNegative ? -1 : 0;
+
+            for (int i = 0; i < contents.Length; i++)
+            {
+                accum <<= 8;
+                accum |= contentSpan[i];
+            }
+
+            _data = _data.Slice(headerLength + contents.Length);
+            value = accum;
+            return true;
+        }
+
+        private bool TryReadUnsignedInteger(
+            int sizeLimit,
+            Asn1Tag expectedTag,
+            UniversalTagNumber tagNumber,
+            out ulong value)
+        {
+            Debug.Assert(sizeLimit <= sizeof(ulong));
+
+            ReadOnlyMemory<byte> contents = GetIntegerContents(expectedTag, tagNumber, out int headerLength);
+            ReadOnlySpan<byte> contentSpan = contents.Span;
+            int contentLength = contents.Length;
+
+            bool isNegative = (contentSpan[0] & 0x80) != 0;
+
+            if (isNegative)
+            {
+                value = 0;
+                return false;
+            }
+
+            // Ignore any padding zeros.
+            if (contentSpan.Length > 1 && contentSpan[0] == 0)
+            {
+                contentSpan = contentSpan.Slice(1);
+            }
+
+            if (contentSpan.Length > sizeLimit)
+            {
+                value = 0;
+                return false;
+            }
+
+            ulong accum = 0;
+
+            for (int i = 0; i < contentSpan.Length; i++)
+            {
+                accum <<= 8;
+                accum |= contentSpan[i];
+            }
+
+            _data = _data.Slice(headerLength + contentLength);
+            value = accum;
+            return true;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.NamedBitList.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.NamedBitList.cs
@@ -1,0 +1,268 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a NamedBitList with tag UNIVERSAL 3, converting it to the
+        ///   [<see cref="FlagsAttribute"/>] enum specfied by <typeparamref name="TFlagsEnum"/>.
+        /// </summary>
+        /// <typeparam name="TFlagsEnum">Destination enum type</typeparam>
+        /// <returns>
+        ///   the NamedBitList value converted to a <typeparamref name="TFlagsEnum"/>.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the encoded value is too big to fit in a <typeparamref name="TFlagsEnum"/> value
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <typeparamref name="TFlagsEnum"/> is not an enum type --OR--
+        ///   <typeparamref name="TFlagsEnum"/> was not declared with <see cref="FlagsAttribute"/>
+        /// </exception>
+        /// <seealso cref="ReadNamedBitListValue{TFlagsEnum}(Asn1Tag)"/>
+        public TFlagsEnum ReadNamedBitListValue<TFlagsEnum>() where TFlagsEnum : struct =>
+            ReadNamedBitListValue<TFlagsEnum>(Asn1Tag.PrimitiveBitString);
+
+        /// <summary>
+        ///   Reads the next value as a NamedBitList with tag UNIVERSAL 3, converting it to the
+        ///   [<see cref="FlagsAttribute"/>] enum specfied by <typeparamref name="TFlagsEnum"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <typeparam name="TFlagsEnum">Destination enum type</typeparam>
+        /// <returns>
+        ///   the NamedBitList value converted to a <typeparamref name="TFlagsEnum"/>.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the encoded value is too big to fit in a <typeparamref name="TFlagsEnum"/> value
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <typeparamref name="TFlagsEnum"/> is not an enum type --OR--
+        ///   <typeparamref name="TFlagsEnum"/> was not declared with <see cref="FlagsAttribute"/>
+        ///   --OR--
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <remarks>
+        ///   The bit alignment performed by this method is to interpret the most significant bit
+        ///   in the first byte of the value as the least significant bit in <typeparamref name="TFlagsEnum"/>,
+        ///   with bits increasing in value until the least significant bit of the first byte, proceeding
+        ///   with the most significant bit of the second byte, and so on. Under this scheme, the following
+        ///   ASN.1 type declaration and C# enumeration can be used together:
+        ///
+        ///   <code>
+        ///     KeyUsage ::= BIT STRING {
+        ///       digitalSignature   (0),
+        ///       nonRepudiation     (1),
+        ///       keyEncipherment    (2),
+        ///       dataEncipherment   (3),
+        ///       keyAgreement       (4),
+        ///       keyCertSign        (5),
+        ///       cRLSign            (6),
+        ///       encipherOnly       (7),
+        ///       decipherOnly       (8) }
+        ///   </code>
+        ///
+        ///   <code>
+        ///     [Flags]
+        ///     enum KeyUsage
+        ///     {
+        ///         None              = 0,
+        ///         DigitalSignature  = 1 &lt;&lt; (0),
+        ///         NonRepudiation    = 1 &lt;&lt; (1),
+        ///         KeyEncipherment   = 1 &lt;&lt; (2),
+        ///         DataEncipherment  = 1 &lt;&lt; (3),
+        ///         KeyAgreement      = 1 &lt;&lt; (4),
+        ///         KeyCertSign       = 1 &lt;&lt; (5),
+        ///         CrlSign           = 1 &lt;&lt; (6),
+        ///         EncipherOnly      = 1 &lt;&lt; (7),
+        ///         DecipherOnly      = 1 &lt;&lt; (8),
+        ///     }
+        ///   </code>
+        ///
+        ///   Note that while the example here uses the KeyUsage NamedBitList from
+        ///   <a href="https://tools.ietf.org/html/rfc3280#section-4.2.1.3">RFC 3280 (4.2.1.3)</a>,
+        ///   the example enum uses values thar are different from
+        ///   <see cref="System.Security.Cryptography.X509Certificates.X509KeyUsageFlags"/>.
+        /// </remarks>
+        public TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(Asn1Tag expectedTag) where TFlagsEnum : struct
+        {
+            Type tFlagsEnum = typeof(TFlagsEnum);
+
+            return (TFlagsEnum)Enum.ToObject(tFlagsEnum, ReadNamedBitListValue(expectedTag, tFlagsEnum));
+        }
+
+        /// <summary>
+        ///   Reads the next value as a NamedBitList with tag UNIVERSAL 3, converting it to the
+        ///   [<see cref="FlagsAttribute"/>] enum specfied by <paramref name="tFlagsEnum"/>.
+        /// </summary>
+        /// <param name="tFlagsEnum">Type object representing the destination type.</param>
+        /// <returns>
+        ///   the NamedBitList value converted to a <paramref name="tFlagsEnum"/>.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the encoded value is too big to fit in a <paramref name="tFlagsEnum"/> value
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tFlagsEnum"/> is not an enum type --OR--
+        ///   <paramref name="tFlagsEnum"/> was not declared with <see cref="FlagsAttribute"/>
+        /// </exception>
+        /// <seealso cref="ReadNamedBitListValue{TFlagsEnum}(Asn1Tag)"/>
+        public Enum ReadNamedBitListValue(Type tFlagsEnum) =>
+            ReadNamedBitListValue(Asn1Tag.PrimitiveBitString, tFlagsEnum);
+
+        /// <summary>
+        ///   Reads the next value as a NamedBitList with tag UNIVERSAL 3, converting it to the
+        ///   [<see cref="FlagsAttribute"/>] enum specfied by <paramref name="tFlagsEnum"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="tFlagsEnum">Type object representing the destination type.</param>
+        /// <returns>
+        ///   the NamedBitList value converted to a <paramref name="tFlagsEnum"/>.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR---
+        ///   the encoded value is too big to fit in a <paramref name="tFlagsEnum"/> value
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tFlagsEnum"/> is not an enum type --OR--
+        ///   <paramref name="tFlagsEnum"/> was not declared with <see cref="FlagsAttribute"/>
+        ///   --OR--
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <seealso cref="ReadNamedBitListValue{TFlagsEnum}(Asn1Tag)"/>
+        public Enum ReadNamedBitListValue(Asn1Tag expectedTag, Type tFlagsEnum)
+        {
+            // This will throw an ArgumentException if TEnum isn't an enum type,
+            // so we don't need to validate it.
+            Type backingType = tFlagsEnum.GetEnumUnderlyingType();
+
+            if (!tFlagsEnum.IsDefined(typeof(FlagsAttribute), false))
+            {
+                throw new ArgumentException(
+                    SR.Cryptography_Asn_NamedBitListRequiresFlagsEnum,
+                    nameof(tFlagsEnum));
+            }
+
+            int sizeLimit = Marshal.SizeOf(backingType);
+            Span<byte> stackSpan = stackalloc byte[sizeLimit];
+            ReadOnlyMemory<byte> saveData = _data;
+
+            // If TryCopyBitStringBytes succeeds but anything else fails _data will have moved,
+            // so if anything throws here just move _data back to what it was.
+            try
+            {
+                if (!TryCopyBitStringBytes(expectedTag, stackSpan, out int unusedBitCount, out int bytesWritten))
+                {
+                    throw new CryptographicException(
+                        SR.Format(SR.Cryptography_Asn_NamedBitListValueTooBig, tFlagsEnum.Name));
+                }
+
+                if (bytesWritten == 0)
+                {
+                    // The mode isn't relevant, zero is always zero.
+                    return (Enum)Enum.ToObject(tFlagsEnum, 0);
+                }
+
+                ReadOnlySpan<byte> valueSpan = stackSpan.Slice(0, bytesWritten);
+
+                // Now that the 0-bounds check is out of the way:
+                // 
+                // T-REC-X.690-201508 sec 11.2.2
+                if (RuleSet == AsnEncodingRules.DER ||
+                    RuleSet == AsnEncodingRules.CER)
+                {
+                    byte lastByte = valueSpan[bytesWritten - 1];
+
+                    // No unused bits tests 0x01, 1 is 0x02, 2 is 0x04, etc.
+                    // We already know that TryCopyBitStringBytes checked that the
+                    // declared unused bits were 0, this checks that the last "used" bit
+                    // isn't also zero.
+                    byte testBit = (byte)(1 << unusedBitCount);
+
+                    if ((lastByte & testBit) == 0)
+                    {
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+                }
+
+                // Consider a NamedBitList defined as
+                //
+                //   SomeList ::= BIT STRING {
+                //     a(0), b(1), c(2), d(3), e(4), f(5), g(6), h(7), i(8), j(9), k(10)
+                //   }
+                //
+                // The BIT STRING encoding of (a | j) is
+                //   unusedBitCount = 6,
+                //   contents: 0x80 0x40  (0b10000000_01000000)
+                //
+                // A the C# exposure of this structure we adhere to is
+                //
+                // [Flags]
+                // enum SomeList
+                // {
+                //     A = 1,
+                //     B = 1 << 1,
+                //     C = 1 << 2,
+                //     ...
+                // }
+                //
+                // Which happens to be exactly backwards from how the bits are encoded, but the complexity
+                // only needs to live here.
+                return (Enum)Enum.ToObject(tFlagsEnum, InterpretNamedBitListReversed(valueSpan));
+            }
+            catch
+            {
+                _data = saveData;
+                throw;
+            }
+        }
+
+        private static long InterpretNamedBitListReversed(ReadOnlySpan<byte> valueSpan)
+        {
+            Debug.Assert(valueSpan.Length <= sizeof(long));
+
+            long accum = 0;
+            long currentBitValue = 1;
+
+            for (int byteIdx = 0; byteIdx < valueSpan.Length; byteIdx++)
+            {
+                byte byteVal = valueSpan[byteIdx];
+
+                for (int bitIndex = 7; bitIndex >= 0; bitIndex--)
+                {
+                    int test = 1 << bitIndex;
+
+                    if ((byteVal & test) != 0)
+                    {
+                        accum |= currentBitValue;
+                    }
+
+                    currentBitValue <<= 1;
+                }
+            }
+
+            return accum;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Null.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Null.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a NULL with tag UNIVERSAL 5.
+        /// </summary>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public void ReadNull() => ReadNull(Asn1Tag.Null);
+
+        /// <summary>
+        ///   Reads the next value as a NULL with a specified tag.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public void ReadNull(Asn1Tag expectedTag)
+        {
+            Asn1Tag tag = ReadTagAndLength(out int? length, out int headerLength);
+            CheckExpectedTag(tag, expectedTag, UniversalTagNumber.Null);
+
+            // T-REC-X.690-201508 sec 8.8.1
+            // T-REC-X.690-201508 sec 8.8.2
+            if (tag.IsConstructed || length != 0)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            _data = _data.Slice(headerLength);
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.OctetString.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.OctetString.cs
@@ -1,0 +1,591 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as an OCTET STRING with tag UNIVERSAL 4, copying the value
+        ///   into a provided destination buffer.
+        /// </summary>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveOctetStringBytes(out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadOctetString()"/>
+        public bool TryCopyOctetStringBytes(
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            return TryCopyOctetStringBytes(
+                Asn1Tag.PrimitiveOctetString,
+                destination,
+                out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as an OCTET STRING with a specified tag, copying the value
+        ///   into a provided destination buffer.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveOctetStringBytes(Asn1Tag,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadOctetString(Asn1Tag)"/>
+        public bool TryCopyOctetStringBytes(
+            Asn1Tag expectedTag,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            if (TryReadPrimitiveOctetStringBytes(
+                expectedTag,
+                out Asn1Tag actualTag,
+                out int? contentLength,
+                out int headerLength,
+                out ReadOnlyMemory<byte> contents))
+            {
+                if (contents.Length > destination.Length)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                contents.Span.CopyTo(destination);
+                bytesWritten = contents.Length;
+                _data = _data.Slice(headerLength + contents.Length);
+                return true;
+            }
+
+            Debug.Assert(actualTag.IsConstructed);
+
+            bool copied = TryCopyConstructedOctetStringContents(
+                Slice(_data, headerLength, contentLength),
+                destination,
+                contentLength == null,
+                out int bytesRead,
+                out bytesWritten);
+
+            if (copied)
+            {
+                _data = _data.Slice(headerLength + bytesRead);
+            }
+
+            return copied;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an OCTET STRING with tag UNIVERSAL 4, copying the value
+        ///   into a provided destination buffer.
+        /// </summary>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveOctetStringBytes(out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadOctetString()"/>
+        public bool TryCopyOctetStringBytes(
+            ArraySegment<byte> destination,
+            out int bytesWritten)
+        {
+            return TryCopyOctetStringBytes(
+                Asn1Tag.PrimitiveOctetString,
+                destination.AsSpan(),
+                out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as an OCTET STRING with a specified tag, copying the value
+        ///   into a provided destination buffer.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveOctetStringBytes(Asn1Tag,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadOctetString(Asn1Tag)"/>
+        public bool TryCopyOctetStringBytes(
+            Asn1Tag expectedTag,
+            ArraySegment<byte> destination,
+            out int bytesWritten)
+        {
+            return TryCopyOctetStringBytes(
+                expectedTag,
+                destination.AsSpan(),
+                out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as an OCTET STRING with tag UNIVERSAL 4, returning the value
+        ///   in a byte array.
+        /// </summary>
+        /// <returns>
+        ///   a copy of the contents in a newly allocated, precisely sized, array.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveOctetStringBytes(out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="TryCopyOctetStringBytes(Span{byte},out int)"/>
+        /// <seealso cref="ReadOctetString(Asn1Tag)"/>
+        public byte[] ReadOctetString()
+        {
+            return ReadOctetString(Asn1Tag.PrimitiveOctetString);
+        }
+
+        /// <summary>
+        ///   Reads the next value as an OCTET STRING with tag UNIVERSAL 4, returning the value
+        ///   in a byte array.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <returns>
+        ///   a copy of the value in a newly allocated, precisely sized, array.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveOctetStringBytes(Asn1Tag,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="TryCopyOctetStringBytes(Asn1Tag,Span{byte},out int)"/>
+        /// <seealso cref="ReadOctetString()"/>
+        public byte[] ReadOctetString(Asn1Tag expectedTag)
+        {
+            ReadOnlyMemory<byte> memory;
+
+            if (TryReadPrimitiveOctetStringBytes(expectedTag, out memory))
+            {
+                return memory.ToArray();
+            }
+
+            memory = PeekEncodedValue();
+
+            // Guaranteed long enough
+            byte[] rented = ArrayPool<byte>.Shared.Rent(memory.Length);
+            int dataLength = 0;
+
+            try
+            {
+                if (!TryCopyOctetStringBytes(expectedTag, rented, out dataLength))
+                {
+                    Debug.Fail("TryCopyOctetStringBytes failed with a pre-allocated buffer");
+                    throw new CryptographicException();
+                }
+
+                byte[] alloc = new byte[dataLength];
+                rented.AsSpan(0, dataLength).CopyTo(alloc);
+                return alloc;
+            }
+            finally
+            {
+                rented.AsSpan(0, dataLength).Clear();
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        private bool TryReadPrimitiveOctetStringBytes(
+            Asn1Tag expectedTag,
+            out Asn1Tag actualTag,
+            out int? contentLength,
+            out int headerLength,
+            out ReadOnlyMemory<byte> contents,
+            UniversalTagNumber universalTagNumber = UniversalTagNumber.OctetString)
+        {
+            actualTag = ReadTagAndLength(out contentLength, out headerLength);
+            CheckExpectedTag(actualTag, expectedTag, universalTagNumber);
+
+            if (actualTag.IsConstructed)
+            {
+                if (RuleSet == AsnEncodingRules.DER)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                contents = default(ReadOnlyMemory<byte>);
+                return false;
+            }
+
+            Debug.Assert(contentLength.HasValue);
+            ReadOnlyMemory<byte> encodedValue = Slice(_data, headerLength, contentLength.Value);
+
+            if (RuleSet == AsnEncodingRules.CER && encodedValue.Length > MaxCERSegmentSize)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            contents = encodedValue;
+            return true;
+        }
+
+        private bool TryReadPrimitiveOctetStringBytes(
+            Asn1Tag expectedTag,
+            UniversalTagNumber universalTagNumber,
+            out ReadOnlyMemory<byte> contents)
+        {
+            if (TryReadPrimitiveOctetStringBytes(
+                expectedTag,
+                out _,
+                out _,
+                out int headerLength,
+                out contents,
+                universalTagNumber))
+            {
+                _data = _data.Slice(headerLength + contents.Length);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an OCTET STRING with tag UNIVERSAL 4, returning the contents
+        ///   as a <see cref="ReadOnlyMemory{T}"/> over the original data.
+        /// </summary>
+        /// <param name="contents">
+        ///   On success, receives a <see cref="ReadOnlyMemory{T}"/> over the original data
+        ///   corresponding to the contents of the OCTET STRING.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if the OCTET STRING value had a primitive encoding,
+        ///   <c>false</c> and does not advance the reader if it had a constructed encoding.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="TryCopyOctetStringBytes(Span{byte},out int)"/>
+        public bool TryReadPrimitiveOctetStringBytes(out ReadOnlyMemory<byte> contents) =>
+            TryReadPrimitiveOctetStringBytes(Asn1Tag.PrimitiveOctetString, out contents);
+
+        /// <summary>
+        ///   Reads the next value as an OCTET STRING with a specified tag, returning the contents
+        ///   as a <see cref="ReadOnlyMemory{T}"/> over the original data.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="contents">
+        ///   On success, receives a <see cref="ReadOnlyMemory{T}"/> over the original data
+        ///   corresponding to the value of the OCTET STRING.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if the OCTET STRING value had a primitive encoding,
+        ///   <c>false</c> and does not advance the reader if it had a constructed encoding.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <seealso cref="TryCopyOctetStringBytes(Asn1Tag,Span{byte},out int)"/>
+        public bool TryReadPrimitiveOctetStringBytes(Asn1Tag expectedTag, out ReadOnlyMemory<byte> contents)
+        {
+            return TryReadPrimitiveOctetStringBytes(expectedTag, UniversalTagNumber.OctetString, out contents);
+        }
+
+        private int CountConstructedOctetString(ReadOnlyMemory<byte> source, bool isIndefinite)
+        {
+            int contentLength = CopyConstructedOctetString(
+                source,
+                Span<byte>.Empty,
+                false,
+                isIndefinite,
+                out _);
+
+            // T-REC-X.690-201508 sec 9.2
+            if (RuleSet == AsnEncodingRules.CER && contentLength <= MaxCERSegmentSize)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            return contentLength;
+        }
+
+        private void CopyConstructedOctetString(
+            ReadOnlyMemory<byte> source,
+            Span<byte> destination,
+            bool isIndefinite,
+            out int bytesRead,
+            out int bytesWritten)
+        {
+            bytesWritten = CopyConstructedOctetString(
+                source,
+                destination,
+                true,
+                isIndefinite,
+                out bytesRead);
+        }
+
+        private int CopyConstructedOctetString(
+            ReadOnlyMemory<byte> source,
+            Span<byte> destination,
+            bool write,
+            bool isIndefinite,
+            out int bytesRead)
+        {
+            bytesRead = 0;
+            int lastSegmentLength = MaxCERSegmentSize;
+
+            AsnReader tmpReader = new AsnReader(source, RuleSet);
+            Stack<(AsnReader, bool, int)> readerStack = null;
+            int totalLength = 0;
+            Asn1Tag tag = Asn1Tag.ConstructedBitString;
+            Span<byte> curDest = destination;
+
+            do
+            {
+                while (tmpReader.HasData)
+                {
+                    tag = tmpReader.ReadTagAndLength(out int? length, out int headerLength);
+
+                    if (tag == Asn1Tag.PrimitiveOctetString)
+                    {
+                        if (RuleSet == AsnEncodingRules.CER && lastSegmentLength != MaxCERSegmentSize)
+                        {
+                            // T-REC-X.690-201508 sec 9.2
+                            throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                        }
+
+                        Debug.Assert(length != null);
+
+                        // The call to Slice here sanity checks the data bounds, length.Value is not
+                        // reliable unless this call has succeeded.
+                        ReadOnlyMemory<byte> contents = Slice(tmpReader._data, headerLength, length.Value);
+
+                        int localLen = headerLength + contents.Length;
+                        tmpReader._data = tmpReader._data.Slice(localLen);
+
+                        bytesRead += localLen;
+                        totalLength += contents.Length;
+                        lastSegmentLength = contents.Length;
+
+                        if (RuleSet == AsnEncodingRules.CER && lastSegmentLength > MaxCERSegmentSize)
+                        {
+                            // T-REC-X.690-201508 sec 9.2
+                            throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                        }
+
+                        if (write)
+                        {
+                            contents.Span.CopyTo(curDest);
+                            curDest = curDest.Slice(contents.Length);
+                        }
+                    }
+                    else if (tag == Asn1Tag.EndOfContents && isIndefinite)
+                    {
+                        ValidateEndOfContents(tag, length, headerLength);
+
+                        bytesRead += headerLength;
+
+                        if (readerStack?.Count > 0)
+                        {
+                            (AsnReader topReader, bool wasIndefinite, int pushedBytesRead) = readerStack.Pop();
+                            topReader._data = topReader._data.Slice(bytesRead);
+
+                            bytesRead += pushedBytesRead;
+                            isIndefinite = wasIndefinite;
+                            tmpReader = topReader;
+                        }
+                        else
+                        {
+                            // We have matched the EndOfContents that brought us here.
+                            break;
+                        }
+                    }
+                    else if (tag == Asn1Tag.ConstructedOctetString)
+                    {
+                        if (RuleSet == AsnEncodingRules.CER)
+                        {
+                            // T-REC-X.690-201508 sec 9.2
+                            throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                        }
+
+                        if (readerStack == null)
+                        {
+                            readerStack = new Stack<(AsnReader, bool, int)>();
+                        }
+
+                        readerStack.Push((tmpReader, isIndefinite, bytesRead));
+
+                        tmpReader = new AsnReader(
+                            Slice(tmpReader._data, headerLength, length),
+                            RuleSet);
+
+                        bytesRead = headerLength;
+                        isIndefinite = (length == null);
+                    }
+                    else
+                    {
+                        // T-REC-X.690-201508 sec 8.6.4.1 (in particular, Note 2)
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+                }
+
+                if (isIndefinite && tag != Asn1Tag.EndOfContents)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                if (readerStack?.Count > 0)
+                {
+                    (AsnReader topReader, bool wasIndefinite, int pushedBytesRead) = readerStack.Pop();
+
+                    tmpReader = topReader;
+                    tmpReader._data = tmpReader._data.Slice(bytesRead);
+
+                    isIndefinite = wasIndefinite;
+                    bytesRead += pushedBytesRead;
+                }
+                else
+                {
+                    tmpReader = null;
+                }
+            } while (tmpReader != null);
+
+            return totalLength;
+        }
+
+        private bool TryCopyConstructedOctetStringContents(
+            ReadOnlyMemory<byte> source,
+            Span<byte> dest,
+            bool isIndefinite,
+            out int bytesRead,
+            out int bytesWritten)
+        {
+            bytesRead = 0;
+
+            int contentLength = CountConstructedOctetString(source, isIndefinite);
+
+            if (dest.Length < contentLength)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            CopyConstructedOctetString(source, dest, isIndefinite, out bytesRead, out bytesWritten);
+
+            Debug.Assert(bytesWritten == contentLength);
+            return true;
+        }
+
+        private ReadOnlySpan<byte> GetOctetStringContents(
+            Asn1Tag expectedTag,
+            UniversalTagNumber universalTagNumber,
+            out int bytesRead,
+            ref byte[] rented,
+            Span<byte> tmpSpace = default)
+        {
+            Debug.Assert(rented == null);
+
+            if (TryReadPrimitiveOctetStringBytes(
+                expectedTag,
+                out Asn1Tag actualTag,
+                out int? contentLength,
+                out int headerLength,
+                out ReadOnlyMemory<byte> contentsOctets,
+                universalTagNumber))
+            {
+                bytesRead = headerLength + contentsOctets.Length;
+                return contentsOctets.Span;
+            }
+
+            Debug.Assert(actualTag.IsConstructed);
+
+            ReadOnlyMemory<byte> source = Slice(_data, headerLength, contentLength);
+            bool isIndefinite = contentLength == null;
+            int octetStringLength = CountConstructedOctetString(source, isIndefinite);
+
+            if (tmpSpace.Length < octetStringLength)
+            {
+                rented = ArrayPool<byte>.Shared.Rent(octetStringLength);
+                tmpSpace = rented;
+            }
+
+            CopyConstructedOctetString(
+                source,
+                tmpSpace,
+                isIndefinite,
+                out int localBytesRead,
+                out int bytesWritten);
+
+            Debug.Assert(bytesWritten == octetStringLength);
+
+            bytesRead = headerLength + localBytesRead;
+            return tmpSpace.Slice(0, bytesWritten);
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Oid.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Oid.cs
@@ -1,0 +1,314 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Numerics;
+using System.Text;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as an OBJECT IDENTIFIER with tag UNIVERSAL 6, returning
+        ///   the value in a dotted decimal format string.
+        /// </summary>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public string ReadObjectIdentifierAsString() =>
+            ReadObjectIdentifierAsString(Asn1Tag.ObjectIdentifier);
+
+        /// <summary>
+        ///   Reads the next value as an OBJECT IDENTIFIER with a specified tag, returning
+        ///   the value in a dotted decimal format string.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public string ReadObjectIdentifierAsString(Asn1Tag expectedTag)
+        {
+            string oidValue = ReadObjectIdentifierAsString(expectedTag, out int bytesRead);
+
+            _data = _data.Slice(bytesRead);
+
+            return oidValue;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an OBJECT IDENTIFIER with tag UNIVERSAL 6, returning
+        ///   the value as an <see cref="Oid"/>.
+        /// </summary>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public Oid ReadObjectIdentifier() =>
+            ReadObjectIdentifier(Asn1Tag.ObjectIdentifier);
+
+        /// <summary>
+        ///   Reads the next value as an OBJECT IDENTIFIER with a specified tag, returning
+        ///   the value as an <see cref="Oid"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public Oid ReadObjectIdentifier(Asn1Tag expectedTag)
+        {
+            string oidValue = ReadObjectIdentifierAsString(expectedTag, out int bytesRead);
+            // Specifying null for friendly name makes the lookup deferred until first read
+            // of the Oid.FriendlyName property.
+            Oid oid = new Oid(oidValue, null);
+
+            // Don't slice until the return object has been created.
+            _data = _data.Slice(bytesRead);
+
+            return oid;
+        }
+
+        private static void ReadSubIdentifier(
+            ReadOnlySpan<byte> source,
+            out int bytesRead,
+            out long? smallValue,
+            out BigInteger? largeValue)
+        {
+            Debug.Assert(source.Length > 0);
+
+            // T-REC-X.690-201508 sec 8.19.2 (last sentence)
+            if (source[0] == 0x80)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            // First, see how long the segment is
+            int end = -1;
+            int idx;
+
+            for (idx = 0; idx < source.Length; idx++)
+            {
+                // If the high bit isn't set this marks the end of the sub-identifier.
+                bool endOfIdentifier = (source[idx] & 0x80) == 0;
+
+                if (endOfIdentifier)
+                {
+                    end = idx;
+                    break;
+                }
+            }
+
+            if (end < 0)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            bytesRead = end + 1;
+            long accum = 0;
+
+            // Fast path, 9 or fewer bytes => fits in a signed long.
+            // (7 semantic bits per byte * 9 bytes = 63 bits, which leaves the sign bit alone)
+            if (bytesRead <= 9)
+            {
+                for (idx = 0; idx < bytesRead; idx++)
+                {
+                    byte cur = source[idx];
+                    accum <<= 7;
+                    accum |= (byte)(cur & 0x7F);
+                }
+
+                largeValue = null;
+                smallValue = accum;
+                return;
+            }
+
+            // Slow path, needs temporary storage.
+
+            const int SemanticByteCount = 7;
+            const int ContentByteCount = 8;
+
+            // Every 8 content bytes turns into 7 integer bytes, so scale the count appropriately.
+            // Add one while we're shrunk to account for the needed padding byte or the len%8 discarded bytes.
+            int bytesRequired = ((bytesRead / ContentByteCount) + 1) * SemanticByteCount;
+            byte[] tmpBytes = ArrayPool<byte>.Shared.Rent(bytesRequired);
+            // Ensure all the bytes are zeroed out for BigInteger's parsing.
+            Array.Clear(tmpBytes, 0, tmpBytes.Length);
+
+            Span<byte> writeSpan = tmpBytes;
+            Span<byte> accumValueBytes = stackalloc byte[sizeof(long)];
+            int nextStop = bytesRead;
+            idx = bytesRead - ContentByteCount;
+
+            while (nextStop > 0)
+            {
+                byte cur = source[idx];
+
+                accum <<= 7;
+                accum |= (byte)(cur & 0x7F);
+
+                idx++;
+
+                if (idx >= nextStop)
+                {
+                    Debug.Assert(idx == nextStop);
+                    Debug.Assert(writeSpan.Length >= SemanticByteCount);
+
+                    BinaryPrimitives.WriteInt64LittleEndian(accumValueBytes, accum);
+                    Debug.Assert(accumValueBytes[7] == 0);
+                    accumValueBytes.Slice(0, SemanticByteCount).CopyTo(writeSpan);
+                    writeSpan = writeSpan.Slice(SemanticByteCount);
+
+                    accum = 0;
+                    nextStop -= ContentByteCount;
+                    idx = Math.Max(0, nextStop - ContentByteCount);
+                }
+            }
+
+            int bytesWritten = tmpBytes.Length - writeSpan.Length;
+
+            // Verify our bytesRequired calculation. There should be at most 7 padding bytes.
+            // If the length % 8 is 7 we'll have 0 padding bytes, but the sign bit is still clear.
+            //
+            // 8 content bytes had a sign bit problem, so we gave it a second 7-byte block, 7 remain.
+            // 7 content bytes got a single block but used and wrote 7 bytes, but only 49 of the 56 bits.
+            // 6 content bytes have a padding count of 1.
+            // 1 content byte has a padding count of 6.
+            // 0 content bytes is illegal, but see 8 for the cycle.
+            int paddingByteCount = bytesRequired - bytesWritten;
+            Debug.Assert(paddingByteCount >= 0 && paddingByteCount < sizeof(long));
+
+            largeValue = new BigInteger(tmpBytes);
+            smallValue = null;
+
+            Array.Clear(tmpBytes, 0, bytesWritten);
+            ArrayPool<byte>.Shared.Return(tmpBytes);
+        }
+
+        private string ReadObjectIdentifierAsString(Asn1Tag expectedTag, out int totalBytesRead)
+        {
+            Asn1Tag tag = ReadTagAndLength(out int? length, out int headerLength);
+            CheckExpectedTag(tag, expectedTag, UniversalTagNumber.ObjectIdentifier);
+
+            // T-REC-X.690-201508 sec 8.19.1
+            // T-REC-X.690-201508 sec 8.19.2 says the minimum length is 1
+            if (tag.IsConstructed || length < 1)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            ReadOnlyMemory<byte> contentsMemory = Slice(_data, headerLength, length.Value);
+            ReadOnlySpan<byte> contents = contentsMemory.Span;
+
+            // Each byte can contribute a 3 digit value and a '.' (e.g. "126."), but usually
+            // they convey one digit and a separator.
+            //
+            // The OID with the most arcs which were found after a 30 minute search is
+            // "1.3.6.1.4.1.311.60.2.1.1" (EV cert jurisdiction of incorporation - locality)
+            // which has 11 arcs.
+            // The longest "known" segment is 16 bytes, a UUID-as-an-arc value.
+            // 16 * 11 = 176 bytes for an "extremely long" OID.
+            //
+            // So pre-allocate the StringBuilder with at most 1020 characters, an input longer than
+            // 255 encoded bytes will just have to re-allocate.
+            StringBuilder builder = new StringBuilder(((byte)contents.Length) * 4);
+
+            ReadSubIdentifier(contents, out int bytesRead, out long? smallValue, out BigInteger? largeValue);
+
+            // T-REC-X.690-201508 sec 8.19.4
+            // The first two subidentifiers (X.Y) are encoded as (X * 40) + Y, because Y is
+            // bounded [0, 39] for X in {0, 1}, and only X in {0, 1, 2} are legal.
+            // So:
+            // * identifier < 40 => X = 0, Y = identifier.
+            // * identifier < 80 => X = 1, Y = identifier - 40.
+            // * else: X = 2, Y = identifier - 80.
+            byte firstArc;
+
+            if (smallValue != null)
+            {
+                long firstIdentifier = smallValue.Value;
+
+                if (firstIdentifier < 40)
+                {
+                    firstArc = 0;
+                }
+                else if (firstIdentifier < 80)
+                {
+                    firstArc = 1;
+                    firstIdentifier -= 40;
+                }
+                else
+                {
+                    firstArc = 2;
+                    firstIdentifier -= 80;
+                }
+
+                builder.Append(firstArc);
+                builder.Append('.');
+                builder.Append(firstIdentifier);
+            }
+            else
+            {
+                Debug.Assert(largeValue != null);
+                BigInteger firstIdentifier = largeValue.Value;
+
+                // We're only here because we were bigger than long.MaxValue, so
+                // we're definitely on arc 2.
+                Debug.Assert(firstIdentifier > long.MaxValue);
+
+                firstArc = 2;
+                firstIdentifier -= 80;
+
+                builder.Append(firstArc);
+                builder.Append('.');
+                builder.Append(firstIdentifier.ToString());
+            }
+
+            contents = contents.Slice(bytesRead);
+
+            while (!contents.IsEmpty)
+            {
+                ReadSubIdentifier(contents, out bytesRead, out smallValue, out largeValue);
+                // Exactly one should be non-null.
+                Debug.Assert((smallValue == null) != (largeValue == null));
+
+                builder.Append('.');
+
+                if (smallValue != null)
+                {
+                    builder.Append(smallValue.Value);
+                }
+                else
+                {
+                    builder.Append(largeValue.Value.ToString());
+                }
+
+                contents = contents.Slice(bytesRead);
+            }
+
+            totalBytesRead = headerLength + length.Value;
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Sequence.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Sequence.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a SEQUENCE or SEQUENCE-OF with tag UNIVERSAL 16
+        ///   and returns the result as an <see cref="AsnReader"/> positioned at the first
+        ///   value in the sequence (or with <see cref="HasData"/> == <c>false</c>).
+        /// </summary>
+        /// <returns>
+        ///   an <see cref="AsnReader"/> positioned at the first
+        ///   value in the sequence (or with <see cref="HasData"/> == <c>false</c>).
+        /// </returns>
+        /// <remarks>
+        ///   the nested content is not evaluated by this method, and may contain data
+        ///   which is not valid under the current encoding rules.
+        /// </remarks>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <see cref="ReadSequence(Asn1Tag)"/>
+        public AsnReader ReadSequence() => ReadSequence(Asn1Tag.Sequence);
+
+        /// <summary>
+        ///   Reads the next value as a SEQUENCE or SEQUENCE-OF with the specified tag
+        ///   and returns the result as an <see cref="AsnReader"/> positioned at the first
+        ///   value in the sequence (or with <see cref="HasData"/> == <c>false</c>).
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <returns>
+        ///   an <see cref="AsnReader"/> positioned at the first
+        ///   value in the sequence (or with <see cref="HasData"/> == <c>false</c>).
+        /// </returns>
+        /// <remarks>
+        ///   the nested content is not evaluated by this method, and may contain data
+        ///   which is not valid under the current encoding rules.
+        /// </remarks>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public AsnReader ReadSequence(Asn1Tag expectedTag)
+        {
+            Asn1Tag tag = ReadTagAndLength(out int? length, out int headerLength);
+            CheckExpectedTag(tag, expectedTag, UniversalTagNumber.Sequence);
+
+            // T-REC-X.690-201508 sec 8.9.1
+            // T-REC-X.690-201508 sec 8.10.1
+            if (!tag.IsConstructed)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            int suffix = 0;
+
+            if (length == null)
+            {
+                length = SeekEndOfContents(_data.Slice(headerLength));
+                suffix = EndOfContentsEncodedLength;
+            }
+
+            ReadOnlyMemory<byte> contents = Slice(_data, headerLength, length.Value);
+
+            _data = _data.Slice(headerLength + contents.Length + suffix);
+            return new AsnReader(contents, RuleSet);
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.SetOf.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.SetOf.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a SET-OF with the specified tag
+        ///   and returns the result as an <see cref="AsnReader"/> positioned at the first
+        ///   value in the set-of (or with <see cref="HasData"/> == <c>false</c>).
+        /// </summary>
+        /// <param name="skipSortOrderValidation">
+        ///   <c>true</c> to always accept the data in the order it is presented,
+        ///   <c>false</c> to verify that the data is sorted correctly when the
+        ///   encoding rules say sorting was required (CER and DER).
+        /// </param>
+        /// <returns>
+        ///   an <see cref="AsnReader"/> positioned at the first
+        ///   value in the set-of (or with <see cref="HasData"/> == <c>false</c>).
+        /// </returns>
+        /// <remarks>
+        ///   the nested content is not evaluated by this method (aside from sort order, when
+        ///   required), and may contain data which is not valid under the current encoding rules.
+        /// </remarks>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        public AsnReader ReadSetOf(bool skipSortOrderValidation = false) =>
+            ReadSetOf(Asn1Tag.SetOf, skipSortOrderValidation);
+
+        /// <summary>
+        ///   Reads the next value as a SET-OF with the specified tag
+        ///   and returns the result as an <see cref="AsnReader"/> positioned at the first
+        ///   value in the set-of (or with <see cref="HasData"/> == <c>false</c>).
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="skipSortOrderValidation">
+        ///   <c>true</c> to always accept the data in the order it is presented,
+        ///   <c>false</c> to verify that the data is sorted correctly when the
+        ///   encoding rules say sorting was required (CER and DER).
+        /// </param>
+        /// <returns>
+        ///   an <see cref="AsnReader"/> positioned at the first
+        ///   value in the set-of (or with <see cref="HasData"/> == <c>false</c>).
+        /// </returns>
+        /// <remarks>
+        ///   the nested content is not evaluated by this method (aside from sort order, when
+        ///   required), and may contain data which is not valid under the current encoding rules.
+        /// </remarks>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public AsnReader ReadSetOf(Asn1Tag expectedTag, bool skipSortOrderValidation = false)
+        {
+            Asn1Tag tag = ReadTagAndLength(out int? length, out int headerLength);
+            CheckExpectedTag(tag, expectedTag, UniversalTagNumber.SetOf);
+
+            // T-REC-X.690-201508 sec 8.12.1
+            if (!tag.IsConstructed)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            int suffix = 0;
+
+            if (length == null)
+            {
+                length = SeekEndOfContents(_data.Slice(headerLength));
+                suffix = EndOfContentsEncodedLength;
+            }
+
+            ReadOnlyMemory<byte> contents = Slice(_data, headerLength, length.Value);
+
+            if (!skipSortOrderValidation)
+            {
+                // T-REC-X.690-201508 sec 11.6
+                // BER data is not required to be sorted.
+                if (RuleSet == AsnEncodingRules.DER ||
+                    RuleSet == AsnEncodingRules.CER)
+                {
+                    AsnReader reader = new AsnReader(contents, RuleSet);
+                    ReadOnlyMemory<byte> current = ReadOnlyMemory<byte>.Empty;
+                    SetOfValueComparer comparer = SetOfValueComparer.Instance;
+
+                    while (reader.HasData)
+                    {
+                        ReadOnlyMemory<byte> previous = current;
+                        current = reader.ReadEncodedValue();
+
+                        if (comparer.Compare(current, previous) < 0)
+                        {
+                            throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                        }
+                    }
+                }
+            }
+
+            _data = _data.Slice(headerLength + contents.Length + suffix);
+            return new AsnReader(contents, RuleSet);
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Text.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.Text.cs
@@ -1,0 +1,730 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as character string with a UNIVERSAL tag appropriate to the specified
+        ///   encoding type, returning the contents as an unprocessed <see cref="ReadOnlyMemory{T}"/>
+        ///   over the original data.
+        /// </summary>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <param name="contents">
+        ///   On success, receives a <see cref="ReadOnlyMemory{T}"/> over the original data
+        ///   corresponding to the contents of the character string.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if the value had a primitive encoding,
+        ///   <c>false</c> and does not advance the reader if it had a constructed encoding.
+        /// </returns>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="TryCopyCharacterStringBytes(UniversalTagNumber,Span{byte},out int)"/>
+        public bool TryReadPrimitiveCharacterStringBytes(
+            UniversalTagNumber encodingType,
+            out ReadOnlyMemory<byte> contents)
+        {
+            return TryReadPrimitiveCharacterStringBytes(
+                new Asn1Tag(encodingType),
+                encodingType,
+                out contents);
+        }
+
+        /// <summary>
+        ///   Reads the next value as a character with a specified tag, returning the contents
+        ///   as an unprocessed <see cref="ReadOnlyMemory{T}"/> over the original data.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <param name="contents">
+        ///   On success, receives a <see cref="ReadOnlyMemory{T}"/> over the original data
+        ///   corresponding to the value of the OCTET STRING.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if the OCTET STRING value had a primitive encoding,
+        ///   <c>false</c> and does not advance the reader if it had a constructed encoding.
+        /// </returns>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not the same as
+        ///   <paramref name="encodingType"/>.
+        /// </exception>
+        /// <seealso cref="TryCopyCharacterStringBytes(Asn1Tag,UniversalTagNumber,Span{byte},out int)"/>
+        public bool TryReadPrimitiveCharacterStringBytes(
+            Asn1Tag expectedTag,
+            UniversalTagNumber encodingType,
+            out ReadOnlyMemory<byte> contents)
+        {
+            CheckCharacterStringEncodingType(encodingType);
+
+            // T-REC-X.690-201508 sec 8.23.3, all character strings are encoded as octet strings.
+            return TryReadPrimitiveOctetStringBytes(expectedTag, encodingType, out contents);
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with a UNIVERSAL tag appropriate to the specified
+        ///   encoding type, copying the value into a provided destination buffer.
+        /// </summary>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes(UniversalTagNumber,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadCharacterString(UniversalTagNumber)"/>
+        /// <seealso cref="TryCopyCharacterString(UniversalTagNumber,Span{char},out int)"/>
+        public bool TryCopyCharacterStringBytes(
+            UniversalTagNumber encodingType,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            return TryCopyCharacterStringBytes(
+                new Asn1Tag(encodingType),
+                encodingType,
+                destination,
+                out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with the specified tag and
+        ///   encoding type, copying the value into a provided destination buffer.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not the same as
+        ///   <paramref name="encodingType"/>.
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes(Asn1Tag,UniversalTagNumber,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadCharacterString(Asn1Tag,UniversalTagNumber)"/>
+        /// <seealso cref="TryCopyCharacterString(Asn1Tag,UniversalTagNumber,Span{char},out int)"/>
+        public bool TryCopyCharacterStringBytes(
+            Asn1Tag expectedTag,
+            UniversalTagNumber encodingType,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            CheckCharacterStringEncodingType(encodingType);
+
+            bool copied = TryCopyCharacterStringBytes(
+                expectedTag,
+                encodingType,
+                destination,
+                out int bytesRead,
+                out bytesWritten);
+
+            if (copied)
+            {
+                _data = _data.Slice(bytesRead);
+            }
+
+            return copied;
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with a UNIVERSAL tag appropriate to the specified
+        ///   encoding type, copying the value into a provided destination buffer.
+        /// </summary>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes(UniversalTagNumber,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadCharacterString(UniversalTagNumber)"/>
+        /// <seealso cref="TryCopyCharacterString(UniversalTagNumber,Span{char},out int)"/>
+        public bool TryCopyCharacterStringBytes(
+            UniversalTagNumber encodingType,
+            ArraySegment<byte> destination,
+            out int bytesWritten)
+        {
+            return TryCopyCharacterStringBytes(
+                new Asn1Tag(encodingType),
+                encodingType,
+                destination.AsSpan(),
+                out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with the specified tag and
+        ///   encoding type, copying the value into a provided destination buffer.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not the same as
+        ///   <paramref name="encodingType"/>.
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes(Asn1Tag,UniversalTagNumber,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadCharacterString(Asn1Tag,UniversalTagNumber)"/>
+        /// <seealso cref="TryCopyCharacterString(Asn1Tag,UniversalTagNumber,Span{char},out int)"/>
+        public bool TryCopyCharacterStringBytes(
+            Asn1Tag expectedTag,
+            UniversalTagNumber encodingType,
+            ArraySegment<byte> destination,
+            out int bytesWritten)
+        {
+            return TryCopyCharacterStringBytes(
+                expectedTag,
+                encodingType,
+                destination.AsSpan(),
+                out bytesWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with a UNIVERSAL tag appropriate to the specified
+        ///   encoding type, copying the decoded value into a provided destination buffer.
+        /// </summary>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="charsWritten">
+        ///   On success, receives the number of chars written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the string did not successfully decode
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes(UniversalTagNumber,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadCharacterString(UniversalTagNumber)"/>
+        /// <seealso cref="TryCopyCharacterStringBytes(UniversalTagNumber,Span{byte},out int)"/>
+        public bool TryCopyCharacterString(
+            UniversalTagNumber encodingType,
+            Span<char> destination,
+            out int charsWritten)
+        {
+            return TryCopyCharacterString(
+                new Asn1Tag(encodingType),
+                encodingType,
+                destination,
+                out charsWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with the specified tag and
+        ///   encoding type, copying the decoded value into a provided destination buffer.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="charsWritten">
+        ///   On success, receives the number of chars written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the string did not successfully decode
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not the same as
+        ///   <paramref name="encodingType"/>.
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes(Asn1Tag,UniversalTagNumber,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="TryCopyCharacterStringBytes(Asn1Tag,UniversalTagNumber,Span{byte},out int)"/>
+        /// <seealso cref="ReadCharacterString(Asn1Tag,UniversalTagNumber)"/>
+        public bool TryCopyCharacterString(
+            Asn1Tag expectedTag,
+            UniversalTagNumber encodingType,
+            Span<char> destination,
+            out int charsWritten)
+        {
+            Text.Encoding encoding = AsnCharacterStringEncodings.GetEncoding(encodingType);
+            return TryCopyCharacterString(expectedTag, encodingType, encoding, destination, out charsWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with a UNIVERSAL tag appropriate to the specified
+        ///   encoding type, copying the decoded value into a provided destination buffer.
+        /// </summary>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="charsWritten">
+        ///   On success, receives the number of chars written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the string did not successfully decode
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes(UniversalTagNumber,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="ReadCharacterString(UniversalTagNumber)"/>
+        /// <seealso cref="TryCopyCharacterStringBytes(UniversalTagNumber,ArraySegment{byte},out int)"/>
+        /// <seealso cref="TryCopyCharacterString(Asn1Tag,UniversalTagNumber,ArraySegment{char},out int)"/>
+        public bool TryCopyCharacterString(
+            UniversalTagNumber encodingType,
+            ArraySegment<char> destination,
+            out int charsWritten)
+        {
+            return TryCopyCharacterString(
+                new Asn1Tag(encodingType),
+                encodingType,
+                destination.AsSpan(),
+                out charsWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with the specified tag and
+        ///   encoding type, copying the decoded value into a provided destination buffer.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="charsWritten">
+        ///   On success, receives the number of chars written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <c>false</c> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the string did not successfully decode
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not the same as
+        ///   <paramref name="encodingType"/>.
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes(Asn1Tag,UniversalTagNumber,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="TryCopyCharacterStringBytes(Asn1Tag,UniversalTagNumber,ArraySegment{byte},out int)"/>
+        /// <seealso cref="ReadCharacterString(Asn1Tag,UniversalTagNumber)"/>
+        public bool TryCopyCharacterString(
+            Asn1Tag expectedTag,
+            UniversalTagNumber encodingType,
+            ArraySegment<char> destination,
+            out int charsWritten)
+        {
+            return TryCopyCharacterString(
+                expectedTag,
+                encodingType,
+                destination.AsSpan(),
+                out charsWritten);
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with a UNIVERSAL tag appropriate to the specified
+        ///   encoding type, returning the decoded value as a <see cref="string"/>.
+        /// </summary>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <returns>
+        ///   the decoded value as a <see cref="string"/>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the string did not successfully decode
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes(UniversalTagNumber,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="TryCopyCharacterStringBytes(UniversalTagNumber,Span{byte},out int)"/>
+        /// <seealso cref="TryCopyCharacterString(UniversalTagNumber,Span{char},out int)"/>
+        /// <seealso cref="ReadCharacterString(Asn1Tag,UniversalTagNumber)"/>
+        public string ReadCharacterString(UniversalTagNumber encodingType) =>
+            ReadCharacterString(new Asn1Tag(encodingType), encodingType);
+
+        /// <summary>
+        ///   Reads the next value as character string with the specified tag and
+        ///   encoding type, returning the decoded value as a <see cref="string"/>.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="encodingType">
+        ///   A <see cref="UniversalTagNumber"/> corresponding to the value type to process.
+        /// </param>
+        /// <returns>
+        ///   the decoded value as a <see cref="string"/>.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules --OR--
+        ///   the string did not successfully decode
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not the same as
+        ///   <paramref name="encodingType"/>.
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes(Asn1Tag,UniversalTagNumber,out ReadOnlyMemory{byte})"/>
+        /// <seealso cref="TryCopyCharacterStringBytes(Asn1Tag,UniversalTagNumber,Span{byte},out int)"/>
+        /// <seealso cref="TryCopyCharacterString(Asn1Tag,UniversalTagNumber,Span{char},out int)"/>
+        public string ReadCharacterString(Asn1Tag expectedTag, UniversalTagNumber encodingType)
+        {
+            Text.Encoding encoding = AsnCharacterStringEncodings.GetEncoding(encodingType);
+            return ReadCharacterString(expectedTag, encodingType, encoding);
+        }
+
+        // T-REC-X.690-201508 sec 8.23
+        private bool TryCopyCharacterStringBytes(
+            Asn1Tag expectedTag,
+            UniversalTagNumber universalTagNumber,
+            Span<byte> destination,
+            out int bytesRead,
+            out int bytesWritten)
+        {
+            // T-REC-X.690-201508 sec 8.23.3, all character strings are encoded as octet strings.
+            if (TryReadPrimitiveOctetStringBytes(
+                expectedTag,
+                out Asn1Tag actualTag,
+                out int? contentLength,
+                out int headerLength,
+                out ReadOnlyMemory<byte> contents,
+                universalTagNumber))
+            {
+                bytesWritten = contents.Length;
+
+                if (destination.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    bytesRead = 0;
+                    return false;
+                }
+
+                contents.Span.CopyTo(destination);
+                bytesRead = headerLength + bytesWritten;
+                return true;
+            }
+
+            Debug.Assert(actualTag.IsConstructed);
+
+            bool copied = TryCopyConstructedOctetStringContents(
+                Slice(_data, headerLength, contentLength),
+                destination,
+                contentLength == null,
+                out int contentBytesRead,
+                out bytesWritten);
+
+            if (copied)
+            {
+                bytesRead = headerLength + contentBytesRead;
+            }
+            else
+            {
+                bytesRead = 0;
+            }
+
+            return copied;
+        }
+
+        private static unsafe bool TryCopyCharacterString(
+            ReadOnlySpan<byte> source,
+            Span<char> destination,
+            Text.Encoding encoding,
+            out int charsWritten)
+        {
+            if (source.Length == 0)
+            {
+                charsWritten = 0;
+                return true;
+            }
+
+            fixed (byte* bytePtr = &MemoryMarshal.GetReference(source))
+            fixed (char* charPtr = &MemoryMarshal.GetReference(destination))
+            {
+                try
+                {
+                    int charCount = encoding.GetCharCount(bytePtr, source.Length);
+
+                    if (charCount > destination.Length)
+                    {
+                        charsWritten = 0;
+                        return false;
+                    }
+
+                    charsWritten = encoding.GetChars(bytePtr, source.Length, charPtr, destination.Length);
+                    Debug.Assert(charCount == charsWritten);
+                }
+                catch (DecoderFallbackException e)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+                }
+
+                return true;
+            }
+        }
+
+        private string ReadCharacterString(
+            Asn1Tag expectedTag,
+            UniversalTagNumber universalTagNumber,
+            Text.Encoding encoding)
+        {
+            byte[] rented = null;
+
+            // T-REC-X.690-201508 sec 8.23.3, all character strings are encoded as octet strings.
+            ReadOnlySpan<byte> contents = GetOctetStringContents(
+                expectedTag,
+                universalTagNumber,
+                out int bytesRead,
+                ref rented);
+
+            try
+            {
+                string str;
+
+                if (contents.Length == 0)
+                {
+                    str = string.Empty;
+                }
+                else
+                {
+                    unsafe
+                    {
+                        fixed (byte* bytePtr = &MemoryMarshal.GetReference(contents))
+                        {
+                            try
+                            {
+                                str = encoding.GetString(bytePtr, contents.Length);
+                            }
+                            catch (DecoderFallbackException e)
+                            {
+                                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+                            }
+                        }
+                    }
+                }
+
+                _data = _data.Slice(bytesRead);
+                return str;
+            }
+            finally
+            {
+                if (rented != null)
+                {
+                    Array.Clear(rented, 0, contents.Length);
+                    ArrayPool<byte>.Shared.Return(rented);
+                }
+            }
+        }
+
+        private bool TryCopyCharacterString(
+            Asn1Tag expectedTag,
+            UniversalTagNumber universalTagNumber,
+            Text.Encoding encoding,
+            Span<char> destination,
+            out int charsWritten)
+        {
+            byte[] rented = null;
+
+            // T-REC-X.690-201508 sec 8.23.3, all character strings are encoded as octet strings.
+            ReadOnlySpan<byte> contents = GetOctetStringContents(
+                expectedTag,
+                universalTagNumber,
+                out int bytesRead,
+                ref rented);
+
+            try
+            {
+                bool copied = TryCopyCharacterString(
+                    contents,
+                    destination,
+                    encoding,
+                    out charsWritten);
+
+                if (copied)
+                {
+                    _data = _data.Slice(bytesRead);
+                }
+
+                return copied;
+            }
+            finally
+            {
+                if (rented != null)
+                {
+                    Array.Clear(rented, 0, contents.Length);
+                    ArrayPool<byte>.Shared.Return(rented);
+                }
+            }
+        }
+
+        private static void CheckCharacterStringEncodingType(UniversalTagNumber encodingType)
+        {
+            // T-REC-X.680-201508 sec 41
+            switch (encodingType)
+            {
+                case UniversalTagNumber.BMPString:
+                case UniversalTagNumber.GeneralString:
+                case UniversalTagNumber.GraphicString:
+                case UniversalTagNumber.IA5String:
+                case UniversalTagNumber.ISO646String:
+                case UniversalTagNumber.NumericString:
+                case UniversalTagNumber.PrintableString:
+                case UniversalTagNumber.TeletexString:
+                // T61String is an alias for TeletexString (already listed)
+                case UniversalTagNumber.UniversalString:
+                case UniversalTagNumber.UTF8String:
+                case UniversalTagNumber.VideotexString:
+                    // VisibleString is an alias for ISO646String (already listed)
+                    return;
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(encodingType));
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.UtcTime.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.UtcTime.cs
@@ -1,0 +1,227 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public partial class AsnReader
+    {
+
+        /// <summary>
+        ///   Reads the next value as a UTCTime with tag UNIVERSAL 23.
+        /// </summary>
+        /// <param name="twoDigitYearMax">
+        ///   The largest year to represent with this value.
+        ///   The default value, 2049, represents the 1950-2049 range for X.509 certificates.
+        /// </param>
+        /// <returns>
+        ///   a DateTimeOffset representing the value encoded in the UTCTime.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <seealso cref="System.Globalization.Calendar.TwoDigitYearMax"/>
+        /// <seealso cref="ReadUtcTime(System.Security.Cryptography.Asn1.Asn1Tag,int)"/>
+        public DateTimeOffset ReadUtcTime(int twoDigitYearMax = 2049) =>
+            ReadUtcTime(Asn1Tag.UtcTime, twoDigitYearMax);
+
+
+        /// <summary>
+        ///   Reads the next value as a UTCTime with a specified tag.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="twoDigitYearMax">
+        ///   The largest year to represent with this value.
+        ///   The default value, 2049, represents the 1950-2049 range for X.509 certificates.
+        /// </param>
+        /// <returns>
+        ///   a DateTimeOffset representing the value encoded in the UTCTime.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   the next value does not have the correct tag --OR--
+        ///   the length encoding is not valid under the current encoding rules --OR--
+        ///   the contents are not valid under the current encoding rules
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <seealso cref="System.Globalization.Calendar.TwoDigitYearMax"/>
+        public DateTimeOffset ReadUtcTime(Asn1Tag expectedTag, int twoDigitYearMax = 2049)
+        {
+            // T-REC-X.680-201510 sec 47.3 says it is IMPLICIT VisibleString, which means
+            // that BER is allowed to do complex constructed forms.
+
+            // The full allowed formats (T-REC-X.680-201510 sec 47.3)
+            // YYMMDDhhmmZ  (a, b1, c1)
+            // YYMMDDhhmm+hhmm (a, b1, c2+)
+            // YYMMDDhhmm-hhmm (a, b1, c2-)
+            // YYMMDDhhmmssZ (a, b2, c1)
+            // YYMMDDhhmmss+hhmm (a, b2, c2+)
+            // YYMMDDhhmmss-hhmm (a, b2, c2-)
+
+            // CER and DER are restricted to YYMMDDhhmmssZ
+            // T-REC-X.690-201510 sec 11.8
+
+            byte[] rented = null;
+            // The longest format is 17 bytes.
+            Span<byte> tmpSpace = stackalloc byte[17];
+
+            ReadOnlySpan<byte> contents = GetOctetStringContents(
+                expectedTag,
+                UniversalTagNumber.UtcTime,
+                out int bytesRead,
+                ref rented,
+                tmpSpace);
+
+            DateTimeOffset value = ParseUtcTime(contents, twoDigitYearMax);
+
+            if (rented != null)
+            {
+                Debug.Fail($"UtcTime did not fit in tmpSpace ({contents.Length} total)");
+                Array.Clear(rented, 0, contents.Length);
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+
+            _data = _data.Slice(bytesRead);
+            return value;
+        }
+
+        private DateTimeOffset ParseUtcTime(ReadOnlySpan<byte> contentOctets, int twoDigitYearMax)
+        {
+            // The full allowed formats (T-REC-X.680-201510 sec 47.3)
+            // a) YYMMDD
+            // b1) hhmm
+            // b2) hhmmss
+            // c1) Z
+            // c2) {+|-}hhmm
+            //
+            // YYMMDDhhmmZ  (a, b1, c1)
+            // YYMMDDhhmm+hhmm (a, b1, c2+)
+            // YYMMDDhhmm-hhmm (a, b1, c2-)
+            // YYMMDDhhmmssZ (a, b2, c1)
+            // YYMMDDhhmmss+hhmm (a, b2, c2+)
+            // YYMMDDhhmmss-hhmm (a, b2, c2-)
+
+            const int NoSecondsZulu = 11;
+            const int NoSecondsOffset = 15;
+            const int HasSecondsZulu = 13;
+            const int HasSecondsOffset = 17;
+
+            // T-REC-X.690-201510 sec 11.8
+            if (RuleSet == AsnEncodingRules.DER || RuleSet == AsnEncodingRules.CER)
+            {
+                if (contentOctets.Length != HasSecondsZulu)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+            }
+
+            // 11, 13, 15, 17 are legal.
+            // Range check + odd.
+            if (contentOctets.Length < NoSecondsZulu ||
+                contentOctets.Length > HasSecondsOffset ||
+                (contentOctets.Length & 1) != 1)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            ReadOnlySpan<byte> contents = contentOctets;
+
+            int year = ParseNonNegativeIntAndSlice(ref contents, 2);
+            int month = ParseNonNegativeIntAndSlice(ref contents, 2);
+            int day = ParseNonNegativeIntAndSlice(ref contents, 2);
+            int hour = ParseNonNegativeIntAndSlice(ref contents, 2);
+            int minute = ParseNonNegativeIntAndSlice(ref contents, 2);
+            int second = 0;
+            int offsetHour = 0;
+            int offsetMinute = 0;
+            bool minus = false;
+
+            if (contentOctets.Length == HasSecondsOffset ||
+                contentOctets.Length == HasSecondsZulu)
+            {
+                second = ParseNonNegativeIntAndSlice(ref contents, 2);
+            }
+
+            if (contentOctets.Length == NoSecondsZulu ||
+                contentOctets.Length == HasSecondsZulu)
+            {
+                if (contents[0] != 'Z')
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+            }
+            else
+            {
+                Debug.Assert(
+                    contentOctets.Length == NoSecondsOffset ||
+                    contentOctets.Length == HasSecondsOffset);
+
+                if (contents[0] == '-')
+                {
+                    minus = true;
+                }
+                else if (contents[0] != '+')
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                contents = contents.Slice(1);
+                offsetHour = ParseNonNegativeIntAndSlice(ref contents, 2);
+                offsetMinute = ParseNonNegativeIntAndSlice(ref contents, 2);
+                Debug.Assert(contents.IsEmpty);
+            }
+
+            // ISO 8601:2004 4.2.1 restricts a "minute" value to [00,59].
+            // The "hour" value is effectively bound to [00,23] by the same section, but
+            // is bound to [00,14] by DateTimeOffset, so no additional check is required here.
+            if (offsetMinute > 59)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            TimeSpan offset = new TimeSpan(offsetHour, offsetMinute, 0);
+
+            if (minus)
+            {
+                offset = -offset;
+            }
+
+            // Apply the twoDigitYearMax value.
+            // Example: year=50, TDYM=2049
+            //  century = 20
+            //  year > 49 => century = 19
+            //  scaledYear = 1900 + 50 = 1950
+            //
+            // Example: year=49, TDYM=2049
+            //  century = 20
+            //  year is not > 49 => century = 20
+            //  scaledYear = 2000 + 49 = 2049
+            int century = twoDigitYearMax / 100;
+
+            if (year > twoDigitYearMax % 100)
+            {
+                century--;
+            }
+
+            int scaledYear = century * 100 + year;
+
+            try
+            {
+                return new DateTimeOffset(scaledYear, month, day, hour, minute, second, offset);
+            }
+            catch (Exception e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnReader.cs
@@ -1,0 +1,457 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers.Text;
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    /// <summary>
+    ///   A stateful, forward-only reader for BER-, CER-, or DER-encoded ASN.1 data.
+    /// </summary>
+    public partial class AsnReader
+    {
+        // T-REC-X.690-201508 sec 9.2
+        internal const int MaxCERSegmentSize = 1000;
+
+        // T-REC-X.690-201508 sec 8.1.5 says only 0000 is legal.
+        private const int EndOfContentsEncodedLength = 2;
+
+        private ReadOnlyMemory<byte> _data;
+
+        /// <summary>
+        ///   The <see cref="AsnEncodingRules"/> in use by this reader.
+        /// </summary>
+        public AsnEncodingRules RuleSet { get; }
+
+        /// <summary>
+        ///   An indication of whether or not the reader has remaining data available to process.
+        /// </summary>
+        public bool HasData => !_data.IsEmpty;
+
+        /// <summary>
+        ///   Construct an <see cref="AsnReader"/> over <paramref name="data"/> with a given ruleset.
+        /// </summary>
+        /// <param name="data">The data to read.</param>
+        /// <param name="ruleSet">The encoding constraints for the reader.</param>
+        /// <remarks>
+        ///   This constructor does not evaluate <paramref name="data"/> for correctness,
+        ///   any correctness checks are done as part of member methods.
+        ///
+        ///   This constructor does not copy <paramref name="data"/>. The caller is responsible for
+        ///   ensuring that the values do not change until the reader is finished.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="ruleSet"/> is not defined.
+        /// </exception>
+        public AsnReader(ReadOnlyMemory<byte> data, AsnEncodingRules ruleSet)
+        {
+            CheckEncodingRules(ruleSet);
+
+            _data = data;
+            RuleSet = ruleSet;
+        }
+
+        /// <summary>
+        ///   Throws a standardized <see cref="CryptographicException"/> if the reader has remaining
+        ///   data, performs no function if <see cref="HasData"/> returns <c>false</c>.
+        /// </summary>
+        /// <remarks>
+        ///   This method provides a standardized target and standardized exception for reading a
+        ///   "closed" structure, such as the nested content for an explicitly tagged value.
+        /// </remarks>
+        public void ThrowIfNotEmpty()
+        {
+            if (HasData)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+        }
+
+        /// <summary>
+        ///   Read the encoded tag at the next data position, without advancing the reader.
+        /// </summary>
+        /// <returns>
+        ///   The decoded <see cref="Asn1Tag"/> value.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   a tag could not be decoded at the reader's current position.
+        /// </exception>
+        public Asn1Tag PeekTag()
+        {
+            if (Asn1Tag.TryDecode(_data.Span, out Asn1Tag tag, out int bytesRead))
+            {
+                return tag;
+            }
+
+            throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+        }
+
+        /// <summary>
+        ///   Get a <see cref="ReadOnlyMemory{T}"/> view of the next encoded value without
+        ///   advancing the reader. For indefinite length encodings this includes the
+        ///   End of Contents marker.
+        /// </summary>
+        /// <returns>A <see cref="ReadOnlyMemory{T}"/> view of the next encoded value.</returns>
+        /// <exception cref="CryptographicException">
+        ///   The reader is positioned at a point where the tag or length is invalid
+        ///   under the current encoding rules.
+        /// </exception>
+        /// <seealso cref="PeekContentBytes"/>
+        /// <seealso cref="ReadEncodedValue"/>
+        public ReadOnlyMemory<byte> PeekEncodedValue()
+        {
+            Asn1Tag tag = ReadTagAndLength(out int? length, out int bytesRead);
+
+            if (length == null)
+            {
+                int contentsLength = SeekEndOfContents(_data.Slice(bytesRead));
+                return Slice(_data, 0, bytesRead + contentsLength + EndOfContentsEncodedLength);
+            }
+
+            return Slice(_data, 0, bytesRead + length.Value);
+        }
+
+        /// <summary>
+        ///   Get a <see cref="ReadOnlyMemory{T}"/> view of the content octets (bytes) of the
+        ///   next encoded value without advancing the reader.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="ReadOnlyMemory{T}"/> view of the contents octets of the next encoded value.
+        /// </returns>
+        /// <exception cref="CryptographicException">
+        ///   The reader is positioned at a point where the tag or length is invalid
+        ///   under the current encoding rules.
+        /// </exception>
+        /// <seealso cref="PeekEncodedValue"/>
+        public ReadOnlyMemory<byte> PeekContentBytes()
+        {
+            Asn1Tag tag = ReadTagAndLength(out int? length, out int bytesRead);
+
+            if (length == null)
+            {
+                return Slice(_data, bytesRead, SeekEndOfContents(_data.Slice(bytesRead)));
+            }
+
+            return Slice(_data, bytesRead, length.Value);
+        }
+
+        /// <summary>
+        ///   Get a <see cref="ReadOnlyMemory{T}"/> view of the next encoded value,
+        ///   and advance the reader past it. For an indefinite length encoding this includes
+        ///   the End of Contents marker.
+        /// </summary>
+        /// <returns>A <see cref="ReadOnlyMemory{T}"/> view of the next encoded value.</returns>
+        /// <seealso cref="PeekEncodedValue"/>
+        public ReadOnlyMemory<byte> ReadEncodedValue()
+        {
+            ReadOnlyMemory<byte> encodedValue = PeekEncodedValue();
+            _data = _data.Slice(encodedValue.Length);
+            return encodedValue;
+        }
+
+        private static bool TryReadLength(
+            ReadOnlySpan<byte> source,
+            AsnEncodingRules ruleSet,
+            out int? length,
+            out int bytesRead)
+        {
+            length = null;
+            bytesRead = 0;
+
+            CheckEncodingRules(ruleSet);
+
+            if (source.IsEmpty)
+            {
+                return false;
+            }
+
+            // T-REC-X.690-201508 sec 8.1.3
+
+            byte lengthOrLengthLength = source[bytesRead];
+            bytesRead++;
+            const byte MultiByteMarker = 0x80;
+
+            // 0x00-0x7F are direct length values.
+            // 0x80 is BER/CER indefinite length.
+            // 0x81-0xFE says that the length takes the next 1-126 bytes.
+            // 0xFF is forbidden.
+            if (lengthOrLengthLength == MultiByteMarker)
+            {
+                // T-REC-X.690-201508 sec 10.1 (DER: Length forms)
+                if (ruleSet == AsnEncodingRules.DER)
+                {
+                    bytesRead = 0;
+                    return false;
+                }
+
+                // Null length == indefinite.
+                return true;
+            }
+
+            if (lengthOrLengthLength < MultiByteMarker)
+            {
+                length = lengthOrLengthLength;
+                return true;
+            }
+
+            if (lengthOrLengthLength == 0xFF)
+            {
+                bytesRead = 0;
+                return false;
+            }
+
+            byte lengthLength = (byte)(lengthOrLengthLength & ~MultiByteMarker);
+
+            // +1 for lengthOrLengthLength
+            if (lengthLength + 1 > source.Length)
+            {
+                bytesRead = 0;
+                return false;
+            }
+
+            // T-REC-X.690-201508 sec 9.1 (CER: Length forms)
+            // T-REC-X.690-201508 sec 10.1 (DER: Length forms)
+            bool minimalRepresentation =
+                ruleSet == AsnEncodingRules.DER || ruleSet == AsnEncodingRules.CER;
+
+            // The ITU-T specifications tecnically allow lengths up to ((2^128) - 1), but
+            // since Span's length is a signed Int32 we're limited to identifying memory
+            // that is within ((2^31) - 1) bytes of the tag start.
+            if (minimalRepresentation && lengthLength > sizeof(int))
+            {
+                bytesRead = 0;
+                return false;
+            }
+
+            uint parsedLength = 0;
+
+            for (int i = 0; i < lengthLength; i++)
+            {
+                byte current = source[bytesRead];
+                bytesRead++;
+
+                if (parsedLength == 0)
+                {
+                    if (minimalRepresentation && current == 0)
+                    {
+                        bytesRead = 0;
+                        return false;
+                    }
+
+                    if (!minimalRepresentation && current != 0)
+                    {
+                        // Under BER rules we could have had padding zeros, so
+                        // once the first data bits come in check that we fit within
+                        // sizeof(int) due to Span bounds.
+
+                        if (lengthLength - i > sizeof(int))
+                        {
+                            bytesRead = 0;
+                            return false;
+                        }
+                    }
+                }
+
+                parsedLength <<= 8;
+                parsedLength |= current;
+            }
+
+            // This value cannot be represented as a Span length.
+            if (parsedLength > int.MaxValue)
+            {
+                bytesRead = 0;
+                return false;
+            }
+
+            if (minimalRepresentation && parsedLength < MultiByteMarker)
+            {
+                bytesRead = 0;
+                return false;
+            }
+
+            Debug.Assert(bytesRead > 0);
+            length = (int)parsedLength;
+            return true;
+        }
+
+        internal Asn1Tag ReadTagAndLength(out int? contentsLength, out int bytesRead)
+        {
+            if (Asn1Tag.TryDecode(_data.Span, out Asn1Tag tag, out int tagBytesRead) &&
+                TryReadLength(_data.Slice(tagBytesRead).Span, RuleSet, out int? length, out int lengthBytesRead))
+            {
+                int allBytesRead = tagBytesRead + lengthBytesRead;
+
+                if (tag.IsConstructed)
+                {
+                    // T-REC-X.690-201508 sec 9.1 (CER: Length forms) says constructed is always indefinite.
+                    if (RuleSet == AsnEncodingRules.CER && length != null)
+                    {
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                    }
+                }
+                else if (length == null)
+                {
+                    // T-REC-X.690-201508 sec 8.1.3.2 says primitive encodings must use a definite form.
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+
+                bytesRead = allBytesRead;
+                contentsLength = length;
+                return tag;
+            }
+
+            throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+        }
+
+        private static void ValidateEndOfContents(Asn1Tag tag, int? length, int headerLength)
+        {
+            // T-REC-X.690-201508 sec 8.1.5 excludes the BER 8100 length form for 0.
+            if (tag.IsConstructed || length != 0 || headerLength != EndOfContentsEncodedLength)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+        }
+
+        /// <summary>
+        /// Get the number of bytes between the start of <paramref name="source" /> and
+        /// the End-of-Contents marker
+        /// </summary>
+        private int SeekEndOfContents(ReadOnlyMemory<byte> source)
+        {
+            ReadOnlyMemory<byte> cur = source;
+            int totalLen = 0;
+
+            AsnReader tmpReader = new AsnReader(cur, RuleSet);
+            // Our reader is bounded by int.MaxValue.
+            // The most aggressive data input would be a one-byte tag followed by
+            // indefinite length "ad infinitum", which would be half the input.
+            // So the depth marker can never overflow the signed integer space.
+            int depth = 1;
+
+            while (tmpReader.HasData)
+            {
+                Asn1Tag tag = tmpReader.ReadTagAndLength(out int? length, out int bytesRead);
+
+                if (tag == Asn1Tag.EndOfContents)
+                {
+                    ValidateEndOfContents(tag, length, bytesRead);
+
+                    depth--;
+
+                    if (depth == 0)
+                    {
+                        // T-REC-X.690-201508 sec 8.1.1.1 / 8.1.1.3 indicate that the
+                        // End-of-Contents octets are "after" the contents octets, not
+                        // "at the end" of them, so we don't include these bytes in the
+                        // accumulator.
+                        return totalLen;
+                    }
+                }
+
+                // We found another indefinite length, that means we need to find another
+                // EndOfContents marker to balance it out.
+                if (length == null)
+                {
+                    depth++;
+                    tmpReader._data = tmpReader._data.Slice(bytesRead);
+                    totalLen += bytesRead;
+                }
+                else
+                {
+                    // This will throw a CryptographicException if the length exceeds our bounds.
+                    ReadOnlyMemory<byte> tlv = Slice(tmpReader._data, 0, bytesRead + length.Value);
+                    
+                    // No exception? Then slice the data and continue.
+                    tmpReader._data = tmpReader._data.Slice(tlv.Length);
+                    totalLen += tlv.Length;
+                }
+            }
+
+            throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+        }
+
+        private static int ParseNonNegativeIntAndSlice(ref ReadOnlySpan<byte> data, int bytesToRead)
+        {
+            int value = ParseNonNegativeInt(Slice(data, 0, bytesToRead));
+            data = data.Slice(bytesToRead);
+
+            return value;
+        }
+
+        private static int ParseNonNegativeInt(ReadOnlySpan<byte> data)
+        {
+            if (Utf8Parser.TryParse(data, out uint value, out int consumed) &&
+                value <= int.MaxValue &&
+                consumed == data.Length)
+            {
+                return (int)value;
+            }
+
+            throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+        }
+
+        private static ReadOnlySpan<byte> SliceAtMost(ReadOnlySpan<byte> source, int longestPermitted)
+        {
+            int len = Math.Min(longestPermitted, source.Length);
+            return source.Slice(0, len);
+        }
+
+        private static ReadOnlySpan<byte> Slice(ReadOnlySpan<byte> source, int offset, int length)
+        {
+            Debug.Assert(offset >= 0);
+
+            if (length < 0 || source.Length - offset < length)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            return source.Slice(offset, length);
+        }
+
+        private static ReadOnlyMemory<byte> Slice(ReadOnlyMemory<byte> source, int offset, int? length)
+        {
+            Debug.Assert(offset >= 0);
+
+            if (length == null)
+            {
+                return source.Slice(offset);
+            }
+
+            int lengthVal = length.Value;
+
+            if (lengthVal < 0 || source.Length - offset < lengthVal)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            return source.Slice(offset, lengthVal);
+        }
+
+        private static void CheckEncodingRules(AsnEncodingRules ruleSet)
+        {
+            if (ruleSet != AsnEncodingRules.BER &&
+                ruleSet != AsnEncodingRules.CER &&
+                ruleSet != AsnEncodingRules.DER)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ruleSet));
+            }
+        }
+
+        private static void CheckExpectedTag(Asn1Tag tag, Asn1Tag expectedTag, UniversalTagNumber tagNumber)
+        {
+            if (expectedTag.TagClass == TagClass.Universal && expectedTag.TagValue != (int)tagNumber)
+            {
+                throw new ArgumentException(
+                    SR.Cryptography_Asn_UniversalValueIsFixed,
+                    nameof(expectedTag));
+            }
+
+            if (expectedTag.TagClass != tag.TagClass || expectedTag.TagValue != tag.TagValue)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.BitString.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.BitString.cs
@@ -1,0 +1,201 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Write a Bit String value with a tag UNIVERSAL 3.
+        /// </summary>
+        /// <param name="bitString">The value to write.</param>
+        /// <param name="unusedBitCount">
+        ///   The number of trailing bits which are not semantic.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="unusedBitCount"/> is not in the range [0,7]
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <paramref name="bitString"/> has length 0 and <paramref name="unusedBitCount"/> is not 0 --OR--
+        ///   <paramref name="bitString"/> is not empty and any of the bits identified by
+        ///   <paramref name="unusedBitCount"/> is set
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteBitString(ReadOnlySpan<byte> bitString, int unusedBitCount = 0)
+        {
+            WriteBitStringCore(Asn1Tag.PrimitiveBitString, bitString, unusedBitCount);
+        }
+
+        /// <summary>
+        ///   Write a Bit String value with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="bitString">The value to write.</param>
+        /// <param name="unusedBitCount">
+        ///   The number of trailing bits which are not semantic.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="unusedBitCount"/> is not in the range [0,7]
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <paramref name="bitString"/> has length 0 and <paramref name="unusedBitCount"/> is not 0 --OR--
+        ///   <paramref name="bitString"/> is not empty and any of the bits identified by
+        ///   <paramref name="unusedBitCount"/> is set
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteBitString(Asn1Tag tag, ReadOnlySpan<byte> bitString, int unusedBitCount = 0)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.BitString);
+
+            // Primitive or constructed, doesn't matter.
+            WriteBitStringCore(tag, bitString, unusedBitCount);
+        }
+
+        // T-REC-X.690-201508 sec 8.6
+        private void WriteBitStringCore(Asn1Tag tag, ReadOnlySpan<byte> bitString, int unusedBitCount)
+        {
+            // T-REC-X.690-201508 sec 8.6.2.2
+            if (unusedBitCount < 0 || unusedBitCount > 7)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(unusedBitCount),
+                    unusedBitCount,
+                    SR.Cryptography_Asn_UnusedBitCountRange);
+            }
+
+            CheckDisposed();
+
+            // T-REC-X.690-201508 sec 8.6.2.3
+            if (bitString.Length == 0 && unusedBitCount != 0)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            // If 3 bits are "unused" then build a mask for them to check for 0.
+            // 1 << 3 => 0b0000_1000
+            // subtract 1 => 0b000_0111
+            int mask = (1 << unusedBitCount) - 1;
+            byte lastByte = bitString.IsEmpty ? (byte)0 : bitString[bitString.Length - 1];
+
+            if ((lastByte & mask) != 0)
+            {
+                // T-REC-X.690-201508 sec 11.2
+                //
+                // This could be ignored for BER, but since DER is more common and
+                // it likely suggests a program error on the caller, leave it enabled for
+                // BER for now.
+                // TODO: Probably warrants a distinct message.
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            if (RuleSet == AsnEncodingRules.CER)
+            {
+                // T-REC-X.690-201508 sec 9.2
+                //
+                // If it's not within a primitive segment, use the constructed encoding.
+                // (>= instead of > because of the unused bit count byte)
+                if (bitString.Length >= AsnReader.MaxCERSegmentSize)
+                {
+                    WriteConstructedCerBitString(tag, bitString, unusedBitCount);
+                    return;
+                }
+            }
+
+            // Clear the constructed flag, if present.
+            WriteTag(tag.AsPrimitive());
+            // The unused bits byte requires +1.
+            WriteLength(bitString.Length + 1);
+            _buffer[_offset] = (byte)unusedBitCount;
+            _offset++;
+            bitString.CopyTo(_buffer.AsSpan(_offset));
+            _offset += bitString.Length;
+        }
+
+        // T-REC-X.690-201508 sec 9.2, 8.6
+        private void WriteConstructedCerBitString(Asn1Tag tag, ReadOnlySpan<byte> payload, int unusedBitCount)
+        {
+            const int MaxCERSegmentSize = AsnReader.MaxCERSegmentSize;
+            // Every segment has an "unused bit count" byte.
+            const int MaxCERContentSize = MaxCERSegmentSize - 1;
+            Debug.Assert(payload.Length > MaxCERContentSize);
+
+            WriteTag(tag.AsConstructed());
+            // T-REC-X.690-201508 sec 9.1
+            // Constructed CER uses the indefinite form.
+            WriteLength(-1);
+
+            int fullSegments = Math.DivRem(payload.Length, MaxCERContentSize, out int lastContentSize);
+
+            // The tag size is 1 byte.
+            // The length will always be encoded as 82 03 E8 (3 bytes)
+            // And 1000 content octets (by T-REC-X.690-201508 sec 9.2)
+            const int FullSegmentEncodedSize = 1004;
+            Debug.Assert(
+                FullSegmentEncodedSize == 1 + 1 + MaxCERSegmentSize + GetEncodedLengthSubsequentByteCount(MaxCERSegmentSize));
+
+            int remainingEncodedSize;
+
+            if (lastContentSize == 0)
+            {
+                remainingEncodedSize = 0;
+            }
+            else
+            {
+                // One byte of tag, minimum one byte of length, and one byte of unused bit count.
+                remainingEncodedSize = 3 + lastContentSize + GetEncodedLengthSubsequentByteCount(lastContentSize);
+            }
+
+            // Reduce the number of copies by pre-calculating the size.
+            // +2 for End-Of-Contents
+            int expectedSize = fullSegments * FullSegmentEncodedSize + remainingEncodedSize + 2;
+            EnsureWriteCapacity(expectedSize);
+
+            byte[] ensureNoExtraCopy = _buffer;
+            int savedOffset = _offset;
+
+            ReadOnlySpan<byte> remainingData = payload;
+            Span<byte> dest;
+            Asn1Tag primitiveBitString = Asn1Tag.PrimitiveBitString;
+
+            while (remainingData.Length > MaxCERContentSize)
+            {
+                // T-REC-X.690-201508 sec 8.6.4.1
+                WriteTag(primitiveBitString);
+                WriteLength(MaxCERSegmentSize);
+                // 0 unused bits in this segment.
+                _buffer[_offset] = 0;
+                _offset++;
+
+                dest = _buffer.AsSpan(_offset);
+                remainingData.Slice(0, MaxCERContentSize).CopyTo(dest);
+
+                remainingData = remainingData.Slice(MaxCERContentSize);
+                _offset += MaxCERContentSize;
+            }
+
+            WriteTag(primitiveBitString);
+            WriteLength(remainingData.Length + 1);
+
+            _buffer[_offset] = (byte)unusedBitCount;
+            _offset++;
+
+            dest = _buffer.AsSpan(_offset);
+            remainingData.CopyTo(dest);
+            _offset += remainingData.Length;
+
+            WriteEndOfContents();
+
+            Debug.Assert(_offset - savedOffset == expectedSize, $"expected size was {expectedSize}, actual was {_offset - savedOffset}");
+            Debug.Assert(_buffer == ensureNoExtraCopy, $"_buffer was replaced during {nameof(WriteConstructedCerBitString)}");
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Boolean.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Boolean.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Write a Boolean value with tag UNIVERSAL 1.
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteBoolean(bool value)
+        {
+            WriteBooleanCore(Asn1Tag.Boolean, value);
+        }
+
+        /// <summary>
+        ///   Write a Boolean value with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        public void WriteBoolean(Asn1Tag tag, bool value)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.Boolean);
+
+            WriteBooleanCore(tag.AsPrimitive(), value);
+        }
+
+        // T-REC-X.690-201508 sec 11.1, 8.2
+        private void WriteBooleanCore(Asn1Tag tag, bool value)
+        {
+            Debug.Assert(!tag.IsConstructed);
+            WriteTag(tag);
+            WriteLength(1);
+            // Ensured by WriteLength
+            Debug.Assert(_offset < _buffer.Length);
+            _buffer[_offset] = (byte)(value ? 0xFF : 0x00);
+            _offset++;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Enumerated.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Enumerated.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Write a non-[<see cref="FlagsAttribute"/>] enum value as an Enumerated with
+        ///   tag UNIVERSAL 10.
+        /// </summary>
+        /// <param name="enumValue">The boxed enumeration value to write</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="enumValue"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="enumValue"/> is not a boxed enum value --OR--
+        ///   the unboxed type of <paramref name="enumValue"/> is declared [<see cref="FlagsAttribute"/>]
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteEnumeratedValue(Asn1Tag,object)"/>
+        /// <seealso cref="WriteEnumeratedValue{T}(T)"/>
+        public void WriteEnumeratedValue(object enumValue)
+        {
+            if (enumValue == null)
+                throw new ArgumentNullException(nameof(enumValue));
+
+            WriteEnumeratedValue(Asn1Tag.Enumerated, enumValue);
+        }
+
+        /// <summary>
+        ///   Write a non-[<see cref="FlagsAttribute"/>] enum value as an Enumerated with
+        ///   tag UNIVERSAL 10.
+        /// </summary>
+        /// <param name="enumValue">The boxed enumeration value to write</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="enumValue"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <typeparamref name="TEnum"/> is not a boxed enum value --OR--
+        ///   <typeparamref name="TEnum"/> is declared [<see cref="FlagsAttribute"/>]
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteEnumeratedValue(Asn1Tag,object)"/>
+        /// <seealso cref="WriteEnumeratedValue{TEnum}(TEnum)"/>
+        public void WriteEnumeratedValue<TEnum>(TEnum enumValue) where TEnum : struct
+        {
+            WriteEnumeratedValue(Asn1Tag.Enumerated, typeof(TEnum), enumValue);
+        }
+
+        /// <summary>
+        ///   Write a non-[<see cref="FlagsAttribute"/>] enum value as an Enumerated with
+        ///   tag UNIVERSAL 10.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="enumValue">The boxed enumeration value to write.</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="enumValue"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method --OR--
+        ///   <paramref name="enumValue"/> is not a boxed enum value --OR--
+        ///   the unboxed type of <paramref name="enumValue"/> is declared [<see cref="FlagsAttribute"/>]
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteEnumeratedValue(System.Security.Cryptography.Asn1.Asn1Tag,object)"/>
+        /// <seealso cref="WriteEnumeratedValue{T}(T)"/>
+        public void WriteEnumeratedValue(Asn1Tag tag, object enumValue)
+        {
+            if (enumValue == null)
+                throw new ArgumentNullException(nameof(enumValue));
+
+            WriteEnumeratedValue(tag.AsPrimitive(), enumValue.GetType(), enumValue);
+        }
+
+        /// <summary>
+        ///   Write a non-[<see cref="FlagsAttribute"/>] enum value as an Enumerated with
+        ///   tag UNIVERSAL 10.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="enumValue">The boxed enumeration value to write.</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="enumValue"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method --OR--
+        ///   <typeparamref name="TEnum"/> is not an enum --OR--
+        ///   <typeparamref name="TEnum"/> is declared [<see cref="FlagsAttribute"/>]
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteEnumeratedValue(Asn1Tag,object)"/>
+        /// <seealso cref="WriteEnumeratedValue{T}(T)"/>
+        public void WriteEnumeratedValue<TEnum>(Asn1Tag tag, TEnum enumValue) where TEnum : struct
+        {
+            WriteEnumeratedValue(tag.AsPrimitive(), typeof(TEnum), enumValue);
+        }
+
+        // T-REC-X.690-201508 sec 8.4
+        private void WriteEnumeratedValue(Asn1Tag tag, Type tEnum, object enumValue)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.Enumerated);
+
+            Type backingType = tEnum.GetEnumUnderlyingType();
+
+            if (tEnum.IsDefined(typeof(FlagsAttribute), false))
+            {
+                throw new ArgumentException(
+                    SR.Cryptography_Asn_EnumeratedValueRequiresNonFlagsEnum,
+                    nameof(tEnum));
+            }
+
+            if (backingType == typeof(ulong))
+            {
+                ulong numericValue = Convert.ToUInt64(enumValue);
+                // T-REC-X.690-201508 sec 8.4
+                WriteNonNegativeIntegerCore(tag, numericValue);
+            }
+            else
+            {
+                // All other types fit in a (signed) long.
+                long numericValue = Convert.ToInt64(enumValue);
+                // T-REC-X.690-201508 sec 8.4
+                WriteIntegerCore(tag, numericValue);
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.GeneralizedTime.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.GeneralizedTime.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Write the provided <see cref="DateTimeOffset"/> as a GeneralizedTime with tag
+        ///   UNIVERSAL 24, optionally excluding the fractional seconds.
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <param name="omitFractionalSeconds">
+        ///   <c>true</c> to treat the fractional seconds in <paramref name="value"/> as 0 even if
+        ///   a non-zero value is present.
+        /// </param>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteGeneralizedTime(Asn1Tag,DateTimeOffset,bool)"/>
+        public void WriteGeneralizedTime(DateTimeOffset value, bool omitFractionalSeconds = false)
+        {
+            WriteGeneralizedTimeCore(Asn1Tag.GeneralizedTime, value, omitFractionalSeconds);
+        }
+
+        /// <summary>
+        ///   Write the provided <see cref="DateTimeOffset"/> as a GeneralizedTime with a specified
+        ///   UNIVERSAL 24, optionally excluding the fractional seconds.
+        /// </summary>
+        /// <param name="tag">The tagto write.</param>
+        /// <param name="value">The value to write.</param>
+        /// <param name="omitFractionalSeconds">
+        ///   <c>true</c> to treat the fractional seconds in <paramref name="value"/> as 0 even if
+        ///   a non-zero value is present.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteGeneralizedTime(System.Security.Cryptography.Asn1.Asn1Tag,System.DateTimeOffset,bool)"/>
+        public void WriteGeneralizedTime(Asn1Tag tag, DateTimeOffset value, bool omitFractionalSeconds = false)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.GeneralizedTime);
+
+            // Clear the constructed flag, if present.
+            WriteGeneralizedTimeCore(tag.AsPrimitive(), value, omitFractionalSeconds);
+        }
+
+        // T-REC-X.680-201508 sec 46
+        // T-REC-X.690-201508 sec 11.7
+        private void WriteGeneralizedTimeCore(Asn1Tag tag, DateTimeOffset value, bool omitFractionalSeconds)
+        {
+            // GeneralizedTime under BER allows many different options:
+            // * (HHmmss), (HHmm), (HH)
+            // * "(value).frac", "(value),frac"
+            // * frac == 0 may be omitted or emitted
+            // non-UTC offset in various formats
+            //
+            // We're not allowing any of them.
+            // Just encode as the CER/DER common restrictions.
+            //
+            // This results in the following formats:
+            // yyyyMMddHHmmssZ
+            // yyyyMMddHHmmss.f?Z
+            //
+            // where "f?" is anything from "f" to "fffffff" (tenth of a second down to 100ns/1-tick)
+            // with no trailing zeros.
+            DateTimeOffset normalized = value.ToUniversalTime();
+
+            if (normalized.Year > 9999)
+            {
+                // This is unreachable since DateTimeOffset guards against this internally.
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            // We're only loading in sub-second ticks.
+            // Ticks are defined as 1e-7 seconds, so their printed form
+            // is at the longest "0.1234567", or 9 bytes.
+            Span<byte> fraction = stackalloc byte[0];
+
+            if (!omitFractionalSeconds)
+            {
+                long floatingTicks = normalized.Ticks % TimeSpan.TicksPerSecond;
+
+                if (floatingTicks != 0)
+                {
+                    // We're only loading in sub-second ticks.
+                    // Ticks are defined as 1e-7 seconds, so their printed form
+                    // is at the longest "0.1234567", or 9 bytes.
+                    fraction = stackalloc byte[9];
+
+                    decimal decimalTicks = floatingTicks;
+                    decimalTicks /= TimeSpan.TicksPerSecond;
+
+                    if (!Utf8Formatter.TryFormat(decimalTicks, fraction, out int bytesWritten, new StandardFormat('G')))
+                    {
+                        Debug.Fail($"Utf8Formatter.TryFormat could not format {floatingTicks} / TicksPerSecond");
+                        throw new CryptographicException();
+                    }
+
+                    Debug.Assert(bytesWritten > 2, $"{bytesWritten} should be > 2");
+                    Debug.Assert(fraction[0] == (byte)'0');
+                    Debug.Assert(fraction[1] == (byte)'.');
+
+                    fraction = fraction.Slice(1, bytesWritten - 1);
+                }
+            }
+
+            // yyyy, MM, dd, hh, mm, ss
+            const int IntegerPortionLength = 4 + 2 + 2 + 2 + 2 + 2;
+            // Z, and the optional fraction.
+            int totalLength = IntegerPortionLength + 1 + fraction.Length;
+
+            // Because GeneralizedTime is IMPLICIT VisibleString it technically can have
+            // a constructed form.
+            // DER says character strings must be primitive.
+            // CER says character strings <= 1000 encoded bytes must be primitive.
+            // So we'll just make BER be primitive, too.
+            Debug.Assert(!tag.IsConstructed);
+            WriteTag(tag);
+            WriteLength(totalLength);
+
+            int year = normalized.Year;
+            int month = normalized.Month;
+            int day = normalized.Day;
+            int hour = normalized.Hour;
+            int minute = normalized.Minute;
+            int second = normalized.Second;
+
+            Span<byte> baseSpan = _buffer.AsSpan(_offset);
+            StandardFormat d4 = new StandardFormat('D', 4);
+            StandardFormat d2 = new StandardFormat('D', 2);
+
+            if (!Utf8Formatter.TryFormat(year, baseSpan.Slice(0, 4), out _, d4) ||
+                !Utf8Formatter.TryFormat(month, baseSpan.Slice(4, 2), out _, d2) ||
+                !Utf8Formatter.TryFormat(day, baseSpan.Slice(6, 2), out _, d2) ||
+                !Utf8Formatter.TryFormat(hour, baseSpan.Slice(8, 2), out _, d2) ||
+                !Utf8Formatter.TryFormat(minute, baseSpan.Slice(10, 2), out _, d2) ||
+                !Utf8Formatter.TryFormat(second, baseSpan.Slice(12, 2), out _, d2))
+            {
+                Debug.Fail($"Utf8Formatter.TryFormat failed to build components of {normalized:O}");
+                throw new CryptographicException();
+            }
+
+            _offset += IntegerPortionLength;
+            fraction.CopyTo(baseSpan.Slice(IntegerPortionLength));
+            _offset += fraction.Length;
+
+            _buffer[_offset] = (byte)'Z';
+            _offset++;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Integer.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Integer.cs
@@ -1,0 +1,353 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Numerics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Write an Integer value with tag UNIVERSAL 2.
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteInteger(long value)
+        {
+            WriteIntegerCore(Asn1Tag.Integer, value);
+        }
+
+        /// <summary>
+        ///   Write an Integer value with tag UNIVERSAL 2.
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteInteger(ulong value)
+        {
+            WriteNonNegativeIntegerCore(Asn1Tag.Integer, value);
+        }
+
+        /// <summary>
+        ///   Write an Integer value with tag UNIVERSAL 2.
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteInteger(BigInteger value)
+        {
+            WriteIntegerCore(Asn1Tag.Integer, value);
+        }
+
+        /// <summary>
+        ///   Write an Integer value with a specified tag.
+        /// </summary>
+        /// <param name="value">The integer value to write, in signed big-endian byte order.</param>
+        /// <exception cref="CryptographicException">
+        ///   the 9 most sigificant bits are all set --OR--
+        ///   the 9 most sigificant bits are all unset
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteInteger(ReadOnlySpan<byte> value)
+        {
+            WriteIntegerCore(Asn1Tag.Integer, value);
+        }
+
+        /// <summary>
+        ///   Write an Integer value with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteInteger(Asn1Tag tag, long value)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.Integer);
+
+            WriteIntegerCore(tag.AsPrimitive(), value);
+        }
+
+        /// <summary>
+        ///   Write an Integer value with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteInteger(Asn1Tag tag, ulong value)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.Integer);
+
+            WriteNonNegativeIntegerCore(tag.AsPrimitive(), value);
+        }
+
+        /// <summary>
+        ///   Write an Integer value with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteInteger(Asn1Tag tag, BigInteger value)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.Integer);
+
+            WriteIntegerCore(tag.AsPrimitive(), value);
+        }
+
+        /// <summary>
+        ///   Write an Integer value with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="value">The integer value to write, in signed big-endian byte order.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the 9 most sigificant bits are all set --OR--
+        ///   the 9 most sigificant bits are all unset
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteInteger(Asn1Tag tag, ReadOnlySpan<byte> value)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.Integer);
+
+            WriteIntegerCore(tag.AsPrimitive(), value);
+        }
+
+        /// <summary>
+        ///   Write an Integer value with tag UNIVERSAL 2.
+        /// </summary>
+        /// <param name="value">The integer value to write, in unsigned big-endian byte order.</param>
+        /// <exception cref="CryptographicException">
+        ///   the 9 most sigificant bits are all unset
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteIntegerUnsigned(ReadOnlySpan<byte> value)
+        {
+            WriteIntegerUnsignedCore(Asn1Tag.Integer, value);
+        }
+
+        /// <summary>
+        ///   Write an Integer value with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="value">The integer value to write, in unsigned big-endian byte order.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   the 9 most sigificant bits are all unset
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteIntegerUnsigned(Asn1Tag tag, ReadOnlySpan<byte> value)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.Integer);
+
+            WriteIntegerUnsignedCore(tag.AsPrimitive(), value);
+        }
+
+        // T-REC-X.690-201508 sec 8.3
+        private void WriteIntegerCore(Asn1Tag tag, long value)
+        {
+            if (value >= 0)
+            {
+                WriteNonNegativeIntegerCore(tag, (ulong)value);
+                return;
+            }
+
+            int valueLength;
+
+            if (value >= sbyte.MinValue)
+                valueLength = 1;
+            else if (value >= short.MinValue)
+                valueLength = 2;
+            else if (value >= unchecked((long)0xFFFFFFFF_FF800000))
+                valueLength = 3;
+            else if (value >= int.MinValue)
+                valueLength = 4;
+            else if (value >= unchecked((long)0xFFFFFF80_00000000))
+                valueLength = 5;
+            else if (value >= unchecked((long)0xFFFF8000_00000000))
+                valueLength = 6;
+            else if (value >= unchecked((long)0xFF800000_00000000))
+                valueLength = 7;
+            else
+                valueLength = 8;
+
+            Debug.Assert(!tag.IsConstructed);
+            WriteTag(tag);
+            WriteLength(valueLength);
+
+            long remaining = value;
+            int idx = _offset + valueLength - 1;
+
+            do
+            {
+                _buffer[idx] = (byte)remaining;
+                remaining >>= 8;
+                idx--;
+            } while (idx >= _offset);
+
+#if DEBUG
+            if (valueLength > 1)
+            {
+                // T-REC-X.690-201508 sec 8.3.2
+                // Cannot start with 9 bits of 1 (or 9 bits of 0, but that's not this method).
+                Debug.Assert(_buffer[_offset] != 0xFF || _buffer[_offset + 1] < 0x80);
+            }
+#endif
+
+            _offset += valueLength;
+        }
+
+        // T-REC-X.690-201508 sec 8.3
+        private void WriteNonNegativeIntegerCore(Asn1Tag tag, ulong value)
+        {
+            int valueLength;
+
+            // 0x80 needs two bytes: 0x00 0x80
+            if (value < 0x80)
+                valueLength = 1;
+            else if (value < 0x8000)
+                valueLength = 2;
+            else if (value < 0x800000)
+                valueLength = 3;
+            else if (value < 0x80000000)
+                valueLength = 4;
+            else if (value < 0x80_00000000)
+                valueLength = 5;
+            else if (value < 0x8000_00000000)
+                valueLength = 6;
+            else if (value < 0x800000_00000000)
+                valueLength = 7;
+            else if (value < 0x80000000_00000000)
+                valueLength = 8;
+            else
+                valueLength = 9;
+
+            // Clear the constructed bit, if it was set.
+            Debug.Assert(!tag.IsConstructed);
+            WriteTag(tag);
+            WriteLength(valueLength);
+
+            ulong remaining = value;
+            int idx = _offset + valueLength - 1;
+
+            do
+            {
+                _buffer[idx] = (byte)remaining;
+                remaining >>= 8;
+                idx--;
+            } while (idx >= _offset);
+
+#if DEBUG
+            if (valueLength > 1)
+            {
+                // T-REC-X.690-201508 sec 8.3.2
+                // Cannot start with 9 bits of 0 (or 9 bits of 1, but that's not this method).
+                Debug.Assert(_buffer[_offset] != 0 || _buffer[_offset + 1] > 0x7F);
+            }
+#endif
+
+            _offset += valueLength;
+        }
+
+        private void WriteIntegerUnsignedCore(Asn1Tag tag, ReadOnlySpan<byte> value)
+        {
+            if (value.IsEmpty)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            // T-REC-X.690-201508 sec 8.3.2
+            if (value.Length > 1 && value[0] == 0 && value[1] < 0x80)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            Debug.Assert(!tag.IsConstructed);
+            WriteTag(tag);
+
+            if (value[0] >= 0x80)
+            {
+                WriteLength(checked(value.Length + 1));
+                _buffer[_offset] = 0;
+                _offset++;
+            }
+            else
+            {
+                WriteLength(value.Length);
+            }
+
+            value.CopyTo(_buffer.AsSpan(_offset));
+            _offset += value.Length;
+        }
+
+        private void WriteIntegerCore(Asn1Tag tag, ReadOnlySpan<byte> value)
+        {
+            CheckDisposed();
+
+            if (value.IsEmpty)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+            }
+
+            // T-REC-X.690-201508 sec 8.3.2
+            if (value.Length > 1)
+            {
+                ushort bigEndianValue = (ushort)(value[0] << 8 | value[1]);
+                const ushort RedundancyMask = 0b1111_1111_1000_0000;
+                ushort masked = (ushort)(bigEndianValue & RedundancyMask);
+
+                // If the first 9 bits are all 0 or are all 1, the value is invalid.
+                if (masked == 0 || masked == RedundancyMask)
+                {
+                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
+                }
+            }
+
+            Debug.Assert(!tag.IsConstructed);
+            WriteTag(tag);
+            WriteLength(value.Length);
+            // WriteLength ensures the content-space
+            value.CopyTo(_buffer.AsSpan(_offset));
+            _offset += value.Length;
+        }
+
+        // T-REC-X.690-201508 sec 8.3
+        private void WriteIntegerCore(Asn1Tag tag, BigInteger value)
+        {
+            // TODO: Split this for netstandard vs netcoreapp for span-perf?.
+            byte[] encoded = value.ToByteArray();
+            Array.Reverse(encoded);
+
+            Debug.Assert(!tag.IsConstructed);
+            WriteTag(tag);
+            WriteLength(encoded.Length);
+            Buffer.BlockCopy(encoded, 0, _buffer, _offset, encoded.Length);
+            _offset += encoded.Length;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.NamedBitList.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.NamedBitList.cs
@@ -1,0 +1,168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Write a [<see cref="FlagsAttribute"/>] enum value as a NamedBitList with
+        ///   tag UNIVERSAL 3.
+        /// </summary>
+        /// <param name="enumValue">The boxed enumeration value to write</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="enumValue"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="enumValue"/> is not a boxed enum value --OR--
+        ///   the unboxed type of <paramref name="enumValue"/> is not declared [<see cref="FlagsAttribute"/>]
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteNamedBitList(Asn1Tag,object)"/>
+        /// <seealso cref="WriteNamedBitList{T}(T)"/>
+        public void WriteNamedBitList(object enumValue)
+        {
+            if (enumValue == null)
+                throw new ArgumentNullException(nameof(enumValue));
+
+            WriteNamedBitList(Asn1Tag.PrimitiveBitString, enumValue);
+        }
+
+        /// <summary>
+        ///   Write a [<see cref="FlagsAttribute"/>] enum value as a NamedBitList with
+        ///   tag UNIVERSAL 3.
+        /// </summary>
+        /// <param name="enumValue">The enumeration value to write</param>
+        /// <exception cref="ArgumentException">
+        ///   <typeparamref name="TEnum"/> is not an enum value --OR--
+        ///   <typeparamref name="TEnum"/> is not declared [<see cref="FlagsAttribute"/>]
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteNamedBitList{T}(Asn1Tag,T)"/>
+        public void WriteNamedBitList<TEnum>(TEnum enumValue) where TEnum : struct
+        {
+            WriteNamedBitList(Asn1Tag.PrimitiveBitString, enumValue);
+        }
+
+        /// <summary>
+        ///   Write a [<see cref="FlagsAttribute"/>] enum value as a NamedBitList with
+        ///   a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="enumValue">The boxed enumeration value to write</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method --OR--
+        ///   <paramref name="enumValue"/> is not a boxed enum value --OR--
+        ///   the unboxed type of <paramref name="enumValue"/> is not declared [<see cref="FlagsAttribute"/>]
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="enumValue"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteNamedBitList(Asn1Tag tag, object enumValue)
+        {
+            if (enumValue == null)
+                throw new ArgumentNullException(nameof(enumValue));
+
+            CheckUniversalTag(tag, UniversalTagNumber.BitString);
+
+            WriteNamedBitList(tag, enumValue.GetType(), enumValue);
+        }
+
+        /// <summary>
+        ///   Write a [<see cref="FlagsAttribute"/>] enum value as a NamedBitList with
+        ///   a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="enumValue">The enumeration value to write</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method --OR--
+        ///   <typeparamref name="TEnum"/> is not an enum value --OR--
+        ///   <typeparamref name="TEnum"/> is not declared [<see cref="FlagsAttribute"/>]
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteNamedBitList<TEnum>(Asn1Tag tag, TEnum enumValue) where TEnum : struct
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.BitString);
+
+            WriteNamedBitList(tag, typeof(TEnum), enumValue);
+        }
+
+        private void WriteNamedBitList(Asn1Tag tag, Type tEnum, object enumValue)
+        {
+            Type backingType = tEnum.GetEnumUnderlyingType();
+
+            if (!tEnum.IsDefined(typeof(FlagsAttribute), false))
+            {
+                throw new ArgumentException(
+                    SR.Cryptography_Asn_NamedBitListRequiresFlagsEnum,
+                    nameof(tEnum));
+            }
+
+            ulong integralValue;
+
+            if (backingType == typeof(ulong))
+            {
+                integralValue = Convert.ToUInt64(enumValue);
+            }
+            else
+            {
+                // All other types fit in a (signed) long.
+                long numericValue = Convert.ToInt64(enumValue);
+                integralValue = unchecked((ulong)numericValue);
+            }
+
+            WriteNamedBitList(tag, integralValue);
+        }
+
+        // T-REC-X.680-201508 sec 22
+        // T-REC-X.690-201508 sec 8.6, 11.2.2
+        private void WriteNamedBitList(Asn1Tag tag, ulong integralValue)
+        {
+            Span<byte> temp = stackalloc byte[sizeof(ulong)];
+            // Reset to all zeros, since we're just going to or-in bits we need.
+            temp.Clear();
+
+            int indexOfHighestSetBit = -1;
+
+            for (int i = 0; integralValue != 0; integralValue >>= 1, i++)
+            {
+                if ((integralValue & 1) != 0)
+                {
+                    temp[i / 8] |= (byte)(0x80 >> (i % 8));
+                    indexOfHighestSetBit = i;
+                }
+            }
+
+            if (indexOfHighestSetBit < 0)
+            {
+                // No bits were set; this is an empty bit string.
+                // T-REC-X.690-201508 sec 11.2.2-note2
+                WriteBitString(tag, ReadOnlySpan<byte>.Empty);
+            }
+            else
+            {
+                // At least one bit was set.
+                // Determine the shortest length necessary to represent the bit string.
+
+                // Since "bit 0" gets written down 0 => 1.
+                // Since "bit 8" is in the second byte 8 => 2.
+                // That makes the formula ((bit / 8) + 1) instead of ((bit + 7) / 8).
+                int byteLen = (indexOfHighestSetBit / 8) + 1;
+                int unusedBitCount = 7 - (indexOfHighestSetBit % 8);
+
+                WriteBitString(
+                    tag,
+                    temp.Slice(0, byteLen),
+                    unusedBitCount);
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Null.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Null.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Write NULL with tag UNIVERSAL 5.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteNull()
+        {
+            WriteNullCore(Asn1Tag.Null);
+        }
+
+        /// <summary>
+        ///   Write NULL with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteNull(Asn1Tag tag)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.Null);
+
+            WriteNullCore(tag.AsPrimitive());
+        }
+
+        // T-REC-X.690-201508 sec 8.8
+        private void WriteNullCore(Asn1Tag tag)
+        {
+            Debug.Assert(!tag.IsConstructed);
+            WriteTag(tag);
+            WriteLength(0);
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.OctetString.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.OctetString.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Write an Octet String with tag UNIVERSAL 4.
+        /// </summary>
+        /// <param name="octetString">The value to write.</param>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteOctetString(Asn1Tag,ReadOnlySpan{byte})"/>
+        public void WriteOctetString(ReadOnlySpan<byte> octetString)
+        {
+            WriteOctetString(Asn1Tag.PrimitiveOctetString, octetString);
+        }
+
+        /// <summary>
+        ///   Write an Octet String value with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="octetString">The value to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteOctetString(Asn1Tag tag, ReadOnlySpan<byte> octetString)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.OctetString);
+
+            // Primitive or constructed, doesn't matter.
+            WriteOctetStringCore(tag, octetString);
+        }
+
+        // T-REC-X.690-201508 sec 8.7
+        private void WriteOctetStringCore(Asn1Tag tag, ReadOnlySpan<byte> octetString)
+        {
+            if (RuleSet == AsnEncodingRules.CER)
+            {
+                // If it's bigger than a primitive segment, use the constructed encoding
+                // T-REC-X.690-201508 sec 9.2
+                if (octetString.Length > AsnReader.MaxCERSegmentSize)
+                {
+                    WriteConstructedCerOctetString(tag, octetString);
+                    return;
+                }
+            }
+
+            // Clear the constructed flag, if present.
+            WriteTag(tag.AsPrimitive());
+            WriteLength(octetString.Length);
+            octetString.CopyTo(_buffer.AsSpan(_offset));
+            _offset += octetString.Length;
+        }
+
+        // T-REC-X.690-201508 sec 9.2, 8.7
+        private void WriteConstructedCerOctetString(Asn1Tag tag, ReadOnlySpan<byte> payload)
+        {
+            const int MaxCERSegmentSize = AsnReader.MaxCERSegmentSize;
+            Debug.Assert(payload.Length > MaxCERSegmentSize);
+
+            WriteTag(tag.AsConstructed());
+            WriteLength(-1);
+
+            int fullSegments = Math.DivRem(payload.Length, MaxCERSegmentSize, out int lastSegmentSize);
+
+            // The tag size is 1 byte.
+            // The length will always be encoded as 82 03 E8 (3 bytes)
+            // And 1000 content octets (by T-REC-X.690-201508 sec 9.2)
+            const int FullSegmentEncodedSize = 1004;
+            Debug.Assert(
+                FullSegmentEncodedSize == 1 + 1 + MaxCERSegmentSize + GetEncodedLengthSubsequentByteCount(MaxCERSegmentSize));
+
+            int remainingEncodedSize;
+
+            if (lastSegmentSize == 0)
+            {
+                remainingEncodedSize = 0;
+            }
+            else
+            {
+                // One byte of tag, and minimum one byte of length.
+                remainingEncodedSize = 2 + lastSegmentSize + GetEncodedLengthSubsequentByteCount(lastSegmentSize);
+            }
+
+            // Reduce the number of copies by pre-calculating the size.
+            // +2 for End-Of-Contents
+            int expectedSize = fullSegments * FullSegmentEncodedSize + remainingEncodedSize + 2;
+            EnsureWriteCapacity(expectedSize);
+
+            byte[] ensureNoExtraCopy = _buffer;
+            int savedOffset = _offset;
+
+            ReadOnlySpan<byte> remainingData = payload;
+            Span<byte> dest;
+            Asn1Tag primitiveOctetString = Asn1Tag.PrimitiveOctetString;
+
+            while (remainingData.Length > MaxCERSegmentSize)
+            {
+                // T-REC-X.690-201508 sec 8.7.3.2-note2
+                WriteTag(primitiveOctetString);
+                WriteLength(MaxCERSegmentSize);
+
+                dest = _buffer.AsSpan(_offset);
+                remainingData.Slice(0, MaxCERSegmentSize).CopyTo(dest);
+
+                _offset += MaxCERSegmentSize;
+                remainingData = remainingData.Slice(MaxCERSegmentSize);
+            }
+
+            WriteTag(primitiveOctetString);
+            WriteLength(remainingData.Length);
+            dest = _buffer.AsSpan(_offset);
+            remainingData.CopyTo(dest);
+            _offset += remainingData.Length;
+
+            WriteEndOfContents();
+
+            Debug.Assert(_offset - savedOffset == expectedSize, $"expected size was {expectedSize}, actual was {_offset - savedOffset}");
+            Debug.Assert(_buffer == ensureNoExtraCopy, $"_buffer was replaced during {nameof(WriteConstructedCerOctetString)}");
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Oid.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Oid.cs
@@ -1,0 +1,313 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Numerics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Write an Object Identifier with a specified tag.
+        /// </summary>
+        /// <param name="oid">The object identifier to write.</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="oid"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <paramref name="oid"/>.<see cref="Oid.Value"/> is not a valid dotted decimal
+        ///   object identifier
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteObjectIdentifier(Oid oid)
+        {
+            if (oid == null)
+                throw new ArgumentNullException(nameof(oid));
+
+            CheckDisposed();
+
+            if (oid.Value == null)
+                throw new CryptographicException(SR.Argument_InvalidOidValue);
+
+            WriteObjectIdentifier(oid.Value);
+        }
+
+        /// <summary>
+        ///   Write an Object Identifier with a specified tag.
+        /// </summary>
+        /// <param name="oidValue">The object identifier to write.</param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="oidValue"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <paramref name="oidValue"/> is not a valid dotted decimal
+        ///   object identifier
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteObjectIdentifier(string oidValue)
+        {
+            if (oidValue == null)
+                throw new ArgumentNullException(nameof(oidValue));
+
+            WriteObjectIdentifier(oidValue.AsSpan());
+        }
+
+        /// <summary>
+        ///   Write an Object Identifier with tag UNIVERSAL 6.
+        /// </summary>
+        /// <param name="oidValue">The object identifier to write.</param>
+        /// <exception cref="CryptographicException">
+        ///   <paramref name="oidValue"/> is not a valid dotted decimal
+        ///   object identifier
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteObjectIdentifier(ReadOnlySpan<char> oidValue)
+        {
+            WriteObjectIdentifierCore(Asn1Tag.ObjectIdentifier, oidValue);
+        }
+
+        /// <summary>
+        ///   Write an Object Identifier with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="oid">The object identifier to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="oid"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <paramref name="oid"/>.<see cref="Oid.Value"/> is not a valid dotted decimal
+        ///   object identifier
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteObjectIdentifier(Asn1Tag tag, Oid oid)
+        {
+            if (oid == null)
+                throw new ArgumentNullException(nameof(oid));
+
+            CheckUniversalTag(tag, UniversalTagNumber.ObjectIdentifier);
+            CheckDisposed();
+
+            if (oid.Value == null)
+                throw new CryptographicException(SR.Argument_InvalidOidValue);
+
+            WriteObjectIdentifier(tag, oid.Value);
+        }
+
+        /// <summary>
+        ///   Write an Object Identifier with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="oidValue">The object identifier to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="oidValue"/> is <c>null</c>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <paramref name="oidValue"/> is not a valid dotted decimal
+        ///   object identifier
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteObjectIdentifier(Asn1Tag tag, string oidValue)
+        {
+            if (oidValue == null)
+                throw new ArgumentNullException(nameof(oidValue));
+
+            WriteObjectIdentifier(tag, oidValue.AsSpan());
+        }
+
+        /// <summary>
+        ///   Write an Object Identifier with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="oidValue">The object identifier to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <paramref name="oidValue"/> is not a valid dotted decimal
+        ///   object identifier
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteObjectIdentifier(Asn1Tag tag, ReadOnlySpan<char> oidValue)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.ObjectIdentifier);
+
+            WriteObjectIdentifierCore(tag.AsPrimitive(), oidValue);
+        }
+
+
+        // T-REC-X.690-201508 sec 8.19
+        private void WriteObjectIdentifierCore(Asn1Tag tag, ReadOnlySpan<char> oidValue)
+        {
+            CheckDisposed();
+
+            // T-REC-X.690-201508 sec 8.19.4
+            // The first character is in { 0, 1, 2 }, the second will be a '.', and a third (digit)
+            // will also exist.
+            if (oidValue.Length < 3)
+                throw new CryptographicException(SR.Argument_InvalidOidValue);
+            if (oidValue[1] != '.')
+                throw new CryptographicException(SR.Argument_InvalidOidValue);
+
+            // The worst case is "1.1.1.1.1", which takes 4 bytes (5 components, with the first two condensed)
+            // Longer numbers get smaller: "2.1.127" is only 2 bytes. (81d (0x51) and 127 (0x7F))
+            // So length / 2 should prevent any reallocations.
+            var localPool = ArrayPool<byte>.Shared;
+            byte[] tmp = localPool.Rent(oidValue.Length / 2);
+            int tmpOffset = 0;
+
+            try
+            {
+                int firstComponent;
+
+                switch (oidValue[0])
+                {
+                    case '0':
+                        firstComponent = 0;
+                        break;
+                    case '1':
+                        firstComponent = 1;
+                        break;
+                    case '2':
+                        firstComponent = 2;
+                        break;
+                    default:
+                        throw new CryptographicException(SR.Argument_InvalidOidValue);
+                }
+
+                // The first two components are special:
+                // ITU X.690 8.19.4:
+                //   The numerical value of the first subidentifier is derived from the values of the first two
+                //   object identifier components in the object identifier value being encoded, using the formula:
+                //       (X*40) + Y
+                //   where X is the value of the first object identifier component and Y is the value of the
+                //   second object identifier component.
+                //       NOTE - This packing of the first two object identifier components recognizes that only
+                //          three values are allocated from the root node, and at most 39 subsequent values from
+                //          nodes reached by X = 0 and X = 1.
+
+                // skip firstComponent and the trailing .
+                ReadOnlySpan<char> remaining = oidValue.Slice(2);
+
+                BigInteger subIdentifier = ParseSubIdentifier(ref remaining);
+                subIdentifier += 40 * firstComponent;
+
+                int localLen = EncodeSubIdentifier(tmp.AsSpan(tmpOffset), ref subIdentifier);
+                tmpOffset += localLen;
+
+                while (!remaining.IsEmpty)
+                {
+                    subIdentifier = ParseSubIdentifier(ref remaining);
+                    localLen = EncodeSubIdentifier(tmp.AsSpan(tmpOffset), ref subIdentifier);
+                    tmpOffset += localLen;
+                }
+
+                Debug.Assert(!tag.IsConstructed);
+                WriteTag(tag);
+                WriteLength(tmpOffset);
+                Buffer.BlockCopy(tmp, 0, _buffer, _offset, tmpOffset);
+                _offset += tmpOffset;
+            }
+            finally
+            {
+                Array.Clear(tmp, 0, tmpOffset);
+                localPool.Return(tmp);
+            }
+        }
+
+        private static BigInteger ParseSubIdentifier(ref ReadOnlySpan<char> oidValue)
+        {
+            int endIndex = oidValue.IndexOf('.');
+
+            if (endIndex == -1)
+            {
+                endIndex = oidValue.Length;
+            }
+            else if (endIndex == 0 || endIndex == oidValue.Length - 1)
+            {
+                throw new CryptographicException(SR.Argument_InvalidOidValue);
+            }
+
+            // The following code is equivalent to
+            // BigInteger.TryParse(temp, NumberStyles.None, CultureInfo.InvariantCulture, out value)
+            // TODO: Split this for netstandard vs netcoreapp for span-perf?.
+            BigInteger value = BigInteger.Zero;
+
+            for (int position = 0; position < endIndex; position++)
+            {
+                if (position > 0 && value == 0)
+                {
+                    // T-REC X.680-201508 sec 12.26
+                    throw new CryptographicException(SR.Argument_InvalidOidValue);
+                }
+
+                value *= 10;
+                value += AtoI(oidValue[position]);
+            }
+
+            oidValue = oidValue.Slice(Math.Min(oidValue.Length, endIndex + 1));
+            return value;
+        }
+
+        private static int AtoI(char c)
+        {
+            if (c >= '0' && c <= '9')
+            {
+                return c - '0';
+            }
+
+            throw new CryptographicException(SR.Argument_InvalidOidValue);
+        }
+
+        // ITU-T-X.690-201508 sec 8.19.5
+        private static int EncodeSubIdentifier(Span<byte> dest, ref BigInteger subIdentifier)
+        {
+            Debug.Assert(dest.Length > 0);
+
+            if (subIdentifier.IsZero)
+            {
+                dest[0] = 0;
+                return 1;
+            }
+
+            BigInteger unencoded = subIdentifier;
+            int idx = 0;
+
+            do
+            {
+                BigInteger cur = unencoded & 0x7F;
+                byte curByte = (byte)cur;
+
+                if (subIdentifier != unencoded)
+                {
+                    curByte |= 0x80;
+                }
+
+                unencoded >>= 7;
+                dest[idx] = curByte;
+                idx++;
+            }
+            while (unencoded != BigInteger.Zero);
+
+            Reverse(dest.Slice(0, idx));
+            return idx;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Sequence.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Sequence.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Begin writing a Sequence with tag UNIVERSAL 16.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="PushSequence(Asn1Tag)"/>
+        /// <seealso cref="PopSequence()"/>
+        public void PushSequence()
+        {
+            PushSequenceCore(Asn1Tag.Sequence);
+        }
+
+        /// <summary>
+        ///   Begin writing a Sequence with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="PopSequence(Asn1Tag)"/>
+        public void PushSequence(Asn1Tag tag)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.Sequence);
+
+            // Assert the constructed flag, in case it wasn't.
+            PushSequenceCore(tag.AsConstructed());
+        }
+
+        /// <summary>
+        ///   Indicate that the open Sequence with tag UNIVERSAL 16 is closed,
+        ///   returning the writer to the parent context.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        ///   the writer is not currently positioned within a Sequence with tag UNIVERSAL 16
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="PopSequence(Asn1Tag)"/>
+        /// <seealso cref="PushSequence()"/>
+        public void PopSequence()
+        {
+            PopSequenceCore(Asn1Tag.Sequence);
+        }
+
+        /// <summary>
+        ///   Indicate that the open Sequence with the specified tag is closed,
+        ///   returning the writer to the parent context.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   the writer is not currently positioned within a Sequence with the specified tag
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="PopSequence(System.Security.Cryptography.Asn1.Asn1Tag)"/>
+        /// <seealso cref="PushSequence()"/>
+        public void PopSequence(Asn1Tag tag)
+        {
+            // PopSequence shouldn't be used to pop a SetOf.
+            CheckUniversalTag(tag, UniversalTagNumber.Sequence);
+
+            // Assert the constructed flag, in case it wasn't.
+            PopSequenceCore(tag.AsConstructed());
+        }
+
+        // T-REC-X.690-201508 sec 8.9, 8.10
+        private void PushSequenceCore(Asn1Tag tag)
+        {
+            PushTag(tag.AsConstructed(), UniversalTagNumber.Sequence);
+        }
+
+        // T-REC-X.690-201508 sec 8.9, 8.10
+        private void PopSequenceCore(Asn1Tag tag)
+        {
+            PopTag(tag, UniversalTagNumber.Sequence);
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.SetOf.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.SetOf.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Begin writing a Set-Of with a tag UNIVERSAL 17.
+        /// </summary>
+        /// <remarks>
+        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes
+        ///   the writer will sort the Set-Of elements when the tag is closed.
+        /// </remarks>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="PushSetOf(Asn1Tag)"/>
+        /// <seealso cref="PopSetOf()"/>
+        public void PushSetOf()
+        {
+            PushSetOf(Asn1Tag.SetOf);
+        }
+
+        /// <summary>
+        ///   Begin writing a Set-Of with a specified tag.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <remarks>
+        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes
+        ///   the writer will sort the Set-Of elements when the tag is closed.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="PopSetOf(Asn1Tag)"/>
+        public void PushSetOf(Asn1Tag tag)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.SetOf);
+
+            // Assert the constructed flag, in case it wasn't.
+            PushSetOfCore(tag.AsConstructed());
+        }
+
+        /// <summary>
+        ///   Indicate that the open Set-Of with the tag UNIVERSAL 17 is closed,
+        ///   returning the writer to the parent context.
+        /// </summary>
+        /// <remarks>
+        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes
+        ///   the writer will sort the Set-Of elements when the tag is closed.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        ///   the writer is not currently positioned within a Sequence with tag UNIVERSAL 17
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="PopSetOf(Asn1Tag)"/>
+        /// <seealso cref="PushSetOf()"/>
+        public void PopSetOf()
+        {
+            PopSetOfCore(Asn1Tag.SetOf);
+        }
+
+        /// <summary>
+        ///   Indicate that the open Set-Of with the specified tag is closed,
+        ///   returning the writer to the parent context.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <remarks>
+        ///   In <see cref="AsnEncodingRules.CER"/> and <see cref="AsnEncodingRules.DER"/> modes
+        ///   the writer will sort the Set-Of elements when the tag is closed.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   the writer is not currently positioned within a Set-Of with the specified tag
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="PushSetOf(Asn1Tag)"/>
+        public void PopSetOf(Asn1Tag tag)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.SetOf);
+
+            // Assert the constructed flag, in case it wasn't.
+            PopSetOfCore(tag.AsConstructed());
+        }
+
+        // T-REC-X.690-201508 sec 8.12
+        // The writer claims SetOf, and not Set, so as to avoid the field
+        // ordering clause of T-REC-X.690-201508 sec 9.3
+        private void PushSetOfCore(Asn1Tag tag)
+        {
+            PushTag(tag, UniversalTagNumber.SetOf);
+        }
+
+        // T-REC-X.690-201508 sec 8.12
+        private void PopSetOfCore(Asn1Tag tag)
+        {
+            // T-REC-X.690-201508 sec 11.6
+            bool sortContents = RuleSet == AsnEncodingRules.CER || RuleSet == AsnEncodingRules.DER;
+
+            PopTag(tag, UniversalTagNumber.SetOf, sortContents);
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Text.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.Text.cs
@@ -1,0 +1,207 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Write the provided string using the specified encoding type using the UNIVERSAL
+        ///   tag corresponding to the encoding type.
+        /// </summary>
+        /// <param name="encodingType">
+        ///   The <see cref="UniversalTagNumber"/> corresponding to the encoding to use.
+        /// </param>
+        /// <param name="str">The string to write.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="str"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a restricted character string encoding type --OR--
+        ///   <paramref name="encodingType"/> is a restricted character string encoding type that is not
+        ///   currently supported by this method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteCharacterString(Asn1Tag,UniversalTagNumber,string)"/>
+        public void WriteCharacterString(UniversalTagNumber encodingType, string str)
+        {
+            if (str == null)
+                throw new ArgumentNullException(nameof(str));
+
+            WriteCharacterString(encodingType, str.AsSpan());
+        }
+
+        /// <summary>
+        ///   Write the provided string using the specified encoding type using the UNIVERSAL
+        ///   tag corresponding to the encoding type.
+        /// </summary>
+        /// <param name="encodingType">
+        ///   The <see cref="UniversalTagNumber"/> corresponding to the encoding to use.
+        /// </param>
+        /// <param name="str">The string to write.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a restricted character string encoding type --OR--
+        ///   <paramref name="encodingType"/> is a restricted character string encoding type that is not
+        ///   currently supported by this method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteCharacterString(Asn1Tag,UniversalTagNumber,ReadOnlySpan{char})"/>
+        public void WriteCharacterString(UniversalTagNumber encodingType, ReadOnlySpan<char> str)
+        {
+            Text.Encoding encoding = AsnCharacterStringEncodings.GetEncoding(encodingType);
+
+            WriteCharacterStringCore(new Asn1Tag(encodingType), encoding, str);
+        }
+
+        /// <summary>
+        ///   Write the provided string using the specified encoding type using the specified
+        ///   tag corresponding to the encoding type.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="encodingType">
+        ///   The <see cref="UniversalTagNumber"/> corresponding to the encoding to use.
+        /// </param>
+        /// <param name="str">The string to write.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="str"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a restricted character string encoding type --OR--
+        ///   <paramref name="encodingType"/> is a restricted character string encoding type that is not
+        ///   currently supported by this method
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteCharacterString(Asn1Tag tag, UniversalTagNumber encodingType, string str)
+        {
+            if (str == null)
+                throw new ArgumentNullException(nameof(str));
+
+            WriteCharacterString(tag, encodingType, str.AsSpan());
+        }
+
+        /// <summary>
+        ///   Write the provided string using the specified encoding type using the specified
+        ///   tag corresponding to the encoding type.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="encodingType">
+        ///   The <see cref="UniversalTagNumber"/> corresponding to the encoding to use.
+        /// </param>
+        /// <param name="str">The string to write.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a restricted character string encoding type --OR--
+        ///   <paramref name="encodingType"/> is a restricted character string encoding type that is not
+        ///   currently supported by this method
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void WriteCharacterString(Asn1Tag tag, UniversalTagNumber encodingType, ReadOnlySpan<char> str)
+        {
+            CheckUniversalTag(tag, encodingType);
+
+            Text.Encoding encoding = AsnCharacterStringEncodings.GetEncoding(encodingType);
+            WriteCharacterStringCore(tag, encoding, str);
+        }
+
+        // T-REC-X.690-201508 sec 8.23
+        private void WriteCharacterStringCore(Asn1Tag tag, Text.Encoding encoding, ReadOnlySpan<char> str)
+        {
+            int size = -1;
+
+            // T-REC-X.690-201508 sec 9.2
+            if (RuleSet == AsnEncodingRules.CER)
+            {
+                // TODO: Split this for netstandard vs netcoreapp for span?.
+                unsafe
+                {
+                    fixed (char* strPtr = &MemoryMarshal.GetReference(str))
+                    {
+                        size = encoding.GetByteCount(strPtr, str.Length);
+
+                        // If it exceeds the primitive segment size, use the constructed encoding.
+                        if (size > AsnReader.MaxCERSegmentSize)
+                        {
+                            WriteConstructedCerCharacterString(tag, encoding, str, size);
+                            return;
+                        }
+                    }
+                }
+            }
+
+            // TODO: Split this for netstandard vs netcoreapp for span?.
+            unsafe
+            {
+                fixed (char* strPtr = &MemoryMarshal.GetReference(str))
+                {
+                    if (size < 0)
+                    {
+                        size = encoding.GetByteCount(strPtr, str.Length);
+                    }
+
+                    // Clear the constructed tag, if present.
+                    WriteTag(tag.AsPrimitive());
+                    WriteLength(size);
+                    Span<byte> dest = _buffer.AsSpan(_offset, size);
+
+                    fixed (byte* destPtr = &MemoryMarshal.GetReference(dest))
+                    {
+                        int written = encoding.GetBytes(strPtr, str.Length, destPtr, dest.Length);
+
+                        if (written != size)
+                        {
+                            Debug.Fail($"Encoding produced different answer for GetByteCount ({size}) and GetBytes ({written})");
+                            throw new InvalidOperationException();
+                        }
+                    }
+
+                    _offset += size;
+                }
+            }
+        }
+
+        private void WriteConstructedCerCharacterString(Asn1Tag tag, Text.Encoding encoding, ReadOnlySpan<char> str, int size)
+        {
+            Debug.Assert(size > AsnReader.MaxCERSegmentSize);
+
+            byte[] tmp;
+
+            // TODO: Split this for netstandard vs netcoreapp for span?.
+            var localPool = ArrayPool<byte>.Shared;
+            unsafe
+            {
+                fixed (char* strPtr = &MemoryMarshal.GetReference(str))
+                {
+                    tmp = localPool.Rent(size);
+
+                    fixed (byte* destPtr = tmp)
+                    {
+                        int written = encoding.GetBytes(strPtr, str.Length, destPtr, tmp.Length);
+
+                        if (written != size)
+                        {
+                            Debug.Fail(
+                                $"Encoding produced different answer for GetByteCount ({size}) and GetBytes ({written})");
+                            throw new InvalidOperationException();
+                        }
+                    }
+                }
+            }
+
+            WriteConstructedCerOctetString(tag, tmp.AsSpan(0, size));
+            Array.Clear(tmp, 0, size);
+            localPool.Return(tmp);
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.UtcTime.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.UtcTime.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+
+namespace System.Security.Cryptography.Asn1
+{
+    public sealed partial class AsnWriter
+    {
+        /// <summary>
+        ///   Write the provided <see cref="DateTimeOffset"/> as a UTCTime with tag
+        ///   UNIVERSAL 23, and accepting the two-digit year as valid in context.
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteUtcTime(Asn1Tag,DateTimeOffset)"/>
+        /// <seealso cref="WriteUtcTime(DateTimeOffset,int)"/>
+        public void WriteUtcTime(DateTimeOffset value)
+        {
+            WriteUtcTimeCore(Asn1Tag.UtcTime, value);
+        }
+
+        /// <summary>
+        ///   Write the provided <see cref="DateTimeOffset"/> as a UTCTime with a specified tag,
+        ///   accepting the two-digit year as valid in context.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteUtcTime(Asn1Tag,DateTimeOffset,int)"/>
+        /// <seealso cref="System.Globalization.Calendar.TwoDigitYearMax"/>
+        public void WriteUtcTime(Asn1Tag tag, DateTimeOffset value)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.UtcTime);
+
+            // Clear the constructed flag, if present.
+            WriteUtcTimeCore(tag.AsPrimitive(), value);
+        }
+
+        /// <summary>
+        ///   Write the provided <see cref="DateTimeOffset"/> as a UTCTime with tag
+        ///   UNIVERSAL 23, provided the year is in the allowed range.
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <param name="twoDigitYearMax">
+        ///   The maximum valid year for <paramref name="value"/>, after conversion to UTC.
+        ///   For the X.509 Time.utcTime range of 1950-2049, pass <c>2049</c>.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="value"/>.<see cref="DateTimeOffset.Year"/> (after conversion to UTC)
+        ///   is not in the range
+        ///   (<paramref name="twoDigitYearMax"/> - 100, <paramref name="twoDigitYearMax"/>]
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteUtcTime(Asn1Tag,DateTimeOffset,int)"/>
+        /// <seealso cref="System.Globalization.Calendar.TwoDigitYearMax"/>
+        public void WriteUtcTime(DateTimeOffset value, int twoDigitYearMax)
+        {
+            // Defer to the longer override for twoDigitYearMax validity.
+            WriteUtcTime(Asn1Tag.UtcTime, value, twoDigitYearMax);
+        }
+
+        /// <summary>
+        ///   Write the provided <see cref="DateTimeOffset"/> as a UTCTime with a specified tag,
+        ///   provided the year is in the allowed range.
+        /// </summary>
+        /// <param name="tag">The tag to write.</param>
+        /// <param name="value">The value to write.</param>
+        /// <param name="twoDigitYearMax">
+        ///   The maximum valid year for <paramref name="value"/>, after conversion to UTC.
+        ///   For the X.509 Time.utcTime range of 1950-2049, pass <c>2049</c>.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="tag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="value"/>.<see cref="DateTimeOffset.Year"/> (after conversion to UTC)
+        ///   is not in the range
+        ///   (<paramref name="twoDigitYearMax"/> - 100, <paramref name="twoDigitYearMax"/>]
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        /// <seealso cref="WriteUtcTime(System.Security.Cryptography.Asn1.Asn1Tag,System.DateTimeOffset,int)"/>
+        /// <seealso cref="System.Globalization.Calendar.TwoDigitYearMax"/>
+        public void WriteUtcTime(Asn1Tag tag, DateTimeOffset value, int twoDigitYearMax)
+        {
+            CheckUniversalTag(tag, UniversalTagNumber.UtcTime);
+
+            value = value.ToUniversalTime();
+
+            if (value.Year > twoDigitYearMax || value.Year <= twoDigitYearMax - 100)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            WriteUtcTimeCore(tag.AsPrimitive(), value);
+        }
+
+        // T-REC-X.680-201508 sec 47
+        // T-REC-X.690-201508 sec 11.8
+        private void WriteUtcTimeCore(Asn1Tag tag, DateTimeOffset value)
+        {
+            // Because UtcTime is IMPLICIT VisibleString it technically can have
+            // a constructed form.
+            // DER says character strings must be primitive.
+            // CER says character strings <= 1000 encoded bytes must be primitive.
+            // So we'll just make BER be primitive, too.
+            Debug.Assert(!tag.IsConstructed);
+            WriteTag(tag);
+
+            // BER allows for omitting the seconds, but that's not an option we need to expose.
+            // BER allows for non-UTC values, but that's also not an option we need to expose.
+            // So the format is always yyMMddHHmmssZ (13)
+            const int UtcTimeValueLength = 13;
+            WriteLength(UtcTimeValueLength);
+
+            DateTimeOffset normalized = value.ToUniversalTime();
+
+            int year = normalized.Year;
+            int month = normalized.Month;
+            int day = normalized.Day;
+            int hour = normalized.Hour;
+            int minute = normalized.Minute;
+            int second = normalized.Second;
+
+            Span<byte> baseSpan = _buffer.AsSpan(_offset);
+            StandardFormat format = new StandardFormat('D', 2);
+
+            if (!Utf8Formatter.TryFormat(year % 100, baseSpan.Slice(0, 2), out _, format) ||
+                !Utf8Formatter.TryFormat(month, baseSpan.Slice(2, 2), out _, format) ||
+                !Utf8Formatter.TryFormat(day, baseSpan.Slice(4, 2), out _, format) ||
+                !Utf8Formatter.TryFormat(hour, baseSpan.Slice(6, 2), out _, format) ||
+                !Utf8Formatter.TryFormat(minute, baseSpan.Slice(8, 2), out _, format) ||
+                !Utf8Formatter.TryFormat(second, baseSpan.Slice(10, 2), out _, format))
+            {
+                Debug.Fail($"Utf8Formatter.TryFormat failed to build components of {normalized:O}");
+                throw new CryptographicException();
+            }
+
+            _buffer[_offset + 12] = (byte)'Z';
+
+            _offset += UtcTimeValueLength;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnWriter.cs
@@ -1,0 +1,582 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Enable CHECK_ACCURATE_ENSURE to ensure that the AsnWriter is not ever
+// abusing the normal EnsureWriteCapacity + ArrayPool behaviors of rounding up.
+//#define CHECK_ACCURATE_ENSURE
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace System.Security.Cryptography.Asn1
+{
+    /// <summary>
+    ///   A writer for BER-, CER-, and DER-encoded ASN.1 data.
+    /// </summary>
+    public sealed partial class AsnWriter : IDisposable
+    {
+        private byte[] _buffer;
+        private int _offset;
+        private Stack<(Asn1Tag,int,UniversalTagNumber)> _nestingStack;
+
+        /// <summary>
+        ///   The <see cref="AsnEncodingRules"/> in use by this writer.
+        /// </summary>
+        public AsnEncodingRules RuleSet { get; }
+
+        /// <summary>
+        ///   Create a new <see cref="AsnWriter"/> with a given set of encoding rules.
+        /// </summary>
+        /// <param name="ruleSet">The encoding constraints for the writer.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="ruleSet"/> is not defined.
+        /// </exception>
+        public AsnWriter(AsnEncodingRules ruleSet)
+        {
+            if (ruleSet != AsnEncodingRules.BER &&
+                ruleSet != AsnEncodingRules.CER &&
+                ruleSet != AsnEncodingRules.DER)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ruleSet));
+            }
+
+            RuleSet = ruleSet;
+        }
+
+        /// <summary>
+        ///   Release the resources held by this writer.
+        /// </summary>
+        public void Dispose()
+        {
+            _nestingStack = null;
+
+            if (_buffer != null)
+            {
+                Array.Clear(_buffer, 0, _offset);
+#if !CHECK_ACCURATE_ENSURE
+                ArrayPool<byte>.Shared.Return(_buffer);
+#endif
+                _buffer = null;
+            }
+
+            _offset = -1;
+        }
+
+        /// <summary>
+        ///   Reset the writer to have no data, without releasing resources.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public void Reset()
+        {
+            CheckDisposed();
+
+            if (_offset > 0)
+            {
+                Debug.Assert(_buffer != null);
+                Array.Clear(_buffer, 0, _offset);
+                _offset = 0;
+
+                _nestingStack?.Clear();
+            }
+        }
+
+        /// <summary>
+        ///   Gets the number of bytes that would be written by <see cref="TryEncode"/>.
+        /// </summary>
+        /// <returns>
+        ///   The number of bytes that would be written by <see cref="TryEncode"/>, or -1
+        ///   if a <see cref="PushSequence()"/> or <see cref="PushSetOf()"/> has not been completed.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public int GetEncodedLength()
+        {
+            CheckDisposed();
+
+            if ((_nestingStack?.Count ?? 0) != 0)
+            {
+                return -1;
+            }
+
+            return _offset;
+        }
+
+        /// <summary>
+        ///   Write the encoded representation of the data to <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> if the encode succeeded,
+        ///   <c>false</c> if <paramref name="destination"/> is too small.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   A <see cref="PushSequence()"/> or <see cref="PushSetOf()"/> has not been closed via
+        ///   <see cref="PopSequence()"/> or <see cref="PopSetOf()"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public bool TryEncode(Span<byte> destination, out int bytesWritten)
+        {
+            CheckDisposed();
+
+            if ((_nestingStack?.Count ?? 0) != 0)
+                throw new InvalidOperationException(SR.Cryptography_AsnWriter_EncodeUnbalancedStack);
+
+            // If the stack is closed out then everything is a definite encoding (BER, DER) or a
+            // required indefinite encoding (CER). So we're correctly sized up, and ready to copy.
+            if (destination.Length < _offset)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            if (_offset == 0)
+            {
+                bytesWritten = 0;
+                return true;
+            }
+
+            bytesWritten = _offset;
+            _buffer.AsSpan(0, _offset).CopyTo(destination);
+            return true;
+        }
+
+        /// <summary>
+        ///   Return a new array containing the encoded value.
+        /// </summary>
+        /// <returns>A precisely-sized array containing the encoded value.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   A <see cref="PushSequence()"/> or <see cref="PushSetOf()"/> has not been closed via
+        ///   <see cref="PopSequence()"/> or <see cref="PopSetOf()"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public byte[] Encode()
+        {
+            CheckDisposed();
+
+            if ((_nestingStack?.Count ?? 0) != 0)
+            {
+                throw new InvalidOperationException(SR.Cryptography_AsnWriter_EncodeUnbalancedStack);
+            }
+
+            if (_offset == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
+            // If the stack is closed out then everything is a definite encoding (BER, DER) or a
+            // required indefinite encoding (CER). So we're correctly sized up, and ready to copy.
+            return _buffer.AsSpan(0, _offset).ToArray();
+        }
+
+        internal ReadOnlySpan<byte> EncodeAsSpan()
+        {
+            CheckDisposed();
+
+            if ((_nestingStack?.Count ?? 0) != 0)
+            {
+                throw new InvalidOperationException(SR.Cryptography_AsnWriter_EncodeUnbalancedStack);
+            }
+
+            if (_offset == 0)
+            {
+                return ReadOnlySpan<byte>.Empty;
+            }
+
+            // If the stack is closed out then everything is a definite encoding (BER, DER) or a
+            // required indefinite encoding (CER). So we're correctly sized up, and ready to copy.
+            return new ReadOnlySpan<byte>(_buffer, 0, _offset);
+        }
+
+        private void CheckDisposed()
+        {
+            if (_offset < 0)
+            {
+                throw new ObjectDisposedException(nameof(AsnWriter));
+            }
+        }
+
+        private void EnsureWriteCapacity(int pendingCount)
+        {
+            CheckDisposed();
+
+            if (pendingCount < 0)
+            {
+                throw new OverflowException();
+            }
+
+            if (_buffer == null || _buffer.Length - _offset < pendingCount)
+            {
+#if CHECK_ACCURATE_ENSURE
+// A debug paradigm to make sure that throughout the execution nothing ever writes
+// past where the buffer was "allocated".  This causes quite a number of reallocs
+// and copies, so it's a #define opt-in.
+                byte[] newBytes = new byte[_offset + pendingCount];
+
+                if (_buffer != null)
+                {
+                    Buffer.BlockCopy(_buffer, 0, newBytes, 0, _offset);
+                }
+#else
+                const int BlockSize = 1024;
+                // While the ArrayPool may have similar logic, make sure we don't run into a lot of
+                // "grow a little" by asking in 1k steps.
+                int blocks = checked(_offset + pendingCount + (BlockSize - 1)) / BlockSize;
+                var localPool = ArrayPool<byte>.Shared;
+                byte[] newBytes = localPool.Rent(BlockSize * blocks);
+
+                if (_buffer != null)
+                {
+                    Buffer.BlockCopy(_buffer, 0, newBytes, 0, _offset);
+                    Array.Clear(_buffer, 0, _offset);
+                    localPool.Return(_buffer);
+                }
+#endif
+
+#if DEBUG
+                // Ensure no "implicit 0" is happening
+                for (int i = _offset; i < newBytes.Length; i++)
+                {
+                    newBytes[i] ^= 0xFF;
+                }
+#endif
+
+                _buffer = newBytes;
+            }
+        }
+
+        private void WriteTag(Asn1Tag tag)
+        {
+            int spaceRequired = tag.CalculateEncodedSize();
+            EnsureWriteCapacity(spaceRequired);
+
+            if (!tag.TryEncode(_buffer.AsSpan(_offset, spaceRequired), out int written) ||
+                written != spaceRequired)
+            {
+                Debug.Fail($"TryWrite failed or written was wrong value ({written} vs {spaceRequired})");
+                throw new CryptographicException();
+            }
+
+            _offset += spaceRequired;
+        }
+
+        // T-REC-X.690-201508 sec 8.1.3
+        private void WriteLength(int length)
+        {
+            const byte MultiByteMarker = 0x80;
+            Debug.Assert(length >= -1);
+
+            // If the indefinite form has been requested.
+            // T-REC-X.690-201508 sec 8.1.3.6
+            if (length == -1)
+            {
+                EnsureWriteCapacity(1);
+                _buffer[_offset] = MultiByteMarker;
+                _offset++;
+                return;
+            }
+
+            Debug.Assert(length >= 0);
+
+            // T-REC-X.690-201508 sec 8.1.3.3, 8.1.3.4
+            if (length < MultiByteMarker)
+            {
+                // Pre-allocate the pending data since we know how much.
+                EnsureWriteCapacity(1 + length);
+                _buffer[_offset] = (byte)length;
+                _offset++;
+                return;
+            }
+
+            // The rest of the method implements T-REC-X.680-201508 sec 8.1.3.5
+            int lengthLength = GetEncodedLengthSubsequentByteCount(length);
+
+            // Pre-allocate the pending data since we know how much.
+            EnsureWriteCapacity(lengthLength + 1 + length);
+            _buffer[_offset] = (byte)(MultiByteMarker | lengthLength);
+
+            // No minus one because offset didn't get incremented yet.
+            int idx = _offset + lengthLength;
+
+            int remaining = length;
+
+            do
+            {
+                _buffer[idx] = (byte)remaining;
+                remaining >>= 8;
+                idx--;
+            } while (remaining > 0);
+
+            Debug.Assert(idx == _offset);
+            _offset += lengthLength + 1;
+        }
+
+        // T-REC-X.690-201508 sec 8.1.3.5
+        private static int GetEncodedLengthSubsequentByteCount(int length)
+        {
+            if (length < 0)
+                throw new OverflowException();
+            if (length <= 0x7F)
+                return 0;
+            if (length <= byte.MaxValue)
+                return 1;
+            if (length <= ushort.MaxValue)
+                return 2;
+            if (length <= 0x00FFFFFF)
+                return 3;
+
+            return 4;
+        }
+
+        /// <summary>
+        ///   Write a single value which has already been encoded.
+        /// </summary>
+        /// <param name="preEncodedValue">The value to write.</param>
+        /// <remarks>
+        ///   This method only checks that the tag and length are encoded according to the current ruleset,
+        ///   and that the end of the value is the end of the input. The contents are not evaluated for
+        ///   semantic meaning.
+        /// </remarks>
+        /// <exception cref="CryptographicException">
+        ///   <paramref name="preEncodedValue"/> could not be read under the current encoding rules --OR--
+        ///   <paramref name="preEncodedValue"/> has data beyond the end of the first value
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The writer has been Disposed.</exception>
+        public unsafe void WriteEncodedValue(ReadOnlySpan<byte> preEncodedValue)
+        {
+            CheckDisposed();
+
+            fixed (byte* ptr = &MemoryMarshal.GetReference(preEncodedValue))
+            {
+                using (MemoryManager<byte> manager = new PointerMemoryManager<byte>(ptr, preEncodedValue.Length))
+                {
+                    WriteEncodedValue(manager.Memory);
+                }
+            }
+        }
+
+        private void WriteEncodedValue(ReadOnlyMemory<byte> preEncodedValue)
+        {
+            AsnReader reader = new AsnReader(preEncodedValue, RuleSet);
+
+            // Is it legal under the current rules?
+            ReadOnlyMemory<byte> parsedBack = reader.ReadEncodedValue();
+
+            if (reader.HasData)
+            {
+                throw new ArgumentException(
+                    SR.Cryptography_WriteEncodedValue_OneValueAtATime,
+                    nameof(preEncodedValue));
+            }
+
+            Debug.Assert(parsedBack.Length == preEncodedValue.Length);
+
+            EnsureWriteCapacity(preEncodedValue.Length);
+            preEncodedValue.Span.CopyTo(_buffer.AsSpan(_offset));
+            _offset += preEncodedValue.Length;
+        }
+
+        // T-REC-X.690-201508 sec 8.1.5
+        private void WriteEndOfContents()
+        {
+            EnsureWriteCapacity(2);
+            _buffer[_offset++] = 0;
+            _buffer[_offset++] = 0;
+        }
+
+        private void PushTag(Asn1Tag tag, UniversalTagNumber tagType)
+        {
+            CheckDisposed();
+
+            if (_nestingStack == null)
+            {
+                _nestingStack = new Stack<(Asn1Tag,int,UniversalTagNumber)>();
+            }
+
+            Debug.Assert(tag.IsConstructed);
+            WriteTag(tag);
+            _nestingStack.Push((tag, _offset, tagType));
+            // Indicate that the length is indefinite.
+            // We'll come back and clean this up (as appropriate) in PopTag.
+            WriteLength(-1);
+        }
+
+        private void PopTag(Asn1Tag tag, UniversalTagNumber tagType, bool sortContents=false)
+        {
+            CheckDisposed();
+
+            if (_nestingStack == null || _nestingStack.Count == 0)
+            {
+                throw new InvalidOperationException(SR.Cryptography_AsnWriter_PopWrongTag);
+            }
+
+            (Asn1Tag stackTag, int lenOffset, UniversalTagNumber stackTagType) = _nestingStack.Peek();
+
+            Debug.Assert(tag.IsConstructed);
+            if (stackTag != tag || stackTagType != tagType)
+            {
+                throw new InvalidOperationException(SR.Cryptography_AsnWriter_PopWrongTag);
+            }
+
+            _nestingStack.Pop();
+
+            if (sortContents)
+            {
+                SortContents(_buffer, lenOffset + 1, _offset);
+            }
+
+            // BER could use the indefinite encoding that CER does.
+            // But since the definite encoding form is easier to read (doesn't require a contextual
+            // parser to find the end-of-contents marker) some ASN.1 readers (including the previous
+            // incarnation of AsnReader) may choose not to support it.
+            //
+            // So, BER will use the DER rules here, in the interest of broader compatibility.
+
+            // T-REC-X.690-201508 sec 9.1 (constructed CER => indefinite length)
+            // T-REC-X.690-201508 sec 8.1.3.6
+            if (RuleSet == AsnEncodingRules.CER)
+            {
+                WriteEndOfContents();
+                return;
+            }
+
+            int containedLength = _offset - 1 - lenOffset;
+            Debug.Assert(containedLength >= 0);
+
+            int shiftSize = GetEncodedLengthSubsequentByteCount(containedLength);
+
+            // Best case, length fits in the compact byte
+            if (shiftSize == 0)
+            {
+                _buffer[lenOffset] = (byte)containedLength;
+                return;
+            }
+
+            // We're currently at the end, so ensure we have room for N more bytes.
+            EnsureWriteCapacity(shiftSize);
+
+            // Buffer.BlockCopy correctly does forward-overlapped, so use it.
+            int start = lenOffset + 1;
+            Buffer.BlockCopy(_buffer, start, _buffer, start + shiftSize, containedLength);
+
+            int tmp = _offset;
+            _offset = lenOffset;
+            WriteLength(containedLength);
+            Debug.Assert(_offset - lenOffset - 1 == shiftSize);
+            _offset = tmp + shiftSize;
+        }
+
+        private static void SortContents(byte[] buffer, int start, int end)
+        {
+            Debug.Assert(buffer != null);
+            Debug.Assert(end >= start);
+
+            int len = end - start;
+
+            if (len == 0)
+            {
+                return;
+            }
+
+            // Since BER can read everything and the reader does not mutate data
+            // just use a BER reader for identifying the positions of the values
+            // within this memory segment.
+            //
+            // Since it's not mutating, any restrictions imposed by CER or DER will
+            // still be maintained.
+            var reader = new AsnReader(new ReadOnlyMemory<byte>(buffer, start, len), AsnEncodingRules.BER);
+
+            List<(int, int)> positions = new List<(int, int)>();
+
+            int pos = start;
+
+            while (reader.HasData)
+            {
+                ReadOnlyMemory<byte> encoded = reader.ReadEncodedValue();
+                positions.Add((pos, encoded.Length));
+                pos += encoded.Length;
+            }
+
+            Debug.Assert(pos == end);
+
+            var comparer = new ArrayIndexSetOfValueComparer(buffer);
+            positions.Sort(comparer);
+
+            ArrayPool<byte> localPool = ArrayPool<byte>.Shared;
+            byte[] tmp = localPool.Rent(len);
+
+            pos = 0;
+
+            foreach ((int offset, int length) in positions)
+            {
+                Buffer.BlockCopy(buffer, offset, tmp, pos, length);
+                pos += length;
+            }
+
+            Debug.Assert(pos == len);
+
+            Buffer.BlockCopy(tmp, 0, buffer, start, len);
+            Array.Clear(tmp, 0, len);
+            localPool.Return(tmp);
+        }
+
+        internal static void Reverse(Span<byte> span)
+        {
+            int i = 0;
+            int j = span.Length - 1;
+
+            while (i < j)
+            {
+                byte tmp = span[i];
+                span[i] = span[j];
+                span[j] = tmp;
+
+                i++;
+                j--;
+            }
+        }
+
+        private static void CheckUniversalTag(Asn1Tag tag, UniversalTagNumber universalTagNumber)
+        {
+            if (tag.TagClass == TagClass.Universal && tag.TagValue != (int)universalTagNumber)
+            {
+                throw new ArgumentException(
+                    SR.Cryptography_Asn_UniversalValueIsFixed,
+                    nameof(tag));
+            }
+        }
+
+        private class ArrayIndexSetOfValueComparer : IComparer<(int, int)>
+        {
+            private readonly byte[] _data;
+
+            public ArrayIndexSetOfValueComparer(byte[] data)
+            {
+                _data = data;
+            }
+
+            public int Compare((int, int) x, (int, int) y)
+            {
+                (int xOffset, int xLength) = x;
+                (int yOffset, int yLength) = y;
+
+                int value =
+                    SetOfValueComparer.Instance.Compare(
+                        new ReadOnlyMemory<byte>(_data, xOffset, xLength),
+                        new ReadOnlyMemory<byte>(_data, yOffset, yLength));
+
+                if (value == 0)
+                {
+                    // Whichever had the lowest index wins (once sorted, stay sorted)
+                    return xOffset - yOffset;
+                }
+
+                return value;
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/SetOfValueComparer.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/SetOfValueComparer.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Security.Cryptography.Asn1
+{
+    internal class SetOfValueComparer : IComparer<ReadOnlyMemory<byte>>
+    {
+        internal static SetOfValueComparer Instance { get; } = new SetOfValueComparer();
+
+        public int Compare(ReadOnlyMemory<byte> x, ReadOnlyMemory<byte> y)
+        {
+            ReadOnlySpan<byte> xSpan = x.Span;
+            ReadOnlySpan<byte> ySpan = y.Span;
+
+            int min = Math.Min(x.Length, y.Length);
+            int diff;
+
+            for (int i = 0; i < min; i++)
+            {
+                int xVal = xSpan[i];
+                byte yVal = ySpan[i];
+                diff = xVal - yVal;
+
+                if (diff != 0)
+                {
+                    return diff;
+                }
+            }
+
+            // The sorting rules (T-REC-X.690-201508 sec 11.6) say that the shorter one
+            // counts as if it are padded with as many 0x00s on the right as required for
+            // comparison.
+            //
+            // But, since a shorter definite value will have already had the length bytes
+            // compared, it was already different.  And a shorter indefinite value will
+            // have hit end-of-contents, making it already different.
+            //
+            // This is here because the spec says it should be, but no values are known
+            // which will make diff != 0.
+            diff = x.Length - y.Length;
+
+            if (diff != 0)
+            {
+                return diff;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/TagClass.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/TagClass.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    /// <summary>
+    ///   The tag class for a particular ASN.1 tag.
+    /// </summary>
+    // Uses a masked overlay of the tag class encoding.
+    // T-REC-X.690-201508 sec 8.1.2.2
+    public enum TagClass : byte
+    {
+        /// <summary>
+        ///   The Universal tag class
+        /// </summary>
+        Universal = 0,
+
+        /// <summary>
+        ///   The Application tag class
+        /// </summary>
+        Application = 0b0100_0000,
+
+        /// <summary>
+        ///   The Context-Specific tag class
+        /// </summary>
+        ContextSpecific = 0b1000_0000,
+
+        /// <summary>
+        ///   The Private tag class
+        /// </summary>
+        Private = 0b1100_0000,
+    }
+}

--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/UniversalTagNumber.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/UniversalTagNumber.cs
@@ -1,0 +1,223 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.Asn1
+{
+    /// <summary>
+    ///   Tag assignments for the UNIVERSAL class in ITU-T X.680.
+    /// </summary>
+    // ITU-T-REC.X.680-201508 sec 8.6
+    public enum UniversalTagNumber
+    {
+        /// <summary>
+        ///   The reserved identifier for the End-of-Contents marker in an indefinite
+        ///   length encoding.
+        /// </summary>
+        EndOfContents = 0,
+
+        /// <summary>
+        ///   The universal class tag value for Boolean.
+        /// </summary>
+        Boolean = 1,
+
+        /// <summary>
+        ///   The universal class tag value for Integer.
+        /// </summary>
+        Integer = 2,
+
+        /// <summary>
+        ///   The universal class tag value for Bit String.
+        /// </summary>
+        BitString = 3,
+
+        /// <summary>
+        ///   The universal class tag value for Octet String.
+        /// </summary>
+        OctetString = 4,
+
+        /// <summary>
+        ///   The universal class tag value for Null.
+        /// </summary>
+        Null = 5,
+
+        /// <summary>
+        ///   The universal class tag value for Object Identifier.
+        /// </summary>
+        ObjectIdentifier = 6,
+
+        /// <summary>
+        ///   The universal class tag value for Object Descriptor.
+        /// </summary>
+        ObjectDescriptor = 7,
+
+        /// <summary>
+        ///   The universal class tag value for External.
+        /// </summary>
+        External = 8,
+
+        /// <summary>
+        ///   The universal class tag value for Instance-Of.
+        /// </summary>
+        InstanceOf = External,
+
+        /// <summary>
+        ///   The universal class tag value for Real.
+        /// </summary>
+        Real = 9,
+
+        /// <summary>
+        ///   The universal class tag value for Enumerated.
+        /// </summary>
+        Enumerated = 10,
+
+        /// <summary>
+        ///   The universal class tag value for Embedded-PDV.
+        /// </summary>
+        Embedded = 11,
+
+        /// <summary>
+        ///   The universal class tag value for UTF8String.
+        /// </summary>
+        UTF8String = 12,
+
+        /// <summary>
+        ///   The universal class tag value for Relative Object Identifier.
+        /// </summary>
+        RelativeObjectIdentifier = 13,
+
+        /// <summary>
+        ///   The universal class tag value for Time.
+        /// </summary>
+        Time = 14,
+
+        // 15 is reserved
+
+        /// <summary>
+        ///   The universal class tag value for Sequence.
+        /// </summary>
+        Sequence = 16,
+
+        /// <summary>
+        ///   The universal class tag value for Sequence-Of.
+        /// </summary>
+        SequenceOf = Sequence,
+
+        /// <summary>
+        ///   The universal class tag value for Set.
+        /// </summary>
+        Set = 17,
+
+        /// <summary>
+        ///   The universal class tag value for Set-Of.
+        /// </summary>
+        SetOf = Set,
+
+        /// <summary>
+        ///   The universal class tag value for NumericString.
+        /// </summary>
+        NumericString = 18,
+
+        /// <summary>
+        ///   The universal class tag value for PrintableString.
+        /// </summary>
+        PrintableString = 19,
+
+        /// <summary>
+        ///   The universal class tag value for TeletexString (T61String).
+        /// </summary>
+        TeletexString = 20,
+
+        /// <summary>
+        ///   The universal class tag value for T61String (TeletexString).
+        /// </summary>
+        T61String = TeletexString,
+
+        /// <summary>
+        ///   The universal class tag value for VideotexString.
+        /// </summary>
+        VideotexString = 21,
+
+        /// <summary>
+        ///   The universal class tag value for IA5String.
+        /// </summary>
+        IA5String = 22,
+
+        /// <summary>
+        ///   The universal class tag value for UTCTime.
+        /// </summary>
+        UtcTime = 23,
+
+        /// <summary>
+        ///   The universal class tag value for GeneralizedTime.
+        /// </summary>
+        GeneralizedTime = 24,
+
+        /// <summary>
+        ///   The universal class tag value for GraphicString.
+        /// </summary>
+        GraphicString = 25,
+
+        /// <summary>
+        ///   The universal class tag value for VisibleString (ISO646String).
+        /// </summary>
+        VisibleString = 26,
+
+        /// <summary>
+        ///   The universal class tag value for ISO646String (VisibleString).
+        /// </summary>
+        ISO646String = VisibleString,
+
+        /// <summary>
+        ///   The universal class tag value for GeneralString.
+        /// </summary>
+        GeneralString = 27,
+
+        /// <summary>
+        ///   The universal class tag value for UniversalString.
+        /// </summary>
+        UniversalString = 28,
+
+        /// <summary>
+        ///   The universal class tag value for an unrestricted character string.
+        /// </summary>
+        UnrestrictedCharacterString = 29,
+
+        /// <summary>
+        ///   The universal class tag value for BMPString.
+        /// </summary>
+        BMPString = 30,
+
+        /// <summary>
+        ///   The universal class tag value for Date.
+        /// </summary>
+        Date = 31,
+
+        /// <summary>
+        ///   The universal class tag value for Time-Of-Day.
+        /// </summary>
+        TimeOfDay = 32,
+
+        /// <summary>
+        ///   The universal class tag value for Date-Time.
+        /// </summary>
+        DateTime = 33,
+
+        /// <summary>
+        ///   The universal class tag value for Duration.
+        /// </summary>
+        Duration = 34,
+
+        /// <summary>
+        ///   The universal class tag value for Object Identifier
+        ///   Internationalized Resource Identifier (IRI).
+        /// </summary>
+        ObjectIdentifierIRI = 35,
+
+        /// <summary>
+        ///   The universal class tag value for Relative Object Identifier
+        ///   Internationalized Resource Identifier (IRI).
+        /// </summary>
+        RelativeObjectIdentifierIRI = 36,
+    }
+}


### PR DESCRIPTION
These files are identical to the files at

https://github.com/dotnet/corefxlab/tree/42ab2422b190521dd21c5c9e816810cf23f6a828/src/System.Security.Cryptography.Asn1.Experimental/System/Security/Cryptography/Asn1

though PointerMemoryManager is not included (already present in corefx)

This separate directory is being used to make for easy copying back and forth to corefxlab as needed.

Changes to return the classes to `internal` and actually consume these files will come as a followup.