### PR TITLE
[release/2.1] Port Improve X509Chain handling of NotSignatureValid on Linux

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509StoreCtx.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509StoreCtx.cs
@@ -19,6 +19,29 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetChain")]
         internal static extern SafeX509StackHandle X509StoreCtxGetChain(SafeX509StoreCtxHandle ctx);
 
+        [DllImport(Libraries.CryptoNative)]
+        private static extern int CryptoNative_X509StoreCtxResetForSignatureError(
+            SafeX509StoreCtxHandle ctx,
+            out SafeX509StoreHandle newStore);
+
+        internal static void X509StoreCtxResetForSignatureError(
+            SafeX509StoreCtxHandle ctx,
+            out SafeX509StoreHandle newStore)
+        {
+            if (CryptoNative_X509StoreCtxResetForSignatureError(ctx, out newStore) != 1)
+            {
+                newStore.Dispose();
+                newStore = null;
+                throw CreateOpenSslCryptographicException();
+            }
+
+            if (newStore.IsInvalid)
+            {
+                newStore.Dispose();
+                newStore = null;
+            }
+        }
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetSharedUntrusted")]
         private static extern SafeSharedX509StackHandle X509StoreCtxGetSharedUntrusted_private(SafeX509StoreCtxHandle ctx);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/apibridge.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/apibridge.cpp
@@ -484,6 +484,16 @@ extern "C" int32_t local_SSL_is_init_finished(const SSL* ssl)
     return SSL_state(ssl) == SSL_ST_OK;
 }
 
