### PR TITLE
Add support for binding to COM objects in WPF

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -1555,6 +1555,11 @@ namespace System.ComponentModel
             {
                 Type type = instance.GetType();
 
+                if (type.IsCOMObject)
+                {
+                    type = ComObjectType;
+                }
+
                 if (createDelegator)
                 {
                     node = new TypeDescriptionNode(new DelegatingTypeDescriptionProvider(type));
@@ -2889,8 +2894,26 @@ namespace System.ComponentModel
             }
         }
 
+        [TypeDescriptionProvider(typeof(ComNativeDescriptorProxy))]
         private sealed class TypeDescriptorComObject
         {
+        }
+
+        private sealed class ComNativeDescriptorProxy : TypeDescriptionProvider
+        {
+            private readonly TypeDescriptionProvider _comNativeDescriptor;
+
+            public ComNativeDescriptorProxy()
+            {
+                Assembly assembly = Assembly.Load("System.Windows.Forms");
+                Type realComNativeDescriptor = assembly.GetType("System.Windows.Forms.ComponentModel.Com2Interop.ComNativeDescriptor");
+                _comNativeDescriptor = (TypeDescriptionProvider)Activator.CreateInstance(realComNativeDescriptor);
+            }
+
+            public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object instance)
+            {
+                return _comNativeDescriptor.GetTypeDescriptor(objectType, instance);
+            }
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2899,6 +2899,9 @@ namespace System.ComponentModel
         {
         }
 
+        // This class is being used to aid in diagnosability. The alternative to having this proxy would be
+        // to set the fully qualified type name in the TypeDescriptionProvider attribute. The issue with the
+        // string method is the failure is silent during type load making diagnosing the issue difficult.
         private sealed class ComNativeDescriptorProxy : TypeDescriptionProvider
         {
             private readonly TypeDescriptionProvider _comNativeDescriptor;
@@ -2906,7 +2909,7 @@ namespace System.ComponentModel
             public ComNativeDescriptorProxy()
             {
                 Assembly assembly = Assembly.Load("System.Windows.Forms");
-                Type realComNativeDescriptor = assembly.GetType("System.Windows.Forms.ComponentModel.Com2Interop.ComNativeDescriptor");
+                Type realComNativeDescriptor = assembly.GetType("System.Windows.Forms.ComponentModel.Com2Interop.ComNativeDescriptor", throwOnError: true);
                 _comNativeDescriptor = (TypeDescriptionProvider)Activator.CreateInstance(realComNativeDescriptor);
             }
 


### PR DESCRIPTION
This enables loading of https://github.com/dotnet/winforms/blob/master/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs to handle the inspection of COM objects.

cc @davidwrighton @jkoritzinsky 