### PR TITLE
Add test for HttpWebRequest default proxy credentials

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -20,6 +20,8 @@ using Xunit.Abstractions;
 
 namespace System.Net.Tests
 {
+    using Configuration = System.Net.Test.Common.Configuration;
+
     public partial class HttpWebRequestTest : RemoteExecutorTestBase
     {
         private const string RequestBody = "This is data to POST.";
@@ -27,7 +29,7 @@ namespace System.Net.Tests
         private readonly NetworkCredential _explicitCredential = new NetworkCredential("user", "password", "domain");
         private readonly ITestOutputHelper _output;
 
-        public static readonly object[][] EchoServers = System.Net.Test.Common.Configuration.Http.EchoServers;
+        public static readonly object[][] EchoServers = Configuration.Http.EchoServers;
 
         public static IEnumerable<object[]> Dates_ReadValue_Data()
         {
@@ -1312,6 +1314,44 @@ namespace System.Net.Tests
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
             Assert.NotNull(request.Proxy);
+        }
+
+        [OuterLoop("Uses external server")]
+        [PlatformSpecific(TestPlatforms.AnyUnix)] // The default proxy is resolved via WinINet on Windows.
+        [Fact]
+        public async Task ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed()
+        {
+            const string ExpectedUsername = "rightusername";
+            const string ExpectedPassword = "rightpassword";
+            LoopbackServer.Options options =
+                new LoopbackServer.Options { IsProxy = true, Username = ExpectedUsername, Password = ExpectedPassword };
+
+            await LoopbackServer.CreateServerAsync(async (proxyServer, proxyUri) =>
+            {
+                // HttpWebRequest/HttpClient will read a default proxy from the http_proxy environment variable. Ensure
+                // that when it does our default proxy credentials are used. To avoid messing up anything else in this
+                // process we run the test in another process.
+                var psi = new ProcessStartInfo();
+                Task<List<string>> proxyTask = null;
+
+                proxyTask = proxyServer.AcceptConnectionPerformAuthenticationAndCloseAsync("Proxy-Authenticate: Basic realm=\"NetCore\"\r\n");
+                psi.Environment.Add("http_proxy", $"http://{proxyUri.Host}:{proxyUri.Port}");
+
+                RemoteInvoke(async () =>
+                {
+                    WebRequest.DefaultWebProxy.Credentials = new NetworkCredential(ExpectedUsername, ExpectedPassword);
+                    HttpWebRequest request = HttpWebRequest.CreateHttp(Configuration.Http.RemoteEchoServer);
+
+                    using (var response = (HttpWebResponse) await request.GetResponseAsync())
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    }
+
+                    return SuccessExitCode;
+                }, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
+
+                await proxyTask;
+            }, options);
         }
 
         [Theory, MemberData(nameof(EchoServers))]

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -21,6 +21,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.cs">
       <Link>Common\System\Net\Http\LoopbackServer.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackServer.AuthenticationHelpers.cs">
+      <Link>Common\System\Net\Http\LoopbackServer.AuthenticationHelpers.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Http\GenericLoopbackServer.cs">
       <Link>Common\System\Net\Http\GenericLoopbackServer.cs</Link>
     </Compile>


### PR DESCRIPTION
It's easier to simulate default system proxy settings on Linux since it uses environment
variables. Add a test to verify that the proxy credentials are passed from
WebRequest.DefaultWebProxy.Credentials to the system proxy.

Follow-up to PR #36059