### PR TITLE
Add polymorphic serialization support for typeof(object)

### DIFF
--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -67,9 +67,9 @@
     <Compile Include="System\Text\Json\Serialization\JsonClassInfo.AddProperty.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonEnumerableConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPropertyInfo.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonPropertyInfoCommon.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPropertyInfoNotNullable.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPropertyInfoNullable.cs" />
-    <Compile Include="System\Text\Json\Serialization\JsonPropertyInfoOfTClassTPropertyTUnderlying.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.HandleArray.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.Stream.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.HandleValue.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace System.Text.Json.Serialization
@@ -11,32 +12,7 @@ namespace System.Text.Json.Serialization
     {
         private void AddProperty(Type propertyType, PropertyInfo propertyInfo, Type classType, JsonSerializerOptions options)
         {
-            Type collectionElementType = null;
-            ClassType propertyClassType = GetClassType(propertyType);
-            if (propertyClassType == ClassType.Enumerable)
-            {
-                collectionElementType = GetElementType(propertyType);
-                // todo: if collectionElementType is object, create loosely-typed collection (JsonArray).
-            }
-
-            // Create the JsonPropertyInfo<TType, TProperty>
-            Type genericPropertyType;
-            if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
-            {
-                Type underlyingPropertyType = Nullable.GetUnderlyingType(propertyType);
-                genericPropertyType = typeof(JsonPropertyInfoNullable<,>).MakeGenericType(classType, underlyingPropertyType);
-            }
-            else
-            {
-                genericPropertyType = typeof(JsonPropertyInfoNotNullable<,>).MakeGenericType(classType, propertyType);
-            }
-            
-            JsonPropertyInfo jsonInfo = (JsonPropertyInfo)Activator.CreateInstance(
-                genericPropertyType,
-                BindingFlags.Instance | BindingFlags.NonPublic,
-                binder: null,
-                new object[] { classType, propertyType, propertyInfo, collectionElementType, options },
-                culture: null);
+            JsonPropertyInfo jsonInfo = CreateProperty(propertyType, propertyType, propertyInfo, classType, options);
 
             if (propertyInfo != null)
             {
@@ -63,7 +39,8 @@ namespace System.Text.Json.Serialization
                     tempArray.CopyTo(jsonInfo._escapedName, 0);
 
                     // We clear the array because it is "user data" (although a property name).
-                    ArrayPool<byte>.Shared.Return(tempArray, clearArray: true);
+                    new Span<byte>(tempArray, 0, written).Clear();
+                    ArrayPool<byte>.Shared.Return(tempArray);
                 }
 
                 _property_refs.Add(new PropertyRef(GetKey(propertyNameBytes), jsonInfo));
@@ -73,6 +50,53 @@ namespace System.Text.Json.Serialization
                 // A single property or an IEnumerable
                 _property_refs.Add(new PropertyRef(0, jsonInfo));
             }
+        }
+
+        internal JsonPropertyInfo CreateProperty(Type declaredPropertyType, Type runtimePropertyType, PropertyInfo propertyInfo, Type parentClassType, JsonSerializerOptions options)
+        {
+            Type collectionElementType = null;
+            ClassType propertyClassType = GetClassType(runtimePropertyType);
+            if (propertyClassType == ClassType.Enumerable)
+            {
+                collectionElementType = GetElementType(runtimePropertyType);
+                // todo: if collectionElementType is object, create loosely-typed collection (JsonArray).
+            }
+
+            // Create the JsonPropertyInfo<TType, TProperty>
+            Type propertyInfoClassType;
+            if (runtimePropertyType.IsGenericType && runtimePropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                Type underlyingPropertyType = Nullable.GetUnderlyingType(runtimePropertyType);
+                propertyInfoClassType = typeof(JsonPropertyInfoNullable<,>).MakeGenericType(parentClassType, underlyingPropertyType);
+            }
+            else
+            {
+                // For now we only support polymorphism with base type == typeof(object).
+                Debug.Assert(declaredPropertyType == runtimePropertyType || declaredPropertyType == typeof(object));
+                propertyInfoClassType = typeof(JsonPropertyInfoNotNullable<,,>).MakeGenericType(parentClassType, declaredPropertyType, runtimePropertyType);
+            }
+
+            JsonPropertyInfo jsonInfo = (JsonPropertyInfo)Activator.CreateInstance(
+                propertyInfoClassType,
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                new object[] { parentClassType, declaredPropertyType, runtimePropertyType, propertyInfo, collectionElementType, options },
+                culture: null);
+
+            return jsonInfo;
+        }
+
+        internal JsonPropertyInfo CreatePolymorphicProperty(JsonPropertyInfo property, Type runtimePropertyType, JsonSerializerOptions options)
+        {
+            // For now we only support typeof(object) for polymorphism.
+            Debug.Assert(property?.DeclaredPropertyType == typeof(object));
+            Debug.Assert(runtimePropertyType != typeof(object));
+
+            JsonPropertyInfo runtimeProperty = CreateProperty(property.DeclaredPropertyType, runtimePropertyType, property?.PropertyInfo, Type, options);
+            runtimeProperty._name = property._name;
+            runtimeProperty._escapedName = property._escapedName;
+
+            return runtimeProperty;
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
@@ -10,14 +10,21 @@ namespace System.Text.Json.Serialization
     /// <summary>
     /// Represents a strongly-typed property that is a <see cref="Nullable{T}"/>.
     /// </summary>
-    internal sealed class JsonPropertyInfoNullable<TClass, TProperty> : JsonPropertyInfo<TClass, TProperty?, TProperty>
+    internal sealed class JsonPropertyInfoNullable<TClass, TProperty> 
+        : JsonPropertyInfoCommon<TClass, TProperty?, TProperty>
         where TProperty : struct
     {
         // should this be cached somewhere else so that it's not populated per TClass as well as TProperty?
         private static readonly Type s_underlyingType = typeof(TProperty);
 
-        internal JsonPropertyInfoNullable(Type classType, Type propertyType, PropertyInfo propertyInfo, Type elementType, JsonSerializerOptions options) :
-            base(classType, propertyType, propertyInfo, elementType, options)
+        internal JsonPropertyInfoNullable(
+            Type parentClassType,
+            Type declaredPropertyType,
+            Type runtimePropertyType,
+            PropertyInfo propertyInfo,
+            Type elementType,
+            JsonSerializerOptions options) :
+            base(parentClassType, declaredPropertyType, runtimePropertyType, propertyInfo, elementType, options)
         {
         }
 
@@ -48,7 +55,7 @@ namespace System.Text.Json.Serialization
                     }
                 }
 
