### PR TITLE
Cleaning up the P/Invoke signatures for QPF and QPC to avoid marshalling and pinning

### DIFF
--- a/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
@@ -8,10 +8,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestampResolution", BestFitMapping = false, ExactSpelling = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestampResolution", ExactSpelling = true)]
         internal static extern unsafe long GetTimestampResolution();
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestamp", BestFitMapping = false, ExactSpelling = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestamp", ExactSpelling = true)]
         internal static extern unsafe long GetTimestamp();
     }
 }

--- a/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
@@ -9,9 +9,9 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestampResolution", BestFitMapping = false, ExactSpelling = true)]
-        internal static extern unsafe BOOL GetTimestampResolution(long* resolution);
+        internal static extern unsafe long GetTimestampResolution();
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestamp", BestFitMapping = false, ExactSpelling = true)]
-        internal static extern unsafe BOOL GetTimestamp(long* timestamp);
+        internal static extern unsafe long GetTimestamp();
     }
 }

--- a/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
@@ -8,10 +8,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestampResolution")]
-        internal static extern bool GetTimestampResolution(out long resolution);
+        [DllImport(Libraries.SystemNative, BestFitMapping = false, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SystemNative_GetTimestampResolution", ExactSpelling = true, PreserveSig = true, SetLastError = false, ThrowOnUnmappableChar = false)]
+        internal static extern unsafe int GetTimestampResolution(long* resolution);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestamp")]
-        internal static extern bool GetTimestamp(out long timestamp);
+        [DllImport(Libraries.SystemNative, BestFitMapping = false, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SystemNative_GetTimestamp", ExactSpelling = true, PreserveSig = true, SetLastError = false, ThrowOnUnmappableChar = false)]
+        internal static extern unsafe int GetTimestamp(long* timestamp);
     }
 }

--- a/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
@@ -9,9 +9,9 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestampResolution", ExactSpelling = true)]
-        internal static extern unsafe long GetTimestampResolution();
+        internal static extern long GetTimestampResolution();
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestamp", ExactSpelling = true)]
-        internal static extern unsafe long GetTimestamp();
+        internal static extern long GetTimestamp();
     }
 }

--- a/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
@@ -8,10 +8,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, BestFitMapping = false, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SystemNative_GetTimestampResolution", ExactSpelling = true, PreserveSig = true, SetLastError = false, ThrowOnUnmappableChar = false)]
-        internal static extern unsafe int GetTimestampResolution(long* resolution);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestampResolution", BestFitMapping = false, ExactSpelling = true)]
+        internal static extern unsafe BOOL GetTimestampResolution(long* resolution);
 
-        [DllImport(Libraries.SystemNative, BestFitMapping = false, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SystemNative_GetTimestamp", ExactSpelling = true, PreserveSig = true, SetLastError = false, ThrowOnUnmappableChar = false)]
-        internal static extern unsafe int GetTimestamp(long* timestamp);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestamp", BestFitMapping = false, ExactSpelling = true)]
+        internal static extern unsafe BOOL GetTimestamp(long* timestamp);
     }
 }

--- a/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.GetTimestamp.cs
@@ -9,9 +9,9 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestampResolution", ExactSpelling = true)]
-        internal static extern long GetTimestampResolution();
+        internal static extern ulong GetTimestampResolution();
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestamp", ExactSpelling = true)]
-        internal static extern long GetTimestamp();
+        internal static extern ulong GetTimestamp();
     }
 }

--- a/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceCounter.cs
+++ b/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceCounter.cs
@@ -2,14 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32)]
-        internal static extern bool QueryPerformanceCounter(out long value);
+        // The actual native signature is:
+        //      BOOL WINAPI QueryPerformanceCounter(
+        //          _Out_ LARGE_INTEGER* lpPerformanceCount
+        //      );
+        //
+        // We return an int (rather than a bool) to avoid the marshalling overhead.
+        // We take a long* (rather than a out long) to avoid the pinning overhead.
+        // We don't set last error since we don't need the extended error info.
+
+        [DllImport(Libraries.Kernel32, BestFitMapping = false, CallingConvention = CallingConvention.Winapi, EntryPoint = "QueryPerformanceCounter", ExactSpelling = true, PreserveSig = true, SetLastError = false)]
+        internal static extern unsafe int QueryPerformanceCounter(long* lpPerformanceCount);
     }
 }

