### PR TITLE
Add DateTimeOffset converter to JsonSerializer

### DIFF
--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -51,6 +51,7 @@
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterByte.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterChar.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterDateTime.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterDateTimeOffset.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterDecimal.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterDouble.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterEnum.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultConverters.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultConverters.cs
@@ -53,6 +53,12 @@ namespace System.Text.Json.Serialization.Converters
                 case TypeCode.String:
                     return new JsonValueConverterString();
             }
+
+            if (type == typeof(DateTimeOffset))
+            {
+                return new JsonValueConverterDateTimeOffset();
+            }
+
             return null;
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTimeOffset.cs
@@ -6,19 +6,19 @@ using System.Text.Json.Serialization.Policies;
 
 namespace System.Text.Json.Serialization.Converters
 {
-    internal sealed class JsonValueConverterDateTime : JsonValueConverter<DateTime>
+    internal sealed class JsonValueConverterDateTimeOffset : JsonValueConverter<DateTimeOffset>
     {
-        public override bool TryRead(Type valueType, ref Utf8JsonReader reader, out DateTime value)
+        public override bool TryRead(Type valueType, ref Utf8JsonReader reader, out DateTimeOffset value)
         {
-            return reader.TryGetDateTime(out value);
+            return reader.TryGetDateTimeOffset(out value);
         }
 
-        public override void Write(DateTime value, ref Utf8JsonWriter writer)
+        public override void Write(DateTimeOffset value, ref Utf8JsonWriter writer)
         {
             writer.WriteStringValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, DateTime value, ref Utf8JsonWriter writer)
+        public override void Write(Span<byte> escapedPropertyName, DateTimeOffset value, ref Utf8JsonWriter writer)
         {
             writer.WriteString(escapedPropertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -225,7 +225,7 @@ namespace System.Text.Json.Serialization
             }
 
             // A Type is considered a value if it implements IConvertible.
-            if (typeof(IConvertible).IsAssignableFrom(type))
+            if (typeof(IConvertible).IsAssignableFrom(type) || type == typeof(DateTimeOffset))
             {
                 return ClassType.Value;
             }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.cs
@@ -37,6 +37,7 @@ namespace System.Text.Json.Serialization.Tests
         public float MySingle { get; set; }
         public double MyDouble { get; set; }
         public DateTime MyDateTime { get; set; }
+        public DateTimeOffset MyDateTimeOffset { get; set; }
         public SampleEnum MyEnum { get; set; }
         public short[] MyInt16Array { get; set; }
         public int[] MyInt32Array { get; set; }
@@ -54,6 +55,7 @@ namespace System.Text.Json.Serialization.Tests
         public float[] MySingleArray { get; set; }
         public double[] MyDoubleArray { get; set; }
         public DateTime[] MyDateTimeArray { get; set; }
+        public DateTimeOffset[] MyDateTimeOffsetArray { get; set; }
         public SampleEnum[] MyEnumArray { get; set; }
 
         public static readonly string s_json =
@@ -74,6 +76,7 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyDouble"" : 2.2," +
                 @"""MyDecimal"" : 3.3," +
                 @"""MyDateTime"" : ""2019-01-30T12:01:02.0000000Z""," +
+                @"""MyDateTimeOffset"" : ""2019-01-30T12:01:02.0000000+01:00""," +
                 @"""MyEnum"" : 2," + // int by default
                 @"""MyInt16Array"" : [1]," +
                 @"""MyInt32Array"" : [2]," +
@@ -91,6 +94,7 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyDoubleArray"" : [2.2]," +
                 @"""MyDecimalArray"" : [3.3]," +
                 @"""MyDateTimeArray"" : [""2019-01-30T12:01:02.0000000Z""]," +
+                @"""MyDateTimeOffsetArray"" : [""2019-01-30T12:01:02.0000000+01:00""]," +
                 @"""MyEnumArray"" : [2]" + // int by default
                 @"}";
 
@@ -114,6 +118,7 @@ namespace System.Text.Json.Serialization.Tests
             MyDouble = 2.2d;
             MyDecimal = 3.3m;
             MyDateTime = new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc);
+            MyDateTimeOffset = new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0));
             MyEnum = SampleEnum.Two;
 
             MyInt16Array = new short[] { 1 };
@@ -132,6 +137,7 @@ namespace System.Text.Json.Serialization.Tests
             MyDoubleArray = new double[] { 2.2d };
             MyDecimalArray = new decimal[] { 3.3m };
             MyDateTimeArray = new DateTime[] { new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc) };
