### PR TITLE
Fix SqlClient Kerberos on Linux

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -205,6 +205,8 @@
     <Compile Include="System\Data\SqlClient\SNI\SNINpHandle.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SNIPacket.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SNIProxy.cs" />
+    <Compile Include="System\Data\SqlClient\SNI\SNIProxy.Windows.cs" Condition="'$(TargetsNetCoreApp)' != 'true' OR '$(TargetsUnix)' != 'true'" />
+    <Compile Include="System\Data\SqlClient\SNI\SNIProxy.Unix.cs" Condition="'$(TargetsNetCoreApp)' == 'true' AND '$(TargetsUnix)' == 'true'" />
     <Compile Include="System\Data\SqlClient\SNI\SNITcpHandle.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SslOverTdsStream.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SNICommon.cs" />

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.Unix.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.Unix.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Data.SqlClient.SNI
+{
+    /// <summary>
+    /// Managed SNI proxy implementation. Contains many SNI entry points used by SqlClient.
+    /// </summary>
+    internal partial class SNIProxy
+    {
+        // On Unix/Linux the format for the SPN is SERVICE@HOST. This is because the System.Net.Security.Native
+        // GSS-API layer uses GSS_C_NT_HOSTBASED_SERVICE format for the SPN.
+        private const string SpnServiceHostSeparator = "@";
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.Windows.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Data.SqlClient.SNI
+{
+    /// <summary>
+    /// Managed SNI proxy implementation. Contains many SNI entry points used by SqlClient.
+    /// </summary>
+    internal partial class SNIProxy
+    {
+        // On Windows the format for the SPN is SERVICE/HOST. So the separator character between the
+        // SERVICE and HOST components is "/".
+        private const string SpnServiceHostSeparator = "/";
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -18,7 +18,7 @@ namespace System.Data.SqlClient.SNI
     /// <summary>
     /// Managed SNI proxy implementation. Contains many SNI entry points used by SqlClient.
     /// </summary>
-    internal class SNIProxy
+    internal partial class SNIProxy
     {
         private const int DefaultSqlServerPort = 1433;
         private const int DefaultSqlServerDacPort = 1434;
@@ -342,7 +342,7 @@ namespace System.Data.SqlClient.SNI
                 // If the DNS lookup failed, then resort to using the user provided hostname to construct the SPN.
                 fullyQualifiedDomainName = hostEntry?.HostName ?? hostNameOrAddress;
             }
-            string serverSpn = SqlServerSpnHeader + "/" + fullyQualifiedDomainName;
+            string serverSpn = SqlServerSpnHeader + SpnServiceHostSeparator + fullyQualifiedDomainName;
             if (!string.IsNullOrWhiteSpace(portOrInstanceName))
             {
                 serverSpn += ":" + portOrInstanceName;


### PR DESCRIPTION
This PR is a follow-up to PR #36329. In that previous PR, I changed to use the
GSS_C_NT_HOSTBASED_SERVICE format for the SPN. That requires using a '@' separator
character instead of a "/". I had assumed since System.Data.SqlClient was including
the source files from Common for SafeDeleteNegoContext.cs that it would have the
corresponding change to use the proper separator character. However, it appears that
the file was only included to get the project building. It was using a separate file
to calculate the SPN.

The customer requiring these fixes reported that Kerberos was working properly now
for HttpClient and NegotiateStream. But SqlClient was still broken.

This PR completes the fix so that SqlClient will work properly with Kerberos especially
in multiple domain/realm environments. This fix was manually tested in the enterprise
scenario test lab.