### PR TITLE
Unlock SslStream for writes after failed write

### DIFF
--- a/src/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.SECURITY_STATUS.cs
@@ -43,6 +43,7 @@ internal static partial class Interop
         IllegalMessage = unchecked((int)0x80090326),
         CertUnknown = unchecked((int)0x80090327),
         CertExpired = unchecked((int)0x80090328),
+        DecryptFailure = unchecked((int)0x80090330),
         AlgorithmMismatch = unchecked((int)0x80090331),
         SecurityQosFailed = unchecked((int)0x80090332),
         SmartcardLogonRequired = unchecked((int)0x8009033E),

--- a/src/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
+++ b/src/Common/src/System/Net/SecurityStatusAdapterPal.Windows.cs
@@ -10,7 +10,7 @@ namespace System.Net
 {
     internal static class SecurityStatusAdapterPal
     {
-        private const int StatusDictionarySize = 41;
+        private const int StatusDictionarySize = 42;
 
 #if DEBUG
         static SecurityStatusAdapterPal()
@@ -34,6 +34,7 @@ namespace System.Net
             { Interop.SECURITY_STATUS.ContextExpired, SecurityStatusPalErrorCode.ContextExpired },
             { Interop.SECURITY_STATUS.ContinueNeeded, SecurityStatusPalErrorCode.ContinueNeeded },
             { Interop.SECURITY_STATUS.CredentialsNeeded, SecurityStatusPalErrorCode.CredentialsNeeded },
+            { Interop.SECURITY_STATUS.DecryptFailure, SecurityStatusPalErrorCode.DecryptFailure },
             { Interop.SECURITY_STATUS.DowngradeDetected, SecurityStatusPalErrorCode.DowngradeDetected },
             { Interop.SECURITY_STATUS.IllegalMessage, SecurityStatusPalErrorCode.IllegalMessage },
             { Interop.SECURITY_STATUS.IncompleteCredentials, SecurityStatusPalErrorCode.IncompleteCredentials },

--- a/src/Common/src/System/Net/SecurityStatusPal.cs
+++ b/src/Common/src/System/Net/SecurityStatusPal.cs
@@ -62,6 +62,7 @@ namespace System.Net
         IllegalMessage,
         CertUnknown,
         CertExpired,
+        DecryptFailure,
         AlgorithmMismatch,
         SecurityQosFailed,
         SmartcardLogonRequired,

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -789,7 +789,7 @@ namespace System.Net.Security
         {
             CheckThrow(true);
             SslWriteAsync writeAdapter = new SslWriteAsync(this, cancellationToken);
-            return WriteAsyncInternal(writeAdapter, buffer);
+            return new ValueTask(WriteAsyncInternal(writeAdapter, buffer));
         }
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -113,8 +113,6 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ActiveIssue(36076)]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework does not recover well from underlying stream failures")]
         [Fact]
         public async Task Write_CorrectlyUnlocksAfterFailure()
         {
@@ -131,14 +129,11 @@ namespace System.Net.Security.Tests
                 Assert.Same(clientStream.ExceptionToThrow, thrown.InnerException);
                 clientStream.ExceptionToThrow = null;
 
-                // Validate that the SslStream continues to be usable
-                for (byte b = 42; b < 52; b++)
-                {
-                    await WriteAsync(clientSslStream, new byte[1] { b }, 0, 1);
-                    byte[] buffer = new byte[1];
-                    Assert.Equal(1, await ReadAsync(serverSslStream, buffer, 0, 1));
-                    Assert.Equal(b, buffer[0]);
-                }
+                // Validate that the SslStream continues to be writable. However, the stream is still largely
+                // unusable: because the previously encrypted data won't have been written to the underlying
+                // stream and thus not received by the reader, if we tried to validate this data being received
+                // by the reader, it would likely fail with a decryption error.
+                await WriteAsync(clientSslStream, new byte[1] { 42 }, 0, 1);
             }
         }
 

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
@@ -36,7 +36,7 @@ namespace System.Net.Security
         {
         }
 
-        private ValueTask WriteAsyncInternal<TWriteAdapter>(TWriteAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
+        private Task WriteAsyncInternal<TWriteAdapter>(TWriteAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
             where TWriteAdapter : struct, ISslWriteAdapter => default;
 
         private ValueTask<int> ReadAsyncInternal<TReadAdapter>(TReadAdapter adapter, Memory<byte> buffer) => default;


### PR DESCRIPTION
If we try to write to the underlying stream and that throws synchronously, we neglect to "unlock" the stream for writes, and all future attempts to write will throw an exception saying that the stream is being used for a concurrent write.  This change just ensures we appropriately unlock in that case.  However, even if we do, such an error is still likely to be fatal to the SSL connection, as the writer will have encrypted data that the reader never receives, and thus subsequent data the reader receives from subsequent writes is likely to be non-decryptable.  That said, if a write to the underlying stream throws, the connection is probably already toast.

This is the only thing I can see in the code that could lead to the behavior described in https://github.com/dotnet/corefx/issues/36076 (assuming the app code is correctly ensuring one-at-a-time behavior), so without a repro to say otherwise...
Fixes https://github.com/dotnet/corefx/issues/36076.

cc: @davidsh, @Drawaes, @pieter-venter