### PR TITLE
[release/1.0.0] Remove unused variable from the `RemoveRange` method of `List<T>` class

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/List.cs
+++ b/src/System.Collections/src/System/Collections/Generic/List.cs
@@ -1009,7 +1009,6 @@ namespace System.Collections.Generic
 
             if (count > 0)
             {
-                int i = _size;
                 _size -= count;
                 if (index < _size)
                 {


### PR DESCRIPTION
The `i` variable in the `RemoveRange` method of `System.Collections.Generic.List<T>` class is declared, but not used, so it can be removed.