### PR TITLE
Update tests for changed definition of CharSet.Auto on Unix

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemAutoTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemAutoTests.cs
@@ -17,13 +17,6 @@ namespace System.Runtime.InteropServices.Tests
             try
             {
                 Assert.NotEqual(IntPtr.Zero, ptr);
-
-                // Make sure the native memory is correctly laid out.
-                for (int i = 0; i < s.Length; i++)
-                {
-                    Assert.Equal(s[i], (char)Marshal.ReadInt16(IntPtr.Add(ptr, i << 1)));
-                }
-
                 // Make sure the memory roundtrips.
                 Assert.Equal(s, Marshal.PtrToStringAuto(ptr));
             }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToHGlobalAutoTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/StringToHGlobalAutoTests.cs
@@ -17,13 +17,6 @@ namespace System.Runtime.InteropServices.Tests
 
             try
             {
-                // Make sure the native memory is correctly laid out.
-                for (int i = 0; i < s.Length; i++)
-                {
-                    char c = (char)Marshal.ReadInt16(IntPtr.Add(ptr, i << 1));
-                    Assert.Equal(s[i], c);
-                }
-
                 // Make sure the memory roundtrips.
                 Assert.Equal(s, Marshal.PtrToStringAuto(ptr));
             }


### PR DESCRIPTION
Updated tests for changes in dotnet/coreclr#23664

Remove native string layout checks for Auto since meaning of Auto is not the same for Windows/Unix and the native layout is already tested in other unit tests.