### PR TITLE
Fix CryptoStream.Dispose to only transform final block when writing

### DIFF
--- a/src/System.Security.Cryptography.Primitives/tests/CryptoStream.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptoStream.netcoreapp.cs
@@ -64,29 +64,29 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
             }
         }
 
-        [Theory]
-        [InlineData("Aes")]
-        [InlineData("Rijndael")]
-        public static void PaddedAesRijdnael_PartialRead_Success(string algName)
+        [Fact]
+        public static void PaddedAes_PartialRead_Success()
         {
-            SymmetricAlgorithm alg = SymmetricAlgorithm.Create(algName);
-            alg.Mode = CipherMode.CBC;
-            alg.Key = alg.IV = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, };
-
-            var memoryStream = new MemoryStream();
-            using (var cryptoStream = new CryptoStream(memoryStream, alg.CreateEncryptor(), CryptoStreamMode.Write, leaveOpen: true))
+            using (Aes aes = Aes.Create())
             {
-                cryptoStream.Write(Encoding.ASCII.GetBytes("Sample string that's bigger than cryptoAlg.BlockSize"));
-                cryptoStream.FlushFinalBlock();
-            }
+                aes.Mode = CipherMode.CBC;
+                aes.Key = aes.IV = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, };
 
-            memoryStream.Position = 0;
-            using (var cryptoStream = new CryptoStream(memoryStream, alg.CreateDecryptor(), CryptoStreamMode.Read))
-            {
-                cryptoStream.ReadByte(); // Partially read the CryptoStream before disposing it.
-            }
+                var memoryStream = new MemoryStream();
+                using (var cryptoStream = new CryptoStream(memoryStream, aes.CreateEncryptor(), CryptoStreamMode.Write, leaveOpen: true))
+                {
+                    cryptoStream.Write(Encoding.ASCII.GetBytes("Sample string that's bigger than cryptoAlg.BlockSize"));
+                    cryptoStream.FlushFinalBlock();
+                }
 
-            // No exception should be thrown.
+                memoryStream.Position = 0;
+                using (var cryptoStream = new CryptoStream(memoryStream, aes.CreateDecryptor(), CryptoStreamMode.Read))
+                {
+                    cryptoStream.ReadByte(); // Partially read the CryptoStream before disposing it.
+                }
+
+                // No exception should be thrown.
+            }
         }
 
         private sealed class DerivedCryptoStream : CryptoStream

--- a/src/System.Security.Cryptography.Primitives/tests/CryptoStream.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptoStream.netcoreapp.cs
@@ -64,6 +64,31 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
             }
         }
 
+        [Theory]
+        [InlineData("Aes")]
+        [InlineData("Rijndael")]
+        public static void PaddedAesRijdnael_PartialRead_Success(string algName)
+        {
+            SymmetricAlgorithm alg = SymmetricAlgorithm.Create(algName);
+            alg.Mode = CipherMode.CBC;
+            alg.Key = alg.IV = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, };
+
+            var memoryStream = new MemoryStream();
+            using (var cryptoStream = new CryptoStream(memoryStream, alg.CreateEncryptor(), CryptoStreamMode.Write, leaveOpen: true))
+            {
+                cryptoStream.Write(Encoding.ASCII.GetBytes("Sample string that's bigger than cryptoAlg.BlockSize"));
+                cryptoStream.FlushFinalBlock();
+            }
+
+            memoryStream.Position = 0;
+            using (var cryptoStream = new CryptoStream(memoryStream, alg.CreateDecryptor(), CryptoStreamMode.Read))
+            {
+                cryptoStream.ReadByte(); // Partially read the CryptoStream before disposing it.
+            }
+
+            // No exception should be thrown.
+        }
+
         private sealed class DerivedCryptoStream : CryptoStream
         {
             public bool DisposeInvoked;


### PR DESCRIPTION
When reading, the final transform isn't required, and using it can result in exceptions when the stream is only partially read.

Fixes https://github.com/dotnet/corefx/issues/7779
cc: @bartonjs