### PR TITLE
Add missing deserialization ctor to ChannelClosedException

### DIFF
--- a/src/System.Threading.Channels/ref/System.Threading.Channels.netcoreapp.cs
+++ b/src/System.Threading.Channels/ref/System.Threading.Channels.netcoreapp.cs
@@ -7,6 +7,10 @@
 
 namespace System.Threading.Channels
 {
+    public partial class ChannelClosedException : System.InvalidOperationException
+    {
+        protected ChannelClosedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
     public abstract partial class ChannelReader<T>
     {
         public virtual System.Collections.Generic.IAsyncEnumerable<T> ReadAllAsync() { throw null; }

--- a/src/System.Threading.Channels/src/System.Threading.Channels.csproj
+++ b/src/System.Threading.Channels/src/System.Threading.Channels.csproj
@@ -14,6 +14,7 @@
     <Compile Include="System\Threading\Channels\BoundedChannelFullMode.cs" />
     <Compile Include="System\Threading\Channels\Channel.cs" />
     <Compile Include="System\Threading\Channels\ChannelClosedException.cs" />
+    <Compile Include="System\Threading\Channels\ChannelClosedException.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="System\Threading\Channels\ChannelOptions.cs" />
     <Compile Include="System\Threading\Channels\ChannelReader.cs" />
     <Compile Include="System\Threading\Channels\ChannelReader.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />

--- a/src/System.Threading.Channels/src/System/Threading/Channels/ChannelClosedException.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/ChannelClosedException.cs
@@ -5,7 +5,7 @@
 namespace System.Threading.Channels
 {
     /// <summary>Exception thrown when a channel is used after it's been closed.</summary>
-    public class ChannelClosedException : InvalidOperationException
+    public partial class ChannelClosedException : InvalidOperationException
     {
         /// <summary>Initializes a new instance of the <see cref="ChannelClosedException"/> class.</summary>
         public ChannelClosedException() :

--- a/src/System.Threading.Channels/src/System/Threading/Channels/ChannelClosedException.netcoreapp.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/ChannelClosedException.netcoreapp.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Threading.Channels
+{
+    /// <summary>Exception thrown when a channel is used after it's been closed.</summary>
+    [Serializable]
+    public partial class ChannelClosedException : InvalidOperationException
+    {
+        /// <summary>Initializes a new instance of the <see cref="ChannelClosedException"/> class with serialized data.</summary>
+        /// <param name="info">The object that holds the serialized object data.</param>
+        /// <param name="context">The contextual information about the source or destination.</param>
+        protected ChannelClosedException(SerializationInfo info, StreamingContext context) :
+            base(info, context)
+        {
+        }
+    }
+}

--- a/src/System.Threading.Channels/tests/ChannelClosedExceptionTests.cs
+++ b/src/System.Threading.Channels/tests/ChannelClosedExceptionTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.Threading.Channels.Tests
 {
-    public class ChannelClosedExceptionTests
+    public partial class ChannelClosedExceptionTests
     {
         [Fact]
         public void Ctors()

--- a/src/System.Threading.Channels/tests/ChannelClosedExceptionTests.netcoreapp.cs
+++ b/src/System.Threading.Channels/tests/ChannelClosedExceptionTests.netcoreapp.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Xunit;
+
+namespace System.Threading.Channels.Tests
+{
+    public partial class ChannelClosedExceptionTests
+    {
+        [Fact]
+        public void Serialization_Roundtrip()
+        {
+            var s = new MemoryStream();
+
+            var inner = new InvalidOperationException("inner");
+            var outer = new ChannelClosedException("outer", inner);
+
+            new BinaryFormatter().Serialize(s, outer);
+            s.Position = 0;
+
+            var newOuter = (ChannelClosedException)new BinaryFormatter().Deserialize(s);
+            Assert.NotSame(outer, newOuter);
+            Assert.Equal(outer.Message, newOuter.Message);
+
+            Assert.NotNull(newOuter.InnerException);
+            Assert.NotSame(inner, newOuter.InnerException);
+            Assert.Equal(inner.Message, newOuter.InnerException.Message);
+        }
+    }
+}

--- a/src/System.Threading.Channels/tests/System.Threading.Channels.Tests.csproj
+++ b/src/System.Threading.Channels/tests/System.Threading.Channels.Tests.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <Compile Include="BoundedChannelTests.cs" />
     <Compile Include="ChannelClosedExceptionTests.cs" />
+    <Compile Include="ChannelClosedExceptionTests.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="ChannelTestBase.cs" />
     <Compile Include="ChannelTestBase.netcoreapp.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="ChannelTests.cs" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/35748

@terrajobst, do I need to run this through API review?  Or since it's just a part of the pattern that it should have implemented from the get-go, can we give it a pass?

cc: @ViktorHofer, @danmosemsft, @tarekgh 