### PR TITLE
Workaround for official builds until BAR is fixed

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -12,7 +12,7 @@ Param(
 
 $ci = $true
 $binaryLog = $true
-$warnAsError = $true
+$warnAsError = $false
 
 . $PSScriptRoot\tools.ps1
 


### PR DESCRIPTION
Official builds are still failing, we haven't been able to publish assets in the past 10 days or so.
This is temporary until we consume https://github.com/dotnet/arcade-services/pull/282 fix. Which usually takes around a day or two to get to corefx.

cc: @jcagme @ViktorHofer @ericstj 