--- a/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceCounter.cs
+++ b/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceCounter.cs
@@ -13,11 +13,10 @@ internal partial class Interop
         //          _Out_ LARGE_INTEGER* lpPerformanceCount
         //      );
         //
-        // We return an int (rather than a bool) to avoid the marshalling overhead.
         // We take a long* (rather than a out long) to avoid the pinning overhead.
         // We don't set last error since we don't need the extended error info.
 
-        [DllImport(Libraries.Kernel32, BestFitMapping = false, CallingConvention = CallingConvention.Winapi, EntryPoint = "QueryPerformanceCounter", ExactSpelling = true, PreserveSig = true, SetLastError = false)]
-        internal static extern unsafe int QueryPerformanceCounter(long* lpPerformanceCount);
+        [DllImport(Libraries.Kernel32, BestFitMapping = false, ExactSpelling = true)]
+        internal static extern unsafe BOOL QueryPerformanceCounter(long* lpPerformanceCount);
     }
 }

--- a/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceCounter.cs
+++ b/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceCounter.cs
@@ -16,7 +16,7 @@ internal partial class Interop
         // We take a long* (rather than a out long) to avoid the pinning overhead.
         // We don't set last error since we don't need the extended error info.
 
-        [DllImport(Libraries.Kernel32, BestFitMapping = false, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
         internal static extern unsafe BOOL QueryPerformanceCounter(long* lpPerformanceCount);
     }
 }

--- a/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceFrequency.cs
+++ b/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceFrequency.cs
@@ -13,11 +13,10 @@ internal partial class Interop
         //          _Out_ LARGE_INTEGER* lpFrequency
         //      );
         //
-        // We return an int (rather than a bool) to avoid the marshalling overhead.
         // We take a long* (rather than a out long) to avoid the pinning overhead.
         // We don't set last error since we don't need the extended error info.
 
-        [DllImport(Libraries.Kernel32, BestFitMapping = false, CallingConvention = CallingConvention.Winapi, EntryPoint = "QueryPerformanceFrequency", ExactSpelling = true, PreserveSig = true, SetLastError = false)]
-        internal static extern unsafe int QueryPerformanceFrequency(long* lpFrequency);
+        [DllImport(Libraries.Kernel32, BestFitMapping = false, ExactSpelling = true)]
+        internal static extern unsafe BOOL QueryPerformanceFrequency(long* lpFrequency);
     }
 }

--- a/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceFrequency.cs
+++ b/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceFrequency.cs
@@ -2,14 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32)]
-        internal static extern bool QueryPerformanceFrequency(out long value);
+        // The actual native signature is:
+        //      BOOL WINAPI QueryPerformanceFrequency(
+        //          _Out_ LARGE_INTEGER* lpFrequency
+        //      );
+        //
+        // We return an int (rather than a bool) to avoid the marshalling overhead.
+        // We take a long* (rather than a out long) to avoid the pinning overhead.
+        // We don't set last error since we don't need the extended error info.
+
+        [DllImport(Libraries.Kernel32, BestFitMapping = false, CallingConvention = CallingConvention.Winapi, EntryPoint = "QueryPerformanceFrequency", ExactSpelling = true, PreserveSig = true, SetLastError = false)]
+        internal static extern unsafe int QueryPerformanceFrequency(long* lpFrequency);
     }
 }

--- a/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceFrequency.cs
+++ b/src/Common/src/Interop/Windows/Kernel32/Interop.QueryPerformanceFrequency.cs
@@ -16,7 +16,7 @@ internal partial class Interop
         // We take a long* (rather than a out long) to avoid the pinning overhead.
         // We don't set last error since we don't need the extended error info.
 
-        [DllImport(Libraries.Kernel32, BestFitMapping = false, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
         internal static extern unsafe BOOL QueryPerformanceFrequency(long* lpFrequency);
     }
 }

--- a/src/Native/Unix/System.Native/pal_time.c
+++ b/src/Native/Unix/System.Native/pal_time.c
@@ -48,6 +48,10 @@ int32_t SystemNative_UTimensat(const char* path, TimeSpec* times)
     return result;
 }
 
