### PR TITLE
Fix HttpWebRequest to use WebRequest.DefaultWebProxy credentials

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1152,6 +1152,13 @@ namespace System.Net
                 {
                     handler.Proxy = _proxy;
                 }
+                else
+                {
+                    // Since this HttpWebRequest is using the default system proxy, we need to 
+                    // pass any proxy credentials that the developer might have set via the
+                    // WebRequest.DefaultWebProxy.Credentials property.
+                    handler.DefaultProxyCredentials = _proxy.Credentials;
+                }
 
                 handler.ClientCertificates.AddRange(ClientCertificates);
 


### PR DESCRIPTION
If the HttpWebRequest is using the default system proxy, we need to pass any proxy
credentials that the developer might have set via the WebRequest.DefaultWebProxy.Credentials
property. This matches .NET Framework behavior.

I tested this manually using Fiddler as the authenticating proxy.

Fixes #36058