### PR TITLE
Add JsonSerializer Xml doc and change DefaultBufferSize semantics

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -295,13 +295,10 @@
     <value>The specified type {0} must derive from the specific value's type {1}.</value>
   </data>
   <data name="SerializationInvalidBufferSize" xml:space="preserve">
-    <value>The value must be greater than zero or equal to -1.</value>
+    <value>The value must be greater than zero.</value>
   </data>
   <data name="BufferWriterAdvancedTooFar" xml:space="preserve">
     <value>Cannot advance past the end of the buffer, which has a size of {0}.</value>
-  </data>
-  <data name="EnumConverterNotImplemented" xml:space="preserve">
-    <value>EnumConverter is not yet supported on .NET Standard 2.0.</value>
   </data>
   <data name="InvalidComparison" xml:space="preserve">
     <value>Cannot compare the value of a token type '{0}' to text.</value>

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -7,13 +7,15 @@ namespace System.Text.Json.Serialization
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Read the UTF-8 encoded JSON and return the converted value.
+        /// Parse the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
         /// </summary>
-        /// <returns>The converted value.</returns>
-        /// <param name="utf8Json">The UTF-8 encoded JSON"/>.</param>
-        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
+        /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
+        /// <param name="utf8Json">JSON text to parse.</param>
+        /// <param name="options">Options to control the behavior during parsing.</param>
         /// <exception cref="JsonReaderException">
