### PR TITLE
Fix: TraceId is not available before Activity starts

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -510,8 +510,7 @@ namespace System.Diagnostics
                         }
                         catch
                         {
-                            // ActivityTraceId.CreateFromString(_parentId.AsSpan(3, 32) 
-                            // throws if parent is invalid W3C Id
+                            // ActivityTraceId.CreateFromString throws if parent is invalid W3C Id
                         }
                     }
                 }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -736,6 +736,9 @@ namespace System.Diagnostics
             return canSet;
         }
 
+#if ALLOW_PARTIALLY_TRUSTED_CALLERS
+        [SecuritySafeCritical]
+#endif
         private bool TrySetTraceIdFromParent()
         {
             Debug.Assert(!_traceIdSet);

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -496,24 +496,9 @@ namespace System.Diagnostics
             {
                 if (!_traceIdSet)
                 {
-                    if (_id != null && IdFormat == ActivityIdFormat.W3C)
-                    {
-                        _traceId = ActivityTraceId.CreateFromString(_id.AsSpan(3, 32));
-                        _traceIdSet = true;
-                    }
-                    else if (_parentId != null && IsW3CId(_parentId))
-                    {
-                        try
-                        {
-                            _traceId = ActivityTraceId.CreateFromString(_parentId.AsSpan(3, 32));
-                            _traceIdSet = true;
-                        }
-                        catch
-                        {
-                            // ActivityTraceId.CreateFromString throws if parent is invalid W3C Id
-                        }
-                    }
+                    TrySetTraceIdFromParent();
                 }
+
                 return ref _traceId;
             }
         }
@@ -617,27 +602,11 @@ namespace System.Diagnostics
             // Get the TraceId from the parent or make a new one.  
             if (!_traceIdSet)
             {
-                if (Parent != null && Parent.IdFormat == ActivityIdFormat.W3C)
-                {
-                    _traceId = Parent.TraceId;
-                }
-                else if (_parentId != null && IsW3CId(_parentId))
-                {
-                    try
-                    {
-                        _traceId = ActivityTraceId.CreateFromString(_parentId.AsSpan(3, 32));
-                    }
-                    catch
-                    {
-                        _traceId = ActivityTraceId.CreateRandom();
-                    }
-                }
-                else
+                if (!TrySetTraceIdFromParent())
                 {
                     _traceId = ActivityTraceId.CreateRandom();
+                    _traceIdSet = true;
                 }
-
-                _traceIdSet = true;
             }
             // Create a new SpanID. 
             _spanId = ActivitySpanId.CreateRandom();
@@ -765,6 +734,30 @@ namespace System.Diagnostics
             }
 
             return canSet;
+        }
+
+        private bool TrySetTraceIdFromParent()
+        {
+            Debug.Assert(!_traceIdSet);
+
+            if (Parent != null && Parent.IdFormat == ActivityIdFormat.W3C)
+            {
+                _traceId = Parent.TraceId;
+                _traceIdSet = true;
+            }
+            else if (_parentId != null && IsW3CId(_parentId))
+            {
+                try
+                {
+                    _traceId = ActivityTraceId.CreateFromString(_parentId.AsSpan(3, 32));
+                    _traceIdSet = true;
+                }
+                catch
+                {
+                }
+            }
+
+            return _traceIdSet;
         }
 
         private string _rootId;

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -501,6 +501,19 @@ namespace System.Diagnostics
                         _traceId = ActivityTraceId.CreateFromString(_id.AsSpan(3, 32));
                         _traceIdSet = true;
                     }
+                    else if (_parentId != null && IsW3CId(_parentId))
+                    {
+                        try
+                        {
+                            _traceId = ActivityTraceId.CreateFromString(_parentId.AsSpan(3, 32));
+                            _traceIdSet = true;
+                        }
+                        catch
+                        {
+                            // ActivityTraceId.CreateFromString(_parentId.AsSpan(3, 32) 
+                            // throws if parent is invalid W3C Id
+                        }
+                    }
                 }
                 return ref _traceId;
             }

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -631,10 +631,21 @@ namespace System.Diagnostics.Tests
 
                 Assert.Equal("0123456789abcdef0123456789abcdef", activity.TraceId.ToHexString());
 
