### PR TITLE
Fix SslStreamStreamToStreamTest to exercise correct overloads

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/LoggingTest.cs
@@ -40,7 +40,7 @@ namespace System.Net.Security.Tests
                         // Invoke tests that'll cause some events to be generated
                         var test = new SslStreamStreamToStreamTest_Async();
                         test.SslStream_StreamToStream_Authentication_Success().GetAwaiter().GetResult();
-                        test.SslStream_StreamToStream_Successive_ClientWrite_Sync_Success().GetAwaiter().GetResult();
+                        test.SslStream_StreamToStream_Successive_ClientWrite_Success().GetAwaiter().GetResult();
                     });
                     Assert.DoesNotContain(events, ev => ev.EventId == 0); // errors from the EventSource itself
                     Assert.InRange(events.Count, 1, int.MaxValue);

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNetworkStreamTest.cs
@@ -3,11 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net.Sockets;
-using System.Net.Test.Common;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;


### PR DESCRIPTION
The SslStreamStreamToStreamTest is set up as a base class from which three test classes derive, one for each of Async, Begin/End, and Sync.  But the base class isn't actually deferring to the derived types to customize most of the functionality being executed, namely read/write methods.  This PR fixes that, so that the base class properly exercises the relevant methods, customized to the base type.

cc: @davidsh