### PR TITLE
Clean up some tests and move to new Azure endpoint

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Http.cs
+++ b/src/Common/tests/System/Net/Configuration.Http.cs
@@ -10,7 +10,6 @@ namespace System.Net.Test.Common
     {
         public static partial class Http
         {
-            private static readonly string DefaultAzureServer = "corefx-net.cloudapp.net";
             private static readonly string DefaultHttp2AzureServer = "corefx-net-http2.azurewebsites.net";
 
             public static string Host => GetValue("COREFX_HTTPHOST", DefaultAzureServer);
@@ -49,7 +48,6 @@ namespace System.Net.Test.Common
 
             private const string EchoHandler = "Echo.ashx";
             private const string EmptyContentHandler = "EmptyContent.ashx";
-            private const string StatusCodeHandler = "StatusCode.ashx";
             private const string RedirectHandler = "Redirect.ashx";
             private const string VerifyUploadHandler = "VerifyUpload.ashx";
             private const string DeflateHandler = "Deflate.ashx";
@@ -97,29 +95,6 @@ namespace System.Net.Test.Common
                         EchoHandler,
                         userName,
                         password));
-            }
-
-            public static Uri StatusCodeUri(bool secure, int statusCode)
-            {
-                return new Uri(
-                    string.Format(
-                        "{0}://{1}/{2}?statuscode={3}",
-                        secure ? HttpsScheme : HttpScheme,
-                        Host,
-                        StatusCodeHandler,
-                        statusCode));
-            }
-
-            public static Uri StatusCodeUri(bool secure, int statusCode, string statusDescription)
-            {
-                return new Uri(
-                    string.Format(
-                        "{0}://{1}/{2}?statuscode={3}&statusDescription={4}",
-                        secure ? HttpsScheme : HttpScheme,
-                        Host,
-                        StatusCodeHandler,
-                        statusCode,
-                        statusDescription));
             }
 
             public static Uri RedirectUriForDestinationUri(bool secure, int statusCode, Uri destinationUri, int hops, bool relative = false)

--- a/src/Common/tests/System/Net/Configuration.Security.cs
+++ b/src/Common/tests/System/Net/Configuration.Security.cs
@@ -8,8 +8,6 @@ namespace System.Net.Test.Common
     {
         public static partial class Security
         {
-            private static readonly string DefaultAzureServer = "corefx-net.cloudapp.net";
-
             // Domain server environment.
             public static string ActiveDirectoryName => GetValue("COREFX_NET_AD_DOMAINNAME");
             public static string ActiveDirectoryUserName => GetValue("COREFX_NET_AD_USERNAME");

--- a/src/Common/tests/System/Net/Configuration.cs
+++ b/src/Common/tests/System/Net/Configuration.cs
@@ -7,7 +7,7 @@ namespace System.Net.Test.Common
     public static partial class Configuration
     {
         #pragma warning disable 414
-        private static readonly string DefaultAzureServer = "corefx-net.cloudapp.net";
+        private static readonly string DefaultAzureServer = "corefx-net-http11.azurewebsites.net";
         #pragma warning restore 414
 
         private static string GetValue(string envName, string defaultValue=null)

--- a/src/Common/tests/System/Net/WebSockets/WebSocketCreateTest.cs
+++ b/src/Common/tests/System/Net/WebSockets/WebSocketCreateTest.cs
@@ -42,7 +42,7 @@ namespace System.Net.WebSockets.Tests
             Assert.NotNull(CreateFromStream(new MemoryStream(), true, null, Timeout.InfiniteTimeSpan));
         }
 
-        [OuterLoop] // Connects to external server.
+        [OuterLoop("Uses external servers")]
         [Theory]
         [MemberData(nameof(EchoServers))]
         public async Task WebSocketProtocol_CreateFromConnectedStream_CanSendReceiveData(Uri echoUri)
@@ -150,7 +150,7 @@ namespace System.Net.WebSockets.Tests
             }
         }
 
-        [OuterLoop] // Connects to external server.
+        [OuterLoop("Uses external servers")]
         [Theory]
         [MemberData(nameof(EchoServersAndBoolean))]
         public async Task WebSocketProtocol_CreateFromConnectedStream_CloseAsyncClosesStream(Uri echoUri, bool explicitCloseAsync)
