### PR TITLE
Fix: System.IO.Ports runtime package signing

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -42,9 +42,6 @@ parameters:
   #     - script: echo Hello World
   #       displayName: MyScript
 
-  # Optional: enableMicrobuild -> Boolean - if microbuild plugin for signing should be enabled
-  # Default: false
-
   # Optional: preBuildSteps -> Array -> list of steps to be executed before common build steps.
   # In example, to install build dependencies, or setup an environment.
   #   preBuildSteps:
@@ -90,15 +87,11 @@ jobs:
 
         - _args: -restore -build -configuration $(_BuildConfig) -ci -buildtests -arch $(_architecture) -framework $(_framework) $(_archiveTestsParameter)
         - _commonArguments: $(_args)
-        - _windowsOfficialBuildArguments: ''
 
         # Windows variables
         - ${{ if eq(parameters.targetOS, 'Windows_NT') }}:
           - _buildScript: build.cmd
           - _msbuildCommand: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 -warnaserror:0 -ci
-          - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
-            - _windowsOfficialBuildArguments: -sign
-                                              /p:DotNetSignType=$(_SignType)
 
         # Non-Windows variables
         - ${{ if ne(parameters.targetOS, 'Windows_NT') }}:
@@ -107,13 +100,9 @@ jobs:
           - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
             - _commonArguments: $(_args) -stripSymbols
 
-        - ${{ if and(eq(job.enableMicrobuild, 'true'), eq(parameters.isOfficialBuild, 'true')) }}:
-          - _TeamName: DotNetCore
-          - _SignType: real
-
         # pass along job properties
         ${{ each property in job }}:
-          ${{ if and(ne(property.key, 'job'), ne(property.key, 'variables'), ne(property.key, 'enableMicrobuild')) }}:
+          ${{ if and(ne(property.key, 'job'), ne(property.key, 'variables')) }}:
             ${{ property.key }}: ${{ property.value }}
 
         # enable helix telemetry -- we only send telemetry during official builds
@@ -126,9 +115,6 @@ jobs:
 
         # enabling publish build artifacts, will publish all build logs under /artifacts/log/
         enablePublishBuildArtifacts: true
-
-        ${{ if ne(job.enableMicrobuild, '') }}:
-          enableMicrobuild: ${{ job.enableMicrobuild }}
 
         ${{ if eq(job.timeoutInMinutes, '') }}:
           timeoutInMinutes: 150
@@ -160,7 +146,6 @@ jobs:
                     /p:OuterLoop=$(_outerloop)
                     ${{ job.buildExtraArguments }}
                     $(_msbuildCommonParameters)
-                    $(_windowsOfficialBuildArguments)
               displayName: Build Sources and Tests
 
           - ${{ if ne(job.customBuildSteps[0], '') }}:

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -4,142 +4,155 @@ parameters:
   dependsOn: ''
 
 jobs:
-  - job: PublishPackages
-    displayName: Publish Packages
-    timeoutInMinutes: 120
+  - template: ../common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      jobs:
+      - job: PublishPackages
+        displayName: Publish Packages
+        timeoutInMinutes: 120
 
-    ${{ if ne(parameters.dependsOn, '') }}:
-      dependsOn: ${{ parameters.dependsOn }}
+        ${{ if ne(parameters.dependsOn, '') }}:
+          dependsOn: ${{ parameters.dependsOn }}
 
-    pool:
-      name: dotnet-internal-temp
+        pool:
+          name: dotnet-internal-temp
 
-    workspace: 
-      clean: all
+        workspace:
+          clean: all
 
