### PR TITLE
Shrink ReadOnlySequence by 8 bytes

### DIFF
--- a/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
+++ b/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
@@ -22,7 +22,7 @@ namespace System.Buffers
                 int index = source.First.Span.IndexOf(value);
                 if (index != -1)
                 {
-                    return source.GetPosition(index);
+                    return source.Seek(index);
                 }
 
                 return null;

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -16,7 +16,7 @@ namespace System.Buffers
     [DebuggerDisplay("{ToString(),raw}")]
     public readonly partial struct ReadOnlySequence<T>
     {
-        // The data is essinatlly two SequencePositions, however the Start and End SequencePositions are deconstructed to improve packing.
+        // The data is essentially two SequencePositions, however the Start and End SequencePositions are deconstructed to improve packing.
         private readonly object _startObject;
         private readonly object _endObject;
         private readonly int _startInteger;

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -16,8 +16,11 @@ namespace System.Buffers
     [DebuggerDisplay("{ToString(),raw}")]
     public readonly partial struct ReadOnlySequence<T>
     {
-        private readonly SequencePosition _sequenceStart;
-        private readonly SequencePosition _sequenceEnd;
+        // The data is essinatlly two SequencePositions, however the Start and End SequencePositions are deconstructed to improve packing.
+        private readonly object _startObject;
+        private readonly object _endObject;
+        private readonly int _startInteger;
+        private readonly int _endInteger;
 
         /// <summary>
         /// Returns empty <see cref="ReadOnlySequence{T}"/>
@@ -40,7 +43,7 @@ namespace System.Buffers
         public bool IsSingleSegment
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _sequenceStart.GetObject() == _sequenceEnd.GetObject();
+            get => _startObject == _endObject;
         }
 
         /// <summary>
@@ -51,12 +54,20 @@ namespace System.Buffers
         /// <summary>
         /// A position to the start of the <see cref="ReadOnlySequence{T}"/>.
         /// </summary>
-        public SequencePosition Start => _sequenceStart;
+        public SequencePosition Start
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new SequencePosition(_startObject, _startInteger);
+        }
 
         /// <summary>
         /// A position to the end of the <see cref="ReadOnlySequence{T}"/>
         /// </summary>
-        public SequencePosition End => _sequenceEnd;
+        public SequencePosition End
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new SequencePosition(_endObject, _endInteger);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ReadOnlySequence(object startSegment, int startIndexAndFlags, object endSegment, int endIndexAndFlags)
@@ -67,8 +78,10 @@ namespace System.Buffers
             Debug.Assert((startSegment != null && endSegment != null) ||
                 (startSegment == null && endSegment == null && startIndexAndFlags == 0 && endIndexAndFlags == 0));
 
-            _sequenceStart = new SequencePosition(startSegment, startIndexAndFlags);
-            _sequenceEnd = new SequencePosition(endSegment, endIndexAndFlags);
+            _startObject = startSegment;
+            _endObject = endSegment;
+            _startInteger = startIndexAndFlags;
+            _endInteger = endIndexAndFlags;
         }
 
         /// <summary>
@@ -85,8 +98,10 @@ namespace System.Buffers
                 (startSegment == endSegment && endIndex < startIndex))
                 ThrowHelper.ThrowArgumentValidationException(startSegment, startIndex, endSegment);
 
-            _sequenceStart = new SequencePosition(startSegment, ReadOnlySequence.SegmentToSequenceStart(startIndex));
-            _sequenceEnd = new SequencePosition(endSegment, ReadOnlySequence.SegmentToSequenceEnd(endIndex));
+            _startObject = startSegment;
+            _endObject = endSegment;
+            _startInteger = ReadOnlySequence.SegmentToSequenceStart(startIndex);
+            _endInteger = ReadOnlySequence.SegmentToSequenceEnd(endIndex);
         }
 
         /// <summary>
@@ -97,8 +112,10 @@ namespace System.Buffers
             if (array == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
 
-            _sequenceStart = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceStart(0));
-            _sequenceEnd = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceEnd(array.Length));
+            _startObject = array;
+            _endObject = array;
+            _startInteger = ReadOnlySequence.ArrayToSequenceStart(0);
+            _endInteger = ReadOnlySequence.ArrayToSequenceEnd(array.Length);
         }
 
         /// <summary>