+extern "C" X509Stack* local_X509_STORE_CTX_get0_chain(X509_STORE_CTX* ctx)
+{
+    return ctx ? ctx->chain : NULL;
+}
+
+extern "C" X509_STORE* local_X509_STORE_CTX_get0_store(X509_STORE_CTX* ctx)
+{
+    return ctx ? ctx->ctx: NULL;
+}
+
 extern "C" X509Stack* local_X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx)
 {
     return ctx ? ctx->untrusted : nullptr;

--- a/src/Native/Unix/System.Security.Cryptography.Native/apibridge.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/apibridge.h
@@ -35,6 +35,8 @@ extern "C" int32_t local_X509_NAME_get0_der(X509_NAME* x509Name, const uint8_t**
 extern "C" int32_t local_X509_PUBKEY_get0_param(
     ASN1_OBJECT** palgOid, const uint8_t** pkeyBytes, int* pkeyBytesLen, X509_ALGOR** palg, X509_PUBKEY* pubkey);
 extern "C" X509* local_X509_STORE_CTX_get0_cert(X509_STORE_CTX* ctx);
+extern "C" STACK_OF(X509)* local_X509_STORE_CTX_get0_chain(X509_STORE_CTX* ctx);
+extern "C" X509_STORE* local_X509_STORE_CTX_get0_store(X509_STORE_CTX* ctx);
 extern "C" STACK_OF(X509) * local_X509_STORE_CTX_get0_untrusted(X509_STORE_CTX* ctx);
 extern "C" const ASN1_TIME* local_X509_get0_notAfter(const X509* x509);
 extern "C" const ASN1_TIME* local_X509_get0_notBefore(const X509* x509);

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl_1_0_structs.h
@@ -132,8 +132,29 @@ struct x509_st
 
 struct x509_store_ctx_st
 {
-    const void* _ignored0;
+    X509_STORE* ctx;
     int _ignored1;
     X509* cert;
     STACK_OF(X509*) untrusted;
+    const void* _ignored2;
+    const void* _ignored3;
+    const void* _ignored4;
+    // For comparison purposes to the 1.0.x headers:
+    // BEGIN FUNCTION POINTERS
+    const void* _ignored5;
+    const void* _ignored6;
+    const void* _ignored7;
+    const void* _ignored8;
+    const void* _ignored9;
+    const void* _ignored10;
+    const void* _ignored11;
+    const void* _ignored12;
+    const void* _ignored13;
+    const void* _ignored14;
+    const void* _ignored15;
+    const void* _ignored16;
+    // END FUNCTION POINTERS
+    int _ignored17;
+    int _ignored18;
+    STACK_OF(X509*) chain;
 };

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.cpp
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.cpp
@@ -317,3 +317,123 @@ extern "C" X509* CryptoNative_X509UpRef(X509* x509)
 
     return x509;
 }
+
+extern "C" int32_t CryptoNative_X509StoreCtxResetForSignatureError(X509_STORE_CTX* storeCtx, X509_STORE** newStore)
+{
+    if (storeCtx == NULL || newStore == NULL)
+    {
+        return -1;
+    }
+
+    *newStore = NULL;
+
+    int errorDepth = X509_STORE_CTX_get_error_depth(storeCtx);
+    X509Stack* chain = X509_STORE_CTX_get0_chain(storeCtx);
+    int chainLength = sk_X509_num(chain);
+    X509_STORE* store = X509_STORE_CTX_get0_store(storeCtx);
+
+    // If the signature error was reported at the last element
+    if (chainLength - 1 == errorDepth)
+    {
+        X509* root;
+        X509* last = sk_X509_value(chain, errorDepth);
+
+        // If the last element is in the trust store we need to build a new trust store.
+        if (X509_STORE_CTX_get1_issuer(&root, storeCtx, last))
+        {
+            if (root == last)
+            {
+                // We know it's a non-zero refcount after this because last has one, too.
+                // So go ahead and undo the get1.
+                X509_free(root);
+
+                X509_STORE* tmpNew = X509_STORE_new();
+
+                if (tmpNew == NULL)
+                {
+                    return 0;
+                }
+
+                X509* duplicate = X509_dup(last);
+
+                if (duplicate == NULL)
+                {
+                    X509_STORE_free(tmpNew);
+                    return 0;
+                }
+
+                if (!X509_STORE_add_cert(tmpNew, duplicate))
+                {
+                    X509_free(duplicate);
+                    X509_STORE_free(tmpNew);
+                    return 0;
+                }
+
+                *newStore = tmpNew;
+                store = tmpNew;
+                chainLength--;
+            }
+            else
+            {
+                // This really shouldn't happen, since if we could have resolved it now
+                // it should have resolved during chain walk.
+                //
+                // But better safe than sorry.
+                X509_free(root);
+            }
+        }
+    }
+
+    X509Stack* untrusted = X509_STORE_CTX_get0_untrusted(storeCtx);
+    X509* cur;
+
+    while ((cur = sk_X509_pop(untrusted)) != NULL)
+    {
+        X509_free(cur);
+    }
+
+    for (int i = chainLength - 1; i > 0; --i)
+    {
+        cur = sk_X509_value(chain, i);
+
+        // errorDepth and lower need to be duplicated to avoid x->valid taint.
+        if (i <= errorDepth)
+        {
+            X509* duplicate = X509_dup(cur);
+
+            if (duplicate == NULL)
+            {
+                return 0;
+            }
+
+            if (!sk_X509_push(untrusted, duplicate))
+            {
+                X509err(X509_F_X509_VERIFY_CERT, ERR_R_MALLOC_FAILURE);
+                X509_free(duplicate);
+                return 0;
+            }
+        }
+        else
+        {
+            if (sk_X509_push(untrusted, cur))
+            {
+                X509_up_ref(cur);
+            }
+            else
+            {
+                X509err(X509_F_X509_VERIFY_CERT, ERR_R_MALLOC_FAILURE);
+                return 0;
+            }
+        }
+    }
+
+    X509* leafDup = X509_dup(X509_STORE_CTX_get0_cert(storeCtx));
+
+    if (leafDup == NULL)
+    {
+        return 0;
+    }
+
+    X509_STORE_CTX_cleanup(storeCtx);
+    return CryptoNative_X509StoreCtxInit(storeCtx, store, leafDup, untrusted);
+}

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -303,3 +303,12 @@ Unlike X509Duplicate, this modifies an existing object, so no new memory is allo
 Returns the input value.
 */
 extern "C" X509* CryptoNative_X509UpRef(X509* x509);
+
+/*
+Duplicates any certificate at or below the level where the error marker is.
+
+Outputs a new store with a clone of the root, if necessary.
+
+The new store does not have any properties set other than the trust. (Mainly, CRLs are lost)
+*/
+extern "C" int32_t CryptoNative_X509StoreCtxResetForSignatureError(X509_STORE_CTX* storeCtx, X509_STORE** newStore);

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -711,5 +711,78 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal(issuer.RawData, chain.ChainElements[1].Certificate.RawData);
             }
         }
