### PR TITLE
Enable interactive internal tools authentication

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -65,7 +65,7 @@
           AfterTargets="Restore">
 
     <PropertyGroup>
-      <ToolsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', '.tools'))</ToolsDir>
+      <ToolsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', '.tools', 'CredentialsProvider'))</ToolsDir>
       <CredentialsProviderScriptUrl Condition="'$(OS)' == 'Windows_NT'">https://raw.githubusercontent.com/Microsoft/artifacts-credprovider/master/helpers/installcredprovider.ps1</CredentialsProviderScriptUrl>
       <CredentialsProviderScriptUrl Condition="'$(OS)' != 'Windows_NT'">https://raw.githubusercontent.com/Microsoft/artifacts-credprovider/master/helpers/installcredprovider.sh</CredentialsProviderScriptUrl>
     </PropertyGroup>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -65,11 +65,12 @@
           AfterTargets="Restore">
 
     <PropertyGroup>
+      <ToolsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', '.tools'))</ToolsDir>
       <CredentialsProviderScriptUrl Condition="'$(OS)' == 'Windows_NT'">https://raw.githubusercontent.com/Microsoft/artifacts-credprovider/master/helpers/installcredprovider.ps1</CredentialsProviderScriptUrl>
       <CredentialsProviderScriptUrl Condition="'$(OS)' != 'Windows_NT'">https://raw.githubusercontent.com/Microsoft/artifacts-credprovider/master/helpers/installcredprovider.sh</CredentialsProviderScriptUrl>
     </PropertyGroup>
 
-    <DownloadFile SourceUrl="$(CredentialsProviderScriptUrl)" DestinationFolder="$(ArtifactsDir)">
+    <DownloadFile SourceUrl="$(CredentialsProviderScriptUrl)" DestinationFolder="$(ToolsDir)">
       <Output TaskParameter="DownloadedFile" ItemName="CredentialsProviderScriptPath" />
     </DownloadFile>
 

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -59,13 +59,22 @@
     <RepoTool Include="dotnet-reportgenerator-globaltool" Version="$(DotNetReportGeneratorGlobalToolPackageVersion)" />
   </ItemGroup>
 
-  <!--
-    Temporarily opt-in as dotnet restore interactive doesn't seem to work.
-    https://github.com/NuGet/Home/issues/7812. Use nuget restore meanwhile.
-  -->
+  <!-- Opt-in target to restore internal tools with interactive authentication. -->
   <Target Name="InitOptionalTools"
           Condition="'$(RestoreInternalTools)' == 'true'"
           AfterTargets="Restore">
+
+    <PropertyGroup>
+      <CredentialsProviderScriptUrl Condition="'$(OS)' == 'Windows_NT'">https://raw.githubusercontent.com/Microsoft/artifacts-credprovider/master/helpers/installcredprovider.ps1</CredentialsProviderScriptUrl>
+      <CredentialsProviderScriptUrl Condition="'$(OS)' != 'Windows_NT'">https://raw.githubusercontent.com/Microsoft/artifacts-credprovider/master/helpers/installcredprovider.sh</CredentialsProviderScriptUrl>
+    </PropertyGroup>
+
+    <DownloadFile SourceUrl="$(CredentialsProviderScriptUrl)" DestinationFolder="$(ArtifactsDir)">
+      <Output TaskParameter="DownloadedFile" ItemName="CredentialsProviderScriptPath" />
+    </DownloadFile>
+
+    <Exec Condition="'$(OS)' == 'Windows_NT'" Command="powershell -ExecutionPolicy ByPass -NoProfile -File &quot;%(CredentialsProviderScriptPath.Identity)&quot;" />
+    <Exec Condition="'$(OS)' != 'Windows_NT'" Command="chmod +x &quot;%(CredentialsProviderScriptPath.Identity)&quot; %26%26 &quot;%(CredentialsProviderScriptPath.Identity)&quot;" />
 
     <PropertyGroup>
       <OptionalToolDir>$([MSBuild]::NormalizeDirectory('$(RepositoryEngineeringDir)', 'common', 'internal'))</OptionalToolDir>


### PR DESCRIPTION
Implement interactive authentication for internal tools: https://github.com/NuGet/Home/issues/7812#event-2249734446

Tested locally on Windows and Ubuntu (WSL) and both work fine. The authentication needs to be completed in 90sec otherwise it will fail.

Also created https://github.com/Microsoft/artifacts-credprovider/pull/85 to submit a minor bug in the shell script.