### PR TITLE
Change values of Microsoft.XmlSerializer.Generator command parameters through msbuild properties

### DIFF
--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -5,6 +5,7 @@
     <_SerializerPdbIntermediateFolder>$(IntermediateOutputPath)$(_SerializationAssemblyName).pdb</_SerializerPdbIntermediateFolder>
     <_SerializerCsIntermediateFolder>$(IntermediateOutputPath)$(_SerializationAssemblyName).cs</_SerializerCsIntermediateFolder>
     <_SGenWarningText>SGEN: Fail to generate the serializer for $(AssemblyName)$(TargetExt). Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again.</_SGenWarningText>
+    <_SGenRspWarningText>Fail to generate response file for Microsoft.XmlSerializer.Generator, serializer is generating with default settings.</_SGenRspWarningText>
     <_SerializationAssemblyDisabledWarnings>$(NoWarn);219;162;$(SerializationAssemblyDisabledWarnings)</_SerializationAssemblyDisabledWarnings>
     <_SgenRspFilePath>$(IntermediateOutputPath)sgen.rsp</_SgenRspFilePath>
     <_CscRspFilePath>$(IntermediateOutputPath)csc.rsp</_CscRspFilePath>
@@ -15,8 +16,7 @@
     <Delete Condition="Exists('$(_SerializerPdbIntermediateFolder)') == 'true'" Files="$(_SerializerPdbIntermediateFolder)" ContinueOnError="true"/>
     <Delete Condition="Exists('$(_SerializerCsIntermediateFolder)') == 'true'"  Files="$(_SerializerCsIntermediateFolder)" ContinueOnError="true"/>
     <Message Text="Running Serialization Tool" Importance="normal" />
-    <Exec Condition="!Exists('$(_SgenRspFilePath)')" Command="dotnet Microsoft.XmlSerializer.Generator &quot;$(IntermediateOutputPath)$(AssemblyName)$(TargetExt)&quot; --force --quiet --reference &quot;@(ReferencePath)&quot;" ContinueOnError="true"/>
-    <Exec Condition="Exists('$(_SgenRspFilePath)')" Command="dotnet Microsoft.XmlSerializer.Generator &quot;$(IntermediateOutputPath)$(AssemblyName)$(TargetExt)&quot;  --force --quiet --reference &quot;@(ReferencePath)&quot; $(_SgenRspFilePath)" ContinueOnError="true"/>
+    <Exec Command="dotnet Microsoft.XmlSerializer.Generator &quot;$(IntermediateOutputPath)$(AssemblyName)$(TargetExt)&quot; --force --quiet $(_SgenRspFilePath)" ContinueOnError="true"/>
     <Warning Condition="Exists('$(_SerializerCsIntermediateFolder)') != 'true'" Text="$(_SGenWarningText)" />
     <Csc Condition="Exists('$(_SerializerCsIntermediateFolder)') AND !Exists('$(_CscRspFilePath)')" ContinueOnError="true" OutputAssembly="$(_SerializerDllIntermediateFolder)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(_SerializerCsIntermediateFolder)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(_SerializationAssemblyDisabledWarnings)"/>
     <Csc Condition="Exists('$(_SerializerCsIntermediateFolder)') AND Exists('$(_CscRspFilePath)')" ContinueOnError="true" OutputAssembly="$(_SerializerDllIntermediateFolder)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(_SerializerCsIntermediateFolder)" TargetType="Library" ResponseFiles="$(_CscRspFilePath)"  ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(_SerializationAssemblyDisabledWarnings)"/>
@@ -27,8 +27,11 @@
   </Target>
 
   <Target Name="GenerateRspFiles" BeforeTargets="GenerateSerializationAssembly">
+    <PropertyGroup>
+      <SGenReferences Condition=" '$(SGenReferences)' == ''">@(ReferencePath)</SGenReferences>
+    </PropertyGroup>
     <ItemGroup>
-      <SgenRspFile Include ="--reference $(SGenReferences.Replace(';', '%3B'))" Condition=" '$(SGenReferences)' != ''" />
+      <SgenRspFile Include ="--reference $(SGenReferences.Replace(';', '%3B'))" />
       <SgenRspFile Include ="--type $(SGenTypes.Replace(';', '%3B'))" Condition=" '$(SGenTypes)' != ''" />
       <SgenRspFile Include ="--verbose" Condition=" '$(SGenVerbose)' == 'true'" />
       <SgenRspFile Include ="--proxytypes" Condition=" '$(SGenProxyTypes)' == 'true'" />
