### PR TITLE
Fix SendWithPingUtilityAsync to catch InvalidOperationException

### DIFF
--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -328,12 +328,13 @@ namespace System.Net.NetworkInformation
                 if (finished == timeoutTask && !p.HasExited)
                 {
                     // Try to kill the ping process if it didn't return. If it is already in the process of exiting, 
-                    // a Win32Exception will be thrown.
+                    // a Win32Exception will be thrown or we will get InvalidOperationException if it already exited.
                     try
                     {
                         p.Kill();
                     }
                     catch (Win32Exception) { }
+                    catch (System.InvalidOperationException) { }
                     return CreateTimedOutPingReply();
                 }
                 else

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -334,7 +334,7 @@ namespace System.Net.NetworkInformation
                         p.Kill();
                     }
                     catch (Win32Exception) { }
-                    catch (System.InvalidOperationException) { }
+                    catch (InvalidOperationException) { }
                     return CreateTimedOutPingReply();
                 }
                 else


### PR DESCRIPTION
fixes #35969

recondition as Kill may return more exceptions than we expected. 