@@ -111,8 +128,10 @@ namespace System.Buffers
                 (uint)length > (uint)(array.Length - start))
                 ThrowHelper.ThrowArgumentValidationException(array, start);
 
-            _sequenceStart = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceStart(start));
-            _sequenceEnd = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceEnd(start + length));
+            _startObject = array;
+            _endObject = array;
+            _startInteger = ReadOnlySequence.ArrayToSequenceStart(start);
+            _endInteger = ReadOnlySequence.ArrayToSequenceEnd(start + length);
         }
 
         /// <summary>
@@ -123,30 +142,38 @@ namespace System.Buffers
         {
             if (MemoryMarshal.TryGetMemoryManager(memory, out MemoryManager<T> manager, out int index, out int length))
             {
-                _sequenceStart = new SequencePosition(manager, ReadOnlySequence.MemoryManagerToSequenceStart(index));
-                _sequenceEnd = new SequencePosition(manager, ReadOnlySequence.MemoryManagerToSequenceEnd(length));
+                _startObject = manager;
+                _endObject = manager;
+                _startInteger = ReadOnlySequence.MemoryManagerToSequenceStart(index);
+                _endInteger = ReadOnlySequence.MemoryManagerToSequenceEnd(length);
             }
             else if (MemoryMarshal.TryGetArray(memory, out ArraySegment<T> segment))
             {
                 T[] array = segment.Array;
                 int start = segment.Offset;
-                _sequenceStart = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceStart(start));
-                _sequenceEnd = new SequencePosition(array, ReadOnlySequence.ArrayToSequenceEnd(start + segment.Count));
+                _startObject = array;
+                _endObject = array;
+                _startInteger = ReadOnlySequence.ArrayToSequenceStart(start);
+                _endInteger = ReadOnlySequence.ArrayToSequenceEnd(start + segment.Count);
             }
             else if (typeof(T) == typeof(char))
             {
                 if (!MemoryMarshal.TryGetString((ReadOnlyMemory<char>)(object)memory, out string text, out int start, out length))
                     ThrowHelper.ThrowInvalidOperationException();
 
-                _sequenceStart = new SequencePosition(text, ReadOnlySequence.StringToSequenceStart(start));
-                _sequenceEnd = new SequencePosition(text, ReadOnlySequence.StringToSequenceEnd(start + length));
+                _startObject = text;
+                _endObject = text;
+                _startInteger = ReadOnlySequence.StringToSequenceStart(start);
+                _endInteger = ReadOnlySequence.StringToSequenceEnd(start + length);
             }
             else
             {
                 // Should never be reached
                 ThrowHelper.ThrowInvalidOperationException();
-                _sequenceStart = default;
-                _sequenceEnd = default;
+                _startObject = null;
+                _endObject = null;
+                _startInteger = 0;
+                _endInteger = 0;
             }
         }
 
@@ -163,11 +190,11 @@ namespace System.Buffers
             SequencePosition begin;
             SequencePosition end;
 
-            int startIndex = GetIndex(_sequenceStart);
-            int endIndex = GetIndex(_sequenceEnd);
+            int startIndex = GetIndex(_startInteger);
+            int endIndex = GetIndex(_endInteger);
 
