### PR TITLE
Fix Kerberos/NTLM for multiple domain/realm environments in Linux

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
@@ -41,7 +41,6 @@ internal static partial class Interop
             out Status minorStatus,
             string inputName,
             int inputNameByteCount,
-            bool isNtlmTarget,
             out SafeGssNameHandle outputName);
 
         [DllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_ReleaseName")]
@@ -77,9 +76,7 @@ internal static partial class Interop
             bool isNtlmOnly,
             IntPtr cbt,
             int cbtSize,
-            bool isNtlmFallback,
-            SafeGssNameHandle targetNameKerberos,
-            SafeGssNameHandle targetNameNtlm,
+            SafeGssNameHandle targetName,
             uint reqFlags,
             byte[] inputBytes,
             int inputLength,

--- a/src/Common/src/Microsoft/Win32/SafeHandles/GssSafeHandles.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/GssSafeHandles.cs
@@ -31,13 +31,13 @@ namespace Microsoft.Win32.SafeHandles
             return retHandle;
         }
 
-        public static SafeGssNameHandle CreateTarget(string name, bool isNtlmTarget)
+        public static SafeGssNameHandle CreateTarget(string name)
         {
             Debug.Assert(!string.IsNullOrEmpty(name), "Invalid target name passed to SafeGssNameHandle create");
             SafeGssNameHandle retHandle;
             Interop.NetSecurityNative.Status minorStatus;
             Interop.NetSecurityNative.Status status = Interop.NetSecurityNative.ImportTargetName(
-                out minorStatus, name, Encoding.UTF8.GetByteCount(name), isNtlmTarget, out retHandle);
+                out minorStatus, name, Encoding.UTF8.GetByteCount(name), out retHandle);
 
             if (status != Interop.NetSecurityNative.Status.GSS_S_COMPLETE)
             {

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
@@ -237,18 +237,7 @@ uint32_t NetSecurityNative_InitSecContext(uint32_t* minorStatus,
                                                 retFlags,
                                                 NULL);
 
-    if (isNtlm)
-    {
-        *isNtlmUsed = 1;
-    }
-    else if (majorStatus == GSS_S_COMPLETE && gss_oid_equal(outmech, krbMech) != 0)
-    {
-        *isNtlmUsed = 0;
-    }
-    else
-    {
-        *isNtlmUsed = 1;
-    }
+    *isNtlmUsed = (isNtlm || majorStatus != GSS_S_COMPLETE || gss_oid_equal(outmech, krbMech) == 0) ? 1 : 0;
 
     NetSecurityNative_MoveBuffer(&gssBuffer, outBuffer);
     return majorStatus;

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
@@ -147,28 +147,15 @@ NetSecurityNative_ImportUserName(uint32_t* minorStatus, char* inputName, uint32_
 uint32_t NetSecurityNative_ImportTargetName(uint32_t* minorStatus,
                                             char* inputName,
                                             uint32_t inputNameLen,
-                                            uint32_t isNtlmTarget,
                                             GssName** outputName)
 {
     assert(minorStatus != NULL);
     assert(inputName != NULL);
-    assert(isNtlmTarget == 0 || isNtlmTarget == 1);
     assert(outputName != NULL);
     assert(*outputName == NULL);
 
-    gss_OID nameType;
-
-    if (isNtlmTarget)
-    {
-        nameType = GSS_C_NT_HOSTBASED_SERVICE;
-    }
-    else
-    {
-        nameType = (gss_OID)(unsigned long)GSS_KRB5_NT_PRINCIPAL_NAME;
-    }
-
     GssBuffer inputNameBuffer = {.length = inputNameLen, .value = inputName};
-    return gss_import_name(minorStatus, &inputNameBuffer, nameType, outputName);
+    return gss_import_name(minorStatus, &inputNameBuffer, GSS_C_NT_HOSTBASED_SERVICE, outputName);
 }
 
 uint32_t NetSecurityNative_InitSecContext(uint32_t* minorStatus,
@@ -177,9 +164,7 @@ uint32_t NetSecurityNative_InitSecContext(uint32_t* minorStatus,
                                           uint32_t isNtlm,
                                           void* cbt,
                                           int32_t cbtSize,
-                                          int32_t isNtlmFallback,
-                                          GssName* targetNameKerberos,
-                                          GssName* targetNameNtlm,
+                                          GssName* targetName,
                                           uint32_t reqFlags,
                                           uint8_t* inputBytes,
                                           uint32_t inputLength,
@@ -190,9 +175,7 @@ uint32_t NetSecurityNative_InitSecContext(uint32_t* minorStatus,
     assert(minorStatus != NULL);
     assert(contextHandle != NULL);
     assert(isNtlm == 0 || isNtlm == 1);
-    assert(isNtlm == 1 || targetNameKerberos != NULL);
-    assert(isNtlmFallback == 0 || isNtlmFallback == 1);
-    assert(targetNameNtlm != NULL);
+    assert(targetName != NULL);
     assert(inputBytes != NULL || inputLength == 0);
     assert(outBuffer != NULL);
     assert(retFlags != NULL);
@@ -203,6 +186,7 @@ uint32_t NetSecurityNative_InitSecContext(uint32_t* minorStatus,
 // Note: *contextHandle is null only in the first call and non-null in the subsequent calls
 
 #if HAVE_GSS_SPNEGO_MECHANISM
+    gss_OID krbMech = GSS_KRB5_MECHANISM;
     gss_OID desiredMech;
     if (isNtlm)
     {
@@ -212,9 +196,8 @@ uint32_t NetSecurityNative_InitSecContext(uint32_t* minorStatus,
     {
         desiredMech = GSS_SPNEGO_MECHANISM;
     }
-
-    gss_OID krbMech = GSS_KRB5_MECHANISM;
 #else
+    gss_OID krbMech = (gss_OID)(unsigned long)gss_mech_krb5;
     gss_OID_desc gss_mech_OID_desc;
     if (isNtlm)
     {
@@ -226,10 +209,8 @@ uint32_t NetSecurityNative_InitSecContext(uint32_t* minorStatus,
     }
 
     gss_OID desiredMech = &gss_mech_OID_desc;
-    gss_OID krbMech = (gss_OID)(unsigned long)gss_mech_krb5;
 #endif
 
-    *isNtlmUsed = 1;
     GssBuffer inputToken = {.length = inputLength, .value = inputBytes};
     GssBuffer gssBuffer = {.length = 0, .value = NULL};
     gss_OID_desc* outmech;
@@ -242,49 +223,31 @@ uint32_t NetSecurityNative_InitSecContext(uint32_t* minorStatus,
         gssCbt.application_data.value = cbt;
     }
 
-    GssName* targetName;
-    if (isNtlm || isNtlmFallback)
+    uint32_t majorStatus = gss_init_sec_context(minorStatus,
+                                                claimantCredHandle,
+                                                contextHandle,
+                                                targetName,
+                                                desiredMech,
+                                                reqFlags,
+                                                0,
+                                                (cbt != NULL) ? &gssCbt : GSS_C_NO_CHANNEL_BINDINGS,
+                                                &inputToken,
+                                                &outmech,
+                                                &gssBuffer,
+                                                retFlags,
+                                                NULL);
+
+    if (isNtlm)
     {
-        targetName = targetNameNtlm;
+        *isNtlmUsed = 1;
+    }
+    else if (majorStatus == GSS_S_COMPLETE && gss_oid_equal(outmech, krbMech) != 0)
+    {
+        *isNtlmUsed = 0;
     }
     else
     {
-        targetName = targetNameKerberos;
-    }
-    
-    uint32_t majorStatus;
-    uint32_t retryCount = 0;
-    bool retry;
-    do
-    {
-        majorStatus = gss_init_sec_context(minorStatus,
-                                           claimantCredHandle,
-                                           contextHandle,
-                                           targetName,
-                                           desiredMech,
-                                           reqFlags,
-                                           0,
-                                           (cbt != NULL) ? &gssCbt : GSS_C_NO_CHANNEL_BINDINGS,
-                                           &inputToken,
-                                           &outmech,
-                                           &gssBuffer,
-                                           retFlags,
-                                           NULL);
-
-        // If SPNEGO fails to generate optimistic Kerberos token on initial call then fall back to SPNEGO-wrapped NTLM.
-        retry = false;
-        if ((majorStatus == GSS_S_FAILURE || majorStatus == GSS_S_BAD_NAMETYPE) &&
-            *contextHandle == NULL && !isNtlm && ++retryCount <= 1)
-        {
-            targetName = targetNameNtlm;
-            retry = true;
-        }
-    } while (retry);
-
-    // Outmech can be null when gssntlmssp lib uses NTLM mechanism
-    if (outmech != NULL && gss_oid_equal(outmech, krbMech) != 0)
-    {
-        *isNtlmUsed = 0;
+        *isNtlmUsed = 1;
     }
 
     NetSecurityNative_MoveBuffer(&gssBuffer, outBuffer);

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.h
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.h
@@ -82,7 +82,6 @@ Shims the gss_import_name method with nametype = GSS_C_NT_USER_NAME.
 DLLEXPORT uint32_t NetSecurityNative_ImportTargetName(uint32_t* minorStatus,
                                                          char* inputName,
                                                          uint32_t inputNameLen,
-                                                         uint32_t isNtlmTarget,
                                                          GssName** outputName);
 
 /*
@@ -110,9 +109,7 @@ DLLEXPORT uint32_t NetSecurityNative_InitSecContext(uint32_t* minorStatus,
                                                     uint32_t isNtlm,
                                                     void* cbt,
                                                     int32_t cbtSize,
-                                                    int32_t isNtlmFallback,
-                                                    GssName* targetNameKerberos,
-                                                    GssName* targetNameNtlm,
+                                                    GssName* targetName,
                                                     uint32_t reqFlags,
                                                     uint8_t* inputBytes,
                                                     uint32_t inputLength,


### PR DESCRIPTION
This PR addresses some issues reported by a customer (not thru GitHub). They noticed that
multiple domain scenarios were working in .NET Core 2.0 but broke in .NET Core 2.1 on Linux.

While the previous PR #35383 solved the Negotiate Kerberos to NTLM fallback issue,
it added more complexity than necessary. The retry logic I added wasn't really necessary
because the original code that used GSS_KRB5_NT_PRINCIPAL_NAME format for the target name
was wrong. That logic only works for pure Kerberos environments and doesn't handle domain
or realm referrals. So, it only handles the default Kerberos realm on the single Linux
client. In addition, using GSS_KRB5_NT_PRINCIPAL_NAME defeats the logic of the SPNEGO mechanism.
That is why I originally needed to add the retry logic using GSS_C_NT_HOSTBASED_SERVICE format
for the target name.

The multiple domain/realm scenario worked in .NET Core 2.0 because it used CurlHandler.
And libcurl always uses GSS_C_NT_HOSTBASED_SERVICE format for target name.

This PR reworks the logic to use the GSS_C_NT_HOSTBASED_SERVICE format. It also removes the
now unneeded retry logic. I tested this against Windows and Linux as well as pure Kerberos
and Kerberos to NTLM fallback (using SPNEGO).

I added more tests. These tests are currently part of the enterprise scenario tests we are
building. They are activated via environment variables.

By definining all of the environment variables below, I am able to run the System.Net.Security
and System.Net.Http enterprise-scenario tests. Both SocketsHttpHandler in System.Net.Http and
NegotiateStream in System.Net.Security use the same common GSS-API logic in CoreFx.

Define domain-joined server remote endpoint:
* COREFX_NET_SECURITY_NEGOSERVERURI
* COREFX_DOMAINJOINED_HTTPHOST
* COREFX_NET_AD_DOMAINNAME
* COREFX_NET_AD_PASSWORD
* COREFX_NET_AD_USERNAME

Define standalone server remote endpoint:
* COREFX_NET_SERVER_PASSWORD
* COREFX_NET_SERVER_USERNAME
* COREFX_WINDOWSSERVER_HTTPHOST