### PR TITLE
Added IReadOnlySet interface, implemented by HashSet and SortedSet

### DIFF
--- a/src/Common/src/CoreLib/System/Collections/Generic/IReadOnlySet.cs
+++ b/src/Common/src/CoreLib/System/Collections/Generic/IReadOnlySet.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace System.Collections.Generic
+{
+    // Provides a read-only view of a generic set.
+    public interface IReadOnlySet<T> : IReadOnlyCollection<T>
+    {
+        bool Contains(T item);
+    }
+}

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -50,7 +50,7 @@ namespace System.Collections.Generic
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "By design")]
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public class HashSet<T> : ICollection<T>, ISet<T>, IReadOnlyCollection<T>, ISerializable, IDeserializationCallback
+    public class HashSet<T> : ICollection<T>, ISet<T>, IReadOnlySet<T>, ISerializable, IDeserializationCallback
     {
         // store lower 31 bits of hash code
         private const int Lower31BitMask = 0x7FFFFFFF;

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -46,7 +46,7 @@ namespace System.Collections.Generic
     [DebuggerDisplay("Count = {Count}")]
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public partial class SortedSet<T> : ISet<T>, ICollection<T>, ICollection, IReadOnlyCollection<T>, ISerializable, IDeserializationCallback
+    public partial class SortedSet<T> : ISet<T>, ICollection<T>, ICollection, IReadOnlySet<T>, ISerializable, IDeserializationCallback
     {
         #region Local variables/constants
 


### PR DESCRIPTION
This PR adds an IReadOnlySet interface which extends IReadOnlyCollection, and changes HashSet and SortedSet to implement that interface rather than IReadOnlyCollection. Refer to issue #1973.