### PR TITLE
Fix netfx test runs

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -194,7 +194,7 @@
           BeforeTargets="ResolveReferences">
 
     <PropertyGroup>
-      <TestSdkTFM Condition="'$(TargetsNetFx)' == 'true'">net45</TestSdkTFM>
+      <TestSdkTFM Condition="'$(TargetsNetFx)' == 'true'">net40</TestSdkTFM>
       <TestSdkTFM Condition="'$(TargetsUap)' == 'true'">uap10.0</TestSdkTFM>
       <TestSdkTFM Condition="'$(TestSdkTFM)' == ''">netcoreapp1.0</TestSdkTFM>
     </PropertyGroup>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -200,12 +200,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(PackagesDir)$(MicrosoftNetTestSdkPackageName)\$(MicrosoftNETTestSdkPackageVersion)\build\$(TestSdkTFM)\*.*">
+      <_copyLocalPaths Include="$(PackagesDir)$(MicrosoftNetTestSdkPackageName)\$(MicrosoftNETTestSdkPackageVersion)\build\$(TestSdkTFM)\*.*" />
+      <ReferenceCopyLocalPaths Include="@(_copyLocalPaths)">
         <Private>false</Private>
         <NuGetPackageId>$(MicrosoftNetTestSdkPackageName)</NuGetPackageId>
         <NuGetPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</NuGetPackageVersion>
       </ReferenceCopyLocalPaths>
     </ItemGroup>
+
+    <Error Condition="'@(_copyLocalPaths)' != ''"
+           Text="Error: looks like no assets were found under: $(PackagesDir)$(MicrosoftNetTestSdkPackageName)\$(MicrosoftNETTestSdkPackageVersion)\build\$(TestSdkTFM)\*.*" />
 
   </Target>
 

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -200,16 +200,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_copyLocalPaths Include="$(PackagesDir)$(MicrosoftNetTestSdkPackageName)\$(MicrosoftNETTestSdkPackageVersion)\build\$(TestSdkTFM)\*.*" />
-      <ReferenceCopyLocalPaths Include="@(_copyLocalPaths)">
+      <_microsoftNetTestSdkAssets Include="$(PackagesDir)$(MicrosoftNetTestSdkPackageName)\$(MicrosoftNETTestSdkPackageVersion)\build\$(TestSdkTFM)\*.*" />
+      <ReferenceCopyLocalPaths Include="@(_microsoftNetTestSdkAssets)">
         <Private>false</Private>
         <NuGetPackageId>$(MicrosoftNetTestSdkPackageName)</NuGetPackageId>
         <NuGetPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</NuGetPackageVersion>
       </ReferenceCopyLocalPaths>
     </ItemGroup>
 
-    <Error Condition="'@(_copyLocalPaths)' != ''"
-           Text="Error: looks like no assets were found under: $(PackagesDir)$(MicrosoftNetTestSdkPackageName)\$(MicrosoftNETTestSdkPackageVersion)\build\$(TestSdkTFM)\*.*" />
+    <Error Condition="'@(_microsoftNetTestSdkAssets)' != ''"
+           Text="Error: no assets for test sdk package where found under: $(PackagesDir)$(MicrosoftNetTestSdkPackageName)\$(MicrosoftNETTestSdkPackageVersion)\build\$(TestSdkTFM)\*.*" />
 
   </Target>
 


### PR DESCRIPTION
Fixes: #36079 

This was broken when we updated to the new package since the folder structure within the package changed from net45 to net40. 

The main problem here was not only that the package changed its TFM, but also that for `\external\*.depproj` we first restore for `netstandard` and then for the actual target group. In this case when we restore for `netstandard` we binplace the SDK test package assets for `netcoreapp1.0` which try and compile the `Microsoft.NET.Test.Sdk.Program.cs` file. So now that we didn't find any assets for `net45` TFM these targets where not overridden when restoring for `netfx` so we where getting `netcoreapp1.0` targets out of this package.

We really need to fix this project as it seems pretty hacky and error prone in the future. Will open an issue for that.

cc: @stephentoub @ViktorHofer @ericstj 