### PR TITLE
Fix WSAStartup interop

### DIFF
--- a/src/Common/src/Interop/Windows/WinSock/Interop.WSAStartup.cs
+++ b/src/Common/src/Interop/Windows/WinSock/Interop.WSAStartup.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
 using System.Net.Sockets;
 
@@ -10,26 +9,45 @@ internal static partial class Interop
 {
     internal static partial class Winsock
     {
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct WSAData
-        {
-            internal short wVersion;
-            internal short wHighVersion;
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 257)]
-            internal string szDescription;
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 129)]
-            internal string szSystemStatus;
-            internal short iMaxSockets;
-            internal short iMaxUdpDg;
-            internal IntPtr lpVendorInfo;
-        }
-
         // Important: this API is called once by the System.Net.NameResolution contract implementation.
         // WSACleanup is not called and will be automatically performed at process shutdown.
-        [DllImport(Interop.Libraries.Ws2_32, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true, SetLastError = true)]
-        internal static extern SocketError WSAStartup(
-                                           [In] short wVersionRequested,
-                                           [Out] out WSAData lpWSAData
-                                           );
+        internal static unsafe SocketError WSAStartup()
+        {
+            WSAData d;
+            return WSAStartup(0x0202 /* 2.2 */, &d);
+        }
+
+        [DllImport(Libraries.Ws2_32, SetLastError = true)]
+        private static extern unsafe SocketError WSAStartup(short wVersionRequested, WSAData* lpWSAData);
+
+        [StructLayout(LayoutKind.Sequential, Size = 408)]
+        private unsafe struct WSAData
+        {
+            // WSADATA is defined as follows:
+            //
+            //     typedef struct WSAData {
+            //             WORD                    wVersion;
+            //             WORD                    wHighVersion;
+            //     #ifdef _WIN64
+            //             unsigned short          iMaxSockets;
+            //             unsigned short          iMaxUdpDg;
+            //             char FAR *              lpVendorInfo;
+            //             char                    szDescription[WSADESCRIPTION_LEN+1];
+            //             char                    szSystemStatus[WSASYS_STATUS_LEN+1];
+            //     #else
+            //             char                    szDescription[WSADESCRIPTION_LEN+1];
+            //             char                    szSystemStatus[WSASYS_STATUS_LEN+1];
+            //             unsigned short          iMaxSockets;
+            //             unsigned short          iMaxUdpDg;
+            //             char FAR *              lpVendorInfo;
+            //     #endif
+            //     } WSADATA, FAR * LPWSADATA;
+            //
+            // Important to notice is that its layout / order of fields differs between
+            // 32-bit and 64-bit systems.  However, we don't actually need any of the
+            // data it contains; it suffices to ensure that this struct is large enough
+            // to hold either layout, which is 400 bytes on 32-bit and 408 bytes on 64-bit.
+            // Thus, we don't declare any fields here, and simply make the size 408 bytes.
+        }
     }
 }

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -296,12 +296,7 @@ namespace System.Net
                 {
                     if (!s_initialized)
                     {
-                        Interop.Winsock.WSAData wsaData = new Interop.Winsock.WSAData();
-
-                        SocketError errorCode =
-                            Interop.Winsock.WSAStartup(
-                                (short)0x0202, // we need 2.2
-                                out wsaData);
+                        SocketError errorCode = Interop.Winsock.WSAStartup();
 
                         if (errorCode != SocketError.Success)
                         {


### PR DESCRIPTION
Our WSAStartup interop is incorrect, but thankfully other than it adding some unnecessary cost, it doesn't actually break anything.

The WSADATA struct in Windows differs in layout between 32-bit and 64-bit, making our interop signature wrong.  But, we don't actually read out any of the resulting data, so the incorrectness doesn't negatively impact consumption.  It does incur some unnecessary cost, though, in that the marshaling attributes and the inclusion of `string` in the struct is causing two strings to be allocated that are unnecessary.

This change just deletes the contents of the struct so as to avoid any potential future misuse and to eliminate those allocations.  It then uses the Size on the StructLayout to ensure that the struct is large enough for either the 32-bit or 64-bit interop cases.  And it hides this all with private visibility so that it doesn't leak out into the consuming code.

cc: @davidsh, @jkotas