### PR TITLE
Utf8JsonReader should be consistent when dealing with more than one JSON payload.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -331,50 +331,13 @@ namespace System.Text.Json
                     }
                     _tokenType = JsonTokenType.Number;
                     _consumed += numberOfBytes;
+                    return true;
                 }
                 else if (!ConsumeValueMultiSegment(first))
                 {
                     return false;
                 }
 
-                // Cannot use HasMoreData since the JSON payload contains a single, non-primitive value
-                // and hence must be handled differently.
-                if (_consumed >= (uint)_buffer.Length)
-                {
-                    goto SetIsNotPrimitiveAndReturnTrue;
-                }
-
-                if (_buffer[_consumed] <= JsonConstants.Space)
-                {
-                    SkipWhiteSpaceMultiSegment();
-                    if (_consumed >= (uint)_buffer.Length)
-                    {
-                        goto SetIsNotPrimitiveAndReturnTrue;
-                    }
-                }
-
-                if (_readerOptions.CommentHandling != JsonCommentHandling.Disallow)
-                {
-                    if (_readerOptions.CommentHandling == JsonCommentHandling.Allow)
-                    {
-                        // This is necessary to avoid throwing when the user has 1 or more comments as the first token
-                        // OR if there is a comment after a single, non-primitive value.
-                        // In this mode, ConsumeValue consumes the comment and we need to return it as a token.
-                        // along with future comments in subsequeunt reads.
-                        if (_tokenType == JsonTokenType.Comment || _buffer[_consumed] == JsonConstants.Slash)
-                        {
-                            return true;
-                        }
-                    }
-                    else
-                    {
-                        Debug.Assert(_readerOptions.CommentHandling == JsonCommentHandling.Skip);
-                        goto SetIsNotPrimitiveAndReturnTrue;
-                    }
-                }
-                ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndAfterSingleJson, _buffer[_consumed]);
-
-            SetIsNotPrimitiveAndReturnTrue:
                 if (_tokenType == JsonTokenType.StartObject || _tokenType == JsonTokenType.StartArray)
                 {
                     _isNotPrimitive = true;
@@ -1611,7 +1574,7 @@ namespace System.Text.Json
                 }
             }
 
-            if (!_isNotPrimitive)
+            if (CurrentDepth == 0)
             {
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndAfterSingleJson, marker);
             }
@@ -1718,7 +1681,7 @@ namespace System.Text.Json
                 first = _buffer[_consumed];
             }
 
-            if (!_isNotPrimitive && _tokenType != JsonTokenType.None)
+            if (CurrentDepth == 0 && _tokenType != JsonTokenType.None)
             {
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndAfterSingleJson, first);
             }
@@ -2008,7 +1971,7 @@ namespace System.Text.Json
                 }
                 goto Done;
             }
-            else if (!_isNotPrimitive)
+            else if (CurrentDepth == 0)
             {
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndAfterSingleJson, marker);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -729,54 +729,13 @@ namespace System.Text.Json
                     _tokenType = JsonTokenType.Number;
                     _consumed += numberOfBytes;
                     _bytePositionInLine += numberOfBytes;
+                    return true;
                 }
                 else if (!ConsumeValue(first))
                 {
                     return false;
                 }
 