-                ThrowHelper.ThrowJsonReaderException_DeserializeUnableToConvertValue(PropertyType, reader, state);
+                ThrowHelper.ThrowJsonReaderException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state);
             }
         }
 
@@ -63,7 +70,7 @@ namespace System.Text.Json.Serialization
                 }
             }
 
-            ThrowHelper.ThrowJsonReaderException_DeserializeUnableToConvertValue(PropertyType, reader, state);
+            ThrowHelper.ThrowJsonReaderException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state);
         }
 
         // todo: have the caller check if current.Enumerator != null and call WriteEnumerable of the underlying property directly to avoid an extra virtual call.

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -23,7 +23,7 @@ namespace System.Text.Json.Serialization
                 return;
             }
 
-            Type arrayType = state.Current.JsonPropertyInfo.PropertyType;
+            Type arrayType = state.Current.JsonPropertyInfo.RuntimePropertyType;
             if (!typeof(IEnumerable).IsAssignableFrom(arrayType) || (arrayType.IsArray && arrayType.GetArrayRank() > 1))
             {
                 ThrowHelper.ThrowJsonReaderException_DeserializeUnableToConvertValue(arrayType, reader, state);
@@ -35,7 +35,7 @@ namespace System.Text.Json.Serialization
                 if (state.Current.EnumerableCreated)
                 {
                     // A nested json array so push a new stack frame.
-                    Type elementType = state.Current.JsonClassInfo.ElementClassInfo.GetPolicyProperty().PropertyType;
+                    Type elementType = state.Current.JsonClassInfo.ElementClassInfo.GetPolicyProperty().RuntimePropertyType;
 
                     state.Push();
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json.Serialization
             else if (state.Current.JsonPropertyInfo != null)
             {
                 // Nested object
-                Type objType = state.Current.JsonPropertyInfo.PropertyType;
+                Type objType = state.Current.JsonPropertyInfo.RuntimePropertyType;
                 state.Push();
                 state.Current.JsonClassInfo = options.GetOrAddClass(objType);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization
     /// </summary>
     public static partial class JsonSerializer
     {
-        internal static readonly JsonPropertyInfo s_missingProperty = new JsonPropertyInfoNotNullable<object, object>();
+        internal static readonly JsonPropertyInfo s_missingProperty = new JsonPropertyInfoNotNullable<object, object, object>();
         private static readonly JsonSerializerOptions s_defaultSettings = new JsonSerializerOptions();
 
         private static object ReadCore(

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleEnumerable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleEnumerable.cs
@@ -68,9 +68,14 @@ namespace System.Text.Json.Serialization
                 {
                     elementClassInfo.GetPolicyProperty().WriteEnumerable(options, ref state.Current, ref writer);
                 }
+                else if (state.Current.Enumerator.Current == null)
+                {
+                    // Write a null object or enumerable.
+                    writer.WriteNullValue();
+                }
                 else
                 {
-                    // An object or another enumerator requires a new stack frame
+                    // An object or another enumerator requires a new stack frame.
                     object nextValue = state.Current.Enumerator.Current;
                     state.Push(elementClassInfo, nextValue);
                 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleEnumerable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleEnumerable.cs
@@ -25,20 +25,20 @@ namespace System.Text.Json.Serialization
         {
             Debug.Assert(state.Current.JsonPropertyInfo.ClassType == ClassType.Enumerable);
 
-            JsonPropertyInfo propertyInfo = state.Current.JsonPropertyInfo;
+            JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
 
             if (state.Current.Enumerator == null)
             {
-                if (propertyInfo._name == null)
+                if (jsonPropertyInfo._name == null)
                 {
                     writer.WriteStartArray();
                 }
                 else
                 {
-                    writer.WriteStartArray(propertyInfo._name);
+                    writer.WriteStartArray(jsonPropertyInfo._name);
                 }
 
-                IEnumerable enumerable = (IEnumerable)propertyInfo.GetValueAsObject(state.Current.CurrentValue, options);
+                IEnumerable enumerable = (IEnumerable)jsonPropertyInfo.GetValueAsObject(state.Current.CurrentValue, options);
 
                 if (enumerable != null)
                 {
@@ -48,6 +48,22 @@ namespace System.Text.Json.Serialization
 
             if (state.Current.Enumerator != null && state.Current.Enumerator.MoveNext())
             {
+                // If the enumerator contains typeof(object), get the run-time type
+                if (elementClassInfo.ClassType == ClassType.Object && jsonPropertyInfo.ElementClassInfo.Type == typeof(object))
+                {
+                    object currentValue = state.Current.Enumerator.Current;
+                    if (currentValue != null)
+                    {
+                        Type runtimeType = currentValue.GetType();
+                        
+                        // Ignore object() instances since they are handled as an empty object.
+                        if (runtimeType != typeof(object))
+                        {
+                            elementClassInfo = options.GetOrAddClass(runtimeType);
+                        }
+                    }
+                }
+
                 if (elementClassInfo.ClassType == ClassType.Value)
                 {
                     elementClassInfo.GetPolicyProperty().WriteEnumerable(options, ref state.Current, ref writer);
@@ -55,9 +71,8 @@ namespace System.Text.Json.Serialization
                 else
                 {
                     // An object or another enumerator requires a new stack frame
-                    JsonClassInfo nextClassInfo = propertyInfo.ElementClassInfo;
                     object nextValue = state.Current.Enumerator.Current;
-                    state.Push(nextClassInfo, nextValue);
+                    state.Push(elementClassInfo, nextValue);
                 }
 
                 return false;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
@@ -57,13 +57,38 @@ namespace System.Text.Json.Serialization
         {
             Debug.Assert(state.Current.JsonClassInfo.ClassType == ClassType.Object);
 
-            JsonPropertyInfo propertyInfo = state.Current.JsonClassInfo.GetProperty(state.Current.PropertyIndex);
-            state.Current.JsonPropertyInfo = propertyInfo;
+            JsonPropertyInfo jsonPropertyInfo = state.Current.JsonClassInfo.GetProperty(state.Current.PropertyIndex);
+            ClassType propertyClassType = jsonPropertyInfo.ClassType;
 
-            ClassType propertyClassType = propertyInfo.ClassType;
+            bool obtainedValue = false;
+            object currentValue = null;
+
+            // Check for polymorphism.
+            if (jsonPropertyInfo.RuntimePropertyType == typeof(object))
+            {
+                Debug.Assert(propertyClassType == ClassType.Object);
+
+                currentValue = jsonPropertyInfo.GetValueAsObject(state.Current.CurrentValue, options);
+                obtainedValue = true;
+
+                if (currentValue != null)
+                {
+                    Type runtimeType = currentValue.GetType();
+
+                    // Ignore object() instances since they are handled as an empty object.
+                    if (runtimeType != typeof(object))
+                    {
+                        propertyClassType = JsonClassInfo.GetClassType(runtimeType);
+                        jsonPropertyInfo = state.Current.JsonClassInfo.CreatePolymorphicProperty(jsonPropertyInfo, runtimeType, options);
+                    }
+                }
+            }
+
+            state.Current.JsonPropertyInfo = jsonPropertyInfo;
+
             if (propertyClassType == ClassType.Value)
             {
-                propertyInfo.Write(options, ref state.Current, ref writer);
+                jsonPropertyInfo.Write(options, ref state.Current, ref writer);
                 state.Current.NextProperty();
                 return true;
             }
@@ -71,7 +96,7 @@ namespace System.Text.Json.Serialization
             // A property that returns an enumerator keeps the same stack frame.
             if (propertyClassType == ClassType.Enumerable)
             {
-                bool endOfEnumerable = HandleEnumerable(propertyInfo.ElementClassInfo, options, ref writer, ref state);
+                bool endOfEnumerable = HandleEnumerable(jsonPropertyInfo.ElementClassInfo, options, ref writer, ref state);
                 if (endOfEnumerable)
                 {
                     state.Current.NextProperty();
@@ -80,23 +105,33 @@ namespace System.Text.Json.Serialization
                 return endOfEnumerable;
             }
 
-            // A property that returns an object requires a new stack frame.
-            object value = propertyInfo.GetValueAsObject(state.Current.CurrentValue, options);
-            if (value != null)
+            // A property that returns an object.
+            if (!obtainedValue)
             {
+                currentValue = jsonPropertyInfo.GetValueAsObject(state.Current.CurrentValue, options);
+            }
+
+            if (currentValue != null)
+            {
+                // A new stack frame is required.
                 JsonPropertyInfo previousPropertyInfo = state.Current.JsonPropertyInfo;
 
                 state.Current.NextProperty();
 
-                JsonClassInfo nextClassInfo = options.GetOrAddClass(propertyInfo.PropertyType);
-                state.Push(nextClassInfo, value);
+                JsonClassInfo nextClassInfo = options.GetOrAddClass(jsonPropertyInfo.RuntimePropertyType);
+                state.Push(nextClassInfo, currentValue);
 
                 // Set the PropertyInfo so we can obtain the property name in order to write it.
                 state.Current.JsonPropertyInfo = previousPropertyInfo;
             }
-            else if (!propertyInfo.IgnoreNullPropertyValueOnWrite(options))
+            else
             {
-                writer.WriteNull(propertyInfo._escapedName);
+                if (!jsonPropertyInfo.IgnoreNullPropertyValueOnWrite(options))
+                {
+                    writer.WriteNull(jsonPropertyInfo._escapedName);
+                }
+
+                state.Current.NextProperty();
             }
 
             return true;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Diagnostics;
 
 namespace System.Text.Json.Serialization
 {
@@ -69,6 +70,8 @@ namespace System.Text.Json.Serialization
 
         private static void WriteCore(ArrayBufferWriter<byte> output, object value, Type type, JsonSerializerOptions options)
         {
+            Debug.Assert(type != null || value == null);
+
             var writerState = new JsonWriterState(options.WriterOptions);
             var writer = new Utf8JsonWriter(output, writerState);
 
@@ -78,7 +81,8 @@ namespace System.Text.Json.Serialization
             }
             else
             {
-                if (type == null)
+                //  We treat typeof(object) special and allow polymorphic behavior.
+                if (type == typeof(object))
                 {
                     type = value.GetType();
                 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
@@ -29,6 +29,10 @@ namespace System.Text.Json.Serialization
             return isFinalBlock;
         }
 
+        // There are three conditions to consider for an object (primitive value, enumerable or object) being processed here:
+        // 1) The object type was specified as the root-level return type to a Parse\Read method.
+        // 2) The object is property on a parent object.
+        // 3) The object is an element in an enumerable.
         private static bool Write(
             ref Utf8JsonWriter writer,
             int flushThreshold,
@@ -64,6 +68,6 @@ namespace System.Text.Json.Serialization
             } while (continueWriting);
 
             return true;
-        }        
+        }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -75,7 +75,7 @@ namespace System.Text.Json.Serialization
                 return JsonClassInfo.ElementClassInfo.Type;
             }
 
-            return JsonPropertyInfo.PropertyType;
+            return JsonPropertyInfo.RuntimePropertyType;
         }
 
         internal static object CreateEnumerableValue(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
@@ -87,7 +87,7 @@ namespace System.Text.Json.Serialization
                 return null;
             }
 
-            Type propType = state.Current.JsonPropertyInfo.PropertyType;
+            Type propType = state.Current.JsonPropertyInfo.RuntimePropertyType;
             if (typeof(IList).IsAssignableFrom(propType))
             {
                 // If IList, add the members as we create them.

--- a/src/System.Text.Json/tests/Serialization/Null.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.WriteTests.cs
@@ -26,5 +26,26 @@ namespace System.Text.Json.Serialization.Tests
             string json = JsonSerializer.ToString(input, options);
             Assert.Equal(@"{}", json);
         }
+
+        [Fact]
+        public static void NullReferences()
+        {
+            var obj = new ObjectWithObjectProperties();
+            obj.Address = null;
+            obj.Array = null;
+            obj.List = null;
+            obj.NullableInt = null;
+            obj.NullableIntArray = null;
+
+            string json = JsonSerializer.ToString(obj);
+            Assert.Equal(ObjectWithObjectProperties.ExpectedJsonAllNulls, json);
+        }
+
+        [Fact]
+        public static void NullArrayElement()
+        {
+            string json = JsonSerializer.ToString(new ObjectWithObjectProperties[]{ null });
+            Assert.Equal("[null]", json);
+        }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
@@ -28,7 +28,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ArrayAsRootObject()
         {
-            const string ExpectedJson = @"[1,true,{""City"":""MyCity""},{},""foo""]";
+            const string ExpectedJson = @"[1,true,{""City"":""MyCity""},null,""foo""]";
 
             Address address = new Address();
             address.Initialize();
@@ -82,12 +82,12 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(typeof(object), typeof(ObjectWithObjectProperties).GetProperty("NullableInt").PropertyType);
             Assert.Equal(typeof(object), typeof(ObjectWithObjectProperties).GetProperty("NullableIntArray").PropertyType);
 
-            var person = new ObjectWithObjectProperties();
+            var obj = new ObjectWithObjectProperties();
 
-            string json = JsonSerializer.ToString(person);
+            string json = JsonSerializer.ToString(obj);
             Assert.Equal(ObjectWithObjectProperties.ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(person);
+            json = JsonSerializer.ToString<object>(obj);
             Assert.Equal(ObjectWithObjectProperties.ExpectedJson, json);
         }
 
@@ -95,15 +95,15 @@ namespace System.Text.Json.Serialization.Tests
         public static void NestedObjectAsRootObjectIgnoreNullable()
         {
             // Ensure that null properties are properly written and support ignore.
-            var person = new ObjectWithObjectProperties();
-            person.NullableInt = null;
+            var obj = new ObjectWithObjectProperties();
+            obj.NullableInt = null;
 
-            string json = JsonSerializer.ToString(person);
+            string json = JsonSerializer.ToString(obj);
             Assert.Equal(ObjectWithObjectProperties.ExpectedJsonNullInt, json);
 
             JsonSerializerOptions options = new JsonSerializerOptions();
             options.IgnoreNullPropertyValueOnWrite = true;
-            json = JsonSerializer.ToString(person, options);
+            json = JsonSerializer.ToString(obj, options);
             Assert.Equal(ObjectWithObjectProperties.ExpectedJsonNullIntIgnoreNulls, json);
         }
 

--- a/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -9,7 +10,105 @@ namespace System.Text.Json.Serialization.Tests
     public static class PolymorphicTests
     {
         [Fact]
-        public static void Standard()
+        public static void PrimitivesAsRootObject()
+        {
+            string json = JsonSerializer.ToString<object>(1);
+            Assert.Equal("1", json);
+
+            json = JsonSerializer.ToString(1, typeof(object));
+            Assert.Equal("1", json);
+
+            json = JsonSerializer.ToString<object>("foo");
+            Assert.Equal(@"""foo""", json);
+
+            json = JsonSerializer.ToString("foo", typeof(object));
+            Assert.Equal(@"""foo""", json);
+        }
+
+        [Fact]
+        public static void ArrayAsRootObject()
+        {
+            const string ExpectedJson = @"[1,true,{""City"":""MyCity""},{},""foo""]";
+
+            Address address = new Address();
+            address.Initialize();
+
+            object[] array = new object[] { 1, true, address, null, "foo" };
+            string json = JsonSerializer.ToString(array);
+            Assert.Equal(ExpectedJson, json);
+
+            json = JsonSerializer.ToString<object>(array);
+            Assert.Equal(ExpectedJson, json);
+
+            List<object> list = new List<object> { 1, true, address, null, "foo" };
+            json = JsonSerializer.ToString(list);
+            Assert.Equal(ExpectedJson, json);
+
+            json = JsonSerializer.ToString<object>(list);
+            Assert.Equal(ExpectedJson, json);
+        }
+
+        [Fact]
+        public static void SimpleTestClassAsRootObject()
+        {
+            // Sanity checks on test type.
+            Assert.Equal(typeof(object), typeof(SimpleTestClassWithObject).GetProperty("MyInt16").PropertyType);
+            Assert.Equal(typeof(object), typeof(SimpleTestClassWithObject).GetProperty("MyBooleanTrue").PropertyType);
+            Assert.Equal(typeof(object), typeof(SimpleTestClassWithObject).GetProperty("MyInt16Array").PropertyType);
+
+            var obj = new SimpleTestClassWithObject();
+            obj.Initialize();
+
+            // Verify with actual type.
+            string json = JsonSerializer.ToString(obj);
+            Assert.Contains(@"""MyInt16"":1", json);
+            Assert.Contains(@"""MyBooleanTrue"":true", json);
+            Assert.Contains(@"""MyInt16Array"":[1]", json);
+
+            // Verify with object type.
+            json = JsonSerializer.ToString<object>(obj);
+            Assert.Contains(@"""MyInt16"":1", json);
+            Assert.Contains(@"""MyBooleanTrue"":true", json);
+            Assert.Contains(@"""MyInt16Array"":[1]", json);
+        }
+
+        [Fact]
+        public static void NestedObjectAsRootObject()
+        {
+            // Sanity checks on test type.
+            Assert.Equal(typeof(object), typeof(ObjectWithObjectProperties).GetProperty("Address").PropertyType);
+            Assert.Equal(typeof(object), typeof(ObjectWithObjectProperties).GetProperty("List").PropertyType);
+            Assert.Equal(typeof(object), typeof(ObjectWithObjectProperties).GetProperty("Array").PropertyType);
+            Assert.Equal(typeof(object), typeof(ObjectWithObjectProperties).GetProperty("NullableInt").PropertyType);
+            Assert.Equal(typeof(object), typeof(ObjectWithObjectProperties).GetProperty("NullableIntArray").PropertyType);
+
+            var person = new ObjectWithObjectProperties();
+
+            string json = JsonSerializer.ToString(person);
+            Assert.Equal(ObjectWithObjectProperties.ExpectedJson, json);
+
+            json = JsonSerializer.ToString<object>(person);
+            Assert.Equal(ObjectWithObjectProperties.ExpectedJson, json);
+        }
+
+        [Fact]
+        public static void NestedObjectAsRootObjectIgnoreNullable()
+        {
+            // Ensure that null properties are properly written and support ignore.
+            var person = new ObjectWithObjectProperties();
+            person.NullableInt = null;
+
+            string json = JsonSerializer.ToString(person);
+            Assert.Equal(ObjectWithObjectProperties.ExpectedJsonNullInt, json);
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.IgnoreNullPropertyValueOnWrite = true;
+            json = JsonSerializer.ToString(person, options);
+            Assert.Equal(ObjectWithObjectProperties.ExpectedJsonNullIntIgnoreNulls, json);
+        }
+
+        [Fact]
+        public static void StaticAnalysisBaseline()
         {
             Customer customer = new Customer();
             customer.Initialize();

--- a/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
@@ -14,15 +14,29 @@ namespace System.Text.Json.Serialization.Tests
         {
             string json = JsonSerializer.ToString<object>(1);
             Assert.Equal("1", json);
-
             json = JsonSerializer.ToString(1, typeof(object));
             Assert.Equal("1", json);
 
             json = JsonSerializer.ToString<object>("foo");
             Assert.Equal(@"""foo""", json);
-
             json = JsonSerializer.ToString("foo", typeof(object));
             Assert.Equal(@"""foo""", json);
+
+            json = JsonSerializer.ToString<object>(true);
+            Assert.Equal(@"true", json);
+            json = JsonSerializer.ToString(true, typeof(object));
+            Assert.Equal(@"true", json);
+
+            json = JsonSerializer.ToString<object>(null);
+            Assert.Equal(@"null", json);
+            json = JsonSerializer.ToString(null, typeof(object));
+            Assert.Equal(@"null", json);
+
+            Decimal pi = 3.1415926535897932384626433833m;
+            json = JsonSerializer.ToString<object>(pi);
+            Assert.Equal(@"3.1415926535897932384626433833", json);
+            json = JsonSerializer.ToString(pi, typeof(object));
+            Assert.Equal(@"3.1415926535897932384626433833", json);
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/TestClasses.Polymorphic.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.Polymorphic.cs
@@ -113,6 +113,8 @@ namespace System.Text.Json.Serialization.Tests
             @"{""Address"":{""City"":""MyCity""},""List"":[""Hello"",""World""],""Array"":[""Hello"",""Again""],""NullableInt"":null,""NullableIntArray"":[null,42,null]}";
         public const string ExpectedJsonNullIntIgnoreNulls = 
             @"{""Address"":{""City"":""MyCity""},""List"":[""Hello"",""World""],""Array"":[""Hello"",""Again""],""NullableIntArray"":[null,42,null]}";
+        public const string ExpectedJsonAllNulls =
+            @"{""Address"":null,""List"":null,""Array"":null,""NullableInt"":null,""NullableIntArray"":null}";
 
         public object /*Address*/ Address { get; set; }
         public object /*List<string>*/ List { get; set; }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.Polymorphic.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.Polymorphic.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -101,6 +102,42 @@ namespace System.Text.Json.Serialization.Tests
         {
             Assert.Equal("MyState", State);
             base.Verify();
+        }
+    }
+
+    public class ObjectWithObjectProperties
+    {
+        public const string ExpectedJson = 
+            @"{""Address"":{""City"":""MyCity""},""List"":[""Hello"",""World""],""Array"":[""Hello"",""Again""],""NullableInt"":42,""NullableIntArray"":[null,42,null]}";
+        public const string ExpectedJsonNullInt =
+            @"{""Address"":{""City"":""MyCity""},""List"":[""Hello"",""World""],""Array"":[""Hello"",""Again""],""NullableInt"":null,""NullableIntArray"":[null,42,null]}";
+        public const string ExpectedJsonNullIntIgnoreNulls = 
+            @"{""Address"":{""City"":""MyCity""},""List"":[""Hello"",""World""],""Array"":[""Hello"",""Again""],""NullableIntArray"":[null,42,null]}";
+
+        public object /*Address*/ Address { get; set; }
+        public object /*List<string>*/ List { get; set; }
+        public object /*string[]*/ Array { get; set; }
+        public object /*int?*/ NullableInt { get; set; }
+        public object /*int?[]*/ NullableIntArray { get; set; }
+
+        public ObjectWithObjectProperties()
+        {
+            Address = new Address();
+            ((Address)Address).Initialize();
+
+            List = new List<string>
+            {
+                "Hello", "World"
+            };
+
+            Array = new string[]
+            {
+                "Hello", "Again"
+            };
+
+            NullableInt = new int?(42);
+
+            NullableIntArray = new int?[] { null, 42, null };
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.cs
@@ -175,6 +175,162 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class SimpleTestClassWithObject : ITestClass
+    {
+        public object MyInt16 { get; set; }
+        public object MyInt32 { get; set; }
+        public object MyInt64 { get; set; }
+        public object MyUInt16 { get; set; }
+        public object MyUInt32 { get; set; }
+        public object MyUInt64 { get; set; }
+        public object MyByte { get; set; }
+        public object MySByte { get; set; }
+        public object MyChar { get; set; }
+        public object MyString { get; set; }
+        public object MyDecimal { get; set; }
+        public object MyBooleanTrue { get; set; }
+        public object MyBooleanFalse { get; set; }
+        public object MySingle { get; set; }
+        public object MyDouble { get; set; }
+        public object MyDateTime { get; set; }
+        public object MyEnum { get; set; }
+        public object MyInt16Array { get; set; }
+        public object MyInt32Array { get; set; }
+        public object MyInt64Array { get; set; }
+        public object MyUInt16Array { get; set; }
+        public object MyUInt32Array { get; set; }
+        public object MyUInt64Array { get; set; }
+        public object MyByteArray { get; set; }
+        public object MySByteArray { get; set; }
+        public object MyCharArray { get; set; }
+        public object MyStringArray { get; set; }
+        public object MyDecimalArray { get; set; }
+        public object MyBooleanTrueArray { get; set; }
+        public object MyBooleanFalseArray { get; set; }
+        public object MySingleArray { get; set; }
+        public object MyDoubleArray { get; set; }
+        public object MyDateTimeArray { get; set; }
+        public object MyEnumArray { get; set; }
+
+        public static readonly string s_json =
+                @"{" +
+                @"""MyInt16"" : 1," +
+                @"""MyInt32"" : 2," +
+                @"""MyInt64"" : 3," +
+                @"""MyUInt16"" : 4," +
+                @"""MyUInt32"" : 5," +
+                @"""MyUInt64"" : 6," +
+                @"""MyByte"" : 7," +
+                @"""MySByte"" : 8," +
+                @"""MyChar"" : ""a""," +
+                @"""MyString"" : ""Hello""," +
+                @"""MyBooleanTrue"" : true," +
+                @"""MyBooleanFalse"" : false," +
+                @"""MySingle"" : 1.1," +
+                @"""MyDouble"" : 2.2," +
+                @"""MyDecimal"" : 3.3," +
+                @"""MyDateTime"" : ""2019-01-30T12:01:02.0000000Z""," +
+                @"""MyEnum"" : 2," + // int by default
+                @"""MyInt16Array"" : [1]," +
+                @"""MyInt32Array"" : [2]," +
+                @"""MyInt64Array"" : [3]," +
+                @"""MyUInt16Array"" : [4]," +
+                @"""MyUInt32Array"" : [5]," +
+                @"""MyUInt64Array"" : [6]," +
+                @"""MyByteArray"" : [7]," +
+                @"""MySByteArray"" : [8]," +
+                @"""MyCharArray"" : [""a""]," +
+                @"""MyStringArray"" : [""Hello""]," +
+                @"""MyBooleanTrueArray"" : [true]," +
+                @"""MyBooleanFalseArray"" : [false]," +
+                @"""MySingleArray"" : [1.1]," +
+                @"""MyDoubleArray"" : [2.2]," +
+                @"""MyDecimalArray"" : [3.3]," +
+                @"""MyDateTimeArray"" : [""2019-01-30T12:01:02.0000000Z""]," +
+                @"""MyEnumArray"" : [2]" + // int by default
+                @"}";
+
+        public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
+
+        public void Initialize()
+        {
+            MyInt16 = (short)1;
+            MyInt32 = (int)2;
+            MyInt64 = (long)3;
+            MyUInt16 = (ushort)4;
+            MyUInt32 = (uint)5;
+            MyUInt64 = (ulong)6;
+            MyByte = (byte)7;
+            MySByte =(sbyte) 8;
+            MyChar = 'a';
+            MyString = "Hello";
+            MyBooleanTrue = true;
+            MyBooleanFalse = false;
+            MySingle = 1.1f;
+            MyDouble = 2.2d;
+            MyDecimal = 3.3m;
+            MyDateTime = new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc);
+            MyEnum = SampleEnum.Two;
+
+            MyInt16Array = new short[] { 1 };
+            MyInt32Array = new int[] { 2 };
+            MyInt64Array = new long[] { 3 };
+            MyUInt16Array = new ushort[] { 4 };
+            MyUInt32Array = new uint[] { 5 };
+            MyUInt64Array = new ulong[] { 6 };
+            MyByteArray = new byte[] { 7 };
+            MySByteArray = new sbyte[] { 8 };
+            MyCharArray = new char[] { 'a' };
+            MyStringArray = new string[] { "Hello" };
+            MyBooleanTrueArray = new bool[] { true };
+            MyBooleanFalseArray = new bool[] { false };
+            MySingleArray = new float[] { 1.1f };
+            MyDoubleArray = new double[] { 2.2d };
+            MyDecimalArray = new decimal[] { 3.3m };
+            MyDateTimeArray = new DateTime[] { new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc) };
+            MyEnumArray = new SampleEnum[] { SampleEnum.Two };
+        }
+
+        public void Verify()
+        {
+            Assert.Equal((short)1, MyInt16);
+            Assert.Equal((int)2, MyInt32);
+            Assert.Equal((long)3, MyInt64);
+            Assert.Equal((ushort)4, MyUInt16);
+            Assert.Equal((uint)5, MyUInt32);
+            Assert.Equal((ulong)6, MyUInt64);
+            Assert.Equal((byte)7, MyByte);
+            Assert.Equal((sbyte)8, MySByte);
+            Assert.Equal('a', MyChar);
+            Assert.Equal("Hello", MyString);
+            Assert.Equal(3.3m, MyDecimal);
+            Assert.Equal(false, MyBooleanFalse);
+            Assert.Equal(true, MyBooleanTrue);
+            Assert.Equal(1.1f, MySingle);
+            Assert.Equal(2.2d, MyDouble);
+            Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc), MyDateTime);
+            Assert.Equal(SampleEnum.Two, MyEnum);
+
+            Assert.Equal((short)1, ((short[])MyInt16Array)[0]);
+            Assert.Equal((int)2, ((int[])MyInt32Array)[0]);
+            Assert.Equal((long)3, ((long[])MyInt64Array)[0]);
+            Assert.Equal((ushort)4, ((ushort[])MyUInt16Array)[0]);
+            Assert.Equal((uint)5, ((uint[])MyUInt32Array)[0]);
+            Assert.Equal((ulong)6, ((ulong[])MyUInt64Array)[0]);
+            Assert.Equal((byte)7, ((byte[])MyByteArray)[0]);
+            Assert.Equal((sbyte)8, ((sbyte[])MySByteArray)[0]);
+            Assert.Equal('a', ((char[])MyCharArray)[0]);
+            Assert.Equal("Hello", ((string[])MyStringArray)[0]);
+            Assert.Equal(3.3m, ((decimal[])MyDecimalArray)[0]);
+            Assert.Equal(false, ((bool[])MyBooleanFalseArray)[0]);
+            Assert.Equal(true, ((bool[])MyBooleanTrueArray)[0]);
+            Assert.Equal(1.1f, ((float[])MySingleArray)[0]);
+            Assert.Equal(2.2d, ((double[])MyDoubleArray)[0]);
+            Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc), ((DateTime[])MyDateTimeArray)[0]);
+            Assert.Equal(SampleEnum.Two, ((SampleEnum[])MyEnumArray)[0]);
+        }
+    }
+
     public abstract class SimpleBaseClassWithNullables
     {
         public short? MyInt16 { get; set; }


### PR DESCRIPTION
Partial implementation of https://github.com/dotnet/corefx/issues/36166

When `typeof(object)` is encountered, we obtain the run-time type via `object.GetType()`.

This feature only works for serialization. For deserialization, we are planning on deserializing into a `JsonElement` for such cases (since we don't know the CLR type, and don't want to guess).

cc @pranavkm 
