### PR TITLE
Add (Try)GetDateTime(Offset) to Utf8JsonReader

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -173,6 +173,8 @@ namespace System.Text.Json
         public System.Buffers.ReadOnlySequence<byte> ValueSequence { get { throw null; } }
         public System.ReadOnlySpan<byte> ValueSpan { get { throw null; } }
         public bool GetBoolean() { throw null; }
+        public DateTime GetDateTime() { throw null; }
+        public DateTimeOffset GetDateTimeOffset() { throw null; }
         public decimal GetDecimal() { throw null; }
         public double GetDouble() { throw null; }
         public int GetInt32() { throw null; }
@@ -184,6 +186,8 @@ namespace System.Text.Json
         [System.CLSCompliantAttribute(false)]
         public ulong GetUInt64() { throw null; }
         public bool Read() { throw null; }
+        public bool TryGetDateTime(out DateTime value) { throw null; }
+        public bool TryGetDateTimeOffset(out DateTimeOffset value) { throw null; }
         public bool TryGetDecimal(out decimal value) { throw null; }
         public bool TryGetDouble(out double value) { throw null; }
         public bool TryGetInt32(out int value) { throw null; }

--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -303,9 +303,6 @@
     <value>EnumConverter is not yet supported on .NET Standard 2.0.</value>
   </data>
   <data name="FormatDateTime" xml:space="preserve">
-    <value>The JSON value is of unsupported or incorrect ISO 8601 format.</value>
-  </data>
-  <data name="FormatDateTimeOffset" xml:space="preserve">
-    <value>The JSON value is of unsupported or incorrect ISO 8601 format.</value>
+    <value>The JSON value is of unsupported DateTime format.</value>
   </data>
 </root>

--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -303,6 +303,9 @@
     <value>EnumConverter is not yet supported on .NET Standard 2.0.</value>
   </data>
   <data name="FormatDateTime" xml:space="preserve">
-    <value>The JSON value is of unsupported DateTime format.</value>
+    <value>The JSON value is of unsupported format for a DateTime.</value>
+  </data>
+  <data name="FormatDateTimeOffset" xml:space="preserve">
+    <value>The JSON value is of unsupported format for a DateTimeOffset.</value>
   </data>
 </root>

--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -302,4 +302,10 @@
   <data name="EnumConverterNotImplemented" xml:space="preserve">
     <value>EnumConverter is not yet supported on .NET Standard 2.0.</value>
   </data>
+  <data name="FormatDateTime" xml:space="preserve">
+    <value>The JSON value is of unsupported or incorrect ISO 8601 format.</value>
+  </data>
+  <data name="FormatDateTimeOffset" xml:space="preserve">
+    <value>The JSON value is of unsupported or incorrect ISO 8601 format.</value>
+  </data>
 </root>

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -16,6 +16,7 @@
     <Compile Include="System\Text\Json\JsonConstants.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.cs" />
     <Compile Include="System\Text\Json\JsonTokenType.cs" />
+    <Compile Include="System\Text\Json\Reader\JsonReaderHelper.Date.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.Serialization.cs" />
     <Compile Include="System\Text\Json\Document\JsonDocument.cs" />

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -16,7 +16,6 @@
     <Compile Include="System\Text\Json\JsonConstants.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.cs" />
     <Compile Include="System\Text\Json\JsonTokenType.cs" />
-    <Compile Include="System\Text\Json\Reader\JsonReaderHelper.Date.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.Serialization.cs" />
     <Compile Include="System\Text\Json\Document\JsonDocument.cs" />
@@ -35,6 +34,7 @@
     <Compile Include="System\Text\Json\Reader\ConsumeTokenResult.cs" />
     <Compile Include="System\Text\Json\Reader\JsonReaderException.cs" />
     <Compile Include="System\Text\Json\Reader\JsonReaderHelper.cs" />
+    <Compile Include="System\Text\Json\Reader\JsonReaderHelper.Date.cs" />
     <Compile Include="System\Text\Json\Reader\JsonReaderHelper.Unescaping.cs" />
     <Compile Include="System\Text\Json\Reader\JsonReaderOptions.cs" />
     <Compile Include="System\Text\Json\Reader\JsonReaderState.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -23,7 +23,6 @@ namespace System.Text.Json
         public const byte FormFeed = (byte)'\f';
         public const byte Asterisk = (byte)'*';
         public const byte Colon = (byte)':';
-        public const byte Minus = (byte)'-';
         public const byte Period = (byte)'.';
         public const byte Plus = (byte)'+';
         public const byte Hyphen = (byte)'-';
@@ -64,8 +63,8 @@ namespace System.Text.Json
         public const int MaximumFormatDateTimeLength = 27;    // StandardFormat 'O', e.g. 2017-06-12T05:30:45.7680000
         public const int MaximumFormatDateTimeOffsetLength = 33;  // StandardFormat 'O', e.g. 2017-06-12T05:30:45.7680000-07:00
         public const int MaxDateTimeUtcOffsetHours = 14; // The UTC offset portion of a TimeSpan or DateTime can be no more than 14 hours and no less than -14 hours.
+        public const int DateTimeNumFractionDigits = 7;  // TimeSpan and DateTime formats allow exactly up to many digits for specifying the fraction after the seconds.
         public const int MaxDateTimeFraction = 9_999_999;  // The largest fraction expressible by TimeSpan and DateTime formats
-        public const int MaxDateTimeFractionDiv10 = 999_999;
 
         internal const char ScientificNotationFormat = 'e';
 

--- a/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -22,6 +22,13 @@ namespace System.Text.Json
         public const byte BackSpace = (byte)'\b';
         public const byte FormFeed = (byte)'\f';
         public const byte Asterisk = (byte)'*';
+        public const byte Colon = (byte)':';
+        public const byte Minus = (byte)'-';
+        public const byte Period = (byte)'.';
+        public const byte Plus = (byte)'+';
+        public const byte Hyphen = (byte)'-';
+        public const byte UtcOffsetToken = (byte)'Z';
+        public const byte TimePrefix = (byte)'T';
 
         public static ReadOnlySpan<byte> TrueValue => new byte[] { (byte)'t', (byte)'r', (byte)'u', (byte)'e' };
         public static ReadOnlySpan<byte> FalseValue => new byte[] { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };
