### PR TITLE
Include correct error code in WebSocket.ThrowOnInvalidState

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -174,7 +174,7 @@ namespace System.Net.WebSockets
 
                 if (response.StatusCode != HttpStatusCode.SwitchingProtocols)
                 {
-                    throw new WebSocketException(SR.Format(SR.net_WebSockets_Connect101Expected, (int) response.StatusCode));
+                    throw new WebSocketException(WebSocketError.NotAWebSocket, SR.Format(SR.net_WebSockets_Connect101Expected, (int) response.StatusCode));
                 }
 
                 // The Connection, Upgrade, and SecWebSocketAccept headers are required and with specific values.
@@ -227,7 +227,7 @@ namespace System.Net.WebSockets
                 {
                     throw;
                 }
-                throw new WebSocketException(SR.net_webstatus_ConnectFailure, exc);
+                throw new WebSocketException(WebSocketError.Faulted, SR.net_webstatus_ConnectFailure, exc);
             }
             finally
             {
@@ -280,10 +280,10 @@ namespace System.Net.WebSockets
             string[] array = (string[])values;
             if (array.Length != 1 || !string.Equals(array[0], expectedValue, StringComparison.OrdinalIgnoreCase))
             {
-                throw new WebSocketException(SR.Format(SR.net_WebSockets_InvalidResponseHeader, name, string.Join(", ", array)));
+                throw new WebSocketException(WebSocketError.HeaderError, SR.Format(SR.net_WebSockets_InvalidResponseHeader, name, string.Join(", ", array)));
             }
         }
 
-        private static void ThrowConnectFailure() => throw new WebSocketException(SR.net_webstatus_ConnectFailure);
+        private static void ThrowConnectFailure() => throw new WebSocketException(WebSocketError.Faulted, SR.net_webstatus_ConnectFailure);
     }
 }

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.WinRT.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.WinRT.cs
@@ -52,7 +52,7 @@ namespace System.Net.WebSockets
             {
                 WebErrorStatus status = RTWebSocketError.GetStatus(ex.HResult);
                 var inner = new Exception(status.ToString(), ex);
-                WebSocketException wex = new WebSocketException(SR.net_webstatus_ConnectFailure, inner);
+                WebSocketException wex = new WebSocketException(WebSocketError.Faulted, SR.net_webstatus_ConnectFailure, inner);
                 if (NetEventSource.IsEnabled) NetEventSource.Error(_webSocket, wex);
                 throw wex;
             }

--- a/src/System.Net.WebSockets.Client/tests/AbortTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/AbortTest.cs
@@ -33,7 +33,10 @@ namespace System.Net.WebSockets.Client.Tests
 
                 Assert.Equal(ResourceHelper.GetExceptionMessage("net_webstatus_ConnectFailure"), ex.Message);
 
-                Assert.Equal(WebSocketError.Success, ex.WebSocketErrorCode);
+                if (PlatformDetection.IsNetCore) // bug fix in netcoreapp: https://github.com/dotnet/corefx/pull/35960
+                {
+                    Assert.Equal(WebSocketError.Faulted, ex.WebSocketErrorCode);
+                }
                 Assert.Equal(WebSocketState.Closed, cws.State);
             }
         }

--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -30,7 +30,10 @@ namespace System.Net.WebSockets.Client.Tests
                 Assert.Equal(
                     ResourceHelper.GetExceptionMessage("net_webstatus_ConnectFailure"),
                     ex.Message);
-                Assert.Equal(WebSocketError.Success, ex.WebSocketErrorCode);
+                if (PlatformDetection.IsNetCore) // bug fix in netcoreapp: https://github.com/dotnet/corefx/pull/35960
+                {
+                    Assert.Equal(WebSocketError.Faulted, ex.WebSocketErrorCode);
+                }
                 Assert.Equal(WebSocketState.Closed, cws.State);
             }
         }

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketTestBase.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketTestBase.cs
@@ -47,7 +47,7 @@ namespace System.Net.WebSockets.Client.Tests
                     server = new Uri(string.Format("ws://{0}", Guid.NewGuid().ToString()));
                     exceptionMessage = ResourceHelper.GetExceptionMessage("net_webstatus_ConnectFailure");
 
-                    yield return new object[] { server, exceptionMessage };
+                    yield return new object[] { server, exceptionMessage, WebSocketError.Faulted };
                 }
 
                 // Known server but not a real websocket endpoint.
@@ -56,7 +56,7 @@ namespace System.Net.WebSockets.Client.Tests
                     var ub = new UriBuilder("ws", server.Host, server.Port, server.PathAndQuery);
                     exceptionMessage = ResourceHelper.GetExceptionMessage("net_WebSockets_Connect101Expected", (int) HttpStatusCode.OK);
 
-                    yield return new object[] { ub.Uri, exceptionMessage };
+                    yield return new object[] { ub.Uri, exceptionMessage, WebSocketError.NotAWebSocket };
                 }
             }
         }

