### PR TITLE
Remove remaining usage of Contract.*

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary.cs
@@ -160,7 +160,6 @@ namespace System.Collections.Immutable
             Requires.NotNull(source, nameof(source));
             Requires.NotNull(keySelector, nameof(keySelector));
             Requires.NotNull(elementSelector, nameof(elementSelector));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             return ImmutableDictionary<TKey, TValue>.Empty.WithComparers(keyComparer, valueComparer)
                 .AddRange(source.Select(element => new KeyValuePair<TKey, TValue>(keySelector(element), elementSelector(element))));
@@ -255,7 +254,6 @@ namespace System.Collections.Immutable
         public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source, IEqualityComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
         {
             Requires.NotNull(source, nameof(source));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             var existingDictionary = source as ImmutableDictionary<TKey, TValue>;
             if (existingDictionary != null)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
@@ -304,7 +304,6 @@ namespace System.Collections.Immutable
         public ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value)
         {
             Requires.NotNullAllowStructs(key, nameof(key));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             var result = Add(key, value, KeyCollisionBehavior.ThrowIfValueDifferent, this.Origin);
             return result.Finalize(this);
@@ -318,7 +317,6 @@ namespace System.Collections.Immutable
         public ImmutableDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
         {
             Requires.NotNull(pairs, nameof(pairs));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             return this.AddRange(pairs, false);
         }
@@ -330,8 +328,6 @@ namespace System.Collections.Immutable
         public ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value)
         {
             Requires.NotNullAllowStructs(key, nameof(key));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
-            Contract.Ensures(!Contract.Result<ImmutableDictionary<TKey, TValue>>().IsEmpty);
 
             var result = Add(key, value, KeyCollisionBehavior.SetValue, this.Origin);
             return result.Finalize(this);
@@ -347,7 +343,6 @@ namespace System.Collections.Immutable
         public ImmutableDictionary<TKey, TValue> SetItems(IEnumerable<KeyValuePair<TKey, TValue>> items)
         {
             Requires.NotNull(items, nameof(items));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             var result = AddRange(items, this.Origin, KeyCollisionBehavior.SetValue);
             return result.Finalize(this);
@@ -360,7 +355,6 @@ namespace System.Collections.Immutable
         public ImmutableDictionary<TKey, TValue> Remove(TKey key)
         {
             Requires.NotNullAllowStructs(key, nameof(key));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             var result = Remove(key, this.Origin);
             return result.Finalize(this);
@@ -373,7 +367,6 @@ namespace System.Collections.Immutable
         public ImmutableDictionary<TKey, TValue> RemoveRange(IEnumerable<TKey> keys)
         {
             Requires.NotNull(keys, nameof(keys));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             int count = _count;
             var root = _root;
@@ -1091,7 +1084,6 @@ namespace System.Collections.Immutable
         private ImmutableDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs, bool avoidToHashMap)
         {
             Requires.NotNull(pairs, nameof(pairs));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             // Some optimizations may apply if we're an empty list.
             if (this.IsEmpty && !avoidToHashMap)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.Minimal.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.Minimal.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
 
@@ -167,7 +166,6 @@ namespace System.Collections.Immutable
         internal static IOrderedCollection<T> AsOrderedCollection<T>(this IEnumerable<T> sequence)
         {
             Requires.NotNull(sequence, nameof(sequence));
-            Contract.Ensures(Contract.Result<IOrderedCollection<T>>() != null);
 
             var orderedCollection = sequence as IOrderedCollection<T>;
             if (orderedCollection != null)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
@@ -81,8 +81,6 @@ namespace System.Collections.Immutable
         /// </summary>
         public ImmutableHashSet<T> Clear()
         {
-            Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableHashSet<T>>().IsEmpty);
             return this.IsEmpty ? this : ImmutableHashSet<T>.Empty.WithComparer(_equalityComparer);
         }
 
@@ -195,8 +193,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableHashSet<T> Add(T item)
         {
-            Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
-
             var result = Add(item, this.Origin);
             return result.Finalize(this);
         }
@@ -206,8 +202,6 @@ namespace System.Collections.Immutable
         /// </summary>
         public ImmutableHashSet<T> Remove(T item)
         {
-            Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
-
             var result = Remove(item, this.Origin);
             return result.Finalize(this);
         }
@@ -245,7 +239,6 @@ namespace System.Collections.Immutable
         public ImmutableHashSet<T> Union(IEnumerable<T> other)
         {
             Requires.NotNull(other, nameof(other));
-            Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
 
             return this.Union(other, avoidWithComparer: false);
         }
@@ -257,7 +250,6 @@ namespace System.Collections.Immutable
         public ImmutableHashSet<T> Intersect(IEnumerable<T> other)
         {
             Requires.NotNull(other, nameof(other));
-            Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
 
             var result = Intersect(other, this.Origin);
             return result.Finalize(this);
@@ -283,7 +275,6 @@ namespace System.Collections.Immutable
         public ImmutableHashSet<T> SymmetricExcept(IEnumerable<T> other)
         {
             Requires.NotNull(other, nameof(other));
-            Contract.Ensures(Contract.Result<IImmutableSet<T>>() != null);
 
             var result = SymmetricExcept(other, this.Origin);
             return result.Finalize(this);
@@ -446,7 +437,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableHashSet<T> WithComparer(IEqualityComparer<T> equalityComparer)
         {
-            Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
             if (equalityComparer == null)
             {
                 equalityComparer = EqualityComparer<T>.Default;
@@ -460,6 +450,7 @@ namespace System.Collections.Immutable
             {
                 var result = new ImmutableHashSet<T>(equalityComparer);
                 result = result.Union(this, avoidWithComparer: true);
+                Debug.Assert(result != null);
                 return result;
             }
         }
@@ -1041,7 +1032,6 @@ namespace System.Collections.Immutable
         private ImmutableHashSet<T> Union(IEnumerable<T> items, bool avoidWithComparer)
         {
             Requires.NotNull(items, nameof(items));
-            Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
 
             // Some optimizations may apply if we're an empty set.
             if (this.IsEmpty && !avoidWithComparer)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Enumerator.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Enumerator.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
 
 namespace System.Collections.Immutable
 {
@@ -249,9 +248,6 @@ namespace System.Collections.Immutable
             /// </summary>
             private void ThrowIfDisposed()
             {
-                Contract.Ensures(_root != null);
-                Contract.EnsuresOnThrow<ObjectDisposedException>(_root == null);
-
                 // Since this is a struct, copies might not have been marked as disposed.
                 // But the stack we share across those copies would know.
                 // This trick only works when we have a non-null stack.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.Node.cs
@@ -69,8 +69,8 @@ namespace System.Collections.Immutable
             /// </summary>
             private Node()
             {
-                Contract.Ensures(this.IsEmpty);
                 _frozen = true; // the empty node is *always* frozen.
+                Debug.Assert(this.IsEmpty);
             }
 
             /// <summary>
@@ -86,7 +86,6 @@ namespace System.Collections.Immutable
                 Requires.NotNull(left, nameof(left));
                 Requires.NotNull(right, nameof(right));
                 Debug.Assert(!frozen || (left._frozen && right._frozen));
-                Contract.Ensures(!this.IsEmpty);
 
                 _key = key;
                 _left = left;
@@ -94,6 +93,8 @@ namespace System.Collections.Immutable
                 _height = ParentHeight(left, right);
                 _count = ParentCount(left, right);
                 _frozen = frozen;
+
+                Debug.Assert(!this.IsEmpty);
             }
 
             /// <summary>
@@ -106,7 +107,6 @@ namespace System.Collections.Immutable
             {
                 get
                 {
-                    Contract.Ensures(Contract.Result<bool>() == (_left == null));
                     Debug.Assert(!(_left == null ^ _right == null));
                     return _left == null;
                 }
@@ -441,7 +441,6 @@ namespace System.Collections.Immutable
             internal Node RemoveAll(Predicate<T> match)
             {
                 Requires.NotNull(match, nameof(match));
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 var result = this;
                 var enumerator = new Enumerator(result);
@@ -467,6 +466,7 @@ namespace System.Collections.Immutable
                     enumerator.Dispose();
                 }
 
+                Debug.Assert(result != null);
                 return result;
             }
 
@@ -558,7 +558,6 @@ namespace System.Collections.Immutable
             internal Node Sort(Comparison<T> comparison)
             {
                 Requires.NotNull(comparison, nameof(comparison));
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 // PERF: Eventually this might be reimplemented in a way that does not require allocating an array.
                 var array = new T[this.Count];
@@ -1018,7 +1017,6 @@ namespace System.Collections.Immutable
             internal ImmutableList<T> FindAll(Predicate<T> match)
             {
                 Requires.NotNull(match, nameof(match));
-                Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
                 if (this.IsEmpty)
                 {
@@ -1060,7 +1058,6 @@ namespace System.Collections.Immutable
             internal int FindIndex(Predicate<T> match)
             {
                 Requires.NotNull(match, nameof(match));
-                Contract.Ensures(Contract.Result<int>() >= -1);
 
                 return this.FindIndex(0, _count, match);
             }
@@ -1168,7 +1165,6 @@ namespace System.Collections.Immutable
             internal int FindLastIndex(Predicate<T> match)
             {
                 Requires.NotNull(match, nameof(match));
-                Contract.Ensures(Contract.Result<int>() >= -1);
 
                 return this.IsEmpty ? -1 : this.FindLastIndex(this.Count - 1, this.Count, match);
             }
@@ -1259,7 +1255,6 @@ namespace System.Collections.Immutable
             {
                 Debug.Assert(!this.IsEmpty);
                 Debug.Assert(!_right.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 return _right.MutateLeft(this.MutateRight(_right._left));
             }
@@ -1272,7 +1267,6 @@ namespace System.Collections.Immutable
             {
                 Debug.Assert(!this.IsEmpty);
                 Debug.Assert(!_left.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 return _left.MutateRight(this.MutateLeft(_left._right));
             }
@@ -1286,7 +1280,6 @@ namespace System.Collections.Immutable
                 Debug.Assert(!this.IsEmpty);
                 Debug.Assert(!_right.IsEmpty);
                 Debug.Assert(!_right._left.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 // The following is an optimized version of rotating the right child right, then rotating the parent left.
                 Node right = _right;
@@ -1305,7 +1298,6 @@ namespace System.Collections.Immutable
                 Debug.Assert(!this.IsEmpty);
                 Debug.Assert(!_left.IsEmpty);
                 Debug.Assert(!_left._right.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 // The following is an optimized version of rotating the left child left, then rotating the parent right.
                 Node left = _left;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -222,8 +222,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> Add(T value)
         {
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableList<T>>().Count == this.Count + 1);
             var result = _root.Add(value);
             return this.Wrap(result);
         }
@@ -235,8 +233,6 @@ namespace System.Collections.Immutable
         public ImmutableList<T> AddRange(IEnumerable<T> items)
         {
             Requires.NotNull(items, nameof(items));
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableList<T>>().Count >= this.Count);
 
             // Some optimizations may apply if we're an empty list.
             if (this.IsEmpty)
@@ -256,8 +252,6 @@ namespace System.Collections.Immutable
         public ImmutableList<T> Insert(int index, T item)
         {
             Requires.Range(index >= 0 && index <= this.Count, nameof(index));
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableList<T>>().Count == this.Count + 1);
             return this.Wrap(_root.Insert(index, item));
         }
 
@@ -269,7 +263,6 @@ namespace System.Collections.Immutable
         {
             Requires.Range(index >= 0 && index <= this.Count, nameof(index));
             Requires.NotNull(items, nameof(items));
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
             var result = _root.InsertRange(index, items);
 
@@ -288,7 +281,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> Remove(T value, IEqualityComparer<T> equalityComparer)
         {
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
             int index = this.IndexOf(value, equalityComparer);
             return index < 0 ? this : this.RemoveAt(index);
         }
@@ -304,7 +296,6 @@ namespace System.Collections.Immutable
         {
             Requires.Range(index >= 0 && index <= this.Count, nameof(index));
             Requires.Range(count >= 0 && index + count <= this.Count, nameof(count));
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
             var result = _root;
             int remaining = count;
@@ -341,8 +332,6 @@ namespace System.Collections.Immutable
         public ImmutableList<T> RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer)
         {
             Requires.NotNull(items, nameof(items));
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableList<T>>().Count <= this.Count);
 
             // Some optimizations may apply if we're an empty list.
             if (this.IsEmpty)
@@ -372,8 +361,6 @@ namespace System.Collections.Immutable
         public ImmutableList<T> RemoveAt(int index)
         {
             Requires.Range(index >= 0 && index < this.Count, nameof(index));
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableList<T>>().Count == this.Count - 1);
             var result = _root.RemoveAt(index);
             return this.Wrap(result);
         }
@@ -393,7 +380,6 @@ namespace System.Collections.Immutable
         public ImmutableList<T> RemoveAll(Predicate<T> match)
         {
             Requires.NotNull(match, nameof(match));
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
             return this.Wrap(_root.RemoveAll(match));
         }
@@ -416,9 +402,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer)
         {
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableList<T>>().Count == this.Count);
-
             int index = this.IndexOf(oldValue, equalityComparer);
             if (index < 0)
             {
@@ -464,7 +447,6 @@ namespace System.Collections.Immutable
         public ImmutableList<T> Sort(Comparison<T> comparison)
         {
             Requires.NotNull(comparison, nameof(comparison));
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
             return this.Wrap(_root.Sort(comparison));
         }
 
@@ -501,7 +483,6 @@ namespace System.Collections.Immutable
             Requires.Range(index >= 0, nameof(index));
             Requires.Range(count >= 0, nameof(count));
             Requires.Range(index + count <= this.Count, nameof(count));
-            Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
             return this.Wrap(_root.Sort(index, count, comparer));
         }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue_1.cs
@@ -63,8 +63,7 @@ namespace System.Collections.Immutable
         /// </summary>
         public ImmutableQueue<T> Clear()
         {
-            Contract.Ensures(Contract.Result<ImmutableQueue<T>>().IsEmpty);
-            Contract.Assume(s_EmptyField.IsEmpty);
+            Debug.Assert(s_EmptyField.IsEmpty);
             return Empty;
         }
 
@@ -90,8 +89,7 @@ namespace System.Collections.Immutable
         {
             get
             {
-                Contract.Ensures(Contract.Result<ImmutableQueue<T>>().IsEmpty);
-                Contract.Assume(s_EmptyField.IsEmpty);
+                Debug.Assert(s_EmptyField.IsEmpty);
                 return s_EmptyField;
             }
         }
@@ -101,7 +99,7 @@ namespace System.Collections.Immutable
         /// </summary>
         IImmutableQueue<T> IImmutableQueue<T>.Clear()
         {
-            Contract.Assume(s_EmptyField.IsEmpty);
+            Debug.Assert(s_EmptyField.IsEmpty);
             return this.Clear();
         }
 
@@ -112,8 +110,6 @@ namespace System.Collections.Immutable
         {
             get
             {
-                Contract.Ensures(Contract.Result<ImmutableStack<T>>() != null);
-
                 // Although this is a lazy-init pattern, no lock is required because
                 // this instance is immutable otherwise, and a double-assignment from multiple
                 // threads is harmless.
@@ -122,6 +118,7 @@ namespace System.Collections.Immutable
                     _backwardsReversed = _backwards.Reverse();
                 }
 
+                Debug.Assert(_backwardsReversed != null);
                 return _backwardsReversed;
             }
         }
@@ -168,8 +165,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableQueue<T> Enqueue(T value)
         {
-            Contract.Ensures(!Contract.Result<ImmutableQueue<T>>().IsEmpty);
-
             if (this.IsEmpty)
             {
                 return new ImmutableQueue<T>(ImmutableStack.Create(value), ImmutableStack<T>.Empty);

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary.cs
@@ -156,7 +156,6 @@ namespace System.Collections.Immutable
             Requires.NotNull(source, nameof(source));
             Requires.NotNull(keySelector, nameof(keySelector));
             Requires.NotNull(elementSelector, nameof(elementSelector));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             return ImmutableSortedDictionary<TKey, TValue>.Empty.WithComparers(keyComparer, valueComparer)
                 .AddRange(source.Select(element => new KeyValuePair<TKey, TValue>(keySelector(element), elementSelector(element))));
@@ -222,7 +221,6 @@ namespace System.Collections.Immutable
         public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source, IComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
         {
             Requires.NotNull(source, nameof(source));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             var existingDictionary = source as ImmutableSortedDictionary<TKey, TValue>;
             if (existingDictionary != null)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.Node.cs
@@ -62,8 +62,8 @@ namespace System.Collections.Immutable
             /// </summary>
             private Node()
             {
-                Contract.Ensures(this.IsEmpty);
                 _frozen = true; // the empty node is *always* frozen.
+                Debug.Assert(this.IsEmpty);
             }
 
             /// <summary>
@@ -81,10 +81,6 @@ namespace System.Collections.Immutable
                 Requires.NotNull(left, nameof(left));
                 Requires.NotNull(right, nameof(right));
                 Debug.Assert(!frozen || (left._frozen && right._frozen));
-                Contract.Ensures(!this.IsEmpty);
-                Contract.Ensures(_key != null);
-                Contract.Ensures(_left == left);
-                Contract.Ensures(_right == right);
 
                 _key = key;
                 _value = value;
@@ -92,6 +88,8 @@ namespace System.Collections.Immutable
                 _right = right;
                 _height = checked((byte)(1 + Math.Max(left._height, right._height)));
                 _frozen = frozen;
+
+                Debug.Assert(!this.IsEmpty);
             }
 
             /// <summary>
@@ -104,7 +102,6 @@ namespace System.Collections.Immutable
             {
                 get
                 {
-                    Contract.Ensures((_left != null && _right != null) || Contract.Result<bool>());
                     return _left == null;
                 }
             }
@@ -276,7 +273,6 @@ namespace System.Collections.Immutable
             internal static Node NodeTreeFromSortedDictionary(SortedDictionary<TKey, TValue> dictionary)
             {
                 Requires.NotNull(dictionary, nameof(dictionary));
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 var list = dictionary.AsOrderedCollection();
                 return NodeTreeFromList(list, 0, list.Count);
@@ -505,7 +501,6 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (tree._right.IsEmpty)
                 {
@@ -525,7 +520,6 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (tree._left.IsEmpty)
                 {
@@ -545,7 +539,6 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (tree._right.IsEmpty)
                 {
@@ -565,7 +558,6 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (tree._left.IsEmpty)
                 {
@@ -626,7 +618,6 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (IsRightHeavy(tree))
                 {
@@ -656,7 +647,6 @@ namespace System.Collections.Immutable
                 Requires.NotNull(items, nameof(items));
                 Requires.Range(start >= 0, nameof(start));
                 Requires.Range(length >= 0, nameof(length));
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (length == 0)
                 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
@@ -84,9 +84,6 @@ namespace System.Collections.Immutable
         /// </summary>
         public ImmutableSortedDictionary<TKey, TValue> Clear()
         {
-            Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>().IsEmpty);
-            Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>().KeyComparer == ((ISortKeyCollection<TKey>)this).KeyComparer);
             return _root.IsEmpty ? this : Empty.WithComparers(_keyComparer, _valueComparer);
         }
 
@@ -263,7 +260,6 @@ namespace System.Collections.Immutable
         public ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value)
         {
             Requires.NotNullAllowStructs(key, nameof(key));
-            Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
             bool mutated;
             var result = _root.Add(key, value, _keyComparer, _valueComparer, out mutated);
             return this.Wrap(result, _count + 1);
@@ -276,8 +272,6 @@ namespace System.Collections.Immutable
         public ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value)
         {
             Requires.NotNullAllowStructs(key, nameof(key));
-            Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
-            Contract.Ensures(!Contract.Result<ImmutableSortedDictionary<TKey, TValue>>().IsEmpty);
             bool replacedExistingValue, mutated;
             var result = _root.SetItem(key, value, _keyComparer, _valueComparer, out replacedExistingValue, out mutated);
             return this.Wrap(result, replacedExistingValue ? _count : _count + 1);
@@ -293,7 +287,6 @@ namespace System.Collections.Immutable
         public ImmutableSortedDictionary<TKey, TValue> SetItems(IEnumerable<KeyValuePair<TKey, TValue>> items)
         {
             Requires.NotNull(items, nameof(items));
-            Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             return this.AddRange(items, overwriteOnCollision: true, avoidToSortedMap: false);
         }
@@ -306,7 +299,6 @@ namespace System.Collections.Immutable
         public ImmutableSortedDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> items)
         {
             Requires.NotNull(items, nameof(items));
-            Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
 
             return this.AddRange(items, overwriteOnCollision: false, avoidToSortedMap: false);
         }
@@ -318,7 +310,6 @@ namespace System.Collections.Immutable
         public ImmutableSortedDictionary<TKey, TValue> Remove(TKey value)
         {
             Requires.NotNullAllowStructs(value, nameof(value));
-            Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
             bool mutated;
             var result = _root.Remove(value, _keyComparer, out mutated);
             return this.Wrap(result, _count - 1);
@@ -331,7 +322,6 @@ namespace System.Collections.Immutable
         public ImmutableSortedDictionary<TKey, TValue> RemoveRange(IEnumerable<TKey> keys)
         {
             Requires.NotNull(keys, nameof(keys));
-            Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
 
             var result = _root;
             int count = _count;
@@ -355,8 +345,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedDictionary<TKey, TValue> WithComparers(IComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
         {
-            Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>().IsEmpty == this.IsEmpty);
             if (keyComparer == null)
             {
                 keyComparer = Comparer<TKey>.Default;
@@ -832,7 +820,6 @@ namespace System.Collections.Immutable
         private ImmutableSortedDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> items, bool overwriteOnCollision, bool avoidToSortedMap)
         {
             Requires.NotNull(items, nameof(items));
-            Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
 
             // Some optimizations may apply if we're an empty set.
             if (this.IsEmpty && !avoidToSortedMap)

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Enumerator.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Enumerator.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
 
 namespace System.Collections.Immutable
 {
@@ -194,9 +193,6 @@ namespace System.Collections.Immutable
             /// </summary>
             private void ThrowIfDisposed()
             {
-                Contract.Ensures(_root != null);
-                Contract.EnsuresOnThrow<ObjectDisposedException>(_root == null);
-
                 // Since this is a struct, copies might not have been marked as disposed.
                 // But the stack we share across those copies would know.
                 // This trick only works when we have a non-null stack.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.Node.cs
@@ -68,8 +68,8 @@ namespace System.Collections.Immutable
             /// </summary>
             private Node()
             {
-                Contract.Ensures(this.IsEmpty);
                 _frozen = true; // the empty node is *always* frozen.
+                Debug.Assert(this.IsEmpty);
             }
 
             /// <summary>
@@ -612,7 +612,6 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (tree._right.IsEmpty)
                 {
@@ -632,7 +631,6 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (tree._left.IsEmpty)
                 {
@@ -652,7 +650,6 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (tree._right.IsEmpty)
                 {
@@ -672,7 +669,6 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (tree._left.IsEmpty)
                 {
@@ -733,7 +729,6 @@ namespace System.Collections.Immutable
             {
                 Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
-                Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (IsRightHeavy(tree))
                 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
@@ -76,8 +76,6 @@ namespace System.Collections.Immutable
         /// </summary>
         public ImmutableSortedSet<T> Clear()
         {
-            Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>().IsEmpty);
             return _root.IsEmpty ? this : Empty.WithComparer(_comparer);
         }
 
@@ -198,7 +196,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedSet<T> Add(T value)
         {
-            Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
             bool mutated;
             return this.Wrap(_root.Add(value, _comparer, out mutated));
         }
@@ -209,7 +206,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedSet<T> Remove(T value)
         {
-            Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
             bool mutated;
             return this.Wrap(_root.Remove(value, _comparer, out mutated));
         }
@@ -249,7 +245,7 @@ namespace System.Collections.Immutable
         public ImmutableSortedSet<T> Intersect(IEnumerable<T> other)
         {
             Requires.NotNull(other, nameof(other));
-            Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
+
             var newSet = this.Clear();
             foreach (var item in other.GetEnumerableDisposable<T, Enumerator>())
             {
@@ -259,6 +255,7 @@ namespace System.Collections.Immutable
                 }
             }
 
+            Debug.Assert(newSet != null);
             return newSet;
         }
 
@@ -319,7 +316,6 @@ namespace System.Collections.Immutable
         public ImmutableSortedSet<T> Union(IEnumerable<T> other)
         {
             Requires.NotNull(other, nameof(other));
-            Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
 
             ImmutableSortedSet<T> immutableSortedSet;
             if (TryCastToImmutableSortedSet(other, out immutableSortedSet) && immutableSortedSet.KeyComparer == this.KeyComparer) // argument is a compatible immutable sorted set
@@ -360,7 +356,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedSet<T> WithComparer(IComparer<T> comparer)
         {
-            Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
             if (comparer == null)
             {
                 comparer = Comparer<T>.Default;
@@ -374,6 +369,7 @@ namespace System.Collections.Immutable
             {
                 var result = new ImmutableSortedSet<T>(Node.EmptyNode, comparer);
                 result = result.Union(this);
+                Debug.Assert(result != null);
                 return result;
             }
         }
@@ -1064,7 +1060,6 @@ namespace System.Collections.Immutable
         private ImmutableSortedSet<T> UnionIncremental(IEnumerable<T> items)
         {
             Requires.NotNull(items, nameof(items));
-            Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
 
             // Let's not implement in terms of ImmutableSortedSet.Add so that we're
             // not unnecessarily generating a new wrapping set object for each item.
@@ -1105,7 +1100,6 @@ namespace System.Collections.Immutable
         private ImmutableSortedSet<T> LeafToRootRefill(IEnumerable<T> addedItems)
         {
             Requires.NotNull(addedItems, nameof(addedItems));
-            Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
 
             // Rather than build up the immutable structure in the incremental way,
             // build it in such a way as to generate minimal garbage, by assembling

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack.cs
@@ -92,7 +92,6 @@ namespace System.Collections.Immutable
         public static IImmutableStack<T> Pop<T>(this IImmutableStack<T> stack, out T value)
         {
             Requires.NotNull(stack, nameof(stack));
-            Contract.Ensures(Contract.Result<IImmutableStack<T>>() != null);
 
             value = stack.Peek();
             return stack.Pop();

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack_1.cs
@@ -66,9 +66,7 @@ namespace System.Collections.Immutable
         {
             get
             {
-                Contract.Ensures(Contract.Result<ImmutableStack<T>>() != null);
-                Contract.Ensures(Contract.Result<ImmutableStack<T>>().IsEmpty);
-                Contract.Assume(s_EmptyField.IsEmpty);
+                Debug.Assert(s_EmptyField.IsEmpty);
                 return s_EmptyField;
             }
         }
@@ -78,9 +76,7 @@ namespace System.Collections.Immutable
         /// </summary>
         public ImmutableStack<T> Clear()
         {
-            Contract.Ensures(Contract.Result<ImmutableStack<T>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableStack<T>>().IsEmpty);
-            Contract.Assume(s_EmptyField.IsEmpty);
+            Debug.Assert(s_EmptyField.IsEmpty);
             return Empty;
         }
 
@@ -149,8 +145,6 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableStack<T> Push(T value)
         {
-            Contract.Ensures(Contract.Result<ImmutableStack<T>>() != null);
-            Contract.Ensures(!Contract.Result<ImmutableStack<T>>().IsEmpty);
             return new ImmutableStack<T>(value, this);
         }
 
@@ -173,12 +167,12 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableStack<T> Pop()
         {
-            Contract.Ensures(Contract.Result<ImmutableStack<T>>() != null);
             if (this.IsEmpty)
             {
                 throw new InvalidOperationException(SR.InvalidEmptyOperation);
             }
 
+            Debug.Assert(_tail != null);
             return _tail;
         }
 
@@ -253,15 +247,14 @@ namespace System.Collections.Immutable
         [Pure]
         internal ImmutableStack<T> Reverse()
         {
-            Contract.Ensures(Contract.Result<ImmutableStack<T>>() != null);
-            Contract.Ensures(Contract.Result<ImmutableStack<T>>().IsEmpty == this.IsEmpty);
-
             var r = this.Clear();
             for (ImmutableStack<T> f = this; !f.IsEmpty; f = f.Pop())
             {
                 r = r.Push(f.Peek());
             }
 
+            Debug.Assert(r != null);
+            Debug.Assert(r.IsEmpty == IsEmpty);
             return r;
         }
     }

--- a/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
@@ -2,15 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-// ReSharper disable CheckNamespace
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 
 namespace System.Linq
-// ReSharper restore CheckNamespace
 {
     /// <summary>
     /// LINQ extension method overrides that offer greater efficiency for <see cref="ImmutableArray{T}"/> than the standard LINQ methods

--- a/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/Queue.cs
@@ -381,7 +381,6 @@ namespace System.Collections
                 }
             }
 
-            [SuppressMessage("Microsoft.Contracts", "CC1055")]  // Thread safety problems with precondition - can't express the precondition as of Dev10.
             public override object Dequeue()
             {
                 lock (_root)
@@ -398,7 +397,6 @@ namespace System.Collections
                 }
             }
 
-            [SuppressMessage("Microsoft.Contracts", "CC1055")]  // Thread safety problems with precondition - can't express the precondition as of Dev10.
             public override object Peek()
             {
                 lock (_root)

--- a/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/SortedList.cs
@@ -708,7 +708,6 @@ namespace System.Collections
                 }
             }
 
-            [SuppressMessage("Microsoft.Contracts", "CC1055")]  // Skip extra error checking to avoid *potential* AppCompat problems.
             public override object GetByIndex(int index)
             {
                 lock (_root)
@@ -725,7 +724,6 @@ namespace System.Collections
                 }
             }
 
-            [SuppressMessage("Microsoft.Contracts", "CC1055")]  // Skip extra error checking to avoid *potential* AppCompat problems.
             public override object GetKey(int index)
             {
                 lock (_root)
@@ -761,7 +759,6 @@ namespace System.Collections
                 }
             }
 
-            [SuppressMessage("Microsoft.Contracts", "CC1055")]  // Skip extra error checking to avoid *potential* AppCompat problems.
             public override int IndexOfValue(object value)
             {
                 lock (_root)
@@ -770,7 +767,6 @@ namespace System.Collections
                 }
             }
 
-            [SuppressMessage("Microsoft.Contracts", "CC1055")]  // Skip extra error checking to avoid *potential* AppCompat problems.
             public override void RemoveAt(int index)
             {
                 lock (_root)
@@ -787,7 +783,6 @@ namespace System.Collections
                 }
             }
 
-            [SuppressMessage("Microsoft.Contracts", "CC1055")]  // Skip extra error checking to avoid *potential* AppCompat problems.
             public override void SetByIndex(int index, object value)
             {
                 lock (_root)

--- a/src/System.ComponentModel.Composition/src/Microsoft/Internal/Requires.cs
+++ b/src/System.ComponentModel.Composition/src/Microsoft/Internal/Requires.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Reflection;
 
@@ -20,7 +19,6 @@ namespace Microsoft.Internal
         {
             NotNull(values, parameterName);
             NotNullElements(values, parameterName);
-            Contract.EndContractBlock();
         }
 
         [DebuggerStepThrough]
@@ -29,7 +27,6 @@ namespace Microsoft.Internal
             where TValue : class
         {
             NotNullElements(values, parameterName);
-            Contract.EndContractBlock();
         }
 
         [DebuggerStepThrough]
@@ -37,18 +34,22 @@ namespace Microsoft.Internal
             where T : class
         {
             NotNullElements(values, parameterName);
-            Contract.EndContractBlock();
         }
 
         [DebuggerStepThrough]
         private static void NotNullElements<T>(IEnumerable<T> values, string parameterName)
             where T : class
         {
-            if (values != null && !Contract.ForAll(values, (value) => value != null))
+            if (values != null)
             {
-                throw ExceptionBuilder.CreateContainsNullElement(parameterName);
+                foreach (T value in values)
+                {
+                    if (value is null)
+                    {
+                        throw ExceptionBuilder.CreateContainsNullElement(parameterName);
+                    }
+                }
             }
-            Contract.EndContractBlock();
         }
 
         [DebuggerStepThrough]
@@ -79,11 +80,16 @@ namespace Microsoft.Internal
             where TKey : class
             where TValue : class
         {
-            if (values != null && !Contract.ForAll(values, (keyValue) => keyValue.Key != null && keyValue.Value != null))
+            if (values != null)
             {
-                throw ExceptionBuilder.CreateContainsNullElement(parameterName);
+                foreach (KeyValuePair<TKey, TValue> keyValue in values)
+                {
+                    if (keyValue.Key is null || keyValue.Value is null)
+                    {
+                        throw ExceptionBuilder.CreateContainsNullElement(parameterName);
+                    }
+                }
             }
-            Contract.EndContractBlock();
         }
 
         [DebuggerStepThrough]
@@ -94,7 +100,6 @@ namespace Microsoft.Internal
             {
                 throw new ArgumentException(SR.Format(SR.ArgumentOutOfRange_InvalidEnumInSet, parameterName, value, enumFlagSet.ToString()), parameterName);
             }
-            Contract.EndContractBlock();
         }
 
         public static void NotNull<T>(T value, string parameterName)

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/AttributedModelServices.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/AttributedModelServices.cs
@@ -7,8 +7,8 @@ using System.ComponentModel.Composition.AttributedModel;
 using System.ComponentModel.Composition.Hosting;
 using System.ComponentModel.Composition.Primitives;
 using System.ComponentModel.Composition.ReflectionModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Internal;
@@ -21,7 +21,6 @@ namespace System.ComponentModel.Composition
         public static TMetadataView GetMetadataView<TMetadataView>(IDictionary<string, object> metadata)
         {
             Requires.NotNull(metadata, nameof(metadata));
-            Contract.Ensures(Contract.Result<TMetadataView>() != null);
 
             return MetadataViewProvider.GetMetadataView<TMetadataView>(metadata);
         }
@@ -29,7 +28,6 @@ namespace System.ComponentModel.Composition
         public static ComposablePart CreatePart(object attributedPart)
         {
             Requires.NotNull(attributedPart, nameof(attributedPart));
-            Contract.Ensures(Contract.Result<ComposablePart>() != null);
 
             return AttributedModelDiscovery.CreatePart(attributedPart);
         }
@@ -38,7 +36,6 @@ namespace System.ComponentModel.Composition
         {
             Requires.NotNull(attributedPart, nameof(attributedPart));
             Requires.NotNull(reflectionContext, nameof(reflectionContext));
-            Contract.Ensures(Contract.Result<ComposablePart>() != null);
 
             return AttributedModelDiscovery.CreatePart(attributedPart, reflectionContext);
         }
@@ -47,7 +44,6 @@ namespace System.ComponentModel.Composition
         {
             Requires.NotNull(partDefinition, nameof(partDefinition));
             Requires.NotNull(attributedPart, nameof(attributedPart));
-            Contract.Ensures(Contract.Result<ComposablePart>() != null);
 
             var reflectionComposablePartDefinition = partDefinition as ReflectionComposablePartDefinition;
             if(reflectionComposablePartDefinition == null)
@@ -61,7 +57,6 @@ namespace System.ComponentModel.Composition
         public static ComposablePartDefinition CreatePartDefinition(Type type, ICompositionElement origin)
         {
             Requires.NotNull(type, nameof(type));
-            Contract.Ensures(Contract.Result<ComposablePartDefinition>() != null);
 
             return AttributedModelServices.CreatePartDefinition(type, origin, false);
         }
@@ -82,7 +77,6 @@ namespace System.ComponentModel.Composition
         public static string GetTypeIdentity(Type type)
         {
             Requires.NotNull(type, nameof(type));
-            Contract.Ensures(!string.IsNullOrEmpty(Contract.Result<string>()));
 
             return ContractNameServices.GetTypeIdentity(type);
         }
@@ -90,7 +84,6 @@ namespace System.ComponentModel.Composition
         public static string GetTypeIdentity(MethodInfo method)
         {
             Requires.NotNull(method, nameof(method));
-            Contract.Ensures(!string.IsNullOrEmpty(Contract.Result<string>()));
 
             return ContractNameServices.GetTypeIdentityFromMethod(method);
         }
@@ -98,7 +91,6 @@ namespace System.ComponentModel.Composition
         public static string GetContractName(Type type)
         {
             Requires.NotNull(type, nameof(type));
-            Contract.Ensures(!string.IsNullOrEmpty(Contract.Result<string>()));
 
             return AttributedModelServices.GetTypeIdentity(type);
         }
@@ -106,7 +98,6 @@ namespace System.ComponentModel.Composition
         public static ComposablePart AddExportedValue<T>(this CompositionBatch batch, T exportedValue)
         {
             Requires.NotNull(batch, nameof(batch));
-            Contract.Ensures(Contract.Result<ComposablePart>() != null);
 
             string contractName = AttributedModelServices.GetContractName(typeof(T));
 
@@ -125,7 +116,6 @@ namespace System.ComponentModel.Composition
         public static ComposablePart AddExportedValue<T>(this CompositionBatch batch, string contractName, T exportedValue)
         {
             Requires.NotNull(batch, nameof(batch));
-            Contract.Ensures(Contract.Result<ComposablePart>() != null);
 
             string typeIdentity = AttributedModelServices.GetTypeIdentity(typeof(T));
 
@@ -148,12 +138,12 @@ namespace System.ComponentModel.Composition
         {
             Requires.NotNull(batch, nameof(batch));
             Requires.NotNull(attributedPart, nameof(attributedPart));
-            Contract.Ensures(Contract.Result<ComposablePart>() != null);
 
             ComposablePart part = AttributedModelServices.CreatePart(attributedPart);
 
             batch.AddPart(part);
 
+            Debug.Assert(part != null);
             return part;
         }
 
@@ -190,11 +180,11 @@ namespace System.ComponentModel.Composition
         {
             Requires.NotNull(compositionService, nameof(compositionService));
             Requires.NotNull(attributedPart, nameof(attributedPart));
-            Contract.Ensures(Contract.Result<ComposablePart>() != null);
 
             ComposablePart part = AttributedModelServices.CreatePart(attributedPart);
             compositionService.SatisfyImportsOnce(part);
 
+            Debug.Assert(part != null);
             return part;
         }
 
@@ -220,11 +210,11 @@ namespace System.ComponentModel.Composition
             Requires.NotNull(compositionService, nameof(compositionService));
             Requires.NotNull(attributedPart, nameof(attributedPart));
             Requires.NotNull(reflectionContext, nameof(reflectionContext));
-            Contract.Ensures(Contract.Result<ComposablePart>() != null);
 
             ComposablePart part = AttributedModelServices.CreatePart(attributedPart, reflectionContext);
             compositionService.SatisfyImportsOnce(part);
 
+            Debug.Assert(part != null);
             return part;
         }
 

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AggregateCatalog.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AggregateCatalog.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition.Primitives;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading;
 using Microsoft.Internal;
@@ -169,7 +168,7 @@ namespace System.ComponentModel.Composition.Hosting
             get
             {
                 ThrowIfDisposed();
-                Contract.Ensures(Contract.Result<ICollection<ComposablePartCatalog>>() != null);
+                Debug.Assert(_catalogs != null);
 
                 return _catalogs;
             }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AggregateExportProvider.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AggregateExportProvider.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition.Primitives;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading;
 using Microsoft.Internal.Collections;
@@ -129,7 +128,7 @@ namespace System.ComponentModel.Composition.Hosting
             get
             {
                 ThrowIfDisposed();
-                Contract.Ensures(Contract.Result<ReadOnlyCollection<ExportProvider>>() != null);
+                Debug.Assert(_readOnlyProviders != null);
 
                 return _readOnlyProviders;
             }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ApplicationCatalog.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ApplicationCatalog.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition.Primitives;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -167,8 +166,6 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         [DebuggerStepThrough]
-        [ContractArgumentValidator]
-        [SuppressMessage("Microsoft.Contracts", "CC1053", Justification = "Suppressing warning because this validator has no public contract")]
         private void ThrowIfDisposed()
         {
             if (_isDisposed)

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AssemblyCatalog.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AssemblyCatalog.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition.Primitives;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
@@ -468,7 +467,7 @@ namespace System.ComponentModel.Composition.Hosting
         {
             get
             {
-                Contract.Ensures(Contract.Result<Assembly>() != null);
+                Debug.Assert(_assembly != null);
 
                 return _assembly;
             }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CatalogExportProvider.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CatalogExportProvider.cs
@@ -8,7 +8,6 @@ using System.ComponentModel.Composition.Primitives;
 using System.ComponentModel.Composition.ReflectionModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -119,7 +118,7 @@ namespace System.ComponentModel.Composition.Hosting
             get
             {
                 ThrowIfDisposed();
-                Contract.Ensures(Contract.Result<ComposablePartCatalog>() != null);
+                Debug.Assert(_catalog != null);
 
                 return _catalog;
             }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ComposablePartCatalogChangeEventArgs.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ComposablePartCatalogChangeEventArgs.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.ComponentModel.Composition.Primitives;
-using System.Diagnostics.Contracts;
 using Microsoft.Internal;
 using Microsoft.Internal.Collections;
 
@@ -61,7 +61,7 @@ namespace System.ComponentModel.Composition.Hosting
         {
             get
             {
-                Contract.Ensures(Contract.Result<IEnumerable<ComposablePartDefinition>>() != null);
+                Debug.Assert(_addedDefinitions != null);
 
                 return _addedDefinitions;
             }
@@ -78,8 +78,8 @@ namespace System.ComponentModel.Composition.Hosting
         {
             get
             {
-                Contract.Ensures(Contract.Result<IEnumerable<ComposablePartDefinition>>() != null);
-                
+                Debug.Assert(_removedDefinitions != null);
+
                 return _removedDefinitions;
             }
         }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionBatch.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionBatch.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition.Primitives;
-using System.Diagnostics.Contracts;
 using Microsoft.Internal;
 
 namespace System.ComponentModel.Composition.Hosting
@@ -72,11 +72,10 @@ namespace System.ComponentModel.Composition.Hosting
         {
             get
             {
-                Contract.Ensures(Contract.Result<ReadOnlyCollection<ComposablePart>>() != null);
-
                 lock (_lock)
                 {
                     _copyNeededForAdd = true;
+                    Debug.Assert(_readOnlyPartsToAdd != null);
                     return _readOnlyPartsToAdd;
                 }
             }
@@ -90,11 +89,10 @@ namespace System.ComponentModel.Composition.Hosting
         {
             get
             {
-                Contract.Ensures(Contract.Result <ReadOnlyCollection<ComposablePart>>() != null);
-
                 lock (_lock)
                 {
                     _copyNeededForRemove = true;
+                    Debug.Assert(_readOnlyPartsToRemove != null);
                     return _readOnlyPartsToRemove;
                 }
             }
@@ -166,7 +164,6 @@ namespace System.ComponentModel.Composition.Hosting
         public ComposablePart AddExport(Export export)
         {
             Requires.NotNull(export, nameof(export));
-            Contract.Ensures(Contract.Result<ComposablePart>() != null);
 
             ComposablePart part = new SingleExportComposablePart(export);
 

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionContainer.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionContainer.cs
@@ -7,7 +7,6 @@ using System.Collections.ObjectModel;
 using System.ComponentModel.Composition.Primitives;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Threading;
 using Microsoft.Internal;
 
@@ -283,7 +282,7 @@ namespace System.ComponentModel.Composition.Hosting
             get
             {
                 ThrowIfDisposed();
-                Contract.Ensures(Contract.Result<ReadOnlyCollection<ExportProvider>>() != null);
+                Debug.Assert(_providers != null);
 
                 return _providers;
             }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/DirectoryCatalog.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/DirectoryCatalog.cs
@@ -8,7 +8,6 @@ using System.Composition.Diagnostics;
 using System.ComponentModel.Composition.Primitives;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -387,8 +386,8 @@ namespace System.ComponentModel.Composition.Hosting
         {
             get
             {
-                Contract.Ensures(Contract.Result<string>() != null);
-                
+                Debug.Assert(_fullPath != null);
+
                 return _fullPath;
             }
         }
@@ -400,10 +399,9 @@ namespace System.ComponentModel.Composition.Hosting
         {
             get
             {
-                Contract.Ensures(Contract.Result<ReadOnlyCollection<string>>() != null);
-
                 using (new ReadLock(_thisLock))
                 {
+                    Debug.Assert(_loadedFiles != null);
                     return _loadedFiles;
                 }
             }
@@ -416,8 +414,8 @@ namespace System.ComponentModel.Composition.Hosting
         {
             get
             {
-                Contract.Ensures(Contract.Result<string>() != null);
-                
+                Debug.Assert(_path != null);
+
                 return _path;
             }
         }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ExportProvider.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ExportProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition.Primitives;
-using System.Diagnostics.Contracts;
+using System.Diagnostics;
 using System.Globalization;
 using Microsoft.Internal;
 
@@ -97,13 +97,13 @@ namespace System.ComponentModel.Composition.Hosting
         public IEnumerable<Export> GetExports(ImportDefinition definition, AtomicComposition atomicComposition)
         {
             Requires.NotNull(definition, nameof(definition));
-            Contract.Ensures(Contract.Result<IEnumerable<Export>>() != null);
 
             IEnumerable<Export> exports;
             ExportCardinalityCheckResult result = TryGetExportsCore(definition, atomicComposition, out exports);
             switch(result)
             {
                 case ExportCardinalityCheckResult.Match:
+                    Debug.Assert(exports != null);
                     return exports;
                 case ExportCardinalityCheckResult.NoExports:
                     throw new ImportCardinalityMismatchException(SR.Format(SR.CardinalityMismatch_NoExports, definition));

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ExportsChangeEventArgs.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ExportsChangeEventArgs.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition.Primitives;
-using System.Diagnostics.Contracts;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Internal;
 using Microsoft.Internal.Collections;
@@ -64,7 +64,7 @@ namespace System.ComponentModel.Composition.Hosting
         {
             get
             {
-                Contract.Ensures(Contract.Result<IEnumerable<ExportDefinition>>() != null);
+                Debug.Assert(_addedExports != null);
 
                 return _addedExports;
             }
@@ -81,7 +81,7 @@ namespace System.ComponentModel.Composition.Hosting
         {
             get
             {
-                Contract.Ensures(Contract.Result<IEnumerable<ExportDefinition>>() != null);
+                Debug.Assert(_removedExports != null);
 
                 return _removedExports;
             }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ImportSourceImportDefinitionHelpers.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ImportSourceImportDefinitionHelpers.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition.Primitives;
-using System.Diagnostics.Contracts;
+using System.Diagnostics;
 using System.Linq.Expressions;
 using Microsoft.Internal;
 
@@ -50,8 +50,6 @@ namespace System.ComponentModel.Composition.Hosting
             {
                 get
                 {
-                    Contract.Ensures(Contract.Result<IDictionary<string, object>>() != null);
-
                     var reply = _metadata;
                     if(reply == null)
                     {
@@ -60,6 +58,7 @@ namespace System.ComponentModel.Composition.Hosting
                         _metadata = reply;
                     }
 
+                    Debug.Assert(reply != null);
                     return reply;
                 }
             }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ComposablePartCatalog.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ComposablePartCatalog.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading;
 using Microsoft.Internal;
@@ -102,7 +101,6 @@ namespace System.ComponentModel.Composition.Primitives
             ThrowIfDisposed();
 
             Requires.NotNull(definition, nameof(definition));
-            Contract.Ensures(Contract.Result<IEnumerable<Tuple<ComposablePartDefinition, ExportDefinition>>>() != null);
 
             List<Tuple<ComposablePartDefinition, ExportDefinition>> exports = null;
             var candidateParts = GetCandidateParts(definition);
@@ -120,6 +118,7 @@ namespace System.ComponentModel.Composition.Primitives
                 }
             }
 
+            Debug.Assert(exports != null || _EmptyExportsList != null);
             return exports ?? _EmptyExportsList;
         }
 

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ContractBasedImportDefinition.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ContractBasedImportDefinition.cs
@@ -4,8 +4,8 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition.Hosting;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
@@ -212,11 +212,10 @@ namespace System.ComponentModel.Composition.Primitives
         {
             get
             {
-                Contract.Ensures(Contract.Result<IEnumerable<KeyValuePair<string, Type>>>() != null);
-                
                 // NOTE : unlike other arguments, we validate this one as late as possible, because its validation may lead to type loading
                 ValidateRequiredMetadata();
 
+                Debug.Assert(_requiredMetadata != null);
                 return _requiredMetadata;
             }
         }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/Export.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/Export.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Threading;
 using Microsoft.Internal;
 
@@ -142,8 +142,6 @@ namespace System.ComponentModel.Composition.Primitives
         {
             get 
             {
-                Contract.Ensures(Contract.Result<ExportDefinition>() != null);
-                
                 if (_definition != null)
                 {
                     return _definition;
@@ -173,7 +171,7 @@ namespace System.ComponentModel.Composition.Primitives
         {
             get 
             {
-                Contract.Ensures(Contract.Result<IDictionary<string, object>>() != null);
+                Debug.Assert(Definition.Metadata != null);
 
                 return Definition.Metadata; 
             }        

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ExportDefinition.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ExportDefinition.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
+using System.Diagnostics;
 using Microsoft.Internal;
 
 namespace System.ComponentModel.Composition.Primitives
@@ -84,8 +84,6 @@ namespace System.ComponentModel.Composition.Primitives
         {
             get 
             {
-                Contract.Ensures(!string.IsNullOrEmpty(Contract.Result<string>()));
-
                 if (_contractName != null)
                 {
                     return _contractName;
@@ -119,7 +117,7 @@ namespace System.ComponentModel.Composition.Primitives
         {
             get 
             {
-                Contract.Ensures(Contract.Result<IDictionary<string, object>>() != null);
+                Debug.Assert(_metadata != null);
 
                 return _metadata; 
             }

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ImportDefinition.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ImportDefinition.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq.Expressions;
 using Microsoft.Internal;
@@ -133,7 +133,7 @@ namespace System.ComponentModel.Composition.Primitives
         {
             get 
             {
-                Contract.Ensures(Contract.Result<string>() != null);
+                Debug.Assert(_contractName != null);
 
                 return _contractName; 
             }
@@ -163,7 +163,7 @@ namespace System.ComponentModel.Composition.Primitives
         {
             get
             {
-                Contract.Ensures(Contract.Result<IDictionary<string, object>>() != null);
+                Debug.Assert(_metadata != null);
 
                 return _metadata;
             }
@@ -205,8 +205,6 @@ namespace System.ComponentModel.Composition.Primitives
         {
             get
             {
-                Contract.Ensures(Contract.Result<Expression<Func<ExportDefinition, bool>>>() != null);
-                
                 if (_constraint != null)
                 {
                     return _constraint;

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionModelServices.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionModelServices.cs
@@ -4,8 +4,8 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition.Primitives;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -18,7 +18,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         public static Lazy<Type> GetPartType(ComposablePartDefinition partDefinition)
         {
             Requires.NotNull(partDefinition, nameof(partDefinition));
-            Contract.Ensures(Contract.Result<Lazy<Type>>() != null);
 
             ReflectionComposablePartDefinition reflectionPartDefinition = partDefinition as ReflectionComposablePartDefinition;
             if (reflectionPartDefinition == null)
@@ -75,7 +74,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         public static Lazy<ParameterInfo> GetImportingParameter(ImportDefinition importDefinition)
         {
             Requires.NotNull(importDefinition, nameof(importDefinition));
-            Contract.Ensures(Contract.Result<Lazy<ParameterInfo>>() != null);
 
             ReflectionParameterImportDefinition reflectionParameterImportDefinition = importDefinition as ReflectionParameterImportDefinition;
             if (reflectionParameterImportDefinition == null)
@@ -85,6 +83,7 @@ namespace System.ComponentModel.Composition.ReflectionModel
                     nameof(importDefinition));
             }
 
+            Debug.Assert(reflectionParameterImportDefinition.ImportingLazyParameter != null);
             return reflectionParameterImportDefinition.ImportingLazyParameter;
         }
 
@@ -113,7 +112,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         public static ContractBasedImportDefinition GetExportFactoryProductImportDefinition(ImportDefinition importDefinition)
         {
             Requires.NotNull(importDefinition, nameof(importDefinition));
-            Contract.Ensures(Contract.Result<ContractBasedImportDefinition>() != null);
 
             IPartCreatorImportDefinition partCreatorImportDefinition = importDefinition as IPartCreatorImportDefinition;
             if (partCreatorImportDefinition == null)
@@ -136,7 +134,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
             ICompositionElement origin)
         {
             Requires.NotNull(partType, nameof(partType));
-            Contract.Ensures(Contract.Result<ComposablePartDefinition>() != null);
 
             return new ReflectionComposablePartDefinition(
                 new ReflectionPartCreationInfo(
@@ -157,7 +154,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         {
             Requires.NotNullOrEmpty(contractName, nameof(contractName));
             Requires.IsInMembertypeSet(exportingMember.MemberType, nameof(exportingMember), MemberTypes.Field | MemberTypes.Property | MemberTypes.NestedType | MemberTypes.TypeInfo | MemberTypes.Method);
-            Contract.Ensures(Contract.Result<ExportDefinition>() != null);
 
             return new ReflectionMemberExportDefinition(
                 exportingMember,
@@ -222,7 +218,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         {
             Requires.NotNullOrEmpty(contractName, nameof(contractName));
             Requires.IsInMembertypeSet(importingMember.MemberType, nameof(importingMember), MemberTypes.Property | MemberTypes.Field);
-            Contract.Ensures(Contract.Result<ContractBasedImportDefinition>() != null);
 
             if (isExportFactory)
             {
@@ -282,7 +277,6 @@ namespace System.ComponentModel.Composition.ReflectionModel
         {
             Requires.NotNull(parameter, nameof(parameter));
             Requires.NotNullOrEmpty(contractName, nameof(contractName));
-            Contract.Ensures(Contract.Result<ContractBasedImportDefinition>() != null);
 
             if (isExportFactory)
             {

--- a/src/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ImportSourceImportDefinitionHelpers.cs
+++ b/src/System.ComponentModel.Composition/tests/System/ComponentModel/Composition/ImportSourceImportDefinitionHelpers.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq.Expressions;
 using Microsoft.Internal;
-using System.Diagnostics.Contracts;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.Composition.Primitives;
@@ -51,8 +50,6 @@ namespace System.ComponentModel.Composition.Hosting
             {
                 get
                 {
-                    Contract.Ensures(Contract.Result<IDictionary<string, object>>() != null);
-
                     var reply = this._metadata;
                     if(reply == null)
                     {

--- a/src/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.IO;
 using System.Net.Http.Headers;
-using System.Diagnostics.Contracts;
 
 namespace System.Net.Http
 {
@@ -25,7 +24,6 @@ namespace System.Net.Http
             {
                 throw new ArgumentNullException(nameof(nameValueCollection));
             }
-            Contract.EndContractBlock();
 
             // Encode and concatenate data
             StringBuilder builder = new StringBuilder();

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.IO;
 using System.Net.Mail;
@@ -248,7 +247,7 @@ namespace System.Net.Http.Headers
 
             // Since we never re-use a "found" value in 'y', we expect 'alreadyFound' to have all fields set to 'true'.
             // Otherwise the two collections can't be equal and we should not get here.
-            Debug.Assert(Contract.ForAll(alreadyFound, value => { return value; }),
+            Debug.Assert(Array.TrueForAll(alreadyFound, value => value),
                 "Expected all values in 'alreadyFound' to be true since collections are considered equal.");
 
             return true;

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderParser.cs
@@ -4,7 +4,6 @@
 
 using System.Collections;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 
 namespace System.Net.Http.Headers
 {

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Text;
 
 namespace System.Net.Http.Headers
@@ -702,8 +701,6 @@ namespace System.Net.Http.Headers
 
         private HeaderStoreItemInfo GetOrCreateHeaderInfo(HeaderDescriptor descriptor, bool parseRawValues)
         {
-            Contract.Ensures(Contract.Result<HeaderStoreItemInfo>() != null);
-
             HeaderStoreItemInfo result = null;
             bool found = false;
             if (parseRawValues)
@@ -720,6 +717,7 @@ namespace System.Net.Http.Headers
                 result = CreateAndAddHeaderToStore(descriptor);
             }
 
+            Debug.Assert(result != null);
             return result;
         }
 
@@ -1182,8 +1180,6 @@ namespace System.Net.Http.Headers
 
         private static string[] GetValuesAsStrings(HeaderDescriptor descriptor, HeaderStoreItemInfo info, object exclude = null)
         {
-            Contract.Ensures(Contract.Result<string[]>() != null);
-
             int length = GetValueCount(info);
             string[] values;
 
@@ -1212,6 +1208,7 @@ namespace System.Net.Http.Headers
                 values = Array.Empty<string>();
             }
 
+            Debug.Assert(values != null);
             return values;
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Headers/RangeItemHeaderValue.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/RangeItemHeaderValue.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Globalization;
 
 namespace System.Net.Http.Headers
@@ -100,8 +99,6 @@ namespace System.Net.Http.Headers
         {
             Debug.Assert(rangeCollection != null);
             Debug.Assert(startIndex >= 0);
-            Contract.Ensures((Contract.Result<int>() == 0) || (rangeCollection.Count > 0),
-                "If we can parse the string, then we expect to have at least one range item.");
 
             if ((string.IsNullOrEmpty(input)) || (startIndex >= input.Length))
             {

--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -4,7 +4,6 @@
 
 using System.Buffers;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Text;
@@ -495,9 +494,6 @@ namespace System.Net.Http
 
         private MemoryStream CreateMemoryStream(long maxBufferSize, out Exception error)
         {
-            Contract.Ensures((Contract.Result<MemoryStream>() != null) ||
-                (Contract.ValueAtReturn<Exception>(out error) != null));
-
             error = null;
 
             // If we have a Content-Length allocate the right amount of buffer up-front. Also check whether the

--- a/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
@@ -75,7 +75,6 @@ namespace System.Net.Http
         internal static int GetTokenLength(string input, int startIndex)
         {
             Debug.Assert(input != null);
-            Contract.Ensures((Contract.Result<int>() >= 0) && (Contract.Result<int>() <= (input.Length - startIndex)));
 
             if (startIndex >= input.Length)
             {
@@ -133,7 +132,6 @@ namespace System.Net.Http
         internal static int GetWhitespaceLength(string input, int startIndex)
         {
             Debug.Assert(input != null);
-            Contract.Ensures((Contract.Result<int>() >= 0) && (Contract.Result<int>() <= (input.Length - startIndex)));
 
             if (startIndex >= input.Length)
             {
@@ -216,7 +214,6 @@ namespace System.Net.Http
         {
             Debug.Assert(input != null);
             Debug.Assert((startIndex >= 0) && (startIndex < input.Length));
-            Contract.Ensures((Contract.Result<int>() >= 0) && (Contract.Result<int>() <= (input.Length - startIndex)));
 
             int current = startIndex;
             char c;
@@ -261,7 +258,6 @@ namespace System.Net.Http
         {
             Debug.Assert(input != null);
             Debug.Assert(startIndex >= 0);
-            Contract.Ensures((Contract.Result<int>() >= 0) && (Contract.Result<int>() <= (input.Length - startIndex)));
 
             host = null;
             if (startIndex >= input.Length)
@@ -326,8 +322,6 @@ namespace System.Net.Http
         {
             Debug.Assert(input != null);
             Debug.Assert((startIndex >= 0) && (startIndex < input.Length));
-            Contract.Ensures((Contract.ValueAtReturn(out length) >= 0) &&
-                (Contract.ValueAtReturn(out length) <= (input.Length - startIndex)));
 
             length = 0;
 
@@ -364,8 +358,6 @@ namespace System.Net.Http
         {
             Debug.Assert(input != null);
             Debug.Assert((startIndex >= 0) && (startIndex < input.Length));
-            Contract.Ensures((Contract.Result<HttpParseResult>() != HttpParseResult.Parsed) ||
-                (Contract.ValueAtReturn<int>(out length) > 0));
 
             length = 0;
 

--- a/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Text;
@@ -49,7 +48,6 @@ namespace System.Net.Http
             {
                 throw new ArgumentException(SR.net_http_argument_empty_string, nameof(subtype));
             }
-            Contract.EndContractBlock();
             ValidateBoundary(boundary);
 
             _boundary = boundary;
@@ -90,7 +88,6 @@ namespace System.Net.Http
             {
                 throw new ArgumentException(SR.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, boundary), nameof(boundary));
             }
-            Contract.EndContractBlock();
 
             const string AllowedMarks = @"'()+_,-./:=? ";
 
@@ -121,7 +118,6 @@ namespace System.Net.Http
             {
                 throw new ArgumentNullException(nameof(content));
             }
-            Contract.EndContractBlock();
 
             _nestedContent.Add(content);
         }

--- a/src/System.Net.Http/src/System/Net/Http/MultipartFormDataContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MultipartFormDataContent.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Net.Http.Headers;
 
 namespace System.Net.Http
@@ -31,7 +30,6 @@ namespace System.Net.Http
             {
                 throw new ArgumentNullException(nameof(content));
             }
-            Contract.EndContractBlock();
 
             if (content.Headers.ContentDisposition == null)
             {
@@ -51,7 +49,6 @@ namespace System.Net.Http
             {
                 throw new ArgumentException(SR.net_http_argument_empty_string, nameof(name));
             }
-            Contract.EndContractBlock();
 
             AddInternal(content, name, null);
         }
@@ -70,7 +67,6 @@ namespace System.Net.Http
             {
                 throw new ArgumentException(SR.net_http_argument_empty_string, nameof(fileName));
             }
-            Contract.EndContractBlock();
 
             AddInternal(content, name, fileName);
         }

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/NetFxToWinRtStreamAdapter.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/NetFxToWinRtStreamAdapter.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Runtime.InteropServices;
@@ -142,8 +141,6 @@ namespace System.IO
         {
             Debug.Assert(stream != null);
             Debug.Assert(stream.CanRead || stream.CanWrite || stream.CanSeek);
-            Contract.EndContractBlock();
-
             Debug.Assert(!stream.CanRead || (stream.CanRead && this is IInputStream));
             Debug.Assert(!stream.CanWrite || (stream.CanWrite && this is IOutputStream));
             Debug.Assert(!stream.CanSeek || (stream.CanSeek && this is IRandomAccessStream));
@@ -252,10 +249,6 @@ namespace System.IO
                 throw ex;
             }
 
-            // Commented due to a reported CCRewrite bug. Should uncomment when fixed:
-            //Contract.Ensures(Contract.Result<IAsyncOperationWithProgress<IBuffer, UInt32>>() != null);
-            //Contract.EndContractBlock();
-
             Stream str = EnsureNotDisposed();
 
             IAsyncOperationWithProgress<IBuffer, uint> readAsyncOperation;
@@ -303,10 +296,6 @@ namespace System.IO
                 throw ex;
             }
 
-            // Commented due to a reported CCRewrite bug. Should uncomment when fixed:
-            //Contract.Ensures(Contract.Result<IAsyncOperationWithProgress<UInt32, UInt32>>() != null);
-            //Contract.EndContractBlock();
-
             Stream str = EnsureNotDisposed();
             return StreamOperationsImplementation.WriteAsync_AbstractStream(str, buffer);
         }
@@ -314,9 +303,6 @@ namespace System.IO
 
         public IAsyncOperation<bool> FlushAsync()
         {
-            Contract.Ensures(Contract.Result<IAsyncOperation<Boolean>>() != null);
-            Contract.EndContractBlock();
-
             Stream str = EnsureNotDisposed();
             return StreamOperationsImplementation.FlushAsync_AbstractStream(str);
         }
@@ -337,9 +323,6 @@ namespace System.IO
                 ex.SetErrorCode(__HResults.E_INVALIDARG);
                 throw ex;
             }
-
-            // Commented due to a reported CCRewrite bug. Should uncomment when fixed:
-            //Contract.EndContractBlock();
 
             Stream str = EnsureNotDisposed();
             long pos = unchecked((long)position);
@@ -376,8 +359,6 @@ namespace System.IO
         {
             get
             {
-                Contract.Ensures(Contract.Result<UInt64>() >= 0);
-
                 Stream str = EnsureNotDisposed();
                 return (ulong)str.Position;
             }
@@ -388,8 +369,6 @@ namespace System.IO
         {
             get
             {
-                Contract.Ensures(Contract.Result<UInt64>() >= 0);
-
                 Stream str = EnsureNotDisposed();
                 return (ulong)str.Length;
             }
@@ -402,9 +381,6 @@ namespace System.IO
                     ex.SetErrorCode(__HResults.E_INVALIDARG);
                     throw ex;
                 }
-
-                // Commented due to a reported CCRewrite bug. Should uncomment when fixed:
-                //Contract.EndContractBlock();
 
                 Stream str = EnsureNotDisposed();
 

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationsImplementation.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationsImplementation.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Runtime.InteropServices;
@@ -36,7 +35,6 @@ namespace System.IO
             Debug.Assert(0 <= count);
             Debug.Assert(count <= int.MaxValue);
             Debug.Assert(count <= buffer.Capacity);
-            Contract.EndContractBlock();
 
             // We will return a different buffer to the user backed directly by the memory stream (avoids memory copy).
             // This is permitted by the WinRT stream contract.
@@ -72,7 +70,6 @@ namespace System.IO
             Debug.Assert(count <= int.MaxValue);
             Debug.Assert(count <= buffer.Capacity);
             Debug.Assert(options == InputStreamOptions.None || options == InputStreamOptions.Partial || options == InputStreamOptions.ReadAhead);
-            Contract.EndContractBlock();
 
             int bytesRequested = (int)count;
 
@@ -166,7 +163,6 @@ namespace System.IO
             Debug.Assert(stream != null);
             Debug.Assert(stream.CanWrite);
             Debug.Assert(buffer != null);
-            Contract.EndContractBlock();
 
             // Choose the optimal writing strategy for the kind of buffer supplied:
             Func<CancellationToken, IProgress<uint>, Task<uint>> writeOperation;
@@ -230,7 +226,6 @@ namespace System.IO
         {
             Debug.Assert(stream != null);
             Debug.Assert(stream.CanWrite);
-            Contract.EndContractBlock();
 
             Func<CancellationToken, Task<bool>> flushOperation = async (cancelToken) =>
             {

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
@@ -81,7 +81,6 @@ namespace System.IO
                                     (winRtStream is IRandomAccessStream && !((IRandomAccessStream)winRtStream).CanWrite)
                                ))
                              );
-            Contract.EndContractBlock();
 
             _winRtStream = winRtStream;
             _canRead = canRead;
@@ -285,7 +284,6 @@ namespace System.IO
             {
                 if (value < 0)
                     throw new ArgumentOutOfRangeException("Position", SR.ArgumentOutOfRange_IO_CannotSeekToNegativePosition);
-                Contract.EndContractBlock();
 
                 IRandomAccessStream wrtStr = EnsureNotDisposed<IRandomAccessStream>();
 
@@ -388,7 +386,6 @@ namespace System.IO
         {
             if (value < 0)
                 throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_CannotResizeStreamToNegative);
-            Contract.EndContractBlock();
 
             IRandomAccessStream wrtStr = EnsureNotDisposed<IRandomAccessStream>();
 
@@ -451,8 +448,6 @@ namespace System.IO
             if (buffer.Length - offset < count)
                 throw new ArgumentException(SR.Argument_InsufficientSpaceInTargetBuffer);
 
-            Contract.EndContractBlock();
-
             IInputStream wrtStr = EnsureNotDisposed<IInputStream>();
             EnsureCanRead();
 
@@ -481,8 +476,6 @@ namespace System.IO
         {
             if (asyncResult == null)
                 throw new ArgumentNullException(nameof(asyncResult));
-
-            Contract.EndContractBlock();
 
             EnsureNotDisposed();
             EnsureCanRead();
@@ -537,8 +530,6 @@ namespace System.IO
             if (buffer.Length - offset < count)
                 throw new ArgumentException(SR.Argument_InsufficientSpaceInTargetBuffer);
 
-            Contract.EndContractBlock();
-
             EnsureNotDisposed();
             EnsureCanRead();
 
@@ -562,10 +553,6 @@ namespace System.IO
 
         public override int ReadByte()
         {
-            Contract.Ensures(Contract.Result<int>() >= -1);
-            Contract.Ensures(Contract.Result<int>() < 256);
-            Contract.EndContractBlock();
-
             // EnsureNotDisposed will be called in Read->BeginRead.
 
             byte[] oneByteArray = OneByteBuffer;
@@ -605,8 +592,6 @@ namespace System.IO
             if (buffer.Length - offset < count)
                 throw new ArgumentException(SR.Argument_InsufficientArrayElementsAfterOffset);
 
-            Contract.EndContractBlock();
-
             IOutputStream wrtStr = EnsureNotDisposed<IOutputStream>();
             EnsureCanWrite();
 
@@ -634,8 +619,6 @@ namespace System.IO
         {
             if (asyncResult == null)
                 throw new ArgumentNullException(nameof(asyncResult));
-
-            Contract.EndContractBlock();
 
             EnsureNotDisposed();
             EnsureCanWrite();
@@ -682,8 +665,6 @@ namespace System.IO
 
             if (buffer.Length - offset < count)
                 throw new ArgumentException(SR.Argument_InsufficientArrayElementsAfterOffset);
-
-            Contract.EndContractBlock();
 
             IOutputStream wrtStr = EnsureNotDisposed<IOutputStream>();
             EnsureCanWrite();

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStreamExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WindowsRuntimeStreamExtensions.cs
@@ -6,7 +6,6 @@ extern alias System_Runtime_Extensions;
 
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -139,8 +138,6 @@ namespace System.IO
                 throw new ArgumentOutOfRangeException(nameof(bufferSize), SR.ArgumentOutOfRange_WinRtAdapterBufferSizeMayNotBeNegative);
 
             Debug.Assert(!string.IsNullOrWhiteSpace(invokedMethodName));
-            Contract.Ensures(Contract.Result<Stream>() != null);
-            Contract.EndContractBlock();
 
             // If the WinRT stream is actually a wrapped managed stream, we will unwrap it and return the original.
             // In that case we do not need to put the wrapper into the map.
@@ -207,9 +204,6 @@ namespace System.IO
             Debug.Assert(bufferSize >= 0);
             Debug.Assert(!string.IsNullOrWhiteSpace(invokedMethodName));
 
-            Contract.Ensures(Contract.Result<Stream>() != null);
-            Contract.EndContractBlock();
-
             // Get the adapter for this windowsRuntimeStream again (it may have been created concurrently).
             // If none exists yet, create a new one:
             Stream adapter = (bufferSize == 0)
@@ -246,9 +240,6 @@ namespace System.IO
             if (!stream.CanRead)
                 throw new NotSupportedException(SR.NotSupported_CannotConvertNotReadableToInputStream);
 
-            Contract.Ensures(Contract.Result<IInputStream>() != null);
-            Contract.EndContractBlock();
-
             object adapter = AsWindowsRuntimeStreamInternal(stream);
 
             IInputStream winRtStream = adapter as IInputStream;
@@ -266,9 +257,6 @@ namespace System.IO
 
             if (!stream.CanWrite)
                 throw new NotSupportedException(SR.NotSupported_CannotConvertNotWritableToOutputStream);
-
-            Contract.Ensures(Contract.Result<IOutputStream>() != null);
-            Contract.EndContractBlock();
 
             object adapter = AsWindowsRuntimeStreamInternal(stream);
 
@@ -288,9 +276,6 @@ namespace System.IO
             if (!stream.CanSeek)
                 throw new NotSupportedException(SR.NotSupported_CannotConvertNotSeekableToRandomAccessStream);
 
-            Contract.Ensures(Contract.Result<IRandomAccessStream>() != null);
-            Contract.EndContractBlock();
-
             object adapter = AsWindowsRuntimeStreamInternal(stream);
 
             IRandomAccessStream winRtStream = adapter as IRandomAccessStream;
@@ -302,9 +287,6 @@ namespace System.IO
 
         private static object AsWindowsRuntimeStreamInternal(Stream stream)
         {
-            Contract.Ensures(Contract.Result<Object>() != null);
-            Contract.EndContractBlock();
-
             // Check to see if the managed stream is actually a wrapper of a WinRT stream:
             // (This can be either an adapter directly, or an adapter wrapped in a BufferedStream.)
             WinRtToNetFxStreamAdapter sAdptr = stream as WinRtToNetFxStreamAdapter;
@@ -349,8 +331,6 @@ namespace System.IO
         private static NetFxToWinRtStreamAdapter AsWindowsRuntimeStreamInternalFactoryHelper(Stream stream)
         {
             Debug.Assert(stream != null);
-            Contract.Ensures(Contract.Result<NetFxToWinRtStreamAdapter>() != null);
-            Contract.EndContractBlock();
 
             // Get the adapter for managed stream again (it may have been created concurrently).
             // If none exists yet, create a new one:

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/AsyncInfo.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/AsyncInfo.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,8 +36,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (taskProvider == null)
                 throw new ArgumentNullException(nameof(taskProvider));
 
-            Contract.EndContractBlock();
-
             return new TaskToAsyncActionAdapter(taskProvider);
         }
 
@@ -62,8 +59,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (taskProvider == null)
                 throw new ArgumentNullException(nameof(taskProvider));
 
-            Contract.EndContractBlock();
-
             return new TaskToAsyncActionWithProgressAdapter<TProgress>(taskProvider);
         }
 
@@ -85,8 +80,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
             if (taskProvider == null)
                 throw new ArgumentNullException(nameof(taskProvider));
-
-            Contract.EndContractBlock();
 
             return new TaskToAsyncOperationAdapter<TResult>(taskProvider);
         }
@@ -113,8 +106,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (taskProvider == null)
                 throw new ArgumentNullException(nameof(taskProvider));
-
-            Contract.EndContractBlock();
 
             return new TaskToAsyncOperationWithProgressAdapter<TResult, TProgress>(taskProvider);
         }
@@ -160,7 +151,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (error == null)
                 throw new ArgumentNullException(nameof(error));
-            Contract.EndContractBlock();
 
             var asyncInfo = new TaskToAsyncActionAdapter(isCanceled: false);
 
@@ -175,7 +165,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (error == null)
                 throw new ArgumentNullException(nameof(error));
-            Contract.EndContractBlock();
 
             var asyncInfo = new TaskToAsyncActionWithProgressAdapter<TProgress>(isCanceled: false);
 
@@ -190,7 +179,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (error == null)
                 throw new ArgumentNullException(nameof(error));
-            Contract.EndContractBlock();
 
             var asyncInfo = new TaskToAsyncOperationAdapter<TResult>(default(TResult));
 
@@ -205,7 +193,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (error == null)
                 throw new ArgumentNullException(nameof(error));
-            Contract.EndContractBlock();
 
             var asyncInfo = new TaskToAsyncOperationWithProgressAdapter<TResult, TProgress>(default(TResult));
 

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBuffer.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBuffer.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -37,11 +36,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (capacity < 0) throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            Contract.Ensures(Contract.Result<IBuffer>() != null);
-            Contract.Ensures(Contract.Result<IBuffer>().Length == unchecked((uint)0));
-            Contract.Ensures(Contract.Result<IBuffer>().Capacity == unchecked((uint)capacity));
-            Contract.EndContractBlock();
-
             return new WindowsRuntimeBuffer(capacity);
         }
 
@@ -56,12 +50,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (data.Length - offset < length) throw new ArgumentException(SR.Argument_InsufficientArrayElementsAfterOffset);
             if (data.Length - offset < capacity) throw new ArgumentException(SR.Argument_InsufficientArrayElementsAfterOffset);
             if (capacity < length) throw new ArgumentException(SR.Argument_InsufficientBufferCapacity);
-
-            Contract.Ensures(Contract.Result<IBuffer>() != null);
-            Contract.Ensures(Contract.Result<IBuffer>().Length == unchecked((uint)length));
-            Contract.Ensures(Contract.Result<IBuffer>().Capacity == unchecked((uint)capacity));
-
-            Contract.EndContractBlock();
 
             byte[] underlyingData = new byte[capacity];
             Buffer.BlockCopy(data, offset, underlyingData, 0, length);
@@ -130,8 +118,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity));
 
-            Contract.EndContractBlock();
-
             _data = new byte[capacity];
             _dataStartOffs = 0;
             _usefulDataLength = 0;
@@ -149,7 +135,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (data.Length - offset < length) throw new ArgumentException(SR.Argument_InsufficientArrayElementsAfterOffset);
             if (data.Length - offset < capacity) throw new ArgumentException(SR.Argument_InsufficientArrayElementsAfterOffset);
             if (capacity < length) throw new ArgumentException(SR.Argument_InsufficientBufferCapacity);
-            Contract.EndContractBlock();
 
             _data = data;
             _dataStartOffs = offset;

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBufferExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBufferExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.Contracts;
 using System.Diagnostics;
 using System.IO;
 using Windows.Foundation;
@@ -22,11 +21,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
 
-            Contract.Ensures(Contract.Result<IBuffer>() != null);
-            Contract.Ensures(Contract.Result<IBuffer>().Length == unchecked((uint)source.Length));
-            Contract.Ensures(Contract.Result<IBuffer>().Capacity == unchecked((uint)source.Length));
-            Contract.EndContractBlock();
-
             return AsBuffer(source, 0, source.Length, source.Length);
         }
 
@@ -38,11 +32,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
             if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
             if (source.Length - offset < length) throw new ArgumentException(SR.Argument_InsufficientArrayElementsAfterOffset);
-
-            Contract.Ensures(Contract.Result<IBuffer>() != null);
-            Contract.Ensures(Contract.Result<IBuffer>().Length == unchecked((uint)length));
-            Contract.Ensures(Contract.Result<IBuffer>().Capacity == unchecked((uint)length));
-            Contract.EndContractBlock();
 
             return AsBuffer(source, offset, length, length);
         }
@@ -58,11 +47,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (source.Length - offset < length) throw new ArgumentException(SR.Argument_InsufficientArrayElementsAfterOffset);
             if (source.Length - offset < capacity) throw new ArgumentException(SR.Argument_InsufficientArrayElementsAfterOffset);
             if (capacity < length) throw new ArgumentException(SR.Argument_InsufficientBufferCapacity);
-
-            Contract.Ensures(Contract.Result<IBuffer>() != null);
-            Contract.Ensures(Contract.Result<IBuffer>().Length == unchecked((uint)length));
-            Contract.Ensures(Contract.Result<IBuffer>().Capacity == unchecked((uint)capacity));
-            Contract.EndContractBlock();
 
             return new WindowsRuntimeBuffer(source, offset, length, capacity);
         }
@@ -83,7 +67,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (destination == null) throw new ArgumentNullException(nameof(destination));
-            Contract.EndContractBlock();
 
             CopyTo(source, 0, destination, 0, source.Length);
         }
@@ -109,7 +92,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (source.Length <= sourceIndex) throw new ArgumentException(SR.Argument_IndexOutOfArrayBounds, nameof(sourceIndex));
             if (source.Length - sourceIndex < count) throw new ArgumentException(SR.Argument_InsufficientArrayElementsAfterOffset);
             if (destination.Capacity - destinationIndex < count) throw new ArgumentException(SR.Argument_InsufficientSpaceInTargetBuffer);
-            Contract.EndContractBlock();
 
             // If destination is backed by a managed array, use the array instead of the pointer as it does not require pinning:
             byte[] destDataArr;
@@ -133,7 +115,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         public static byte[] ToArray(this IBuffer source)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            Contract.EndContractBlock();
 
             return ToArray(source, 0, checked((int)source.Length));
         }
@@ -146,7 +127,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
             if (source.Capacity <= sourceIndex) throw new ArgumentException(SR.Argument_BufferIndexExceedsCapacity);
             if (source.Capacity - sourceIndex < count) throw new ArgumentException(SR.Argument_InsufficientSpaceInSourceBuffer);
-            Contract.EndContractBlock();
 
             if (count == 0)
                 return Array.Empty<Byte>();
@@ -166,7 +146,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (destination == null) throw new ArgumentNullException(nameof(destination));
-            Contract.EndContractBlock();
 
             CopyTo(source, 0, destination, 0, checked((int)source.Length));
         }
@@ -183,7 +162,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (source.Capacity - sourceIndex < count) throw new ArgumentException(SR.Argument_InsufficientSpaceInSourceBuffer);
             if (destination.Length <= destinationIndex) throw new ArgumentException(SR.Argument_IndexOutOfArrayBounds);
             if (destination.Length - destinationIndex < count) throw new ArgumentException(SR.Argument_InsufficientArrayElementsAfterOffset);
-            Contract.EndContractBlock();
 
             // If source is backed by a managed array, use the array instead of the pointer as it does not require pinning:
             byte[] srcDataArr;
@@ -208,7 +186,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (destination == null) throw new ArgumentNullException(nameof(destination));
-            Contract.EndContractBlock();
 
             CopyTo(source, 0, destination, 0, source.Length);
         }
@@ -223,7 +200,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (source.Capacity - sourceIndex < count) throw new ArgumentException(SR.Argument_InsufficientSpaceInSourceBuffer);
             if (destination.Capacity <= destinationIndex) throw new ArgumentException(SR.Argument_BufferIndexExceedsCapacity);
             if (destination.Capacity - destinationIndex < count) throw new ArgumentException(SR.Argument_InsufficientSpaceInTargetBuffer);
-            Contract.EndContractBlock();
 
             // If source are destination are backed by managed arrays, use the arrays instead of the pointers as it does not require pinning:
             byte[] srcDataArr, destDataArr;
@@ -292,8 +268,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer));
 
-            Contract.EndContractBlock();
-
             WindowsRuntimeBuffer winRtBuffer = buffer as WindowsRuntimeBuffer;
             if (winRtBuffer == null)
             {
@@ -322,8 +296,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer));
-
-            Contract.EndContractBlock();
 
             if (otherBuffer == null)
                 return false;
@@ -374,11 +346,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (underlyingStream == null)
                 throw new ArgumentNullException(nameof(underlyingStream));
 
-            Contract.Ensures(Contract.Result<IBuffer>() != null);
-            Contract.Ensures(Contract.Result<IBuffer>().Length == underlyingStream.Length);
-            Contract.Ensures(Contract.Result<IBuffer>().Capacity == underlyingStream.Capacity);
-
-            Contract.EndContractBlock();
             ArraySegment<byte> streamData;
             if (!underlyingStream.TryGetBuffer(out streamData))
             {
@@ -422,11 +389,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             if (underlyingStream.Capacity <= positionInStream)
                 throw new ArgumentException(SR.Argument_StreamPositionBeyondEOS);
 
-            Contract.Ensures(Contract.Result<IBuffer>() != null);
-            Contract.Ensures(Contract.Result<IBuffer>().Length == length);
-            Contract.Ensures(Contract.Result<IBuffer>().Capacity == length);
-
-            Contract.EndContractBlock();
             ArraySegment<byte> streamData;
 
             if (!underlyingStream.TryGetBuffer(out streamData))
@@ -446,11 +408,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-
-            Contract.Ensures(Contract.Result<Stream>() != null);
-            Contract.Ensures(Contract.Result<Stream>().Length == (uint)source.Capacity);
-
-            Contract.EndContractBlock();
 
             byte[] dataArr;
             int dataOffs;
@@ -477,8 +434,6 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (source.Capacity <= byteOffset) throw new ArgumentException(SR.Argument_BufferIndexExceedsCapacity, nameof(byteOffset));
-
-            Contract.EndContractBlock();
 
             byte[] srcDataArr;
             int srcDataOffs;

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.CoreCLR.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.CoreCLR.cs
@@ -6,7 +6,6 @@ using Internal.Runtime.InteropServices.WindowsRuntime;
 using Internal.Threading.Tasks;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -120,8 +119,6 @@ namespace System.Threading.Tasks
             if (asyncInfo == null)
                 throw new ArgumentNullException(nameof(asyncInfo));
 
-            Contract.EndContractBlock();
-            
             AsyncCausalitySupport.RemoveFromActiveTasks(this.Task);
 
             try

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.CoreRT.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/AsyncInfoToTaskBridge.CoreRT.cs
@@ -5,7 +5,6 @@
 using Internal.Interop;
 using Internal.Threading.Tasks;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 using Windows.Foundation;
 
@@ -119,8 +118,6 @@ namespace System.Threading.Tasks
             if (asyncInfo == null)
                 throw new ArgumentNullException(nameof(asyncInfo));
 
-            Contract.EndContractBlock();
-            
             AsyncCausalitySupport.RemoveFromActiveTasks(this.Task);
 
             try

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/TaskToAsyncInfoAdapter.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/Tasks/TaskToAsyncInfoAdapter.cs
@@ -128,10 +128,6 @@ namespace System.Threading.Tasks
                             || (null != (taskProvider as Func<IProgress<TProgressInfo>, Task>))
                             || (null != (taskProvider as Func<CancellationToken, IProgress<TProgressInfo>, Task>)));
 
-            Contract.Ensures(!this.CompletedSynchronously);
-
-            Contract.EndContractBlock();
-
             // The IAsyncInfo is reasonably expected to be created/started by the same code that wires up the Completed and Progress handlers.
             // Record the current SynchronizationContext so that we can invoke completion and progress callbacks in it later.
             _startingContext = GetStartingContext();
@@ -175,10 +171,6 @@ namespace System.Threading.Tasks
             if (underlyingTask.Status == TaskStatus.Created)
                 throw new InvalidOperationException(SR.InvalidOperation_UnstartedTaskSpecified);
 
-            Contract.Ensures(!this.CompletedSynchronously);
-
-            Contract.EndContractBlock();
-
             // The IAsyncInfo is reasonably expected to be created/started by the same code that wires up the Completed and Progress handlers.
             // Record the current SynchronizationContext so that we can invoke completion and progress callbacks in it later.
             _startingContext = GetStartingContext();
@@ -209,9 +201,6 @@ namespace System.Threading.Tasks
         /// <param name="synchronousResult">The result of this synchronously completed IAsyncInfo.</param>
         internal TaskToAsyncInfoAdapter(TResult synchronousResult)
         {
-            Contract.Ensures(this.CompletedSynchronously);
-            Contract.Ensures(this.IsInRunToCompletionState);
-
             // We already completed. There will be no progress callback invokations and a potential completed handler invokation will be synchronous.
             // We do not need the starting SynchronizationContext:
             _startingContext = null;
@@ -368,8 +357,6 @@ namespace System.Threading.Tasks
             get
             {
                 EnsureNotClosed();
-                Contract.Ensures(CompletedSynchronously || Contract.Result<Task>() != null);
-                Contract.EndContractBlock();
 
                 if (CompletedSynchronously)
                     return null;
@@ -761,8 +748,6 @@ namespace System.Threading.Tasks
 
         private Task InvokeTaskProvider(Delegate taskProvider)
         {
-            Contract.EndContractBlock();
-
             var funcVoidTask = taskProvider as Func<Task>;
             if (funcVoidTask != null)
             {

--- a/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Threading/WindowsRuntimeSynchronizationContext.cs
@@ -5,7 +5,6 @@
 using Internal.Runtime.InteropServices.WindowsRuntime;
 using System;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Diagnostics.Tracing;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -118,7 +117,6 @@ namespace System.Threading
         {
             if (d == null)
                 throw new ArgumentNullException(nameof(d));
-            Contract.EndContractBlock();
 
             var ignored = _dispatcher.RunAsync(CoreDispatcherPriority.Normal, new Invoker(d, state).Invoke);
         }
@@ -141,7 +139,6 @@ namespace System.Threading
         {
             if (d == null)
                 throw new ArgumentNullException(nameof(d));
-            Contract.EndContractBlock();
 
             // We explicitly choose to ignore the return value here. This enqueue operation might fail if the 
             // dispatcher queue was shut down before we got here. In that case, we choose to just move on and

--- a/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.CoreCLR.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.CoreCLR.cs
@@ -5,7 +5,6 @@
 using Internal.Runtime.InteropServices.WindowsRuntime;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
@@ -87,8 +86,6 @@ namespace System
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            Contract.EndContractBlock();
-
             // If source is actually a NetFx-to-WinRT adapter, unwrap it instead of creating a new Task:
             var wrapper = source as TaskToAsyncActionAdapter;
             if (wrapper != null && !wrapper.CompletedSynchronously)
@@ -162,8 +159,6 @@ namespace System
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-
-            Contract.EndContractBlock();
 
             // If source is actually a NetFx-to-WinRT adapter, unwrap it instead of creating a new Task:
             var wrapper = source as TaskToAsyncOperationAdapter<TResult>;
@@ -261,8 +256,6 @@ namespace System
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-
-            Contract.EndContractBlock();
 
             // If source is actually a NetFx-to-WinRT adapter, unwrap it instead of creating a new Task:
             var wrapper = source as TaskToAsyncActionWithProgressAdapter<TProgress>;
@@ -371,8 +364,6 @@ namespace System
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            Contract.EndContractBlock();
-
             // If source is actually a NetFx-to-WinRT adapter, unwrap it instead of creating a new Task:
             var wrapper = source as TaskToAsyncOperationWithProgressAdapter<TResult, TProgress>;
             if (wrapper != null && !wrapper.CompletedSynchronously)
@@ -436,8 +427,6 @@ namespace System
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            Contract.EndContractBlock();
-
             return new TaskToAsyncActionAdapter(source, underlyingCancelTokenSource: null);
         }
 
@@ -446,8 +435,6 @@ namespace System
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-
-            Contract.EndContractBlock();
 
             return new TaskToAsyncOperationAdapter<TResult>(source, underlyingCancelTokenSource: null);
         }

--- a/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.CoreRT.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/WindowsRuntimeSystemExtensions.CoreRT.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Diagnostics.Contracts;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -88,8 +87,6 @@ namespace System
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            Contract.EndContractBlock();
-
             // If source is actually a NetFx-to-WinRT adapter, unwrap it instead of creating a new Task:
             var wrapper = source as TaskToAsyncActionAdapter;
             if (wrapper != null && !wrapper.CompletedSynchronously)
@@ -169,8 +166,6 @@ namespace System
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-
-            Contract.EndContractBlock();
 
             // If source is actually a NetFx-to-WinRT adapter, unwrap it instead of creating a new Task:
             var wrapper = source as TaskToAsyncOperationAdapter<TResult>;
@@ -273,8 +268,6 @@ namespace System
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-
-            Contract.EndContractBlock();
 
             // If source is actually a NetFx-to-WinRT adapter, unwrap it instead of creating a new Task:
             var wrapper = source as TaskToAsyncActionWithProgressAdapter<TProgress>;
@@ -388,8 +381,6 @@ namespace System
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            Contract.EndContractBlock();
-
             // If source is actually a NetFx-to-WinRT adapter, unwrap it instead of creating a new Task:
             var wrapper = source as TaskToAsyncOperationWithProgressAdapter<TResult, TProgress>;
             if (wrapper != null && !wrapper.CompletedSynchronously)
@@ -458,8 +449,6 @@ namespace System
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            Contract.EndContractBlock();
-
             return new TaskToAsyncActionAdapter(source, underlyingCancelTokenSource: null);
         }
 
@@ -468,8 +457,6 @@ namespace System
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-
-            Contract.EndContractBlock();
 
             return new TaskToAsyncOperationAdapter<TResult>(source, underlyingCancelTokenSource: null);
         }

--- a/src/System.Runtime/tests/System/EnumTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/EnumTests.netcoreapp.cs
@@ -95,7 +95,6 @@ namespace System.Tests
         [MemberData(nameof(UnsupportedEnumType_TestData))]
         public static void IsDefined_UnsupportedEnumType_ThrowsInvalidOperationException(Type enumType, object value)
         {
-            // A Contract.Assert(false, "...") is hit for certain unsupported primitives
             Exception ex = Assert.ThrowsAny<Exception>(() => Enum.IsDefined(enumType, value));
             string exName = ex.GetType().Name;
             Assert.True(exName == nameof(InvalidOperationException) || exName == "ContractException");
@@ -117,7 +116,6 @@ namespace System.Tests
         [MemberData(nameof(UnsupportedEnum_TestData))]
         public static void ToString_UnsupportedEnumType_ThrowsArgumentException(Enum e)
         {
-            // A Contract.Assert(false, "...") is hit for certain unsupported primitives
             Exception formatXException = Assert.ThrowsAny<Exception>(() => e.ToString("X"));
             string formatXExceptionName = formatXException.GetType().Name;
             Assert.True(formatXExceptionName == nameof(InvalidOperationException) || formatXExceptionName == "ContractException");
@@ -127,7 +125,6 @@ namespace System.Tests
         [MemberData(nameof(UnsupportedEnumType_TestData))]
         public static void Format_UnsupportedEnumType_ThrowsArgumentException(Type enumType, object value)
         {
-            // A Contract.Assert(false, "...") is hit for certain unsupported primitives
             Exception formatGException = Assert.ThrowsAny<Exception>(() => Enum.Format(enumType, value, "G"));
             string formatGExceptionName = formatGException.GetType().Name;
             Assert.True(formatGExceptionName == nameof(InvalidOperationException) || formatGExceptionName == "ContractException");

--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
@@ -14,7 +14,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks.Dataflow.Internal;
 
@@ -43,7 +42,6 @@ namespace System.Threading.Tasks.Dataflow
             // Validate arguments
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (target == null) throw new ArgumentNullException(nameof(target));
-            Contract.EndContractBlock();
 
             // This method exists purely to pass default DataflowLinkOptions 
             // to increase usability of the "90%" case.
@@ -88,7 +86,6 @@ namespace System.Threading.Tasks.Dataflow
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (linkOptions == null) throw new ArgumentNullException(nameof(linkOptions));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-            Contract.EndContractBlock();
 
             // Create the filter, which links to the real target, and then
             // link the real source to this intermediate filter.
@@ -142,7 +139,6 @@ namespace System.Threading.Tasks.Dataflow
                 // is an internal target that should only ever have source non-null.
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
                 if (source == null) throw new ArgumentNullException(nameof(source));
-                Contract.EndContractBlock();
 
                 // Run the filter.
                 bool passedFilter = RunPredicate(messageValue);
@@ -300,7 +296,6 @@ namespace System.Threading.Tasks.Dataflow
         {
             // Validate arguments.  No validation necessary for item.
             if (target == null) throw new ArgumentNullException(nameof(target));
-            Contract.EndContractBlock();
 
             // Fast path check for cancellation
             if (cancellationToken.IsCancellationRequested)
@@ -633,7 +628,6 @@ namespace System.Threading.Tasks.Dataflow
                 // Validate arguments
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
                 if (target == null) throw new ArgumentNullException(nameof(target));
-                Contract.EndContractBlock();
 
                 // If the task has already completed, there's nothing to consume.  This could happen if
                 // cancellation was already requested and completed the task as a result.
@@ -679,7 +673,6 @@ namespace System.Threading.Tasks.Dataflow
                 // Validate arguments
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
                 if (target == null) throw new ArgumentNullException(nameof(target));
-                Contract.EndContractBlock();
 
                 // If the task has already completed, such as due to cancellation, there's nothing to reserve.
                 if (Task.IsCompleted) return false;
@@ -697,7 +690,6 @@ namespace System.Threading.Tasks.Dataflow
                 // Validate arguments
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
                 if (target == null) throw new ArgumentNullException(nameof(target));
-                Contract.EndContractBlock();
 
                 // If this is not the message we posted, bail
                 if (messageHeader.Id != Common.SINGLE_MESSAGE_ID)
@@ -786,7 +778,6 @@ namespace System.Threading.Tasks.Dataflow
         public static bool TryReceive<TOutput>(this IReceivableSourceBlock<TOutput> source, out TOutput item)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            Contract.EndContractBlock();
 
             return source.TryReceive(null, out item);
         }
@@ -1174,7 +1165,6 @@ namespace System.Threading.Tasks.Dataflow
                 // Validate arguments
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
                 if (source == null && consumeToAccept) throw new ArgumentException(SR.Argument_CantConsumeFromANullSource, nameof(consumeToAccept));
-                Contract.EndContractBlock();
 
                 DataflowMessageStatus status = DataflowMessageStatus.NotAvailable;
 
@@ -1442,7 +1432,6 @@ namespace System.Threading.Tasks.Dataflow
         {
             // Validate arguments
             if (source == null) throw new ArgumentNullException(nameof(source));
-            Contract.EndContractBlock();
 
             // Fast path for cancellation
             if (cancellationToken.IsCancellationRequested)
@@ -1563,7 +1552,6 @@ namespace System.Threading.Tasks.Dataflow
             {
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
                 if (source == null) throw new ArgumentNullException(nameof(source));
-                Contract.EndContractBlock();
 
                 TrySetResult(true);
                 return DataflowMessageStatus.DecliningPermanently;
@@ -1579,7 +1567,6 @@ namespace System.Threading.Tasks.Dataflow
             void IDataflowBlock.Fault(Exception exception)
             {
                 if (exception == null) throw new ArgumentNullException(nameof(exception));
-                Contract.EndContractBlock();
                 TrySetResult(false);
             }
 
@@ -1620,7 +1607,6 @@ namespace System.Threading.Tasks.Dataflow
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (source == null) throw new ArgumentNullException(nameof(source));
-            Contract.EndContractBlock();
             return new EncapsulatingPropagator<TInput, TOutput>(target, source);
         }
 
@@ -1652,7 +1638,6 @@ namespace System.Threading.Tasks.Dataflow
             void IDataflowBlock.Fault(Exception exception)
             {
                 if (exception == null) throw new ArgumentNullException(nameof(exception));
-                Contract.EndContractBlock();
 
                 _target.Fault(exception);
             }
@@ -2227,7 +2212,6 @@ namespace System.Threading.Tasks.Dataflow
                 // Validate arguments
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
                 if (source == null && consumeToAccept) throw new ArgumentException(SR.Argument_CantConsumeFromANullSource, nameof(consumeToAccept));
-                Contract.EndContractBlock();
 
                 lock (_completed)
                 {
@@ -2286,7 +2270,6 @@ namespace System.Threading.Tasks.Dataflow
         public static IObservable<TOutput> AsObservable<TOutput>(this ISourceBlock<TOutput> source)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            Contract.EndContractBlock();
             return SourceObservable<TOutput>.From(source);
         }
 
@@ -2353,7 +2336,6 @@ namespace System.Threading.Tasks.Dataflow
             {
                 // Validate arguments
                 if (observer == null) throw new ArgumentNullException(nameof(observer));
-                Contract.EndContractBlock();
                 Common.ContractAssertMonitorStatus(_SubscriptionLock, held: false);
 
                 Task sourceCompletionTask = Common.GetPotentiallyNotSupportedCompletionTask(_source);
@@ -2663,7 +2645,6 @@ namespace System.Threading.Tasks.Dataflow
         public static IObserver<TInput> AsObserver<TInput>(this ITargetBlock<TInput> target)
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
-            Contract.EndContractBlock();
             return new TargetObserver<TInput>(target);
         }
 
@@ -2753,7 +2734,6 @@ namespace System.Threading.Tasks.Dataflow
             DataflowMessageStatus ITargetBlock<TInput>.OfferMessage(DataflowMessageHeader messageHeader, TInput messageValue, ISourceBlock<TInput> source, bool consumeToAccept)
             {
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
-                Contract.EndContractBlock();
 
                 // If the source requires an explicit synchronous consumption, do it
                 if (consumeToAccept)

--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowMessageHeader.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowMessageHeader.cs
@@ -12,7 +12,6 @@
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Threading.Tasks.Dataflow.Internal;
 
 namespace System.Threading.Tasks.Dataflow
@@ -29,7 +28,6 @@ namespace System.Threading.Tasks.Dataflow
         public DataflowMessageHeader(long id)
         {
             if (id == default(long)) throw new ArgumentException(SR.Argument_InvalidMessageId, nameof(id));
-            Contract.EndContractBlock();
 
             _id = id;
         }

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/ActionBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/ActionBlock.cs
@@ -14,7 +14,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks.Dataflow.Internal;
 
@@ -73,8 +72,6 @@ namespace System.Threading.Tasks.Dataflow
             // Validate arguments
             if (action == null) throw new ArgumentNullException(nameof(action));
             if (dataflowBlockOptions == null) throw new ArgumentNullException(nameof(dataflowBlockOptions));
-            Contract.Ensures((_spscTarget != null) ^ (_defaultTarget != null), "One and only one of the two targets must be non-null after construction");
-            Contract.EndContractBlock();
 
             // Ensure we have options that can't be changed by the caller
             dataflowBlockOptions = dataflowBlockOptions.DefaultOrClone();
@@ -125,6 +122,8 @@ namespace System.Threading.Tasks.Dataflow
                 etwLog.DataflowBlockCreated(this, dataflowBlockOptions);
             }
 #endif
+
+            Debug.Assert((_spscTarget != null) ^ (_defaultTarget != null), "One and only one of the two targets must be non-null after construction");
         }
 
         /// <summary>Processes the message with a user-provided action.</summary>
@@ -234,7 +233,6 @@ namespace System.Threading.Tasks.Dataflow
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             if (_defaultTarget != null)
             {

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchBlock.cs
@@ -14,7 +14,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Security;
 using System.Threading.Tasks.Dataflow.Internal;
@@ -52,7 +51,6 @@ namespace System.Threading.Tasks.Dataflow
             if (batchSize < 1) throw new ArgumentOutOfRangeException(nameof(batchSize), SR.ArgumentOutOfRange_GenericPositive);
             if (dataflowBlockOptions == null) throw new ArgumentNullException(nameof(dataflowBlockOptions));
             if (dataflowBlockOptions.BoundedCapacity > 0 && dataflowBlockOptions.BoundedCapacity < batchSize) throw new ArgumentOutOfRangeException(nameof(batchSize), SR.ArgumentOutOfRange_BatchSizeMustBeNoGreaterThanBoundedCapacity);
-            Contract.EndContractBlock();
 
             // Ensure we have options that can't be changed by the caller
             dataflowBlockOptions = dataflowBlockOptions.DefaultOrClone();
@@ -108,7 +106,6 @@ namespace System.Threading.Tasks.Dataflow
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             _target.Complete(exception, dropPendingMessages: true, releaseReservedMessages: false);
         }
@@ -367,7 +364,6 @@ namespace System.Threading.Tasks.Dataflow
                 // Validate arguments
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
                 if (source == null && consumeToAccept) throw new ArgumentException(SR.Argument_CantConsumeFromANullSource, nameof(consumeToAccept));
-                Contract.EndContractBlock();
 
                 lock (IncomingLock)
                 {

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchedJoinBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BatchedJoinBlock.cs
@@ -15,7 +15,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Threading.Tasks.Dataflow.Internal;
 
 namespace System.Threading.Tasks.Dataflow
@@ -60,7 +59,6 @@ namespace System.Threading.Tasks.Dataflow
             if (dataflowBlockOptions == null) throw new ArgumentNullException(nameof(dataflowBlockOptions));
             if (!dataflowBlockOptions.Greedy) throw new ArgumentException(SR.Argument_NonGreedyNotSupported, nameof(dataflowBlockOptions));
             if (dataflowBlockOptions.BoundedCapacity != DataflowBlockOptions.Unbounded) throw new ArgumentException(SR.Argument_BoundedCapacityNotSupported, nameof(dataflowBlockOptions));
-            Contract.EndContractBlock();
 
             // Store arguments
             _batchSize = batchSize;
@@ -165,7 +163,6 @@ namespace System.Threading.Tasks.Dataflow
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             Debug.Assert(_sharedResources != null, "_sharedResources not initialized");
             Debug.Assert(_sharedResources._incomingLock != null, "_sharedResources._incomingLock not initialized");
@@ -324,7 +321,6 @@ namespace System.Threading.Tasks.Dataflow
             {
                 throw new ArgumentException(SR.Argument_NonGreedyNotSupported, nameof(dataflowBlockOptions));
             }
-            Contract.EndContractBlock();
 
             // Store arguments
             _batchSize = batchSize;
@@ -434,7 +430,6 @@ namespace System.Threading.Tasks.Dataflow
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             Debug.Assert(_sharedResources != null, "_sharedResources not initialized");
             Debug.Assert(_sharedResources._incomingLock != null, "_sharedResources._incomingLock not initialized");
@@ -598,7 +593,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (source == null && consumeToAccept) throw new ArgumentException(SR.Argument_CantConsumeFromANullSource, nameof(consumeToAccept));
-            Contract.EndContractBlock();
 
             lock (_sharedResources._incomingLock)
             {
@@ -644,7 +638,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             lock (_sharedResources._incomingLock)
             {

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BroadcastBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BroadcastBlock.cs
@@ -15,7 +15,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Security;
 using System.Threading.Tasks.Dataflow.Internal;
@@ -68,7 +67,6 @@ namespace System.Threading.Tasks.Dataflow
         {
             // Validate arguments
             if (dataflowBlockOptions == null) throw new ArgumentNullException(nameof(dataflowBlockOptions));
-            Contract.EndContractBlock();
 
             // Ensure we have options that can't be changed by the caller
             dataflowBlockOptions = dataflowBlockOptions.DefaultOrClone();
@@ -118,7 +116,6 @@ namespace System.Threading.Tasks.Dataflow
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             CompleteCore(exception, storeExceptionEvenIfAlreadyCompleting: false);
         }
@@ -127,7 +124,6 @@ namespace System.Threading.Tasks.Dataflow
         {
             Debug.Assert(storeExceptionEvenIfAlreadyCompleting || !revertProcessingState,
                             "Indicating dirty processing state may only come with storeExceptionEvenIfAlreadyCompleting==true.");
-            Contract.EndContractBlock();
 
             lock (IncomingLock)
             {
@@ -170,7 +166,6 @@ namespace System.Threading.Tasks.Dataflow
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (source == null && consumeToAccept) throw new ArgumentException(SR.Argument_CantConsumeFromANullSource, nameof(consumeToAccept));
-            Contract.EndContractBlock();
 
             lock (IncomingLock)
             {
@@ -1033,7 +1028,6 @@ namespace System.Threading.Tasks.Dataflow
                 // Validate arguments
                 if (target == null) throw new ArgumentNullException(nameof(target));
                 if (linkOptions == null) throw new ArgumentNullException(nameof(linkOptions));
-                Contract.EndContractBlock();
 
                 lock (OutgoingLock)
                 {
@@ -1064,7 +1058,6 @@ namespace System.Threading.Tasks.Dataflow
                 // Validate arguments
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
                 if (target == null) throw new ArgumentNullException(nameof(target));
-                Contract.EndContractBlock();
 
                 TOutput valueToClone;
                 lock (OutgoingLock) // We may currently be calling out under this lock to the target; requires it to be reentrant
@@ -1105,7 +1098,6 @@ namespace System.Threading.Tasks.Dataflow
                 // Validate arguments
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
                 if (target == null) throw new ArgumentNullException(nameof(target));
-                Contract.EndContractBlock();
 
                 lock (OutgoingLock)
                 {
@@ -1133,7 +1125,6 @@ namespace System.Threading.Tasks.Dataflow
                 // Validate arguments
                 if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
                 if (target == null) throw new ArgumentNullException(nameof(target));
-                Contract.EndContractBlock();
 
                 lock (OutgoingLock)
                 {

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/BufferBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/BufferBlock.cs
@@ -13,7 +13,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Security;
 using System.Threading.Tasks.Dataflow.Internal;
 using System.Diagnostics.CodeAnalysis;
@@ -48,7 +47,6 @@ namespace System.Threading.Tasks.Dataflow
         public BufferBlock(DataflowBlockOptions dataflowBlockOptions)
         {
             if (dataflowBlockOptions == null) throw new ArgumentNullException(nameof(dataflowBlockOptions));
-            Contract.EndContractBlock();
 
             // Ensure we have options that can't be changed by the caller
             dataflowBlockOptions = dataflowBlockOptions.DefaultOrClone();
@@ -95,7 +93,6 @@ namespace System.Threading.Tasks.Dataflow
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (source == null && consumeToAccept) throw new ArgumentException(SR.Argument_CantConsumeFromANullSource, nameof(consumeToAccept));
-            Contract.EndContractBlock();
 
             lock (IncomingLock)
             {
@@ -153,7 +150,6 @@ namespace System.Threading.Tasks.Dataflow
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             CompleteCore(exception, storeExceptionEvenIfAlreadyCompleting: false);
         }
@@ -162,7 +158,6 @@ namespace System.Threading.Tasks.Dataflow
         {
             Debug.Assert(storeExceptionEvenIfAlreadyCompleting || !revertProcessingState,
                             "Indicating dirty processing state may only come with storeExceptionEvenIfAlreadyCompleting==true.");
-            Contract.EndContractBlock();
 
             lock (IncomingLock)
             {

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/JoinBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/JoinBlock.cs
@@ -15,7 +15,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Security;
 using System.Threading.Tasks.Dataflow.Internal;
@@ -53,7 +52,6 @@ namespace System.Threading.Tasks.Dataflow
         {
             // Validate arguments
             if (dataflowBlockOptions == null) throw new ArgumentNullException(nameof(dataflowBlockOptions));
-            Contract.EndContractBlock();
 
             // Ensure we have options that can't be changed by the caller
             dataflowBlockOptions = dataflowBlockOptions.DefaultOrClone();
@@ -148,7 +146,6 @@ namespace System.Threading.Tasks.Dataflow
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             Debug.Assert(_sharedResources != null, "_sharedResources not initialized");
             Debug.Assert(_sharedResources._exceptionAction != null, "_sharedResources._exceptionAction not initialized");
@@ -288,7 +285,6 @@ namespace System.Threading.Tasks.Dataflow
         {
             // Validate arguments
             if (dataflowBlockOptions == null) throw new ArgumentNullException(nameof(dataflowBlockOptions));
-            Contract.EndContractBlock();
 
             // Ensure we have options that can't be changed by the caller
             dataflowBlockOptions = dataflowBlockOptions.DefaultOrClone();
@@ -383,7 +379,6 @@ namespace System.Threading.Tasks.Dataflow
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             Debug.Assert(_sharedResources != null, "_sharedResources not initialized");
             Debug.Assert(_sharedResources._exceptionAction != null, "_sharedResources._exceptionAction not initialized");
@@ -845,7 +840,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (source == null && consumeToAccept) throw new ArgumentException(SR.Argument_CantConsumeFromANullSource, nameof(consumeToAccept));
-            Contract.EndContractBlock();
 
             lock (_sharedResources.IncomingLock)
             {
@@ -956,7 +950,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             CompleteCore(exception, dropPendingMessages: true, releaseReservedMessages: false);
         }

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformBlock.cs
@@ -13,7 +13,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Threading.Tasks.Dataflow.Internal;
 using System.Diagnostics.CodeAnalysis;
 
@@ -98,7 +97,6 @@ namespace System.Threading.Tasks.Dataflow
             if (dataflowBlockOptions == null) throw new ArgumentNullException(nameof(dataflowBlockOptions));
 
             Debug.Assert(transformSync == null ^ transformAsync == null, "Exactly one of transformSync and transformAsync must be null.");
-            Contract.EndContractBlock();
 
             // Ensure we have options that can't be changed by the caller
             dataflowBlockOptions = dataflowBlockOptions.DefaultOrClone();
@@ -339,7 +337,6 @@ namespace System.Threading.Tasks.Dataflow
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             _target.Complete(exception, dropPendingMessages: true);
         }

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
@@ -14,7 +14,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Threading.Tasks.Dataflow.Internal;
 using System.Collections.ObjectModel;
@@ -109,7 +108,6 @@ namespace System.Threading.Tasks.Dataflow
             if (dataflowBlockOptions == null) throw new ArgumentNullException(nameof(dataflowBlockOptions));
 
             Debug.Assert(transformSync == null ^ transformAsync == null, "Exactly one of transformSync and transformAsync must be null.");
-            Contract.EndContractBlock();
 
             // Ensure we have options that can't be changed by the caller
             dataflowBlockOptions = dataflowBlockOptions.DefaultOrClone();
@@ -581,7 +579,6 @@ namespace System.Threading.Tasks.Dataflow
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             _target.Complete(exception, dropPendingMessages: true);
         }

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/WriteOnceBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/WriteOnceBlock.cs
@@ -14,7 +14,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Security;
 using System.Threading.Tasks.Dataflow.Internal;
 
@@ -66,7 +65,6 @@ namespace System.Threading.Tasks.Dataflow
         {
             // Validate arguments
             if (dataflowBlockOptions == null) throw new ArgumentNullException(nameof(dataflowBlockOptions));
-            Contract.EndContractBlock();
 
             // Store the option
             _cloningFunction = cloningFunction;
@@ -217,7 +215,6 @@ namespace System.Threading.Tasks.Dataflow
         void IDataflowBlock.Fault(Exception exception)
         {
             if (exception == null) throw new ArgumentNullException(nameof(exception));
-            Contract.EndContractBlock();
 
             CompleteCore(exception, storeExceptionEvenIfAlreadyCompleting: false);
         }
@@ -232,7 +229,6 @@ namespace System.Threading.Tasks.Dataflow
         {
             Debug.Assert(exception != null || !storeExceptionEvenIfAlreadyCompleting,
                             "When storeExceptionEvenIfAlreadyCompleting is set to true, an exception must be provided.");
-            Contract.EndContractBlock();
 
             bool thisThreadReservedCompletion = false;
             lock (ValueLock)
@@ -313,7 +309,6 @@ namespace System.Threading.Tasks.Dataflow
             // Validate arguments
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (linkOptions == null) throw new ArgumentNullException(nameof(linkOptions));
-            Contract.EndContractBlock();
 
             bool hasValue;
             bool isCompleted;
@@ -353,7 +348,6 @@ namespace System.Threading.Tasks.Dataflow
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (source == null && consumeToAccept) throw new ArgumentException(SR.Argument_CantConsumeFromANullSource, nameof(consumeToAccept));
-            Contract.EndContractBlock();
 
             bool thisThreadReservedCompletion = false;
             lock (ValueLock)
@@ -394,7 +388,6 @@ namespace System.Threading.Tasks.Dataflow
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (target == null) throw new ArgumentNullException(nameof(target));
-            Contract.EndContractBlock();
 
             // As long as the message being requested is the one we have, allow it to be consumed,
             // but make a copy using the provided cloning function.
@@ -416,7 +409,6 @@ namespace System.Threading.Tasks.Dataflow
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (target == null) throw new ArgumentNullException(nameof(target));
-            Contract.EndContractBlock();
 
             // As long as the message is the one we have, it can be "reserved."
             // Reservations on a WriteOnceBlock are not exclusive, because
@@ -430,7 +422,6 @@ namespace System.Threading.Tasks.Dataflow
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (target == null) throw new ArgumentNullException(nameof(target));
-            Contract.EndContractBlock();
 
             // As long as the message is the one we have, everything's fine.
             if (_header.Id != messageHeader.Id) throw new InvalidOperationException(SR.InvalidOperation_MessageNotReservedByTarget);

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/SourceCore.cs
@@ -14,7 +14,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Security;
 
@@ -130,7 +129,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // Validate arguments
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (linkOptions == null) throw new ArgumentNullException(nameof(linkOptions));
-            Contract.EndContractBlock();
 
             // If the block is already completed, there is not much to do -
             // we have to propagate completion if that was requested, and
@@ -165,7 +163,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (target == null) throw new ArgumentNullException(nameof(target));
-            Contract.EndContractBlock();
 
             TOutput consumedMessageValue = default(TOutput);
 
@@ -222,7 +219,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (target == null) throw new ArgumentNullException(nameof(target));
-            Contract.EndContractBlock();
 
             lock (OutgoingLock)
             {
@@ -250,7 +246,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (target == null) throw new ArgumentNullException(nameof(target));
-            Contract.EndContractBlock();
 
             lock (OutgoingLock)
             {

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
@@ -14,7 +14,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.Linq;
 
 namespace System.Threading.Tasks.Dataflow.Internal
@@ -144,7 +143,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
         {
             Debug.Assert(storeExceptionEvenIfAlreadyCompleting || !revertProcessingState,
                             "Indicating dirty processing state may only come with storeExceptionEvenIfAlreadyCompleting==true.");
-            Contract.EndContractBlock();
 
             // Ensure that no new messages may be added
             lock (IncomingLock)
@@ -186,7 +184,6 @@ namespace System.Threading.Tasks.Dataflow.Internal
             // Validate arguments
             if (!messageHeader.IsValid) throw new ArgumentException(SR.Argument_InvalidMessageHeader, nameof(messageHeader));
             if (source == null && consumeToAccept) throw new ArgumentException(SR.Argument_CantConsumeFromANullSource, nameof(consumeToAccept));
-            Contract.EndContractBlock();
 
             lock (IncomingLock)
             {

--- a/src/System.Threading.Tasks/tests/Task/TaskRtTests_Core.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskRtTests_Core.cs
@@ -2316,10 +2316,6 @@ namespace System.Threading.Tasks.Tests
                 ManualResetEvent mreFaulted = new ManualResetEvent(false);
                 bool innerStarted = false;
 
-                // I Think SpinWait has been implemented on all future platforms because
-                // it is in the Contract.
-                // So we can ignore this Thread.SpinWait(100);
-
                 SpinWait sw = new SpinWait();
                 Task tFaulted = Task.Factory.StartNew(delegate
                 {


### PR DESCRIPTION
Only remaining use of System.Diagnostics.Contracts in corefx is tests for the library itself, and usage of the [Pure] attribute.  Most of the remaining use was Contract.Ensures, which is cumbersome to replace, so in most cases I just deleted it (it was dead code anyway); in a few places where I could do so without perturbing existing code and where it had some value, I added back a Debug.Assert.

Fixes https://github.com/dotnet/corefx/issues/15443
cc: @danmosemsft 