### PR TITLE
Fix System.IO.Ports configurations and netfx build

### DIFF
--- a/src/System.IO.Ports/ref/Configurations.props
+++ b/src/System.IO.Ports/ref/Configurations.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <PackageConfigurations>
-      netstandard2.0;
+      netstandard;
       net461;
     </PackageConfigurations>
     <BuildConfigurations>

--- a/src/System.IO.Ports/ref/Configurations.props
+++ b/src/System.IO.Ports/ref/Configurations.props
@@ -1,9 +1,12 @@
 ﻿<Project>
   <PropertyGroup>
-    <BuildConfigurations>
-      netstandard;
-      netfx;
+    <PackageConfigurations>
+      netstandard2.0;
       net461;
+    </PackageConfigurations>
+    <BuildConfigurations>
+      $(PackageConfigurations)
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Ports/ref/Configurations.props
+++ b/src/System.IO.Ports/ref/Configurations.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
-      netfx-Windows_NT;
-      net461-Windows_NT;
+      netfx;
+      net461;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Ports/ref/Configurations.props
+++ b/src/System.IO.Ports/ref/Configurations.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <BuildConfigurations>
       netstandard;
-      netfx;
-      net461;
+      netfx-Windows_NT;
+      net461-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Ports/ref/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/ref/System.IO.Ports.csproj
@@ -5,7 +5,7 @@
     <!-- Must match version supported by frameworks which support 4.0.* inbox.
          Can be removed when API is added and this assembly is versioned to 4.1.* -->
     <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.0.1.0</AssemblyVersion>
-    <Configurations>net461-Debug;net461-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.IO.Ports.cs" />

--- a/src/System.IO.Ports/ref/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/ref/System.IO.Ports.csproj
@@ -5,7 +5,7 @@
     <!-- Must match version supported by frameworks which support 4.0.* inbox.
          Can be removed when API is added and this assembly is versioned to 4.1.* -->
     <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.0.1.0</AssemblyVersion>
-    <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>net461-Debug;net461-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.IO.Ports.cs" />

--- a/src/System.IO.Ports/src/Configurations.props
+++ b/src/System.IO.Ports/src/Configurations.props
@@ -5,12 +5,12 @@
       netstandard-Linux;
       netstandard-OSX;
       netstandard;
-      net461;
+      net461-Windows_NT;
     </PackageConfigurations>
     <BuildConfigurations>
       $(PackageConfigurations)
       uap-Windows_NT;
-      netfx;
+      netfx-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -6,7 +6,7 @@
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard' AND '$(TargetsWindows)' != 'true' AND '$(TargetsLinux)' != 'true' AND '$(TargetsOSX)' != 'true'">SR.PlatformNotSupported_IOPorts</GeneratePlatformNotSupportedAssemblyMessage>
     <DefineConstants>$(DefineConstants);NOSPAN</DefineConstants>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
-    <Configurations>net461-Debug;net461-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;netstandard-Linux-Debug;netstandard-Linux-Release</Configurations>
+    <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;netstandard-Linux-Debug;netstandard-Linux-Release</Configurations>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true' AND ('$(TargetsWindows)' == 'true' OR '$(TargetsLinux)' == 'true' OR '$(TargetsOSX)' == 'true')">
@@ -132,11 +132,6 @@
       <Link>Common\CoreLib\Interop\Windows\Interop.FormatMessage.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'uap' and '$(TargetsWindows)' == 'true'">
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateFile.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.CreateFile.cs</Link>
-    </Compile>
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uap'">
     <Compile Include="$(CommonPath)\Interop\Windows\Mincore\Interop.OpenCommPort.cs">
       <Link>Common\Interop\Windows\Mincore\Interop.OpenCommPort.cs</Link>
@@ -150,6 +145,9 @@
   <ItemGroup Condition="'$(TargetGroup)' != 'uap' and '$(TargetsNetFx)' != 'true' and '$(TargetsWindows)' == 'true'">
     <Compile Include="System\IO\Ports\SerialPort.Win32.cs" />
     <Compile Include="System\IO\Ports\SerialStream.Win32.cs" />
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.CreateFile.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.CreateFile.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">
     <Compile Include="System\IO\Ports\SerialPort.Linux.cs" />

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -27,7 +27,7 @@
     <Compile Include="System\IO\Ports\SerialStream.cs" />
     <Compile Include="System\IO\Ports\StopBits.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'netfx' AND '$(TargetsWindows)' == 'true'">
+  <ItemGroup Condition="'$(TargetsNetFx)' != 'true' AND '$(TargetsWindows)' == 'true'">
     <Compile Include="System\IO\Ports\SerialStream.Windows.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DCB.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.DCB.cs</Link>

--- a/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
+++ b/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{4259DCE9-3480-40BB-B08A-64A2D446264B}</ProjectGuid>
-    <Configurations>netfx-Debug;netfx-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
+    <Configurations>netfx-Debug;netfx-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;netstandard-Linux-Debug;netstandard-Linux-Release;netstandard-OSX-Debug;netstandard-OSX-Release</Configurations>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the options -->
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="SerialPort\BaseStream.cs" />


### PR DESCRIPTION
The netstandard-Windows_NT configuration always wins over netfx. Adding the RID to ensure that the configuration is building. Also moving an Interop file into the right ItemGroup which caused build erros.