### PR TITLE
Add dummy object field to TypedReference in ref assembly

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -3164,6 +3164,7 @@ namespace System
     [System.CLSCompliantAttribute(false)]
     public ref partial struct TypedReference
     {
+        private object _dummy;
         private int _dummyPrimitive;
         public override bool Equals(object o) { throw null; }
         public override int GetHashCode() { throw null; }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/35873

Presumably we need to do something similar in netstandard, @terrajobst?

cc: @jcouv, @jkotas