### PR TITLE
Make Process.{Safe}Handle be a waitable event handle on Unix

### DIFF
--- a/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Windows.cs
+++ b/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Windows.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeProcessHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        private const int DefaultInvalidHandleValue = 0;
-
         protected override bool ReleaseHandle()
         {
             return Interop.Kernel32.CloseHandle(handle);

--- a/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.cs
+++ b/src/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.cs
@@ -13,8 +13,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Security;
 
 namespace Microsoft.Win32.SafeHandles
 {
@@ -23,7 +21,7 @@ namespace Microsoft.Win32.SafeHandles
         internal static readonly SafeProcessHandle InvalidHandle = new SafeProcessHandle();
 
         internal SafeProcessHandle()
-            : this(new IntPtr(DefaultInvalidHandleValue))
+            : this(IntPtr.Zero)
         {
         }
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -159,7 +159,8 @@ namespace System.Diagnostics
                 {
                     if (!_watchingForExit)
                     {
-                        Debug.Assert(_haveProcessHandle, "Process.EnsureWatchingForExit called with no process handle");
+                        Debug.Assert(_waitHandle == null);
+                        Debug.Assert(_registeredWaitHandle == null);
                         Debug.Assert(Associated, "Process.EnsureWatchingForExit called with no associated process");
                         _watchingForExit = true;
                         try
@@ -334,7 +335,8 @@ namespace System.Diagnostics
             }
 
             EnsureState(State.HaveNonExitedId | State.IsLocal);
-            return new SafeProcessHandle(_processId);
+            EnsureWatchingForExit();
+            return new SafeProcessHandle(_processId, _waitHandle.SafeWaitHandle);
         }
 
         /// <summary>
@@ -491,7 +493,7 @@ namespace System.Diagnostics
                     // Store the child's information into this Process object.
                     Debug.Assert(childPid >= 0);
                     SetProcessId(childPid);
-                    SetProcessHandle(new SafeProcessHandle(childPid));
+                    SetProcessHandle(GetProcessHandle());
 
                     return true;
                 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -119,7 +119,7 @@ namespace System.Diagnostics
             get
             {
                 EnsureState(State.Associated);
-                return OpenProcessHandle();
+                return GetOrOpenProcessHandle();
             }
         }
 
@@ -657,7 +657,7 @@ namespace System.Diagnostics
                     {
                         if (value)
                         {
-                            OpenProcessHandle();
+                            GetOrOpenProcessHandle();
                             EnsureWatchingForExit();
                         }
                         else
@@ -1130,7 +1130,7 @@ namespace System.Diagnostics
         /// Opens a long-term handle to the process, with all access.  If a handle exists,
         /// then it is reused.  If the process has exited, it throws an exception.
         /// </summary>
-        private SafeProcessHandle OpenProcessHandle()
+        private SafeProcessHandle GetOrOpenProcessHandle()
         {
             if (!_haveProcessHandle)
             {

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Unix.cs
@@ -56,7 +56,7 @@ namespace System.Diagnostics
         /// <returns>The process ID.</returns>
         public static int GetProcessIdFromHandle(SafeProcessHandle processHandle)
         {
-            return (int)processHandle.DangerousGetHandle(); // not actually dangerous; just wraps a process ID
+            return processHandle.ProcessId;
         }
 
         private static bool IsRemoteMachineCore(string machineName)

--- a/src/System.Runtime/tests/System/ExitCodeTests.Unix.cs
+++ b/src/System.Runtime/tests/System/ExitCodeTests.Unix.cs
@@ -49,7 +49,7 @@ namespace System.Tests
                 Assert.Equal("Application started", processOutput);
 
                 // Send SIGTERM
-                int rv = kill(process.Handle.ToInt32(), SIGTERM);
+                int rv = kill(process.Id, SIGTERM);
                 Assert.Equal(0, rv);
 
                 // Process exits in a timely manner


### PR DESCRIPTION
The documentation for Process.{Safe}Handle state that its value can be used to initialize a SafeWaitHandle that can then be used with a method like WaitHandle.WaitAny. However, on Unix, the SafeProcessHandle we currently return from Process.SafeHandle just uses the process ID as its faux handle value, since on Unix there isn't actually an OS process handle that's waitable in this fashion.

We already have to manufacture a ManualResetEvent to serve as such a wait handle, though. as we use that for WaitForExit, raising the Exited event, and so on.  As such, we can change SafeProcessHandle to be backed by that MRE's handle rather than by the process ID.

Fixes https://github.com/dotnet/corefx/issues/35544
cc: @tmds, @wtgodbe, @krwq