### PR TITLE
Read data from /proc/[pid]/status in addition to /proc/[pid]/stat

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -29,11 +29,11 @@ namespace System.Diagnostics
             var processes = new List<Process>();
             foreach (int pid in ProcessManager.EnumerateProcessIds())
             {
-                Interop.procfs.ParsedStat parsedStat;
-                if (Interop.procfs.TryReadStatFile(pid, out parsedStat, reusableReader) &&
-                    string.Equals(processName, parsedStat.comm, StringComparison.OrdinalIgnoreCase))
+                if (Interop.procfs.TryReadStatFile(pid, out Interop.procfs.ParsedStat parsedStat, reusableReader) &&
+                    string.Equals(processName, parsedStat.comm, StringComparison.OrdinalIgnoreCase) &&
+                    Interop.procfs.TryReadStatusFile(pid, out Interop.procfs.ParsedStatus parsedStatus, reusableReader))
                 {
-                    ProcessInfo processInfo = ProcessManager.CreateProcessInfo(parsedStat, reusableReader);
+                    ProcessInfo processInfo = ProcessManager.CreateProcessInfo(parsedStat, parsedStatus, reusableReader);
                     processes.Add(new Process(machineName, false, processInfo.ProcessId, processInfo));
                 }
             }


### PR DESCRIPTION
This file contains some more information, especially regarding the memory consumption. This adds or improve support for:
 - `Process.PeakWorkingSet64`
 - `Process.PrivateMemorySize64`
 - `Process.PagedMemorySize64`
 - `Process.PagedSystemMemorySize64`
 - `Process.PeakVirtualMemorySize64`
 - `Process.WorkingSet64`
 - `Process.VirtualMemorySize64`

Fixes https://github.com/dotnet/corefx/issues/36086 https://github.com/dotnet/corefx/issues/23449