### PR TITLE
Fix JsonReader bug in multi-segment string processing with escaped characters

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -905,16 +905,17 @@ namespace System.Text.Json
                                                 // We found less than 4 hex digits.
                                                 _lineNumber = prevLineNumber;
                                                 _bytePositionInLine = prevPosition;
+                                                _totalConsumed = prevTotalConsumed;
                                                 return false;
                                             }
 
                                             _totalConsumed += localBuffer.Length;
 
                                             localBuffer = _buffer;
+                                            numberOfHexDigits -= j - idx;
                                             idx = 0;
                                             j = 0;
                                             movedToNext = true;
-                                            numberOfHexDigits -= j - idx;
                                         }
 
                                     DoneWithHex:
@@ -940,6 +941,7 @@ namespace System.Text.Json
                                 }
                                 _lineNumber = prevLineNumber;
                                 _bytePositionInLine = prevPosition;
+                                _totalConsumed = prevTotalConsumed;
                                 return false;
                             }
 
@@ -1080,11 +1082,11 @@ namespace System.Text.Json
                                 }
 
                                 data = _buffer;
+                                numberOfHexDigits -= j - idx;
                                 idx = 0;
                                 j = 0;
                                 HasValueSequence = true;
                                 movedToNext = true;
-                                numberOfHexDigits -= j - idx;
                             }
 
                         DoneWithHex:

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -248,6 +248,62 @@ namespace System.Text.Json.Tests
             }
         }
 
+        [Fact]
+        public static void TestSingleStringsByOne()
+        {
+            string jsonString = "\"Hello, \\u0041hson!\"";
+            string expectedString = "Hello, \\u0041hson!, ";
+
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, 1);
+
+            for (int j = 0; j < dataUtf8.Length; j++)
+            {
+                var utf8JsonReader = new Utf8JsonReader(sequence.Slice(0, j), isFinalBlock: false, default);
+                byte[] resultSequence = JsonTestHelper.ReaderLoop(dataUtf8.Length, out int length, ref utf8JsonReader);
+                string actualStrSequence = Encoding.UTF8.GetString(resultSequence, 0, length);
+
+                long consumed = utf8JsonReader.BytesConsumed;
+                Assert.Equal(consumed, utf8JsonReader.CurrentState.BytesConsumed);
+                utf8JsonReader = new Utf8JsonReader(sequence.Slice(consumed), isFinalBlock: true, utf8JsonReader.CurrentState);
+                resultSequence = JsonTestHelper.ReaderLoop(dataUtf8.Length, out length, ref utf8JsonReader);
+                actualStrSequence += Encoding.UTF8.GetString(resultSequence, 0, length);
+                string message = $"Expected consumed: {dataUtf8.Length - consumed}, Actual consumed: {utf8JsonReader.BytesConsumed}, Index: {j}";
+                Assert.Equal(utf8JsonReader.BytesConsumed, utf8JsonReader.CurrentState.BytesConsumed);
+                Assert.True(dataUtf8.Length - consumed == utf8JsonReader.BytesConsumed, message);
+                Assert.Equal(expectedString, actualStrSequence);
+            }
+        }
+
+        [Fact]
+        public static void TestSingleStrings()
+        {
+            string jsonString = "\"Hello, \\u0041hson!\"";
+            string expectedString = "Hello, \\u0041hson!, ";
+
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            ReadOnlySequence<byte> sequence = JsonTestHelper.CreateSegments(dataUtf8);
+
+            for (int j = 0; j < dataUtf8.Length; j++)
+            {
+                var utf8JsonReader = new Utf8JsonReader(sequence.Slice(0, j), isFinalBlock: false, default);
+                byte[] resultSequence = JsonTestHelper.ReaderLoop(dataUtf8.Length, out int length, ref utf8JsonReader);
+                string actualStrSequence = Encoding.UTF8.GetString(resultSequence, 0, length);
+
+                long consumed = utf8JsonReader.BytesConsumed;
+                Assert.Equal(consumed, utf8JsonReader.CurrentState.BytesConsumed);
+                utf8JsonReader = new Utf8JsonReader(sequence.Slice(consumed), isFinalBlock: true, utf8JsonReader.CurrentState);
+                resultSequence = JsonTestHelper.ReaderLoop(dataUtf8.Length, out length, ref utf8JsonReader);
+                actualStrSequence += Encoding.UTF8.GetString(resultSequence, 0, length);
+                string message = $"Expected consumed: {dataUtf8.Length - consumed}, Actual consumed: {utf8JsonReader.BytesConsumed}, Index: {j}";
+                Assert.Equal(utf8JsonReader.BytesConsumed, utf8JsonReader.CurrentState.BytesConsumed);
+                Assert.True(dataUtf8.Length - consumed == utf8JsonReader.BytesConsumed, message);
+                Assert.Equal(expectedString, actualStrSequence);
+            }
+        }
+
         private static void SpanSequenceStatesAreEqualInvalidJson(byte[] dataUtf8, ReadOnlySequence<byte> sequence, int maxDepth, JsonCommentHandling commentHandling)
         {
             var stateSpan = new JsonReaderState(new JsonReaderOptions { CommentHandling = commentHandling, MaxDepth = maxDepth });


### PR DESCRIPTION
Found a typo/bug in the multi-segment Utf8JsonReader path when testing `TextEquals` (here: https://github.com/dotnet/corefx/pull/35979) where there was a test gap (https://github.com/dotnet/corefx/issues/33584).

**Previous:**
```text
Covered lines: 2776
Line coverage: 84.2% (2776 of 4786)
Branch coverage: 85.4% (1147 of 1342)
```
**Now:**
```text
Covered lines: 2832
Line coverage: 85.8% (2832 of 4788)
Branch coverage: 86.8% (1165 of 1342)
```

cc @bartonjs, @stephentoub