### PR TITLE
Linked doc for debugging tests in Visual Studio

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -125,6 +125,8 @@ For more details, or to test an individual project, see the [developer guide top
 4. Select the corresponding launch profile (green arrow, i.e. `.NET Core xUnit Console`)
 5. F5 (Debug)
 
+For advanced debugging using Visual Studio see [Build, Run and Debug tests using Visual Studio](https://github.com/dotnet/corefx/wiki/Build-and-run-tests#build-run-and-debug-tests-using-visual-studio)
+
 For advanced debugging using WinDBG see [Debugging CoreFX on Windows](https://github.com/dotnet/corefx/blob/master/Documentation/debugging/windows-instructions.md)
 
 ### Notes


### PR DESCRIPTION
While searching how to debug one specific test case using Visual Studio, I ended up on section "Debugging tests in Visual Studio" in this doc, but more information was somewhere else. So proposing this change to provide a link so that developers are led to proper page that has information on advanced features.

@karelz @ahsonkhan 