### PR TITLE
Update System.Activity API to be more readonly

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
@@ -7,6 +7,9 @@
   <PropertyGroup Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'netfx'">
     <DefineConstants>$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD1_3</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Diagnostics.DiagnosticSource.cs" />
   </ItemGroup>

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSource.csproj
@@ -7,9 +7,6 @@
   <PropertyGroup Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'netfx'">
     <DefineConstants>$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD1_3</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Diagnostics.DiagnosticSource.cs" />
   </ItemGroup>
@@ -29,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard1.1' or '$(TargetGroup)' == 'netstandard1.3'">
+    <Reference Include="System.Runtime.InteropServices" />
     <Reference Include="System.Runtime" />
   </ItemGroup>
 </Project>

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -30,12 +30,26 @@ namespace System.Diagnostics
         public string OperationName { get { throw null; } }
         public System.Diagnostics.Activity Parent { get { throw null; } }
         public string ParentId { get { throw null; } }
-        public ref System.Diagnostics.ActivitySpanId ParentSpanId { get { throw null; } }
+        public ref
+#if !NETSTANDARD1_3 // Could not get this to build with ref readonly returns. 
+        readonly
+#endif
+            System.Diagnostics.ActivitySpanId ParentSpanId
+        { get { throw null; } }
         public string RootId { get { throw null; } }
-        public ref System.Diagnostics.ActivitySpanId SpanId { get { throw null; } }
+        public ref
+#if !NETSTANDARD1_3 // Could not get this to build with ref readonly returns. 
+        readonly
+#endif
+            System.Diagnostics.ActivitySpanId SpanId
+        { get { throw null; } }
         public System.DateTime StartTimeUtc { get { throw null; } }
         public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> Tags { get { throw null; } }
-        public ref System.Diagnostics.ActivityTraceId TraceId { get { throw null; } }
+        public ref
+#if !NETSTANDARD1_3 // Could not get this to build with ref readonly returns. 
+        readonly
+#endif
+            System.Diagnostics.ActivityTraceId TraceId { get { throw null; } }
         public string TraceStateString { get { throw null; } set { } }
         public System.Diagnostics.Activity AddBaggage(string key, string value) { throw null; }
         public System.Diagnostics.Activity AddTag(string key, string value) { throw null; }
@@ -56,10 +70,10 @@ namespace System.Diagnostics
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
     [System.Security.SecuritySafeCriticalAttribute]
 #endif
