### PR TITLE
Fix Chr_CharCodeOutOfRange_ThrowsNotSupportedException VB test

### DIFF
--- a/src/Microsoft.VisualBasic.Core/tests/Microsoft.VisualBasic.Core.Tests.csproj
+++ b/src/Microsoft.VisualBasic.Core/tests/Microsoft.VisualBasic.Core.Tests.csproj
@@ -34,6 +34,12 @@
     <Compile Include="StringsTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
+      <Project>{69e46a6f-9966-45a5-8945-2559fe337827}</Project>
+      <Name>RemoteExecutorConsoleApp</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualBasic.Core/tests/StringsTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/StringsTests.cs
@@ -3,13 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using Microsoft.VisualBasic.CompilerServices.Tests;
 using Xunit;
 
 namespace Microsoft.VisualBasic.Tests
 {
-    public class StringsTests
+    public class StringsTests : RemoteExecutorTestBase
     {
         static StringsTests()
         {
@@ -76,7 +78,12 @@ namespace Microsoft.VisualBasic.Tests
         [InlineData(256)]
         public void Chr_CharCodeOutOfRange_ThrowsNotSupportedException(int charCode)
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => Strings.Chr(charCode));
+            RemoteInvoke(charCodeInner =>
+            {
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                CultureInfo.CurrentCulture = new CultureInfo("en-US"); // Strings.Chr doesn't fail on these inputs for all code pages, e.g. 949
+                AssertExtensions.Throws<ArgumentException>(null, () => Strings.Chr(int.Parse(charCodeInner, CultureInfo.InvariantCulture)));
+            }, charCode.ToString(CultureInfo.InvariantCulture)).Dispose();
         }
 
         [Theory]


### PR DESCRIPTION
When run in some cultures, the TextInfo.ANSICodePage in place and that's queried by Strings.Chr doesn't fail for the specified inputs, contrary to what's documented (this is true for both .NET Framework and .NET Core).  This change just fixes the test to always use en-US so as to avoid any issues when the test suite is run with other code pages.

(I'm assuming here we don't actually want to modify the product behavior.)

Fixes https://github.com/dotnet/corefx/issues/36070
cc: @jaredpar, @cston