### PR TITLE
[release/2.1] Use TryAddWithoutValidation in WebSocketHandle.ConnectAsyncCore to 2.1 branch

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -83,7 +83,7 @@ namespace System.Net.WebSockets
                 {
                     foreach (string key in options.RequestHeaders)
                     {
-                        request.Headers.Add(key, options.RequestHeaders[key]);
+                        request.Headers.TryAddWithoutValidation(key, options.RequestHeaders[key]);
                     }
                 }
 
@@ -248,7 +248,7 @@ namespace System.Net.WebSockets
             request.Headers.TryAddWithoutValidation(HttpKnownHeaderNames.SecWebSocketKey, secKey);
             if (options._requestedSubProtocols?.Count > 0)
             {
-                request.Headers.Add(HttpKnownHeaderNames.SecWebSocketProtocol, string.Join(", ", options.RequestedSubProtocols));
+                request.Headers.TryAddWithoutValidation(HttpKnownHeaderNames.SecWebSocketProtocol, string.Join(", ", options.RequestedSubProtocols));
             }
         }
 

--- a/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -221,5 +221,22 @@ namespace System.Net.WebSockets.Client.Tests
                 Assert.Equal(AcceptedProtocol, cws.SubProtocol);
             }
         }
+
+        [ConditionalFact(nameof(WebSocketsSupported))]
+        public async Task ConnectAsync_NonStandardRequestHeaders_HeadersAddedWithoutValidation()
+        {
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                using (var clientSocket = new ClientWebSocket())
+                using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
+                {
+                    clientSocket.Options.SetRequestHeader("Authorization", "AWS4-HMAC-SHA256 Credential= AKIAXXXXXXXXXXXYSZA /20190301/us-east-2/neptune-db/aws4_request, SignedHeaders=host;x-amz-date, Signature=b8155de54d9faab00000000000000000000000000a07e0d7dda49902e4d9202");
+                    await clientSocket.ConnectAsync(uri, cts.Token);
+                }
+            }, server => server.AcceptConnectionAsync(async connection =>
+            {
+                Assert.True(await LoopbackHelper.WebSocketHandshakeAsync(connection));
+            }), new LoopbackServer.Options { WebSocketEndpoint = true });
+        }
     }
 }


### PR DESCRIPTION
**Description**

This is port to 2.1 for issue fixed in #35954. This is regression introduced in 2.1 by increased header validation.

[edit] This changes code that previously threw when a header appeared invalid according to strict IETF standards, to instead not validating at this point.

**Customer Impact**
This is causing pain to several customers including Apache Gremlin.NET (per #35862). There is support ticket for customer with Microsoft Premier Support.

**Regression**
yes

**Risk**
Very low.

Full issue description is here: #35862