-        /// Thrown when the JSON is invalid or when <typeparamref name="TValue"/> is not compatible with the JSON.
+        /// Thrown when the JSON is invalid,
+        /// <typeparamref name="TValue"/> is not compatible with the JSON,
+        /// or when there is remaining data in the Stream.
         /// </exception>
         public static TValue Parse<TValue>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions options = null)
         {
@@ -21,18 +23,21 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// Read the UTF-8 encoded JSON and return the converted value.
+        /// Parse the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
         /// </summary>
-        /// <returns>The converted value.</returns>
-        /// <param name="utf8Json">The UTF-8 encoded JSON.</param>
+        /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
+        /// <param name="utf8Json">JSON text to parse.</param>
         /// <param name="returnType">The type of the object to convert to and return.</param>
-        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
+        /// <param name="options">Options to control the behavior during parsing.</param>
         /// <exception cref="System.ArgumentNullException">
         /// Thrown if <paramref name="returnType"/> is null.
         /// </exception>
         /// <exception cref="JsonReaderException">
-        /// Thrown when the JSON is invalid or when <paramref name="returnType"/> is not compatible with the JSON.
+        /// Thrown when the JSON is invalid,
+        /// <paramref name="returnType"/> is not compatible with the JSON,
+        /// or when there is remaining data in the Stream.
         /// </exception>
+
         public static object Parse(ReadOnlySpan<byte> utf8Json, Type returnType, JsonSerializerOptions options = null)
         {
             if (returnType == null)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -6,18 +6,37 @@ namespace System.Text.Json.Serialization
 {
     public static partial class JsonSerializer
     {
+        /// <summary>
+        /// Read the UTF-8 encoded JSON and return the converted value.
+        /// </summary>
+        /// <returns>The converted value.</returns>
+        /// <param name="utf8Json">The UTF-8 encoded JSON"/>.</param>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
+        /// <exception cref="JsonReaderException">
+        /// Thrown when the JSON is invalid or when <typeparamref name="TValue"/> is not compatible with the JSON.
+        /// </exception>
         public static TValue Parse<TValue>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions options = null)
         {
-            if (utf8Json == null)
-                throw new ArgumentNullException(nameof(utf8Json));
-
             return (TValue)ParseCore(utf8Json, typeof(TValue), options);
         }
 
+        /// <summary>
+        /// Read the UTF-8 encoded JSON and return the converted value.
+        /// </summary>
+        /// <returns>The converted value.</returns>
+        /// <param name="utf8Json">The UTF-8 encoded JSON.</param>
+        /// <param name="returnType">The type of the object to convert to and return.</param>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown if <paramref name="returnType"/> is null.
+        /// </exception>
+        /// <exception cref="JsonReaderException">
+        /// Thrown when the JSON is invalid or when <paramref name="returnType"/> is not compatible with the JSON.
+        /// </exception>
         public static object Parse(ReadOnlySpan<byte> utf8Json, Type returnType, JsonSerializerOptions options = null)
         {
-            if (utf8Json == null)
-                throw new ArgumentNullException(nameof(utf8Json));
+            if (returnType == null)
+                throw new ArgumentNullException(nameof(returnType));
 
             return ParseCore(utf8Json, returnType, options);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -13,16 +13,24 @@ namespace System.Text.Json.Serialization
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Read from a UTF-8 encoded <see cref="System.IO.Stream"/> and return the converted value.
+        /// Read the UTF-8 encoded text representing a single JSON value into a <typeparamref name="TValue"/>.
+        /// The Stream will be read to completion.
         /// </summary>
-        /// <returns>The converted value.</returns>
-        /// <param name="utf8Json">The UTF-8 encoded <see cref="System.IO.Stream"/>.</param>
-        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
-        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.</param>
+        /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
+        /// <param name="utf8Json">JSON data to parse.</param>
+        /// <param name="options">Options to control the behavior during reading.</param>
+        /// <param name="cancellationToken">
+        /// The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.
+        /// </param>
         /// <exception cref="JsonReaderException">
-        /// Thrown when the JSON is invalid or when <typeparamref name="TValue"/> is not compatible with the JSON.
+        /// Thrown when the JSON is invalid,
+        /// <typeparamref name="TValue"/> is not compatible with the JSON,
+        /// or when there is remaining data in the Stream.
         /// </exception>
-        public static ValueTask<TValue> ReadAsync<TValue>(Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
+        public static ValueTask<TValue> ReadAsync<TValue>(
+            Stream utf8Json,
+            JsonSerializerOptions options = null,
+            CancellationToken cancellationToken = default)
         {
             if (utf8Json == null)
                 throw new ArgumentNullException(nameof(utf8Json));
@@ -31,20 +39,29 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// Read from a UTF-8 encoded <see cref="System.IO.Stream"/> and return the converted value.
+        /// Read the UTF-8 encoded text representing a single JSON value into a <paramref name="returnType"/>.
+        /// The Stream will be read to completion.
         /// </summary>
-        /// <returns>The converted value.</returns>
-        /// <param name="utf8Json">The UTF-8 encoded <see cref="System.IO.Stream"/>.</param>
+        /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
+        /// <param name="utf8Json">JSON data to parse.</param>
         /// <param name="returnType">The type of the object to convert to and return.</param>
-        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
-        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.</param>
+        /// <param name="options">Options to control the behavior during reading.</param>
+        /// <param name="cancellationToken">
+        /// The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.
+        /// </param>
         /// <exception cref="System.ArgumentNullException">
         /// Thrown if <paramref name="utf8Json"/> or <paramref name="returnType"/> is null.
         /// </exception>
         /// <exception cref="JsonReaderException">
-        /// Thrown when the JSON is invalid or when <paramref name="returnType"/> is not compatible with the JSON.
+        /// Thrown when the JSON is invalid,
+        /// the <paramref name="returnType"/> is not compatible with the JSON,
+        /// or when there is remaining data in the Stream.
         /// </exception>
-        public static ValueTask<object> ReadAsync(Stream utf8Json, Type returnType, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
+        public static ValueTask<object> ReadAsync(
+            Stream utf8Json,
+            Type returnType,
+            JsonSerializerOptions options = null,
+            CancellationToken cancellationToken = default)
         {
             if (utf8Json == null)
                 throw new ArgumentNullException(nameof(utf8Json));
@@ -55,7 +72,11 @@ namespace System.Text.Json.Serialization
             return ReadAsync<object>(utf8Json, returnType, options, cancellationToken);
         }
 
-        private static async ValueTask<TValue> ReadAsync<TValue>(Stream utf8Json, Type returnType, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
+        private static async ValueTask<TValue> ReadAsync<TValue>(
+            Stream utf8Json,
+            Type returnType,
+            JsonSerializerOptions options = null,
+            CancellationToken cancellationToken = default)
         {
             options ??= s_defaultSettings;
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -12,6 +12,16 @@ namespace System.Text.Json.Serialization
 {
     public static partial class JsonSerializer
     {
+        /// <summary>
+        /// Read from a UTF-8 encoded <see cref="System.IO.Stream"/> and return the converted value.
+        /// </summary>
+        /// <returns>The converted value.</returns>
+        /// <param name="utf8Json">The UTF-8 encoded <see cref="System.IO.Stream"/>.</param>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.</param>
+        /// <exception cref="JsonReaderException">
+        /// Thrown when the JSON is invalid or when <typeparamref name="TValue"/> is not compatible with the JSON.
+        /// </exception>
         public static ValueTask<TValue> ReadAsync<TValue>(Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
             if (utf8Json == null)
@@ -20,6 +30,20 @@ namespace System.Text.Json.Serialization
             return ReadAsync<TValue>(utf8Json, typeof(TValue), options, cancellationToken);
         }
 
+        /// <summary>
+        /// Read from a UTF-8 encoded <see cref="System.IO.Stream"/> and return the converted value.
+        /// </summary>
+        /// <returns>The converted value.</returns>
+        /// <param name="utf8Json">The UTF-8 encoded <see cref="System.IO.Stream"/>.</param>
+        /// <param name="returnType">The type of the object to convert to and return.</param>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the read operation.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown if <paramref name="utf8Json"/> or <paramref name="returnType"/> is null.
+        /// </exception>
+        /// <exception cref="JsonReaderException">
+        /// Thrown when the JSON is invalid or when <paramref name="returnType"/> is not compatible with the JSON.
+        /// </exception>
         public static ValueTask<object> ReadAsync(Stream utf8Json, Type returnType, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
             if (utf8Json == null)
@@ -46,7 +70,7 @@ namespace System.Text.Json.Serialization
             var readerState = new JsonReaderState(options.ReaderOptions);
 
             // todo: switch to ArrayBuffer implementation to handle and simplify the allocs?
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(options.EffectiveBufferSize);
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(options.DefaultBufferSize);
             int bytesInBuffer = 0;
             long totalBytesRead = 0;
             int clearMax = 0;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -6,6 +6,21 @@ namespace System.Text.Json.Serialization
 {
     public static partial class JsonSerializer
     {
+        /// <summary>
+        /// Read the UTF-16 encoded JSON <see cref="System.String"/> and return the converted value.
+        /// </summary>
+        /// <returns>The converted value.</returns>
+        /// <param name="json">The UTF-16 encoded <see cref="System.String"/>.</param>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown if <paramref name="json"/> is null.
+        /// </exception>
+        /// <exception cref="JsonReaderException">
+        /// Thrown when the JSON is invalid or when <typeparamref name="TValue"/> is not compatible with the JSON.
+        /// </exception>
+        /// <remarks>Using a UTF-16 <see cref="System.String"/> is not as efficient as using the
+        /// UTF-8 methods since the implementation natively uses UTF-8.
+        /// </remarks>
         public static TValue Parse<TValue>(string json, JsonSerializerOptions options = null)
         {
             if (json == null)
@@ -14,6 +29,22 @@ namespace System.Text.Json.Serialization
             return (TValue)ParseCore(json, typeof(TValue), options);
         }
 
+        /// <summary>
+        /// Read the UTF-16 encoded JSON <see cref="System.String"/> and return the converted value.
+        /// </summary>
+        /// <returns>The converted value.</returns>
+        /// <param name="json">The UTF-16 encoded <see cref="System.String"/>.</param>
+        /// <param name="returnType">The type of the object to convert to and return.</param>
+        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown if <paramref name="json"/> or <paramref name="returnType"/> is null.
+        /// </exception>
+        /// <exception cref="JsonReaderException">
+        /// Thrown when the JSON is invalid or when <paramref name="returnType"/> is not compatible with the JSON.
+        /// </exception>
+        /// <remarks>Using a UTF-16 <see cref="System.String"/> is not as efficient as using the
+        /// UTF-8 methods since the implementation natively uses UTF-8.
+        /// </remarks>
         public static object Parse(string json, Type returnType, JsonSerializerOptions options = null)
         {
             if (json == null)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -7,16 +7,18 @@ namespace System.Text.Json.Serialization
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Read the UTF-16 encoded JSON <see cref="System.String"/> and return the converted value.
+        /// Parse the text representing a single JSON value into a <typeparamref name="TValue"/>.
         /// </summary>
-        /// <returns>The converted value.</returns>
-        /// <param name="json">The UTF-16 encoded <see cref="System.String"/>.</param>
-        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
+        /// <returns>A <typeparamref name="TValue"/> representation of the JSON value.</returns>
+        /// <param name="json">JSON text to parse.</param>
+        /// <param name="options">Options to control the behavior during parsing.</param>
         /// <exception cref="System.ArgumentNullException">
         /// Thrown if <paramref name="json"/> is null.
         /// </exception>
         /// <exception cref="JsonReaderException">
-        /// Thrown when the JSON is invalid or when <typeparamref name="TValue"/> is not compatible with the JSON.
+        /// Thrown when the JSON is invalid,
+        /// <typeparamref name="TValue"/> is not compatible with the JSON,
+        /// or when there is remaining data in the Stream.
         /// </exception>
         /// <remarks>Using a UTF-16 <see cref="System.String"/> is not as efficient as using the
         /// UTF-8 methods since the implementation natively uses UTF-8.
@@ -30,17 +32,19 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// Read the UTF-16 encoded JSON <see cref="System.String"/> and return the converted value.
+        /// Parse the text representing a single JSON value into a <paramref name="returnType"/>.
         /// </summary>
-        /// <returns>The converted value.</returns>
-        /// <param name="json">The UTF-16 encoded <see cref="System.String"/>.</param>
+        /// <returns>A <paramref name="returnType"/> representation of the JSON value.</returns>
+        /// <param name="json">JSON text to parse.</param>
         /// <param name="returnType">The type of the object to convert to and return.</param>
-        /// <param name="options">The <see cref="JsonSerializerOptions"/> used to read and convert the JSON.</param>
+        /// <param name="options">Options to control the behavior during parsing.</param>
         /// <exception cref="System.ArgumentNullException">
         /// Thrown if <paramref name="json"/> or <paramref name="returnType"/> is null.
         /// </exception>
         /// <exception cref="JsonReaderException">
-        /// Thrown when the JSON is invalid or when <paramref name="returnType"/> is not compatible with the JSON.
+        /// Thrown when the JSON is invalid,
+        /// the <paramref name="returnType"/> is not compatible with the JSON,
+        /// or when there is remaining data in the Stream.
         /// </exception>
         /// <remarks>Using a UTF-16 <see cref="System.String"/> is not as efficient as using the
         /// UTF-8 methods since the implementation natively uses UTF-8.
@@ -61,7 +65,7 @@ namespace System.Text.Json.Serialization
             if (options == null)
                 options = s_defaultSettings;
 
-            // todo: use an array pool here for smaller requests to avoid the alloc. Also doc the API that UTF8 is preferred for perf. 
+            // todo: use an array pool here for smaller requests to avoid the alloc?
             byte[] jsonBytes = JsonReaderHelper.s_utf8Encoding.GetBytes(json);
             var readerState = new JsonReaderState(options: options.ReaderOptions);
             var reader = new Utf8JsonReader(jsonBytes, isFinalBlock: true, readerState);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -7,6 +7,10 @@ using System.Diagnostics;
 
 namespace System.Text.Json.Serialization
 {
+    /// <summary>
+    /// Provides functionality to serialize objects or value types to JSON and
+    /// deserialize JSON into objects or value types.
+    /// </summary>
     public static partial class JsonSerializer
     {
         internal static readonly JsonPropertyInfo s_missingProperty = new JsonPropertyInfoNotNullable<object, object>();

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -7,23 +7,23 @@ namespace System.Text.Json.Serialization
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Convert the value and return as a <see cref="System.Byte"/> array.
+        /// Convert the provided value into a <see cref="System.Byte"/> array.
         /// </summary>
-        /// <returns>The converted value.</returns>
+        /// <returns>A UTF-8 representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
-        /// <param name="options">The options used to convert the value.</param>
+        /// <param name="options">Options to control the convertion behavior.</param>
         public static byte[] ToBytes<TValue>(TValue value, JsonSerializerOptions options = null)
         {
             return WriteCoreBytes(value, typeof(TValue), options);
         }
 
         /// <summary>
-        /// Convert the value and return as a <see cref="System.Byte"/> array.
+        /// Convert the provided value into a <see cref="System.Byte"/> array.
         /// </summary>
-        /// <returns>The converted value.</returns>
+        /// <returns>A UTF-8 representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
         /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
-        /// <param name="options">The options used to convert the value.</param>
+        /// <param name="options">Options to control the convertion behavior.</param>
         public static byte[] ToBytes(object value, Type type, JsonSerializerOptions options = null)
         {
             VerifyValueAndType(value, type);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -6,13 +6,24 @@ namespace System.Text.Json.Serialization
 {
     public static partial class JsonSerializer
     {
-        // Name \ feature is pending closure on API review
+        /// <summary>
+        /// Convert the value and return as a <see cref="System.Byte"/> array.
+        /// </summary>
+        /// <returns>The converted value.</returns>
+        /// <param name="value">The value to convert.</param>
+        /// <param name="options">The options used to convert the value.</param>
         public static byte[] ToBytes<TValue>(TValue value, JsonSerializerOptions options = null)
         {
             return WriteCoreBytes(value, typeof(TValue), options);
         }
 
-        // Name \ feature is pending closure on API review
+        /// <summary>
+        /// Convert the value and return as a <see cref="System.Byte"/> array.
+        /// </summary>
+        /// <returns>The converted value.</returns>
+        /// <param name="value">The value to convert.</param>
+        /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
+        /// <param name="options">The options used to convert the value.</param>
         public static byte[] ToBytes(object value, Type type, JsonSerializerOptions options = null)
         {
             VerifyValueAndType(value, type);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -42,7 +42,7 @@ namespace System.Text.Json.Serialization
 
             byte[] result;
 
-            using (var output = new ArrayBufferWriter<byte>(options.EffectiveBufferSize))
+            using (var output = new ArrayBufferWriter<byte>(options.DefaultBufferSize))
             {
                 WriteCore(output, value, type, options);
                 result = output.WrittenMemory.ToArray();
@@ -58,7 +58,7 @@ namespace System.Text.Json.Serialization
 
             string result;
 
-            using (var output = new ArrayBufferWriter<byte>(options.EffectiveBufferSize))
+            using (var output = new ArrayBufferWriter<byte>(options.DefaultBufferSize))
             {
                 WriteCore(output, value, type, options);
                 result = JsonReaderHelper.TranscodeHelper(output.WrittenMemory.Span);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -11,11 +11,28 @@ namespace System.Text.Json.Serialization
 {
     public static partial class JsonSerializer
     {
+        /// <summary>
+        /// Convert the value and write it to the <see cref="System.IO.Stream"/>.
+        /// </summary>
+        /// <returns>A task to wait on.</returns>
+        /// <param name="value">The value to convert.</param>
+        /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
+        /// <param name="options">The options used to convert the value.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
         public static Task WriteAsync<TValue>(TValue value, Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
             return WriteAsyncCore(value, typeof(TValue), utf8Json, options, cancellationToken);
         }
 
+        /// <summary>
+        /// Convert the value and write it to the <see cref="System.IO.Stream"/>.
+        /// </summary>
+        /// <returns>A task to wait on.</returns>
+        /// <param name="value">The value to convert.</param>
+        /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
+        /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
+        /// <param name="options">The options used to convert the value.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
         public static Task WriteAsync(object value, Type type, Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
             if (utf8Json == null)
@@ -33,7 +50,7 @@ namespace System.Text.Json.Serialization
 
             var writerState = new JsonWriterState(options.WriterOptions);
 
-            using (var bufferWriter = new ArrayBufferWriter<byte>(options.EffectiveBufferSize))
+            using (var bufferWriter = new ArrayBufferWriter<byte>(options.DefaultBufferSize))
             {
                 if (value == null)
                 {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -12,12 +12,12 @@ namespace System.Text.Json.Serialization
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Convert the value and write it to the <see cref="System.IO.Stream"/>.
+        /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
-        /// <returns>A task to wait on.</returns>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
         /// <param name="value">The value to convert.</param>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
-        /// <param name="options">The options used to convert the value.</param>
+        /// <param name="options">Options to control the convertion behavior.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
         public static Task WriteAsync<TValue>(TValue value, Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
@@ -25,13 +25,13 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// Convert the value and write it to the <see cref="System.IO.Stream"/>.
+        /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
-        /// <returns>A task to wait on.</returns>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
         /// <param name="value">The value to convert.</param>
         /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
-        /// <param name="options">The options used to convert the value.</param>
+        /// <param name="options">Options to control the convertion behavior.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
         public static Task WriteAsync(object value, Type type, Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -7,14 +7,14 @@ namespace System.Text.Json.Serialization
     public static partial class JsonSerializer
     {
         /// <summary>
-        /// Convert the value and return as <see cref="System.String"/>.
+        /// Convert the provided value into a <see cref="System.String"/>.
         /// </summary>
-        /// <returns>The converted value.</returns>
+        /// <returns>A <see cref="System.String"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
-        /// <param name="options">The options used to convert the value.</param>
-        /// <remarks>Using a UTF-16 <see cref="System.String"/> is not as efficient as a
-        /// UTF-8 <see cref="System.Byte"/> array since the implementation natively uses UTF-8 and
-        /// requires a conversion to a UTF-16 <see cref="System.String"/>.
+        /// <param name="options">Options to control the convertion behavior.</param>
+        /// <remarks>Using a <see cref="System.String"/> is not as efficient as using UTF-8
+        /// encoding since the implementation internally uses UTF-8. See also <see cref="ToBytes"/>
+        /// and <see cref="WriteAsync"/>.
         /// </remarks>
         public static string ToString<TValue>(TValue value, JsonSerializerOptions options = null)
         {
@@ -22,15 +22,15 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// Convert the value and return as <see cref="System.String"/>.
+        /// Convert the provided value into a <see cref="System.String"/>.
         /// </summary>
-        /// <returns>The converted value.</returns>
+        /// <returns>A <see cref="System.String"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
         /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
-        /// <param name="options">The options used to convert the value.</param>
-        /// <remarks>Using a UTF-16 <see cref="System.String"/> is not as efficient as a
-        /// UTF-8 <see cref="System.Byte"/> array since the implementation natively uses UTF-8 and
-        /// requires a conversion to a UTF-16 <see cref="System.String"/>.
+        /// <param name="options">Options to control the convertion behavior.</param>
+        /// <remarks>Using a <see cref="System.String"/> is not as efficient as using UTF-8
+        /// encoding since the implementation internally uses UTF-8. See also <see cref="ToBytes"/>
+        /// and <see cref="WriteAsync"/>.
         /// </remarks>
         public static string ToString(object value, Type type, JsonSerializerOptions options = null)
         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -6,11 +6,32 @@ namespace System.Text.Json.Serialization
 {
     public static partial class JsonSerializer
     {
+        /// <summary>
+        /// Convert the value and return as <see cref="System.String"/>.
+        /// </summary>
+        /// <returns>The converted value.</returns>
+        /// <param name="value">The value to convert.</param>
+        /// <param name="options">The options used to convert the value.</param>
+        /// <remarks>Using a UTF-16 <see cref="System.String"/> is not as efficient as a
+        /// UTF-8 <see cref="System.Byte"/> array since the implementation natively uses UTF-8 and
+        /// requires a conversion to a UTF-16 <see cref="System.String"/>.
+        /// </remarks>
         public static string ToString<TValue>(TValue value, JsonSerializerOptions options = null)
         {
             return ToStringInternal(value, typeof(TValue), options);
         }
 
+        /// <summary>
+        /// Convert the value and return as <see cref="System.String"/>.
+        /// </summary>
+        /// <returns>The converted value.</returns>
+        /// <param name="value">The value to convert.</param>
+        /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
+        /// <param name="options">The options used to convert the value.</param>
+        /// <remarks>Using a UTF-16 <see cref="System.String"/> is not as efficient as a
+        /// UTF-8 <see cref="System.Byte"/> array since the implementation natively uses UTF-8 and
+        /// requires a conversion to a UTF-16 <see cref="System.String"/>.
+        /// </remarks>
         public static string ToString(object value, Type type, JsonSerializerOptions options = null)
         {
             VerifyValueAndType(value, type);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -6,16 +6,21 @@ using System.Collections.Concurrent;
 
 namespace System.Text.Json.Serialization
 {
+    /// <summary>
+    /// Provides options to be used with <see cref="JsonSerializer"/>.
+    /// </summary>
     public sealed class JsonSerializerOptions
     {
-        internal const int BufferSizeUnspecified = -1;
         internal const int BufferSizeDefault = 16 * 1024;
 
         private ClassMaterializer _classMaterializerStrategy;
-        private int _defaultBufferSize = BufferSizeUnspecified;
+        private int _defaultBufferSize = BufferSizeDefault;
 
         private static readonly ConcurrentDictionary<Type, JsonClassInfo> s_classes = new ConcurrentDictionary<Type, JsonClassInfo>();
 
+        /// <summary>
+        /// Constructs a new <see cref="JsonSerializerOptions"/> instance.
+        /// </summary>
         public JsonSerializerOptions() { }
 
         internal JsonClassInfo GetOrAddClass(Type classType)
@@ -30,9 +35,20 @@ namespace System.Text.Json.Serialization
             return result;
         }
 
+        /// <summary>
+        /// The <see cref="JsonReaderOptions"/> used when deserializing an object or value type.
+        /// </summary>
         public JsonReaderOptions ReaderOptions { get; set; }
+
+        /// <summary>
+        /// The <see cref="JsonWriterOptions"/> used when serializing an object or value type.
+        /// </summary>
         public JsonWriterOptions WriterOptions { get; set; }
 
+        /// <summary>
+        /// The default buffer size used when creating temporary buffers while serializing or deserializing.
+        /// </summary>
+        /// <exception cref="System.ArgumentException">Thrown when the buffer size is less than 1.</exception>
         public int DefaultBufferSize
         {
             get
@@ -41,29 +57,24 @@ namespace System.Text.Json.Serialization
             }
             set
             {
-                if (value == 0 || value < BufferSizeUnspecified)
+                if (value < 1)
                 {
                     throw new ArgumentException(SR.SerializationInvalidBufferSize);
                 }
 
                 _defaultBufferSize = value;
-
-                if (_defaultBufferSize == BufferSizeUnspecified)
-                {
-                    EffectiveBufferSize = BufferSizeDefault;
-                }
-                else
-                {
-                    EffectiveBufferSize = _defaultBufferSize;
-                }
             }
         }
 
+        /// <summary>
+        /// Determines whether null properties are included when serializing.
+        /// </summary>
         public bool IgnoreNullPropertyValueOnWrite { get; set; }
-        public bool IgnoreNullPropertyValueOnRead { get; set; }
 
-        // Used internally for performance to avoid checking BufferSizeUnspecified.
-        internal int EffectiveBufferSize { get; private set; } = BufferSizeDefault;
+        /// <summary>
+        /// Determines whether null properties are applied to object's properties when deserializing.
+        /// </summary>
+        public bool IgnoreNullPropertyValueOnRead { get; set; }
 
         internal ClassMaterializer ClassMaterializerStrategy
         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -36,18 +36,19 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// The <see cref="JsonReaderOptions"/> used when deserializing an object or value type.
+        /// Options to control the <see cref="Utf8JsonReader"/>.
         /// </summary>
         public JsonReaderOptions ReaderOptions { get; set; }
 
         /// <summary>
-        /// The <see cref="JsonWriterOptions"/> used when serializing an object or value type.
+        /// Options to control the <see cref="Utf8JsonWriter"/>.
         /// </summary>
         public JsonWriterOptions WriterOptions { get; set; }
 
         /// <summary>
-        /// The default buffer size used when creating temporary buffers while serializing or deserializing.
+        /// The default buffer size in bytes used when creating temporary buffers.
         /// </summary>
+        /// <remarks>The default size is 16K.</remarks>
         /// <exception cref="System.ArgumentException">Thrown when the buffer size is less than 1.</exception>
         public int DefaultBufferSize
         {
@@ -67,12 +68,12 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// Determines whether null properties are included when serializing.
+        /// Determines whether null values of properties are ignored or whether they are written to the JSON.
         /// </summary>
         public bool IgnoreNullPropertyValueOnWrite { get; set; }
 
         /// <summary>
-        /// Determines whether null properties are applied to object's properties when deserializing.
+        /// Determines whether null values in the JSON are ignored or whether they are set on properties.
         /// </summary>
         public bool IgnoreNullPropertyValueOnRead { get; set; }
 

--- a/src/System.Text.Json/tests/Serialization/OptionsTests.cs
+++ b/src/System.Text.Json/tests/Serialization/OptionsTests.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static partial class OptionsTests
+    {
+        [Fact]
+        public static void DefaultBufferSizeFail()
+        {
+            Assert.Throws<ArgumentException>(() => new JsonSerializerOptions().DefaultBufferSize = 0);
+            Assert.Throws<ArgumentException>(() => new JsonSerializerOptions().DefaultBufferSize = -1);
+        }
+
+        [Fact]
+        public static void DefaultBufferSize()
+        {
+            var options = new JsonSerializerOptions();
+
+            Assert.Equal(16 * 1024, options.DefaultBufferSize);
+
+            options.DefaultBufferSize = 1;
+            Assert.Equal(1, options.DefaultBufferSize);
+        }
+    }
+}

--- a/src/System.Text.Json/tests/Serialization/SpanTests.cs
+++ b/src/System.Text.Json/tests/Serialization/SpanTests.cs
@@ -10,9 +10,9 @@ namespace System.Text.Json.Serialization.Tests
     public static class SpanTests
     {
         [Fact]
-        public static void NullObjectInputFail()
+        public static void ParseNullArgumentFail()
         {
-            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Parse<string>((ReadOnlySpan<byte>)null));
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Parse(new ReadOnlySpan<byte>(), (Type)null));
         }
 
         [Theory]
@@ -32,8 +32,9 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void VerifyValueFail()
+        public static void ToStringNullArgumentFail()
         {
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.ToString((object)null));
             Assert.Throws<ArgumentNullException>(() => JsonSerializer.ToString(new object(), (Type)null));
         }
 

--- a/src/System.Text.Json/tests/Serialization/SpanTests.cs
+++ b/src/System.Text.Json/tests/Serialization/SpanTests.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Serialization.Tests
     public static class SpanTests
     {
         [Fact]
-        public static void ParseNullArgumentFail()
+        public static void ParseNullTypeFail()
         {
             Assert.Throws<ArgumentNullException>(() => JsonSerializer.Parse(new ReadOnlySpan<byte>(), (Type)null));
         }
@@ -32,9 +32,8 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void ToStringNullArgumentFail()
+        public static void ToStringNullTypeFail()
         {
-            Assert.Throws<ArgumentNullException>(() => JsonSerializer.ToString((object)null));
             Assert.Throws<ArgumentNullException>(() => JsonSerializer.ToString(new object(), (Type)null));
         }
 

--- a/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
@@ -11,9 +11,10 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class StreamTests
     {
         [Fact]
-        public static async void NullObjectInputFalse()
+        public static async void NullArgumentFail()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.ReadAsync<string>((Stream)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.ReadAsync(new MemoryStream(), (Type)null));
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/String.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/String.ReadTests.cs
@@ -9,10 +9,10 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class StringTests
     {
         [Fact]
-        public static void NullObjectInputFail()
+        public static void ParseNullArgumentFail()
         {
-
             Assert.Throws<ArgumentNullException>(() => JsonSerializer.Parse<string>((string)null));
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Parse("1", (Type)null));
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/String.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/String.WriteTests.cs
@@ -10,8 +10,9 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class StringTests
     {
         [Fact]
-        public static void VerifyValueFail()
+        public static void ToStringNullArgumentFail()
         {
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.ToString(null, (Type)null));
             Assert.Throws<ArgumentNullException>(() => JsonSerializer.ToString("", (Type)null));
         }
 

--- a/src/System.Text.Json/tests/Serialization/String.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/String.WriteTests.cs
@@ -12,7 +12,6 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ToStringNullArgumentFail()
         {
-            Assert.Throws<ArgumentNullException>(() => JsonSerializer.ToString(null, (Type)null));
             Assert.Throws<ArgumentNullException>(() => JsonSerializer.ToString("", (Type)null));
         }
 

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="Serialization\EnumTests.cs" />
     <Compile Include="Serialization\Null.ReadTests.cs" />
     <Compile Include="Serialization\Null.WriteTests.cs" />
+    <Compile Include="Serialization\OptionsTests.cs" />
     <Compile Include="Serialization\PolymorphicTests.cs" />
     <Compile Include="Serialization\PropertyVisibilityTests.cs" />
     <Compile Include="Serialization\SpanTests.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/36174

Also changes the DefaultBufferSize to return an explicit value for the default value (16K) instead of trying to hide the actual value by returning -1. The main reason for the change is that it may be important for others to be able to easily inspect the actual value being used, plus it is the general pattern that other implementations of a default size use.