@@ -36,7 +39,8 @@
       <CscRspFile Include="-keycontainer:$(SGenKeyContainer)" Condition=" '$(SGenKeyContainer)' != ''" />
       <CscRspFile Include ="-delaysign" Condition=" '$(SGenDelaySign)' == 'true'" />
     </ItemGroup>
-    <WriteLinesToFile Condition="'@(SgenRspFile)'!=''" File="$(_SgenRspFilePath)" Lines="@(SgenRspFile, '%0A')" Overwrite="true" ContinueOnError="true" />
+    <WriteLinesToFile File="$(_SgenRspFilePath)" Lines="@(SgenRspFile, '%0A')" Overwrite="true" ContinueOnError="true" />
+    <Warning Condition="!Exists('$(_SgenRspFilePath)')" Text="$(_SGenRspWarningText)" />
     <WriteLinesToFile Condition="'@(CscRspFile)'!=''" File="$(_CscRspFilePath)" Lines="@(CscRspFile, '%0A')" Overwrite="true" ContinueOnError="true" />
   </Target>
 
@@ -67,7 +71,7 @@
     <Exec Command="dotnet Microsoft.XmlSerializer.Generator --force --quiet --reference &quot;@(ReferencePath)&quot; --assembly &quot;%(_TargetSerializationAssembly.Identity)&quot; --type %(_TargetSerializationAssembly.SerializationTypes) --out &quot;$(IntermediateOutputPath)&quot;" ContinueOnError="true" />
     <Warning Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') != 'true'" Text="SGEN: Fail to generate %(_ReferenceSerializationAssemblyName.Identity)'. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
     <Csc Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') == 'true'" ContinueOnError="true" OutputAssembly="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).dll" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(_SerializationAssemblyDisabledWarnings)"/>
-    <Warning Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).dll') != 'true' And Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') == 'true'" Text="SGEN: Fail to compile %(_ReferenceSerializationAssemblyName.Identity).cs. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
+    <Warning Condition="Exists('$(IntermediateOutputy(_ReferenceSerializationAssemblyName.Identity).dll') != 'true' And Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') == 'true'" Text="SGEN: Fail to compile %(_ReferenceSerializationAssemblyName.Identity).cs. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
     <Copy Condition="Exists('%(_ReferenceSerializerIntermediateFolder.Identity).dll') == 'true'" SourceFiles="%(_ReferenceSerializerIntermediateFolder.Identity).dll" DestinationFolder="$(OutputPath)" />
   </Target>
 

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -6,28 +6,49 @@
     <_SerializerCsIntermediateFolder>$(IntermediateOutputPath)$(_SerializationAssemblyName).cs</_SerializerCsIntermediateFolder>
     <_SGenWarningText>SGEN: Fail to generate the serializer for $(AssemblyName)$(TargetExt). Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again.</_SGenWarningText>
     <_SerializationAssemblyDisabledWarnings>$(NoWarn);219;162;$(SerializationAssemblyDisabledWarnings)</_SerializationAssemblyDisabledWarnings>
+    <_SgenRspFilePath>$(IntermediateOutputPath)sgen.rsp</_SgenRspFilePath>
+    <_CscRspFilePath>$(IntermediateOutputPath)csc.rsp</_CscRspFilePath>
   </PropertyGroup>
+
   <Target Name="GenerateSerializationAssembly" AfterTargets="Build">
     <Delete Condition="Exists('$(_SerializerDllIntermediateFolder)') == 'true'" Files="$(_SerializerDllIntermediateFolder)" ContinueOnError="true"/>
     <Delete Condition="Exists('$(_SerializerPdbIntermediateFolder)') == 'true'" Files="$(_SerializerPdbIntermediateFolder)" ContinueOnError="true"/>
     <Delete Condition="Exists('$(_SerializerCsIntermediateFolder)') == 'true'"  Files="$(_SerializerCsIntermediateFolder)" ContinueOnError="true"/>
     <Message Text="Running Serialization Tool" Importance="normal" />
