### PR TITLE
[System.Native] Fix GetCpuUtilization to return percentage

### DIFF
--- a/src/Native/Unix/System.Native/pal_time.c
+++ b/src/Native/Unix/System.Native/pal_time.c
@@ -193,7 +193,7 @@ int32_t SystemNative_GetCpuUtilization(ProcessCpuInformation* previousCpuInfo)
     int32_t cpuUtilization = 0;
     if (cpuTotalTime > 0 && cpuBusyTime > 0)
     {
-        cpuUtilization = (int32_t)(cpuBusyTime / cpuTotalTime);
+        cpuUtilization = (int32_t)(cpuBusyTime * 100 / cpuTotalTime);
     }
 
     assert(cpuUtilization >= 0 && cpuUtilization <= 100);


### PR DESCRIPTION
This adds a surface `SystemNative_GetCpuUtilizationPercent` that builds on top of the existing `SystemNative_GetCpuUtilization` surface - it just converts the number to a percentage (between 0 - 100). I tried using the current `SystemNative_GetCpuUtilization`, which is calculating the ratio, and is converting it to an int32_t, so it's always giving me 0. I'm not sure if this is the intended behavior, so I just added another surface. 

If this wasn't the intended behavior and is actually a bug I need to fix, please let me know and I can modify this PR to return the percentage all the time.