-    variables:
-      - group: Publish-Build-Assets
-      - group: DotNet-Blob-Feed
-      - group: DotNet-MyGet-Publish
-      - group: DotNet-Versions-Publish
-      - name: _dotnetFeedUrl
-        value: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-      - name: _maestroApiEndpoint
-        value: https://maestro-prod.westus2.cloudapp.azure.com
-      - name: _mygetFeedUrl
-        value: https://dotnet.myget.org/F/dotnet-core/api/v2/package
-      - name: _manifestsDir
-        value: ${{ parameters.artifactsDir }}/AssetManifests
+        variables:
+          - group: Publish-Build-Assets
+          - group: DotNet-Blob-Feed
+          - group: DotNet-MyGet-Publish
+          - group: DotNet-Versions-Publish
+          - _dotnetFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+          - _maestroApiEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
+          - _mygetFeedUrl: https://dotnet.myget.org/F/dotnet-core/api/v2/package
+          - _manifestsDir: ${{ parameters.artifactsDir }}/AssetManifests
+          - _TeamName: DotNetCore
+          - _SignType: real
 
-    steps:
-      - powershell: |
-          $prefix = "refs/heads/"
-          $branch = "$(Build.SourceBranch)"
-          $branchName = $branch
-          if ($branchName.StartsWith($prefix))
-          {
-            $branchName = $branchName.Substring($prefix.Length)
-          }
-          Write-Host "For Build.SourceBranch $branch, FullBranchName is $branchName"
-          Write-Host "##vso[task.setvariable variable=FullBranchName;]$branchName"
-        displayName: Find true SourceBranchName
+        steps:
+          - powershell: |
+              $prefix = "refs/heads/"
+              $branch = "$(Build.SourceBranch)"
+              $branchName = $branch
+              if ($branchName.StartsWith($prefix))
+              {
+                $branchName = $branchName.Substring($prefix.Length)
+              }
+              Write-Host "For Build.SourceBranch $branch, FullBranchName is $branchName"
+              Write-Host "##vso[task.setvariable variable=FullBranchName;]$branchName"
+            displayName: Find true SourceBranchName
 
-      - task: DownloadBuildArtifacts@0
-        displayName: Download packages to publish
-        inputs:
-          artifactName: packages
-          downloadPath: ${{ parameters.artifactsDir }}
+          - task: DownloadBuildArtifacts@0
+            displayName: Download packages to publish
+            inputs:
+              artifactName: packages
+              downloadPath: ${{ parameters.artifactsDir }}
 
-      - script: build.cmd -restore
-        displayName: Restore Tools
+          - script: build.cmd
+                    -restore
+                    -sign
+                    /p:DotNetSignType=$(_SignType)
+                    /p:OfficialBuildId=$(Build.BuildNumber)
+            displayName: Sign packages
 
-      # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-      #           -warnaserror:0 -ci
-      #           /t:PublishPackagesToBlobFeed
-      #           /p:ManifestBuildId=$(Build.BuildNumber)
-      #           /p:ManifestBuildData=Location=$(_dotnetFeedUrl)
-      #           /p:ManifestBranch=$(Build.SourceBranch)
-      #           /p:ManifestCommit=$(Build.SourceVersion)
-      #           /p:ManifestRepoUri=$(Build.Repository.Uri)
-      #           /p:AccountKey=$(dotnetfeed-storage-access-key-1)
-      #           /p:ExpectedFeedUrl=$(_dotnetFeedUrl)
-      #           /p:IncludeSymbolsOnPackagePublish=true
-      #   displayName: Push to dotnet feed
+          - task: PublishBuildArtifacts@1
+            displayName: Publish packages to artifacts container
+            inputs:
+              pathToPublish: $(Build.SourcesDirectory)/artifacts/packages
+              artifactName: packages
+              artifactType: container
 
-      # - task: PublishBuildArtifacts@1
-      #   displayName: Publish assets manifest to artifacts
-      #   inputs:
-      #     pathToPublish: $(_manifestsDir)
-      #     artifactName: BuildAssetsManifest
-      #     artifactType: container
+          # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+          #           -warnaserror:0 -ci
+          #           /t:PublishPackagesToBlobFeed
+          #           /p:ManifestBuildId=$(Build.BuildNumber)
+          #           /p:ManifestBuildData=Location=$(_dotnetFeedUrl)
+          #           /p:ManifestBranch=$(Build.SourceBranch)
+          #           /p:ManifestCommit=$(Build.SourceVersion)
+          #           /p:ManifestRepoUri=$(Build.Repository.Uri)
+          #           /p:AccountKey=$(dotnetfeed-storage-access-key-1)
+          #           /p:ExpectedFeedUrl=$(_dotnetFeedUrl)
+          #           /p:IncludeSymbolsOnPackagePublish=true
+          #   displayName: Push to dotnet feed
 