@@ -56,6 +63,9 @@ namespace System.Text.Json
         public const int MaximumFormatGuidLength = 36;    // default (i.e. 'D'), 8 + 4 + 4 + 4 + 12 + 4 for the hyphens (e.g. 094ffa0a-0442-494d-b452-04003fa755cc)
         public const int MaximumFormatDateTimeLength = 27;    // StandardFormat 'O', e.g. 2017-06-12T05:30:45.7680000
         public const int MaximumFormatDateTimeOffsetLength = 33;  // StandardFormat 'O', e.g. 2017-06-12T05:30:45.7680000-07:00
+        public const int MaxDateTimeUtcOffsetHours = 14; // The UTC offset portion of a TimeSpan or DateTime can be no more than 14 hours and no less than -14 hours.
+        public const int MaxDateTimeFraction = 9_999_999;  // The largest fraction expressible by TimeSpan and DateTime formats
+        public const int MaxDateTimeFractionDiv10 = 999_999;
 
         internal const char ScientificNotationFormat = 'e';
 

--- a/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.Date.cs
@@ -1,0 +1,503 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Text.Json
+{
+    internal static partial class JsonReaderHelper
+    {
+        public static bool TryParseAsISO(ReadOnlySpan<byte> source, out DateTime value, out int bytesConsumed)
+        {
+            if (!TryParseDateTimeOffset(source, out DateTimeOffset dateTimeOffset, out bytesConsumed, out DateTimeKind kind))
+            {
+                value = default;
+                bytesConsumed = 0;
+                return false;
+            }
+
+            switch (kind)
+            {
+                case DateTimeKind.Local:
+                    value = dateTimeOffset.LocalDateTime;
+                    break;
+                case DateTimeKind.Utc:
+                    value = dateTimeOffset.UtcDateTime;
+                    break;
+                default:
+                    Debug.Assert(kind == DateTimeKind.Unspecified);
+                    value = dateTimeOffset.DateTime;
+                    break;
+            }
+
+            return true;
+        }
+
+        public static bool TryParseAsISO(ReadOnlySpan<byte> source, out DateTimeOffset value, out int bytesConsumed)
+        {
+            return TryParseDateTimeOffset(source, out value, out bytesConsumed, out _);
+        }
+
+        //
+        // Flexible ISO 8601 format. One of
+        //
+        // ---------------------------------
+        // YYYY-MM-DD (eg 1997-07-16)
+        // YYYY-MM-DDThh:mm (eg 1997-07-16T19:20)
+        // YYYY-MM-DDThh:mm:ss (eg 1997-07-16T19:20:30)
+        // YYYY-MM-DDThh:mm:ss.s (eg 1997-07-16T19:20:30.45)
+        // YYYY-MM-DDThh:mmTZD (eg 1997-07-16T19:20+01:00)
+        // YYYY-MM-DDThh:mm:ssTZD (eg 1997-07-16T19:20:30+01:00)
+        // YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45Z)
+        // YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
+        // YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45-01:00)
+        // YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+0100)
+        // YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45-0100)
+        private static bool TryParseDateTimeOffset(ReadOnlySpan<byte> source, out DateTimeOffset value, out int bytesConsumed, out DateTimeKind kind)
+        {
+            // Source does not have enough characters for YYYY-MM-DD
+            if (source.Length < 10)
+            {
+                goto ReturnFalse;
+            }
+
+            int year;
+            {
+                uint digit1 = source[0] - (uint)'0';
+                uint digit2 = source[1] - (uint)'0';
+                uint digit3 = source[2] - (uint)'0';
+                uint digit4 = source[3] - (uint)'0';
+
+                if (digit1 > 9 || digit2 > 9 || digit3 > 9 || digit4 > 9)
+                {
+                    goto ReturnFalse;
+                }
+
+                year = (int)(digit1 * 1000 + digit2 * 100 + digit3 * 10 + digit4);
+            }
+
+            if (source[4] != JsonConstants.Hyphen)
+            {
+                goto ReturnFalse;
+            }
+
+            int month;
+            if (!TryGetNextTwoDigits(source.Slice(start: 5, length: 2), out month))
+            {
+                goto ReturnFalse;
+            }
+
+            if (source[7] != JsonConstants.Hyphen)
+            {
+                goto ReturnFalse;
+            }
+
+            int day;
+            if (!TryGetNextTwoDigits(source.Slice(start: 8, length: 2), out day))
+            {
+                goto ReturnFalse;
+            }
+
+            // We now have YYYY-MM-DD
+            bytesConsumed = 10;
+
+            int hour = 0;
+            int minute = 0;
+            int second = 0;
+            int fraction = 0;
+            int offsetHours = 0;
+            int offsetMinutes = 0;
+            byte offsetToken = default;
+
+            if (source.Length < 11)
+            {
+                goto FinishedParsing;
+            }
+
+            byte curByte = source[10];
+
+            if (curByte == JsonConstants.UtcOffsetToken || curByte == JsonConstants.Plus || curByte == JsonConstants.Minus)
+            {
+                goto ReturnFalse;
+            }
+            else if (curByte != JsonConstants.TimePrefix)
+            {
+                goto FinishedParsing;
+            }
+
+            // Source does not have enough characters for YYYY-MM-DDThh:mm
+            if (source.Length < 16)
+            {
+                goto ReturnFalse;
+            }
+
+            if (!TryGetNextTwoDigits(source.Slice(start: 11, length: 2), out hour))
+            {
+                goto ReturnFalse;
+            }
+
+            if (source[13] != JsonConstants.Colon)
+            {
+                goto ReturnFalse;
+            }
+
+            if (!TryGetNextTwoDigits(source.Slice(start: 14, length: 2), out minute))
+            {
+                goto ReturnFalse;
+            }
+
+            // We now have YYYY-MM-DDThh:mm
+            bytesConsumed = 16;
+
+            if (source.Length < 17)
+            {
+                goto FinishedParsing;
+            }
+
+            curByte = source[16];
+
+            int sourceIndex = 16;
+
+            if (curByte == JsonConstants.UtcOffsetToken)
+            {
+                bytesConsumed++;
+                offsetToken = JsonConstants.UtcOffsetToken;
+                goto FinishedParsing;
+            }
+            else if (curByte == JsonConstants.Plus || curByte == JsonConstants.Minus)
+            {
+                offsetToken = curByte;
+                sourceIndex++;
+                goto ParseOffset;
+            }
+            else if (curByte != JsonConstants.Colon)
+            {
+                goto FinishedParsing;
+            }
+
+            if (!TryGetNextTwoDigits(source.Slice(start: 17, length: 2), out second))
+            {
+                goto ReturnFalse;
+            }
+
+            // We now have YYYY-MM-DDThh:mm:ss
+            bytesConsumed = 19;
+
+            if (source.Length < 20)
+            {
+                goto FinishedParsing;
+            }
+
+            curByte = source[19];
+            sourceIndex = 19;
+
+            if (curByte == JsonConstants.UtcOffsetToken)
+            {
+                bytesConsumed++;
+                offsetToken = JsonConstants.UtcOffsetToken;
+                goto FinishedParsing;
+            }
+            else if (curByte == JsonConstants.Plus || curByte == JsonConstants.Minus)
+            {
+                offsetToken = curByte;
+                sourceIndex++;
+                goto ParseOffset;
+            }
+            else if (curByte != JsonConstants.Period)
+            {
+                goto FinishedParsing;
+            }
+
+            // Source does not have enough characters for YYYY-MM-DDThh:mm:ss.s
+            if (source.Length < 21)
+            {
+                value = default;
+                bytesConsumed = 0;
+                kind = default;
+                return false;
+            }
+
+            sourceIndex = 20;
+
+            {
+                while (sourceIndex < source.Length && IsDigit(curByte = source[sourceIndex]))
+                {
+                    int prevFractionTimesTen = fraction * 10;
+
+                    if (!(prevFractionTimesTen + (int)(curByte - (uint)'0') <= JsonConstants.MaxDateTimeFraction))
+                    {
+                        sourceIndex++;
+                        break;
+                    }
+
+                    fraction = prevFractionTimesTen + (int)(curByte - (uint)'0');
+                    sourceIndex++;
+                }
+            }
+
+            if (fraction != 0)
+            {
+                // Note this is 1 order of magnitude less than JsonConstants.MaxDateTimeFraction
+                while (fraction <= JsonConstants.MaxDateTimeFractionDiv10)
+                {
+                    fraction *= 10;
+                }
+            }
+
+            // We now have YYYY-MM-DDThh:mm:ss.s
+            bytesConsumed = sourceIndex;
+
+            if (sourceIndex == source.Length)
+            {
+                goto FinishedParsing;
+            }
+
+            if (curByte == JsonConstants.UtcOffsetToken)
+            {
+                bytesConsumed++;
+                offsetToken = JsonConstants.UtcOffsetToken;
+                goto FinishedParsing;
+            }
+            else if (curByte == JsonConstants.Plus || curByte == JsonConstants.Minus)
+            {
+                offsetToken = source[sourceIndex++];
+                goto ParseOffset;
+            }
+
+            goto FinishedParsing;
+
+        ParseOffset:
+            // Source does not have enough characters for YYYY-MM-DDThh:mm:ss.s+|-hh[:]mm
+            if (source.Length - sourceIndex < 4)
+            {
+                goto ReturnFalse;
+            }
+
+            if (!TryGetNextTwoDigits(source.Slice(start: sourceIndex, length: 2), out offsetHours))
+            {
+                goto ReturnFalse;
+            }
+            sourceIndex += 2;
+
+            if (source[sourceIndex] == JsonConstants.Colon)
+            {
+                sourceIndex += 1;
+            }
+
+            if (!TryGetNextTwoDigits(source.Slice(start: sourceIndex, length: 2), out offsetMinutes))
+            {
+                goto ReturnFalse;
+            }
+            sourceIndex += 2;
+
+            // We now have YYYY-MM-DDThh:mm:ss.s+|-hh[:]mm
+            bytesConsumed = sourceIndex;
+
+        FinishedParsing:
+            if ((offsetToken != JsonConstants.UtcOffsetToken) && (offsetToken != JsonConstants.Plus) && (offsetToken != JsonConstants.Minus))
+            {
+                if (!TryCreateDateTimeOffsetInterpretingDataAsLocalTime(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, out value))
+                {
+                    goto ReturnFalse;
+                }
+
+                kind = DateTimeKind.Unspecified;
+                return true;
+            }
+
+            if (offsetToken == JsonConstants.UtcOffsetToken)
+            {
+                // Same as specifying an offset of "+00:00", except that DateTime's Kind gets set to UTC rather than Local
+                if (!TryCreateDateTimeOffset(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, offsetNegative: false, offsetHours: 0, offsetMinutes: 0, out value))
+                {
+                    goto ReturnFalse;
+                }
+
+                kind = DateTimeKind.Utc;
+                return true;
+            }
+
+            Debug.Assert(offsetToken == JsonConstants.Plus || offsetToken == JsonConstants.Minus);
+
+            if (!TryCreateDateTimeOffset(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, offsetNegative: offsetToken == JsonConstants.Minus, offsetHours: offsetHours, offsetMinutes: offsetMinutes, out value))
+            {
+                goto ReturnFalse;
+            }
+
+            kind = DateTimeKind.Local;
+            return true;
+
+        ReturnFalse:
+            value = default;
+            bytesConsumed = 0;
+            kind = default;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryGetNextTwoDigits(ReadOnlySpan<byte> source, out int value)
+        {
+            Debug.Assert(source.Length == 2);
+
+            uint digit1 = source[0] - (uint)'0';
+            uint digit2 = source[1] - (uint)'0';
+
+            if (digit1 > 9 || digit2 > 9)
+            {
+                value = default;
+                return false;
+            }
+
+            value = (int)(digit1 * 10 + digit2);
+            return true;
+        }
+
+        /// <summary>
+        /// Overflow-safe DateTimeOffset factory.
+        /// </summary>
+        private static bool TryCreateDateTimeOffset(DateTime dateTime, bool offsetNegative, int offsetHours, int offsetMinutes, out DateTimeOffset value)
+        {
+            if (((uint)offsetHours) > JsonConstants.MaxDateTimeUtcOffsetHours)
+            {
+                value = default;
+                return false;
+            }
+
+            if (((uint)offsetMinutes) > 59)
+            {
+                value = default;
+                return false;
+            }
+
+            if (offsetHours == JsonConstants.MaxDateTimeUtcOffsetHours && offsetMinutes != 0)
+            {
+                value = default;
+                return false;
+            }
+
+            long offsetTicks = (((long)offsetHours) * 3600 + ((long)offsetMinutes) * 60) * TimeSpan.TicksPerSecond;
+            if (offsetNegative)
+            {
+                offsetTicks = -offsetTicks;
+            }
+
+            try
+            {
+                value = new DateTimeOffset(ticks: dateTime.Ticks, offset: new TimeSpan(ticks: offsetTicks));
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // If we got here, the combination of the DateTime + UTC offset strayed outside the 1..9999 year range. This case seems rare enough
+                // that it's better to catch the exception rather than replicate DateTime's range checking (which it's going to do anyway.)
+                value = default;
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Overflow-safe DateTimeOffset factory.
+        /// </summary>
+        private static bool TryCreateDateTimeOffset(int year, int month, int day, int hour, int minute, int second, int fraction, bool offsetNegative, int offsetHours, int offsetMinutes, out DateTimeOffset value)
+        {
+            if (!TryCreateDateTime(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, kind: DateTimeKind.Unspecified, out DateTime dateTime))
+            {
+                value = default;
+                return false;
+            }
+
+            if (!TryCreateDateTimeOffset(dateTime: dateTime, offsetNegative: offsetNegative, offsetHours: offsetHours, offsetMinutes: offsetMinutes, out value))
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Overflow-safe DateTimeOffset/Local time conversion factory.
+        /// </summary>
+        private static bool TryCreateDateTimeOffsetInterpretingDataAsLocalTime(int year, int month, int day, int hour, int minute, int second, int fraction, out DateTimeOffset value)
+        {
+            if (!TryCreateDateTime(year: year, month: month, day: day, hour: hour, minute: minute, second: second, fraction: fraction, DateTimeKind.Local, out DateTime dateTime))
+            {
+                value = default;
+                return false;
+            }
+
+            try
+            {
+                value = new DateTimeOffset(dateTime);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // If we got here, the combination of the DateTime + UTC offset strayed outside the 1..9999 year range. This case seems rare enough
+                // that it's better to catch the exception rather than replicate DateTime's range checking (which it's going to do anyway.)
+                value = default;
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Overflow-safe DateTime factory.
+        /// </summary>
+        private static bool TryCreateDateTime(int year, int month, int day, int hour, int minute, int second, int fraction, DateTimeKind kind, out DateTime value)
+        {
+            if (year == 0)
+            {
+                value = default;
+                return false;
+            }
+
+            Debug.Assert(year <= 9999); // All of our callers to date parse the year from fixed 4-digit fields so this value is trusted.
+
+            if ((((uint)month) - 1) >= 12)
+            {
+                value = default;
+                return false;
+            }
+
+            uint dayMinusOne = ((uint)day) - 1;
+            if (dayMinusOne >= 28 && dayMinusOne >= DateTime.DaysInMonth(year, month))
+            {
+                value = default;
+                return false;
+            }
+
+            if (((uint)hour) > 23)
+            {
+                value = default;
+                return false;
+            }
+
+            if (((uint)minute) > 59)
+            {
+                value = default;
+                return false;
+            }
+
+            if (((uint)second) > 59)
+            {
+                value = default;
+                return false;
+            }
+
+            Debug.Assert(fraction >= 0 && fraction <= JsonConstants.MaxDateTimeFraction); // All of our callers to date parse the fraction from fixed 7-digit fields so this value is trusted.
+
+            int[] days = DateTime.IsLeapYear(year) ? s_daysToMonth366 : s_daysToMonth365;
+            int yearMinusOne = year - 1;
+            int totalDays = (yearMinusOne * 365) + (yearMinusOne / 4) - (yearMinusOne / 100) + (yearMinusOne / 400) + days[month - 1] + day - 1;
+            long ticks = totalDays * TimeSpan.TicksPerDay;
+            int totalSeconds = (hour * 3600) + (minute * 60) + second;
+            ticks += totalSeconds * TimeSpan.TicksPerSecond;
+            ticks += fraction;
+            value = new DateTime(ticks: ticks, kind: kind);
+            return true;
+        }
+
+        private static readonly int[] s_daysToMonth365 = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 };
+        private static readonly int[] s_daysToMonth366 = { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 };
+    }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -235,6 +235,62 @@ namespace System.Text.Json
         }
 
         /// <summary>
+        /// Reads the next JSON token value from the source and parses it to a <see cref="DateTime"/>.
+        /// Returns the value if the entire UTF-8 encoded token value can be successfully parsed to a <see cref="DateTime"/>
+        /// value.
+        /// Throws exceptions otherwise.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if trying to get the value of a JSON token that is not a <see cref="JsonTokenType.String"/>.
+        /// <seealso cref="TokenType" />
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// Thrown if the JSON token value is of unsupported or incorrect ISO 8601 format.
+        /// </exception>
+        public DateTime GetDateTime()
+        {
+            if (TokenType != JsonTokenType.String)
+            {
+                throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
+            }
+
+            if (!TryGetDateTime(out DateTime value))
+            {
+                throw ThrowHelper.GetFormatException(DateType.DateTime);
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Reads the next JSON token value from the source and parses it to a <see cref="DateTimeOffset"/>.
+        /// Returns the value if the entire UTF-8 encoded token value can be successfully parsed to a <see cref="DateTimeOffset"/>
+        /// value.
+        /// Throws exceptions otherwise.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if trying to get the value of a JSON token that is not a <see cref="JsonTokenType.String"/>.
+        /// <seealso cref="TokenType" />
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// Thrown if the JSON token value is of unsupported or incorrect ISO 8601 format.
+        /// </exception>
+        public DateTimeOffset GetDateTimeOffset()
+        {
+            if (TokenType != JsonTokenType.String)
+            {
+                throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
+            }
+
+            if (!TryGetDateTimeOffset(out DateTimeOffset value))
+            {
+                throw ThrowHelper.GetFormatException(DateType.DateTime);
+            }
+
+            return value;
+        }
+
+        /// <summary>
         /// Reads the next JSON token value from the source and parses it to an <see cref="int"/>.
         /// Returns true if the entire UTF-8 encoded token value can be successfully 
         /// parsed to an <see cref="int"/> value.
@@ -381,6 +437,48 @@ namespace System.Text.Json
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
             return Utf8Parser.TryParse(span, out value, out int bytesConsumed, _numberFormat) && span.Length == bytesConsumed;
+        }
+
+        /// <summary>
+        /// Reads the next JSON token value from the source and parses it to a <see cref="DateTime"/>.
+        /// Returns true if the entire UTF-8 encoded token value can be successfully
+        /// parsed to a <see cref="DateTime"/> value.
+        /// Returns false otherwise.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if trying to get the value of a JSON token that is not a <see cref="JsonTokenType.String"/>.
+        /// <seealso cref="TokenType" />
+        /// </exception>
+        public bool TryGetDateTime(out DateTime value)
+        {
+            if (TokenType != JsonTokenType.String)
+            {
+                throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
+            }
+
+            ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
+            return JsonReaderHelper.TryParseAsISO(span, out value, out int bytesConsumed) && span.Length == bytesConsumed;
+        }
+
+        /// <summary>
+        /// Reads the next JSON token value from the source and parses it to a <see cref="DateTimeOffset"/>.
+        /// Returns true if the entire UTF-8 encoded token value can be successfully
+        /// parsed to a <see cref="DateTimeOffset"/> value.
+        /// Returns false otherwise.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if trying to get the value of a JSON token that is not a <see cref="JsonTokenType.String"/>.
+        /// <seealso cref="TokenType" />
+        /// </exception>
+        public bool TryGetDateTimeOffset(out DateTimeOffset value)
+        {
+            if (TokenType != JsonTokenType.String)
+            {
+                throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
+            }
+
+            ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
+            return JsonReaderHelper.TryParseAsISO(span, out value, out int bytesConsumed) && span.Length == bytesConsumed;
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -245,15 +245,10 @@ namespace System.Text.Json
         /// <seealso cref="TokenType" />
         /// </exception>
         /// <exception cref="FormatException">
-        /// Thrown if the JSON token value is of unsupported or incorrect ISO 8601 format.
+        /// Thrown if the JSON token value is of an unsupported format. Only a subset of ISO 8601 formats are supported.
         /// </exception>
         public DateTime GetDateTime()
         {
-            if (TokenType != JsonTokenType.String)
-            {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
-            }
-
             if (!TryGetDateTime(out DateTime value))
             {
                 throw ThrowHelper.GetFormatException(DateType.DateTime);
@@ -273,18 +268,13 @@ namespace System.Text.Json
         /// <seealso cref="TokenType" />
         /// </exception>
         /// <exception cref="FormatException">
-        /// Thrown if the JSON token value is of unsupported or incorrect ISO 8601 format.
+        /// Thrown if the JSON token value is of an unsupported format. Only a subset of ISO 8601 formats are supported.
         /// </exception>
         public DateTimeOffset GetDateTimeOffset()
         {
-            if (TokenType != JsonTokenType.String)
-            {
-                throw ThrowHelper.GetInvalidOperationException_ExpectedString(TokenType);
-            }
-
             if (!TryGetDateTimeOffset(out DateTimeOffset value))
             {
-                throw ThrowHelper.GetFormatException(DateType.DateTime);
+                throw ThrowHelper.GetFormatException(DateType.DateTimeOffset);
             }
 
             return value;

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -450,6 +450,26 @@ namespace System.Text.Json
             }
             return new FormatException(message);
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static FormatException GetFormatException(DateType dateType)
+        {
+            string message = "";
+
+            switch (dateType)
+            {
+                case DateType.DateTime:
+                    message = SR.FormatDateTime;
+                    break;
+                case DateType.DateTimeOffset:
+                    message = SR.FormatDateTimeOffset;
+                    break;
+                default:
+                    Debug.Fail($"The DateType enum value: {dateType} is not part of the switch. Add the appropriate case and exception message.");
+                    break;
+            }
+            return new FormatException(message);
+        }
     }
 
     internal enum ExceptionResource
@@ -499,5 +519,11 @@ namespace System.Text.Json
         Single,
         Double,
         Decimal
+    }
+
+    internal enum DateType
+    {
+        DateTime,
+        DateTimeOffset
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -459,8 +459,10 @@ namespace System.Text.Json
             switch (dateType)
             {
                 case DateType.DateTime:
-                case DateType.DateTimeOffset:
                     message = SR.FormatDateTime;
+                    break;
+                case DateType.DateTimeOffset:
+                    message = SR.FormatDateTimeOffset;
                     break;
                 default:
                     Debug.Fail($"The DateType enum value: {dateType} is not part of the switch. Add the appropriate case and exception message.");

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -459,10 +459,8 @@ namespace System.Text.Json
             switch (dateType)
             {
                 case DateType.DateTime:
-                    message = SR.FormatDateTime;
-                    break;
                 case DateType.DateTimeOffset:
-                    message = SR.FormatDateTimeOffset;
+                    message = SR.FormatDateTime;
                     break;
                 default:
                     Debug.Fail($"The DateType enum value: {dateType} is not part of the switch. Add the appropriate case and exception message.");

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -165,7 +165,8 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-16T19:20:30.4555555-14:00 \"" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+14 00\"" };
 
-            // Proper format but invalid time fields
+            // Proper format but invalid calendar date, time, or time zone designator fields
+            yield return new object[] { "\"9999-12-31T23:59:59.9999999\"" }; // This date spills over to year 10_000.
             yield return new object[] { "\"1997-00-16T19:20:30.4555555\"" };
             yield return new object[] { "\"1997-07-16T25:20:30.4555555\"" };
             yield return new object[] { "\"1997-00-16T19:20:30.4555555Z\"" };
@@ -181,6 +182,7 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+10:60\"" };
             yield return new object[] { "\"0000-07-16T19:20:30.4555555+10:00\"" };
             yield return new object[] { "\"2019-02-29T19:20:30.4555555+10:00\"" };
+            yield return new object[] { "\"9999-12-31T23:59:59.9999999-01:00\"" }; // This date spills over to year 10_000.
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -166,7 +166,6 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+14 00\"" };
 
             // Proper format but invalid calendar date, time, or time zone designator fields
-            yield return new object[] { "\"9999-12-31T23:59:59.9999999\"" }; // This date spills over to year 10_000.
             yield return new object[] { "\"1997-00-16T19:20:30.4555555\"" };
             yield return new object[] { "\"1997-07-16T25:20:30.4555555\"" };
             yield return new object[] { "\"1997-00-16T19:20:30.4555555Z\"" };

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -25,12 +25,45 @@ namespace System.Text.Json.Tests
             // Skip test T24:00 till #35830 is fixed.
             // yield return new object[] { "\"1997-07-16T24:00\"", "1997-07-16T24:00" };
 
-            // Test fraction rounding.
-            yield return new object[] { "\"1997-07-16T19:20:30.45555554\"", "1997-07-16T19:20:30.45555554" };
-            // We expect the parser to truncate. `DateTime(Offset).Parse` will round up to 7dp in this case,
-            // so we pass a string representing the Datetime(Offset) we expect to the `Parse` method.
-            yield return new object[] { "\"1997-07-16T19:20:30.45555555\"", "1997-07-16T19:20:30.4555555" };
+            // Test fractions.
+            yield return new object[] { "\"1997-07-16T19:20:30.0\"", "1997-07-16T19:20:30" };
+            yield return new object[] { "\"1997-07-16T19:20:30.000\"", "1997-07-16T19:20:30" };
+            yield return new object[] { "\"1997-07-16T19:20:30.0000000\"", "1997-07-16T19:20:30" };
+            yield return new object[] { "\"1997-07-16T19:20:30.01\"", "1997-07-16T19:20:30.01" };
+            yield return new object[] { "\"1997-07-16T19:20:30.0001\"", "1997-07-16T19:20:30.0001" };
+            yield return new object[] { "\"1997-07-16T19:20:30.0000001\"", "1997-07-16T19:20:30.0000001" };
+            yield return new object[] { "\"1997-07-16T19:20:30.0000323\"", "1997-07-16T19:20:30.0000323" };
+            yield return new object[] { "\"1997-07-16T19:20:30.1\"", "1997-07-16T19:20:30.1" };
+            yield return new object[] { "\"1997-07-16T19:20:30.22\"", "1997-07-16T19:20:30.22" };
+            yield return new object[] { "\"1997-07-16T19:20:30.333\"", "1997-07-16T19:20:30.333" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4444\"", "1997-07-16T19:20:30.4444" };
+            yield return new object[] { "\"1997-07-16T19:20:30.55555\"", "1997-07-16T19:20:30.55555" };
+            yield return new object[] { "\"1997-07-16T19:20:30.666666\"", "1997-07-16T19:20:30.666666" };
+            yield return new object[] { "\"1997-07-16T19:20:30.7777777\"", "1997-07-16T19:20:30.7777777" };
+            yield return new object[] { "\"1997-07-16T19:20:30.1000000\"", "1997-07-16T19:20:30.1" };
+            yield return new object[] { "\"1997-07-16T19:20:30.2200000\"", "1997-07-16T19:20:30.22" };
+            yield return new object[] { "\"1997-07-16T19:20:30.3330000\"", "1997-07-16T19:20:30.333" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4444000\"", "1997-07-16T19:20:30.4444" };
+            yield return new object[] { "\"1997-07-16T19:20:30.5555500\"", "1997-07-16T19:20:30.55555" };
+            yield return new object[] { "\"1997-07-16T19:20:30.6666660\"", "1997-07-16T19:20:30.666666" };
 
+            // Test fraction truncation.
+            yield return new object[] { "\"1997-07-16T19:20:30.0000000000000\"", "1997-07-16T19:20:30" };
+            yield return new object[] { "\"1997-07-16T19:20:30.00000001\"", "1997-07-16T19:20:30" };
+            yield return new object[] { "\"1997-07-16T19:20:30.00000000000001\"", "1997-07-16T19:20:30" };
+            yield return new object[] { "\"1997-07-16T19:20:30.77777770\"", "1997-07-16T19:20:30.7777777" };
+            yield return new object[] { "\"1997-07-16T19:20:30.777777700\"", "1997-07-16T19:20:30.7777777" };
+            yield return new object[] { "\"1997-07-16T19:20:30.45555554\"", "1997-07-16T19:20:30.45555554" };
+            // We expect the parser to truncate. `DateTime(Offset).Parse` will round up to 7dp in these cases,
+            // so we pass a strings representing the Datetime(Offset) we expect to the `Parse` method.
+            yield return new object[] { "\"1997-07-16T19:20:30.45555555\"", "1997-07-16T19:20:30.4555555" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555555555555555\"", "1997-07-16T19:20:30.4555555" };
+
+            // Test Non-UTC timezone designator (TZD).
+            yield return new object[] { "\"1997-07-16T19:20+01:00\"", "1997-07-16T19:20+01:00" };
+            yield return new object[] { "\"1997-07-16T19:20-01:00\"", "1997-07-16T19:20-01:00" };
+            yield return new object[] { "\"1997-07-16T19:20:30+01:00\"", "1997-07-16T19:20:30+01:00" };
+            yield return new object[] { "\"1997-07-16T19:20:30-01:00\"", "1997-07-16T19:20:30-01:00" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+01:00\"", "1997-07-16T19:20:30.4555555+01:00" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555-01:00\"", "1997-07-16T19:20:30.4555555-01:00" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+04:30\"", "1997-07-16T19:20:30.4555555+04:30" };
@@ -39,18 +72,44 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-16T19:20:30.4555555-0100\"", "1997-07-16T19:20:30.4555555-01:00" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+0430\"", "1997-07-16T19:20:30.4555555+04:30" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555-0430\"", "1997-07-16T19:20:30.4555555-04:30" };
+            // Test Non-UTC TZD without minute.
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+01\"", "1997-07-16T19:20:30.4555555+01:00" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555-01\"", "1997-07-16T19:20:30.4555555-01:00" };
+            // Test Non-UTC TZD with max UTC offset hour.
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+14:00\"", "1997-07-16T19:20:30.4555555+14:00" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555-14:00\"", "1997-07-16T19:20:30.4555555-14:00" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+1400\"", "1997-07-16T19:20:30.4555555+14:00" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555-1400\"", "1997-07-16T19:20:30.4555555-14:00" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+14\"", "1997-07-16T19:20:30.4555555+14:00" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555-14\"", "1997-07-16T19:20:30.4555555-14:00" };
+            // Test February 29 on a leap year
+            yield return new object[] { "\"2020-02-29T19:20:30.4555555+10:00\"", "2020-02-29T19:20:30.4555555+10:00" };
+        }
+
+        // UTC TZD test is separate because `DateTime.Parse` for strings with `Z` TZD will return
+        // a `DateTime` with `DateTimeKind.Local` i.e `+00:00` which does not equal our expected result,
+        // a `DateTime` with `DateTimeKind.Utc` i.e `Z`.
+        // Instead, we need to use `DateTime.ParseExact` which returns a DateTime Utc `DateTimeKind`.
+        // Test string, Argument to DateTime(Offset).Parse(Exact)
+        public static IEnumerable<object[]> ValidISO8601TestsWithUtcOffset()
+        {
+            yield return new object[] { "\"1997-07-16T19:20Z\"", "1997-07-16T19:20:00.0000000Z" };
+            yield return new object[] { "\"1997-07-16T19:20:30Z\"", "1997-07-16T19:20:30.0000000Z" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555Z\"", "1997-07-16T19:20:30.4555555Z" };
         }
 
         public static IEnumerable<object[]> InvalidISO8601Tests()
         {
-            // Test junk data appended.
+            // Invalid YYYY-MM-DD
+            yield return new object[] { "\"0997 07-16\"" };
+            yield return new object[] { "\"0997-0a-16\"" };
+            yield return new object[] { "\"0997-07 16\"" };
             yield return new object[] { "\"0997-07-160997-07-16\"" };
             yield return new object[] { "\"0997-07-16abc\"" };
+            yield return new object[] { "\"0997-07-16 \"" };
             yield return new object[] { "\"0997-07-16,0997-07-16\"" };
             yield return new object[] { "\"1997-07-16T19:20abc\"" };
             yield return new object[] { "\"1997-07-16T19:20, 123\"" };
-
-            // Other invalid strings.
             yield return new object[] { "\"997-07-16\"" };
             yield return new object[] { "\"1997-07\"" };
             yield return new object[] { "\"1997-7-06\"" };
@@ -59,6 +118,61 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-6T01\"" };
             yield return new object[] { "\"1997-07-16Z\"" };
             yield return new object[] { "\"1997-07-16+01:00\"" };
+            yield return new object[] { "\"19970716\"" };
+            yield return new object[] { "\"0997-07-166\"" };
+            yield return new object[] { "\"1997-07-1sdsad\"" };
+            yield return new object[] { "\"1997-07-16T19200\"" };
+
+            // Invalid YYYY-MM-DDThh:mm
+            yield return new object[] { "\"1997-07-16T1\"" };
+            yield return new object[] { "\"1997-07-16Ta0:00\"" };
+            yield return new object[] { "\"1997-07-16T19: 20:30\"" };
+            yield return new object[] { "\"1997-07-16 19:20:30\"" };
+            yield return new object[] { "\"1997-07-16T19:2030\"" };
+
+            // Invalid YYYY-MM-DDThh:mm:ss
+            yield return new object[] { "\"1997-07-16T19:20:3a\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30a\"" };
+            yield return new object[] { "\"1997-07-16T19:20:3045\"" };
+            yield return new object[] { "\"1997-07-16T19:20:304555555\"" };
+
+            // Invalid fractions.
+            yield return new object[] { "\"1997-07-16T19:20:30,45\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30 .\"" };
+            yield return new object[] { "\"abc1997-07-16T19:20:30.000\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+\"" };
+
+            // Invalid TZD.
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+-Z\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555Z \"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+01Z\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+01:\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555 +01:00\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+01:\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555- 01:00\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+04 :30\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555-04: 30\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+0100 \"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555-010\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+430\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555--0430\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+0\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555-01005\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+14:00a\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555-14:0\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555-14:00 \"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+14 00\"" };
+
+            // Proper format but invalid time fields
+            yield return new object[] { "\"0000-07-16T19:20:30.4555555+10:00\"" };
+            yield return new object[] { "\"1997-00-16T19:20:30.4555555+10:00\"" };
+            yield return new object[] { "\"1997-07-16T25:20:30.4555555+10:00\"" };
+            yield return new object[] { "\"1997-07-16T19:60:30.4555555+10:00\"" };
+            yield return new object[] { "\"1997-07-16T19:20:60.4555555+10:00\"" };
+            yield return new object[] { "\"2019-02-29T19:20:30.4555555+10:00\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+10:60\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+14:30\"" };
         }
 
         [Fact]
@@ -551,7 +665,7 @@ namespace System.Text.Json.Tests
                     try
                     {
                         json.TryGetDateTime(out DateTime value);
-                        Assert.True(false, "Expected GetDateTime to throw InvalidOperationException due to mismatched token type.");
+                        Assert.True(false, "Expected TryGetDateTime to throw InvalidOperationException due to mismatched token type.");
                     }
                     catch (InvalidOperationException)
                     { }
@@ -559,7 +673,7 @@ namespace System.Text.Json.Tests
                     try
                     {
                         DateTimeOffset value = json.GetDateTimeOffset();
-                        Assert.True(false, "Expected GetDateTime to throw InvalidOperationException due to mismatched token type.");
+                        Assert.True(false, "Expected GetDateTimeOffset to throw InvalidOperationException due to mismatched token type.");
                     }
                     catch (InvalidOperationException)
                     { }
@@ -567,7 +681,7 @@ namespace System.Text.Json.Tests
                     try
                     {
                         json.TryGetDateTimeOffset(out DateTimeOffset value);
-                        Assert.True(false, "Expected GetDateTime to throw InvalidOperationException due to mismatched token type.");
+                        Assert.True(false, "Expected TryGetDateTimeOffset to throw InvalidOperationException due to mismatched token type.");
                     }
                     catch (InvalidOperationException)
                     { }
@@ -884,6 +998,30 @@ namespace System.Text.Json.Tests
                 {
                     DateTimeOffset expected = DateTimeOffset.Parse(expectedString);
 
+                    Assert.True(json.TryGetDateTimeOffset(out DateTimeOffset actual));
+                    Assert.Equal(expected, actual);
+
+                    Assert.Equal(expected, json.GetDateTimeOffset());
+                }
+            }
+
+            Assert.Equal(dataUtf8.Length, json.BytesConsumed);
+            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidISO8601TestsWithUtcOffset))]
+        public static void TestingStringsWithUTCOffsetToDateTime(string jsonString, string expectedString)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            var json = new Utf8JsonReader(dataUtf8, isFinalBlock: true, state: default);
+            while (json.Read())
+            {
+                if (json.TokenType == JsonTokenType.String)
+                {
+                    DateTime expected = DateTime.ParseExact(expectedString, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+
                     Assert.True(json.TryGetDateTime(out DateTime actual));
                     Assert.Equal(expected, actual);
 
@@ -895,44 +1033,28 @@ namespace System.Text.Json.Tests
             Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
-        [Fact]
-        public static void TestingStringsWithUTCOffsetToDateTime()
+        [Theory]
+        [MemberData(nameof(ValidISO8601TestsWithUtcOffset))]
+        public static void TestingStringsWithUTCOffsetToDateTimeOffset(string jsonString, string expectedString)
         {
-            byte[] dataUtf8 = Encoding.UTF8.GetBytes("\"1997-07-16T19:20:30.4555555Z\"");
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
             var json = new Utf8JsonReader(dataUtf8, isFinalBlock: true, state: default);
             while (json.Read())
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    DateTime expected = DateTime.ParseExact("1997-07-16T19:20:30.4555555Z", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-
-                    Assert.True(json.TryGetDateTime(out DateTime actual));
-                    Assert.Equal(expected, actual);
-
-                    Assert.Equal(expected, json.GetDateTime());
-                }
-            }
-        }
-
-        [Fact]
-        public static void TestingStringsWithUTCOffsetToDateTimeOffset()
-        {
-            byte[] dataUtf8 = Encoding.UTF8.GetBytes("\"1997-07-16T19:20:30.4555555Z\"");
-
-            var json = new Utf8JsonReader(dataUtf8, isFinalBlock: true, state: default);
-            while (json.Read())
-            {
-                if (json.TokenType == JsonTokenType.String)
-                {
-                    DateTimeOffset expected = DateTimeOffset.ParseExact("1997-07-16T19:20:30.4555555Z", "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                    DateTimeOffset expected = DateTimeOffset.ParseExact(expectedString, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
 
                     Assert.True(json.TryGetDateTimeOffset(out DateTimeOffset actual));
                     Assert.Equal(expected, actual);
 
-                    Assert.Equal(expected, json.GetDateTime());
+                    Assert.Equal(expected, json.GetDateTimeOffset());
                 }
             }
+
+            Assert.Equal(dataUtf8.Length, json.BytesConsumed);
+            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -971,7 +1093,7 @@ namespace System.Text.Json.Tests
 
                     try
                     {
-                        DateTimeOffset value = json.GetDateTime();
+                        DateTimeOffset value = json.GetDateTimeOffset();
                         Assert.True(false, "Expected GetDateTimeOffset to throw FormatException due to invalid ISO 8601 input.");
                     }
                     catch (FormatException)

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -165,6 +165,8 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+14 00\"" };
 
             // Proper format but invalid time fields
+            yield return new object[] { "\"0000-07-16T19:20:30.4555555+14:30\"" };
+            yield return new object[] { "\"0000-07-16T19:20:30.4555555-14:30\"" };
             yield return new object[] { "\"0000-07-16T19:20:30.4555555+10:00\"" };
             yield return new object[] { "\"1997-00-16T19:20:30.4555555+10:00\"" };
             yield return new object[] { "\"1997-07-16T25:20:30.4555555+10:00\"" };

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -166,6 +166,10 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+14 00\"" };
 
             // Proper format but invalid time fields
+            yield return new object[] { "\"1997-00-16T19:20:30.4555555\"" };
+            yield return new object[] { "\"1997-07-16T25:20:30.4555555\"" };
+            yield return new object[] { "\"1997-00-16T19:20:30.4555555Z\"" };
+            yield return new object[] { "\"1997-07-16T25:20:30.4555555Z\"" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+14:30\"" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555-14:30\"" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+15:00\"" };

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -55,7 +55,7 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-16T19:20:30.777777700\"", "1997-07-16T19:20:30.7777777" };
             yield return new object[] { "\"1997-07-16T19:20:30.45555554\"", "1997-07-16T19:20:30.45555554" };
             // We expect the parser to truncate. `DateTime(Offset).Parse` will round up to 7dp in these cases,
-            // so we pass a strings representing the Datetime(Offset) we expect to the `Parse` method.
+            // so we pass a string representing the Datetime(Offset) we expect to the `Parse` method.
             yield return new object[] { "\"1997-07-16T19:20:30.45555555\"", "1997-07-16T19:20:30.4555555" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555555555555555\"", "1997-07-16T19:20:30.4555555" };
 
@@ -86,10 +86,11 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"2020-02-29T19:20:30.4555555+10:00\"", "2020-02-29T19:20:30.4555555+10:00" };
         }
 
