### PR TITLE
Fix catch exception process test

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1078,7 +1078,7 @@ namespace System.Diagnostics.Tests
             {
                 Assert.NotEmpty(processes);
             }
-            catch (TrueException)
+            catch (NotEmptyException)
             {
                 throw new TrueException(PrintProcesses(), false);
             }


### PR DESCRIPTION
Test fail again, but there was wrong exception caught

https://mc.dot.net/#/user/dotnet-bot/pr~2Fdotnet~2Fcorefx~2Frefs~2Fpull~2F35959~2Fmerge/test~2Ffunctional~2Fcli~2F~2Fouterloop~2F/20190311.3/workItem/System.Diagnostics.Process.Tests/analysis/xunit/System.Diagnostics.Tests.ProcessTests~2FGetProcessesByName_ProcessName_ReturnsExpected

I updated with correct one. `NotEmptyException` does not have message parameter constructor.

Output
```
Pid: '3428' Name: 'MSBuild' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe'
        Pid: '14000' Name: 'conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
        Pid: '15736' Name: 'MSBuild' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe'
        Pid: '5224' Name: 'conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
        Pid: '13984' Name: 'MSBuild' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe'
        Pid: '15444' Name: 'conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
        Pid: '14556' Name: 'ServiceHub.IdentityHost' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\ServiceHub\Hosts\ServiceHub.Host.CLR.x86\ServiceHub.IdentityHost.exe'
        Pid: '16768' Name: 'Microsoft.Alm.Shared.Remoting.RemoteContainer.dll' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\PrivateAssemblies\Microsoft.Alm.Shared.Remoting.RemoteContainer.dll'
        Pid: '17140' Name: 'SearchProtocolHost' Main module: 'C:\WINDOWS\system32\SearchProtocolHost.exe'
        Pid: '17064' Name: 'SearchFilterHost'
        Pid: '17164' Name: 'ServiceHub.SettingsHost' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\ServiceHub\Hosts\ServiceHub.Host.CLR.x86\ServiceHub.SettingsHost.exe'
        Pid: '15780' Name: 'SearchProtocolHost'
        Pid: '16744' Name: 'VBCSCompiler' Main module: 'C:\Users\marco_000\.nuget\packages\microsoft.net.compilers\3.0.0-beta4-final\tools\VBCSCompiler.exe'
        Pid: '16568' Name: 'conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
        Pid: '8096' Name: 'MSBuild' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin\MSBuild.exe'
        Pid: '16232' Name: 'cmd' Main module: 'C:\WINDOWS\SysWOW64\cmd.exe'
        Pid: '1304' Name: 'conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
        Pid: '4332' Name: 'dotnet' Main module: 'D:\git\corefx\artifacts\bin\testhost\netcoreapp-Windows_NT-Debug-x64\dotnet.exe'
        Pid: '15888' Name: 'svchost'
        Current process id: 4332
        Expected: True
        Actual:   False
        Stack Trace:
          D:\git\corefx\src\System.Diagnostics.Process\tests\ProcessTests.cs(1084,0): at System.Diagnostics.Tests.ProcessTests.GetProcessesByName_ProcessName_ReturnsExpected()
```
Old PR https://github.com/dotnet/corefx/pull/35853

/cc @stephentoub @danmosemsft 