### PR TITLE
Fix and re-enable some HttpListener authentication tests

### DIFF
--- a/src/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
+++ b/src/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
@@ -166,7 +166,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [PlatformSpecific(TestPlatforms.Windows, "Managed impl doesn't support NTLM")]
-        [ActiveIssue(20604)]
         public async Task NtlmAuthentication_Conversation_ReturnsExpectedType2Message()
         {
             _listener.AuthenticationSchemes = AuthenticationSchemes.Ntlm;
@@ -188,8 +187,7 @@ namespace System.Net.Tests
             yield return new object[] { "abcd", HttpStatusCode.BadRequest };
         }
 
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [PlatformSpecific(TestPlatforms.Windows, "Managed impl doesn't support NTLM")]
-        [ActiveIssue(20604)]
+        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [PlatformSpecific(TestPlatforms.Windows, "Managed impl doesn't support NTLM")]
         [MemberData(nameof(InvalidNtlmNegotiateAuthentication_TestData))]
         public async Task NtlmAuthentication_InvalidRequestHeaders_ReturnsExpectedStatusCode(string header, HttpStatusCode statusCode)
         {
@@ -212,7 +210,6 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [PlatformSpecific(TestPlatforms.Windows, "Managed impl doesn't support Negotiate")]
-        [ActiveIssue(20604)]
         public async Task NegotiateAuthentication_Conversation_ReturnsExpectedType2Message()
         {
             _listener.AuthenticationSchemes = AuthenticationSchemes.Negotiate;
@@ -226,8 +223,7 @@ namespace System.Net.Tests
             }
         }
 
-        [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [PlatformSpecific(TestPlatforms.Windows, "Managed impl doesn't support Negotiate")]
-        [ActiveIssue(20604)]
+        [ConditionalTheory(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [PlatformSpecific(TestPlatforms.Windows, "Managed impl doesn't support Negotiate")]
         [MemberData(nameof(InvalidNtlmNegotiateAuthentication_TestData))]
         public async Task NegotiateAuthentication_InvalidRequestHeaders_ReturnsExpectedStatusCode(string header, HttpStatusCode statusCode)
         {
@@ -238,7 +234,14 @@ namespace System.Net.Tests
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Negotiate", header);
 
                 HttpResponseMessage message = await AuthenticationFailure(client, statusCode);
-                Assert.Empty(message.Headers.WwwAuthenticate);
+                if (statusCode == HttpStatusCode.Unauthorized)
+                {
+                    Assert.NotEmpty(message.Headers.WwwAuthenticate);
+                }
+                else
+                {
+                    Assert.Empty(message.Headers.WwwAuthenticate);
+                }
             }
         }
 


### PR DESCRIPTION
The Negotiate and NTLM HttpListener tests were disabled due to a behavior of running them
on loopback using an HttpClient with WinHttpHandler. But now the default handler for HttpClient
is SocketsHttpHandler. And it doesn't have this problem with loopback authentication.

Closes #20604