### PR TITLE
Enable VSTest references and LaunchSettings in CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -141,11 +141,6 @@
     <EnableDumpling>false</EnableDumpling>
     <CrashDumpFolder Condition="'$(OS)' == 'Windows_NT'">%TMP%\CoreRunCrashDumps</CrashDumpFolder>
   </PropertyGroup>
-  <!-- Disable VS support files on CI and official builds. -->
-  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(OfficialBuildId)' != ''">
-    <EnableLaunchSettings>false</EnableLaunchSettings>
-    <EnableVSTestReferences>false</EnableVSTestReferences>
-  </PropertyGroup>
 
   <!-- list of nuget package sources passed to nuget restore -->
   <!-- Example to consume local CoreCLR package:


### PR DESCRIPTION
Enable generating launch settings and VSTest references in CI to protect these paths (they broke in the past)