### PR TITLE
Don't allocate a stack

### DIFF
--- a/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
@@ -13,6 +13,7 @@
     <Compile Include="System\IO\Pipelines\FlushResult.cs" />
     <Compile Include="System\IO\Pipelines\InlineScheduler.cs" />
     <Compile Include="System\IO\Pipelines\IDuplexPipe.cs" />
+    <Compile Include="System\IO\Pipelines\BufferSegmentStack.cs" />
     <Compile Include="System\IO\Pipelines\Pipe.DefaultPipeReader.cs" />
     <Compile Include="System\IO\Pipelines\Pipe.DefaultPipeWriter.cs" />
     <Compile Include="System\IO\Pipelines\Pipe.cs" />

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegmentStack.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegmentStack.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegmentStack.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegmentStack.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.IO.Pipelines
+{
+    internal struct BufferSegmentStack
+    {
+        private BufferSegment[] _array;
+        private int _size;
+
+        public BufferSegmentStack(int size)
+        {
+            _array = new BufferSegment[size];
+            _size = 0;
+        }
+
+        public int Count => _size;
+
+        public bool TryPop(out BufferSegment result)
+        {
+            int size = _size - 1;
+            BufferSegment[] array = _array;
+
+            if ((uint)size >= (uint)array.Length)
+            {
+                result = default;
+                return false;
+            }
+
+            _size = size;
+            result = array[size];
+            array[size] = default;
+            return true;
+        }
+
+        // Pushes an item to the top of the stack.
+        public void Push(BufferSegment item)
+        {
+            int size = _size;
+            BufferSegment[] array = _array;
+
+            if ((uint)size < (uint)array.Length)
+            {
+                array[size] = item;
+                _size = size + 1;
+            }
+            else
+            {
+                PushWithResize(item);
+            }
+        }
+
+        // Non-inline from Stack.Push to improve its code quality as uncommon path
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void PushWithResize(BufferSegment item)
+        {
+            Array.Resize(ref _array, 2 * _array.Length);
+            _array[_size] = item;
+            _size++;
+        }
+    }
+}

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -18,7 +18,7 @@ namespace System.IO.Pipelines
     public sealed partial class Pipe
     {
         internal const int InitialSegmentPoolSize = 16; // 65K
-        internal const int MaxPoolSize = 256; // 1MB
+        internal const int MaxSegmentPoolSize = 256; // 1MB
 
         private static readonly Action<object> s_signalReaderAwaitable = state => ((Pipe)state).ReaderCancellationRequested();
         private static readonly Action<object> s_signalWriterAwaitable = state => ((Pipe)state).WriterCancellationRequested();
@@ -44,7 +44,8 @@ namespace System.IO.Pipelines
         private readonly PipeScheduler _readerScheduler;
         private readonly PipeScheduler _writerScheduler;
 
-        private readonly BufferSegmentStack _bufferSegmentPool;
+        // Mutable struct! Don't make this readonly
+        private BufferSegmentStack _bufferSegmentPool;
 
         private readonly DefaultPipeReader _reader;
         private readonly DefaultPipeWriter _writer;
@@ -268,7 +269,7 @@ namespace System.IO.Pipelines
             Debug.Assert(segment != _writingHead, "Returning _writingHead segment that's in use!");
             Debug.Assert(segment != _lastExamined, "Returning _lastExamined segment that's in use!");
 
-            if (_bufferSegmentPool.Count < MaxPoolSize)
+            if (_bufferSegmentPool.Count < MaxSegmentPoolSize)
             {
                 _bufferSegmentPool.Push(segment);
             }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -44,7 +44,7 @@ namespace System.IO.Pipelines
         private readonly PipeScheduler _readerScheduler;
         private readonly PipeScheduler _writerScheduler;
 
-        private readonly Stack<BufferSegment> _bufferSegmentPool;
+        private readonly BufferSegmentStack _bufferSegmentPool;
 
         private readonly DefaultPipeReader _reader;
         private readonly DefaultPipeWriter _writer;
@@ -101,7 +101,7 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.options);
             }
 
-            _bufferSegmentPool = new Stack<BufferSegment>(InitialSegmentPoolSize);
+            _bufferSegmentPool = new BufferSegmentStack(InitialSegmentPoolSize);
 
             _operationState = default;
             _readerCompletion = default;
@@ -253,9 +253,9 @@ namespace System.IO.Pipelines
 
         private BufferSegment CreateSegmentUnsynchronized()
         {
-            if (_bufferSegmentPool.Count > 0)
+            if (_bufferSegmentPool.TryPop(out BufferSegment segment))
             {
-                return _bufferSegmentPool.Pop();
+                return segment;
             }
 
             return new BufferSegment();


### PR DESCRIPTION
- Avoid an extra object allocation by using a struct based stack
