### PR TITLE
Make PipeReader/Writer.AsStream().Dispose complete the reader/writer

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReaderStream.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReaderStream.cs
@@ -20,6 +20,12 @@ namespace System.IO.Pipelines
             _pipeReader = pipeReader;
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            _pipeReader.Complete();
+            base.Dispose(disposing);
+        }
+
         public override bool CanRead => true;
 
         public override bool CanSeek => false;

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriterStream.cs
@@ -18,6 +18,12 @@ namespace System.IO.Pipelines
             _pipeWriter = pipeWriter;
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            _pipeWriter.Complete();
+            base.Dispose(disposing);
+        }
+
         public override bool CanRead => false;
 
         public override bool CanSeek => false;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/36034
cc: @pakrym, @davidfowl 