### PR TITLE
Updating to latest WCF version.

### DIFF
--- a/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <HarvestStablePackage>false</HarvestStablePackage>
-    <PackageVersion>2.1.0</PackageVersion>
+    <PackageVersion>2.1.1</PackageVersion>
     <ServiceModelVersion>4.5.3</ServiceModelVersion>
   </PropertyGroup>
 

--- a/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <HarvestStablePackage>false</HarvestStablePackage>
     <PackageVersion>2.1.0</PackageVersion>
-    <ServiceModelVersion>4.4.1</ServiceModelVersion>
+    <ServiceModelVersion>4.5.3</ServiceModelVersion>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/pkg/Microsoft.Windows.Compatibility/externalIndex.json
+++ b/pkg/Microsoft.Windows.Compatibility/externalIndex.json
@@ -4,35 +4,40 @@
       "StableVersions": [
         "4.4.0",
         "4.3.0",
-        "4.4.1"
+        "4.4.1",
+        "4.5.3"
       ]
     },
     "System.ServiceModel.Duplex": {
       "StableVersions": [
         "4.4.0",
         "4.3.0",
-        "4.4.1"
+        "4.4.1",
+        "4.5.3"
       ]
     },
     "System.ServiceModel.Http": {
       "StableVersions": [
         "4.4.0",
         "4.3.0",
-        "4.4.1"
+        "4.4.1",
+        "4.5.3"
       ]
     },
     "System.ServiceModel.NetTcp": {
       "StableVersions": [
         "4.4.0",
         "4.3.0",
-        "4.4.1"
+        "4.4.1",
+        "4.5.3"
       ]
     },
     "System.ServiceModel.Security": {
       "StableVersions": [
         "4.4.0",
         "4.3.0",
-        "4.4.1"
+        "4.4.1",
+        "4.5.3"
       ]
     }
   }

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -35,6 +35,9 @@
     <Project Include="$(MSBuildThisFileDirectory)System.Data.SqlClient\pkg\System.Data.SqlClient.pkgproj">
       <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
     </Project>
+    <Project Include="$(MSBuildThisFileDirectory)..\pkg\Microsoft.Windows.Compatibility\Microsoft.Windows.Compatibility.builds">
+      <AdditionalProperties>$(AdditionalProperties)</AdditionalProperties>
+    </Project>
   </ItemGroup>
 
   <!-- Need the PackageIndexFile file property from baseline.props -->


### PR DESCRIPTION
Cherry-picked from master with minor conflicts.

#### Description 
WCF packages contained an RID authoring error which was fixed in 4.5.0 and above. The Microsoft.Windows.Compatibility package references our older packages and needs to be updated to reference our newer packages to avoid this old authoring issue.

#### Customer Impact 
This was reported by a customer in dotnet/wcf#3437, they hit the authoring issue which causes an application to fail because it can't find the required implementation assembly.
 
#### Regression? 
Yes in that if they don't use the Microsoft.Windows.Compatibility package it works correctly.
 
#### Risk 
There is no known risk to updating this package to reference our latest WCF packages, the underling authoring problem was known and fixed with our first 4.5.0 package almost a year ago.

#### Packaging Reviewed
Yes, by @wtgodbe