### PR TITLE
Add linux-musl-arm64 RID to Microsoft.Private.CoreFx.NETCoreApp

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/netcoreapp.rids.props
@@ -7,6 +7,9 @@
     <OfficialBuildRID Include="linux-arm64">
       <Platform>arm64</Platform>
     </OfficialBuildRID>
+    <OfficialBuildRID Include="linux-musl-arm64">
+      <Platform>arm64</Platform>
+    </OfficialBuildRID>
     <OfficialBuildRID Include="linux-x64" />
     <OfficialBuildRID Include="linux-musl-x64" />
     <OfficialBuildRID Include="rhel.6-x64" />


### PR DESCRIPTION
Add linux-musl-arm64 to the collections of OfficialBuildRIDs of Microsoft.Private.CoreFx.NETCoreApp

Fixes https://github.com/dotnet/corefx/issues/36617 and https://github.com/dotnet/coreclr/issues/23749

I built corefx locally and below is corresponding section of Microsoft.Private.CoreFx.NETCoreApp/runtime.json:
```js
    "linux-musl-arm64": {
      "Microsoft.Private.CoreFx.NETCoreApp": {
        "runtime.linux-musl-arm64.Microsoft.Private.CoreFx.NETCoreApp": "4.6.0-ci.19205.1"
      }
    },
    "linux-musl-arm64-aot": {
      "Microsoft.Private.CoreFx.NETCoreApp": {
        "runtime.linux-musl-arm64-aot.Microsoft.Private.CoreFx.NETCoreApp": "4.6.0-ci.19205.1"
      }
    },
```