-      # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\sdk-task.ps1
-      #           -task PublishBuildAssets -restore -msbuildEngine dotnet
-      #           /p:ManifestsPath='$(_manifestsDir)'
-      #           /p:BuildAssetRegistryToken=$(MaestroAccessToken)
-      #           /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
-      #           /p:Configuration=${{ parameters.buildConfiguration }}
-      #   displayName: Publish to Build Assets Registry
+          # - task: PublishBuildArtifacts@1
+          #   displayName: Publish assets manifest to artifacts
+          #   inputs:
+          #     pathToPublish: $(_manifestsDir)
+          #     artifactName: BuildAssetsManifest
+          #     artifactType: container
 
-      # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-      #           -warnaserror:0 -ci
-      #           /t:NuGetPush
-      #           /p:NuGetSource=$(_mygetFeedUrl)
-      #           /p:NuGetApiKey=$(dotnet-myget-org-api-key)
-      #   displayName: Push to myget.org
+          # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\sdk-task.ps1
+          #           -task PublishBuildAssets -restore -msbuildEngine dotnet
+          #           /p:ManifestsPath='$(_manifestsDir)'
+          #           /p:BuildAssetRegistryToken=$(MaestroAccessToken)
+          #           /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+          #           /p:Configuration=${{ parameters.buildConfiguration }}
+          #   displayName: Publish to Build Assets Registry
 
-      # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 build.proj
-      #           -warnaserror:0 -ci
-      #           /t:UpdatePublishedVersions
-      #           /p:GitHubAuthToken=$(AccessToken-dotnet-build-bot-public-repo)
-      #           /p:VersionsRepoOwner=dotnet
-      #           /p:VersionsRepo=versions
-      #           /p:VersionsRepoPath=build-info/dotnet/corefx/$(FullBranchName)
-      #           /p:ShippedNuGetPackageGlobPath=${{ parameters.artifactsDir }}/packages/*.nupkg
-      #   displayName: Update dotnet/versions
+          # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+          #           -warnaserror:0 -ci
+          #           /t:NuGetPush
+          #           /p:NuGetSource=$(_mygetFeedUrl)
+          #           /p:NuGetApiKey=$(dotnet-myget-org-api-key)
+          #   displayName: Push to myget.org
 
-  # - job: PublishSymbols
-  #   displayName: Publish Symbols
-  #   timeoutInMinutes: 120
+          # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 build.proj
+          #           -warnaserror:0 -ci
+          #           /t:UpdatePublishedVersions
+          #           /p:GitHubAuthToken=$(AccessToken-dotnet-build-bot-public-repo)
+          #           /p:VersionsRepoOwner=dotnet
+          #           /p:VersionsRepo=versions
+          #           /p:VersionsRepoPath=build-info/dotnet/corefx/$(FullBranchName)
+          #           /p:ShippedNuGetPackageGlobPath=${{ parameters.artifactsDir }}/packages/*.nupkg
+          #   displayName: Update dotnet/versions
 
-  #   ${{ if ne(parameters.dependsOn, '') }}:
-  #     dependsOn: ${{ parameters.dependsOn }}
+      # - job: PublishSymbols
+      #   displayName: Publish Symbols
+      #   timeoutInMinutes: 120
 
-  #   pool:
-  #     name: dotnet-internal-temp
+      #   ${{ if ne(parameters.dependsOn, '') }}:
+      #     dependsOn: ${{ parameters.dependsOn }}
 
-  #   workspace:
-  #     clean: all
+      #   pool:
+      #     name: dotnet-internal-temp
 
