### PR TITLE
Process.Unix: fix unexpected Process.Exited events

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -181,26 +181,33 @@ namespace System.Diagnostics
                 {
                     if (!_watchingForExit)
                     {
-                        Debug.Assert(_waitHandle == null);
                         Debug.Assert(_registeredWaitHandle == null);
                         Debug.Assert(Associated, "Process.EnsureWatchingForExit called with no associated process");
                         _watchingForExit = true;
                         try
                         {
-                            _waitHandle = new ProcessWaitHandle(GetWaitState());
-                            _registeredWaitHandle = ThreadPool.RegisterWaitForSingleObject(_waitHandle,
-                                new WaitOrTimerCallback(CompletionCallback), _waitHandle, -1, true);
+                            _completionCallbackContext = new object();
+                            WaitHandle waitHandle = GetOrCreateProcessWaitHandle();
+                            _registeredWaitHandle = ThreadPool.RegisterWaitForSingleObject(waitHandle,
+                                new WaitOrTimerCallback(CompletionCallback), _completionCallbackContext, -1, true);
                         }
                         catch
                         {
-                            _waitHandle?.Dispose();
-                            _waitHandle = null;
                             _watchingForExit = false;
                             throw;
                         }
                     }
                 }
             }
+        }
+
+        private ProcessWaitHandle GetOrCreateProcessWaitHandle()
+        {
+            if (_waitHandle == null)
+            {
+                _waitHandle = new ProcessWaitHandle(GetWaitState());
+            }
+            return (ProcessWaitHandle)_waitHandle;
         }
 
         /// <summary>
@@ -357,8 +364,7 @@ namespace System.Diagnostics
             }
 
             EnsureState(State.HaveNonExitedId | State.IsLocal);
-            EnsureWatchingForExit();
-            return new SafeProcessHandle(_processId, _waitHandle.SafeWaitHandle);
+            return new SafeProcessHandle(_processId, GetOrCreateProcessWaitHandle().SafeWaitHandle);
         }
 
         /// <summary>
@@ -515,7 +521,7 @@ namespace System.Diagnostics
                     // Store the child's information into this Process object.
                     Debug.Assert(childPid >= 0);
                     SetProcessId(childPid);
-                    SetProcessHandle(GetProcessHandle());
+                    SetProcessHandle(new SafeProcessHandle(_processId, GetOrCreateProcessWaitHandle().SafeWaitHandle));
 
                     return true;
                 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -135,12 +135,11 @@ namespace System.Diagnostics
                 {
                     if (!_watchingForExit)
                     {
-                        Debug.Assert(_haveProcessHandle, "Process.EnsureWatchingForExit called with no process handle");
                         Debug.Assert(Associated, "Process.EnsureWatchingForExit called with no associated process");
                         _watchingForExit = true;
                         try
                         {
-                            _waitHandle = new Interop.Kernel32.ProcessWaitHandle(_processHandle);
+                            _waitHandle = new Interop.Kernel32.ProcessWaitHandle(GetOrOpenProcessHandle());
                             _registeredWaitHandle = ThreadPool.RegisterWaitForSingleObject(_waitHandle,
                                 new WaitOrTimerCallback(CompletionCallback), _waitHandle, -1, true);
                         }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -141,9 +141,8 @@ namespace System.Diagnostics
                         try
                         {
                             _waitHandle = new Interop.Kernel32.ProcessWaitHandle(_processHandle);
-                            _completionCallbackContext = _waitHandle;
                             _registeredWaitHandle = ThreadPool.RegisterWaitForSingleObject(_waitHandle,
-                                new WaitOrTimerCallback(CompletionCallback), _completionCallbackContext, -1, true);
+                                new WaitOrTimerCallback(CompletionCallback), _waitHandle, -1, true);
                         }
                         catch
                         {

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -141,8 +141,9 @@ namespace System.Diagnostics
                         try
                         {
                             _waitHandle = new Interop.Kernel32.ProcessWaitHandle(_processHandle);
+                            _completionCallbackContext = _waitHandle;
                             _registeredWaitHandle = ThreadPool.RegisterWaitForSingleObject(_waitHandle,
-                                new WaitOrTimerCallback(CompletionCallback), _waitHandle, -1, true);
+                                new WaitOrTimerCallback(CompletionCallback), _completionCallbackContext, -1, true);
                         }
                         catch
                         {

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -841,6 +841,7 @@ namespace System.Diagnostics
                     // This sets _waitHandle to null which causes CompletionCallback to not emit events.
                     StopWatchingForExit();
                 }
+
                 if (_haveProcessHandle)
                 {
                     _processHandle.Dispose();

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -657,7 +657,6 @@ namespace System.Diagnostics
                     {
                         if (value)
                         {
-                            GetOrOpenProcessHandle();
                             EnsureWatchingForExit();
                         }
                         else


### PR DESCRIPTION
Extract ProcessWaitHandle creation from EnsureWatchingForExit to avoid
Process.Exited events when user hasn't set EnableRaisingEvents.

Fixes https://github.com/dotnet/corefx/issues/36331