### PR TITLE
Updated tests for new PtrToStringUTF8 behavior

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
+++ b/src/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="System\Runtime\InteropServices\Marshal\ReleaseComObjectTests.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="System\Runtime\InteropServices\Marshal\PtrToStructureTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\PtrToStringAnsiTests.cs" />
+    <Compile Include="System\Runtime\InteropServices\Marshal\PtrToStringAutoTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\PtrToStringBSTR.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\PtrToStringUniTests.cs" />
     <Compile Include="System\Runtime\InteropServices\Marshal\PtrToStringUTF8Tests.cs" Condition="'$(TargetGroup)' == 'netcoreapp'" />

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringAnsiTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringAnsiTests.cs
@@ -49,9 +49,9 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        public void PtrToStringAnsi_NegativeLength_ThrowsArgumentExeption()
+        public void PtrToStringAnsi_NegativeLength_ThrowsArgumentOutOfRangeExeption()
         {
-            AssertExtensions.Throws<ArgumentException>("len", null, () => Marshal.PtrToStringAnsi(new IntPtr(123), -77));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("len", null, () => Marshal.PtrToStringAnsi(new IntPtr(123), -77));
         }
     }
 }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringAnsiTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringAnsiTests.cs
@@ -51,7 +51,7 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void PtrToStringAnsi_NegativeLength_ThrowsArgumentOutOfRangeExeption()
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("len", null, () => Marshal.PtrToStringAnsi(new IntPtr(123), -77));
+            AssertExtensions.Throws<ArgumentOutOfRangeException, ArgumentException>("len", null, () => Marshal.PtrToStringAnsi(new IntPtr(123), -77));
         }
     }
 }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringAutoTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringAutoTests.cs
@@ -27,7 +27,7 @@ namespace System.Runtime.InteropServices.Tests
             IntPtr ptr = Marshal.StringToCoTaskMemAuto(s);
             try
             {
-                Assert.Throws<ArgumentOutOfRangeException, ArgumentException>(() => Marshal.PtrToStringAuto(ptr, -1));
+                AssertExtensions.Throws<ArgumentOutOfRangeException, ArgumentException>(() => Marshal.PtrToStringAuto(ptr, -1));
             }
             finally
             {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringAutoTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringAutoTests.cs
@@ -21,13 +21,13 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        public void PtrToStringAuto_NegativeLength_ThrowsArgumentException()
+        public void PtrToStringAuto_NegativeLength_ThrowsArgumentOutOfRangeException()
         {
             string s = "Hello World";
             IntPtr ptr = Marshal.StringToCoTaskMemAuto(s);
             try
             {
-                AssertExtensions.Throws<ArgumentException>("len", null, () => Marshal.PtrToStringAuto(ptr, -1));
+                Assert.Throws<ArgumentOutOfRangeException>(() => Marshal.PtrToStringAuto(ptr, -1));
             }
             finally
             {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringAutoTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringAutoTests.cs
@@ -27,7 +27,7 @@ namespace System.Runtime.InteropServices.Tests
             IntPtr ptr = Marshal.StringToCoTaskMemAuto(s);
             try
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => Marshal.PtrToStringAuto(ptr, -1));
+                Assert.Throws<ArgumentOutOfRangeException, ArgumentException>(() => Marshal.PtrToStringAuto(ptr, -1));
             }
             finally
             {

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringUTF8Tests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringUTF8Tests.cs
@@ -31,8 +31,6 @@ namespace System.Runtime.InteropServices.Tests
         public void PtrToStringUTF8_ZeroPointer_ReturnsNull()
         {
             Assert.Null(Marshal.PtrToStringUTF8(IntPtr.Zero));
-            Assert.Null(Marshal.PtrToStringUTF8(IntPtr.Zero, 0));
-            Assert.Null(Marshal.PtrToStringUTF8(IntPtr.Zero, 1));
         }
 
         [Fact]
@@ -41,14 +39,19 @@ namespace System.Runtime.InteropServices.Tests
         {
             // Windows Marshal has specific checks that does not do
             // anything if the ptr is less than 64K.
-            Assert.Null(Marshal.PtrToStringUTF8((IntPtr)1, 10));
+            Assert.Null(Marshal.PtrToStringUTF8((IntPtr)1));
         }
 
         [Fact]
-        public void PtrToStringUTF8_NegativeLength_ThrowsArgumentOutOfRangeExeption()
+        public void PtrToStringUTF8_ZeroPointer_ThrowsArgumentNullException()
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("byteLen", null, () => Marshal.PtrToStringUTF8(new IntPtr(123), -77));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("byteLen", null, () => Marshal.PtrToStringUTF8(IntPtr.Zero, -77));
+            AssertExtensions.Throws<ArgumentNullException>("ptr", () => Marshal.PtrToStringUTF8(IntPtr.Zero, 123));
+        }
+
+        [Fact]
+        public void PtrToStringUTF8_NegativeLength_ThrowsArgumentExeption()
+        {
+            AssertExtensions.Throws<ArgumentException>("byteLen", null, () => Marshal.PtrToStringUTF8(new IntPtr(123), -77));
         }
     }
 }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringUTF8Tests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringUTF8Tests.cs
@@ -43,12 +43,14 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void PtrToStringUTF8_ZeroPointer_ThrowsArgumentNullException()
         {
             AssertExtensions.Throws<ArgumentNullException>("ptr", () => Marshal.PtrToStringUTF8(IntPtr.Zero, 123));
         }
 
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void PtrToStringUTF8_NegativeLength_ThrowsArgumentExeption()
         {
             AssertExtensions.Throws<ArgumentException>("byteLen", null, () => Marshal.PtrToStringUTF8(new IntPtr(123), -77));

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringUniTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringUniTests.cs
@@ -49,9 +49,9 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        public void PtrToStringUni_NegativeLength_ThrowsArgumentExeption()
+        public void PtrToStringUni_NegativeLength_ThrowsArgumentOutOfRangeExeption()
         {
-            AssertExtensions.Throws<ArgumentException>("len", null, () => Marshal.PtrToStringUni(new IntPtr(123), -77));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("len", null, () => Marshal.PtrToStringUni(new IntPtr(123), -77));
         }
     }
 }

--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringUniTests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/PtrToStringUniTests.cs
@@ -51,7 +51,7 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void PtrToStringUni_NegativeLength_ThrowsArgumentOutOfRangeExeption()
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("len", null, () => Marshal.PtrToStringUni(new IntPtr(123), -77));
+            AssertExtensions.Throws<ArgumentOutOfRangeException, ArgumentException>("len", null, () => Marshal.PtrToStringUni(new IntPtr(123), -77));
         }
     }
 }


### PR DESCRIPTION
Updated tests to match behavior from dotnet/coreclr#23731.

Blocked on dotnet/coreclr#23731