### PR TITLE
Fix ReflectPropertyDescriptor.IsReadOnly

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
@@ -313,7 +313,7 @@ namespace System.ComponentModel
                         }
                         if (_propInfo != null)
                         {
-                            _getMethod = _propInfo.GetMethod;
+                            _getMethod = _propInfo.GetGetMethod(nonPublic: true);
                         }
                         if (_getMethod == null)
                         {
@@ -399,7 +399,7 @@ namespace System.ComponentModel
                             PropertyInfo p = t.GetProperty(name, PropertyType, Array.Empty<Type>(), null);
                             if (p != null)
                             {
-                                _setMethod = p.SetMethod;
+                                _setMethod = p.GetSetMethod(nonPublic: false);
                                 if (_setMethod != null)
                                 {
                                     break;
@@ -425,7 +425,7 @@ namespace System.ComponentModel
                         }
                         if (_propInfo != null)
                         {
-                            _setMethod = _propInfo.SetMethod;
+                            _setMethod = _propInfo.GetSetMethod(nonPublic: true);
                         }
                     }
                     else

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -1171,8 +1171,8 @@ namespace System.ComponentModel
                             continue;
                         }
 
-                        MethodInfo getMethod = propertyInfo.GetMethod;
-                        MethodInfo setMethod = propertyInfo.SetMethod;
+                        MethodInfo getMethod = propertyInfo.GetGetMethod(nonPublic: false);
+                        MethodInfo setMethod = propertyInfo.GetSetMethod(nonPublic: false);
                         string name = propertyInfo.Name;
 
                         // If the property only overrode "set", then we don't

--- a/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
@@ -160,7 +160,6 @@ namespace System.ComponentModel.Tests
             Assert.False(property.IsReadOnly);
         }
 
-
         class ReadOnlyPropertyTestClass
         {
             public bool BarReadOnly { get; private set; }

--- a/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
@@ -160,10 +160,23 @@ namespace System.ComponentModel.Tests
             Assert.False(property.IsReadOnly);
         }
 
-        class ReadOnlyPropertyTestClass
+        [Fact]
+        public static void ReadOnlyVirtualPropertyReturnsTrue()
+        {
+            PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ReadOnlyPropertyTestClass), new[] { BrowsableAttribute.Yes }).Find("BarReadOnlyBaseClass", true);
+            Assert.True(property.IsReadOnly);
+        }
+
+        class ReadOnlyPropertyTestBaseClass
+        {
+            public virtual bool BarReadOnlyBaseClass { get; }
+        }
+
+        class ReadOnlyPropertyTestClass : ReadOnlyPropertyTestBaseClass
         {
             public bool BarReadOnly { get; private set; }
             public bool BarNotReadOnly { get; set; }
+            public override bool BarReadOnlyBaseClass { get; }
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
@@ -143,5 +143,28 @@ namespace System.ComponentModel.Tests
 
             Assert.True(propertyDescriptor.ShouldSerializeValue(component));
         }
+
+        [Fact]
+        public static void ReadOnlyPropertyReturnsTrue()
+        {
+            var foo = new ReadOnlyPropertyTestClass();
+            PropertyDescriptor property = TypeDescriptor.GetProperties(foo).Find("BarReadOnly", true);
+            Assert.True(property.IsReadOnly);
+        }
+
+        [Fact]
+        public static void ReadOnlyPropertyReturnsFalse()
+        {
+            var foo = new ReadOnlyPropertyTestClass();
+            PropertyDescriptor property = TypeDescriptor.GetProperties(foo).Find("BarNotReadOnly", true);
+            Assert.False(property.IsReadOnly);
+        }
+
+
+        class ReadOnlyPropertyTestClass
+        {
+            public bool BarReadOnly { get; private set; }
+            public bool BarNotReadOnly { get; set; }
+        }
     }
 }


### PR DESCRIPTION
When this code was ported from Desktop, the implementation was changed to use `PropertyInfo.GetMethod/SetMethod` which gets private properties as well. This breaks `ReflectPropertyDescriptor.IsReadOnly` when the set method is marked as private, because we're always able to find it via reflection, so we `return false` even though it is indeed read only.

Fixes: https://github.com/dotnet/corefx/issues/33629

cc: @jkotas 