-  #   variables:
-  #     - group: DotNet-Symbol-Server-Pats
-  #     - name: _msdlSymbolServerUrl
-  #       value: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
-  #     - name: _symwebSymbolServerUrl
-  #       value: https://microsoft.artifacts.visualstudio.com/DefaultCollection
-  #     - name: _symbolExpirationInDays
-  #       value: 30
+      #   workspace:
+      #     clean: all
 
-  #   steps:
-  #     - task: DownloadBuildArtifacts@0
-  #       displayName: Download symbols to publish
-  #       inputs:
-  #         artifactName: packages
-  #         downloadPath: ${{ parameters.artifactsDir }}
+      #   variables:
+      #     - group: DotNet-Symbol-Server-Pats
+      #     - name: _msdlSymbolServerUrl
+      #       value: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
+      #     - name: _symwebSymbolServerUrl
+      #       value: https://microsoft.artifacts.visualstudio.com/DefaultCollection
+      #     - name: _symbolExpirationInDays
+      #       value: 30
 
-  #     - script: build.cmd -restore
-  #       displayName: Restore Tools
+      #   steps:
+      #     - task: DownloadBuildArtifacts@0
+      #       displayName: Download symbols to publish
+      #       inputs:
+      #         artifactName: packages
+      #         downloadPath: ${{ parameters.artifactsDir }}
 
-  #     - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-  #               -warnaserror:0 -ci
-  #               /t:PublishSymbols
-  #               /p:SymbolServerPath=$(_msdlSymbolServerUrl)
-  #               /p:SymbolServerPAT=$(microsoft-symbol-server-pat)
-  #       displayName: Publish symbols to msdl
+      #     - script: build.cmd -restore
+      #       displayName: Restore Tools
 
-  #     - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-  #               -warnaserror:0 -ci
-  #               /t:PublishSymbols
-  #               /p:SymbolServerPath=$(_symwebSymbolServerUrl)
-  #               /p:SymbolServerPAT=$(symweb-symbol-server-pat)
-  #       displayName: Publish symbols to symweb
+      #     - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+      #               -warnaserror:0 -ci
+      #               /t:PublishSymbols
+      #               /p:SymbolServerPath=$(_msdlSymbolServerUrl)
+      #               /p:SymbolServerPAT=$(microsoft-symbol-server-pat)
+      #       displayName: Publish symbols to msdl
+
+      #     - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+      #               -warnaserror:0 -ci
+      #               /t:PublishSymbols
+      #               /p:SymbolServerPath=$(_symwebSymbolServerUrl)
+      #               /p:SymbolServerPAT=$(symweb-symbol-server-pat)
+      #       displayName: Publish symbols to symweb

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -66,93 +66,93 @@ jobs:
               artifactName: packages
               artifactType: container
 
-          # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-          #           -warnaserror:0 -ci
-          #           /t:PublishPackagesToBlobFeed
-          #           /p:ManifestBuildId=$(Build.BuildNumber)
-          #           /p:ManifestBuildData=Location=$(_dotnetFeedUrl)
-          #           /p:ManifestBranch=$(Build.SourceBranch)
-          #           /p:ManifestCommit=$(Build.SourceVersion)
-          #           /p:ManifestRepoUri=$(Build.Repository.Uri)
-          #           /p:AccountKey=$(dotnetfeed-storage-access-key-1)
-          #           /p:ExpectedFeedUrl=$(_dotnetFeedUrl)
-          #           /p:IncludeSymbolsOnPackagePublish=true
-          #   displayName: Push to dotnet feed
+          - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+                    -warnaserror:0 -ci
+                    /t:PublishPackagesToBlobFeed
+                    /p:ManifestBuildId=$(Build.BuildNumber)
+                    /p:ManifestBuildData=Location=$(_dotnetFeedUrl)
+                    /p:ManifestBranch=$(Build.SourceBranch)
+                    /p:ManifestCommit=$(Build.SourceVersion)
+                    /p:ManifestRepoUri=$(Build.Repository.Uri)
+                    /p:AccountKey=$(dotnetfeed-storage-access-key-1)
+                    /p:ExpectedFeedUrl=$(_dotnetFeedUrl)
+                    /p:IncludeSymbolsOnPackagePublish=true
+            displayName: Push to dotnet feed
 
