### PR TITLE
Console: Unix: Improve Cursor{Left,Top} performance by caching them

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetTerminalInvalidationHandler.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetTerminalInvalidationHandler.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Sys
+    {
+        internal delegate void TerminalInvalidationCallback();
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetTerminalInvalidationHandler")]
+        internal static extern void SetTerminalInvalidationHandler(TerminalInvalidationCallback handler);
+    }
+}

--- a/src/Native/Unix/System.Native/pal_signal.h
+++ b/src/Native/Unix/System.Native/pal_signal.h
@@ -55,3 +55,11 @@ DLLEXPORT uint32_t SystemNative_RegisterForSigChld(SigChldCallback callback);
  * It could also be a custom handler registered by other code before us.
  */
 DLLEXPORT void SystemNative_RestoreAndHandleCtrl(CtrlCode ctrlCode);
+
+typedef void (*TerminalInvalidationCallback)(void);
+
+/**
+ * Hooks up the specified callback for notifications when SIGCHLD, SIGCONT, SIGWINCH are received.
+  *
+ */
+DLLEXPORT void SystemNative_SetTerminalInvalidationHandler(TerminalInvalidationCallback callback);

--- a/src/System.Console/src/FxCopBaseline.cs
+++ b/src/System.Console/src/FxCopBaseline.cs
@@ -20,3 +20,6 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#WriteStdoutAnsiString(System.String,System.Boolean)")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#ForegroundColor")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#BackgroundColor")]
+[assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#SetCursorPosition(System.Int32,System.Int32)")]
+[assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#GetWindowSize(System.Int32&,System.Int32&)")]
+[assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#UpdatedCachedCursorPosition(System.Byte*,System.Int32,System.Int32)")]

--- a/src/System.Console/src/FxCopBaseline.cs
+++ b/src/System.Console/src/FxCopBaseline.cs
@@ -17,6 +17,6 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#GetCursorPosition(System.Int32&,System.Int32&)")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#RefreshColors(System.ConsoleColor&,System.ConsoleColor)")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#EnsureInitializedCore()")]
-[assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#WriteStdoutAnsiString(System.String)")]
+[assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#WriteStdoutAnsiString(System.String,System.Boolean)")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#ForegroundColor")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#BackgroundColor")]

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -238,6 +238,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.RestoreAndHandleCtrl.cs">
       <Link>Common\Interop\Unix\Interop.RestoreAndHandleCtrl.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetTerminalInvalidationHandler.cs">
+      <Link>Common\Interop\Unix\Interop.SetTerminalInvalidationHandler.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetSignalForBreak.cs">
       <Link>Common\Interop\Unix\Interop.SetSignalForBreak.cs</Link>
     </Compile>

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -363,8 +363,8 @@ namespace System
                     Interop.Sys.WinSize winsize;
                     if (Interop.Sys.GetWindowSize(out winsize) == 0)
                     {
-                        s_windowWidth = winsize.Row;
-                        s_windowHeight = winsize.Col;
+                        s_windowWidth = winsize.Col;
+                        s_windowHeight = winsize.Row;
                     }
                     else
                     {

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -126,7 +126,10 @@ namespace System
                 keyInfo = new ConsoleKeyInfo('\r', keyInfo.Key, shift, alt, control);
             }
 
-            if (!intercept && !previouslyProcessed) Console.Write(keyInfo.KeyChar);
+            if (!intercept && !previouslyProcessed && keyInfo.KeyChar != '\0')
+            {
+                Console.Write(keyInfo.KeyChar);
+            }
             return keyInfo;
         }
 

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -1321,8 +1321,8 @@ namespace System
                     }
                 }
 
-                SetCachedCursorPosition(left, top);
-
+                // We pass cursorVersion because it may have have changed since our earlier check by calling Window{Width/Height}.
+                SetCachedCursorPosition(left, top, cursorVersion);
 
                 void IncrementY()
                 {

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -1281,8 +1281,7 @@ namespace System
                     return;
                 }
 
-                int width = WindowWidth;
-                int height = WindowHeight;
+                GetWindowSize(out int width, out int height);
 
                 for (int i = 0; i < count; i++)
                 {

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -26,8 +26,7 @@ namespace System
         // We also need to invalidate these values when certain signals occur.
         // We don't want to take the lock in the signal handling thread for this.
         // Instead, we set a flag. Before reading a cached value, a call to CheckTerminalSettingsInvalidated
-        // will invalidate the cached values if a signal had occured. After updating the cached values,
-        // a call to the same method ensures we invalidate the values if a signal occured in the meanwhile.
+        // will invalidate the cached values if a signal has occured.
         private static int s_cursorVersion; // Gets incremented each time the cursor position changed.
                                             // Used to synchronize between lock (Console.Out) blocks.
         private static int s_cursorLeft;    // Cached CursorLeft, -1 when invalid.
@@ -266,9 +265,6 @@ namespace System
             {
                 InvalidateCachedCursorPosition();
             }
-
-            // Invalidate after writing cached values.
-            CheckTerminalSettingsInvalidated();
         }
 
         private static void InvalidateCachedCursorPosition()
@@ -378,9 +374,6 @@ namespace System
                 }
                 width = s_windowWidth;
                 height = s_windowHeight;
-
-                // Invalidate after writing cached values.
-                CheckTerminalSettingsInvalidated();
             }
         }
 

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -1313,7 +1313,7 @@ namespace System
                     }
                 }
 
-                // We pass cursorVersion because it may have have changed since our earlier check by calling Window{Width/Height}.
+                // We pass cursorVersion because it may have have changed the earlier check by calling GetWindowSize.
                 SetCachedCursorPosition(left, top, cursorVersion);
 
                 void IncrementY()


### PR DESCRIPTION
We keep a cached version for CursorLeft and CursorTop. When we write
data to stdout, we try to update the cached values based on the buffer
content, or we invalidate the cursor position.

A lock is used to deal with multi-threading issues. We synchronize
between some blocks using a 'version' field. This field is incremented
each time a cursor change may have occured. If the value has not
changed between two blocks, we know the the cursor is still at the same
position.

On signals that may mean the cursor position has changed (SIGCONT,
SIGCHLD, SIGWINCH) we invalidate the cached values.

Fixes https://github.com/dotnet/corefx/issues/32174
Fixes https://github.com/dotnet/corefx/issues/31517
Contributes to https://github.com/dotnet/corefx/issues/34885