### PR TITLE
Add RIDs Mono cares about, or has been known to

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -1,4 +1,35 @@
 {
+  "aix": [
+    "aix",
+    "unix",
+    "any",
+    "base"
+  ],
+  "aix-ppc64": [
+    "aix-ppc64",
+    "aix",
+    "unix-ppc64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "aix.7.2": [
+    "aix.7.2",
+    "aix",
+    "unix",
+    "any",
+    "base"
+  ],
+  "aix.7.2-ppc64": [
+    "aix.7.2-ppc64",
+    "aix.7.2",
+    "aix-ppc64",
+    "aix",
+    "unix-ppc64",
+    "unix",
+    "any",
+    "base"
+  ],
   "alpine": [
     "alpine",
     "linux-musl",
@@ -303,6 +334,36 @@
     "any",
     "base"
   ],
+  "debian-ppc64el": [
+    "debian-ppc64el",
+    "debian",
+    "linux-ppc64el",
+    "linux",
+    "unix-ppc64el",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian-s390x": [
+    "debian-s390x",
+    "debian",
+    "linux-s390x",
+    "linux",
+    "unix-s390x",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian-mipsel": [
+    "debian-mipsel",
+    "debian",
+    "linux-mipsel",
+    "linux",
+    "unix-mipsel",
+    "unix",
+    "any",
+    "base"
+  ],
   "debian.8": [
     "debian.8",
     "debian",
@@ -371,6 +432,42 @@
     "any",
     "base"
   ],
+  "debian.8-ppc64el": [
+    "debian.8-ppc64el",
+    "debian.8",
+    "debian-ppc64el",
+    "debian",
+    "linux-ppc64el",
+    "linux",
+    "unix-ppc64el",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.8-s390x": [
+    "debian.8-s390x",
+    "debian.8",
+    "debian-s390x",
+    "debian",
+    "linux-s390x",
+    "linux",
+    "unix-s390x",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.8-mipsel": [
+    "debian.8-mipsel",
+    "debian.8",
+    "debian-mipsel",
+    "debian",
+    "linux-mipsel",
+    "linux",
+    "unix-mipsel",
+    "unix",
+    "any",
+    "base"
+  ],
   "debian.9": [
     "debian.9",
     "debian",
@@ -435,6 +532,146 @@
     "linux-x86",
     "linux",
     "unix-x86",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.9-ppc64el": [
+    "debian.9-ppc64el",
+    "debian.9",
+    "debian-ppc64el",
+    "debian",
+    "linux-ppc64el",
+    "linux",
+    "unix-ppc64el",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.9-s390x": [
+    "debian.9-s390x",
+    "debian.9",
+    "debian-s390x",
+    "debian",
+    "linux-s390x",
+    "linux",
+    "unix-s390x",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.9-mipsel": [
+    "debian.9-mipsel",
+    "debian.9",
+    "debian-mipsel",
+    "debian",
+    "linux-mipsel",
+    "linux",
+    "unix-mipsel",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.10": [
+    "debian.10",
+    "debian",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.10-arm": [
+    "debian.10-arm",
+    "debian.10",
+    "debian-arm",
+    "debian",
+    "linux-arm",
+    "linux",
+    "unix-arm",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.10-arm64": [
+    "debian.10-arm64",
+    "debian.10",
+    "debian-arm64",
+    "debian",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.10-armel": [
+    "debian.10-armel",
+    "debian.10",
+    "debian-armel",
+    "debian",
+    "linux-armel",
+    "linux",
+    "unix-armel",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.10-x64": [
+    "debian.10-x64",
+    "debian.10",
+    "debian-x64",
+    "debian",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.10-x86": [
+    "debian.10-x86",
+    "debian.10",
+    "debian-x86",
+    "debian",
+    "linux-x86",
+    "linux",
+    "unix-x86",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.10-ppc64el": [
+    "debian.10-ppc64el",
+    "debian.10",
+    "debian-ppc64el",
+    "debian",
+    "linux-ppc64el",
+    "linux",
+    "unix-ppc64el",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.10-s390x": [
+    "debian.10-s390x",
+    "debian.10",
+    "debian-s390x",
+    "debian",
+    "linux-s390x",
+    "linux",
+    "unix-s390x",
+    "unix",
+    "any",
+    "base"
+  ],
+  "debian.10-mipsel": [
+    "debian.10-mipsel",
+    "debian.10",
+    "debian-mipsel",
+    "debian",
+    "linux-mipsel",
+    "linux",
+    "unix-mipsel",
     "unix",
     "any",
     "base"
@@ -812,6 +1049,38 @@
     "linux-x86",
     "linux",
     "unix-x86",
+    "unix",
+    "any",
+    "base"
+  ],
+  "linux-ppc64": [
+    "linux-ppc64",
+    "linux",
+    "unix-ppc64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "linux-ppc64el": [
+    "linux-ppc64el",
+    "linux",
+    "unix-ppc64el",
+    "unix",
+    "any",
+    "base"
+  ],
+  "linux-s390x": [
+    "linux-s390x",
+    "linux",
+    "unix-s390x",
+    "unix",
+    "any",
+    "base"
+  ],
+  "linux-mipsel": [
+    "linux-mipsel",
+    "linux",
+    "unix-mipsel",
     "unix",
     "any",
     "base"
@@ -1724,6 +1993,104 @@
     "osx-x64",
     "osx",
     "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "raspbian": [
+    "raspbian",
+    "debian",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "raspbian-arm": [
+    "raspbian-arm",
+    "raspbian",
+    "debian-arm",
+    "debian",
+    "linux-arm",
+    "linux",
+    "unix-arm",
+    "unix",
+    "any",
+    "base"
+  ],
+  "raspbian.8": [
+    "raspbian.8",
+    "raspbian",
+    "debian.8",
+    "debian",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "raspbian.8-arm": [
+    "raspbian.8-arm",
+    "raspbian.8",
+    "raspbian-arm",
+    "raspbian",
+    "debian.8-arm",
+    "debian.8",
+    "debian-arm",
+    "debian",
+    "linux-arm",
+    "linux",
+    "unix-arm",
+    "unix",
+    "any",
+    "base"
+  ],
+  "raspbian.9": [
+    "raspbian.9",
+    "raspbian",
+    "debian.9",
+    "debian",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "raspbian.9-arm": [
+    "raspbian.9-arm",
+    "raspbian.9",
+    "raspbian-arm",
+    "raspbian",
+    "debian.9-arm",
+    "debian.9",
+    "debian-arm",
+    "debian",
+    "linux-arm",
+    "linux",
+    "unix-arm",
+    "unix",
+    "any",
+    "base"
+  ],
+  "raspbian.10": [
+    "raspbian.10",
+    "raspbian",
+    "debian.10",
+    "debian",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "raspbian.10-arm": [
+    "raspbian.10-arm",
+    "raspbian.10",
+    "raspbian-arm",
+    "raspbian",
+    "debian.10-arm",
+    "debian.10",
+    "debian-arm",
+    "debian",
+    "linux-arm",
+    "linux",
+    "unix-arm",
     "unix",
     "any",
     "base"
@@ -2976,6 +3343,30 @@
   ],
   "unix-x86": [
     "unix-x86",
+    "unix",
+    "any",
+    "base"
+  ],
+  "unix-ppc64": [
+    "unix-ppc64",
+    "unix",
+    "any",
+    "base"
+  ],
+  "unix-ppc64el": [
+    "unix-ppc64el",
+    "unix",
+    "any",
+    "base"
+  ],
+  "unix-s390x": [
+    "unix-s390x",
+    "unix",
+    "any",
+    "base"
+  ],
+  "unix-mipsel": [
+    "unix-mipsel",
     "unix",
     "any",
     "base"

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -1,5 +1,27 @@
 {
   "runtimes": {
+    "aix": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "aix-ppc64": {
+      "#import": [
+        "unix-ppc64",
+        "unix"
+      ]
+    },
+    "aix.7.2": {
+      "#import": [
+        "aix"
+      ]
+    },
+    "aix.7.2-ppc64": {
+      "#import": [
+        "aix.7.2",
+        "aix-ppc64"
+      ]
+    },
     "alpine": {
       "#import": [
         "linux-musl"
@@ -161,6 +183,24 @@
         "linux-x86"
       ]
     },
+    "debian-ppc64el": {
+      "#import": [
+        "debian",
+        "linux-ppc64el"
+      ]
+    },
+    "debian-s390x": {
+      "#import": [
+        "debian",
+        "linux-s390x"
+      ]
+    },
+    "debian-mipsel": {
+      "#import": [
+        "debian",
+        "linux-mipsel"
+      ]
+    },
     "debian.8": {
       "#import": [
         "debian"
@@ -196,6 +236,24 @@
         "debian-x86"
       ]
     },
+    "debian.8-ppc64el": {
+      "#import": [
+        "debian.8",
+        "debian-ppc64el"
+      ]
+    },
+    "debian.8-s390x": {
+      "#import": [
+        "debian.8",
+        "debian-s390x"
+      ]
+    },
+    "debian.8-mipsel": {
+      "#import": [
+        "debian.8",
+        "debian-mipsel"
+      ]
+    },
     "debian.9": {
       "#import": [
         "debian"
@@ -229,6 +287,77 @@
       "#import": [
         "debian.9",
         "debian-x86"
+      ]
+    },
+    "debian.9-ppc64el": {
+      "#import": [
+        "debian.9",
+        "debian-ppc64el"
+      ]
+    },
+    "debian.9-s390x": {
+      "#import": [
+        "debian.9",
+        "debian-s390x"
+      ]
+    },
+    "debian.9-mipsel": {
+      "#import": [
+        "debian.9",
+        "debian-mipsel"
+      ]
+    },
+    "debian.10": {
+      "#import": [
+        "debian"
+      ]
+    },
+    "debian.10-arm": {
+      "#import": [
+        "debian.10",
+        "debian-arm"
+      ]
+    },
+    "debian.10-arm64": {
+      "#import": [
+        "debian.10",
+        "debian-arm64"
+      ]
+    },
+    "debian.10-armel": {
+      "#import": [
+        "debian.10",
+        "debian-armel"
+      ]
+    },
+    "debian.10-x64": {
+      "#import": [
+        "debian.10",
+        "debian-x64"
+      ]
+    },
+    "debian.10-x86": {
+      "#import": [
+        "debian.10",
+        "debian-x86"
+      ]
+    },
+    "debian.10-ppc64el": {
+      "#import": [
+        "debian.10",
+        "debian-ppc64el"
+      ]
+    },
+    "debian.10-s390x": {
+      "#import": [
+        "debian.10",
+        "debian-s390x"
+      ]
+    },
+    "debian.10-mipsel": {
+      "#import": [
+        "debian.10",
+        "debian-mipsel"
       ]
     },
     "fedora": {
@@ -453,6 +582,30 @@
       "#import": [
         "linux",
         "unix-x86"
+      ]
+    },
+    "linux-ppc64": {
+      "#import": [
+        "linux",
+        "unix-ppc64"
+      ]
+    },
+    "linux-ppc64el": {
+      "#import": [
+        "linux",
+        "unix-ppc64el"
+      ]
+    },
+    "linux-s390x": {
+      "#import": [
+        "linux",
+        "unix-s390x"
+      ]
+    },
+    "linux-mipsel": {
+      "#import": [
+        "linux",
+        "unix-mipsel"
       ]
     },
     "linuxmint.17": {
@@ -799,6 +952,50 @@
       "#import": [
         "osx.10.14",
         "osx.10.13-x64"
+      ]
+    },
+    "raspbian": {
+      "#import": [
+        "debian"
+      ]
+    },
+    "raspbian-arm": {
+      "#import": [
+        "raspbian",
+        "linux-arm"
+      ]
+    },
+    "raspbian.8": {
+      "#import": [
+        "debian.8"
+      ]
+    },
+    "raspbian.8-arm": {
+      "#import": [
+        "raspbian.8",
+        "raspbian-arm"
+      ]
+    },
+    "raspbian.9": {
+      "#import": [
+        "debian.9"
+      ]
+    },
+    "raspbian.9-arm": {
+      "#import": [
+        "raspbian.9",
+        "raspbian-arm"
+      ]
+    },
+    "raspbian.10": {
+      "#import": [
+        "debian.10"
+      ]
+    },
+    "raspbian.10-arm": {
+      "#import": [
+        "raspbian.10",
+        "raspbian-arm"
       ]
     },
     "rhel": {
@@ -1371,6 +1568,26 @@
       ]
     },
     "unix-x86": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-ppc64": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-ppc64el": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-s390x": {
+      "#import": [
+        "unix"
+      ]
+    },
+    "unix-mipsel": {
       "#import": [
         "unix"
       ]

--- a/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -2,15 +2,21 @@
   <ItemGroup>
     <RuntimeGroup Include="unix">
       <Parent>any</Parent>
-      <Architectures>x64;x86;arm;armel;arm64</Architectures>
+      <Architectures>x64;x86;arm;armel;arm64;ppc64;ppc64el;s390x;mipsel</Architectures>
     </RuntimeGroup>
     <RuntimeGroup Include="linux">
       <Parent>unix</Parent>
-      <Architectures>x64;x86;arm;armel;arm64</Architectures>
+      <Architectures>x64;x86;arm;armel;arm64;ppc64;ppc64el;s390x;mipsel</Architectures>
     </RuntimeGroup>
     <RuntimeGroup Include="linux-musl">
       <Parent>linux</Parent>
       <Architectures>x64;x86;arm;armel;arm64</Architectures>
+    </RuntimeGroup>
+
+    <RuntimeGroup Include="aix">
+      <Parent>unix</Parent>
+      <Architectures>ppc64</Architectures>
+      <Versions>7.2</Versions>
     </RuntimeGroup>
 
     <RuntimeGroup Include="alpine">
@@ -34,8 +40,8 @@
 
     <RuntimeGroup Include="debian">
       <Parent>linux</Parent>
-      <Architectures>x64;x86;arm;armel;arm64</Architectures>
-      <Versions>8;9</Versions>
+      <Architectures>x64;x86;arm;armel;arm64;ppc64el;s390x;mipsel</Architectures>
+      <Versions>8;9;10</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 
@@ -93,6 +99,14 @@
       <Parent>unix</Parent>
       <Architectures>x64</Architectures>
       <Versions>11;11.0;11.1;11.2</Versions>
+    </RuntimeGroup>
+
+    <!-- raspbian is Debian, built for Pi CPU. It is NOT Debian compatible on Pi 1 & Zero silicon -->
+    <RuntimeGroup Include="raspbian">
+      <Parent>debian</Parent>
+      <Architectures>arm</Architectures>
+      <Versions>8;9;10</Versions>
+      <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
 
     <!-- rhel 6 is independent -->


### PR DESCRIPTION
Hopefully I got the correct places updated.

This isn't a complete list - @nealef will likely have opinions on which distributions should have zSeries entries, and @NattyNarwhal will complain I didn't add enough variety to the AIX entry. There's also room for improvement in the RHEL entries - I have a RHEL for PPC64el license in a desk drawer, so that's certainly a thing too.

* Generic UNIX PPC64
* Generic UNIX PPC64 Little Endian
* Generic UNIX zSeries
* Generic UNIX MIPS Little Endian
* Generic Linux PPC64
* Generic Linux PPC64 Little Endian
* Generic Linux zSeries
* Generic Linux MIPS Little Endian
* AIX 7.2 PPC64
* Debian 8 PPC64 Little Endian
* Debian 8 zSeries
* Debian 8 MIPS Little Endian
* Debian 9 PPC64 Little Endian
* Debian 9 zSeries
* Debian 9 MIPS Little Endian
* Debian 10 ARM Little Endian (v5)
* Debian 10 ARM Little Endian with Hard Float (v7)
* Debian 10 ARM64 (v8)
* Debian 10 x86
* Debian 10 x64
* Debian 10 PPC64 Little Endian
* Debian 10 zSeries
* Debian 10 MIPS Little Endian
* Raspbian 8 ARM Little Endian with Hard Float (v6)
* Raspbian 9 ARM Little Endian with Hard Float (v6)
* Raspbian 10 ARM Little Endian with Hard Float (v6)