### PR TITLE
Fix typo

### DIFF
--- a/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorConsoleApp/RemoteExecutorConsoleApp.cs
@@ -96,7 +96,7 @@ namespace RemoteExecutorConsoleApp
                 (instance as IDisposable)?.Dispose();
             }
 
-            // Environment.Exit not supported on .Net Native - don't even call it to avoid the nuisance exception.
+            // Environment.Exit not supported on .NET Native - don't even call it to avoid the nuisance exception.
             if (!RuntimeInformation.FrameworkDescription.StartsWith(".NET Native", StringComparison.OrdinalIgnoreCase))
             {
                 // Use Exit rather than simply returning the exit code so that we forcibly shut down

--- a/src/Common/tests/System/Net/Prerequisites/Servers/buildAndPackage.ps1
+++ b/src/Common/tests/System/Net/Prerequisites/Servers/buildAndPackage.ps1
@@ -3,7 +3,7 @@
 # See the LICENSE file in the project root for more information.
 
 # Requires Visual Studio Command Prompt
-# Requires Azure SDK and .Net Framework SDK installed on the build machine.
+# Requires Azure SDK and .NET Framework SDK installed on the build machine.
 
 $cdir = pwd
 $folderName = "CoreFxNetCloudService"

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -59,7 +59,7 @@ namespace System
         public static bool SupportsClientAlpn => SupportsAlpn ||
             (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && PlatformDetection.OSXVersion > new Version(10, 12));
 
-        // Officially, .Net Native only supports processes running in an AppContainer. However, the majority of tests still work fine
+        // Officially, .NET Native only supports processes running in an AppContainer. However, the majority of tests still work fine
         // in a normal Win32 process and we often do so as running in an AppContainer imposes a substantial tax in debuggability
         // and investigatability. This predicate is used in ConditionalFacts to disable the specific tests that really need to be
         // running in AppContainer when running on .NetNative.

--- a/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/OverloadResolution.vb
+++ b/src/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/CompilerServices/OverloadResolution.vb
@@ -2110,7 +2110,7 @@ skipargument:
 
         End Sub
 
-        ' Type.IsEquivalentTo is not supported in .Net 4.0
+        ' Type.IsEquivalentTo is not supported in .NET Framework 4.0
         Private Shared Function GetArgumentType(ByVal argument As Object) As Type
             'A Nothing object has no type.
             If argument Is Nothing Then Return Nothing

--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryTest.cs
@@ -268,7 +268,7 @@ namespace System.Collections.Immutable.Tests
                 .Add("firstKey", "1").Add("secondKey", "2");
             var exception = AssertExtensions.Throws<ArgumentException>(null, () => map.Add("firstKey", "3"));
 
-            if (!PlatformDetection.IsNetNative) //.Net Native toolchain removes exception messages.
+            if (!PlatformDetection.IsNetNative) //.NET Native toolchain removes exception messages.
             {
                 Assert.Contains("firstKey", exception.Message);
             }

--- a/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSortedDictionaryTest.cs
@@ -313,7 +313,7 @@ namespace System.Collections.Immutable.Tests
             var map = ImmutableSortedDictionary.Create<string, string>()
                 .Add("firstKey", "1").Add("secondKey", "2");
             var exception = AssertExtensions.Throws<ArgumentException>(null, () => map.Add("firstKey", "3"));
-            if (!PlatformDetection.IsNetNative) //.Net Native toolchain removes exception messages.
+            if (!PlatformDetection.IsNetNative) //.NET Native toolchain removes exception messages.
             {
                 Assert.Contains("firstKey", exception.Message);
             }

--- a/src/System.ComponentModel.Composition/src/Microsoft/Internal/Collections/CollectionServices.CollectionOfObject.cs
+++ b/src/System.ComponentModel.Composition/src/Microsoft/Internal/Collections/CollectionServices.CollectionOfObject.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Internal.Collections
                 return (ICollection<object>)collectionObject;
             }
 
-            // Most common .Net collections implement IList as well so for those
+            // Most common .NET collections implement IList as well so for those
             // cases we can optimize the wrapping instead of using reflection to create
             // a generic type.
             if (typeof(IList).IsAssignableFrom(collectionObject.GetType()))

--- a/src/System.ComponentModel.TypeConverter/tests/ContainerTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/ContainerTests.cs
@@ -321,7 +321,7 @@ namespace System.ComponentModel.Tests
             ex = AssertExtensions.Throws<ArgumentException>(null, () => container.Add(c2, "dup"));
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.NotNull(ex.Message);
                 Assert.True(ex.Message.IndexOf("'dup'") != -1);
@@ -336,7 +336,7 @@ namespace System.ComponentModel.Tests
             // unique and case-insensitive
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.NotNull(ex.Message);
                 Assert.True(ex.Message.IndexOf("'duP'") != -1);
@@ -361,7 +361,7 @@ namespace System.ComponentModel.Tests
             // unique and case-insensitive
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.NotNull(ex.Message);
                 Assert.True(ex.Message.IndexOf("'dup'") != -1);
