### PR TITLE
Porting XEvent Delay BugFix from .Net Framework to 3.0

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -1274,15 +1274,6 @@ namespace System.Data.SqlClient
                 AssertValidState();
             }
 
-            if ((_messageStatus != TdsEnums.ST_EOM) && ((_inBytesPacket == 0) || (_inBytesUsed == _inBytesRead)))
-            {
-                if (!TryPrepareBuffer())
-                {
-                    return false;
-                }
-            }
-
-            AssertValidState();
             return true;
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -1763,7 +1763,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 using (SqlConnection xEventsReadConnection = new SqlConnection(connectionString))
                 {
                     xEventsReadConnection.Open();
-                    string xEventDataStreamCommand = @"select [type], [data] from sys.fn_MSxe_read_event_stream ('" + sessionName + "',0)";
+                    string xEventDataStreamCommand ="USE master; " + @"select [type], [data] from sys.fn_MSxe_read_event_stream ('" + sessionName + "',0)";
                     using (SqlCommand cmd = new SqlCommand(xEventDataStreamCommand, xEventsReadConnection))
                     {
                         SqlDataReader reader = cmd.ExecuteReader(System.Data.CommandBehavior.SequentialAccess);

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Data.SqlTypes;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -1755,13 +1754,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
 
        private static void TestXEventsStreaming(string connectionString)
         {   
-           while (!Debugger.IsAttached)
-           {
-               Console.WriteLine("Waiting for debugger to attach");               
-               Console.WriteLine( Process.GetCurrentProcess().Id); 
-               Thread.Sleep(2000);
-           }
-           Console.WriteLine("Debugger attached");
             string sessionName = "xeventStreamTest";
             SetupXevent(connectionString, sessionName);
             Task.Factory.StartNew(() =>

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -1755,6 +1755,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
        private static void TestXEventsStreaming(string connectionString)
         {   
             string sessionName = "xeventStreamTest";
+            //Create XEvent
             SetupXevent(connectionString, sessionName);
             Task.Factory.StartNew(() =>
             {
@@ -1792,12 +1793,12 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     }
                 }
             }).Wait(10000);
+            //Delete XEvent 
+            DeleteXevent(connectionString, sessionName);
         }
 
         private static void SetupXevent(string connectionString, string sessionName)
-        {
-            string deleteXeventSessionCommand = @"IF EXISTS (select * from sys.server_event_sessions where name ='" + sessionName + "') DROP  EVENT SESSION [" + sessionName + "] ON SERVER";
-
+        {            
             string xEventCreateAndStartCommandText = @"CREATE EVENT SESSION [" + sessionName + @"] ON SERVER 
                         ADD EVENT sqlserver.user_event(ACTION(package0.event_sequence))
                         ADD TARGET package0.ring_buffer
@@ -1811,14 +1812,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                             STARTUP_STATE=OFF)
                             
                         ALTER EVENT SESSION [" + sessionName + "] ON SERVER STATE = START ";
-            using (SqlConnection connection = new SqlConnection(connectionString))
-            {
-                connection.Open();
-                using (SqlCommand deleteXeventSession = new SqlCommand(deleteXeventSessionCommand, connection))
-                {
-                    deleteXeventSession.ExecuteNonQuery();
-                }
-            }
+            
             using (SqlConnection connection = new SqlConnection(connectionString))
             {
                 connection.Open();
@@ -1827,6 +1821,21 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     createXeventSession.ExecuteNonQuery();                    
                 }
             }
+        }
+
+        private static void DeleteXevent(string connectionString, string sessionName)
+        { 
+            string deleteXeventSessionCommand = @"IF EXISTS (select * from sys.server_event_sessions where name ='" + sessionName + "') DROP  EVENT SESSION [" + sessionName + "] ON SERVER";
+            
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                using (SqlCommand deleteXeventSession = new SqlCommand(deleteXeventSessionCommand, connection))
+                {
+                    deleteXeventSession.ExecuteNonQuery();
+                }
+            }
+            
         }
     
         private static void TimeoutDuringReadAsyncWithClosedReaderTest(string connectionString)

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Data.SqlTypes;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -60,7 +61,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             ReadTextReader(connectionString);
             StreamingBlobDataTypes(connectionString);
             OutOfOrderGetChars(connectionString);
-
+            TestXEventsStreaming(connectionString);
             // These tests fail with named pipes, since they try to do DNS lookups on named pipe paths.
             if (!usingNamePipes)
             {
@@ -1751,6 +1752,91 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 }
             }
         }
