### PR TITLE
Change Write to fill the remaining Span

### DIFF
--- a/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
+++ b/src/System.Memory/src/System/Buffers/BuffersExtensions.cs
@@ -138,7 +138,7 @@ namespace System.Buffers
                 input = input.Slice(writeSize);
                 if (input.Length > 0)
                 {
-                    destination = writer.GetSpan(input.Length);
+                    destination = writer.GetSpan();
                     continue;
                 }
 

--- a/src/System.Memory/tests/BuffersExtensions/BuffersExtensionsTests.cs
+++ b/src/System.Memory/tests/BuffersExtensions/BuffersExtensionsTests.cs
@@ -22,9 +22,10 @@ namespace System.Buffers.Tests
         [Fact]
         public void WritingToMultiSegmentBuffer()
         {
-            IBufferWriter<byte> bufferWriter = new TestBufferWriterMultiSegment();
+            var bufferWriter = new TestBufferWriterMultiSegment();
             bufferWriter.Write(Encoding.UTF8.GetBytes("Hello"));
             bufferWriter.Write(Encoding.UTF8.GetBytes(" World!"));
+            Assert.Equal(12, bufferWriter.Comitted.Count);
             Assert.Equal("Hello World!", bufferWriter.ToString());
         }
 
@@ -38,7 +39,7 @@ namespace System.Buffers.Tests
                 _written += bytes;
             }
 
-            public Memory<byte> GetMemory(int sizeHint  = 0) => _buffer.AsMemory().Slice(_written);
+            public Memory<byte> GetMemory(int sizeHint = 0) => _buffer.AsMemory().Slice(_written);
 
             public Span<byte> GetSpan(int sizeHint) => _buffer.AsSpan().Slice(_written);
 
@@ -53,6 +54,8 @@ namespace System.Buffers.Tests
             private byte[] _current = new byte[0];
             private List<byte[]> _commited = new List<byte[]>();
 
+            public List<byte[]> Comitted => _commited;
+
             public void Advance(int bytes)
             {
                 if (bytes == 0)
@@ -61,13 +64,13 @@ namespace System.Buffers.Tests
                 _current = new byte[0];
             }
 
-            public Memory<byte> GetMemory(int sizeHint  = 0)
+            public Memory<byte> GetMemory(int sizeHint = 0)
             {
-                if (sizeHint  == 0)
-                    sizeHint  = _current.Length + 1;
-                if (sizeHint  < _current.Length)
+                if (sizeHint == 0)
+                    sizeHint = _current.Length + 1;
+                if (sizeHint < _current.Length)
                     throw new InvalidOperationException();
-                var newBuffer = new byte[sizeHint ];
+                var newBuffer = new byte[sizeHint];
                 _current.CopyTo(newBuffer.AsSpan());
                 _current = newBuffer;
                 return _current;
@@ -95,5 +98,5 @@ namespace System.Buffers.Tests
                 return builder.ToString();
             }
         }
-    }  
+    }
 }


### PR DESCRIPTION
- We made some changes to make the sizeHint a minimum instead of just a hint. This means that passing in a huge buffer could result in a heap allocation if the underlying impl cannot provide a pooled version (like in pipelines or something backed by any MemoryPool impl). Instead of asking for a single contiguous buffer of the remaining input size, just pass 0 as the sizeHint and let the underlying implementation return a buffer to use.


Another potential strate Pick a minimum buffer size we think is reasonable (min(4K, input.Length))