### PR TITLE
increase max test duration from 10 to 15 minutes

### DIFF
--- a/eng/sendtohelix.proj
+++ b/eng/sendtohelix.proj
@@ -10,7 +10,7 @@
     <HelixBuild Condition="'$(HelixBuild)' == ''">$(BUILD_BUILDNUMBER)</HelixBuild>
     <HelixBuild Condition="'$(HelixBuild)' == ''">default</HelixBuild>
 
-    <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">600</TimeoutInSeconds>
+    <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">900</TimeoutInSeconds>
     <_timeoutSpan>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</_timeoutSpan>
     
     <!-- We need to enable xunit reporter so that it parses test results


### PR DESCRIPTION
I did test runs with Linq.Parallel and it was typically finishing between 9:20 - 9:50. 
I was thinking about bumping this only for ARM platforms but we do occasionally see timeouts on Nano and Windows 7. There should be no harm to normal runs. If there is true hanging test we will just know 5 minutes later. Since that is rare now, it seems like good compromise. 
Was also originally about doubling this number but I decided to add 50% for now and watch test results for a while. 

In ideal case, we would be able to set this per test set and perhaps architecture. Helix supports timeout per work item but corefx build currently has no way how to handle it. 