### PR TITLE
ensuring that calling GetPart will call GetPartCore

### DIFF
--- a/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
@@ -1135,7 +1135,23 @@ namespace System.IO.Packaging
             if (_partList.ContainsKey(validatePartUri))
                 return _partList[validatePartUri];
             else
-                return null;
+            {
+                //Ideally we should decide whether we should query the underlying layer for the part based on the
+                //FileShare enum. But since we do not have that information, currently the design is to always
+                //ask the underlying layer, this allows for incremental access to the package.
+                //Note:
+                //Currently this incremental behavior for GetPart is not consistent with the GetParts method
+                //which just queries the underlying layer once.
+                PackagePart returnedPart = GetPartCore(validatePartUri);
+
+                if (returnedPart != null)
+                {
+                    // Add the part to the _partList if there is no prefix collision
+                    AddIfNoPrefixCollisionDetected(validatePartUri, returnedPart);
+                }
+
+                return returnedPart;
+            }
         }
 
         /// <summary>

--- a/src/System.IO.Packaging/tests/Tests.cs
+++ b/src/System.IO.Packaging/tests/Tests.cs
@@ -3757,15 +3757,15 @@ namespace System.IO.Packaging.Tests
         }
 
         [Fact]
-        public void SupportNonPartEnumerableDerivedPackageTypes()
+        public void GetPartCallsGetPartCore()
         {
             // Package is an abstract class that others can derive from. Those derived classes can override GetPartsCore and potentially not
             // return anything. Furthermore, it is not guaranteed that GetPartsCore will have been called if the package wasn't created using
             // the Package.Open API, which only ensures that ZipPackage's internal data structures are filled in.
-            var mockPackage = new NonEnumerablePackage();
+            NonEnumerablePackage mockPackage = new NonEnumerablePackage();
 
-            var partUri = new Uri("/idontexist.xml", UriKind.Relative);
-            var part = mockPackage.GetPart(partUri);
+            Uri partUri = new Uri("/idontexist.xml", UriKind.Relative);
+            PackagePart part = mockPackage.GetPart(partUri);
 
             Assert.NotNull(part);
             Assert.Equal(part.Uri, partUri);

--- a/src/System.IO.Packaging/tests/Tests.cs
+++ b/src/System.IO.Packaging/tests/Tests.cs
@@ -3770,6 +3770,9 @@ namespace System.IO.Packaging.Tests
             Assert.NotNull(part);
             Assert.Equal(part.Uri, partUri);
             Assert.IsType(typeof(MockPackagePart), part);
+
+            // Validate we get the same object back if we call GetPart again
+            Assert.Same(part, mockPackage.GetPart(partUri));
         }
 
         private const string DocumentRelationshipType = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";


### PR DESCRIPTION
Package is an abstract class that others can derive from. Those derived classes can override GetPartsCore and potentially not return anything. Furthermore, it is not guaranteed that GetPartsCore will have been called if the package wasn't created using the Package.Open API, which only ensures that ZipPackage's internal data structures are filled in.

This PR adds back the call to the protected virtual method GetPartCore if the part doesn't exist in the cache, adds it, and then returns it to the caller

Fixes ##36388