### PR TITLE
Tweak Console's read buffer size

### DIFF
--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -11,7 +11,16 @@ namespace System
 {
     public static class Console
     {
-        private const int DefaultConsoleBufferSize = 256; // default size of buffer used in stream readers/writers
+        // Unlike many other buffer sizes throughout .NET, which often only affect performance, this buffer size has a
+        // functional impact on interactive console apps, where the size of the buffer passed to ReadFile/Console impacts
+        // how many characters the cmd window will allow to be typed as part of a single line. It also does affect perf,
+        // in particular when input is redirected and data may be consumed from a larger source. This 4K default size is the
+        // same as is currently used by most other environments/languages tried.
+        internal const int ReadBufferSize = 4096;
+        // There's no visible functional impact to the write buffer size, and as we auto flush on every write,
+        // there's little benefit to having a large buffer.  So we use a smaller buffer size to reduce working set.
+        private const int WriteBufferSize = 256;
+
         private static object InternalSyncObject = new object(); // for synchronizing changing of Console's static fields
         private static TextReader s_in;
         private static TextWriter s_out, s_error;
@@ -120,7 +129,7 @@ namespace System
                 new StreamWriter(
                     stream: outputStream,
                     encoding: OutputEncoding.RemovePreamble(), // This ensures no prefix is written to the stream.
-                    bufferSize: DefaultConsoleBufferSize,
+                    bufferSize: WriteBufferSize,
                     leaveOpen: true) { AutoFlush = true });
         }
 

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -46,7 +46,6 @@ namespace System
         }
 
         private static SyncTextReader s_stdInReader;
-        private const int DefaultBufferSize = 255;
 
         private static SyncTextReader StdInReader
         {
@@ -54,16 +53,20 @@ namespace System
             {
                 EnsureInitialized();
 
+                // StdInReader is only used when input isn't redirected and we're working
+                // with an interactive terminal.  In that case, performance isn't critical
+                // and we can use a smaller buffer to minimize working set.
+                const int InteractiveBufferSize = 255;
+
                 return Console.EnsureInitialized(
                         ref s_stdInReader,
                         () => SyncTextReader.GetSynchronizedTextReader(
                             new StdInReader(
                                 encoding: Console.InputEncoding,
-                                bufferSize: DefaultBufferSize)));
+                                bufferSize: InteractiveBufferSize)));
             }
         }
 
-        private const int DefaultConsoleBufferSize = 256; // default size of buffer used in stream readers/writers
         internal static TextReader GetOrCreateReader()
         {
             if (Console.IsInputRedirected)
@@ -76,7 +79,7 @@ namespace System
                         stream: inputStream,
                         encoding: Console.InputEncoding,
                         detectEncodingFromByteOrderMarks: false,
-                        bufferSize: DefaultConsoleBufferSize,
+                        bufferSize: Console.ReadBufferSize,
                         leaveOpen: true)
                         );
             }

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -12,8 +12,6 @@ namespace System
     // Provides Windows-based support for System.Console.
     internal static class ConsolePal
     {
-        private const int DefaultConsoleBufferSize = 256; // default size of buffer used in stream readers/writers
-
         private static IntPtr InvalidHandleValue => new IntPtr(-1);
 
         private static bool IsWindows7()
@@ -179,7 +177,7 @@ namespace System
                     stream: inputStream,
                     encoding: new ConsoleEncoding(Console.InputEncoding),
                     detectEncodingFromByteOrderMarks: false,
-                    bufferSize: DefaultConsoleBufferSize,
+                    bufferSize: Console.ReadBufferSize,
                     leaveOpen: true));
         }
 


### PR DESCRIPTION
Unlike most buffer sizes throughout .NET, where buffer size primarily impacts performance, the size used for the Console's read buffer actually impacts visible functionality to an end user.  On Windows, when ReadFile/Console are called to read from a cmd window configured in the default fashion, the size of the buffer passed in determines how long a line can be typed by the user; the shorter the buffer, the less the user will be able to type.  Currently .NET uses a buffer of size 256, which ends up meaning a user can't type a line longer than 254 characters.

There is also a performance impact to the buffer size of the read buffer, in that (in particular for redirected input where the input might be coming from a large file) the smaller the buffer the more reads are required to consume the contents of the file.  In local measurements, reading a 365M text file with Console.ReadLine took ~6s with a 256 char buffer and ~1.3s with a 4K char buffer (a 16K char buffer improved on that only slightly, at around ~1.1s).  Changing the size of the write buffers doesn't have a significant impact in contrast, as Console is configured to flush automatically on every read.

In experimenting with other languages/environments, I found that VC++, Go, and Rust by default all appear to use a 4K buffer (it looks like Python defaults to a 16K buffer).

Given all this, I'm changing Console's read buffer to be 4096 chars instead of 256 chars.  I've left the rest of the buffer sizes at 256, but consolidated some of the constants.

If a developer wants a larger or smaller size, they can effectively change it with:
```C#
Console.SetIn(new StreamReader(Console.OpenStandardInput(), Encoding.UTF8, false, BufferSize));
```

Fixes #36188
cc: @wtgodbe, @danmosemsft, @tmds