### PR TITLE
Move package testing to RS5 (less busy queue)

### DIFF
--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -170,9 +170,9 @@ jobs:
         variables:
           - _outerloop: false
           - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-            - allConfigurationsQueues: Windows.10.Amd64.ClientRS4.Open
+            - allConfigurationsQueues: Windows.10.Amd64.ClientRS5.Open
           - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
-            - allConfigurationsQueues: Windows.10.Amd64.ClientRS4
+            - allConfigurationsQueues: Windows.10.Amd64.ClientRS5
 
         customBuildSteps:
           - script: build.cmd


### PR DESCRIPTION
Relates to: #35693 

Based on @MattGal's suggestion there, let's move to a less busy queue and see if that improves time spent on the `Send to Helix` step for this leg.

cc: @stephentoub 