### PR TITLE
Optimize recursion of System.Net.Http.HttpRuleParser.GetExpressionLength

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
@@ -310,12 +310,12 @@ namespace System.Net.Http
 
         internal static HttpParseResult GetCommentLength(string input, int startIndex, out int length)
         {
-            return GetExpressionLength(input, startIndex, '(', ')', true, 0, out length);
+            return GetExpressionLength(input, startIndex, '(', ')', true, 1, out length);
         }
 
         internal static HttpParseResult GetQuotedStringLength(string input, int startIndex, out int length)
         {
-            return GetExpressionLength(input, startIndex, '"', '"', false, 0, out length);
+            return GetExpressionLength(input, startIndex, '"', '"', false, 1, out length);
         }
 
         // quoted-pair = "\" CHAR
@@ -391,8 +391,6 @@ namespace System.Net.Http
                 // If we support nested expressions and we find an open-char, then parse the nested expressions.
                 if (supportsNesting && (input[current] == openChar))
                 {
-                    nestedCount++;
-
                     // Check if we exceeded the number of nested calls.
                     if (nestedCount > maxNestedCount)
                     {
@@ -401,7 +399,7 @@ namespace System.Net.Http
 
                     int nestedLength = 0;
                     HttpParseResult nestedResult = GetExpressionLength(input, current, openChar, closeChar,
-                        supportsNesting, nestedCount, out nestedLength);
+                        supportsNesting, nestedCount + 1, out nestedLength);
 
                     switch (nestedResult)
                     {
@@ -423,7 +421,6 @@ namespace System.Net.Http
                             Debug.Fail("Unknown enum result: " + nestedResult);
                             break;
                     }
-                    nestedCount--;
 
                     // after nested call we continue with parsing
                     continue;

--- a/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
@@ -12,7 +12,7 @@ namespace System.Net.Http
     internal static class HttpRuleParser
     {
         private static readonly bool[] s_tokenChars = CreateTokenChars();
-        private const int maxNestedCount = 5;
+        private const int MaxNestedCount = 5;
 
         internal const char CR = (char)13;
         internal const char LF = (char)10;
@@ -392,7 +392,7 @@ namespace System.Net.Http
                 if (supportsNesting && (input[current] == openChar))
                 {
                     // Check if we exceeded the number of nested calls.
-                    if (nestedCount > maxNestedCount)
+                    if (nestedCount > MaxNestedCount)
                     {
                         return HttpParseResult.InvalidFormat;
                     }

--- a/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
@@ -310,14 +310,12 @@ namespace System.Net.Http
 
         internal static HttpParseResult GetCommentLength(string input, int startIndex, out int length)
         {
-            int nestedCount = 0;
-            return GetExpressionLength(input, startIndex, '(', ')', true, ref nestedCount, out length);
+            return GetExpressionLength(input, startIndex, '(', ')', true, 0, out length);
         }
 
         internal static HttpParseResult GetQuotedStringLength(string input, int startIndex, out int length)
         {
-            int nestedCount = 0;
-            return GetExpressionLength(input, startIndex, '"', '"', false, ref nestedCount, out length);
+            return GetExpressionLength(input, startIndex, '"', '"', false, 0, out length);
         }
 
         // quoted-pair = "\" CHAR
@@ -360,7 +358,7 @@ namespace System.Net.Http
         // comments, resulting in a stack overflow exception. In addition having more than 1 nested comment (if any)
         // is unusual.
         private static HttpParseResult GetExpressionLength(string input, int startIndex, char openChar,
-            char closeChar, bool supportsNesting, ref int nestedCount, out int length)
+            char closeChar, bool supportsNesting, int nestedCount, out int length)
         {
             Debug.Assert(input != null);
             Debug.Assert((startIndex >= 0) && (startIndex < input.Length));
@@ -394,43 +392,38 @@ namespace System.Net.Http
                 if (supportsNesting && (input[current] == openChar))
                 {
                     nestedCount++;
-                    try
+
+                    // Check if we exceeded the number of nested calls.
+                    if (nestedCount > maxNestedCount)
                     {
-                        // Check if we exceeded the number of nested calls.
-                        if (nestedCount > maxNestedCount)
-                        {
+                        return HttpParseResult.InvalidFormat;
+                    }
+
+                    int nestedLength = 0;
+                    HttpParseResult nestedResult = GetExpressionLength(input, current, openChar, closeChar,
+                        supportsNesting, nestedCount, out nestedLength);
+
+                    switch (nestedResult)
+                    {
+                        case HttpParseResult.Parsed:
+                            current += nestedLength; // Add the length of the nested expression and continue.
+                            break;
+
+                        case HttpParseResult.NotParsed:
+                            Debug.Fail("'NotParsed' is unexpected: We started nested expression " +
+                                "parsing, because we found the open-char. So either it's a valid nested " +
+                                "expression or it has invalid format.");
+                            break;
+
+                        case HttpParseResult.InvalidFormat:
+                            // If the nested expression is invalid, we can't continue, so we fail with invalid format.
                             return HttpParseResult.InvalidFormat;
-                        }
 
-                        int nestedLength = 0;
-                        HttpParseResult nestedResult = GetExpressionLength(input, current, openChar, closeChar,
-                            supportsNesting, ref nestedCount, out nestedLength);
-
-                        switch (nestedResult)
-                        {
-                            case HttpParseResult.Parsed:
-                                current += nestedLength; // Add the length of the nested expression and continue.
-                                break;
-
-                            case HttpParseResult.NotParsed:
-                                Debug.Fail("'NotParsed' is unexpected: We started nested expression " +
-                                    "parsing, because we found the open-char. So either it's a valid nested " +
-                                    "expression or it has invalid format.");
-                                break;
-
-                            case HttpParseResult.InvalidFormat:
-                                // If the nested expression is invalid, we can't continue, so we fail with invalid format.
-                                return HttpParseResult.InvalidFormat;
-
-                            default:
-                                Debug.Fail("Unknown enum result: " + nestedResult);
-                                break;
-                        }
+                        default:
+                            Debug.Fail("Unknown enum result: " + nestedResult);
+                            break;
                     }
-                    finally
-                    {
-                        nestedCount--;
-                    }
+                    nestedCount--;
 
                     // after nested call we continue with parsing
                     continue;


### PR DESCRIPTION
Fixing past bug I found a unuseful `ref` param passed to `GetQuotedStringLength` used by GetCommentLength/GetQuotedStringLength parser. 
I tried to remove `ref` to improve performance thank's to less dereferencing and better usage of registers.
I wrote a test
```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Configs;
using System.Collections.Generic;
using System.Net.Http;

namespace HttpRulerParser
{
    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
    [CategoriesColumn]
    public class HttpRuleParserComment
    {
        [Params(100)]
        public int Count { get; set; }

        public IEnumerable<string> Comments => new[]
        {
            "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/7.0)",
            "((comment)(comment(comment)))"
        };


        public IEnumerable<string> QuotedStrings => new[]
        {
            "token \"quoted string\" token",
            "\"a\\ü\\\"b\\\"c\\\"\\\"d\\\"\""
        };

        [BenchmarkCategory("Comment"), Benchmark(Baseline = true)]
        [ArgumentsSource(nameof(Comments))]
        public void GetCommentLength_Old(string comment)
        {
            for (int i = 0; i < Count; i++)
            {
                HttpRuleParserOld.GetCommentLength(comment, 0, out int len);
            }
        }

        [BenchmarkCategory("Comment"), Benchmark()]
        [ArgumentsSource(nameof(Comments))]
        public void GetCommentLength_New(string comment)
        {
            for (int i = 0; i < Count; i++)
            {
                HttpRuleParserNew.GetCommentLength(comment, 0, out int len);
            }
        }

        [BenchmarkCategory("Quoted"), Benchmark(Baseline = true)]
        [ArgumentsSource(nameof(QuotedStrings))]
        public void GetQuotedStringLength_Old(string quotedString)
        {
            for (int i = 0; i < Count; i++)
            {
                HttpRuleParserOld.GetQuotedStringLength(quotedString, 0, out int len);
            }
        }

        [BenchmarkCategory("Quoted"), Benchmark()]
        [ArgumentsSource(nameof(QuotedStrings))]
        public void GetQuotedStringLength_New(string quotedString)
        {
            for (int i = 0; i < Count; i++)
            {
                HttpRuleParserNew.GetQuotedStringLength(quotedString, 0, out int len);
            }
        }
    }
}
```
Results
``` ini

BenchmarkDotNet=v0.11.4, OS=Windows 10.0.17134.590 (1803/April2018Update/Redstone4)
Intel Core i7 CPU 860 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
Frequency=2727538 Hz, Resolution=366.6310 ns, Timer=TSC
.NET Core SDK=3.0.100-preview3-010431
  [Host]     : .NET Core 3.0.0-preview3-27503-5 (CoreCLR 4.6.27422.72, CoreFX 4.7.19.12807), 64bit RyuJIT
  DefaultJob : .NET Core 3.0.0-preview3-27503-5 (CoreCLR 4.6.27422.72, CoreFX 4.7.19.12807), 64bit RyuJIT


```
|                    Method | Categories | Count |         quotedString |              comment |        Mean |      Error |     StdDev | Ratio | RatioSD |
|-------------------------- |----------- |------ |--------------------- |--------------------- |------------:|-----------:|-----------:|------:|--------:|
| **GetQuotedStringLength_Old** |     **Quoted** |   **100** |   **&quot;a\ü\&quot;b\&quot;c\&quot;\&quot;d\&quot;&quot;** |                    **?** |  **9,284.0 ns** | **179.270 ns** | **257.103 ns** |  **1.00** |    **0.00** |
| GetQuotedStringLength_New |     Quoted |   100 |   &quot;a\ü\&quot;b\&quot;c\&quot;\&quot;d\&quot;&quot; |                    ? |  8,387.3 ns | 166.098 ns | 197.728 ns |  0.90 |    0.03 |
|                           |            |       |                      |                      |             |            |            |       |         |
|      **GetCommentLength_Old** |    **Comment** |   **100** |                    **?** | **((com(...)nt))) [29]** | **26,042.2 ns** | **158.638 ns** | **148.390 ns** |  **1.00** |    **0.00** |
|      GetCommentLength_New |    Comment |   100 |                    ? | ((com(...)nt))) [29] | 22,839.2 ns |  84.810 ns |  70.820 ns |  0.88 |    0.01 |
|                           |            |       |                      |                      |             |            |            |       |         |
|      **GetCommentLength_Old** |    **Comment** |   **100** |                    **?** | **Mozil(...)/7.0) [63]** |  **1,384.1 ns** |  **24.599 ns** |  **20.541 ns** |  **1.00** |    **0.00** |
|      GetCommentLength_New |    Comment |   100 |                    ? | Mozil(...)/7.0) [63] |    635.6 ns |   9.051 ns |   8.467 ns |  0.46 |    0.01 |
|                           |            |       |                      |                      |             |            |            |       |         |
| **GetQuotedStringLength_Old** |     **Quoted** |   **100** | **token(...)token [27]** |                    **?** |  **1,402.8 ns** |  **19.091 ns** |  **17.858 ns** |  **1.00** |    **0.00** |
| GetQuotedStringLength_New |     Quoted |   100 | token(...)token [27] |                    ? |    626.6 ns |   3.480 ns |   2.906 ns |  0.45 |    0.01 |

/cc @davidsh @geoffkizer @stephentoub 