### PR TITLE
stabilize Http2GetAsync_TrailerHeaders_TrailingHeaderNoBody test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.TrailingHeaders.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.TrailingHeaders.cs
@@ -351,7 +351,7 @@ namespace System.Net.Http.Functional.Tests
             using (var server = Http2LoopbackServer.CreateServer())
             using (var client = new HttpClient(CreateHttpClientHandler(useSocketsHttpHandler: true, useHttp2LoopbackServer: true)))
             {
-                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address, HttpCompletionOption.ResponseHeadersRead);
+                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
 
                 await server.EstablishConnectionAsync();
 


### PR DESCRIPTION
The test never intended to read only headers. (caused by copy from other test) 
Since there is no body frame processing runs and Assert.Contains() may or may not succeed.