### PR TITLE
Move test ilc to 1.0.0 since that is the version the produce in the dev branch

### DIFF
--- a/eng/dependencies.props
+++ b/eng/dependencies.props
@@ -25,7 +25,7 @@
   <PropertyGroup>
     <ProjectNTfsExpectedPrerelease>beta-27519-00</ProjectNTfsExpectedPrerelease>
     <ProjectNTfsTestILCExpectedPrerelease>beta-27519-00</ProjectNTfsTestILCExpectedPrerelease>
-    <ProjectNTfsTestILCPackageVersion>1.1.0-beta-27519-00</ProjectNTfsTestILCPackageVersion>
+    <ProjectNTfsTestILCPackageVersion>1.0.0-beta-27519-00</ProjectNTfsTestILCPackageVersion>
 
     <!-- CoreFX-built SNI identity package -->
     <RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniPackageVersion>


### PR DESCRIPTION
This fixes our official builds failing to restore this package. 