@@ -184,7 +184,8 @@ namespace System.Net.WebSockets.Tests
             }
         }
 
-        [OuterLoop] // Connects to external server.
+        [ActiveIssue(36016)]
+        [OuterLoop("Uses external servers")]
         [Theory]
         [MemberData(nameof(EchoServersAndBoolean))]
         public async Task WebSocketProtocol_CreateFromConnectedStream_CloseAsyncAfterCloseReceivedClosesStream(Uri echoUri, bool useCloseOutputAsync)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2349,23 +2349,21 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [OuterLoop("Uses external server")]
         [Theory]
         [InlineData(HttpStatusCode.MethodNotAllowed, "Custom description")]
         [InlineData(HttpStatusCode.MethodNotAllowed, "")]
         public async Task GetAsync_CallMethod_ExpectedStatusLine(HttpStatusCode statusCode, string reasonPhrase)
         {
-            using (HttpClient client = CreateHttpClient())
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
-                using (HttpResponseMessage response = await client.GetAsync(Configuration.Http.StatusCodeUri(
-                    false,
-                    (int)statusCode,
-                    reasonPhrase)))
+                using (HttpClient client = CreateHttpClient())
+                using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
                     Assert.Equal(statusCode, response.StatusCode);
                     Assert.Equal(reasonPhrase, response.ReasonPhrase);
                 }
-            }
+            }, server => server.AcceptConnectionSendCustomResponseAndCloseAsync(
+                $"HTTP/1.1 {(int)statusCode} {reasonPhrase}\r\nContent-Length: 0\r\n\r\n"));
         }
 
 #endregion

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1247,17 +1247,16 @@ namespace System.Net.Tests
             Assert.Equal(WebExceptionStatus.NameResolutionFailure, ex.Status);
         }
 
-        public static object[][] StatusCodeServers = {
-            new object[] { System.Net.Test.Common.Configuration.Http.StatusCodeUri(false, 404) },
-            new object[] { System.Net.Test.Common.Configuration.Http.StatusCodeUri(true, 404) },
-        };
-
-        [Theory, MemberData(nameof(StatusCodeServers))]
-        public async Task GetResponseAsync_ResourceNotFound_ThrowsWebException(Uri remoteServer)
+        [Fact]
+        public async Task GetResponseAsync_ResourceNotFound_ThrowsWebException()
         {
-            HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            WebException ex = await Assert.ThrowsAsync<WebException>(() => request.GetResponseAsync());
-            Assert.Equal(WebExceptionStatus.ProtocolError, ex.Status);
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                WebException ex = await Assert.ThrowsAsync<WebException>(() => request.GetResponseAsync());
+                Assert.Equal(WebExceptionStatus.ProtocolError, ex.Status);
+            }, server => server.AcceptConnectionSendCustomResponseAndCloseAsync(
+                $"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"));
         }
 
         [Theory, MemberData(nameof(EchoServers))]