-    <Exec Command="dotnet Microsoft.XmlSerializer.Generator &quot;$(IntermediateOutputPath)$(AssemblyName)$(TargetExt)&quot; --force --quiet --reference &quot;@(ReferencePath)&quot;" ContinueOnError="true"/>
+    <Exec Condition="!Exists('$(_SgenRspFilePath)')" Command="dotnet Microsoft.XmlSerializer.Generator &quot;$(IntermediateOutputPath)$(AssemblyName)$(TargetExt)&quot; --force --quiet --reference &quot;@(ReferencePath)&quot;" ContinueOnError="true"/>
+    <Exec Condition="Exists('$(_SgenRspFilePath)')" Command="dotnet Microsoft.XmlSerializer.Generator &quot;$(IntermediateOutputPath)$(AssemblyName)$(TargetExt)&quot;  --force --quiet --reference &quot;@(ReferencePath)&quot; $(_SgenRspFilePath)" ContinueOnError="true"/>
     <Warning Condition="Exists('$(_SerializerCsIntermediateFolder)') != 'true'" Text="$(_SGenWarningText)" />
-    <Csc Condition="Exists('$(_SerializerCsIntermediateFolder)') == 'true'" ContinueOnError="true" OutputAssembly="$(_SerializerDllIntermediateFolder)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(_SerializerCsIntermediateFolder)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(_SerializationAssemblyDisabledWarnings)"/>
+    <Csc Condition="Exists('$(_SerializerCsIntermediateFolder)') AND !Exists('$(_CscRspFilePath)')" ContinueOnError="true" OutputAssembly="$(_SerializerDllIntermediateFolder)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(_SerializerCsIntermediateFolder)" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(_SerializationAssemblyDisabledWarnings)"/>
+    <Csc Condition="Exists('$(_SerializerCsIntermediateFolder)') AND Exists('$(_CscRspFilePath)')" ContinueOnError="true" OutputAssembly="$(_SerializerDllIntermediateFolder)" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(_SerializerCsIntermediateFolder)" TargetType="Library" ResponseFiles="$(_CscRspFilePath)"  ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(_SerializationAssemblyDisabledWarnings)"/>
     <Warning Condition="Exists('$(_SerializerDllIntermediateFolder)') != 'true' And Exists('$(_SerializerCsIntermediateFolder)') == 'true'" Text="$(_SGenWarningText)"/>
     <Copy Condition="Exists('$(_SerializerDllIntermediateFolder)') == 'true'" SourceFiles="$(_SerializerDllIntermediateFolder)" DestinationFolder="$(OutputPath)" />
+    <Delete Condition="Exists('$(_SgenRspFilePath)')" Files="$(_SgenRspFilePath)" />
+    <Delete Condition="Exists('$(_CscRspFilePath)')" Files="$(_CscRspFilePath)" />
   </Target>
-  
+
+  <Target Name="GenerateRspFiles" BeforeTargets="GenerateSerializationAssembly">
+    <ItemGroup>
+      <SgenRspFile Include ="--reference $(SGenReferences.Replace(';', '%3B'))" Condition=" '$(SGenReferences)' != ''" />
+      <SgenRspFile Include ="--type $(SGenTypes.Replace(';', '%3B'))" Condition=" '$(SGenTypes)' != ''" />
+      <SgenRspFile Include ="--verbose" Condition=" '$(SGenVerbose)' == 'true'" />
+      <SgenRspFile Include ="--proxytypes" Condition=" '$(SGenProxyTypes)' == 'true'" />
+      <CscRspFile Include="-keyfile:$(SGenKeyFile)" Condition=" '$(SGenKeyFile)' != ''" />
+      <CscRspFile Include="-keycontainer:$(SGenKeyContainer)" Condition=" '$(SGenKeyContainer)' != ''" />
+      <CscRspFile Include ="-delaysign" Condition=" '$(SGenDelaySign)' == 'true'" />
+    </ItemGroup>
+    <WriteLinesToFile Condition="'@(SgenRspFile)'!=''" File="$(_SgenRspFilePath)" Lines="@(SgenRspFile, '%0A')" Overwrite="true" ContinueOnError="true" />
+    <WriteLinesToFile Condition="'@(CscRspFile)'!=''" File="$(_CscRspFilePath)" Lines="@(CscRspFile, '%0A')" Overwrite="true" ContinueOnError="true" />
+  </Target>
+
   <Target Name="CleanSerializationAssembly" AfterTargets="CoreClean">
     <Message Text="Cleaning serialization files..." Importance="normal"/>
     <Delete Condition="Exists('$(OutputPath)\$(_SerializationAssemblyName).dll') == 'true'" Files="$(OutputPath)\$(_SerializationAssemblyName).dll" />
   </Target>