--- a/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -18,7 +18,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(UnavailableWebSocketServers))]
-        public async Task ConnectAsync_NotWebSocketServer_ThrowsWebSocketExceptionWithMessage(Uri server, string exceptionMessage)
+        public async Task ConnectAsync_NotWebSocketServer_ThrowsWebSocketExceptionWithMessage(Uri server, string exceptionMessage, WebSocketError errorCode)
         {
             using (var cws = new ClientWebSocket())
             {
@@ -26,7 +26,10 @@ namespace System.Net.WebSockets.Client.Tests
                 WebSocketException ex = await Assert.ThrowsAsync<WebSocketException>(() =>
                     cws.ConnectAsync(server, cts.Token));
 
-                Assert.Equal(WebSocketError.Success, ex.WebSocketErrorCode);
+                if (PlatformDetection.IsNetCore) // bug fix in netcoreapp: https://github.com/dotnet/corefx/pull/35960
+                {
+                    Assert.Equal(errorCode, ex.WebSocketErrorCode);
+                }
                 Assert.Equal(WebSocketState.Closed, cws.State);
 
                 // .NET Framework and UAP implmentations have different exception message from .NET Core.
@@ -198,7 +201,10 @@ namespace System.Net.WebSockets.Client.Tests
                 WebSocketException ex = await Assert.ThrowsAsync<WebSocketException>(() =>
                     cws.ConnectAsync(ub.Uri, cts.Token));
 
-                Assert.Equal(WebSocketError.Success, ex.WebSocketErrorCode);
+                if (PlatformDetection.IsNetCore) // bug fix in netcoreapp: https://github.com/dotnet/corefx/pull/35960
+                {
+                    Assert.Equal(WebSocketError.Faulted, ex.WebSocketErrorCode);
+                }
                 Assert.Equal(WebSocketState.Closed, cws.State);
                 Assert.Equal(ResourceHelper.GetExceptionMessage("net_webstatus_ConnectFailure"), ex.Message);
             }

--- a/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -26,7 +26,7 @@ namespace System.Net.WebSockets.Client.Tests
                 WebSocketException ex = await Assert.ThrowsAsync<WebSocketException>(() =>
                     cws.ConnectAsync(server, cts.Token));
 
-                if (PlatformDetection.IsNetCore) // bug fix in netcoreapp: https://github.com/dotnet/corefx/pull/35960
+                if (PlatformDetection.IsNetCore && !PlatformDetection.IsUap) // bug fix in netcoreapp: https://github.com/dotnet/corefx/pull/35960
                 {
                     Assert.Equal(errorCode, ex.WebSocketErrorCode);
                 }

--- a/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocket.cs
+++ b/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocket.cs
@@ -100,7 +100,7 @@ namespace System.Net.WebSockets
                 validStatesText = string.Join(", ", validStates);
             }
 
-            throw new WebSocketException(SR.Format(SR.net_WebSockets_InvalidState, state, validStatesText));
+            throw new WebSocketException(WebSocketError.InvalidState, SR.Format(SR.net_WebSockets_InvalidState, state, validStatesText));
         }
 
         protected static bool IsStateTerminal(WebSocketState state) => 

--- a/src/System.Net.WebSockets/tests/WebSocketTests.cs
+++ b/src/System.Net.WebSockets/tests/WebSocketTests.cs
@@ -130,7 +130,7 @@ namespace System.Net.WebSockets.Tests
         public static void ThrowOnInvalidState_ThrowsIfNotInValidList(WebSocketState state, WebSocketState[] validStates)
         {
             WebSocketException wse = Assert.Throws<WebSocketException>(() => ExposeProtectedWebSocket.ThrowOnInvalidState(state, validStates));
-            if (!PlatformDetection.IsFullFramework) // https://github.com/dotnet/corefx/issues/30779
+            if (PlatformDetection.IsNetCore) // bug fix in netcoreapp: https://github.com/dotnet/corefx/pull/35960
             {
                 Assert.Equal(WebSocketError.InvalidState, wse.WebSocketErrorCode);
             }

--- a/src/System.Net.WebSockets/tests/WebSocketTests.cs
+++ b/src/System.Net.WebSockets/tests/WebSocketTests.cs
@@ -129,7 +129,11 @@ namespace System.Net.WebSockets.Tests
         [InlineData(WebSocketState.Open, new WebSocketState[] { WebSocketState.Aborted, WebSocketState.CloseSent })]
         public static void ThrowOnInvalidState_ThrowsIfNotInValidList(WebSocketState state, WebSocketState[] validStates)
         {
-            Assert.Throws<WebSocketException>(() => ExposeProtectedWebSocket.ThrowOnInvalidState(state, validStates));
+            WebSocketException wse = Assert.Throws<WebSocketException>(() => ExposeProtectedWebSocket.ThrowOnInvalidState(state, validStates));
+            if (!PlatformDetection.IsFullFramework) // https://github.com/dotnet/corefx/issues/30779
+            {
+                Assert.Equal(WebSocketError.InvalidState, wse.WebSocketErrorCode);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
The exception for invalid state should include InvalidState, not the default of Success (which is weird default ;-)

Fixes https://github.com/dotnet/corefx/issues/30779
cc: @davidsh