### PR TITLE
Fix corefx official builds

### DIFF
--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -7,7 +7,6 @@ jobs:
   - template: ../common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true
-      enablePublishBuildArtifacts: true
       jobs:
       - job: PublishPackages
         displayName: Publish Packages
@@ -56,6 +55,7 @@ jobs:
           - script: build.cmd
                     -restore
                     -sign
+                    -ci
                     /p:DotNetSignType=$(_SignType)
                     /p:OfficialBuildId=$(Build.BuildNumber)
             displayName: Sign packages
@@ -141,7 +141,7 @@ jobs:
               artifactName: packages
               downloadPath: ${{ parameters.artifactsDir }}
 
-          - script: build.cmd -restore
+          - script: build.cmd -restore -ci
             displayName: Restore Tools
 
           - script: powershell -ExecutionPolicy ByPass -NoProfile eng\common\msbuild.ps1 eng\publish.proj


### PR DESCRIPTION
Fixes: #36248 
This was causing arcade to be restored to the user's NuGet cache, which caused Maestro's task to fail, due to try to run a `git` command setting working directory to: `Environment.CurrentDirectory` which points to arcade restored location. When we restore with `-ci` flag the restore directory is under the repository, so the `git` command won't fail because we're within a repository. 

This was fixed in Maestro to not depend on that: https://github.com/dotnet/arcade-services/pull/274 but let's add this switch to be more resilient.

@tmat I think we should have some sort of validation that ci is set to true when one of the azure devops env vars is set, or at least emit a warning, it is super fragile, that forgetting a build flag, causes really weird issues.

cc: @ericstj @jcagme @danmosemsft @ViktorHofer 