-    public partial struct ActivitySpanId : System.IEquatable<System.Diagnostics.ActivitySpanId>
+    public readonly partial struct ActivitySpanId : System.IEquatable<System.Diagnostics.ActivitySpanId>
     {
-        private object _dummy;
-        private int _dummyPrimitive;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public void CopyTo(System.Span<byte> destination) { }
         public static System.Diagnostics.ActivitySpanId CreateFromBytes(System.ReadOnlySpan<byte> idData) { throw null; }
         public static System.Diagnostics.ActivitySpanId CreateFromString(System.ReadOnlySpan<char> idData) { throw null; }
@@ -76,10 +90,10 @@ namespace System.Diagnostics
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
     [System.Security.SecuritySafeCriticalAttribute]
 #endif
-    public partial struct ActivityTraceId : System.IEquatable<System.Diagnostics.ActivityTraceId>
+    public readonly partial struct ActivityTraceId : System.IEquatable<System.Diagnostics.ActivityTraceId>
     {
-        private object _dummy;
-        private int _dummyPrimitive;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public void CopyTo(System.Span<byte> destination) { }
         public static System.Diagnostics.ActivityTraceId CreateFromBytes(System.ReadOnlySpan<byte> idData) { throw null; }
         public static System.Diagnostics.ActivityTraceId CreateFromString(System.ReadOnlySpan<char> idData) { throw null; }

--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -30,26 +30,12 @@ namespace System.Diagnostics
         public string OperationName { get { throw null; } }
         public System.Diagnostics.Activity Parent { get { throw null; } }
         public string ParentId { get { throw null; } }
-        public ref
-#if !NETSTANDARD1_3 // Could not get this to build with ref readonly returns. 
-        readonly
-#endif
-            System.Diagnostics.ActivitySpanId ParentSpanId
-        { get { throw null; } }
+        public ref readonly System.Diagnostics.ActivitySpanId ParentSpanId { get { throw null; } }
         public string RootId { get { throw null; } }
-        public ref
-#if !NETSTANDARD1_3 // Could not get this to build with ref readonly returns. 
-        readonly
-#endif
-            System.Diagnostics.ActivitySpanId SpanId
-        { get { throw null; } }
+        public ref readonly System.Diagnostics.ActivitySpanId SpanId { get { throw null; } }
         public System.DateTime StartTimeUtc { get { throw null; } }
         public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> Tags { get { throw null; } }
-        public ref
-#if !NETSTANDARD1_3 // Could not get this to build with ref readonly returns. 
-        readonly
-#endif
-            System.Diagnostics.ActivityTraceId TraceId { get { throw null; } }
+        public ref readonly System.Diagnostics.ActivityTraceId TraceId { get { throw null; } }
         public string TraceStateString { get { throw null; } set { } }
         public System.Diagnostics.Activity AddBaggage(string key, string value) { throw null; }
         public System.Diagnostics.Activity AddTag(string key, string value) { throw null; }

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -14,9 +14,6 @@
   <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.1' OR '$(TargetGroup)' == 'net45'">
     <DefineConstants>$(DefineConstants);NO_EVENTSOURCE_COMPLEX_TYPE_SUPPORT</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD1_3</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
     <DefineConstants>$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS;ENABLE_HTTP_HANDLER</DefineConstants>
   </PropertyGroup>

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -14,6 +14,9 @@
   <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.1' OR '$(TargetGroup)' == 'net45'">
     <DefineConstants>$(DefineConstants);NO_EVENTSOURCE_COMPLEX_TYPE_SUPPORT</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard1.3'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD1_3</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'net45' OR '$(TargetGroup)' == 'net46' OR '$(TargetGroup)' == 'netfx'">
     <DefineConstants>$(DefineConstants);ALLOW_PARTIALLY_TRUSTED_CALLERS;ENABLE_HTTP_HANDLER</DefineConstants>
   </PropertyGroup>
@@ -27,6 +30,7 @@
     <Compile Include="System\Diagnostics\Activity.cs" />
     <Compile Include="System\Diagnostics\DiagnosticSourceActivity.cs" />
     <Reference Include="System.Memory" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <None Include="ActivityUserGuide.md" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetGroup)' != 'net45' And '$(TargetGroup)' != 'netstandard1.1'">

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -878,20 +878,17 @@ namespace System.Diagnostics
         /// </summary>
         public string ToHexString()
         {
-            get
+            if (_asHexString == null)
             {
-                if (_asHexString == null)
+                fixed (ulong* idPtr = &_id1)
                 {
-                    fixed (ulong* idPtr = &_id1)
-                    {
-                        // Cast away the read-only-ness of _asHexString, and assign the converted value to it.  
-                        // We are OK with this because conceptually the class is still read-only.  
-                        ref string strRef = ref Unsafe.AsRef(in _asHexString);
-                        strRef = SpanToHexString(new ReadOnlySpan<byte>(idPtr, sizeof(ulong) * 2));
-                    }
+                    // Cast away the read-only-ness of _asHexString, and assign the converted value to it.  
+                    // We are OK with this because conceptually the class is still read-only.  
+                    ref string strRef = ref Unsafe.AsRef(in _asHexString);
+                    strRef = SpanToHexString(new ReadOnlySpan<byte>(idPtr, sizeof(ulong) * 2));
                 }
-                return _asHexString;
             }
+            return _asHexString;
         }
 
         /// <summary>
@@ -1070,22 +1067,19 @@ namespace System.Diagnostics
         /// Returns the TraceId as a 16 character hexadecimal string.  
         /// </summary>
         /// <returns></returns>
-        public string AsHexString
+        public string ToHexString()
         {
-            get
+            if (_asHexString == null)
             {
-                if (_asHexString == null)
+                fixed (ulong* idPtr = &_id1)
                 {
-                    fixed (ulong* idPtr = &_id1)
-                    {
-                        // Cast away the read-only-ness of _asHexString, and assign the converted value to it.  
-                        // We are OK with this because conceptually the class is still read-only.  
-                        ref string strRef = ref Unsafe.AsRef(in _asHexString);
-                        strRef = ActivityTraceId.SpanToHexString(new ReadOnlySpan<byte>(idPtr, sizeof(ulong)));
-                    }
+                    // Cast away the read-only-ness of _asHexString, and assign the converted value to it.  
+                    // We are OK with this because conceptually the class is still read-only.  
+                    ref string strRef = ref Unsafe.AsRef(in _asHexString);
+                    strRef = ActivityTraceId.SpanToHexString(new ReadOnlySpan<byte>(idPtr, sizeof(ulong)));
                 }
-                return _asHexString;
             }
+            return _asHexString;
         }
 
         /// <summary>

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -457,11 +457,7 @@ namespace System.Diagnostics
         /// which will have the effect of updating Activity's instance so all subsequent uses
         /// share the same converted string.  
         /// </summary>
-        public ref
-#if !NETSTANDARD1_3 // Could not get this to build with ref readonly returns. 
-        readonly
-#endif
-            ActivitySpanId SpanId
+        public ref readonly ActivitySpanId SpanId
         {
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
             [System.Security.SecuritySafeCriticalAttribute]
@@ -491,11 +487,7 @@ namespace System.Diagnostics
         /// which will have the effect of updating Activity's instance so all subsequent uses
         /// share the same converted string.  
         /// </summary>
-        public ref
-#if !NETSTANDARD1_3 // Could not get this to build with ref readonly returns. 
-        readonly
-#endif
-             ActivityTraceId TraceId
+        public ref readonly ActivityTraceId TraceId
         {
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
             [System.Security.SecuritySafeCriticalAttribute]
@@ -518,11 +510,7 @@ namespace System.Diagnostics
         /// If the parent Activity ID has the W3C format, this returns the ID for the SpanId part of the ParentId.  
         /// Otherwise it returns a zero SpanId. 
         /// </summary>
-        public ref
-#if !NETSTANDARD1_3 // Could not get this to build with ref readonly returns. 
-        readonly
-#endif
-             ActivitySpanId ParentSpanId
+        public ref readonly ActivitySpanId ParentSpanId
         {
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
             [System.Security.SecuritySafeCriticalAttribute]

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -873,7 +873,7 @@ namespace System.Diagnostics
                     // Cast away the read-only-ness of _asHexString, and assign the converted value to it.  
                     // We are OK with this because conceptually the class is still read-only.  
                     ref string strRef = ref Unsafe.AsRef(in _asHexString);
-                    strRef = SpanToHexString(new ReadOnlySpan<byte>(idPtr, sizeof(ulong) * 2));
+                    Interlocked.CompareExchange(ref strRef, SpanToHexString(new ReadOnlySpan<byte>(idPtr, sizeof(ulong) * 2)), null);
                 }
             }
             return _asHexString;
@@ -1064,7 +1064,7 @@ namespace System.Diagnostics
                     // Cast away the read-only-ness of _asHexString, and assign the converted value to it.  
                     // We are OK with this because conceptually the class is still read-only.  
                     ref string strRef = ref Unsafe.AsRef(in _asHexString);
-                    strRef = ActivityTraceId.SpanToHexString(new ReadOnlySpan<byte>(idPtr, sizeof(ulong)));
+                    Interlocked.CompareExchange(ref strRef, ActivityTraceId.SpanToHexString(new ReadOnlySpan<byte>(idPtr, sizeof(ulong))), null);
                 }
             }
             return _asHexString;


### PR DESCRIPTION
Two new classes ActivityTraceId and ActivitySpanId are better as read-only classes.  These classes have a cache in them so they are not strictly read-only but they are semantically read-only.   

We can treat them as read-only if we use Unsafe APIs to update the cache.  However there were issues with using the Unsafe APIs that blocked that until recently.  This update adds the read-only-ness 

See ttps://github.com/dotnet/corefx/issues/34828  for the new APIs (they have the read-only-ness)
 
And https://github.com/dotnet/corefx/pull/35848 for the original non-read-only version.