### PR TITLE
Disable Json serializer CacheTests since its failing on linux.

### DIFF
--- a/src/System.Text.Json/tests/Serialization/CacheTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CacheTests.cs
@@ -10,6 +10,7 @@ namespace System.Text.Json.Serialization.Tests
     public static class CacheTests
     {
         [Fact]
+        [ActiveIssue(36618)]
         public static void MultipleThreads()
         {
             // Ensure no exceptions are thrown due to caching or other issues.


### PR DESCRIPTION
See https://github.com/dotnet/corefx/issues/36618

cc @safern, @steveharter 