+            MyDateTimeOffsetArray = new DateTimeOffset[] { new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)) };
             MyEnumArray = new SampleEnum[] { SampleEnum.Two };
         }
 
@@ -153,6 +159,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(1.1f, MySingle);
             Assert.Equal(2.2d, MyDouble);
             Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc), MyDateTime);
+            Assert.Equal(new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)), MyDateTimeOffset);
             Assert.Equal(SampleEnum.Two, MyEnum);
 
             Assert.Equal((short)1, MyInt16Array[0]);
@@ -171,6 +178,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(1.1f, MySingleArray[0]);
             Assert.Equal(2.2d, MyDoubleArray[0]);
             Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc), MyDateTimeArray[0]);
+            Assert.Equal(new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)), MyDateTimeOffsetArray[0]);
             Assert.Equal(SampleEnum.Two, MyEnumArray[0]);
         }
     }
@@ -192,6 +200,7 @@ namespace System.Text.Json.Serialization.Tests
         public float? MySingle { get; set; }
         public double? MyDouble { get; set; }
         public DateTime? MyDateTime { get; set; }
+        public DateTimeOffset? MyDateTimeOffset { get; set; }
         public SampleEnum? MyEnum { get; set; }
     }
 
@@ -218,6 +227,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Null(MySingle);
             Assert.Null(MyDouble);
             Assert.Null(MyDateTime);
+            Assert.Null(MyDateTimeOffset);
             Assert.Null(MyEnum);
         }
         public static readonly string s_json =
@@ -237,6 +247,7 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyDouble"" : null," +
                 @"""MyDecimal"" : null," +
                 @"""MyDateTime"" : null," +
+                @"""MyDateTimeOffset"" : null," +
                 @"""MyEnum"" : null" +
                 @"}";
 
@@ -262,6 +273,7 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyDouble"" : 2.2," +
                 @"""MyDecimal"" : 3.3," +
                 @"""MyDateTime"" : ""2019-01-30T12:01:02.0000000Z""," +
+                @"""MyDateTimeOffset"" : ""2019-01-30T12:01:02.0000000+01:00""," +
                 @"""MyEnum"" : 2" + // int by default
                 @"}";
 
@@ -284,6 +296,7 @@ namespace System.Text.Json.Serialization.Tests
             MyDouble = 2.2d;
             MyDecimal = 3.3m;
             MyDateTime = new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc);
+            MyDateTimeOffset = new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0));
             MyEnum = SampleEnum.Two;
         }
 
@@ -304,6 +317,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(MySingle, 1.1f);
             Assert.Equal(MyDouble, 2.2d);
             Assert.Equal(MyDateTime, new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc));
+            Assert.Equal(MyDateTimeOffset, new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)));
             Assert.Equal(MyEnum, SampleEnum.Two);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -201,79 +201,49 @@ namespace System.Text.Json.Serialization.Tests
             string unexpectedString = @"""unexpected string""";
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<byte>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<byte>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<byte?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<byte?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<sbyte>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<sbyte>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<sbyte?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<sbyte?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<short>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<short>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<short?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<short?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<ushort>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<ushort>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<ushort?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<ushort?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<float>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<float>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<float?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<float?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<int>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<int>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<int?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<int?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<uint>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<uint>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<uint?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<uint?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<long>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<long>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<long?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<long?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<ulong>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<ulong>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<ulong?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<ulong?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<decimal>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<decimal>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<decimal?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<decimal?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<double>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<double>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<double?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<double?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTime>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTime>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTime?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTime?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTimeOffset>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTimeOffset>(unexpectedString));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTimeOffset?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTimeOffset?>(unexpectedString));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<string>("1"));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<string>("1"));
 
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<char>("1"));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<char>("1"));
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<char?>("1"));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<char?>("1"));
 
-            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<Enum>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<Enum>(unexpectedString));
         }
 

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -260,6 +260,11 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTime?>(unexpectedString));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTime?>(unexpectedString));
 
+            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTimeOffset>(unexpectedString));
+            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTimeOffset>(unexpectedString));
+            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTimeOffset?>(unexpectedString));
+            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<DateTimeOffset?>(unexpectedString));
+
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<string>("1"));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<string>("1"));
 


### PR DESCRIPTION
Also, use reader/writer parsing/formatting methods for DateTime(Offset) converters.

This partially addresses https://github.com/dotnet/corefx/issues/36023.