-  
+
   <Target Name="CopySerializationAssembly" AfterTargets="PrepareForPublish">
     <Copy Condition="Exists('$(OutputPath)\$(AssemblyName).XmlSerializers.dll')=='true'" SourceFiles="$(OutputPath)\$(AssemblyName).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
   </Target>
-  
+
   <Target Name="GenerateSerializationAssemblyForReferenceAssemblies" AfterTargets="GenerateSerializationAssembly" Condition="@(SerializationAssembly)!=''">
     <ItemGroup>
       <_SearchSerializationAssembly Include="@(Reference)">
@@ -38,7 +59,7 @@
       <_ReferenceSerializationAssemblyName Include="%(SerializationAssembly.Identity).XmlSerializers" />
       <_ReferenceSerializerIntermediateFolder Include="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity)" />
     </ItemGroup>
-    
+
     <Delete Files="%(_ReferenceSerializerIntermediateFolder.Identity).dll" ContinueOnError="true"/>
     <Delete Files="%(_ReferenceSerializerIntermediateFolder.Identity).cs" ContinueOnError="true"/>
     <Delete Files="%(_ReferenceSerializerIntermediateFolder.Identity).pdb" ContinueOnError="true"/>
@@ -58,4 +79,5 @@
   <Target Name="CopySerializerForReferenceAssemblies" AfterTargets="PrepareForPublish" Condition="@(SerializationAssembly)!=''">
     <Copy Condition="Exists('$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll') == 'true'" SourceFiles="$(OutputPath)%(SerializationAssembly.Identity).XmlSerializers.dll" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="false" />
   </Target>
+
 </Project>

--- a/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
+++ b/src/Microsoft.XmlSerializer.Generator/pkg/build/Microsoft.XmlSerializer.Generator.targets
@@ -4,12 +4,30 @@
     <_SerializerDllIntermediateFolder>$(IntermediateOutputPath)$(_SerializationAssemblyName).dll</_SerializerDllIntermediateFolder>
     <_SerializerPdbIntermediateFolder>$(IntermediateOutputPath)$(_SerializationAssemblyName).pdb</_SerializerPdbIntermediateFolder>
     <_SerializerCsIntermediateFolder>$(IntermediateOutputPath)$(_SerializationAssemblyName).cs</_SerializerCsIntermediateFolder>
-    <_SGenWarningText>SGEN: Fail to generate the serializer for $(AssemblyName)$(TargetExt). Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again.</_SGenWarningText>
-    <_SGenRspWarningText>Fail to generate response file for Microsoft.XmlSerializer.Generator, serializer is generating with default settings.</_SGenRspWarningText>
+    <_SGenWarningText>SGEN: Failed to generate the serializer for $(AssemblyName)$(TargetExt). Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again.</_SGenWarningText>
+    <_SGenRspWarningText>Failed to generate response file for Microsoft.XmlSerializer.Generator, serializer is generating with default settings.</_SGenRspWarningText>
     <_SerializationAssemblyDisabledWarnings>$(NoWarn);219;162;$(SerializationAssemblyDisabledWarnings)</_SerializationAssemblyDisabledWarnings>
     <_SgenRspFilePath>$(IntermediateOutputPath)sgen.rsp</_SgenRspFilePath>
     <_CscRspFilePath>$(IntermediateOutputPath)csc.rsp</_CscRspFilePath>
   </PropertyGroup>
+
+  <Target Name="GenerateRspFiles" BeforeTargets="GenerateSerializationAssembly">
+    <PropertyGroup>
+      <SGenReferences Condition="'$(SGenReferences)' == ''">@(ReferencePath)</SGenReferences>
+    </PropertyGroup>
+    <ItemGroup>
+      <SgenRspFile Include ="--reference $(SGenReferences.Replace(';', '%3B'))" />
+      <SgenRspFile Include ="--type $(SGenTypes.Replace(';', '%3B'))" Condition="'$(SGenTypes)' != ''" />
+      <SgenRspFile Include ="--verbose" Condition="'$(SGenVerbose)' == 'true'" />
+      <SgenRspFile Include ="--proxytypes" Condition="'$(SGenProxyTypes)' == 'true'" />
+      <CscRspFile Include="-keyfile:$(SGenKeyFile)" Condition="'$(SGenKeyFile)' != ''" />
+      <CscRspFile Include="-keycontainer:$(SGenKeyContainer)" Condition="'$(SGenKeyContainer)' != ''" />
+      <CscRspFile Include ="-delaysign" Condition="'$(SGenDelaySign)' == 'true'" />
+    </ItemGroup>
+    <WriteLinesToFile File="$(_SgenRspFilePath)" Lines="@(SgenRspFile, '%0A')" Overwrite="true" ContinueOnError="true" />
+    <Warning Condition="!Exists('$(_SgenRspFilePath)')" Text="$(_SGenRspWarningText)" />
+    <WriteLinesToFile Condition="'@(CscRspFile)'!=''" File="$(_CscRspFilePath)" Lines="@(CscRspFile, '%0A')" Overwrite="true" ContinueOnError="true" />
+  </Target>
 
   <Target Name="GenerateSerializationAssembly" AfterTargets="Build">
     <Delete Condition="Exists('$(_SerializerDllIntermediateFolder)') == 'true'" Files="$(_SerializerDllIntermediateFolder)" ContinueOnError="true"/>
