### PR TITLE
Increase timeout for 2 socket option name tests

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -54,7 +54,7 @@ namespace System.Net.Sockets.Tests
             // TODO #5185: Harden against packet loss
             const int DatagramSize = 256;
             const int DatagramsToSend = 256;
-            const int AckTimeout = 5000;
+            const int AckTimeout = 10000;
             const int TestTimeout = 30000;
 
             var left = new Socket(leftAddress.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
@@ -1238,7 +1238,7 @@ namespace System.Net.Sockets.Tests
             // TODO #5185: harden against packet loss
             const int DatagramSize = 256;
             const int DatagramsToSend = 256;
-            const int AckTimeout = 10000;
+            const int AckTimeout = 20000;
             const int TestTimeout = 60000;
 
             using (var left = new UdpClient(new IPEndPoint(leftAddress, 0)))

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -128,7 +128,7 @@ namespace System.Net.Sockets.Tests
                 }
 
                 var cts = new CancellationTokenSource();
-                Assert.True(await Task.WhenAny(receiveTask, Task.Delay(20_000, cts.Token)) == receiveTask, "Waiting for received data timed out");
+                Assert.True(await Task.WhenAny(receiveTask, Task.Delay(30_000, cts.Token)) == receiveTask, "Waiting for received data timed out");
                 cts.Cancel();
 
                 int bytesReceived = await receiveTask;
@@ -245,7 +245,7 @@ namespace System.Net.Sockets.Tests
                 }
 
                 var cts = new CancellationTokenSource();
-                Assert.True(await Task.WhenAny(receiveTask, Task.Delay(20_000, cts.Token)) == receiveTask, "Waiting for received data timed out");
+                Assert.True(await Task.WhenAny(receiveTask, Task.Delay(30_000, cts.Token)) == receiveTask, "Waiting for received data timed out");
                 cts.Cancel();
 
                 int bytesReceived = await receiveTask;


### PR DESCRIPTION
These two time out on UWP F5 runs about 4-5 times a week for some time. Changing 20 sec to 30 sec timeout to see whether that helps.

https://mc.dot.net/#/product/netcore/30/source/official~2Fdotnet~2Fcorefx~2Frefs~2Fheads~2Fmaster/type/test~2Ffunctional~2Fuwp~2F/build/20190328.7/workItem/System.Net.Sockets.Tests/analysis/xunit/System.Net.Sockets.Tests.SocketOptionNameTest~2FMulticastInterface_Set_AnyInterface_Succeeds

https://mc.dot.net/#/product/netcore/30/source/official~2Fdotnet~2Fcorefx~2Frefs~2Fheads~2Fmaster/type/test~2Ffunctional~2Fuwp~2F/build/20190328.7/workItem/System.Net.Sockets.Tests/analysis/xunit/System.Net.Sockets.Tests.SocketOptionNameTest~2FMulticastInterface_Set_IPv6_AnyInterface_Succeeds

cc @wfurt 