### PR TITLE
Add test for string.Concat(object) that ToString returns null

### DIFF
--- a/src/Common/tests/Tests/System/StringTests.cs
+++ b/src/Common/tests/Tests/System/StringTests.cs
@@ -371,8 +371,6 @@ namespace System.Tests
 
             yield return new object[] { new object[] { 1 }, "1" };
             yield return new object[] { new object[] { null }, "" };
-            // dotnet/coreclr#6785, this will be null for the Concat(object) overload but "" for the object[]/IEnumerable<object> overload
-            // yield return new object[] { new object[] { new ObjectWithNullToString() }, "" };
 
             yield return new object[] { new object[] { 1, 2 }, "12" };
             yield return new object[] { new object[] { null, 1 }, "1" };
@@ -399,6 +397,11 @@ namespace System.Tests
 
             // Concat should ignore objects that have a null ToString() value
             yield return new object[] { new object[] { new ObjectWithNullToString(), "Foo", new ObjectWithNullToString(), "Bar", new ObjectWithNullToString() }, "FooBar" };
+
+            if (!PlatformDetection.IsFullFramework)
+            {
+                yield return new object[] { new object[] { new ObjectWithNullToString() }, "" };
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Depends on: https://github.com/dotnet/coreclr/pull/23510 to make it to corefx from coreclr and corert.

cc: @jkotas 