### PR TITLE
Improve test logging: add process name to log

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1104,7 +1104,7 @@ namespace System.Diagnostics.Tests
                     builder.AppendLine();
                 }
                 
-                builder.AppendFormat("Current process id: {0} Process name: '{1}'", Process.GetCurrentProcess().Id, currentProcess.ProcessName);
+                builder.AppendFormat("Current process id: {0} Process name: '{1}' Id: {2}", Process.GetCurrentProcess().Id, currentProcess.ProcessName, currentProcess.Id);
                 return builder.ToString();
             }
         }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1104,7 +1104,7 @@ namespace System.Diagnostics.Tests
                     builder.AppendLine();
                 }
                 
-                builder.AppendFormat("Current process id: {0} Process name: '{1}' Id: {2}", Process.GetCurrentProcess().Id, currentProcess.ProcessName, currentProcess.Id);
+                builder.AppendFormat("Current process id: {0} Process name: '{1}'", currentProcess.Id, currentProcess.ProcessName);
                 return builder.ToString();
             }
         }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1080,14 +1080,14 @@ namespace System.Diagnostics.Tests
             }
             catch (NotEmptyException)
             {
-                throw new TrueException(PrintProcesses(), false);
+                throw new TrueException(PrintProcesses(currentProcess), false);
             }
 
             Assert.All(processes, process => Assert.Equal(".", process.MachineName));
             return;
 
             // Outputs a list of active processes in case of failure: https://github.com/dotnet/corefx/issues/35783
-            string PrintProcesses()
+            string PrintProcesses(Process currentProcess)
             {
                 StringBuilder builder = new StringBuilder();
                 foreach (Process process in Process.GetProcesses())
@@ -1104,7 +1104,7 @@ namespace System.Diagnostics.Tests
                     builder.AppendLine();
                 }
                 
-                builder.AppendFormat("Current process id: {0}", Process.GetCurrentProcess().Id);
+                builder.AppendFormat("Current process id: {0} Process name: '{1}'", Process.GetCurrentProcess().Id, currentProcess.ProcessName);
                 return builder.ToString();
             }
         }


### PR DESCRIPTION
Improve logging for issue https://github.com/dotnet/corefx/issues/35783 
We have a log, current pid process is present on process list https://mc.dot.net/#/user/dotnet-bot/pr~2Fdotnet~2Fcorefx~2Frefs~2Fpull~2F35959~2Fmerge/test~2Ffunctional~2Fcli~2F~2Fouterloop~2F/20190312.1/workItem/System.Diagnostics.Process.Tests/analysis/xunit/System.Diagnostics.Tests.ProcessTests~2FGetProcessesByName_ProcessName_ReturnsExpected

Added current process name to log to understand if issue is something related to it

```
Pid: '10144' Name: 'MSBuild' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\MSBuild.exe'
        Pid: '17164' Name: 'conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
        Pid: '14896' Name: 'MSBuild' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\MSBuild.exe'
        Pid: '20140' Name: 'conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
        Pid: '12432' Name: 'Microsoft.Alm.Shared.Remoting.RemoteContainer.dll' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\Common7\IDE\PrivateAssemblies\Microsoft.Alm.Shared.Remoting.RemoteContainer.dll'
        Pid: '20960' Name: 'MSBuild' Main module: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin\MSBuild.exe'
        Pid: '7324' Name: 'cmd' Main module: 'C:\WINDOWS\SysWOW64\cmd.exe'
        Pid: '13704' Name: 'conhost' Main module: 'C:\WINDOWS\system32\conhost.exe'
        Pid: '17052' Name: 'dotnet' Main module: 'D:\git\corefx\artifacts\bin\testhost\netcoreapp-Windows_NT-Debug-x64\dotnet.exe'
        Current process id: 17052 Process name: 'dotnet'
        Expected: True
        Actual:   False
```

/cc @danmosemsft @stephentoub 