### PR TITLE
Inject W3C  headers in netfx HTTP diagnostics hook

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/HttpHandlerDiagnosticListener.cs
@@ -607,12 +607,14 @@ namespace System.Diagnostics
                 {
                     // do not inject header if it was injected already 
                     // perhaps tracing systems wants to override it
-                    if (request.Headers[TraceParentHeaderName] == null)
+                    if (request.Headers.Get(TraceParentHeaderName) == null)
                     {
                         request.Headers.Add(TraceParentHeaderName, activity.Id);
-                        if (activity.TraceStateString != null)
+
+                        var traceState = activity.TraceStateString;
+                        if (traceState != null)
                         {
-                            request.Headers.Add(TraceStateHeaderName, activity.TraceStateString);
+                            request.Headers.Add(TraceStateHeaderName, traceState);
                         }
                     }
                 }
@@ -620,13 +622,13 @@ namespace System.Diagnostics
                 {
                     // do not inject header if it was injected already 
                     // perhaps tracing systems wants to override it
-                    if (request.Headers[RequestIdHeaderName] == null)
+                    if (request.Headers.Get(RequestIdHeaderName) == null)
                     {
                         request.Headers.Add(RequestIdHeaderName, activity.Id);
                     }
                 }
 
-                if (request.Headers[CorrelationContextHeaderName] == null)
+                if (request.Headers.Get(CorrelationContextHeaderName) == null)
                 {
                     // we expect baggage to be empty or contain a few items
                     using (IEnumerator<KeyValuePair<string, string>> e = activity.Baggage.GetEnumerator())
@@ -656,7 +658,7 @@ namespace System.Diagnostics
             // Response event could be received several times for the same request in case it was redirected
             // IsLastResponse checks if response is the last one (no more redirects will happen)
             // based on response StatusCode and number or redirects done so far
-            if (request.Headers[RequestIdHeaderName] != null && IsLastResponse(request, response.StatusCode))
+            if (request.Headers.Get(RequestIdHeaderName) != null && IsLastResponse(request, response.StatusCode))
             {
                 // only send Stop if request was instrumented
                 this.Write(RequestStopName, new { Request = request, Response = response });
@@ -668,7 +670,7 @@ namespace System.Diagnostics
             // Response event could be received several times for the same request in case it was redirected
             // IsLastResponse checks if response is the last one (no more redirects will happen)
             // based on response StatusCode and number or redirects done so far
-            if (request.Headers[RequestIdHeaderName] != null && IsLastResponse(request, statusCode))
+            if (request.Headers.Get(RequestIdHeaderName) != null && IsLastResponse(request, statusCode))
             {
                 this.Write(RequestStopExName, new { Request = request, StatusCode = statusCode, Headers = headers });
             }

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -288,7 +288,7 @@ namespace System.Diagnostics.Tests
                 return false;
             if (id[52] != '-')
                 return false;
-            return Regex.IsMatch(id, "^[0-9a-f][0-9a-f]-[0-9a-f]*-[0-9a-f]*-[0-9a-f][0-9a-f]$");
+            return Regex.IsMatch(id, "^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$");
         }
 
         public static bool IsLowerCaseHex(string s)
@@ -341,13 +341,13 @@ namespace System.Diagnostics.Tests
 
             // Use in Dictionary (this does assume we have no collisions in IDs over 100 tries (very good).  
             var dict = new Dictionary<ActivityTraceId, string>();
-            for(int i = 0; i < 100; i++)
+            for (int i = 0; i < 100; i++)
             {
                 var newId7 = ActivityTraceId.CreateRandom();
                 dict[newId7] = newId7.ToHexString();
             }
             int ctr = 0;
-            foreach(string value in dict.Values)
+            foreach (string value in dict.Values)
             {
                 string valueInDict;
                 Assert.True(dict.TryGetValue(ActivityTraceId.CreateFromString(value.AsSpan()), out valueInDict));

--- a/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/HttpHandlerDiagnosticListenerTests.cs
@@ -132,6 +132,8 @@ namespace System.Diagnostics.Tests
                 HttpWebRequest startRequest = ReadPublicProperty<HttpWebRequest>(startEvent.Value, "Request");
                 Assert.NotNull(startRequest);
                 Assert.NotNull(startRequest.Headers["Request-Id"]);
+                Assert.Null(startRequest.Headers["traceparent"]);
+                Assert.Null(startRequest.Headers["tracestate"]);
 
                 KeyValuePair<string, object> stopEvent;
                 Assert.True(eventRecords.Records.TryDequeue(out stopEvent));


### PR DESCRIPTION
Depending on the Activity.IdFormat we want to inject [W3C distributed tracing](https://github.com/w3c/trace-context) headers or Request-Id headers.

This change implements this and also prevents injection of any of the correlation headers if it was injected before e.g. by tracing system or explicitly in the app code.