### PR TITLE
Adding the ITensor interfaces SxS with the existing types

### DIFF
--- a/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/IDenseTensor.cs
+++ b/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/IDenseTensor.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Numerics.Tensors
+{
+    public interface IDenseTensor<T> : ITensor<T>, IReadOnlyDenseTensor<T>
+    {
+        new Span<T> Buffer { get; }
+    }
+}

--- a/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/IReadOnlyDenseTensor.cs
+++ b/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/IReadOnlyDenseTensor.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Numerics.Tensors
+{
+    public interface IReadOnlyDenseTensor<T> : IReadOnlyTensor<T>
+    {
+        ReadOnlySpan<T> Buffer { get; }
+        long ElementCount { get; }
+        bool IsColumnMajor { get; }
+
+        long GetStride(long dimension);
+    }
+}

--- a/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/IReadOnlySparseTensor.cs
+++ b/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/IReadOnlySparseTensor.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Numerics.Tensors
+{
+    public interface IReadOnlySparseTensor<T> : IReadOnlyTensor<T>
+    {
+        long ValueCount { get; }
+
+        ReadOnlySpan<long> GetValueIndices(long valueIndex);
+
+        T GetValue(long valueIndex);
+    }
+}

--- a/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/IReadOnlyTensor.cs
+++ b/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/IReadOnlyTensor.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Numerics.Tensors
+{
+    public interface IReadOnlyTensor<T>
+    {
+        long Rank { get; }
+
+        T this[params long[] indices] { get; }
+        T this[ReadOnlySpan<long> indices] { get; }
+
+        long GetDimensionLength(long dimension);
+        IReadOnlyTensor<T> Slice(params (long start, long length)[] ranges);
+        IReadOnlyTensor<T> Slice(ReadOnlySpan<(long start, long length)> ranges);
+        IReadOnlyTensor<T> Reshape(params long[] dimensions);
+        IReadOnlyTensor<T> Reshape(ReadOnlySpan<long> dimensions);
+    }
+}

--- a/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/ISparseTensor.cs
+++ b/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/ISparseTensor.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Numerics.Tensors
+{
+    public interface ISparseTensor<T> : ITensor<T>, IReadOnlySparseTensor<T>
+    {
+        T SetValue(long valueIndex);
+    }
+}

--- a/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/ITensor.cs
+++ b/src/System.Numerics.Tensors/src/System/Numerics/Tensors/Experimental/ITensor.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Numerics.Tensors
+{
+    public interface ITensor<T> : IReadOnlyTensor<T>
+    {
+        new T this[params long[] indices] { get; set; }
+        new T this[ReadOnlySpan<long> indices] { get; set; }
+    }
+}


### PR DESCRIPTION
As per the API review of https://github.com/dotnet/corefx/issues/35765, we are going to check these interfaces in SxS with the existing types so that we can continue prototyping and experimenting with them to determine the ultimate shape that the exposed APIs will take.

This exposes the APIs as proposed and with some of the fixups suggested during the API review meeting. Namely:
* Exposing a concept of a `read only` tensor
* Using `long` (rather than `int`) for the various lengths and indices
* Allowing data (such as strides or dimension lengths) to be stored and retrieved in a non-linear fashion

CC. @eerhardt, @terrajobst, @danmosemsft 