+// Gets the number of "ticks per second" of the underlying monotonic timer.
+//
+// On most Unix platforms, the methods that query the resolution return a value
+// that is "nanoseconds per tick" in which case we need to scale before returning.
 uint64_t SystemNative_GetTimestampResolution()
 {
 #if HAVE_MACH_ABSOLUTE_TIME
@@ -58,7 +62,8 @@ uint64_t SystemNative_GetTimestampResolution()
         return 0;
     }
 
-    return SecondsToNanoSeconds * ((uint64_t)(mtid.denom) / (uint64_t)(mtid.numer));
+    uint64_t nanosecondsPerTick = ((uint64_t)(mtid.denom) / (uint64_t)(mtid.numer));
+    return SecondsToNanoSeconds * nanosecondsPerTick;
 #else
     struct timespec ts;
 
@@ -67,7 +72,8 @@ uint64_t SystemNative_GetTimestampResolution()
         return 0;
     }
 
-    return ((uint64_t)(ts.tv_sec) * SecondsToNanoSeconds) + (uint64_t)(ts.tv_nsec);
+    uint64_t nanosecondsPerTick = ((uint64_t)(ts.tv_sec) * SecondsToNanoSeconds) + (uint64_t)(ts.tv_nsec);
+    return SecondsToNanoSeconds * nanosecondsPerTick;
 #endif
 }
 

--- a/src/Native/Unix/System.Native/pal_time.c
+++ b/src/Native/Unix/System.Native/pal_time.c
@@ -159,13 +159,8 @@ int32_t SystemNative_GetCpuUtilization(ProcessCpuInformation* previousCpuInfo)
             ((uint64_t)(resUsage.ru_utime.tv_usec) * MicroSecondsToNanoSeconds);
     }
 
-    uint64_t timestamp;
-    uint64_t resolution;
-
-    if (!SystemNative_GetTimestamp(&timestamp) || !SystemNative_GetTimestampResolution(&resolution))
-    {
-        return 0;
-    }
+    uint64_t resolution = SystemNative_GetTimestampResolution();
+    uint64_t timestamp = SystemNative_GetTimestamp();
 
     uint64_t currentTime = timestamp * SecondsToNanoSeconds / resolution;
 

--- a/src/Native/Unix/System.Native/pal_time.c
+++ b/src/Native/Unix/System.Native/pal_time.c
@@ -48,75 +48,43 @@ int32_t SystemNative_UTimensat(const char* path, TimeSpec* times)
     return result;
 }
 
-int32_t SystemNative_GetTimestampResolution(uint64_t* resolution)
+uint64_t SystemNative_GetTimestampResolution()
 {
-    assert(resolution);
-
 #if HAVE_MACH_ABSOLUTE_TIME
     mach_timebase_info_data_t mtid;
-    if (mach_timebase_info(&mtid) == KERN_SUCCESS)
-    {
-        *resolution = SecondsToNanoSeconds * ((uint64_t)(mtid.denom) / (uint64_t)(mtid.numer));
-        return 1;
-    }
-    else
-    {
-        *resolution = 0;
-        return 0;
-    }
 
-#elif HAVE_CLOCK_MONOTONIC
+    kern_return_t result = mach_timebase_info(&mtid);
+    assert(result == KERN_SUCCESS);
+    (void)result; // suppress unused parameter warning in release builds
+
+    return SecondsToNanoSeconds * ((uint64_t)(mtid.denom) / (uint64_t)(mtid.numer));
+#else
     // Make sure we can call clock_gettime with MONOTONIC.  Stopwatch invokes
     // GetTimestampResolution as the very first thing, and by calling this here
     // to verify we can successfully, we don't have to branch in GetTimestamp.
+
     struct timespec ts;
-    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) 
-    {
-        *resolution = SecondsToNanoSeconds;
-        return 1;
-    }
-    else
-    {
-        *resolution = 0;
-        return 0;
-    }
 
-#else /* gettimeofday */
-    *resolution = SecondsToMicroSeconds;
-    return 1;
-
+    int result = clock_gettime(CLOCK_MONOTONIC, &ts);
+    assert(result == 0);
+    (void)result; // suppress unused parameter warning in release builds
+    
+    return SecondsToNanoSeconds;
 #endif
 }
 
