### PR TITLE
SafeSocketHandle.Unix: ensure we can't create a new context after the handle is disposed

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Unix.cs
@@ -197,9 +197,10 @@ namespace System.Net.Sockets
 
         private void InnerReleaseHandle()
         {
-            if (_asyncContext != null)
+            SocketAsyncContext context = Interlocked.Exchange(ref _asyncContext, SocketAsyncContext.Closed);
+            if (context != SocketAsyncContext.Closed)
             {
-                _asyncContext.Close();
+                context?.Close();
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.cs
@@ -30,7 +30,7 @@ namespace System.Net.Sockets
             handle = preexistingHandle;
         }
 
-        private SafeSocketHandle() : base(true) { }
+        internal SafeSocketHandle() : base(true) { }
 
         private InnerSafeCloseSocket _innerSocket;
         private volatile bool _released;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1118,12 +1118,13 @@ namespace System.Net.Sockets
 
         private readonly object _registerLock = new object();
 
-        public static readonly SocketAsyncContext Closed;
+        internal static readonly SocketAsyncContext Closed = CreateClosedContext();
 
-        static SocketAsyncContext()
+        private static SocketAsyncContext CreateClosedContext()
         {
-            Closed = new SocketAsyncContext(new SafeSocketHandle());
-            Closed.Close();
+            var closed = new SocketAsyncContext(new SafeSocketHandle());
+            closed.Close();
+            return closed;
         }
 
         public SocketAsyncContext(SafeSocketHandle socket)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1118,6 +1118,14 @@ namespace System.Net.Sockets
 
         private readonly object _registerLock = new object();
 
+        public static readonly SocketAsyncContext Closed;
+
+        static SocketAsyncContext()
+        {
+            Closed = new SocketAsyncContext(new SafeSocketHandle());
+            Closed.Close();
+        }
+
         public SocketAsyncContext(SafeSocketHandle socket)
         {
             _socket = socket;


### PR DESCRIPTION
Most Socket operations first check if the Socket isn't disposed. Once we are past
that check, it's possible we create an AsyncContext for a Socket that got disposed.