@@ -705,7 +705,7 @@ namespace System.ComponentModel.Tests
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => _container.InvokeValidateName((IComponent)null, "A"));
             Assert.Equal(typeof(ArgumentNullException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.NotNull(ex.Message);
                 Assert.Equal("component", ex.ParamName);
@@ -740,7 +740,7 @@ namespace System.ComponentModel.Tests
             // unique and case-insensitive
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.NotNull(ex.Message);
                 Assert.True(ex.Message.IndexOf("'dup'") != -1);
@@ -756,7 +756,7 @@ namespace System.ComponentModel.Tests
             // unique and case-insensitive
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.NotNull(ex.Message);
                 Assert.True(ex.Message.IndexOf("'dup'") != -1);
@@ -774,7 +774,7 @@ namespace System.ComponentModel.Tests
             // unique and case-insensitive
             Assert.Equal(typeof(ArgumentException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.NotNull(ex.Message);
                 Assert.True(ex.Message.IndexOf("'dup'") != -1);

--- a/src/System.ComponentModel.TypeConverter/tests/ContextStackTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/ContextStackTests.cs
@@ -81,7 +81,7 @@ namespace System.ComponentModel.Tests
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => stack.Append(null));
             Assert.Equal(typeof(ArgumentNullException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.NotNull(ex.Message);
                 Assert.Equal("context", ex.ParamName);
@@ -119,7 +119,7 @@ namespace System.ComponentModel.Tests
             ex = Assert.Throws<ArgumentOutOfRangeException>(() => stack[-1]);
             Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.Equal(new ArgumentOutOfRangeException("level").Message, ex.Message);
                 Assert.Equal("level", ex.ParamName);
@@ -129,7 +129,7 @@ namespace System.ComponentModel.Tests
             ex = Assert.Throws<ArgumentOutOfRangeException>(() => stack[-5]);
             Assert.Equal(typeof(ArgumentOutOfRangeException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.Equal(new ArgumentOutOfRangeException("level").Message, ex.Message);
                 Assert.Equal("level", ex.ParamName);
@@ -163,7 +163,7 @@ namespace System.ComponentModel.Tests
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => stack[(Type)null]);
             Assert.Equal(typeof(ArgumentNullException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.NotNull(ex.Message);
                 Assert.Equal("type", ex.ParamName);
@@ -177,7 +177,7 @@ namespace System.ComponentModel.Tests
             ArgumentNullException ex= Assert.Throws<ArgumentNullException>(()=> stack.Push(null));
             Assert.Equal(typeof(ArgumentNullException), ex.GetType());
             Assert.Null(ex.InnerException);
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
             {
                 Assert.NotNull(ex.Message);
                 Assert.Equal("context", ex.ParamName);

--- a/src/System.ComponentModel.TypeConverter/tests/CultureInfoConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/CultureInfoConverterTests.cs
@@ -95,7 +95,7 @@ namespace System.ComponentModel.Tests
                 // a CultureInfo object on this computer
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.True(ex.Message.IndexOf(typeof(CultureInfo).Name) != -1);
@@ -116,7 +116,7 @@ namespace System.ComponentModel.Tests
                 // a CultureInfo object on this computer
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.True(ex.Message.IndexOf(typeof(CultureInfo).Name) != -1);
@@ -137,7 +137,7 @@ namespace System.ComponentModel.Tests
                 // a CultureInfo object on this computer
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.True(ex.Message.IndexOf(typeof(CultureInfo).Name) != -1);

--- a/src/System.Data.Common/src/Resources/Strings.resx
+++ b/src/System.Data.Common/src/Resources/Strings.resx
@@ -413,7 +413,7 @@
   <data name="SQL_WrongType" xml:space="preserve"><value>Expecting argument of type {1}, but received type {0}.</value></data>
   <data name="ADP_InvalidConnectionOptionValue" xml:space="preserve"><value>Invalid value for key '{0}'.</value></data>
   <data name="ADP_KeywordNotSupported" xml:space="preserve"><value>Keyword not supported: '{0}'.</value></data>
-  <data name="ADP_InternalProviderError" xml:space="preserve"><value>Internal .Net Framework Data Provider error {0}.</value></data>
+  <data name="ADP_InternalProviderError" xml:space="preserve"><value>Internal .NET Framework Data Provider error {0}.</value></data>
   <data name="ADP_NoQuoteChange" xml:space="preserve"><value>The QuotePrefix and QuoteSuffix properties cannot be changed once an Insert, Update, or Delete command has been generated.</value></data>
   <data name="ADP_MissingSourceCommand" xml:space="preserve"><value>The DataAdapter.SelectCommand property needs to be initialized.</value></data>
   <data name="ADP_MissingSourceCommandConnection" xml:space="preserve"><value>The DataAdapter.SelectCommand.Connection property needs to be initialized;</value></data>

--- a/src/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
+++ b/src/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
@@ -546,7 +546,7 @@ namespace System.Data.Common
         /// </summary>
         /// <param name="type">type to test for IDynamicMetaObjectProvider</param>
         /// <exception cref="InvalidOperationException">DataSet will not serialize types that implement IDynamicMetaObjectProvider but do not also implement IXmlSerializable</exception>
-        /// <remarks>IDynamicMetaObjectProvider was introduced in .Net Framework V4.0 into System.Core</remarks>
+        /// <remarks>IDynamicMetaObjectProvider was introduced in .NET Framework V4.0 into System.Core</remarks>
         internal static void VerifyIDynamicMetaObjectProvider(Type type)
         {
             if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type) &&

--- a/src/System.Data.Common/tests/System/Data/DataRowTest2.cs
+++ b/src/System.Data.Common/tests/System/Data/DataRowTest2.cs
@@ -696,7 +696,7 @@ namespace System.Data.Tests
             drArrResult = drChild.GetParentRows("Parent-Child", DataRowVersion.Default);
             Assert.Equal(drArrExcepted, drArrResult);
 
-            /* .Net don't work as expected
+            /* .NET don't work as expected
                 //Check DataRowVersion.Proposed
                 // Teting: DataRow.GetParentRows_D_D ,DataRowVersion.Proposed
                 drArrExcepted = dtParent.Select("ParentId=" + drParent["ParentId"],"",DataViewRowState.ModifiedCurrent);

--- a/src/System.Data.Odbc/src/Resources/Strings.resx
+++ b/src/System.Data.Odbc/src/Resources/Strings.resx
@@ -267,7 +267,7 @@
     <value>Keyword not supported: '{0}'.</value>
   </data>
   <data name="ADP_InternalProviderError" xml:space="preserve">
-    <value>Internal .Net Framework Data Provider error {0}.</value>
+    <value>Internal .NET Framework Data Provider error {0}.</value>
   </data>
   <data name="ADP_InvalidMultipartName" xml:space="preserve">
     <value>{0} '{1}'.</value>
@@ -306,7 +306,7 @@
     <value>OdbcCommandBuilder.DeriveParameters failed because the OdbcCommand.CommandText property value is an invalid multipart name</value>
   </data>
   <data name="ODBC_NotSupportedEnumerationValue" xml:space="preserve">
-    <value>The {0} enumeration value, {1}, is not supported by the .Net Framework Odbc Data Provider.</value>
+    <value>The {0} enumeration value, {1}, is not supported by the .NET Framework Odbc Data Provider.</value>
   </data>
   <data name="ADP_CommandTextRequired" xml:space="preserve">
     <value>{0}: CommandText property has not been initialized</value>

--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -243,7 +243,7 @@
     <value>Keyword not supported: '{0}'.</value>
   </data>
   <data name="ADP_InternalProviderError" xml:space="preserve">
-    <value>Internal .Net Framework Data Provider error {0}.</value>
+    <value>Internal .NET Framework Data Provider error {0}.</value>
   </data>
   <data name="ADP_InvalidMultipartName" xml:space="preserve">
     <value>{0} '{1}'.</value>
@@ -273,7 +273,7 @@
     <value>Connecting to a mirrored SQL Server instance using the MultiSubnetFailover connection option is not supported.</value>
   </data>
   <data name="SQL_NotSupportedEnumerationValue" xml:space="preserve">
-    <value>The {0} enumeration value, {1}, is not supported by the .Net Framework SqlClient Data Provider.</value>
+    <value>The {0} enumeration value, {1}, is not supported by the .NET Framework SqlClient Data Provider.</value>
   </data>
   <data name="ADP_CommandTextRequired" xml:space="preserve">
     <value>{0}: CommandText property has not been initialized</value>
@@ -402,7 +402,7 @@
     <value>The instance of SQL Server you attempted to connect to does not support encryption.</value>
   </data>
   <data name="SQL_InvalidSQLServerVersionUnknown" xml:space="preserve">
-    <value>Unsupported SQL Server version.  The .Net Framework SqlClient Data Provider can only be used with SQL Server versions 7.0 and later.</value>
+    <value>Unsupported SQL Server version.  The .NET Framework SqlClient Data Provider can only be used with SQL Server versions 7.0 and later.</value>
   </data>
   <data name="SQL_CannotCreateNormalizer" xml:space="preserve">
     <value>Cannot create normalizer for '{0}'.</value>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDependencyUtils.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDependencyUtils.cs
@@ -23,7 +23,7 @@ namespace System.Data.SqlClient
         internal object _instanceLock = new object();
 
         // Dependency ID -> Dependency hashtable.  1 -> 1 mapping.
-        // 1) Used for ASP.Net to map from ID to dependency.
+        // 1) Used for ASP.NET to map from ID to dependency.
         // 2) Used to enumerate dependencies to invalidate based on server.
         private Dictionary<string, SqlDependency> _dependencyIdToDependencyHash;
 
@@ -254,7 +254,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        // This method is called by SqlCommand to enable ASP.Net scenarios - map from ID to Dependency.
+        // This method is called by SqlCommand to enable ASP.NET scenarios - map from ID to Dependency.
         internal SqlDependency LookupDependencyEntry(string id)
         {
             if (null == id)

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/Randomizer.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/Randomizer.cs
@@ -169,7 +169,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         /// <remarks>
         /// For fast performance, avoid using MemoryStream/BinaryReader or reflection/serialization. I measured the difference between several implementations and found that:
         /// * Difference in time performance between using plain byte array versus MemoryStream with BinaryReader is ~ 1/10!
-        /// * Difference between this implementation and serialization via .Net Serialization is ~1/100!
+        /// * Difference between this implementation and serialization via .NET Serialization is ~1/100!
         /// </remarks>
         protected virtual void Serialize(byte[] binState, out int nextOffset)
         {

--- a/src/System.Diagnostics.Contracts/tests/Utilities.cs
+++ b/src/System.Diagnostics.Contracts/tests/Utilities.cs
@@ -14,7 +14,7 @@ namespace System.Diagnostics.Contracts.Tests
         internal static void AssertThrowsContractException(Action action)
         {
             Exception exc = Assert.ThrowsAny<Exception>(action);
-            if (!PlatformDetection.IsNetNative) // Cannot do internal framework Reflection on .Net Native
+            if (!PlatformDetection.IsNetNative) // Cannot do internal framework Reflection on .NET Native
             {
                 Assert.Equal("ContractException", exc.GetType().Name);
             }

--- a/src/System.Diagnostics.TraceSource/tests/TraceListenerClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceListenerClassTests.cs
@@ -55,7 +55,7 @@ namespace System.Diagnostics.TraceSourceTests
             var listener = new TestTraceListener();
             listener.TraceOutputOptions = TraceOptions.None;
 
-            // NOTE: TraceOptions includes values for 0x01 and 0x20 in .Net 4.5, but not in CoreFX
+            // NOTE: TraceOptions includes values for 0x01 and 0x20 in .NET Framework 4.5, but not in CoreFX
             // These assertions test for those missing values, and the exceptional condition that
             // maintains compatibility with 4.5
             var missingValue = (TraceOptions)0x01;

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -658,7 +658,7 @@ namespace MonoTests.System.Drawing
 
         //  Tests the LockBitmap functions. Makes a hash of the block of pixels that it returns
         // firsts, changes them, and then using GetPixel does another check of the changes.
-        // The results match the .Net framework
+        // The results match the .NET Framework
         private static byte[] DefaultBitmapHash = new byte[] { 0xD8, 0xD3, 0x68, 0x9C, 0x86, 0x7F, 0xB6, 0xA0, 0x76, 0xD6, 0x00, 0xEF, 0xFF, 0xE5, 0x8E, 0x1B };
         private static byte[] FinalWholeBitmapHash = new byte[] { 0x5F, 0x52, 0x98, 0x37, 0xE3, 0x94, 0xE1, 0xA6, 0x06, 0x6C, 0x5B, 0xF1, 0xA9, 0xC2, 0xA9, 0x43 };
 

--- a/src/System.Globalization.Calendars/tests/System/Globalization/CalendarTestBase.cs
+++ b/src/System.Globalization.Calendars/tests/System/Globalization/CalendarTestBase.cs
@@ -144,7 +144,7 @@ namespace System.Globalization.Tests
             int day = 1;
             if (calendar is JapaneseLunisolarCalendar && PlatformDetection.IsFullFramework)
             {
-                // desktop has a bug in JapaneseLunisolarCalendar which is fixed in .Net Core.
+                // desktop has a bug in JapaneseLunisolarCalendar which is fixed in .NET Core.
                 // in case of a new era starts in the middle of a month which means part of the month will belong to one
                 // era and the rest will belong to the new era. When calculating the calendar year number for dates which
                 // in the rest of the month and exist in the new started era, we should still use the old era info instead

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -14,7 +14,7 @@ namespace System.Globalization.Tests
         [Fact]
         public void CurrentCulture()
         {
-            if (PlatformDetection.IsNetNative && !PlatformDetection.IsInAppContainer) // Tide us over until .Net Native ILC tests run are run inside an appcontainer.
+            if (PlatformDetection.IsNetNative && !PlatformDetection.IsInAppContainer) // Tide us over until .NET Native ILC tests run are run inside an appcontainer.
                 return;
 
             RemoteInvoke(() =>
@@ -43,7 +43,7 @@ namespace System.Globalization.Tests
         [Fact]
         public void CurrentUICulture()
         {
-            if (PlatformDetection.IsNetNative && !PlatformDetection.IsInAppContainer) // Tide us over until .Net Native ILC tests run are run inside an appcontainer.
+            if (PlatformDetection.IsNetNative && !PlatformDetection.IsInAppContainer) // Tide us over until .NET Native ILC tests run are run inside an appcontainer.
                 return;
 
             RemoteInvoke(() =>

--- a/src/System.IO/tests/BinaryReader/BinaryReaderTests.cs
+++ b/src/System.IO/tests/BinaryReader/BinaryReaderTests.cs
@@ -115,7 +115,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Difference in behavior that added extra checks to BinaryReader/Writer buffers on .Net Core")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Difference in behavior that added extra checks to BinaryReader/Writer buffers on .NET Core")]
         public void Read_InvalidEncoding()
         {
             using (var str = CreateStream())

--- a/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
@@ -129,7 +129,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void AssertBlock(int n, object obj)
         {
-            if (!PlatformDetection.IsNetNative)  // .Net Native blocks internal framework reflection.
+            if (!PlatformDetection.IsNetNative)  // .NET Native blocks internal framework reflection.
             {
                 AssertTypeName("Block" + n, obj);
             }

--- a/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
@@ -54,7 +54,7 @@ namespace System.Linq.Expressions.Tests
 
             MethodCallExpression expr = Expression.Call(obj, typeof(MS).GetMethod("I" + N), args);
 
-            if (!PlatformDetection.IsNetNative) // .Net Native blocks internal framework reflection.
+            if (!PlatformDetection.IsNetNative) // .NET Native blocks internal framework reflection.
             {
                 Assert.Equal("InstanceMethodCallExpressionN", expr.GetType().Name);
             }
@@ -162,7 +162,7 @@ namespace System.Linq.Expressions.Tests
 
             MethodCallExpression expr = Expression.Call(typeof(MS).GetMethod("S" + N), args);
 
-            if (!PlatformDetection.IsNetNative) // .Net Native blocks internal framework reflection.
+            if (!PlatformDetection.IsNetNative) // .NET Native blocks internal framework reflection.
             {
                 Assert.Equal("MethodCallExpressionN", expr.GetType().Name);
             }
@@ -315,7 +315,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void AssertStaticMethodCall(int n, object obj)
         {
-            if (!PlatformDetection.IsNetNative)  // .Net Native blocks internal framework reflection.
+            if (!PlatformDetection.IsNetNative)  // .NET Native blocks internal framework reflection.
             {
                 AssertTypeName("MethodCallExpression" + n, obj);
             }
@@ -323,7 +323,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void AssertInstanceMethodCall(int n, object obj)
         {
-            if (!PlatformDetection.IsNetNative)  // .Net Native blocks internal framework reflection.
+            if (!PlatformDetection.IsNetNative)  // .NET Native blocks internal framework reflection.
             {
                 AssertTypeName("InstanceMethodCallExpression" + n, obj);
             }

--- a/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
@@ -100,7 +100,7 @@ namespace System.Linq.Expressions.Tests
 
         private static void AssertInvocation(int n, object obj)
         {
-            if (!PlatformDetection.IsNetNative)  // .Net Native blocks internal framework reflection.
+            if (!PlatformDetection.IsNetNative)  // .NET Native blocks internal framework reflection.
             {
                 AssertTypeName("InvocationExpression" + n, obj);
             }

--- a/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
@@ -462,7 +462,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void GroupJoin(Labeled<Operation> source, Labeled<Operation> operation)
         {
             Action<Operation, Operation> groupJoin = (left, right) =>
@@ -485,7 +485,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void GroupJoin_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
             Action<Operation, Operation> groupJoin = (left, right) =>
@@ -545,7 +545,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void Join(Labeled<Operation> source, Labeled<Operation> operation)
         {
             Action<Operation, Operation> join = (left, right) =>
@@ -567,7 +567,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(UnaryOperators))]
         [MemberData(nameof(BinaryOperators))]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void Join_NotPipelined(Labeled<Operation> source, Labeled<Operation> operation)
         {
             Action<Operation, Operation> join = (left, right) =>

--- a/src/System.Linq.Parallel/tests/QueryOperators/GroupJoinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/GroupJoinTests.cs
@@ -198,7 +198,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(GroupJoinMultipleData), new[] { 0, 1, 2, KeyFactor * 2 - 1, KeyFactor * 2 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void GroupJoin_Multiple(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -229,7 +229,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(GroupJoinMultipleData), new int[] { /* Sources.OuterLoopCount */ })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void GroupJoin_Multiple_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin_Multiple(left, leftCount, right, rightCount);
@@ -237,7 +237,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(GroupJoinMultipleData), new[] { 0, 1, 2, KeyFactor * 2 - 1, KeyFactor * 2 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void GroupJoin_Multiple_LeftWithOrderingColisions(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item.AsUnordered().OrderBy(x => 0);
@@ -274,7 +274,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(GroupJoinMultipleData), new int[] { /* Sources.OuterLoopCount */ })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void GroupJoin_Multiple_LeftWithOrderingColisions_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin_Multiple_LeftWithOrderingColisions(left, leftCount, right, rightCount);
@@ -314,7 +314,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(GroupJoinMultipleData), new[] { 0, 1, 2, KeyFactor * 2 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void GroupJoin_CustomComparator(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -345,7 +345,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(GroupJoinMultipleData), new int[] { /* Sources.OuterLoopCount */ })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void GroupJoin_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin_CustomComparator(left, leftCount, right, rightCount);
@@ -354,7 +354,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(GroupJoinMultipleData), new[] { 0, 1, 2, KeyFactor * 2 - 1, KeyFactor * 2 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void GroupJoin_CustomComparator_LeftWithOrderingColisions(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item.AsUnordered().OrderBy(x => x / KeyFactor);
@@ -427,7 +427,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(GroupJoinMultipleData), new int[] { /* Sources.OuterLoopCount */ })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void GroupJoin_CustomComparator_LeftWithOrderingColisions_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin_CustomComparator_LeftWithOrderingColisions(left, leftCount, right, rightCount);

--- a/src/System.Linq.Parallel/tests/QueryOperators/JoinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/JoinTests.cs
@@ -163,7 +163,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(JoinMultipleData), new[] { 0, 1, 2, KeyFactor * 2 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void Join_Multiple(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -181,7 +181,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(JoinMultipleData), new[] { 512, 1024 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void Join_Multiple_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_Multiple(left, leftCount, right, rightCount);
@@ -208,7 +208,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(JoinMultipleData), new[] { 2, KeyFactor - 1, KeyFactor, KeyFactor + 1, KeyFactor * 2 - 1, KeyFactor * 2, KeyFactor * 2 + 1 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void Join_Multiple_LeftWithOrderingColisions(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             LeftOrderingCollisionTestWithOrderedRight validator = new LeftOrderingCollisionTestWithOrderedRight();
@@ -219,7 +219,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(JoinMultipleData), new[] { 512, 1024 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void Join_Multiple_LeftWithOrderingColisions_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_Multiple_LeftWithOrderingColisions(left, leftCount, right, rightCount);
@@ -300,7 +300,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(JoinMultipleData), new[] { 0, 1, 2, KeyFactor * 2 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void Join_CustomComparator(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -333,7 +333,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(JoinMultipleData), new[] { 512, 1024 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void Join_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_CustomComparator(left, leftCount, right, rightCount);
@@ -366,7 +366,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(JoinMultipleData), new[] { 2, KeyFactor - 1, KeyFactor, KeyFactor + 1, KeyFactor * 2 - 1, KeyFactor * 2, KeyFactor * 2 + 1 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void Join_CustomComparator_LeftWithOrderingColisions(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             LeftOrderingCollisionTestWithOrderedRightAndCustomComparator validator = new LeftOrderingCollisionTestWithOrderedRightAndCustomComparator();
@@ -377,7 +377,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(JoinMultipleData), new[] { 512, 1024 })]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.Net core bug fix https://github.com/dotnet/corefx/pull/27930)")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework doesn't preserve the right collection order (.NET core bug fix https://github.com/dotnet/corefx/pull/27930)")]
         public static void Join_CustomComparator_LeftWithOrderingColisions_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_CustomComparator_LeftWithOrderingColisions(left, leftCount, right, rightCount);

--- a/src/System.Management/src/System/Management/ManagementScope.cs
+++ b/src/System.Management/src/System/Management/ManagementScope.cs
@@ -298,7 +298,7 @@ namespace System.Management
 
             if (netFrameworkInstallRoot == null)
             {
-                // In some Windows versions, like Nano Server, the .Net Framework is not installed by default.
+                // In some Windows versions, like Nano Server, the .NET Framework is not installed by default.
                 // It is possible that general failure to access the registry get to this code branch but it is
                 // very unlikely.
                 // Load PNSE delegates. This way it will throw PNSE when methods are used not when type is loaded.

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpException.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpException.cs
@@ -25,7 +25,7 @@ namespace System.Net.Http
         {
             // This method allows common error detection code to be used by consumers
             // of HttpClient. This method converts the ErrorCode returned by WinHTTP
-            // to the same HRESULT value as is provided in the .Net Native implementation
+            // to the same HRESULT value as is provided in the .NET Native implementation
             // of HttpClient under the same error conditions. Clients would access
             // HttpRequestException.InnerException.HRESULT to discover what caused
             // the exception.
@@ -70,7 +70,7 @@ namespace System.Net.Http
             Debug.Assert(!string.IsNullOrEmpty(nameOfCalledFunction));
 
             // Look up specific error message in WINHTTP.DLL since it is not listed in default system resources
-            // and thus can't be found by default .Net interop.
+            // and thus can't be found by default .NET interop.
             IntPtr moduleHandle = Interop.Kernel32.GetModuleHandle(Interop.Libraries.WinHttp);
             string httpError = Interop.Kernel32.GetMessage(error, moduleHandle);
 

--- a/src/System.Net.Http/tests/FunctionalTests/FormUrlEncodedContentTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/FormUrlEncodedContentTest.cs
@@ -108,7 +108,7 @@ namespace System.Net.Http.Functional.Tests
             Stream stream = await content.ReadAsStreamAsync();
             string result = new StreamReader(stream).ReadToEnd().ToLowerInvariant();
 
-            // Result of UrlEncode invoked in .Net 4.6
+            // Result of UrlEncode invoked in .NET Framework 4.6
             // string expectedResult = "key=" + HttpUtility.UrlEncode(testString).ToLowerInvariant();
             // HttpUtility is not part of ProjectK.
 

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -189,7 +189,7 @@ namespace System.Net.Security.Tests
 
                 // TODO #5241: Behavior difference:
                 Assert.Equal(false, clientIdentity.IsAuthenticated);
-                // On .Net Desktop: Assert.Equal(true, clientIdentity.IsAuthenticated);
+                // On .NET Desktop: Assert.Equal(true, clientIdentity.IsAuthenticated);
 
                 IdentityValidator.AssertHasName(clientIdentity, new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).Value);
             }

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -82,7 +82,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
-    <!-- TODO #13070: Add net463 to the condition after the TFM gets updated to the actual .Net 4.7-->
+    <!-- TODO #13070: Add net463 to the condition after the TFM gets updated to the actual .NET Framework 4.7-->
     <Compile Include="..\..\src\System\Net\Security\SniHelper.cs">
       <Link>src\SniHelper.cs</Link>
     </Compile>

--- a/src/System.Net.ServicePoint/tests/System.Net.ServicePoint.Tests.csproj
+++ b/src/System.Net.ServicePoint/tests/System.Net.ServicePoint.Tests.csproj
@@ -7,7 +7,7 @@
     <Compile Include="ServicePointManagerTest.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
-    <!-- TODO #13070: Add net463 to the condition after the TFM gets updated to the actual .Net 4.6.3.-->
+    <!-- TODO #13070: Add net463 to the condition after the TFM gets updated to the actual .NET Framework 4.6.3.-->
     <Compile Include="TlsSystemDefault.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinRTWebSocket.cs
@@ -536,7 +536,7 @@ namespace System.Net.WebSockets
                 {
                     if (_state == currentState)
                     {
-                        // Ordering is important to maintain .Net 4.5 WebSocket implementation exception behavior.
+                        // Ordering is important to maintain .NET Framework 4.5 WebSocket implementation exception behavior.
                         if (_disposed)
                         {
                             throw new ObjectDisposedException(GetType().FullName);

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
@@ -56,7 +56,7 @@ namespace System.Net.WebSockets.Client.Tests
                 InvalidOperationException exception;
                 using (var tcc = new ThreadCultureChange())
                 {
-                    // The .Net Native toolchain optimizes away exception messages.
+                    // The .NET Native toolchain optimizes away exception messages.
                     if (!PlatformDetection.IsNetNative)
                         tcc.ChangeCultureInfo(CultureInfo.InvariantCulture);
 
@@ -64,7 +64,7 @@ namespace System.Net.WebSockets.Client.Tests
                         () => cws.CloseOutputAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()));
                 }
 
-                // The .Net Native toolchain optimizes away exception messages.
+                // The .NET Native toolchain optimizes away exception messages.
                 if (!PlatformDetection.IsNetNative)
                 {
                     string expectedMessage = ResourceHelper.GetExceptionMessage("net_WebSockets_NotConnected");
@@ -104,7 +104,7 @@ namespace System.Net.WebSockets.Client.Tests
 
                 using (var tcc = new ThreadCultureChange())
                 {
-                    // The .Net Native toolchain optimizes away exception messages.
+                    // The .NET Native toolchain optimizes away exception messages.
                     if (!PlatformDetection.IsNetNative)
                         tcc.ChangeCultureInfo(CultureInfo.InvariantCulture);
 
@@ -112,7 +112,7 @@ namespace System.Net.WebSockets.Client.Tests
                         () => cws.ReceiveAsync(segment, ct));
                 }
 
-                // The .Net Native toolchain optimizes away exception messages.
+                // The .NET Native toolchain optimizes away exception messages.
                 if (!PlatformDetection.IsNetNative)
                 {
                     string expectedMessage = ResourceHelper.GetExceptionMessage("net_WebSockets_NotConnected");
@@ -151,7 +151,7 @@ namespace System.Net.WebSockets.Client.Tests
                 InvalidOperationException exception;
                 using (var tcc = new ThreadCultureChange())
                 {
-                    // The .Net Native toolchain optimizes away exception messages.
+                    // The .NET Native toolchain optimizes away exception messages.
                     if (!PlatformDetection.IsNetNative)
                         tcc.ChangeCultureInfo(CultureInfo.InvariantCulture);
 
@@ -159,7 +159,7 @@ namespace System.Net.WebSockets.Client.Tests
                         () => cws.SendAsync(segment, WebSocketMessageType.Text, false, ct));
                 }
 
-                // The .Net Native toolchain optimizes away exception messages.
+                // The .NET Native toolchain optimizes away exception messages.
                 if (!PlatformDetection.IsNetNative)
                 {
                     string expectedMessage = ResourceHelper.GetExceptionMessage("net_WebSockets_NotConnected");

--- a/src/System.Numerics.Vectors/tests/Vector2Tests.cs
+++ b/src/System.Numerics.Vectors/tests/Vector2Tests.cs
@@ -35,7 +35,7 @@ namespace System.Numerics.Tests
             }
             else
             {
-               // The .Net Native code generation optimizer does aggressive optimizations to range checks 
+               // The .NET Native code generation optimizer does aggressive optimizations to range checks 
                // which result in an ArgumentOutOfRangeException exception being thrown at runtime.
                Assert.ThrowsAny<ArgumentException>(() => v1.CopyTo(a, 2));
             }

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -409,7 +409,7 @@ namespace System.PrivateUri.Tests
 
         /// <summary>
         /// First column contains input characters found to be potential issues with the current implementation.
-        /// The second column contains the current (.Net Core 2.1/Framework 4.7.2) Uri behavior for Uri normalization.
+        /// The second column contains the current (.NET Core 2.1/Framework 4.7.2) Uri behavior for Uri normalization.
         /// </summary>
         private static string[,] s_checkIsReservedEscapingStrings =
         {

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/CommonTests.cs
@@ -3417,7 +3417,7 @@ namespace CoreXml.Test.XLinq
                     using (XmlReader reader = doc.CreateReader())
                     {
                         Exception exception = AssertExtensions.Throws<ArgumentException>(null, () => MoveToFirstElement(reader).ReadOuterXml());
-                        if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
+                        if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages
                         {
                             // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
                             // \p{Pf} any kind of closing quote https://www.compart.com/en/unicode/category/Pf
@@ -3615,7 +3615,7 @@ namespace CoreXml.Test.XLinq
                     using (XmlReader reader = doc.CreateReader())
                     {
                         Exception exception = AssertExtensions.Throws<ArgumentException>(null, () => MoveToFirstElement(reader).ReadOuterXml());
-                        if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
+                        if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages
                         {
                             // \b word boundary
                             // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi
@@ -4223,7 +4223,7 @@ namespace CoreXml.Test.XLinq
                     using (XmlReader reader = doc.CreateReader())
                     {
                         Exception exception = AssertExtensions.Throws<ArgumentException>(null, () => MoveToFirstElement(reader).ReadOuterXml());
-                        if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
+                        if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages
                         {
                             // \b word boundary
                             // \p{Pi} any kind of opening quote https://www.compart.com/en/unicode/category/Pi

--- a/src/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
+++ b/src/System.Private.Xml/tests/XmlReader/Tests/AsyncReaderLateInitTests.cs
@@ -78,7 +78,7 @@ namespace System.Xml.Tests
             }
         }
 
-        [Fact, SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".Net Framework throws AggregateException")]
+        [Fact, SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework throws AggregateException")]
         public static void ReadAfterInitializationWithUriOnAsyncReaderTrows()
         {
             using (XmlReader reader = XmlReader.Create("http://test.test/test.html", new XmlReaderSettings() { Async = true }))

--- a/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ExceptionVerifier.cs
+++ b/src/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ExceptionVerifier.cs
@@ -262,7 +262,7 @@ namespace System.Xml.Tests
             _actualMessage = _actualMessage.ToLowerInvariant();
 
 
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away Exception messages
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away Exception messages
             {
                 if (Regex.Match(_actualMessage, _expectedMessage, RegexOptions.Singleline).ToString() != _actualMessage)
                 {

--- a/src/System.Private.Xml/tests/Xslt/XslTransformApi/ExceptionVerifier.cs
+++ b/src/System.Private.Xml/tests/Xslt/XslTransformApi/ExceptionVerifier.cs
@@ -259,7 +259,7 @@ namespace System.Xml.Tests
             _expectedMessage = _expectedMessage.ToLowerInvariant();
             _actualMessage = _actualMessage.ToLowerInvariant();
 
-            if (!PlatformDetection.IsNetNative) // .Net Native toolchain optimizes away exception messages.
+            if (!PlatformDetection.IsNetNative) // .NET Native toolchain optimizes away exception messages.
             {
                 if (Regex.Match(_actualMessage, _expectedMessage, RegexOptions.Singleline).ToString() != _actualMessage)
                 {

--- a/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -34,7 +34,7 @@ namespace System.Reflection
     //         The generated DispatchProxy proxy type does not need to generate implementation methods
     //         for the base type's interfaces, because the base type already must have implemented them.
     //  4. RealProxy required a proxy instance to hold a backpointer to the RealProxy instance to mirror
-    //     the .Net Remoting design that required the proxy and RealProxy to be separate instances.
+    //     the .NET Remoting design that required the proxy and RealProxy to be separate instances.
     //     But the DispatchProxy design encourages the proxy type to *be* an DispatchProxy.  Therefore,
     //     the proxy's 'this' becomes the equivalent of RealProxy's backpointer to RealProxy, so we were
     //     able to remove an extraneous field and ctor arg from the DispatchProxy proxies.

--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/MemberInfoTests.CoreCLR.cs
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/MemberInfoTests.CoreCLR.cs
@@ -55,7 +55,7 @@ namespace System.Reflection.Tests
                 if (!PlatformDetection.IsNetNative)
                     return true;
 
-                // Expected false but in case .Net Native ever changes its mind...
+                // Expected false but in case .NET Native ever changes its mind...
                 return typeof(MetadataTokenTests).HasMetadataToken();
             }
         }

--- a/src/System.Reflection/tests/MemberInfoTests.netcoreapp.cs
+++ b/src/System.Reflection/tests/MemberInfoTests.netcoreapp.cs
@@ -166,7 +166,7 @@ namespace System.Reflection.Tests
         [Fact]
         public static void HasSameMetadataDefinitionAs_Twins()
         {
-            // This situation is particularly treacherous for CoreRT as the .Net Native toolchain can and does assign
+            // This situation is particularly treacherous for CoreRT as the .NET Native toolchain can and does assign
             // the same native metadata tokens to identically structured members in unrelated types.
             Type twin1 = typeof(Twin1);
             Type twin2 = typeof(Twin2);

--- a/src/System.Runtime.Extensions/tests/System/Runtime/Versioning/VersioningHelperTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/Runtime/Versioning/VersioningHelperTests.cs
@@ -10,7 +10,7 @@ namespace System.Runtime.Versioning.Tests
     public static class VersioningHelperTests
     {
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "r3 suffix is hardcoded in .Net Core and return code is not documented")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "r3 suffix is hardcoded in .NET Core and return code is not documented")]
         public static void MakeVersionSafeNameTest()
         {
             string str1 = VersioningHelper.MakeVersionSafeName("TestFile", ResourceScope.Process, ResourceScope.AppDomain);

--- a/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace System.Runtime.Loader.Tests
 {
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "AssemblyLoadContext not supported on .Net Native")]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "AssemblyLoadContext not supported on .NET Native")]
     public partial class AssemblyLoadContextTest
     {
         private const string TestAssembly = "System.Runtime.Loader.Test.Assembly";

--- a/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -44,7 +44,7 @@ namespace System.Runtime.Loader.Tests
         }
     }
 
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "AssemblyLoadContext not supported on .Net Native")]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "AssemblyLoadContext not supported on .NET Native")]
     public class DefaultLoadContextTests
     {
         private const string TestAssemblyName = "System.Runtime.Loader.Noop.Assembly";

--- a/src/System.Runtime.Loader/tests/RefEmitLoadContext/RefEmitLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/RefEmitLoadContext/RefEmitLoadContextTest.cs
@@ -30,7 +30,7 @@ namespace System.Runtime.Loader.Tests
         }
     }
 
-    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "AssemblyLoadContext not supported on .Net Native")]
+    [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot, "AssemblyLoadContext not supported on .NET Native")]
     public class RefEmitLoadContextTests
     {
         public static string s_loadFromPath = null;

--- a/src/System.Runtime/tests/System/Type/TypeTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Type/TypeTests.netcoreapp.cs
@@ -153,9 +153,9 @@ namespace System.Tests
         // works. It's likely that such a type will live in the core assembly so to improve our chances of catching this situation, test IsTypeDefinition
         // on every type exposed out of that assembly.
         //
-        // Skipping this on .Net Native because:
+        // Skipping this on .NET Native because:
         //  - We really don't want to opt in all the metadata in System.Private.CoreLib
-        //  - The .Net Native implementation of IsTypeDefinition is not the one that works by enumerating selected values off CorElementType.
+        //  - The .NET Native implementation of IsTypeDefinition is not the one that works by enumerating selected values off CorElementType.
         //    It has much less need of a test like this.
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.UapAot)]
@@ -177,7 +177,7 @@ namespace System.Tests
                 yield return new object[] { typeof(Outside.Inside) };
                 yield return new object[] { typeof(Outside<>) };
                 yield return new object[] { typeof(IEnumerable<>) };
-                yield return new object[] { 3.GetType().GetType() };  // This yields a reflection-blocked type on .Net Native - which is implemented separately
+                yield return new object[] { 3.GetType().GetType() };  // This yields a reflection-blocked type on .NET Native - which is implemented separately
 
                 if (PlatformDetection.IsWindows)
                     yield return new object[] { Type.GetTypeFromCLSID(default(Guid)) };
@@ -191,7 +191,7 @@ namespace System.Tests
                 Type theT = typeof(Outside<>).GetTypeInfo().GenericTypeParameters[0];
 
                 yield return new object[] { typeof(int[]) };
-                yield return new object[] { theT.MakeArrayType(1) }; // Using an open type as element type gets around .Net Native nonsupport of rank-1 multidim arrays 
+                yield return new object[] { theT.MakeArrayType(1) }; // Using an open type as element type gets around .NET Native nonsupport of rank-1 multidim arrays 
                 yield return new object[] { typeof(int[,]) };
 
                 yield return new object[] { typeof(int).MakeByRefType() };

--- a/src/System.Security.Permissions/tests/SecurityElementTests.cs
+++ b/src/System.Security.Permissions/tests/SecurityElementTests.cs
@@ -94,7 +94,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.True(ex.Message.IndexOf(tagName) != -1);
@@ -115,7 +115,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
 
                     Assert.NotNull(ex.Message);
@@ -149,7 +149,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.True(ex.Message.IndexOf(invalid) != -1);
@@ -170,7 +170,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.NotNull(ex.ParamName);
@@ -202,7 +202,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.NotNull(ex.ParamName);
@@ -224,7 +224,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.NotNull(ex.ParamName);
@@ -291,7 +291,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.NotNull(ex.ParamName);
@@ -334,7 +334,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.True(ex.Message.IndexOf("\"invalid\"") != -1);
@@ -442,7 +442,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.NotNull(ex.ParamName);
@@ -479,7 +479,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.NotNull(ex.ParamName);
@@ -536,7 +536,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.True(ex.Message.IndexOf(invalid) != -1);
@@ -558,7 +558,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.NotNull(ex.ParamName);
@@ -596,7 +596,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.True(ex.Message.IndexOf(invalid) != -1);
@@ -628,7 +628,7 @@ namespace System.Security.Permissions.Tests
             {
                 Assert.Equal(typeof(ArgumentNullException), ex.GetType());
                 Assert.Null(ex.InnerException);
-                if (!PlatformDetection.IsNetNative)  // .Net Native toolchain optimizes away exception messages and paramnames.
+                if (!PlatformDetection.IsNetNative)  // .NET Native toolchain optimizes away exception messages and paramnames.
                 {
                     Assert.NotNull(ex.Message);
                     Assert.NotNull(ex.ParamName);

--- a/src/System.Threading.Thread/tests/ThreadTests.cs
+++ b/src/System.Threading.Thread/tests/ThreadTests.cs
@@ -1170,7 +1170,7 @@ namespace System.Threading.Threads.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Default principal policy on .Net Framework is Unauthenticated Principal")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Default principal policy on .NET Framework is Unauthenticated Principal")]
         public static void DefaultPrincipalPolicyTest()
         {
             DummyClass.RemoteInvoke(() =>
@@ -1180,7 +1180,7 @@ namespace System.Threading.Threads.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Default principal policy on .Net Core is No Principal")]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Default principal policy on .NET Core is No Principal")]
         public static void DefaultPrincipalPolicyTest_Desktop()
         {
             DummyClass.RemoteInvoke(() =>

--- a/src/System.Transactions.Local/src/System/Transactions/TransactionScope.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/TransactionScope.cs
@@ -16,7 +16,7 @@ namespace System.Transactions
 
     //
     //  The legacy TransactionScope uses TLS to store the ambient transaction. TLS data doesn't flow across thread continuations and hence legacy TransactionScope does not compose well with
-    //  new .Net async programming model constructs like Tasks and async/await. To enable TransactionScope to work with Task and async/await, a new TransactionScopeAsyncFlowOption
+    //  new .NET async programming model constructs like Tasks and async/await. To enable TransactionScope to work with Task and async/await, a new TransactionScopeAsyncFlowOption
     //  is introduced. When users opt-in the async flow option, ambient transaction will automatically flow across thread continuations and user can compose TransactionScope with Task and/or    
     //  async/await constructs. 
     // 


### PR DESCRIPTION
According to the [glossary](https://github.com/dotnet/docs/blob/master/docs/standard/glossary.md#net) - rename from `.Net` to `.NET`