-int32_t SystemNative_GetTimestamp(uint64_t* timestamp)
+uint64_t SystemNative_GetTimestamp()
 {
-    assert(timestamp);
-
 #if HAVE_MACH_ABSOLUTE_TIME
-    *timestamp = mach_absolute_time();
-    return 1;
-
-#elif HAVE_CLOCK_MONOTONIC
+    return mach_absolute_time();
+#else
     struct timespec ts;
+
     int result = clock_gettime(CLOCK_MONOTONIC, &ts);
     assert(result == 0); // only possible errors are if MONOTONIC isn't supported or &ts is an invalid address
     (void)result; // suppress unused parameter warning in release builds
-    *timestamp = ((uint64_t)(ts.tv_sec) * SecondsToNanoSeconds) + (uint64_t)(ts.tv_nsec);
-    return 1;
 
-#else
-    struct timeval tv;
-    if (gettimeofday(&tv, NULL) == 0)
-    {
-        *timestamp = ((uint64_t)(tv.tv_sec) * SecondsToMicroSeconds) + (uint64_t)(tv.tv_usec);
-        return 1;
-    }
-    else
-    {
-        *timestamp = 0;
-        return 0;
-    }
-
+    return ((uint64_t)(ts.tv_sec) * SecondsToNanoSeconds) + (uint64_t)(ts.tv_nsec);
 #endif
 }
 

--- a/src/Native/Unix/System.Native/pal_time.h
+++ b/src/Native/Unix/System.Native/pal_time.h
@@ -30,17 +30,13 @@ DLLEXPORT int32_t SystemNative_UTimensat(const char* path, TimeSpec* times);
 
 /**
  * Gets the resolution of the timestamp, in counts per second.
- *
- * Returns 1 on success; otherwise, 0 on failure.
  */
-DLLEXPORT int32_t SystemNative_GetTimestampResolution(uint64_t* resolution);
+DLLEXPORT uint64_t SystemNative_GetTimestampResolution(void);
 
 /**
  * Gets a high-resolution timestamp that can be used for time-interval measurements.
- *
- * Returns 1 on success; otherwise, 0 on failure.
  */
-DLLEXPORT int32_t SystemNative_GetTimestamp(uint64_t* timestamp);
+DLLEXPORT uint64_t SystemNative_GetTimestamp(void);
 
 DLLEXPORT int32_t SystemNative_GetAbsoluteTime(uint64_t* timestamp);
 

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -50,6 +50,9 @@
     <Compile Include="$(CommonPath)\CoreLib\System\Text\ValueStringBuilder.cs">
       <Link>CoreLib\System\Text\ValueStringBuilder.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Interop.BOOL.cs">
