### PR TITLE
Modify Utf8JsonWriter to write DateTime(Offset) values with the smallest output that roundtrips

### DIFF
--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -107,6 +107,7 @@
     <Compile Include="System\Text\Json\Serialization\WriteStack.cs" />
     <Compile Include="System\Text\Json\Serialization\WriteStackFrame.cs" />
     <Compile Include="System\Text\Json\Writer\JsonWriterHelper.cs" />
+    <Compile Include="System\Text\Json\Writer\JsonWriterHelper.Date.cs" />
     <Compile Include="System\Text\Json\Writer\JsonWriterHelper.Escaping.cs" />
     <Compile Include="System\Text\Json\Writer\JsonWriterHelper.Transcoding.cs" />
     <Compile Include="System\Text\Json\Writer\JsonWriterOptions.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -22,6 +22,12 @@ namespace System.Text.Json
         public const byte BackSpace = (byte)'\b';
         public const byte FormFeed = (byte)'\f';
         public const byte Asterisk = (byte)'*';
+        public const byte Colon = (byte)':';
+        public const byte Period = (byte)'.';
+        public const byte Plus = (byte)'+';
+        public const byte Hyphen = (byte)'-';
+        public const byte UtcOffsetToken = (byte)'Z';
+        public const byte TimePrefix = (byte)'T';
 
         public static ReadOnlySpan<byte> TrueValue => new byte[] { (byte)'t', (byte)'r', (byte)'u', (byte)'e' };
         public static ReadOnlySpan<byte> FalseValue => new byte[] { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };
@@ -56,6 +62,8 @@ namespace System.Text.Json
         public const int MaximumFormatGuidLength = 36;    // default (i.e. 'D'), 8 + 4 + 4 + 4 + 12 + 4 for the hyphens (e.g. 094ffa0a-0442-494d-b452-04003fa755cc)
         public const int MaximumFormatDateTimeLength = 27;    // StandardFormat 'O', e.g. 2017-06-12T05:30:45.7680000
         public const int MaximumFormatDateTimeOffsetLength = 33;  // StandardFormat 'O', e.g. 2017-06-12T05:30:45.7680000-07:00
+
+        public static readonly TimeSpan NullUtcOffset = TimeSpan.MinValue;  // Utc offsets must range from -14:00 to 14:00 so this is never a valid offset.
 
         internal const char ScientificNotationFormat = 'e';
 

--- a/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -57,8 +57,6 @@ namespace System.Text.Json
         public const int MaximumFormatDateTimeLength = 27;    // StandardFormat 'O', e.g. 2017-06-12T05:30:45.7680000
         public const int MaximumFormatDateTimeOffsetLength = 33;  // StandardFormat 'O', e.g. 2017-06-12T05:30:45.7680000-07:00
 
-        public static readonly TimeSpan NullUtcOffset = TimeSpan.MinValue;  // Utc offsets must range from -14:00 to 14:00 so this is never a valid offset.
-
         internal const char ScientificNotationFormat = 'e';
 
         // Encoding Helpers

--- a/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -22,12 +22,6 @@ namespace System.Text.Json
         public const byte BackSpace = (byte)'\b';
         public const byte FormFeed = (byte)'\f';
         public const byte Asterisk = (byte)'*';