-            object startObject = _sequenceStart.GetObject();
-            object endObject = _sequenceEnd.GetObject();
+            object startObject = _startObject;
+            object endObject = _endObject;
 
             if (startObject != endObject)
             {
@@ -238,11 +265,11 @@ namespace System.Buffers
             uint sliceEndIndex = (uint)GetIndex(end);
             object sliceEndObject = end.GetObject();
 
-            uint startIndex = (uint)GetIndex(_sequenceStart);
-            object startObject = _sequenceStart.GetObject();
+            uint startIndex = (uint)GetIndex(_startInteger);
+            object startObject = _startObject;
 
-            uint endIndex = (uint)GetIndex(_sequenceEnd);
-            object endObject = _sequenceEnd.GetObject();
+            uint endIndex = (uint)GetIndex(_endInteger);
+            object endObject = _endObject;
 
             // Single-Segment Sequence
             if (startObject == endObject)
@@ -308,11 +335,11 @@ namespace System.Buffers
             uint sliceStartIndex = (uint)GetIndex(start);
             object sliceStartObject = start.GetObject();
 
-            uint startIndex = (uint)GetIndex(_sequenceStart);
-            object startObject = _sequenceStart.GetObject();
+            uint startIndex = (uint)GetIndex(_startInteger);
+            object startObject = _startObject;
 
-            uint endIndex = (uint)GetIndex(_sequenceEnd);
-            object endObject = _sequenceEnd.GetObject();
+            uint endIndex = (uint)GetIndex(_endInteger);
+            object endObject = _endObject;
 
             // Single-Segment Sequence
             if (startObject == endObject)
@@ -414,7 +441,7 @@ namespace System.Buffers
         public ReadOnlySequence<T> Slice(SequencePosition start)
         {
             BoundsCheck(start);
-            return SliceImpl(start, _sequenceEnd);
+            return SliceImpl(start, End);
         }
 
         /// <summary>
@@ -429,8 +456,8 @@ namespace System.Buffers
             if (start == 0)
                 return this;
 
-            SequencePosition begin = Seek(_sequenceStart, _sequenceEnd, start, ExceptionArgument.start);
-            return SliceImpl(begin, _sequenceEnd);
+            SequencePosition begin = Seek(Start, End, start, ExceptionArgument.start);
+            return SliceImpl(begin, End);
         }
 
         /// <inheritdoc />
@@ -463,7 +490,7 @@ namespace System.Buffers
         /// <summary>
         /// Returns a new <see cref="SequencePosition"/> at an <paramref name="offset"/> from the start of the sequence.
         /// </summary>
-        public SequencePosition GetPosition(long offset) => GetPosition(offset, _sequenceStart);
+        public SequencePosition GetPosition(long offset) => GetPosition(offset, Start);
 
         /// <summary>
         /// Returns a new <see cref="SequencePosition"/> at an <paramref name="offset"/> from the <paramref name="origin"/>
@@ -473,7 +500,7 @@ namespace System.Buffers
             if (offset < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException_OffsetOutOfRange();
 
-            return Seek(origin, _sequenceEnd, offset, ExceptionArgument.offset);
+            return Seek(origin, End, offset, ExceptionArgument.offset);
         }
 
         /// <summary>

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -441,7 +441,7 @@ namespace System.Buffers
         public ReadOnlySequence<T> Slice(SequencePosition start)
         {
             BoundsCheck(start);
-            return SliceImpl(start, End);
+            return SliceImpl(start);
         }
 
         /// <summary>
@@ -456,8 +456,8 @@ namespace System.Buffers
             if (start == 0)
                 return this;
 
-            SequencePosition begin = Seek(Start, End, start, ExceptionArgument.start);
-            return SliceImpl(begin, End);
+            SequencePosition begin = Seek(start, ExceptionArgument.start);
+            return SliceImpl(begin);
         }
 
         /// <inheritdoc />
@@ -490,7 +490,13 @@ namespace System.Buffers
         /// <summary>
         /// Returns a new <see cref="SequencePosition"/> at an <paramref name="offset"/> from the start of the sequence.
         /// </summary>
-        public SequencePosition GetPosition(long offset) => GetPosition(offset, Start);
+        public SequencePosition GetPosition(long offset)
+        {
+            if (offset < 0)
+                ThrowHelper.ThrowArgumentOutOfRangeException_OffsetOutOfRange();
+
+            return Seek(offset);
+        }
 
         /// <summary>
         /// Returns a new <see cref="SequencePosition"/> at an <paramref name="offset"/> from the <paramref name="origin"/>
@@ -500,7 +506,7 @@ namespace System.Buffers
             if (offset < 0)
                 ThrowHelper.ThrowArgumentOutOfRangeException_OffsetOutOfRange();
 
-            return Seek(origin, End, offset, ExceptionArgument.offset);
+            return Seek(origin, offset);
         }
 
         /// <summary>


### PR DESCRIPTION
Reduce from 32 bytes to 24 bytes.

Deconstruct the two `SequencePosition`s that make up `ReadOnlySequence` into their composite parts internally so `ReadOnlySequence` is reduced in size by 8 bytes which was previously used in packing and alignment for using the two structs individually.

/cc @stephentoub @ahsonkhan @davidfowl @pakrym 