-        // UTC TZD test is separate because `DateTime.Parse` for strings with `Z` TZD will return
+        // UTC TZD tests are separate because `DateTime.Parse` for strings with `Z` TZD will return
         // a `DateTime` with `DateTimeKind.Local` i.e `+00:00` which does not equal our expected result,
         // a `DateTime` with `DateTimeKind.Utc` i.e `Z`.
         // Instead, we need to use `DateTime.ParseExact` which returns a DateTime Utc `DateTimeKind`.
+        //
         // Test string, Argument to DateTime(Offset).Parse(Exact)
         public static IEnumerable<object[]> ValidISO8601TestsWithUtcOffset()
         {
@@ -165,16 +166,17 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+14 00\"" };
 
             // Proper format but invalid time fields
-            yield return new object[] { "\"0000-07-16T19:20:30.4555555+14:30\"" };
-            yield return new object[] { "\"0000-07-16T19:20:30.4555555-14:30\"" };
-            yield return new object[] { "\"0000-07-16T19:20:30.4555555+10:00\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+14:30\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555-14:30\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555+15:00\"" };
+            yield return new object[] { "\"1997-07-16T19:20:30.4555555-15:00\"" };
             yield return new object[] { "\"1997-00-16T19:20:30.4555555+10:00\"" };
             yield return new object[] { "\"1997-07-16T25:20:30.4555555+10:00\"" };
             yield return new object[] { "\"1997-07-16T19:60:30.4555555+10:00\"" };
             yield return new object[] { "\"1997-07-16T19:20:60.4555555+10:00\"" };
-            yield return new object[] { "\"2019-02-29T19:20:30.4555555+10:00\"" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+10:60\"" };
-            yield return new object[] { "\"1997-07-16T19:20:30.4555555+14:30\"" };
+            yield return new object[] { "\"0000-07-16T19:20:30.4555555+10:00\"" };
+            yield return new object[] { "\"2019-02-29T19:20:30.4555555+10:00\"" };
         }
 
         [Fact]


### PR DESCRIPTION
This change partially addresses https://github.com/dotnet/corefx/issues/34690.

These methods parse JSON strings to DateTime(Offset) objects according to format YYYY-MM-dd[THH:mm[:ss[.fffffff]]Z|+/-HH[[:]mm]]]