### PR TITLE
Various cleanup and feedback

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs
@@ -8,7 +8,7 @@ using System.Threading;
 namespace System.IO.Pipelines
 {
     /// <summary>
-    /// Represents a set of <see cref="Pipe"/> options
+    /// Represents a set of <see cref="Pipe"/> options.
     /// </summary>
     public class PipeOptions
     {
@@ -19,7 +19,7 @@ namespace System.IO.Pipelines
         private const int DefaultPauseWriterThreshold = DefaultMinimumSegmentSize * Pipe.InitialSegmentPoolSize;
 
         /// <summary>
-        /// Default instance of <see cref="PipeOptions"/>
+        /// Default instance of <see cref="PipeOptions"/>.
         /// </summary>
         public static PipeOptions Default { get; } = new PipeOptions();
 

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReaderOptions.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReaderOptions.cs
@@ -9,6 +9,9 @@ using System.Text;
 
 namespace System.IO.Pipelines
 {
+    /// <summary>
+    /// Represents a set of options for controlling the creation of the <see cref="PipeReader"/>.
+    /// </summary>
     public class StreamPipeReaderOptions
     {
         private const int DefaultBufferSize = 4096;
@@ -16,6 +19,9 @@ namespace System.IO.Pipelines
 
         internal static readonly StreamPipeReaderOptions s_default = new StreamPipeReaderOptions();
 
+        /// <summary>
+        /// Creates a new instance of <see cref="StreamPipeReaderOptions"/>.
+        /// </summary>
         public StreamPipeReaderOptions(MemoryPool<byte> pool = null, int bufferSize = DefaultBufferSize, int minimumReadSize = DefaultMinimumReadSize)
         {
             Pool = pool ?? MemoryPool<byte>.Shared;
@@ -35,8 +41,19 @@ namespace System.IO.Pipelines
             MinimumReadSize = minimumReadSize;
         }
 
+        /// <summary>
+        /// The minimum buffer size to use when renting memory from the <see cref="Pool"/>.
+        /// </summary>
         public int BufferSize { get; }
+
+        /// <summary>
+        /// The threshold of remaining bytes in the buffer before a new buffer is allocated.
+        /// </summary>
         public int MinimumReadSize { get; }
+
+        /// <summary>
+        /// The <see cref="MemoryPool{T}"/> to use when allocating memory.
+        /// </summary>
         public MemoryPool<byte> Pool { get; }
     }
 }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -258,7 +258,7 @@ namespace System.IO.Pipelines
             var reg = new CancellationTokenRegistration();
             if (cancellationToken.CanBeCanceled)
             {
-                reg = cancellationToken.Register(state => ((StreamPipeWriter)state).Cancel(), this);
+                reg = cancellationToken.UnsafeRegister(state => ((StreamPipeWriter)state).Cancel(), this);
             }
 
             // Update any buffered data

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -263,6 +263,7 @@ namespace System.IO.Pipelines
 
             // Update any buffered data
             _tail.End += _tailBytesBuffered;
+            _tailBytesBuffered = 0;
 
             using (reg)
             {

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriterOptions.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriterOptions.cs
@@ -9,12 +9,18 @@ using System.Text;
 
 namespace System.IO.Pipelines
 {
+    /// <summary>
+    /// Represents a set of options for controlling the creation of the <see cref="PipeWriter"/>.
+    /// </summary>
     public class StreamPipeWriterOptions
     {
         private const int DefaultMinimumBufferSize = 4096;
 
         internal static StreamPipeWriterOptions s_default = new StreamPipeWriterOptions();
 
+        /// <summary>
+        /// Creates a new instance of <see cref="StreamPipeWriterOptions"/>.
+        /// </summary>
         public StreamPipeWriterOptions(MemoryPool<byte> pool = null, int minimumBufferSize = DefaultMinimumBufferSize)
         {
             Pool = pool ?? MemoryPool<byte>.Shared;
@@ -27,7 +33,14 @@ namespace System.IO.Pipelines
             MinimumBufferSize = minimumBufferSize;
         }
 
+        /// <summary>
+        /// The minimum buffer size to use when renting memory from the <see cref="Pool"/>.
+        /// </summary>
         public int MinimumBufferSize { get; }
+
+        /// <summary>
+        /// The <see cref="MemoryPool{T}"/> to use when allocating memory.
+        /// </summary>
         public MemoryPool<byte> Pool { get; }
     }
 }

--- a/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
+++ b/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
@@ -394,6 +394,13 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        public void InvalidMinimumBufferSize_ThrowsArgException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new StreamPipeWriterOptions(minimumBufferSize: 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new StreamPipeWriterOptions(minimumBufferSize: -1));
+        }
+
+        [Fact]
         public void CallGetMemoryWithNegativeSizeHint_ThrowsArgException()
         {
             PipeWriter writer = PipeWriter.Create(Stream.Null);


### PR DESCRIPTION
- Doc comments for options
- Added test coverage for StreamPipeWriterOptions
- Reset tailBufferedBytes to 0 in StreamPipeWriter.FlushAsync