+      <Link>Common\CoreLib\Interop\Windows\Interop.BOOL.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- WINDOWS: Shared CoreCLR and .NET Native -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Unix.cs
@@ -8,12 +8,12 @@ namespace System.Diagnostics
     {
         private static long QueryPerformanceFrequency()
         {
-            return Interop.Sys.GetTimestampResolution();
+            return (long)Interop.Sys.GetTimestampResolution();
         }
 
         private static long QueryPerformanceCounter()
         {
-            return Interop.Sys.GetTimestamp();
+            return (long)Interop.Sys.GetTimestamp();
         }
     }
 }

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Unix.cs
@@ -6,14 +6,14 @@ namespace System.Diagnostics
 {
     public partial class Stopwatch
     {
-        private static unsafe Interop.BOOL QueryPerformanceFrequency(long* resolution)
+        private static unsafe long QueryPerformanceFrequency()
         {
-            return Interop.Sys.GetTimestampResolution(resolution);
+            return Interop.Sys.GetTimestampResolution();
         }
 
-        private static unsafe Interop.BOOL QueryPerformanceCounter(long* timestamp)
+        private static unsafe long QueryPerformanceCounter()
         {
-            return Interop.Sys.GetTimestamp(timestamp);
+            return Interop.Sys.GetTimestamp();
         }
     }
 }

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Unix.cs
@@ -2,20 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-
 namespace System.Diagnostics
 {
     public partial class Stopwatch
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe int QueryPerformanceFrequency(long* resolution)
+        private static unsafe Interop.BOOL QueryPerformanceFrequency(long* resolution)
         {
             return Interop.Sys.GetTimestampResolution(resolution);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe int QueryPerformanceCounter(long* timestamp)
+        private static unsafe Interop.BOOL QueryPerformanceCounter(long* timestamp)
         {
             return Interop.Sys.GetTimestamp(timestamp);
         }

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Unix.cs
@@ -6,12 +6,12 @@ namespace System.Diagnostics
 {
     public partial class Stopwatch
     {
-        private static unsafe long QueryPerformanceFrequency()
+        private static long QueryPerformanceFrequency()
         {
             return Interop.Sys.GetTimestampResolution();
         }
 
-        private static unsafe long QueryPerformanceCounter()
+        private static long QueryPerformanceCounter()
         {
             return Interop.Sys.GetTimestamp();
         }

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Unix.cs
@@ -2,18 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Diagnostics
 {
     public partial class Stopwatch
     {
-        private static bool QueryPerformanceFrequency(out long value)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int QueryPerformanceFrequency(long* resolution)
         {
-            return Interop.Sys.GetTimestampResolution(out value);
+            return Interop.Sys.GetTimestampResolution(resolution);
         }
 
-        private static bool QueryPerformanceCounter(out long value)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int QueryPerformanceCounter(long* timestamp)
         {
-            return Interop.Sys.GetTimestamp(out value);
+            return Interop.Sys.GetTimestamp(timestamp);
         }
     }
 }

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Windows.cs
@@ -2,20 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-
 namespace System.Diagnostics
 {
     public partial class Stopwatch
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe int QueryPerformanceFrequency(long* lpFrequency)
+        private static unsafe Interop.BOOL QueryPerformanceFrequency(long* lpFrequency)
         {
             return Interop.Kernel32.QueryPerformanceFrequency(lpFrequency);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe int QueryPerformanceCounter(long* lpPerformanceCount)
+        private static unsafe Interop.BOOL QueryPerformanceCounter(long* lpPerformanceCount)
         {
             return Interop.Kernel32.QueryPerformanceCounter(lpPerformanceCount);
         }

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Windows.cs
@@ -6,14 +6,24 @@ namespace System.Diagnostics
 {
     public partial class Stopwatch
     {
-        private static unsafe Interop.BOOL QueryPerformanceFrequency(long* lpFrequency)
+        private static unsafe long QueryPerformanceFrequency()
         {
-            return Interop.Kernel32.QueryPerformanceFrequency(lpFrequency);
+            long resolution;
+
+            Interop.BOOL result = Interop.Kernel32.QueryPerformanceFrequency(&resolution);
+            Debug.Assert(result != Interop.BOOL.FALSE);
+
+            return resolution;
         }
 
-        private static unsafe Interop.BOOL QueryPerformanceCounter(long* lpPerformanceCount)
+        private static unsafe long QueryPerformanceCounter(long* lpPerformanceCount)
         {
-            return Interop.Kernel32.QueryPerformanceCounter(lpPerformanceCount);
+            long timestamp;
+
+            Interop.BOOL result = Interop.Kernel32.QueryPerformanceCounter(&timestamp);
+            Debug.Assert(result != Interop.BOOL.FALSE);
+
+            return timestamp;
         }
     }
 }

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Windows.cs
@@ -2,18 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Diagnostics
 {
     public partial class Stopwatch
     {
-        private static bool QueryPerformanceFrequency(out long value)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int QueryPerformanceFrequency(long* lpFrequency)
         {
-            return Interop.Kernel32.QueryPerformanceFrequency(out value);
+            return Interop.Kernel32.QueryPerformanceFrequency(lpFrequency);
         }
 
-        private static bool QueryPerformanceCounter(out long value)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int QueryPerformanceCounter(long* lpPerformanceCount)
         {
-            return Interop.Kernel32.QueryPerformanceCounter(out value);
+            return Interop.Kernel32.QueryPerformanceCounter(lpPerformanceCount);
         }
     }
 }

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Windows.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.Windows.cs
@@ -11,16 +11,18 @@ namespace System.Diagnostics
             long resolution;
 
             Interop.BOOL result = Interop.Kernel32.QueryPerformanceFrequency(&resolution);
+            // The P/Invoke is documented to never fail on Windows XP or later
             Debug.Assert(result != Interop.BOOL.FALSE);
 
             return resolution;
         }
 
-        private static unsafe long QueryPerformanceCounter(long* lpPerformanceCount)
+        private static unsafe long QueryPerformanceCounter()
         {
             long timestamp;
 
             Interop.BOOL result = Interop.Kernel32.QueryPerformanceCounter(&timestamp);
+            // The P/Invoke is documented to never fail on Windows XP or later
             Debug.Assert(result != Interop.BOOL.FALSE);
 
             return timestamp;

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
@@ -29,7 +29,7 @@ namespace System.Diagnostics
         // to ticks. 
         private static readonly double s_tickFrequency;
 
-        static unsafe Stopwatch()
+        static Stopwatch()
         {
             Frequency = QueryPerformanceFrequency();
             IsHighResolution = true;
@@ -118,7 +118,7 @@ namespace System.Diagnostics
             get { return GetRawElapsedTicks(); }
         }
 
-        public static unsafe long GetTimestamp()
+        public static long GetTimestamp()
         {
             Debug.Assert(IsHighResolution);
             return QueryPerformanceCounter();

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
@@ -29,14 +29,15 @@ namespace System.Diagnostics
         // to ticks. 
         private static readonly double s_tickFrequency;
 
-        static Stopwatch()
+        static unsafe Stopwatch()
         {
-            bool succeeded = QueryPerformanceFrequency(out Frequency);
+            long frequency;
+            int succeeded = QueryPerformanceFrequency(&frequency);
 
-            if (!succeeded)
+            if (succeeded == 0)
             {
                 IsHighResolution = false;
-                Frequency = TicksPerSecond;
+                frequency = TicksPerSecond;
                 s_tickFrequency = 1;
             }
             else
@@ -45,6 +46,7 @@ namespace System.Diagnostics
                 s_tickFrequency = TicksPerSecond;
                 s_tickFrequency /= Frequency;
             }
+            Frequency = frequency;
         }
 
         public Stopwatch()
@@ -127,12 +129,12 @@ namespace System.Diagnostics
             get { return GetRawElapsedTicks(); }
         }
 
-        public static long GetTimestamp()
+        public static unsafe long GetTimestamp()
         {
             if (IsHighResolution)
             {
-                long timestamp = 0;
-                QueryPerformanceCounter(out timestamp);
+                long timestamp;
+                QueryPerformanceCounter(&timestamp);
                 return timestamp;
             }
             else

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
@@ -32,9 +32,9 @@ namespace System.Diagnostics
         static unsafe Stopwatch()
         {
             long frequency;
-            int succeeded = QueryPerformanceFrequency(&frequency);
+            Interop.BOOL result = QueryPerformanceFrequency(&frequency);
 
-            if (succeeded == 0)
+            if (result == Interop.BOOL.FALSE)
             {
                 IsHighResolution = false;
                 frequency = TicksPerSecond;

--- a/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
+++ b/src/System.Runtime.Extensions/src/System/Diagnostics/Stopwatch.cs
@@ -33,9 +33,7 @@ namespace System.Diagnostics
         {
             Frequency = QueryPerformanceFrequency();
             IsHighResolution = true;
-
-            s_tickFrequency = TicksPerSecond;
-            s_tickFrequency /= Frequency;
+            s_tickFrequency = (double)TicksPerSecond / Frequency;
         }
 
         public Stopwatch()
@@ -144,11 +142,8 @@ namespace System.Diagnostics
         private long GetElapsedDateTimeTicks()
         {
             Debug.Assert(IsHighResolution);
-
             // convert high resolution perf counter to DateTime ticks
-            double ticks = GetRawElapsedTicks();
-            ticks *= s_tickFrequency;
-            return unchecked((long)ticks);
+            return unchecked((long)(GetRawElapsedTicks() * s_tickFrequency));
         }
     }
 }


### PR DESCRIPTION
This cleans up the signatures for `QueryPerformanceFrequency` and `QueryPerformanceCounter` to avoid implicit marshalling and pinning that was happening behind the scenes.

This changes were validated using a simple program that was profiled using Intel VTune:
```csharp
static void Main(string[] args)
{
    float res = 0;
    ulong tmp = 0;

    for (int i = 0; i < 1024 * 1024 * 128; i++)
    {
        tmp = (ulong)(Stopwatch.GetTimestamp());
        res += MathF.Sqrt(tmp);
    }

    Console.WriteLine(res);
}
```

Prior to this change:
![Before](https://user-images.githubusercontent.com/10487869/54436060-15e57c80-46ef-11e9-9e6f-05dc438c9bde.jpg)

After this change:
![After](https://user-images.githubusercontent.com/10487869/54436075-1b42c700-46ef-11e9-9689-71d36f7d4b89.jpg)