+
+        [Fact]
+        public static void BuildInvalidSignatureTwice()
+        {
+            byte[] bytes = (byte[])TestData.MsCertificate.Clone();
+            bytes[bytes.Length - 1] ^= 0xFF;
+
+            using (X509Certificate2 cert = new X509Certificate2(bytes))
+            using (ChainHolder chainHolder = new ChainHolder())
+            {
+                X509Chain chain = chainHolder.Chain;
+                chain.ChainPolicy.VerificationTime = cert.NotBefore.AddHours(2);
+                chain.ChainPolicy.VerificationFlags =
+                    X509VerificationFlags.AllowUnknownCertificateAuthority;
+
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+
+                int iter = 0;
+
+                void CheckChain()
+                {
+                    iter++;
+                    bool valid = chain.Build(cert);
+                    X509ChainStatusFlags allFlags = chain.AllStatusFlags();
+
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    {
+                        // OSX considers this to be valid because it doesn't report NotSignatureValid,
+                        // just PartialChain ("I couldn't find an issuer that made the signature work"),
+                        // and PartialChain + AllowUnknownCertificateAuthority == pass.
+                        Assert.True(valid, $"Chain is valid on execution {iter}");
+
+                        Assert.Equal(1, chain.ChainElements.Count);
+
+                        Assert.Equal(
+                            X509ChainStatusFlags.PartialChain,
+                            allFlags);
+                    }
+                    else
+                    {
+                        Assert.False(valid, $"Chain is valid on execution {iter}");
+
+                        Assert.Equal(3, chain.ChainElements.Count);
+
+                        // Clear UntrustedRoot, if it happened.
+                        allFlags &= ~X509ChainStatusFlags.UntrustedRoot;
+
+                        Assert.Equal(
+                            X509ChainStatusFlags.NotSignatureValid,
+                            allFlags);
+                    }
+
+                    chainHolder.DisposeChainElements();
+                }
+
+                CheckChain();
+                CheckChain();
+            }
+        }
+
+        internal static X509ChainStatusFlags AllStatusFlags(this X509Chain chain)
+        {
+            return chain.ChainStatus.Aggregate(
+                X509ChainStatusFlags.NoError,
+                (f, s) => f | s.Status);
+        }
+
+        internal static X509ChainStatusFlags AllStatusFlags(this X509ChainElement chainElement)
+        {
+            return chainElement.ChainElementStatus.Aggregate(
+                X509ChainStatusFlags.NoError,
+                (f, s) => f | s.Status);
+        }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -1,0 +1,210 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{
+    public static class DynamicChainTests
+    {
+        public static object[][] InvalidSignature3Cases { get; } =
+            new object[][]
+            {
+                new object[]
+                {
+                    X509ChainStatusFlags.NotSignatureValid,
+                    X509ChainStatusFlags.NoError,
+                    X509ChainStatusFlags.UntrustedRoot,
+                },
+                new object[]
+                {
+                    X509ChainStatusFlags.NoError,
+                    X509ChainStatusFlags.NotSignatureValid,
+                    X509ChainStatusFlags.UntrustedRoot,
+                },
+                new object[]
+                {
+                    X509ChainStatusFlags.NoError,
+                    X509ChainStatusFlags.NoError,
+                    X509ChainStatusFlags.NotSignatureValid | X509ChainStatusFlags.UntrustedRoot,
+                },
+                new object[]
+                {
+                    X509ChainStatusFlags.NotSignatureValid | X509ChainStatusFlags.NotTimeValid,
+                    X509ChainStatusFlags.NoError,
+                    X509ChainStatusFlags.UntrustedRoot,
+                },
+                new object[]
+                {
+                    X509ChainStatusFlags.NotSignatureValid | X509ChainStatusFlags.NotTimeValid,
+                    X509ChainStatusFlags.NotTimeValid,
+                    X509ChainStatusFlags.UntrustedRoot,
+                },
+                new object[]
+                {
+                    X509ChainStatusFlags.NotSignatureValid | X509ChainStatusFlags.NotTimeValid,
+                    X509ChainStatusFlags.NotTimeValid,
+                    X509ChainStatusFlags.UntrustedRoot | X509ChainStatusFlags.NotTimeValid,
+                },
+            };
+
+        [Theory]
+        [MemberData(nameof(InvalidSignature3Cases))]
+        public static void BuildInvalidSignatureTwice(
+            X509ChainStatusFlags endEntityErrors,
+            X509ChainStatusFlags intermediateErrors,
+            X509ChainStatusFlags rootErrors)
+        {
+            TestDataGenerator.MakeTestChain3(
+                out X509Certificate2 endEntityCert,
+                out X509Certificate2 intermediateCert,
+                out X509Certificate2 rootCert);
+
+            X509Certificate2 TamperIfNeeded(X509Certificate2 input, X509ChainStatusFlags flags)
+            {
+                if ((flags & X509ChainStatusFlags.NotSignatureValid) != 0)
+                {
+                    X509Certificate2 tampered = TamperSignature(input);
+                    input.Dispose();
+                    return tampered;
+                }
+
+                return input;
+            }
+
+            DateTime RewindIfNeeded(DateTime input, X509Certificate2 cert, X509ChainStatusFlags flags)
+            {
+                if ((flags & X509ChainStatusFlags.NotTimeValid) != 0)
+                {
+                    return cert.NotBefore.AddMinutes(-1);
+                }
+
+                return input;
+            }
+
+            int expectedCount = 3;
+
+            DateTime verificationTime = endEntityCert.NotBefore.AddMinutes(1);
+            verificationTime = RewindIfNeeded(verificationTime, endEntityCert, endEntityErrors);
+            verificationTime = RewindIfNeeded(verificationTime, intermediateCert, intermediateErrors);
+            verificationTime = RewindIfNeeded(verificationTime, rootCert, rootErrors);
+
+            // Replace the certs for the scenario.
+            endEntityCert = TamperIfNeeded(endEntityCert, endEntityErrors);
+            intermediateCert = TamperIfNeeded(intermediateCert, intermediateErrors);
+            rootCert = TamperIfNeeded(rootCert, rootErrors);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // For the lower levels, turn NotSignatureValid into PartialChain,
+                // and clear all errors at higher levels.
+
+                if ((endEntityErrors & X509ChainStatusFlags.NotSignatureValid) != 0)
+                {
+                    expectedCount = 1;
+                    endEntityErrors &= ~X509ChainStatusFlags.NotSignatureValid;
+                    endEntityErrors |= X509ChainStatusFlags.PartialChain;
+                    intermediateErrors = X509ChainStatusFlags.NoError;
+                    rootErrors = X509ChainStatusFlags.NoError;
+                }
+                else if ((intermediateErrors & X509ChainStatusFlags.NotSignatureValid) != 0)
+                {
+                    expectedCount = 2;
+                    intermediateErrors &= ~X509ChainStatusFlags.NotSignatureValid;
+                    intermediateErrors |= X509ChainStatusFlags.PartialChain;
+                    rootErrors = X509ChainStatusFlags.NoError;
+                }
+                else if ((rootErrors & X509ChainStatusFlags.NotSignatureValid) != 0)
+                {
+                    rootErrors &= ~X509ChainStatusFlags.NotSignatureValid;
+
+                    // On 10.12 this is just UntrustedRoot.
+                    // On 10.13+ it becomes PartialChain, and UntrustedRoot goes away.
+                    if (PlatformDetection.IsMacOsHighSierraOrHigher)
+                    {
+                        rootErrors &= ~X509ChainStatusFlags.UntrustedRoot;
+                        rootErrors |= X509ChainStatusFlags.PartialChain;
+                    }
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // Windows only reports NotTimeValid on the start-of-chain (end-entity in this case)
+                // If it were possible in this suite to get only a higher-level cert as NotTimeValid
+                // without the lower one, that would have resulted in NotTimeNested.
+                intermediateErrors &= ~X509ChainStatusFlags.NotTimeValid;
+                rootErrors &= ~X509ChainStatusFlags.NotTimeValid;
+            }
+
+            X509ChainStatusFlags expectedAllErrors = endEntityErrors | intermediateErrors | rootErrors;
+
+            // If PartialChain or UntrustedRoot are the only remaining errors, the chain will succeed.
+            const X509ChainStatusFlags SuccessCodes =
+                X509ChainStatusFlags.UntrustedRoot | X509ChainStatusFlags.PartialChain;
+
+            bool expectSuccess = (expectedAllErrors & ~SuccessCodes) == 0;
+
+            using (endEntityCert)
+            using (intermediateCert)
+            using (rootCert)
+            using (ChainHolder chainHolder = new ChainHolder())
+            {
+                X509Chain chain = chainHolder.Chain;
+                chain.ChainPolicy.VerificationTime = verificationTime;
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                chain.ChainPolicy.ExtraStore.Add(intermediateCert);
+                chain.ChainPolicy.ExtraStore.Add(rootCert);
+
+                chain.ChainPolicy.VerificationFlags |=
+                    X509VerificationFlags.AllowUnknownCertificateAuthority;
+
+                int i = 0;
+
+                void CheckChain()
+                {
+                    i++;
+
+                    bool valid = chain.Build(endEntityCert);
+
+                    if (expectSuccess)
+                    {
+                        Assert.True(valid, $"Chain build on iteration {i}");
+                    }
+                    else
+                    {
+                        Assert.False(valid, $"Chain build on iteration {i}");
+                    }
+
+                    Assert.Equal(expectedCount, chain.ChainElements.Count);
+                    Assert.Equal(expectedAllErrors, chain.AllStatusFlags());
+                    
+                    Assert.Equal(endEntityErrors, chain.ChainElements[0].AllStatusFlags());
+
+                    if (expectedCount > 2)
+                    {
+                        Assert.Equal(rootErrors, chain.ChainElements[2].AllStatusFlags());
+                    }
+
+                    if (expectedCount > 1)
+                    {
+                        Assert.Equal(intermediateErrors, chain.ChainElements[1].AllStatusFlags());
+                    }
+
+                    chainHolder.DisposeChainElements();
+                }
+
+                CheckChain();
+                CheckChain();
+            }
+        }
+
+        private static X509Certificate2 TamperSignature(X509Certificate2 input)
+        {
+            byte[] cert = input.RawData;
+            cert[cert.Length - 1] ^= 0xFF;
+            return new X509Certificate2(cert);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -34,6 +34,7 @@
     <Compile Include="ContentTypeTests.cs" />
     <Compile Include="CtorTests.cs" />
     <Compile Include="DSAOther.cs" />
+    <Compile Include="DynamicChainTests.cs" />
     <Compile Include="ECDsaOther.cs" />
     <Compile Include="ExportTests.cs" />
     <Compile Include="ExtensionsTests.cs" />
@@ -46,6 +47,7 @@
     <Compile Include="PublicKeyTests.cs" />
     <Compile Include="RSAOther.cs" />
     <Compile Include="TestData.cs" />
+    <Compile Include="TestDataGenerator.cs" />
     <Compile Include="TestEnvironmentConfiguration.cs" />
     <Compile Include="X500DistinguishedNameEncodingTests.cs" />
     <Compile Include="X500DistinguishedNameTests.cs" />

--- a/src/System.Security.Cryptography.X509Certificates/tests/TestDataGenerator.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/TestDataGenerator.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{
+    internal static class TestDataGenerator
+    {
+        internal static void MakeTestChain3(
+            out X509Certificate2 endEntityCert,
+            out X509Certificate2 intermediateCert,
+            out X509Certificate2 rootCert)
+        {
+            using (RSA rootKey = RSA.Create())
+            using (RSA intermediateKey = RSA.Create())
+            using (RSA endEntityKey = RSA.Create())
+            {
+                ReadOnlySpan<RSA> keys = new[]
+                {
+                    rootKey,
+                    intermediateKey,
+                    endEntityKey,
+                };
+
+                Span<X509Certificate2> certs = new X509Certificate2[keys.Length];
+                MakeTestChain(keys, certs);
+
+                endEntityCert = certs[0];
+                intermediateCert = certs[1];
+                rootCert = certs[2];
+            }
+        }
+
+        internal static void MakeTestChain(
+            ReadOnlySpan<RSA> keys,
+            Span<X509Certificate2> certs,
+            string eeName = "CN=End-Entity",
+            OidCollection eeEku = null)
+        {
+            if (keys.Length < 2)
+                throw new ArgumentException(nameof(keys));
+            if (keys.Length != certs.Length)
+                throw new ArgumentException(nameof(certs));
+            if (string.IsNullOrEmpty(eeName))
+                throw new ArgumentOutOfRangeException(nameof(eeName));
+
+            var caUnlimited = new X509BasicConstraintsExtension(true, false, 0, true);
+            var eeConstraint = new X509BasicConstraintsExtension(false, false, 0, true);
+
+            var caUsage = new X509KeyUsageExtension(
+                X509KeyUsageFlags.CrlSign |
+                    X509KeyUsageFlags.KeyCertSign |
+                    X509KeyUsageFlags.DigitalSignature,
+                false);
+
+            var eeUsage = new X509KeyUsageExtension(
+                X509KeyUsageFlags.DigitalSignature |
+                    X509KeyUsageFlags.NonRepudiation |
+                    X509KeyUsageFlags.KeyEncipherment,
+                false);
+
+            TimeSpan notBeforeInterval = TimeSpan.FromDays(30);
+            TimeSpan notAfterInterval = TimeSpan.FromDays(90);
+            DateTimeOffset eeStart = DateTimeOffset.UtcNow.AddDays(-7);
+            DateTimeOffset eeEnd = eeStart.AddDays(45);
+            byte[] serialBuf = new byte[16];
+
+            int rootIndex = keys.Length - 1;
+
+            HashAlgorithmName hashAlgorithm = HashAlgorithmName.SHA256;
+            RSASignaturePadding signaturePadding = RSASignaturePadding.Pkcs1;
+
+            CertificateRequest rootReq = new CertificateRequest(
+                "CN=Test Root",
+                keys[rootIndex],
+                hashAlgorithm,
+                signaturePadding);
+
+            rootReq.CertificateExtensions.Add(caUnlimited);
+            rootReq.CertificateExtensions.Add(caUsage);
+
+            X509Certificate2 lastWithKey = rootReq.CreateSelfSigned(
+                eeStart - (notBeforeInterval * rootIndex),
+                eeEnd + (notAfterInterval * rootIndex));
+
+            certs[rootIndex] = new X509Certificate2(lastWithKey.RawData);
+
+            int presentationNumber = 0;
+
+            for (int i = rootIndex - 1; i > 0; i--)
+            {
+                presentationNumber++;
+
+                CertificateRequest intermediateReq = new CertificateRequest(
+                    $"CN=Intermediate Layer {presentationNumber}",
+                    keys[i],
+                    hashAlgorithm,
+                    signaturePadding);
+
+                intermediateReq.CertificateExtensions.Add(caUnlimited);
+                intermediateReq.CertificateExtensions.Add(caUsage);
+
+                // Leave serialBuf[0] as 0 to avoid a realloc in the signer
+                RandomNumberGenerator.Fill(serialBuf.AsSpan(1));
+
+                certs[i] = intermediateReq.Create(
+                    lastWithKey,
+                    eeStart - (notBeforeInterval * i),
+                    eeEnd + (notAfterInterval * i),
+                    serialBuf);
+
+                lastWithKey.Dispose();
+                lastWithKey = certs[i].CopyWithPrivateKey(keys[i]);
+            }
+
+            CertificateRequest eeReq = new CertificateRequest(
+                eeName,
+                keys[0],
+                hashAlgorithm,
+                signaturePadding);
+
+            eeReq.CertificateExtensions.Add(eeConstraint);
+            eeReq.CertificateExtensions.Add(eeUsage);
+
+            if (eeEku != null)
+            {
+                eeReq.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(eeEku, false));
+            }
+
+            // Leave serialBuf[0] as 0 to avoid a realloc in the signer
+            RandomNumberGenerator.Fill(serialBuf.AsSpan(1));
+
+            certs[0] = eeReq.Create(lastWithKey, eeStart, eeEnd, serialBuf);
+            lastWithKey.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Port #35801 to release/2.1
Fixes #35654.

#### Description

Building an X509Chain with the same inputs on a given machine is supposed to always produce the same outputs, but in some cases on Linux with OpenSSL 1.0.x errors can not appear when building a chain over the same certificate object (or a distinct CLR object over the same native resource) a second time.

#### Customer Impact

Customers who build an X509Chain multiple times over the same certificate on Linux may not get all the errors on a successive chainwalk, which could result in considering an invalid chain valid.

#### Regression?

No

#### Packaging reviewed? 

* System.Security.Cryptography.X509Certificates only ships in Microsoft.NETCore.App

#### Risk

Low.  The "single build", vast majority, cases are covered by the existing tests; and new tests verify the multi-build case as now uniform across the OSes.