### PR TITLE
Improve process test fail output

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1093,7 +1093,7 @@ namespace System.Diagnostics.Tests
                 StringBuilder builder = new StringBuilder();
                 foreach (Process process in Process.GetProcesses())
                 {
-                    builder.AppendFormat("Pid: {0} Name: {1}'", process.Id, process.ProcessName);
+                    builder.AppendFormat("Pid: '{0}' Name: '{1}'", process.Id, process.ProcessName);
                     try
                     {
                         builder.AppendFormat(" Main module: '{0}'", process.MainModule.FileName);

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -13,6 +13,7 @@ using System.Security;
 using System.Text;
 using System.Threading;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.Diagnostics.Tests
 {
@@ -1074,13 +1075,12 @@ namespace System.Diagnostics.Tests
 
             Process[] processes = Process.GetProcessesByName(currentProcess.ProcessName);
             try
-            { 
+            {
                 Assert.NotEmpty(processes);
             }
-            catch
+            catch(TrueException)
             {
-                PrintProcesses();
-                throw;
+                throw new TrueException(PrintProcesses(), false);
             }
 
             Assert.All(processes, process => Assert.Equal(".", process.MachineName));
@@ -1088,7 +1088,7 @@ namespace System.Diagnostics.Tests
             return;
 
             // Print list of active processes in case of failure https://github.com/dotnet/corefx/issues/35783
-            void PrintProcesses()
+            string PrintProcesses()
             {
                 StringBuilder builder = new StringBuilder();
                 foreach (Process process in Process.GetProcesses())
@@ -1104,12 +1104,9 @@ namespace System.Diagnostics.Tests
                     }
                     builder.AppendLine();
                 }
-
-                // We cannot use xunit ITestOutputHelper because is not marshallable by RemoteInvoker
-                Console.Write(builder);
-                Console.WriteLine("Current process id: {0}", Process.GetCurrentProcess().Id);
+                builder.AppendFormat("Current process id: {0}", Process.GetCurrentProcess().Id);
+                return builder.ToString();
             }
-
         }
 
         public static IEnumerable<object[]> MachineName_TestData()

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1073,35 +1073,42 @@ namespace System.Diagnostics.Tests
             Assert.NotEmpty(currentProcess.ProcessName);
 
             Process[] processes = Process.GetProcessesByName(currentProcess.ProcessName);
-
-            // Print list of active processes in case of failure https://github.com/dotnet/corefx/issues/35783
-            StringBuilder builder = new StringBuilder();
-            foreach (Process process in Process.GetProcesses())
-            {
-                builder.AppendFormat("Name: {0}'", process.ProcessName);
-                try
-                {
-                    builder.AppendFormat(" Main module: '{0}'", process.MainModule.FileName);
-                }
-                catch
-                {
-                    // We cannot read main module of all processes
-                }
-                builder.AppendLine();
-            }
-
             try
             { 
                 Assert.NotEmpty(processes);
             }
             catch
             {
-                // We cannot use xunit ITestOutputHelper because is not marshallable by RemoteInvoker
-                Console.WriteLine(builder);
+                PrintProcesses();
                 throw;
             }
 
             Assert.All(processes, process => Assert.Equal(".", process.MachineName));
+
+            return;
+
+            // Print list of active processes in case of failure https://github.com/dotnet/corefx/issues/35783
+            void PrintProcesses()
+            {
+                StringBuilder builder = new StringBuilder();
+                foreach (Process process in Process.GetProcesses())
+                {
+                    builder.AppendFormat("Name: {0}'", process.ProcessName);
+                    try
+                    {
+                        builder.AppendFormat(" Main module: '{0}'", process.MainModule.FileName);
+                    }
+                    catch
+                    {
+                        // We cannot obtain main module of all processes
+                    }
+                    builder.AppendLine();
+                }
+
+                // We cannot use xunit ITestOutputHelper because is not marshallable by RemoteInvoker
+                Console.WriteLine(builder);
+            }
+
         }
 
         public static IEnumerable<object[]> MachineName_TestData()

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1093,7 +1093,7 @@ namespace System.Diagnostics.Tests
                 StringBuilder builder = new StringBuilder();
                 foreach (Process process in Process.GetProcesses())
                 {
-                    builder.AppendFormat("Name: {0}'", process.ProcessName);
+                    builder.AppendFormat("Pid: {0} Name: {1}'", process.Id, process.ProcessName);
                     try
                     {
                         builder.AppendFormat(" Main module: '{0}'", process.MainModule.FileName);
@@ -1106,7 +1106,8 @@ namespace System.Diagnostics.Tests
                 }
 
                 // We cannot use xunit ITestOutputHelper because is not marshallable by RemoteInvoker
-                Console.WriteLine(builder);
+                Console.Write(builder);
+                Console.WriteLine("Current process id: {0}", Process.GetCurrentProcess().Id);
             }
 
         }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1078,16 +1078,15 @@ namespace System.Diagnostics.Tests
             {
                 Assert.NotEmpty(processes);
             }
