### PR TITLE
Bug fix: await SmtpClient.SendMailAsync never ends

### DIFF
--- a/src/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
+++ b/src/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
@@ -341,6 +341,7 @@ namespace System.Net.Mail
                 if (newResult.CompletedSynchronously)
                 {
                     writer.EndGetContentStream(newResult).Close();
+                    result.InvokeCallback();
                 }
                 return result;
             }

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -309,7 +309,7 @@ namespace System.Net.Mail.Tests
         [InlineData("howdydoo")]
         [InlineData("")]
         [InlineData(null)]
-        public void TestMailDeliveryAsync(string body)
+        async public Task TestMailDeliveryAsync(string body)
         {
             SmtpServer server = new SmtpServer();
             SmtpClient client = new SmtpClient("localhost", server.EndPoint.Port);
@@ -320,10 +320,7 @@ namespace System.Net.Mail.Tests
             {
                 Thread t = new Thread(server.Run);
                 t.Start();
-                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
-                {
-                    client.SendMailAsync(msg).Wait(cts.Token);
-                }
+                await client.SendMailAsync(msg).TimeoutAfter((int)TimeSpan.FromSeconds(30).TotalMilliseconds);
                 t.Join();
 
                 Assert.Equal("<foo@example.com>", server.MailFrom);

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -305,25 +305,31 @@ namespace System.Net.Mail.Tests
             }
         }
 
-        [Fact]
-        public async Task TestMailDeliveryAsync()
+        [Theory]
+        [InlineData("howdydoo")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TestMailDeliveryAsync(string body)
         {
             SmtpServer server = new SmtpServer();
             SmtpClient client = new SmtpClient("localhost", server.EndPoint.Port);
-            MailMessage msg = new MailMessage("foo@example.com", "bar@example.com", "hello", "howdydoo");
+            MailMessage msg = new MailMessage("foo@example.com", "bar@example.com", "hello", body);
             string clientDomain = IPGlobalProperties.GetIPGlobalProperties().HostName.Trim().ToLower();
 
             try
             {
                 Thread t = new Thread(server.Run);
                 t.Start();
-                await client.SendMailAsync(msg);
+                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+                {
+                    client.SendMailAsync(msg).Wait(cts.Token);
+                }
                 t.Join();
 
                 Assert.Equal("<foo@example.com>", server.MailFrom);
                 Assert.Equal("<bar@example.com>", server.MailTo);
                 Assert.Equal("hello", server.Subject);
-                Assert.Equal("howdydoo", server.Body);
+                Assert.Equal(body ?? "", server.Body);
                 Assert.Equal(clientDomain, server.ClientDomain);
             }
             finally

--- a/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -309,7 +309,7 @@ namespace System.Net.Mail.Tests
         [InlineData("howdydoo")]
         [InlineData("")]
         [InlineData(null)]
-        async public Task TestMailDeliveryAsync(string body)
+        public async Task TestMailDeliveryAsync(string body)
         {
             SmtpServer server = new SmtpServer();
             SmtpClient client = new SmtpClient("localhost", server.EndPoint.Port);

--- a/src/System.Net.Mail/tests/Functional/System.Net.Mail.Functional.Tests.csproj
+++ b/src/System.Net.Mail/tests/Functional/System.Net.Mail.Functional.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{A26D88B7-6EF6-4C8C-828B-7B57732CCE38}</ProjectGuid>
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
@@ -25,6 +25,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+      <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
fixes https://github.com/dotnet/corefx/issues/35738

I did some test and seem that issue jump out in case of empty content and synchronous completion of async send

https://github.com/dotnet/corefx/blob/700f035b9533ed4e439de83e99da1293b7a82e93/src/System.Net.Mail/src/System/Net/Mail/MailPriority.cs#L342-L344

becuse in case of non empty content code ends up to call `LazyAsyncResult.InvokeCallback` wrapper with or without exception, invoking `SendMessageCallback`

https://github.com/dotnet/corefx/blob/700f035b9533ed4e439de83e99da1293b7a82e93/src/System.Net.Mail/src/System/Net/Mime/MimePart.cs#L182-L184

In case of empty content `InvokeCallback` is called only in case of "real" async execution

https://github.com/dotnet/corefx/blob/700f035b9533ed4e439de83e99da1293b7a82e93/src/System.Net.Mail/src/System/Net/Mail/MailPriority.cs#L312

I think that in case of `CompletedSynchronously` we missed a call to `LazyAsyncResult.InvokeCallback`, something like:
```cs
  else
            {
                LazyAsyncResult result = new LazyAsyncResult(this, state, callback);
                IAsyncResult newResult = writer.BeginGetContentStream(EmptySendCallback, new EmptySendContext(writer, result));
                if (newResult.CompletedSynchronously)
                {
                    writer.EndGetContentStream(newResult).Close();
                    result.InvokeCallback(); <- missing call to `SendMessageCallback`
                }
                return result;
            }
```

/cc @davidsh
