### PR TITLE
disable SendToRecvFrom_Datagram_UDP test again

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -43,6 +43,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [ActiveIssue(16945)]
         [OuterLoop] // TODO: Issue #11345
         [Theory]
         [MemberData(nameof(Loopbacks))]


### PR DESCRIPTION
related to dotnet/runtime#1712

It is still unreliable and it will need more investigation.