-          # - task: PublishBuildArtifacts@1
-          #   displayName: Publish assets manifest to artifacts
-          #   inputs:
-          #     pathToPublish: $(_manifestsDir)
-          #     artifactName: BuildAssetsManifest
-          #     artifactType: container
+          - task: PublishBuildArtifacts@1
+            displayName: Publish assets manifest to artifacts
+            inputs:
+              pathToPublish: $(_manifestsDir)
+              artifactName: BuildAssetsManifest
+              artifactType: container
 
-          # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\sdk-task.ps1
-          #           -task PublishBuildAssets -restore -msbuildEngine dotnet
-          #           /p:ManifestsPath='$(_manifestsDir)'
-          #           /p:BuildAssetRegistryToken=$(MaestroAccessToken)
-          #           /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
-          #           /p:Configuration=${{ parameters.buildConfiguration }}
-          #   displayName: Publish to Build Assets Registry
+          - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\sdk-task.ps1
+                    -task PublishBuildAssets -restore -msbuildEngine dotnet
+                    /p:ManifestsPath='$(_manifestsDir)'
+                    /p:BuildAssetRegistryToken=$(MaestroAccessToken)
+                    /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+                    /p:Configuration=${{ parameters.buildConfiguration }}
+            displayName: Publish to Build Assets Registry
 
-          # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-          #           -warnaserror:0 -ci
-          #           /t:NuGetPush
-          #           /p:NuGetSource=$(_mygetFeedUrl)
-          #           /p:NuGetApiKey=$(dotnet-myget-org-api-key)
-          #   displayName: Push to myget.org
+          - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+                    -warnaserror:0 -ci
+                    /t:NuGetPush
+                    /p:NuGetSource=$(_mygetFeedUrl)
+                    /p:NuGetApiKey=$(dotnet-myget-org-api-key)
+            displayName: Push to myget.org
 
