### PR TITLE
Remove 2 suffix step 1

### DIFF
--- a/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.Stat.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.Stat.cs
@@ -54,13 +54,13 @@ internal static partial class Interop
             HasBirthTime = 1,
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat2", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat", SetLastError = true)]
         internal static extern int FStat(SafeFileHandle fd, out FileStatus output);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Stat2", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Stat", SetLastError = true)]
         internal static extern int Stat(string path, out FileStatus output);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LStat2", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LStat", SetLastError = true)]
         internal static extern int LStat(string path, out FileStatus output);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Stat.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Stat.Pipe.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat2", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat", SetLastError = true)]
         internal static extern int FStat(SafePipeHandle fd, out FileStatus output);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Stat.Span.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Stat.Span.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
         // without putting too much pressure on the stack.
         private const int StackBufferSize = 256;
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Stat2", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Stat", SetLastError = true)]
         internal unsafe static extern int Stat(ref byte path, out FileStatus output);
 
         internal unsafe static int Stat(ReadOnlySpan<char> path, out FileStatus output)
@@ -26,7 +26,7 @@ internal static partial class Interop
             return result;
         }
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LStat2", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LStat", SetLastError = true)]
         internal static extern int LStat(ref byte path, out FileStatus output);
 
         internal unsafe static int LStat(ReadOnlySpan<char> path, out FileStatus output)

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -178,9 +178,7 @@ static void ConvertFileStatus(const struct stat_* src, FileStatus* dst)
 #endif
 }
 
-// CoreCLR expects the "2" suffixes on these: they should be cleaned up in our
-// next coordinated System.Native changes
-int32_t SystemNative_Stat2(const char* path, FileStatus* output)
+int32_t SystemNative_Stat(const char* path, FileStatus* output)
 {
     struct stat_ result;
     int ret;
@@ -194,7 +192,7 @@ int32_t SystemNative_Stat2(const char* path, FileStatus* output)
     return ret;
 }
 
-int32_t SystemNative_FStat2(intptr_t fd, FileStatus* output)
+int32_t SystemNative_FStat(intptr_t fd, FileStatus* output)
 {
     struct stat_ result;
     int ret;
@@ -208,7 +206,7 @@ int32_t SystemNative_FStat2(intptr_t fd, FileStatus* output)
     return ret;
 }
 
-int32_t SystemNative_LStat2(const char* path, FileStatus* output)
+int32_t SystemNative_LStat(const char* path, FileStatus* output)
 {
     struct stat_ result;
     int ret = lstat_(path, &result);
@@ -219,6 +217,22 @@ int32_t SystemNative_LStat2(const char* path, FileStatus* output)
     }
 
     return ret;
+}
+
+// These "2" suffix functions are pending removal
+int32_t SystemNative_Stat2(const char* path, FileStatus* output)
+{
+    return SystemNative_Stat(path, output);
+}
+
+int32_t SystemNative_FStat2(intptr_t fd, FileStatus* output)
+{
+    return SystemNative_FStat(path, output);
+}
+
+int32_t SystemNative_LStat2(const char* path, FileStatus* output)
+{
+    return SystemNative_LStat(path, output);
 }
 
 static int32_t ConvertOpenFlags(int32_t flags)

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -227,7 +227,7 @@ int32_t SystemNative_Stat2(const char* path, FileStatus* output)
 
 int32_t SystemNative_FStat2(intptr_t fd, FileStatus* output)
 {
-    return SystemNative_FStat(path, output);
+    return SystemNative_FStat(fd, output);
 }
 
 int32_t SystemNative_LStat2(const char* path, FileStatus* output)

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -324,6 +324,27 @@ typedef enum
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
+DLLEXPORT int32_t SystemNative_FStat(intptr_t fd, FileStatus* output);
+
+/**
+ * Get file status from a full path. Implemented as shim to stat(2).
+ *
+ * Returns 0 for success, -1 for failure. Sets errno on failure.
+ */
+DLLEXPORT int32_t SystemNative_Stat(const char* path, FileStatus* output);
+
+/**
+ * Get file stats from a full path. Implemented as shim to lstat(2).
+ *
+ * Returns 0 for success, -1 for failure. Sets errno on failure.
+ */
+DLLEXPORT int32_t SystemNative_LStat(const char* path, FileStatus* output);
+
+/**
+ * Get file status from a descriptor. Implemented as shim to fstat(2).
+ *
+ * Returns 0 for success, -1 for failure. Sets errno on failure.
+ */
 DLLEXPORT int32_t SystemNative_FStat2(intptr_t fd, FileStatus* output);
 
 /**


### PR DESCRIPTION
I promised to remove this before and was reminded that I didn't.

After Interop.Stat.cs is mirrored to CoreCLR, I will put up another PR to delete the "2" methods.