### PR TITLE
Disable BuildInvalidSignatureTwice in X509Certificates.Tests on Windows

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -814,6 +814,7 @@ tHP28fj0LUop/QFojSZPsaPAW6JvoQ0t4hd6WoyX6z7FsA==
             }
         }
 
+        [ActiveIssue(36124, TestPlatforms.Windows)]
         [Fact]
         public static void BuildInvalidSignatureTwice()
         {


### PR DESCRIPTION
To unblock CI: https://github.com/dotnet/corefx/issues/36124

cc @bartonjs, @stephentoub, @tarekgh 