+                // from in-proc parent
+                Activity parent = new Activity("parent");
+                parent.SetParentId("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
+                parent.Start();
+
+                activity = new Activity("child");
+                activity.Start();
+                Assert.Equal("0123456789abcdef0123456789abcdef", activity.TraceId.ToHexString());
+                parent.Stop();
+                activity.Stop();
+
+                // no parent
                 Activity.DefaultIdFormat = ActivityIdFormat.W3C;
                 Activity.ForceDefaultIdFormat = true;
 
-                // no parent
                 activity = new Activity("activity3");
                 Assert.Equal("00000000000000000000000000000000", activity.TraceId.ToHexString());
 

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -263,7 +263,6 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void RootId()
         {
-
             var parentIds = new[]{
                 "123",   //Parent does not start with '|' and does not contain '.'
                 "123.1", //Parent does not start with '|' but contains '.'
@@ -610,6 +609,53 @@ namespace System.Diagnostics.Tests
                 Activity.DefaultIdFormat = ActivityIdFormat.Hierarchical;
                 Activity.Current = null;
             }
+        }
+
+        [Fact]
+        public void TraceIdBeforeStartTests()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+
+            try
+            {
+                Activity activity;
+
+                activity = new Activity("activity1");
+                Assert.Equal("00000000000000000000000000000000", activity.TraceId.ToHexString());
+
+                // from traceparent header
+                activity.SetParentId("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
+                Assert.Equal("0123456789abcdef0123456789abcdef", activity.TraceId.ToHexString());
+
+                // from explicit TraceId and SpanId
+                activity = new Activity("activity2");
+                activity.SetParentId(
+                    ActivityTraceId.CreateFromString("0123456789abcdef0123456789abcdef".AsSpan()),
+                    ActivitySpanId.CreateFromString("0123456789abcdef".AsSpan()));
+
+                Assert.Equal("0123456789abcdef0123456789abcdef", activity.TraceId.ToHexString());
+
+                // from invalid traceparent header
+                activity = new Activity("activity3");
+                activity.SetParentId("123");
+                Assert.Equal("00000000000000000000000000000000", activity.TraceId.ToHexString());
+            }
+            finally
+            {
+                Activity.ForceDefaultIdFormat = false;
+                Activity.DefaultIdFormat = ActivityIdFormat.Hierarchical;
+                Activity.Current = null;
+            }
+        }
+
+        [Fact]
+        public void RootIdBeforeStartTests()
+        {
+            Activity activity = new Activity("activity1");
+            Assert.Null(activity.RootId);
+            activity.SetParentId("|0123456789abcdef0123456789abcdef.0123456789abcdef.");
+            Assert.Equal("0123456789abcdef0123456789abcdef", activity.RootId);
         }
 
         /// <summary>

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -614,17 +614,12 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void TraceIdBeforeStartTests()
         {
-            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-            Activity.ForceDefaultIdFormat = true;
-
             try
             {
                 Activity activity;
 
-                activity = new Activity("activity1");
-                Assert.Equal("00000000000000000000000000000000", activity.TraceId.ToHexString());
-
                 // from traceparent header
+                activity = new Activity("activity1");
                 activity.SetParentId("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
                 Assert.Equal("0123456789abcdef0123456789abcdef", activity.TraceId.ToHexString());
 
@@ -636,8 +631,14 @@ namespace System.Diagnostics.Tests
 
                 Assert.Equal("0123456789abcdef0123456789abcdef", activity.TraceId.ToHexString());
 
-                // from invalid traceparent header
+                Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+                Activity.ForceDefaultIdFormat = true;
+
+                // no parent
                 activity = new Activity("activity3");
+                Assert.Equal("00000000000000000000000000000000", activity.TraceId.ToHexString());
+
+                // from invalid traceparent header
                 activity.SetParentId("123");
                 Assert.Equal("00000000000000000000000000000000", activity.TraceId.ToHexString());
             }


### PR DESCRIPTION
In W3C distributed tracing TraceId is a unique identifier of the whole transaction: all Activities created to trace it, share the same trace id.

Tracing systems may use trace id to apply sampling consistent across multiple services. Sampling decision should be made as early as possible and even before Activity starts. 

Web framework (ASP.NET Core) reads traceparent header (with trace-id and other identifiers) and creates a new Activity. Then sends callback `OnActivityImport` (#36340) to the tracing system. Then tracing system decides whether Activity is sampled in or not (based on sampling bit, trace Id).
Only after that Activity starts.

This change lazily parses traceId when it is set with `Activity.SetParentId(string)` but Activity is not started yet to support above scenario.