-                // Cannot use HasMoreData since the JSON payload contains a single, non-primitive value
-                // and hence must be handled differently.
-                if (_consumed >= (uint)localBuffer.Length)
-                {
-                    goto SetIsNotPrimitiveAndReturnTrue;
-                }
-
-                if (localBuffer[_consumed] <= JsonConstants.Space)
-                {
-                    SkipWhiteSpace();
-                    if (_consumed >= (uint)localBuffer.Length)
-                    {
-                        goto SetIsNotPrimitiveAndReturnTrue;
-                    }
-                }
-
-                if (_readerOptions.CommentHandling != JsonCommentHandling.Disallow)
-                {
-                    if (_readerOptions.CommentHandling == JsonCommentHandling.Allow)
-                    {
-                        // This is necessary to avoid throwing when the user has 1 or more comments as the first token
-                        // OR if there is a comment after a single, non-primitive value.
-                        // In this mode, ConsumeValue consumes the comment and we need to return it as a token.
-                        // along with future comments in subsequeunt reads.
-                        if (_tokenType == JsonTokenType.Comment || localBuffer[_consumed] == JsonConstants.Slash)
-                        {
-                            return true;
-                        }
-                    }
-                    else
-                    {
-                        Debug.Assert(_readerOptions.CommentHandling == JsonCommentHandling.Skip);
-                        if (_tokenType == JsonTokenType.StartObject || _tokenType == JsonTokenType.StartArray)
-                        {
-                            _isNotPrimitive = true;
-                        }
-                        goto SetIsNotPrimitiveAndReturnTrue;
-                    }
-                }
-                ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndAfterSingleJson, localBuffer[_consumed]);
-
-            SetIsNotPrimitiveAndReturnTrue:
                 if (_tokenType == JsonTokenType.StartObject || _tokenType == JsonTokenType.StartArray)
                 {
                     _isNotPrimitive = true;
@@ -1515,7 +1474,7 @@ namespace System.Text.Json
                 }
             }
 
-            if (!_isNotPrimitive)
+            if (CurrentDepth == 0)
             {
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndAfterSingleJson, marker);
             }
@@ -1613,7 +1572,7 @@ namespace System.Text.Json
                 first = _buffer[_consumed];
             }
 
-            if (!_isNotPrimitive && _tokenType != JsonTokenType.None)
+            if (CurrentDepth == 0 && _tokenType != JsonTokenType.None)
             {
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndAfterSingleJson, first);
             }
@@ -1888,7 +1847,7 @@ namespace System.Text.Json
                 }
                 goto Done;
             }
-            else if (!_isNotPrimitive)
+            else if (CurrentDepth == 0)
             {
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndAfterSingleJson, marker);
             }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -742,7 +742,6 @@ namespace System.Text.Json.Tests
                 {
                     jsonReader.Read();
                 }
-                Assert.True(false, $"Expected json.Read to throw JsonReaderException beyond a single vaid JSON payload.");
             });
         }
     }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -666,11 +666,11 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(JsonTokenWithExtraValue))]
         public static void ReadJsonTokenWithExtraValueMultiSegment(string jsonString)
         {
+            byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8, 1);
+
             foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
             {
-                byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
-                ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8, 1);
-
                 TestReadTokenWithExtra(sequence, commentHandling, isFinalBlock: false);
                 TestReadTokenWithExtra(sequence, commentHandling, isFinalBlock: true);
             }
@@ -680,15 +680,15 @@ namespace System.Text.Json.Tests
         [MemberData(nameof(JsonTokenWithExtraValueAndComments))]
         public static void ReadJsonTokenWithExtraValueAndCommentsMultiSegment(string jsonString)
         {
+            byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8, 1);
+
             foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
             {
                 if (commentHandling == JsonCommentHandling.Disallow)
                 {
                     continue;
                 }
-
-                byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
-                ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8, 1);
 
                 TestReadTokenWithExtra(sequence, commentHandling, isFinalBlock: false);
                 TestReadTokenWithExtra(sequence, commentHandling, isFinalBlock: true);
@@ -723,31 +723,27 @@ namespace System.Text.Json.Tests
             if (commentsAppended && commentHandling == JsonCommentHandling.Allow)
             {
                 Assert.True(reader.Read());
-                Assert.True(reader.TokenType == JsonTokenType.Comment);
+                Assert.Equal(JsonTokenType.Comment, reader.TokenType);
                 Assert.True(reader.Read());
-                Assert.True(reader.TokenType == JsonTokenType.Comment);
+                Assert.Equal(JsonTokenType.Comment, reader.TokenType);
             }
 
             Assert.True(reader.Read());
             if (reader.TokenType == JsonTokenType.StartArray || reader.TokenType == JsonTokenType.StartObject)
             {
                 Assert.True(reader.Read());
-                Assert.True(reader.TokenType == JsonTokenType.EndArray || reader.TokenType == JsonTokenType.EndObject);
+                Assert.Contains(reader.TokenType, new[] { JsonTokenType.EndArray, JsonTokenType.EndObject });
             }
 
