### PR TITLE
HTTP2: Don't send RST_STREAM in response to window update on closed stream

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -558,8 +558,7 @@ namespace System.Net.Http
                 Http2Stream http2Stream = GetStream(frameHeader.StreamId);
                 if (http2Stream == null)
                 {
-                    // Don't wait for completion, which could happen asynchronously.
-                    Task ignored = SendRstStreamAsync(frameHeader.StreamId, Http2ProtocolErrorCode.StreamClosed);
+                    // Ignore invalid stream ID, as per RFC
                     return;
                 }
 


### PR DESCRIPTION
From the spec:
> "Endpoints MUST ignore
WINDOW_UPDATE or RST_STREAM frames received in this state, though
endpoints MAY choose to treat frames that arrive a significant
time after sending END_STREAM as a connection error
(Section 5.4.1) of type PROTOCOL_ERROR."

Fixes: #35648