+
+       private static void TestXEventsStreaming(string connectionString)
+        {   
+           while (!Debugger.IsAttached)
+           {
+               Console.WriteLine("Waiting for debugger to attach");               
+               Console.WriteLine( Process.GetCurrentProcess().Id); 
+               Thread.Sleep(2000);
+           }
+           Console.WriteLine("Debugger attached");
+            string sessionName = "xeventStreamTest";
+            SetupXevent(connectionString, sessionName);
+            Task.Factory.StartNew(() =>
+            {
+                // Read XEvents
+                int streamXeventCount = 3;
+                using (SqlConnection xEventsReadConnection = new SqlConnection(connectionString))
+                {
+                    xEventsReadConnection.Open();
+                    string xEventDataStreamCommand = @"select [type], [data] from sys.fn_MSxe_read_event_stream ('" + sessionName + "',0)";
+                    using (SqlCommand cmd = new SqlCommand(xEventDataStreamCommand, xEventsReadConnection))
+                    {
+                        SqlDataReader reader = cmd.ExecuteReader(System.Data.CommandBehavior.SequentialAccess);
+                        for (int i = 0; i < streamXeventCount && reader.Read(); i++)
+                        {
+                            Int32 colType = reader.GetInt32(0);
+                            int cb = (int)reader.GetBytes(1, 0, null, 0, 0);
+                            
+                            byte[] bytes = new byte[cb];
+                            long read = reader.GetBytes(1, 0, bytes, 0, cb);                            
+
+                            // Don't send data on the first read because there is already data in the buffer. 
+                            // Don't send data on the last iteration. We will not be reading that data.
+                            if (i == 0 || i == streamXeventCount - 1) continue;
+
+                            using (SqlConnection xEventWriteConnection = new SqlConnection(connectionString))
+                            {
+                                xEventWriteConnection.Open();
+                                string xEventWriteCommandText = @"exec sp_trace_generateevent 90, N'Test2'";
+                                using (SqlCommand xEventWriteCommand = new SqlCommand(xEventWriteCommandText, xEventWriteConnection))
+                                {
+                                    xEventWriteCommand.ExecuteNonQuery();
+                                }
+                            }
+                        }
+                    }
+                }
+            }).Wait(10000);
+        }
+
+        private static void SetupXevent(string connectionString, string sessionName)
+        {
+            string deleteXeventSessionCommand = @"IF EXISTS (select * from sys.server_event_sessions where name ='" + sessionName + "') DROP  EVENT SESSION [" + sessionName + "] ON SERVER";
+
+            string xEventCreateAndStartCommandText = @"CREATE EVENT SESSION [" + sessionName + @"] ON SERVER 
+                        ADD EVENT sqlserver.user_event(ACTION(package0.event_sequence))
+                        ADD TARGET package0.ring_buffer
+                        WITH (
+                            MAX_MEMORY=4096 KB,
+                            EVENT_RETENTION_MODE=ALLOW_SINGLE_EVENT_LOSS,
+                            MAX_DISPATCH_LATENCY=30 SECONDS,
+                            MAX_EVENT_SIZE=0 KB,
+                            MEMORY_PARTITION_MODE=NONE,
+                            TRACK_CAUSALITY=ON,
+                            STARTUP_STATE=OFF)
+                            
+                        ALTER EVENT SESSION [" + sessionName + "] ON SERVER STATE = START ";
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                using (SqlCommand deleteXeventSession = new SqlCommand(deleteXeventSessionCommand, connection))
+                {
+                    deleteXeventSession.ExecuteNonQuery();
+                }
+            }
+            using (SqlConnection connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                using (SqlCommand createXeventSession = new SqlCommand(xEventCreateAndStartCommandText, connection))
+                {
+                    createXeventSession.ExecuteNonQuery();                    
+                }
+            }
+        }
+    
 
         private static void TimeoutDuringReadAsyncWithClosedReaderTest(string connectionString)
         {

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -1829,7 +1829,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
     
-
         private static void TimeoutDuringReadAsyncWithClosedReaderTest(string connectionString)
         {
             // Create the proxy


### PR DESCRIPTION
The bug description is given below-
The issues is that the XEvents are arriving as expected, but with 1 XEvent delay. It means that to receive the most recent XEvent, the app has to wait for another XEvent to be generated.
For example, when listening for XEvents that fires on every query that the clients are running:
• At startup, if the client is running for example, “select 1”, and then the client doesn't get any XEvent.
• If the client is running “select 2”, then the client receives the “select 1” event.
• If the client is running “select 3”, then the client receives “select 2” event. And so on…

It seems like the server is sending the most recent XEvent on the wire, but the client holds it inside up until the next XEvent is arrived .

This fix already exists in the .Net Framework. This PR merges this fix into .Net Core 3.0.