-            try
+            JsonTestHelper.AssertThrows<JsonReaderException>(reader, (jsonReader) =>
             {
-                reader.Read();
-                if (commentHandling == JsonCommentHandling.Allow && reader.TokenType == JsonTokenType.Comment)
+                jsonReader.Read();
+                if (commentHandling == JsonCommentHandling.Allow && jsonReader.TokenType == JsonTokenType.Comment)
                 {
-                    reader.Read();
+                    jsonReader.Read();
                 }
                 Assert.True(false, $"Expected json.Read to throw JsonReaderException beyond a single vaid JSON payload.");
-            }
-            catch (JsonReaderException ex)
-            {
-                Assert.True(ex.Message.Contains("is invalid after a single JSON value. Expected end of data."), ex.Message);
-            }
+            });
         }
     }
 }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -2042,7 +2042,6 @@ namespace System.Text.Json.Tests
                 {
                     jsonReader.Read();
                 }
-                Assert.True(false, $"Expected json.Read to throw JsonReaderException beyond a single vaid JSON payload.");
             });
         }
 

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -1892,6 +1892,91 @@ namespace System.Text.Json.Tests
             }
         }
 
+        [Theory]
+        [MemberData(nameof(JsonTokenWithExtraValue))]
+        public static void ReadJsonTokenWithExtraValue(string jsonString)
+        {
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
+
+                TestReadTokenWithExtra(utf8, commentHandling, isFinalBlock: false);
+                TestReadTokenWithExtra(utf8, commentHandling, isFinalBlock: true);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(JsonTokenWithExtraValueAndComments))]
+        public static void ReadJsonTokenWithExtraValueAndComments(string jsonString)
+        {
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                if (commentHandling == JsonCommentHandling.Disallow)
+                {
+                    continue;
+                }
+
+                byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
+
+                TestReadTokenWithExtra(utf8, commentHandling, isFinalBlock: false);
+                TestReadTokenWithExtra(utf8, commentHandling, isFinalBlock: true);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(JsonTokenWithExtraValueAndComments))]
+        public static void ReadJsonTokenWithExtraValueAndCommentsAppended(string jsonString)
+        {
+            jsonString = "  /* comment */  /* comment */  " + jsonString;
+            byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                if (commentHandling == JsonCommentHandling.Disallow)
+                {
+                    continue;
+                }
+
+                TestReadTokenWithExtra(utf8, commentHandling, isFinalBlock: false, commentsAppended: true);
+                TestReadTokenWithExtra(utf8, commentHandling, isFinalBlock: true, commentsAppended: true);
+            }
+        }
+
+        private static void TestReadTokenWithExtra(byte[] utf8, JsonCommentHandling commentHandling, bool isFinalBlock, bool commentsAppended = false)
+        {
+            JsonReaderState state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling });
+            Utf8JsonReader reader = new Utf8JsonReader(utf8, isFinalBlock, state);
+
+            if (commentsAppended && commentHandling == JsonCommentHandling.Allow)
+            {
+                Assert.True(reader.Read());
+                Assert.True(reader.TokenType == JsonTokenType.Comment);
+                Assert.True(reader.Read());
+                Assert.True(reader.TokenType == JsonTokenType.Comment);
+            }
+
+            Assert.True(reader.Read());
+            if (reader.TokenType == JsonTokenType.StartArray || reader.TokenType == JsonTokenType.StartObject)
+            {
+                Assert.True(reader.Read());
+                Assert.True(reader.TokenType == JsonTokenType.EndArray || reader.TokenType == JsonTokenType.EndObject);
+            }
+
+            try
+            {
+                reader.Read();
+                if (commentHandling == JsonCommentHandling.Allow && reader.TokenType == JsonTokenType.Comment)
+                {
+                    reader.Read();
+                }
+                Assert.True(false, $"Expected json.Read to throw JsonReaderException beyond a single vaid JSON payload.");
+            }
+            catch (JsonReaderException ex)
+            {
+                Assert.True(ex.Message.Contains("is invalid after a single JSON value. Expected end of data."), ex.Message);
+            }
+        }
+
         public static IEnumerable<object[]> TestCases
         {
             get
@@ -2024,6 +2109,95 @@ namespace System.Text.Json.Tests
                     new object[] {"  null  ", "null"},
                     new object[] {"  true  ", "true"},
                     new object[] {"  false  ", "false"},
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> JsonTokenWithExtraValue
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] {"  true  5 "},
+                    new object[] {"  false  5 "},
+                    new object[] {"  null  5 "},
+                    new object[] {"  5  5 "},
+                    new object[] {"  5.1234e-4  5 "},
+                    new object[] {"  \"hello\"  5 "},
+                    new object[] {"  \"hello\"  \"hello\" "},
+                    new object[] {"  [  ]  5 "},
+                    new object[] {"  [  ]  [] "},
+                    new object[] {"  [  ]  {} "},
+                    new object[] {"  { }  5 "},
+                    new object[] {"  { }  [] "},
+                    new object[] {"  { }  {} "},
+                    new object[] {"  [  ]5 "},
+                    new object[] {"  [  ][] "},
+                    new object[] {"  [  ]{} "},
+                    new object[] {"  { }5 "},
+                    new object[] {"  { }[] "},
+                    new object[] {"  { }{} "},
+                    new object[] {"  { }  5.1234e-4"},
+                    new object[] {"  { }  null "},
+                    new object[] {"  { }  false "},
+                    new object[] {"  { }  true "},
+                    new object[] {"  { }  \"hello\" " },
+                    new object[] {"  { },  5 "},
+                    new object[] {"  { },  [] "},
+                    new object[] {"  { },  {} "},
+                    new object[] {"  { },  5.1234e-4"},
+                    new object[] {"  { },  null "},
+                    new object[] {"  { },  false "},
+                    new object[] {"  { },  true "},
+                    new object[] {"  { },  \"hello\" " },
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> JsonTokenWithExtraValueAndComments
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] {"  true  /* comment */ 5 "},
+                    new object[] {"  false  /* comment */ 5 "},
+                    new object[] {"  null  /* comment */ 5 "},
+                    new object[] {"  5  /* comment */ 5 "},
+                    new object[] {"  5.1234e-4  /* comment */ 5 "},
+                    new object[] {"  \"hello\"  /* comment */ 5 "},
+                    new object[] {"  \"hello\"  /* comment */ \"hello\" "},
+                    new object[] {"  \"hello\"  // comment \n \"hello\" "},
+                    new object[] {"  [  ]  /* comment */ 5 "},
+                    new object[] {"  [  ]  /* comment */ [ ]"},
+                    new object[] {"  [  ]  /* comment */ { }"},
+                    new object[] {"  [  ]  // comment \n 5 "},
+                    new object[] {"  { }  /* comment */ 5 "},
+                    new object[] {"  { }  /* comment */ [] "},
+                    new object[] {"  { }  /* comment */ {} "},
+                    new object[] {"  [  ]/* comment */5 "},
+                    new object[] {"  [  ]/* comment */[ ]"},
+                    new object[] {"  [  ]/* comment */{ }"},
+                    new object[] {"  [  ]// comment \n5 "},
+                    new object[] {"  { }/* comment */5 "},
+                    new object[] {"  { }/* comment */[] "},
+                    new object[] {"  { }/* comment */{} "},
+                    new object[] {"  { }  /* comment */ 5.1234e-4"},
+                    new object[] {"  { }  /* comment */ null "},
+                    new object[] {"  { }  /* comment */ false "},
+                    new object[] {"  { }  /* comment */ true "},
+                    new object[] {"  { }  /* comment */ \"hello\" "},
+                    new object[] {"  { }  // comment \n \"hello\" "},
+                    new object[] {"  { },  /* comment */ 5 "},
+                    new object[] {"  { },  /* comment */ [] "},
+                    new object[] {"  { },  /* comment */ {} "},
+                    new object[] {"  { },  /* comment */ 5.1234e-4"},
+                    new object[] {"  { },  /* comment */ null "},
+                    new object[] {"  { },  /* comment */ false "},
+                    new object[] {"  { },  /* comment */ true "},
+                    new object[] {"  { },  /* comment */ \"hello\" "},
+                    new object[] {"  { },  // comment \n \"hello\" "},
                 };
             }
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/36087

For single value (primitive) JSON tokens, do not eagerly read ahead to check if the payload is valid.

cc @bartonjs, @stephentoub 