### PR TITLE
Fix issue with uppercase HTTP_PROXY and NO_PROXY

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -138,6 +138,7 @@ namespace System.Net.Http
                 proxy = null;
                 return false;
             }
+
             string noProxy = Environment.GetEnvironmentVariable(EnvNoProxyLC) ?? Environment.GetEnvironmentVariable(EnvNoProxyUC);
             proxy = new HttpEnvironmentProxy(httpProxy, httpsProxy, noProxy);
             return true;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -73,7 +73,7 @@ namespace System.Net.Http
             int idx = value.IndexOf(':');
             if (idx != -1)
             {
-                password = value.Substring(idx+1);
+                password = value.Substring(idx + 1);
                 value = value.Substring(0, idx);
             }
 
@@ -81,7 +81,7 @@ namespace System.Net.Http
             if (idx != -1)
             {
                 domain = value.Substring(0, idx);
-                value = value.Substring(idx+1);
+                value = value.Substring(idx + 1);
             }
 
             return new NetworkCredential(value, password, domain);
@@ -138,7 +138,7 @@ namespace System.Net.Http
                 proxy = null;
                 return false;
             }
-			string noProxy = Environment.GetEnvironmentVariable(EnvNoProxyLC) ?? Environment.GetEnvironmentVariable(EnvNoProxyUC);
+            string noProxy = Environment.GetEnvironmentVariable(EnvNoProxyLC) ?? Environment.GetEnvironmentVariable(EnvNoProxyUC);
             proxy = new HttpEnvironmentProxy(httpProxy, httpsProxy, noProxy);
             return true;
         }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -93,9 +93,11 @@ namespace System.Net.Http
         private const string EnvAllProxyUC = "ALL_PROXY";
         private const string EnvAllProxyLC = "all_proxy";
         private const string EnvHttpProxyLC = "http_proxy";
+        private const string EnvHttpProxyUC = "HTTP_PROXY";
         private const string EnvHttpsProxyLC = "https_proxy";
         private const string EnvHttpsProxyUC = "HTTPS_PROXY";
         private const string EnvNoProxyLC = "no_proxy";
+        private const string EnvNoProxyUC = "NO_PROXY";
 
         private Uri _httpProxyUri;      // String URI for HTTP requests
         private Uri _httpsProxyUri;     // String URI for HTTPS requests
@@ -109,7 +111,8 @@ namespace System.Net.Http
             // Note that curl uses HTTPS_PROXY but not HTTP_PROXY.
             // For http, only http_proxy and generic variables are used.
 
-            Uri httpProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpProxyLC));
+            Uri httpProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpProxyLC)) ??
+                             GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpProxyUC));
             Uri httpsProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpsProxyLC)) ??
                              GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpsProxyUC));
 
@@ -135,8 +138,8 @@ namespace System.Net.Http
                 proxy = null;
                 return false;
             }
-
-            proxy = new HttpEnvironmentProxy(httpProxy, httpsProxy, Environment.GetEnvironmentVariable(EnvNoProxyLC));
+			string noProxy = Environment.GetEnvironmentVariable(EnvNoProxyLC) ?? Environment.GetEnvironmentVariable(EnvNoProxyUC);
+            proxy = new HttpEnvironmentProxy(httpProxy, httpsProxy, noProxy);
             return true;
         }
 

--- a/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -211,7 +211,7 @@ namespace System.Net.Http.Tests
         [Theory]
         [InlineData("HTTP_PROXY", "NO_PROXY")]
         [InlineData("http_proxy", "no_proxy")]
-        public void HttpProxy_TryCreate_CaseInsenstiveVariables(string proxy, string noProxy)
+        public void HttpProxy_TryCreate_CaseInsensitiveVariables(string proxy, string noProxy)
         {
             var options = new RemoteInvokeOptions();
             options.StartInfo.EnvironmentVariables.Add(proxy, "http://foo:bar@1.1.1.1:3000");


### PR DESCRIPTION
Fix issue with uppercase HTTP_PROXY and NO_PROXY environment variables.

Currently on Linux only lowercase variables work which is not standard for Linux systems