--- a/src/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/System.Net.WebClient/tests/WebClientTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
@@ -15,6 +16,8 @@ using Xunit;
 
 namespace System.Net.Tests
 {
+    using Configuration = System.Net.Test.Common.Configuration;
+
     public class WebClientTest
     {
         [Fact]
@@ -382,7 +385,7 @@ namespace System.Net.Tests
             Assert.Equal("ArbitraryValue", wc.ResponseHeaders["ArbitraryHeader"]);
         }
 
-        [OuterLoop("Networking test talking to remote server: issue #11345")]
+        [OuterLoop("Uses external servers")]
         [Theory]
         [InlineData("Connection", "close")]
         [InlineData("Expect", "100-continue")]
@@ -390,24 +393,29 @@ namespace System.Net.Tests
         {
             var wc = new WebClient();
             wc.Headers[headerName] = headerValue;
-            await Assert.ThrowsAsync<WebException>(() => wc.DownloadStringTaskAsync(System.Net.Test.Common.Configuration.Http.RemoteEchoServer));
+            await Assert.ThrowsAsync<WebException>(() => wc.DownloadStringTaskAsync(Configuration.Http.RemoteEchoServer));
         }
 
-        [OuterLoop("Networking test talking to remote server: issue #11345")]
+        public static IEnumerable<object[]> RequestHeaders_AddHostHeaderAndSendRequest_ExpectedResult_MemberData()
+        {
+            yield return new object[] { $"http://{Configuration.Http.Host}", true };
+            yield return new object[] { Configuration.Http.Host, false };
+        }
+
+        [OuterLoop("Uses external servers")]
         [Theory]
-        [InlineData("http://localhost", true)]
-        [InlineData("localhost", false)]
+        [MemberData(nameof(RequestHeaders_AddHostHeaderAndSendRequest_ExpectedResult_MemberData))]
         public static async Task RequestHeaders_AddHostHeaderAndSendRequest_ExpectedResult(string hostHeaderValue, bool throwsWebException)
         {
             var wc = new WebClient();
             wc.Headers["Host"] = hostHeaderValue;
             if (throwsWebException)
             {
-                await Assert.ThrowsAsync<WebException>(() => wc.DownloadStringTaskAsync(System.Net.Test.Common.Configuration.Http.RemoteEchoServer));
+                await Assert.ThrowsAsync<WebException>(() => wc.DownloadStringTaskAsync(Configuration.Http.RemoteEchoServer));
             }
             else
             {
-                await wc.DownloadStringTaskAsync(System.Net.Test.Common.Configuration.Http.RemoteEchoServer);
+                await wc.DownloadStringTaskAsync(Configuration.Http.RemoteEchoServer);
             }
         }
 
@@ -469,7 +477,7 @@ namespace System.Net.Tests
     {
         public const int TimeoutMilliseconds = 30 * 1000;
 
-        public static readonly object[][] EchoServers = System.Net.Test.Common.Configuration.Http.EchoServers;
+        public static readonly object[][] EchoServers = Configuration.Http.EchoServers;
         const string ExpectedText =
             "To be, or not to be, that is the question:" +
             "Whether 'tis Nobler in the mind to suffer" +
@@ -605,7 +613,7 @@ namespace System.Net.Tests
             });
         }
 
-        [OuterLoop("Networking test talking to remote server: issue #11345")]
+        [OuterLoop("Uses external servers")]
         [Theory]
         [MemberData(nameof(EchoServers))]
         public async Task OpenWrite_Success(Uri echoServer)
@@ -618,7 +626,7 @@ namespace System.Net.Tests
             }
         }
 
-        [OuterLoop("Networking test talking to remote server: issue #11345")]
+        [OuterLoop("Uses external servers")]
         [Theory]
         [MemberData(nameof(EchoServers))]
         public async Task UploadData_Success(Uri echoServer)
@@ -636,7 +644,7 @@ namespace System.Net.Tests
             }
         }
 
-        [OuterLoop("Networking test talking to remote server: issue #11345")]
+        [OuterLoop("Uses external servers")]
         [Theory]
         [MemberData(nameof(EchoServers))]
         public async Task UploadData_LargeData_Success(Uri echoServer)
@@ -653,7 +661,7 @@ namespace System.Net.Tests
             return new string(Enumerable.Range(0, 512 * 1024).Select(_ => (char)('a' + rand.Next(0, 26))).ToArray());
         }
 
-        [OuterLoop("Networking test talking to remote server: issue #11345")]
+        [OuterLoop("Uses external servers")]
         [Theory]
         [MemberData(nameof(EchoServers))]
         public async Task UploadFile_Success(Uri echoServer)
@@ -672,7 +680,7 @@ namespace System.Net.Tests
             }
         }
 
-        [OuterLoop("Networking test talking to remote server: issue #11345")]
+        [OuterLoop("Uses external servers")]
         [Theory]
         [MemberData(nameof(EchoServers))]
         public async Task UploadString_Success(Uri echoServer)
@@ -682,7 +690,7 @@ namespace System.Net.Tests
             Assert.Contains(ExpectedText, result);
         }
 
-        [OuterLoop("Networking test talking to remote server: issue #11345")]
+        [OuterLoop("Uses external servers")]
         [Theory]
         [MemberData(nameof(EchoServers))]
         public async Task UploadValues_Success(Uri echoServer)