@@ -24,24 +42,6 @@
     <Copy Condition="Exists('$(_SerializerDllIntermediateFolder)') == 'true'" SourceFiles="$(_SerializerDllIntermediateFolder)" DestinationFolder="$(OutputPath)" />
     <Delete Condition="Exists('$(_SgenRspFilePath)')" Files="$(_SgenRspFilePath)" />
     <Delete Condition="Exists('$(_CscRspFilePath)')" Files="$(_CscRspFilePath)" />
-  </Target>
-
-  <Target Name="GenerateRspFiles" BeforeTargets="GenerateSerializationAssembly">
-    <PropertyGroup>
-      <SGenReferences Condition=" '$(SGenReferences)' == ''">@(ReferencePath)</SGenReferences>
-    </PropertyGroup>
-    <ItemGroup>
-      <SgenRspFile Include ="--reference $(SGenReferences.Replace(';', '%3B'))" />
-      <SgenRspFile Include ="--type $(SGenTypes.Replace(';', '%3B'))" Condition=" '$(SGenTypes)' != ''" />
-      <SgenRspFile Include ="--verbose" Condition=" '$(SGenVerbose)' == 'true'" />
-      <SgenRspFile Include ="--proxytypes" Condition=" '$(SGenProxyTypes)' == 'true'" />
-      <CscRspFile Include="-keyfile:$(SGenKeyFile)" Condition=" '$(SGenKeyFile)' != ''" />
-      <CscRspFile Include="-keycontainer:$(SGenKeyContainer)" Condition=" '$(SGenKeyContainer)' != ''" />
-      <CscRspFile Include ="-delaysign" Condition=" '$(SGenDelaySign)' == 'true'" />
-    </ItemGroup>
-    <WriteLinesToFile File="$(_SgenRspFilePath)" Lines="@(SgenRspFile, '%0A')" Overwrite="true" ContinueOnError="true" />
-    <Warning Condition="!Exists('$(_SgenRspFilePath)')" Text="$(_SGenRspWarningText)" />
-    <WriteLinesToFile Condition="'@(CscRspFile)'!=''" File="$(_CscRspFilePath)" Lines="@(CscRspFile, '%0A')" Overwrite="true" ContinueOnError="true" />
   </Target>
 
   <Target Name="CleanSerializationAssembly" AfterTargets="CoreClean">
@@ -71,7 +71,7 @@
     <Exec Command="dotnet Microsoft.XmlSerializer.Generator --force --quiet --reference &quot;@(ReferencePath)&quot; --assembly &quot;%(_TargetSerializationAssembly.Identity)&quot; --type %(_TargetSerializationAssembly.SerializationTypes) --out &quot;$(IntermediateOutputPath)&quot;" ContinueOnError="true" />
     <Warning Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') != 'true'" Text="SGEN: Fail to generate %(_ReferenceSerializationAssemblyName.Identity)'. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
     <Csc Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') == 'true'" ContinueOnError="true" OutputAssembly="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).dll" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" Sources="$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(_SerializationAssemblyDisabledWarnings)"/>