-          # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 build.proj
-          #           -warnaserror:0 -ci
-          #           /t:UpdatePublishedVersions
-          #           /p:GitHubAuthToken=$(AccessToken-dotnet-build-bot-public-repo)
-          #           /p:VersionsRepoOwner=dotnet
-          #           /p:VersionsRepo=versions
-          #           /p:VersionsRepoPath=build-info/dotnet/corefx/$(FullBranchName)
-          #           /p:ShippedNuGetPackageGlobPath=${{ parameters.artifactsDir }}/packages/*.nupkg
-          #   displayName: Update dotnet/versions
+          - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 build.proj
+                    -warnaserror:0 -ci
+                    /t:UpdatePublishedVersions
+                    /p:GitHubAuthToken=$(AccessToken-dotnet-build-bot-public-repo)
+                    /p:VersionsRepoOwner=dotnet
+                    /p:VersionsRepo=versions
+                    /p:VersionsRepoPath=build-info/dotnet/corefx/$(FullBranchName)
+                    /p:ShippedNuGetPackageGlobPath=${{ parameters.artifactsDir }}/packages/*.nupkg
+            displayName: Update dotnet/versions
 
-      # - job: PublishSymbols
-      #   displayName: Publish Symbols
-      #   timeoutInMinutes: 120
+      - job: PublishSymbols
+        displayName: Publish Symbols
+        timeoutInMinutes: 120
 
-      #   ${{ if ne(parameters.dependsOn, '') }}:
-      #     dependsOn: ${{ parameters.dependsOn }}
+        ${{ if ne(parameters.dependsOn, '') }}:
+          dependsOn: ${{ parameters.dependsOn }}
 
-      #   pool:
-      #     name: dotnet-internal-temp
+        pool:
+          name: dotnet-internal-temp
 
-      #   workspace:
-      #     clean: all
+        workspace:
+          clean: all
 
-      #   variables:
-      #     - group: DotNet-Symbol-Server-Pats
-      #     - name: _msdlSymbolServerUrl
-      #       value: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
-      #     - name: _symwebSymbolServerUrl
-      #       value: https://microsoft.artifacts.visualstudio.com/DefaultCollection
-      #     - name: _symbolExpirationInDays
-      #       value: 30
+        variables:
+          - group: DotNet-Symbol-Server-Pats
+          - name: _msdlSymbolServerUrl
+            value: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
+          - name: _symwebSymbolServerUrl
+            value: https://microsoft.artifacts.visualstudio.com/DefaultCollection
+          - name: _symbolExpirationInDays
+            value: 30
 
-      #   steps:
-      #     - task: DownloadBuildArtifacts@0
-      #       displayName: Download symbols to publish
-      #       inputs:
-      #         artifactName: packages
-      #         downloadPath: ${{ parameters.artifactsDir }}
+        steps:
+          - task: DownloadBuildArtifacts@0
+            displayName: Download symbols to publish
+            inputs:
+              artifactName: packages
+              downloadPath: ${{ parameters.artifactsDir }}
 
-      #     - script: build.cmd -restore
-      #       displayName: Restore Tools
+          - script: build.cmd -restore
+            displayName: Restore Tools
 
-      #     - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-      #               -warnaserror:0 -ci
-      #               /t:PublishSymbols
-      #               /p:SymbolServerPath=$(_msdlSymbolServerUrl)
-      #               /p:SymbolServerPAT=$(microsoft-symbol-server-pat)
-      #       displayName: Publish symbols to msdl
+          - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+                    -warnaserror:0 -ci
+                    /t:PublishSymbols
+                    /p:SymbolServerPath=$(_msdlSymbolServerUrl)
+                    /p:SymbolServerPAT=$(microsoft-symbol-server-pat)
+            displayName: Publish symbols to msdl
 
-      #     - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-      #               -warnaserror:0 -ci
-      #               /t:PublishSymbols
-      #               /p:SymbolServerPath=$(_symwebSymbolServerUrl)
-      #               /p:SymbolServerPAT=$(symweb-symbol-server-pat)
-      #       displayName: Publish symbols to symweb
+          - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+                    -warnaserror:0 -ci
+                    /t:PublishSymbols
+                    /p:SymbolServerPath=$(_symwebSymbolServerUrl)
+                    /p:SymbolServerPAT=$(symweb-symbol-server-pat)
+            displayName: Publish symbols to symweb

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -66,12 +66,12 @@ jobs:
       #           /p:IncludeSymbolsOnPackagePublish=true
       #   displayName: Push to dotnet feed
 
-      - task: PublishBuildArtifacts@1
-        displayName: Publish assets manifest to artifacts
-        inputs:
-          pathToPublish: $(_manifestsDir)
-          artifactName: BuildAssetsManifest
-          artifactType: container
+      # - task: PublishBuildArtifacts@1
+      #   displayName: Publish assets manifest to artifacts
+      #   inputs:
+      #     pathToPublish: $(_manifestsDir)
+      #     artifactName: BuildAssetsManifest
+      #     artifactType: container
 
       # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\sdk-task.ps1
       #           -task PublishBuildAssets -restore -msbuildEngine dotnet

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -53,18 +53,18 @@ jobs:
       - script: build.cmd -restore
         displayName: Restore Tools
 
-      - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-                -warnaserror:0 -ci
-                /t:PublishPackagesToBlobFeed
-                /p:ManifestBuildId=$(Build.BuildNumber)
-                /p:ManifestBuildData=Location=$(_dotnetFeedUrl)
-                /p:ManifestBranch=$(Build.SourceBranch)
-                /p:ManifestCommit=$(Build.SourceVersion)
-                /p:ManifestRepoUri=$(Build.Repository.Uri)
-                /p:AccountKey=$(dotnetfeed-storage-access-key-1)
-                /p:ExpectedFeedUrl=$(_dotnetFeedUrl)
-                /p:IncludeSymbolsOnPackagePublish=true
-        displayName: Push to dotnet feed
+      # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+      #           -warnaserror:0 -ci
+      #           /t:PublishPackagesToBlobFeed
+      #           /p:ManifestBuildId=$(Build.BuildNumber)
+      #           /p:ManifestBuildData=Location=$(_dotnetFeedUrl)
+      #           /p:ManifestBranch=$(Build.SourceBranch)
+      #           /p:ManifestCommit=$(Build.SourceVersion)
+      #           /p:ManifestRepoUri=$(Build.Repository.Uri)
+      #           /p:AccountKey=$(dotnetfeed-storage-access-key-1)
+      #           /p:ExpectedFeedUrl=$(_dotnetFeedUrl)
+      #           /p:IncludeSymbolsOnPackagePublish=true
+      #   displayName: Push to dotnet feed
 
       - task: PublishBuildArtifacts@1
         displayName: Publish assets manifest to artifacts
@@ -73,73 +73,73 @@ jobs:
           artifactName: BuildAssetsManifest
           artifactType: container
 
-      - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\sdk-task.ps1
-                -task PublishBuildAssets -restore -msbuildEngine dotnet
-                /p:ManifestsPath='$(_manifestsDir)'
-                /p:BuildAssetRegistryToken=$(MaestroAccessToken)
-                /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
-                /p:Configuration=${{ parameters.buildConfiguration }}
-        displayName: Publish to Build Assets Registry
+      # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\sdk-task.ps1
+      #           -task PublishBuildAssets -restore -msbuildEngine dotnet
+      #           /p:ManifestsPath='$(_manifestsDir)'
+      #           /p:BuildAssetRegistryToken=$(MaestroAccessToken)
+      #           /p:MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com
+      #           /p:Configuration=${{ parameters.buildConfiguration }}
+      #   displayName: Publish to Build Assets Registry
 
-      - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-                -warnaserror:0 -ci
-                /t:NuGetPush
-                /p:NuGetSource=$(_mygetFeedUrl)
-                /p:NuGetApiKey=$(dotnet-myget-org-api-key)
-        displayName: Push to myget.org
+      # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+      #           -warnaserror:0 -ci
+      #           /t:NuGetPush
+      #           /p:NuGetSource=$(_mygetFeedUrl)
+      #           /p:NuGetApiKey=$(dotnet-myget-org-api-key)
+      #   displayName: Push to myget.org
 
-      - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 build.proj
-                -warnaserror:0 -ci
-                /t:UpdatePublishedVersions
-                /p:GitHubAuthToken=$(AccessToken-dotnet-build-bot-public-repo)
-                /p:VersionsRepoOwner=dotnet
-                /p:VersionsRepo=versions
-                /p:VersionsRepoPath=build-info/dotnet/corefx/$(FullBranchName)
-                /p:ShippedNuGetPackageGlobPath=${{ parameters.artifactsDir }}/packages/*.nupkg
-        displayName: Update dotnet/versions
+      # - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 build.proj
+      #           -warnaserror:0 -ci
+      #           /t:UpdatePublishedVersions
+      #           /p:GitHubAuthToken=$(AccessToken-dotnet-build-bot-public-repo)
+      #           /p:VersionsRepoOwner=dotnet
+      #           /p:VersionsRepo=versions
+      #           /p:VersionsRepoPath=build-info/dotnet/corefx/$(FullBranchName)
+      #           /p:ShippedNuGetPackageGlobPath=${{ parameters.artifactsDir }}/packages/*.nupkg
+      #   displayName: Update dotnet/versions
 
-  - job: PublishSymbols
-    displayName: Publish Symbols
-    timeoutInMinutes: 120
+  # - job: PublishSymbols
+  #   displayName: Publish Symbols
+  #   timeoutInMinutes: 120
 
-    ${{ if ne(parameters.dependsOn, '') }}:
-      dependsOn: ${{ parameters.dependsOn }}
+  #   ${{ if ne(parameters.dependsOn, '') }}:
+  #     dependsOn: ${{ parameters.dependsOn }}
 
-    pool:
-      name: dotnet-internal-temp
+  #   pool:
+  #     name: dotnet-internal-temp
 
-    workspace:
-      clean: all
+  #   workspace:
+  #     clean: all
 
-    variables:
-      - group: DotNet-Symbol-Server-Pats
-      - name: _msdlSymbolServerUrl
-        value: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
-      - name: _symwebSymbolServerUrl
-        value: https://microsoft.artifacts.visualstudio.com/DefaultCollection
-      - name: _symbolExpirationInDays
-        value: 30
+  #   variables:
+  #     - group: DotNet-Symbol-Server-Pats
+  #     - name: _msdlSymbolServerUrl
+  #       value: https://microsoftpublicsymbols.artifacts.visualstudio.com/DefaultCollection
+  #     - name: _symwebSymbolServerUrl
+  #       value: https://microsoft.artifacts.visualstudio.com/DefaultCollection
+  #     - name: _symbolExpirationInDays
+  #       value: 30
 
-    steps:
-      - task: DownloadBuildArtifacts@0
-        displayName: Download symbols to publish
-        inputs:
-          artifactName: packages
-          downloadPath: ${{ parameters.artifactsDir }}
+  #   steps:
+  #     - task: DownloadBuildArtifacts@0
+  #       displayName: Download symbols to publish
+  #       inputs:
+  #         artifactName: packages
+  #         downloadPath: ${{ parameters.artifactsDir }}
 
-      - script: build.cmd -restore
-        displayName: Restore Tools
+  #     - script: build.cmd -restore
+  #       displayName: Restore Tools
 
-      - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-                -warnaserror:0 -ci
-                /t:PublishSymbols
-                /p:SymbolServerPath=$(_msdlSymbolServerUrl)
-                /p:SymbolServerPAT=$(microsoft-symbol-server-pat)
-        displayName: Publish symbols to msdl
+  #     - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+  #               -warnaserror:0 -ci
+  #               /t:PublishSymbols
+  #               /p:SymbolServerPath=$(_msdlSymbolServerUrl)
+  #               /p:SymbolServerPAT=$(microsoft-symbol-server-pat)
+  #       displayName: Publish symbols to msdl
 
-      - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
-                -warnaserror:0 -ci
-                /t:PublishSymbols
-                /p:SymbolServerPath=$(_symwebSymbolServerUrl)
-                /p:SymbolServerPAT=$(symweb-symbol-server-pat)
-        displayName: Publish symbols to symweb
+  #     - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj
+  #               -warnaserror:0 -ci
+  #               /t:PublishSymbols
+  #               /p:SymbolServerPath=$(_symwebSymbolServerUrl)
+  #               /p:SymbolServerPAT=$(symweb-symbol-server-pat)
+  #       displayName: Publish symbols to symweb

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -121,7 +121,6 @@ jobs:
           name: Hosted VS2017
 
       submitToHelix: true
-      enableMicrobuild: ${{ parameters.isOfficialBuild }}
       buildExtraArguments: /p:RuntimeOS=win10
 
       variables:
@@ -173,7 +172,6 @@ jobs:
         submitToHelix: true
         # azure pipelines reporter only supports xunit results based tests.
         enableAzurePipelinesReporter: false
-        enableMicrobuild: ${{ parameters.isOfficialBuild }}
 
         variables:
           - _outerloop: false
@@ -242,7 +240,6 @@ jobs:
             name: Hosted VS2017
 
         submitToHelix: false
-        enableMicrobuild: ${{ parameters.isOfficialBuild }}
         buildExtraArguments: /p:RuntimeOS=win10
 
         variables:


### PR DESCRIPTION
cc: @leecow 

This moves signing step from Windows leg to the publish step after the packages from all legs are already downloaded.

Successful build (with stripped out physical publish) can be seen here
https://dnceng.visualstudio.com/internal/_build/results?buildId=122585

I've checked couple of packages from that build with `nuget verify -Signature`

Currently running final test build:
https://dnceng.visualstudio.com/internal/_build/results?buildId=123609