### PR TITLE
Uppercase configuration string

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -96,7 +96,7 @@ foreach ($argument in $PSBoundParameters.Keys)
   {
     "buildtests"        { $arguments += " /p:BuildTests=true" }
     "clean"             { }
-    "configuration"     { $arguments += " /p:ConfigurationGroup=$($PSBoundParameters[$argument]) -configuration $($PSBoundParameters[$argument])" }
+    "configuration"     { $configuration = (Get-Culture).TextInfo.ToTitleCase($($PSBoundParameters[$argument])); $arguments += " /p:ConfigurationGroup=$configuration -configuration $configuration" }
     "framework"         { $arguments += " /p:TargetGroup=$($PSBoundParameters[$argument].ToLowerInvariant())"}
     "os"                { $arguments += " /p:OSGroup=$($PSBoundParameters[$argument])" }
     "allconfigurations" { $arguments += " /p:BuildAllConfigurations=true" }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+if [ ${BASH_VERSION:0:1} -lt 4 ]; then
+  echo $BASH_VERSION
+  echo "Bash version too low. Please upgrade to >= v4"
+  exit 1
+fi
+
 source="${BASH_SOURCE[0]}"
 
 # resolve $source until the file is no longer a symlink
@@ -80,6 +86,7 @@ while [[ $# > 0 ]]; do
       shift 2
       ;;
      -configuration|-c)
+      val=${2^}
       arguments="$arguments /p:ConfigurationGroup=${2^} -configuration ${2^}"
       shift 2
       ;;

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-if [ ${BASH_VERSION:0:1} -lt 4 ]; then
-  echo $BASH_VERSION
-  echo "Bash version too low. Please upgrade to >= v4"
-  exit 1
-fi
-
 source="${BASH_SOURCE[0]}"
 
 # resolve $source until the file is no longer a symlink
@@ -86,8 +80,8 @@ while [[ $# > 0 ]]; do
       shift 2
       ;;
      -configuration|-c)
-      val=${2^}
-      arguments="$arguments /p:ConfigurationGroup=${2^} -configuration ${2^}"
+      val="$(tr '[:lower:]' '[:upper:]' <<< ${2:0:1})${2:1}"
+      arguments="$arguments /p:ConfigurationGroup=$val -configuration $val"
       shift 2
       ;;
      -framework|-f)

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -80,7 +80,7 @@ while [[ $# > 0 ]]; do
       shift 2
       ;;
      -configuration|-c)
-      arguments="$arguments /p:ConfigurationGroup=$2 -configuration $2"
+      arguments="$arguments /p:ConfigurationGroup=${2^} -configuration ${2^}"
       shift 2
       ;;
      -framework|-f)


### PR DESCRIPTION
Upper-casing the first character to allow lower-case configurations in the CLI. Requires bash v4+ (2009 released).