### PR TITLE
Use common .tools dir for global tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,9 @@ syntax: glob
 ### VisualStudio ###
 
 # Tool Runtime Dir
-/[Tt]ools/
 .dotnet/
 .packages/
+.tools/
 
 # User-specific files
 *.suo

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -354,7 +354,7 @@
     <NetStandardRefPath>$(RefRootPath)netstandard/</NetStandardRefPath>
     <NetStandard21RefPath>$(RefRootPath)netstandard2.1/</NetStandard21RefPath>
     <NetFxRefPath>$(RefRootPath)netfx/</NetFxRefPath>
-    <GlobalToolsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'tools'))</GlobalToolsDir>
+    <GlobalToolsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', '.tools', 'globaltools'))</GlobalToolsDir>
     <IbcOptimizationDataDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'ibc'))</IbcOptimizationDataDir>
     <ILAsmToolPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsToolsetDir)', 'ilasm'))</ILAsmToolPath>
     <ILLinkDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsToolsetDir)', 'ILLink'))</ILLinkDir>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -80,7 +80,7 @@
   <Target Name="InitGlobalTools" Condition="'@(RepoTool)' != ''" AfterTargets="Restore">
 
     <PropertyGroup>
-      <GlobalToolsDir>$(ArtifactsDir)tools</GlobalToolsDir>
+      <GlobalToolsDir>$([MSBuild]::NormalizePath('$(RepoRoot)', '.tools', 'globaltools'))</GlobalToolsDir>
     </PropertyGroup>
 
     <!-- List all global tools and save the output. -->


### PR DESCRIPTION
We should move global toos out of the artifacts directory and use the arcade common .tools directory. See https://github.com/dotnet/corefx/pull/36560#discussion_r271835884.

Net improvement: Faster restore and less network traffic per every root build (same as we did for dotnet cli)