-    <Warning Condition="Exists('$(IntermediateOutputy(_ReferenceSerializationAssemblyName.Identity).dll') != 'true' And Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') == 'true'" Text="SGEN: Fail to compile %(_ReferenceSerializationAssemblyName.Identity).cs. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
+    <Warning Condition="Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).dll') != 'true' And Exists('$(IntermediateOutputPath)%(_ReferenceSerializationAssemblyName.Identity).cs') == 'true'" Text="SGEN: Fail to compile %(_ReferenceSerializationAssemblyName.Identity).cs. Please follow the instructions at https://go.microsoft.com/fwlink/?linkid=858594 and try again." />
     <Copy Condition="Exists('%(_ReferenceSerializerIntermediateFolder.Identity).dll') == 'true'" SourceFiles="%(_ReferenceSerializerIntermediateFolder.Identity).dll" DestinationFolder="$(OutputPath)" />
   </Target>
 

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -44,6 +44,8 @@ namespace Microsoft.XmlSerializer.Generator
 
             try
             {
+                args = ParseResponseFile(args);
+
                 for (int i = 0; i < args.Length; i++)
                 {
                     string arg = args[i];
@@ -131,12 +133,9 @@ namespace Microsoft.XmlSerializer.Generator
                         }
                         else
                         {
+                            //if there are multiple --reference switches, the last one will overwrite previous ones.
                             s_references = args[i];
-                            if (!string.IsNullOrEmpty(s_references))
-                            {
-                                ParseReferences();
-                            }
-                        }                        
+                        }
                     }
                     else
                     {
@@ -185,6 +184,11 @@ namespace Microsoft.XmlSerializer.Generator
                     Console.WriteLine("This tool is not intended to be used directly.");
                     Console.WriteLine("Please refer to https://go.microsoft.com/fwlink/?linkid=858594 on how to use it.");
                     return 0;
+                }
+
+                if (!string.IsNullOrEmpty(s_references))
+                {
+                    ParseReferences();
                 }
 
                 GenerateFile(types, assembly, proxyOnly, silent, warnings, force, codePath, parsableErrors);
@@ -614,6 +618,35 @@ namespace Microsoft.XmlSerializer.Generator
             }
 
             return null;
+        }
+
+        private string[] ParseResponseFile(string[] args)
+        {
+            var parsedArgs = new List<string>();
+            foreach (string arg in args)
+            {
+                if (!arg.EndsWith(".rsp"))
+                {
+                    parsedArgs.Add(arg);
+                }
+                else
+                {
+                    foreach (string line in File.ReadAllLines(arg))
+                    {
+                        int i = line.Trim().IndexOf(' ');
+                        if (i < 0)
+                        {
+                            parsedArgs.Add(line);
+                        }
+                        else
+                        {
+                            parsedArgs.Add(line.Substring(0, i));
+                            parsedArgs.Add(line.Substring(i + 1));
+                        }
+                    }
+                }
+            }
+            return parsedArgs.ToArray();
         }
     }
 }

--- a/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
+++ b/src/Microsoft.XmlSerializer.Generator/src/Sgen.cs
@@ -631,19 +631,26 @@ namespace Microsoft.XmlSerializer.Generator
                 }
                 else
                 {
-                    foreach (string line in File.ReadAllLines(arg))
+                    try
                     {
-                        int i = line.Trim().IndexOf(' ');
-                        if (i < 0)
+                        foreach (string line in File.ReadAllLines(arg))
                         {
-                            parsedArgs.Add(line);
-                        }
-                        else
-                        {
-                            parsedArgs.Add(line.Substring(0, i));
-                            parsedArgs.Add(line.Substring(i + 1));
+                            int i = line.Trim().IndexOf(' ');
+                            if (i < 0)
+                            {
+                                parsedArgs.Add(line);
+                            }
+                            else
+                            {
+                                parsedArgs.Add(line.Substring(0, i));
+                                parsedArgs.Add(line.Substring(i + 1));
+                            }
                         }
                     }
+                    //If for any reasons the rsp file is not generated, this argument will be ignored and serializer will be generated with default settings
+                    catch (FileNotFoundException)
+                    { }
+                    
                 }
             }
             return parsedArgs.ToArray();


### PR DESCRIPTION
Currently, Microsoft.XmlSerializer.Generator command is kind of "hard coded" in our target file, users cannot add/change switches to the command or modify their values. With this change, users can modify their PropertyGroup in the .csproj to change it.
Ex:
```xml
<PropertyGroup>
    <SGenReferences>C:\myfolder\abc.dll;C:\myfolder\def.dll</SGenReferences>
    <SGenTypes>SgenTestProgram.MyType1;SgenTestProgram.MyType2</SGenTypes>
    <SGenProxyTypes>false</SGenProxyTypes>
    <SGenVerbose>true</SGenVerbose>
    <SGenKeyFile>mykey.snk</SGenKeyFile>
    <SGenDelaySign>true</SGenDelaySign>
</PropertyGroup>
```