### PR TITLE
Improve performance of Pipe.Reader.AsStream()

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -54,10 +54,11 @@ namespace System.IO.Pipelines
         /// Returns a <see cref="Stream"/> that wraps the <see cref="PipeReader"/>.
         /// </summary>
         /// <returns>The <see cref="Stream"/>.</returns>
-        public virtual Stream AsStream()
-        {
-            return _stream ?? (_stream = new PipeReaderStream(this));
-        }
+        public virtual Stream AsStream() => _stream ?? (_stream = CreateStream());
+
+        /// <summary>Creates a <see cref="Stream"/> to be returned from <see cref="AsStream"/>.</summary>
+        /// <returns>The <see cref="Stream"/>.</returns>
+        internal virtual PipeReaderStream CreateStream() => new PipeReaderStream(this);
 
         /// <summary>
         /// Cancel to currently pending or if none is pending next call to <see cref="ReadAsync"/>, without completing the <see cref="PipeReader"/>.


### PR DESCRIPTION
The Stream returned from the base PipeReader uses public APIs on PipeReader because it needs to work with any PipeReader implementation.  But the vast majority case is a PipeReader returned from Pipe, and the Stream returned from its AsStream can make use of internals on Pipe.  This change does so, reducing the overheads involved in accessing a reader as a stream.

One thing I don't love about this is that it moves a little more work under the lock, which can increase contention, but in doing so avoids the need to take the lock a second time for synchronous completion, which can reduce contention.

cc: @benaadams, @davidfowl, @ahsonkhan 

Before:
```
      Method |        Mean |     Error |    StdDev | Allocated |
------------ |------------:|----------:|----------:|----------:|
   ReadByte1 | 27,698.7 ns | 201.84 ns | 157.58 ns |       0 B |
 ReadByte128 |    804.0 ns |  16.04 ns |  38.44 ns |       0 B |
```

After:
```
      Method |        Mean |     Error |    StdDev | Allocated |
------------ |------------:|----------:|----------:|----------:|
   ReadByte1 | 19,197.3 ns | 381.99 ns | 439.90 ns |       0 B |
 ReadByte128 |    600.2 ns |  11.34 ns |  11.13 ns |       0 B |
```

Benchmark:
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Attributes.Jobs;
using BenchmarkDotNet.Running;
using System;
using System.IO;
using System.IO.Pipelines;
using System.Threading.Tasks;

[MemoryDiagnoser]
[InProcess]
public class Benchmark
{
    private static void Main() => BenchmarkRunner.Run<Benchmark>();

    private readonly byte[] _data = new byte[128];
    private readonly byte[] _buffer1 = new byte[1];
    private readonly byte[] _buffer128 = new byte[128];
    private readonly Pipe _pipe = new Pipe();

    [Benchmark]
    public async Task ReadByte1()
    {
        await _pipe.Writer.WriteAsync(_data);
        _pipe.Writer.Complete();
        Stream s = _pipe.Reader.AsStream();

        while (await s.ReadAsync(_buffer1) != 0) ;

        _pipe.Reader.Complete();
        _pipe.Reset();
    }

    [Benchmark]
    public async Task ReadByte128()
    {
        await _pipe.Writer.WriteAsync(_data);
        _pipe.Writer.Complete();
        Stream s = _pipe.Reader.AsStream();

        while (await s.ReadAsync(_buffer128) != 0) ;

        _pipe.Reader.Complete();
        _pipe.Reset();
    }
}
```