### PR TITLE
improve parsing of Digest authentication header

### DIFF
--- a/src/Common/tests/System/Net/Http/LoopbackServer.AuthenticationHelpers.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.AuthenticationHelpers.cs
@@ -108,7 +108,7 @@ namespace System.Net.Test.Common
             for (int i = 0; i < values.Length; i++)
             {
                 string trimmedValue = values[i].Trim();
-                if (trimmedValue.Contains(nameof(username)))
+                if (trimmedValue.StartsWith(nameof(username)))
                 {
                     // Username is a quoted string.
                     int startIndex = trimmedValue.IndexOf('"');
@@ -123,11 +123,11 @@ namespace System.Net.Test.Common
                     if (string.IsNullOrEmpty(username))
                         return false;
                 }
-                else if (trimmedValue.Contains(nameof(userhash)) && trimmedValue.Contains("true"))
+                else if (trimmedValue.StartsWith(nameof(userhash)) && trimmedValue.Contains("true"))
                 {
                     userhash = true;
                 }
-                else if (trimmedValue.Contains(nameof(uri)))
+                else if (trimmedValue.StartsWith(nameof(uri)))
                 {
                     int startIndex = trimmedValue.IndexOf('"');
                     if (startIndex != -1)
@@ -140,7 +140,7 @@ namespace System.Net.Test.Common
                     if (string.IsNullOrEmpty(uri))
                         return false;
                 }
-                else if (trimmedValue.Contains(nameof(realm)))
+                else if (trimmedValue.StartsWith(nameof(realm)))
                 {
                     // Realm is a quoted string.
                     int startIndex = trimmedValue.IndexOf('"');
@@ -154,9 +154,10 @@ namespace System.Net.Test.Common
                     if (string.IsNullOrEmpty(realm))
                         return false;
                 }
-                else if (trimmedValue.Contains(nameof(cnonce)))
+                else if (trimmedValue.StartsWith(nameof(cnonce)))
                 {
                     // CNonce is a quoted string.
+
                     int startIndex = trimmedValue.IndexOf('"');
                     if (startIndex != -1)
                     {
@@ -164,7 +165,7 @@ namespace System.Net.Test.Common
                         cnonce = trimmedValue.Substring(startIndex, trimmedValue.Length - startIndex - 1);
                     }
                 }
-                else if (trimmedValue.Contains(nameof(nonce)))
+                else if (trimmedValue.StartsWith(nameof(nonce)))
                 {
                     // Nonce is a quoted string.
                     int startIndex = trimmedValue.IndexOf('"');
@@ -178,7 +179,7 @@ namespace System.Net.Test.Common
                     if (string.IsNullOrEmpty(nonce))
                         return false;
                 }
-                else if (trimmedValue.Contains(nameof(response)))
+                else if (trimmedValue.StartsWith(nameof(response)))
                 {
                     // response is a quoted string.
                     int startIndex = trimmedValue.IndexOf('"');
@@ -192,7 +193,7 @@ namespace System.Net.Test.Common
                     if (string.IsNullOrEmpty(response))
                         return false;
                 }
-                else if (trimmedValue.Contains(nameof(algorithm)))
+                else if (trimmedValue.StartsWith(nameof(algorithm)))
                 {
                     int startIndex = trimmedValue.IndexOf('=');
                     if (startIndex != -1)
@@ -201,7 +202,7 @@ namespace System.Net.Test.Common
                         algorithm = trimmedValue.Substring(startIndex, trimmedValue.Length - startIndex).Trim();
                     }
                 }
-                else if (trimmedValue.Contains(nameof(opaque)))
+                else if (trimmedValue.StartsWith(nameof(opaque)))
                 {
                     // Opaque is a quoted string.
                     int startIndex = trimmedValue.IndexOf('"');
@@ -211,7 +212,7 @@ namespace System.Net.Test.Common
                         opaque = trimmedValue.Substring(startIndex, trimmedValue.Length - startIndex - 1);
                     }
                 }
-                else if (trimmedValue.Contains(nameof(qop)))
+                else if (trimmedValue.StartsWith(nameof(qop)))
                 {
                     int startIndex = trimmedValue.IndexOf('"');
                     if (startIndex != -1)
@@ -225,7 +226,7 @@ namespace System.Net.Test.Common
                         qop = trimmedValue.Substring(startIndex, trimmedValue.Length - startIndex).Trim();
                     }
                 }
-                else if (trimmedValue.Contains(nameof(nc)))
+                else if (trimmedValue.StartsWith(nameof(nc)))
                 {
                     int startIndex = trimmedValue.IndexOf('=');
                     if (startIndex != -1)

--- a/src/Common/tests/System/Net/Http/LoopbackServer.AuthenticationHelpers.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.AuthenticationHelpers.cs
@@ -157,7 +157,6 @@ namespace System.Net.Test.Common
                 else if (trimmedValue.StartsWith(nameof(cnonce)))
                 {
                     // CNonce is a quoted string.
-
                     int startIndex = trimmedValue.IndexOf('"');
                     if (startIndex != -1)
                     {


### PR DESCRIPTION
related to #28065 I had following test failing occasionally on both Unix & Windows. 
```
     System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_Authentication_Test.HttpClientHandler_Authe
  ntication_Succeeds(authenticateHeader: "Digest realm=\"testrealm\", nonce=\"My8xNi8yMDE5ID"..., result: True) [FAIL]
        Assert.Equal() Failure
        Expected: OK
        Actual:   Unauthorized
        Stack Trace:
          C:\Users\toweinfu\wfurt-corefx\src\System.Net.Http\tests\FunctionalTests\HttpClientHandlerTest.Authentication
  .cs(44,0): at System.Net.Http.Functional.Tests.HttpClientHandler_Authentication_Test.<>c.<<-cctor>b__27_0>d.MoveNext(
  )
          --- End of stack trace from previous location where exception was thrown ---
```

After some digging I realized that the test is consistently failing with particular values on cnonce and nonce. For example `cnonce="FSA2UUe6A9lt6Au5"` would pass but `cnonce="v56TuriC5mLc7MM7"` would consistently fail. 

It turned out our loopback AuthenticationHelper used something like:
```
else if (trimmedValue.Contains(nameof(uri)))
.. // process uri
else if (trimmedValue.Contains(nameof(cnonce)))
... //process cnonce
```

In this case cnonce itself contains sequence of characters 'u' 'r' 'i' and because of the sequencing we fail to pass correct values to ComputeHash().

This change replace String.Contains with more strict String.StartsWith 