-        public const byte Colon = (byte)':';
-        public const byte Period = (byte)'.';
-        public const byte Plus = (byte)'+';
-        public const byte Hyphen = (byte)'-';
-        public const byte UtcOffsetToken = (byte)'Z';
-        public const byte TimePrefix = (byte)'T';
 
         public static ReadOnlySpan<byte> TrueValue => new byte[] { (byte)'t', (byte)'r', (byte)'u', (byte)'e' };
         public static ReadOnlySpan<byte> FalseValue => new byte[] { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
@@ -1,0 +1,199 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Text.Json
+{
+    internal static partial class JsonWriterHelper
+    {
+        public static bool TryFormatToISO(DateTimeOffset value, Span<byte> destination, out int bytesWritten)
+        {
+            return TryFormatDateTime(value.DateTime, value.Offset, destination, out bytesWritten);
+        }
+
+        public static bool TryFormatToISO(DateTime value, Span<byte> destination, out int bytesWritten)
+        {
+            return TryFormatDateTime(value, JsonConstants.NullUtcOffset, destination, out bytesWritten);
+        }
+
+        //
+        // ISO 8601 format
+        // If the milliseconds part of the date is zero, we omit the fraction part of the output string,
+        // else we write the fraction up to 7 decimal places with no trailing zeros. i.e. the format is
+        // YYYY-MM-DDThh:mm:ss[.s]TZD where TZD = Z or +-hh:mm.
+        // e.g.
+        //   ---------------------------------
+        //   2017-06-12T05:30:45.768-07:00
+        //   2017-06-12T05:30:45.00768Z           (Z is short for "+00:00" but also distinguishes DateTimeKind.Utc from DateTimeKind.Local)
+        //   2017-06-12T05:30:45                  (interpreted as local time wrt to current time zone)
+        private static bool TryFormatDateTime(DateTime value, TimeSpan offset, Span<byte> destination, out int bytesWritten)
+        {
+            // Must write YYYY-MM-DDThh:mm:ss
+            const int MinimumBytesNeeded = 19;
+
+            int bytesRequired = MinimumBytesNeeded;
+            DateTimeKind kind = DateTimeKind.Local;
+
+            if (offset == JsonConstants.NullUtcOffset)
+            {
+                kind = value.Kind;
+                if (kind == DateTimeKind.Local)
+                {
+                    offset = TimeZoneInfo.Local.GetUtcOffset(value);
+                    bytesRequired += 6;
+                }
+                else if (kind == DateTimeKind.Utc)
+                {
+                    bytesRequired += 1;
+                }
+            }
+            else
+            {
+                bytesRequired += 6;
+            }
+
+            if (destination.Length < bytesRequired)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            bytesWritten = bytesRequired;
+
+            uint fraction = (uint)(value.Ticks % TimeSpan.TicksPerSecond);
+            int numFractionDigits = 0;
+
+            if (fraction > 0)
+            {
+                // Remove trailing zeros
+                while (fraction % 10 == 0)
+                {
+                    fraction /= 10;
+                }
+
+                numFractionDigits = (int)Math.Floor(Math.Log10(fraction) + 1);
+                bytesWritten += numFractionDigits + 1 /* Account for fraction period */;
+            }
+
+            // Hoist most of the bounds checks on buffer.
+            { var unused = destination[MinimumBytesNeeded - 1]; }
+
+            WriteFourDecimalDigits((uint)value.Year, destination, 0);
+            destination[4] = JsonConstants.Hyphen;
+
+            WriteTwoDecimalDigits((uint)value.Month, destination, 5);
+            destination[7] = JsonConstants.Hyphen;
+
+            WriteTwoDecimalDigits((uint)value.Day, destination, 8);
+            destination[10] = JsonConstants.TimePrefix;
+
+            WriteTwoDecimalDigits((uint)value.Hour, destination, 11);
+            destination[13] = JsonConstants.Colon;
+
+            WriteTwoDecimalDigits((uint)value.Minute, destination, 14);
+            destination[16] = JsonConstants.Colon;
+
+            WriteTwoDecimalDigits((uint)value.Second, destination, 17);
+
+            int offsetIndex = 19;
+            if (fraction > 0)
+            {
+                destination[19] = JsonConstants.Period;
+                WriteDigits(fraction, destination.Slice(20, numFractionDigits));
+
+                offsetIndex += numFractionDigits + 1 /* Account for fraction period */;
+            }
+
+            if (kind == DateTimeKind.Local)
+            {
+                byte sign;
+
+                if (offset < default(TimeSpan) /* a "const" version of TimeSpan.Zero */)
+                {
+                    sign = JsonConstants.Hyphen;
+                    offset = TimeSpan.FromTicks(-offset.Ticks);
+                }
+                else
+                {
+                    sign = JsonConstants.Plus;
+                }
+
+                // Writing the value backward allows the JIT to optimize by
+                // performing a single bounds check against buffer.
+                WriteTwoDecimalDigits((uint)offset.Minutes, destination, offsetIndex + 4);
+                destination[offsetIndex + 3] = JsonConstants.Colon;
+                WriteTwoDecimalDigits((uint)offset.Hours, destination, offsetIndex + 1);
+                destination[offsetIndex] = sign;
+
+            }
+            else if (kind == DateTimeKind.Utc)
+            {
+                destination[offsetIndex] = JsonConstants.UtcOffsetToken;
+            }
+
+            return true;
+        }
+
+        // The following methods are borrowed verbatim from src/Common/src/CoreLib/System/Buffers/Text/Utf8Formatter/FormattingHelpers.cs
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WriteDigits(uint value, Span<byte> buffer)
+        {
+            // We can mutate the 'value' parameter since it's a copy-by-value local.
+            // It'll be used to represent the value left over after each division by 10.
+
+            for (int i = buffer.Length - 1; i >= 1; i--)
+            {
+                uint temp = '0' + value;
+                value /= 10;
+                buffer[i] = (byte)(temp - (value * 10));
+            }
+
+            Debug.Assert(value < 10);
+            buffer[0] = (byte)('0' + value);
+        }
+
+        /// <summary>
+        /// Writes a value [ 0000 .. 9999 ] to the buffer starting at the specified offset.
+        /// This method performs best when the starting index is a constant literal.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WriteFourDecimalDigits(uint value, Span<byte> buffer, int startingIndex = 0)
+        {
+            Debug.Assert(0 <= value && value <= 9999);
+
+            uint temp = '0' + value;
+            value /= 10;
+            buffer[startingIndex + 3] = (byte)(temp - (value * 10));
+
+            temp = '0' + value;
+            value /= 10;
+            buffer[startingIndex + 2] = (byte)(temp - (value * 10));
+
+            temp = '0' + value;
+            value /= 10;
+            buffer[startingIndex + 1] = (byte)(temp - (value * 10));
+
+            buffer[startingIndex] = (byte)('0' + value);
+        }
+
+        /// <summary>
+        /// Writes a value [ 00 .. 99 ] to the buffer starting at the specified offset.
+        /// This method performs best when the starting index is a constant literal.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WriteTwoDecimalDigits(uint value, Span<byte> buffer, int startingIndex = 0)
+        {
+            Debug.Assert(0 <= value && value <= 99);
+
+            uint temp = '0' + value;
+            value /= 10;
+            buffer[startingIndex + 1] = (byte)(temp - (value * 10));
+
+            buffer[startingIndex] = (byte)('0' + value);
+        }
+    }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.Json
 {
@@ -42,11 +43,17 @@ namespace System.Text.Json
 
             if (fraction > 0)
             {
-                // Remove trailing zeros
                 int numFractionDigits = 7;
-                while (fraction % 10 == 0)
+
+                // Remove trailing zeros
+                while (true)
                 {
-                    fraction /= 10;
+                    uint quotient = DivMod(fraction, 10, out uint remainder);
+                    if (remainder != 0)
+                    {
+                        break;
+                    }
+                    fraction = quotient;
                     numFractionDigits--;
                 }
 
@@ -92,6 +99,16 @@ namespace System.Text.Json
                     bytesWritten = bufferEnd + 1;
                 }
             }
+        }
+
+        // We don't have access to System.Buffers.Text.FormattingHelpers.DivMod,
+        // so this is a copy of the implementation.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint DivMod(uint numerator, uint denominator, out uint modulo)
+        {
+            uint div = numerator / denominator;
+            modulo = numerator - (div * denominator);
+            return div;
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
@@ -278,7 +278,7 @@ namespace System.Text.Json
 
             JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
 
-            if (_buffer.Length < bytesWritten)
+            if (_buffer.Length - idx < bytesWritten)
             {
                 AdvanceAndGrow(ref idx, bytesWritten);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
-using System.Buffers.Text;
 using System.Diagnostics;
 
 namespace System.Text.Json
@@ -269,14 +268,12 @@ namespace System.Text.Json
             _buffer[idx++] = JsonConstants.Quote;
         }
 
-        private static readonly StandardFormat s_dateTimeStandardFormat = new StandardFormat('O');
-
         private void FormatLoop(DateTime value, ref int idx)
         {
-            if (!Utf8Formatter.TryFormat(value, _buffer.Slice(idx), out int bytesWritten, s_dateTimeStandardFormat))
+            if (!JsonWriterHelper.TryFormatToISO(value, _buffer.Slice(idx), out int bytesWritten))
             {
                 AdvanceAndGrow(ref idx, JsonConstants.MaximumFormatDateTimeLength);
-                bool result = Utf8Formatter.TryFormat(value, _buffer, out bytesWritten, s_dateTimeStandardFormat);
+                bool result = JsonWriterHelper.TryFormatToISO(value, _buffer, out bytesWritten);
                 Debug.Assert(result);
             }
             idx += bytesWritten;

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
@@ -276,17 +276,14 @@ namespace System.Text.Json
             bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
             Debug.Assert(result);
 
-            JsonWriterHelper.TrimDateTimeOffsetString(tempSpan.Slice(0, bytesWritten), out bytesWritten);
+            JsonWriterHelper.TrimDateTime(tempSpan.Slice(0, bytesWritten), out bytesWritten);
 
             if (_buffer.Slice(idx).Length < bytesWritten)
             {
                 AdvanceAndGrow(ref idx, bytesWritten);
-                tempSpan.Slice(0, bytesWritten).CopyTo(_buffer);
             }
-            else
-            {
-                tempSpan.Slice(0, bytesWritten).CopyTo(_buffer.Slice(idx));
-            }
+
+            tempSpan.Slice(0, bytesWritten).CopyTo(_buffer.Slice(idx));
 
             idx += bytesWritten;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
@@ -276,9 +276,9 @@ namespace System.Text.Json
             bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
             Debug.Assert(result);
 
-            JsonWriterHelper.TrimDateTime(tempSpan.Slice(0, bytesWritten), out bytesWritten);
+            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
 
-            if (_buffer.Slice(idx).Length < bytesWritten)
+            if (_buffer.Length < bytesWritten)
             {
                 AdvanceAndGrow(ref idx, bytesWritten);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -278,7 +278,7 @@ namespace System.Text.Json
 
             JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
 
-            if (_buffer.Length < bytesWritten)
+            if (_buffer.Length - idx < bytesWritten)
             {
                 AdvanceAndGrow(ref idx, bytesWritten);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
-using System.Buffers.Text;
 using System.Diagnostics;
 
 namespace System.Text.Json
@@ -271,10 +270,10 @@ namespace System.Text.Json
 
         private void FormatLoop(DateTimeOffset value, ref int idx)
         {
-            if (!Utf8Formatter.TryFormat(value, _buffer.Slice(idx), out int bytesWritten, s_dateTimeStandardFormat))
+            if (!JsonWriterHelper.TryFormatToISO(value, _buffer.Slice(idx), out int bytesWritten))
             {
                 AdvanceAndGrow(ref idx, JsonConstants.MaximumFormatDateTimeOffsetLength);
-                bool result = Utf8Formatter.TryFormat(value, _buffer, out bytesWritten, s_dateTimeStandardFormat);
+                bool result = JsonWriterHelper.TryFormatToISO(value, _buffer, out bytesWritten);
                 Debug.Assert(result);
             }
             idx += bytesWritten;

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -276,17 +276,14 @@ namespace System.Text.Json
             bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
             Debug.Assert(result);
 
-            JsonWriterHelper.TrimDateTimeOffsetString(tempSpan.Slice(0, bytesWritten), out bytesWritten);
+            JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
 
             if (_buffer.Slice(idx).Length < bytesWritten)
             {
                 AdvanceAndGrow(ref idx, bytesWritten);
-                tempSpan.Slice(0, bytesWritten).CopyTo(_buffer);
             }
-            else
-            {
-                tempSpan.Slice(0, bytesWritten).CopyTo(_buffer.Slice(idx));
-            }
+
+            tempSpan.Slice(0, bytesWritten).CopyTo(_buffer.Slice(idx));
 
             idx += bytesWritten;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -278,7 +278,7 @@ namespace System.Text.Json
 
             JsonWriterHelper.TrimDateTimeOffset(tempSpan.Slice(0, bytesWritten), out bytesWritten);
 
-            if (_buffer.Slice(idx).Length < bytesWritten)
+            if (_buffer.Length < bytesWritten)
             {
                 AdvanceAndGrow(ref idx, bytesWritten);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Diagnostics;
 
 namespace System.Text.Json
@@ -270,12 +271,23 @@ namespace System.Text.Json
 
         private void FormatLoop(DateTimeOffset value, ref int idx)
         {
-            if (!JsonWriterHelper.TryFormatToISO(value, _buffer.Slice(idx), out int bytesWritten))
+            Span<byte> tempSpan = stackalloc byte[JsonConstants.MaximumFormatDateTimeOffsetLength];
+
+            bool result = Utf8Formatter.TryFormat(value, tempSpan, out int bytesWritten, s_dateTimeStandardFormat);
+            Debug.Assert(result);
+
+            JsonWriterHelper.TrimDateTimeOffsetString(tempSpan.Slice(0, bytesWritten), out bytesWritten);
+
+            if (_buffer.Slice(idx).Length < bytesWritten)
             {
-                AdvanceAndGrow(ref idx, JsonConstants.MaximumFormatDateTimeOffsetLength);
-                bool result = JsonWriterHelper.TryFormatToISO(value, _buffer, out bytesWritten);
-                Debug.Assert(result);
+                AdvanceAndGrow(ref idx, bytesWritten);
+                tempSpan.Slice(0, bytesWritten).CopyTo(_buffer);
             }
+            else
+            {
+                tempSpan.Slice(0, bytesWritten).CopyTo(_buffer.Slice(idx));
+            }
+
             idx += bytesWritten;
         }
     }

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -146,7 +146,7 @@ namespace System.Text.Json.Tests
         {
             var state = new JsonWriterState(options: new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation });
 
-            var output = new FixedSizedBufferWriter(28);
+            var output = new FixedSizedBufferWriter(20);
 
             var jsonUtf8 = new Utf8JsonWriter(output, state);
 
@@ -159,14 +159,14 @@ namespace System.Text.Json.Tests
             }
             catch (ArgumentException) { }
 
-            output = new FixedSizedBufferWriter(29);
+            output = new FixedSizedBufferWriter(21);
             jsonUtf8 = new Utf8JsonWriter(output, state);
             jsonUtf8.WriteStringValue(date);
             jsonUtf8.Flush();
             string actualStr = Encoding.UTF8.GetString(output.Formatted);
 
-            Assert.Equal(29, output.Formatted.Length);
-            Assert.Equal($"\"{date.ToString("O")}\"", actualStr);
+            Assert.Equal(21, output.Formatted.Length);
+            Assert.Equal($"\"{date.ToString("yyyy-MM-ddTHH:mm:ss")}\"", actualStr);
         }
 
         [Theory]
@@ -178,7 +178,7 @@ namespace System.Text.Json.Tests
         {
             var state = new JsonWriterState(options: new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation });
 
-            var output = new FixedSizedBufferWriter(34);
+            var output = new FixedSizedBufferWriter(26);
 
             var jsonUtf8 = new Utf8JsonWriter(output, state);
 
@@ -191,14 +191,14 @@ namespace System.Text.Json.Tests
             }
             catch (ArgumentException) { }
 
-            output = new FixedSizedBufferWriter(35);
+            output = new FixedSizedBufferWriter(27);
             jsonUtf8 = new Utf8JsonWriter(output, state);
             jsonUtf8.WriteStringValue(date);
             jsonUtf8.Flush();
             string actualStr = Encoding.UTF8.GetString(output.Formatted);
 
-            Assert.Equal(35, output.Formatted.Length);
-            Assert.Equal($"\"{date.ToString("O")}\"", actualStr);
+            Assert.Equal(27, output.Formatted.Length);
+            Assert.Equal($"\"{date.ToString("yyyy-MM-ddTHH:mm:ssK")}\"", actualStr);
         }
 
         [Theory]
@@ -3464,7 +3464,6 @@ namespace System.Text.Json.Tests
             {
                 Formatting = prettyPrint ? Formatting.Indented : Formatting.None,
                 StringEscapeHandling = StringEscapeHandling.EscapeHtml,
-                DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffffff"
             };
 
             json.WriteStartObject();
@@ -3497,7 +3496,6 @@ namespace System.Text.Json.Tests
             {
                 Formatting = prettyPrint ? Formatting.Indented : Formatting.None,
                 StringEscapeHandling = StringEscapeHandling.EscapeHtml,
-                DateFormatString = "yyyy-MM-ddTHH:mm:ss.fffffffzzz"
             };
 
             json.WriteStartObject();


### PR DESCRIPTION
This fixes https://github.com/dotnet/corefx/issues/34576.

We call `Utf8Formatter.TryParse` which formats to the roundtrippable custom format "O", then apply trimming logic that
- drops the fraction part of the output if the milliseconds part of the date is zero, else
- writes the fraction part up to 7 decimal places with no trailing zeros.