### PR TITLE
32bit process may not throw on negative allocation

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -48,6 +48,7 @@ namespace System
         public static bool IsArm64Process { get { throw null; } }
         public static bool IsArmOrArm64Process { get { throw null; } }
         public static bool IsArmProcess { get { throw null; } }
+        public static bool Is32BitProcess { get { throw null; } }
         public static bool IsCentos6 { get { throw null; } }
         public static bool IsDebian { get { throw null; } }
         public static bool IsDebian8 { get { throw null; } }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
@@ -40,6 +40,7 @@ namespace System
         public static bool IsNotArmNorArm64Process => !IsArmOrArm64Process;
         public static bool IsArgIteratorSupported => IsWindows && IsNotArmProcess;
         public static bool IsArgIteratorNotSupported => !IsArgIteratorSupported;
+        public static bool Is32BitProcess => IntPtr.Size == 4;
 
         public static bool IsNotInAppContainer => !IsInAppContainer;
         public static bool IsWinRTSupported => IsWindows && !IsWindows7;

--- a/src/System.Drawing.Common/tests/Imaging/EncoderParameterTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/EncoderParameterTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Drawing.Imaging.Tests
@@ -316,10 +317,13 @@ namespace System.Drawing.Imaging.Tests
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(-1)]
         [InlineData(int.MinValue)]
+        // This test may depend on amount of RAM and system configuration and load.
         public void Ctor_Encoder_NegativeNumberOfValues_Type_Value_OutOfMemoryException(int numberOfValues)
         {
-            if (numberOfValues == -1 && PlatformDetection.IsUbuntu1710OrHigher) // [ActiveIssue(24274)]
-                return;
+            if (PlatformDetection.Is32BitProcess)
+            {
+                throw new SkipTestException("backwards compatibility on 32 bit platforms may not throw");
+            }
 
             IntPtr anyValue = IntPtr.Zero;
             EncoderParameterValueType anyTypw = EncoderParameterValueType.ValueTypeAscii;


### PR DESCRIPTION
According to @jkotas there is compat layer in coreclr where we cast negative numbers to uint and pass them to os. That turns this test to attempt to allocate 2G (or 4G for -1) 
That may or may not throw OutOfMemoryException.

I also tested on Ubuntu18 and I did not see any problems so I removed the condition.
fixes #24274 