--- a/src/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -17,7 +17,8 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public CloseTest(ITestOutputHelper output) : base(output) { }
 
-        [OuterLoop] // TODO: Issue #11345
+        [ActiveIssue(36016)]
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServersAndBoolean))]
         public async Task CloseAsync_ServerInitiatedClose_Success(Uri server, bool useCloseOutputAsync)
         {
@@ -64,7 +65,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_ClientInitiatedClose_Success(Uri server)
         {
@@ -84,7 +85,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_CloseDescriptionIsMaxLength_Success(Uri server)
         {
@@ -98,7 +99,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_CloseDescriptionIsMaxLengthPlusOne_ThrowsArgumentException(Uri server)
         {
@@ -123,7 +124,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_CloseDescriptionHasUnicode_Success(Uri server)
         {
@@ -141,7 +142,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_CloseDescriptionIsNull_Success(Uri server)
         {
@@ -158,7 +159,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_ClientInitiated_CanReceive_CanClose(Uri server)
         {
@@ -196,7 +197,8 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [ActiveIssue(36016)]
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_ServerInitiated_CanSend(Uri server)
         {
@@ -243,7 +245,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_CloseDescriptionIsNull_Success(Uri server)
         {
@@ -259,7 +261,7 @@ namespace System.Net.WebSockets.Client.Tests
         }
 
         [ActiveIssue(20362, TargetFrameworkMonikers.Netcoreapp)]
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_DuringConcurrentReceiveAsync_ExpectedStates(Uri server)
         {
@@ -296,7 +298,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external server")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_DuringConcurrentReceiveAsync_ExpectedStates(Uri server)
         {

--- a/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -187,7 +187,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         [OuterLoop] // TODO: Issue #11345
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
-        public async Task ConnectAsync_PassNoSubProtocol_ServerRequires_ThrowsWebSocketExceptionWithMessage(Uri server)
+        public async Task ConnectAsync_PassNoSubProtocol_ServerRequires_ThrowsWebSocketException(Uri server)
         {
             const string AcceptedProtocol = "CustomProtocol";
 
@@ -200,13 +200,13 @@ namespace System.Net.WebSockets.Client.Tests
 
                 WebSocketException ex = await Assert.ThrowsAsync<WebSocketException>(() =>
                     cws.ConnectAsync(ub.Uri, cts.Token));
-
+                _output.WriteLine(ex.Message);
                 if (PlatformDetection.IsNetCore) // bug fix in netcoreapp: https://github.com/dotnet/corefx/pull/35960
                 {
-                    Assert.Equal(WebSocketError.Faulted, ex.WebSocketErrorCode);
+                    Assert.True(ex.WebSocketErrorCode == WebSocketError.Faulted ||
+                        ex.WebSocketErrorCode == WebSocketError.NotAWebSocket);
                 }
                 Assert.Equal(WebSocketState.Closed, cws.State);
-                Assert.Equal(ResourceHelper.GetExceptionMessage("net_webstatus_ConnectFailure"), ex.Message);
             }
         }
 


### PR DESCRIPTION
This PR changes the Azure test endpoint for HTTP/1.1 and WebSocket tests to use
Azure App Service instead of the classic Azure Cloud Service endpoint. This now
matches the HTTP/2.0 endpoint architecture.

We are deprecating the use of Azure Cloud Service endpoints because they are hard
to deploy and maintain. Azure App Service, on the other hand, provides a lot of benefits
including built in production/staging slots, TLS certificate handling and easier
integration with Azure DevOps deployment models.

There are a few downsides to Azure App Service which are known feature limitations.
Since it uses ARR (reverse proxy), it causes websocket connections to be proxied.
This results in some behavior changes for some edge condition tests we have. For example,
when a websocket handshake fails (due to subprotocol mismatch for example), the client
side doesn't see a TCP disconnect. Instead, due to the reverse proxy, we end up getting
an HTTP status code (like 500). Either way, it is a websocket handshake failure. So, I've
updated a few tests to be less brittle for that. I also opened another issue #36016 to
track moving a few websocket tests to the loopback websocket server which doesn't yet
have full capability.

I also converted an HTTP statusline test to use the loopback server.