### PR TITLE
make mmap tests friendlier to containers

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -5,6 +5,7 @@
 using Microsoft.Win32.SafeHandles;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.IO.MemoryMappedFiles.Tests
@@ -56,7 +57,7 @@ namespace System.IO.MemoryMappedFiles.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Read)]
         [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Write)]
         [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWrite)]
@@ -80,10 +81,21 @@ namespace System.IO.MemoryMappedFiles.Tests
             AssertExtensions.ThrowsIf<IOException>(PlatformDetection.IsUap && mapAccess == MemoryMappedFileAccess.ReadWriteExecute && viewAccess == MemoryMappedFileAccess.ReadWriteExecute,
             () =>
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
-                using (MemoryMappedViewAccessor acc = mmf.CreateViewAccessor(0, Capacity, viewAccess))
+                try {
+                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+                    using (MemoryMappedViewAccessor acc = mmf.CreateViewAccessor(0, Capacity, viewAccess))
+                    {
+                        ValidateMemoryMappedViewAccessor(acc, Capacity, viewAccess);
+                    }
+                }
+                catch (UnauthorizedAccessException)
                 {
-                    ValidateMemoryMappedViewAccessor(acc, Capacity, viewAccess);
+                    if (PlatformDetection.IsInContainer && (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
+                    {
+                        throw new SkipTestException("Execute permission failing in container.");
+                    }
+
+                    throw;
                 }
             });
         }

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -81,7 +81,8 @@ namespace System.IO.MemoryMappedFiles.Tests
             AssertExtensions.ThrowsIf<IOException>(PlatformDetection.IsUap && mapAccess == MemoryMappedFileAccess.ReadWriteExecute && viewAccess == MemoryMappedFileAccess.ReadWriteExecute,
             () =>
             {
-                try {
+                try
+                {
                     using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
                     using (MemoryMappedViewAccessor acc = mmf.CreateViewAccessor(0, Capacity, viewAccess))
                     {

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -5,6 +5,7 @@
 using Microsoft.Win32.SafeHandles;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.IO.MemoryMappedFiles.Tests
@@ -56,7 +57,7 @@ namespace System.IO.MemoryMappedFiles.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Read)]
         [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.Write)]
         [InlineData(MemoryMappedFileAccess.ReadWriteExecute, MemoryMappedFileAccess.ReadWrite)]
@@ -80,10 +81,22 @@ namespace System.IO.MemoryMappedFiles.Tests
             AssertExtensions.ThrowsIf<IOException>(PlatformDetection.IsUap && mapAccess == MemoryMappedFileAccess.ReadWriteExecute && viewAccess == MemoryMappedFileAccess.ReadWriteExecute,
             () =>
             {
-                using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
-                using (MemoryMappedViewStream s = mmf.CreateViewStream(0, Capacity, viewAccess))
+                try
                 {
-                    ValidateMemoryMappedViewStream(s, Capacity, viewAccess);
+                    using (MemoryMappedFile mmf = MemoryMappedFile.CreateNew(null, Capacity, mapAccess))
+                    using (MemoryMappedViewStream s = mmf.CreateViewStream(0, Capacity, viewAccess))
+                    {
+                        ValidateMemoryMappedViewStream(s, Capacity, viewAccess);
+                    }
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    if (PlatformDetection.IsInContainer && (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
+                    {
+                        throw new SkipTestException("Execute permission failing in container.");
+                    }
+
+                    throw;
                 }
             });
         }


### PR DESCRIPTION
Even if it is possible to construct container in a way this test pass, that is not the case even when started with `--privileged` flag.

This change makes it easier to run MemoryMappedFiles tests inside containers. 
If privilege is not available it will report test skip instead of failure. 

```
helixbot@eea8b9b5c8fa:/mnt/wfurt-corefx-arm/artifacts/bin/tests/System.IO.MemoryMappedFiles.Tests/netcoreapp-Linux-Debug-arm$ ../../../testhost/netcoreapp-Linux-Debug-arm/dotnet xunit.console.dll System.IO.MemoryMappedFiles.Tests.dll -xml testResults.xml -nologo -notrait category=nonnetcoreapptests -notrait category=nonlinuxtests -notrait category=failing
 Discovering: System.IO.MemoryMappedFiles.Tests (method display = ClassAndMethod, method display options = None)
  Discovered:  System.IO.MemoryMappedFiles.Tests (found 80 of 103 test cases)
  Starting:    System.IO.MemoryMappedFiles.Tests (parallel test collections = on, max threads = 6)
    System.IO.MemoryMappedFiles.Tests.MemoryMappedViewStreamTests.ValidAccessLevelCombinations(mapAccess: ReadWriteExecute, viewAccess: ReadWriteExecute) [SKIP]
      Execute permission failing in container.
    System.IO.MemoryMappedFiles.Tests.MemoryMappedViewStreamTests.ValidAccessLevelCombinations(mapAccess: ReadWriteExecute, viewAccess: ReadExecute) [SKIP]
      Execute permission failing in container.
    System.IO.MemoryMappedFiles.Tests.MemoryMappedViewAccessorTests.ValidAccessLevelCombinations(mapAccess: ReadWriteExecute, viewAccess: ReadWriteExecute) [SKIP]
      Execute permission failing in container.
    System.IO.MemoryMappedFiles.Tests.MemoryMappedViewAccessorTests.ValidAccessLevelCombinations(mapAccess: ReadWriteExecute, viewAccess: ReadExecute) [SKIP]
      Execute permission failing in container.
  Finished:    System.IO.MemoryMappedFiles.Tests
=== TEST EXECUTION SUMMARY ===
   System.IO.MemoryMappedFiles.Tests  Total: 345, Errors: 0, Failed: 0, Skipped: 4, Time: 5.316s
``` 

