### PR TITLE
Fix Korean Calendar Test

### DIFF
--- a/src/System.Globalization.Calendars/tests/KoreanCalendar/KoreanCalendarTwoDigitYearMax.cs
+++ b/src/System.Globalization.Calendars/tests/KoreanCalendar/KoreanCalendarTwoDigitYearMax.cs
@@ -13,8 +13,6 @@ namespace System.Globalization.Tests
         {
             var calendar = new KoreanCalendar();
             Assert.True(calendar.TwoDigitYearMax == 4362 || calendar.TwoDigitYearMax == 4382, $"Unexpected calendar.TwoDigitYearMax {calendar.TwoDigitYearMax}");
-
-            Assert.Equal(4362, new KoreanCalendar().TwoDigitYearMax);
         }
 
         [Theory]


### PR DESCRIPTION
Removing the wrong and redundant test line from the Korean Calendar tests.

Fixes #36422