-            catch(TrueException)
+            catch (TrueException)
             {
                 throw new TrueException(PrintProcesses(), false);
             }
 
             Assert.All(processes, process => Assert.Equal(".", process.MachineName));
-
             return;
 
-            // Print list of active processes in case of failure https://github.com/dotnet/corefx/issues/35783
+            // Outputs a list of active processes in case of failure: https://github.com/dotnet/corefx/issues/35783
             string PrintProcesses()
             {
                 StringBuilder builder = new StringBuilder();
@@ -1104,6 +1103,7 @@ namespace System.Diagnostics.Tests
                     }
                     builder.AppendLine();
                 }
+                
                 builder.AppendFormat("Current process id: {0}", Process.GetCurrentProcess().Id);
                 return builder.ToString();
             }


### PR DESCRIPTION
contributes to https://github.com/dotnet/corefx/issues/35783

Output sample
```
  ...
  Pid: 15388 Name: MSBuild' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\MSBuild.exe'
  Pid: 18128 Name: conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
  Pid: 3172 Name: Microsoft.Alm.Shared.Remoting.RemoteContainer.dll' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\common7\ide\PrivateAssemblies\Microsoft.Alm.Shared.Remoting.RemoteContainer.dll'
  Pid: 10644 Name: smartscreen' Main module: 'C:\Windows\System32\smartscreen.exe'
  Pid: 5764 Name: ConEmu64' Main module: 'C:\tools\cmder\vendor\conemu-maximus5\ConEmu64.exe'
  Pid: 15132 Name: ConEmuC64' Main module: 'C:\tools\cmder\vendor\conemu-maximus5\ConEmu\ConEmuC64.exe'
  Pid: 9324 Name: conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
  Pid: 7312 Name: cmd' Main module: 'C:\WINDOWS\SYSTEM32\cmd.exe'
  Pid: 6216 Name: VBCSCompiler' Main module: 'C:\Users\Marco\.nuget\packages\microsoft.net.compilers\3.0.0-beta4-final\tools\VBCSCompiler.exe'
  Pid: 17984 Name: conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
  Pid: 13024 Name: svchost' Main module: 'C:\WINDOWS\system32\svchost.exe'
  Pid: 17384 Name: MSBuild' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin\MSBuild.exe'
  Pid: 8004 Name: cmd' Main module: 'C:\WINDOWS\SysWOW64\cmd.exe'
  Pid: 16692 Name: conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
  Pid: 16116 Name: dotnet' Main module: 'C:\git\corefx\artifacts\bin\testhost\netcoreapp-Windows_NT-Debug-x64\dotnet.exe'
  Current process id: 16116
      System.Diagnostics.Tests.ProcessTests.GetProcessesByName_ProcessName_ReturnsExpected [FAIL]
        Assert.False() Failure
        Expected: False
        Actual:   True
        Stack Trace:
          C:\git\corefx\src\System.Diagnostics.Process\tests\ProcessTests.cs(1079,0): at System.Diagnostics.Tests.ProcessTests.GetProcessesByName_ProcessName_ReturnsExpected()
   ...
```

/cc @danmosemsft @ahsonkhan 