### PR TITLE
SqlClient make managed connection more async

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
@@ -192,7 +192,7 @@ namespace System.Data.SqlClient.SNI
         /// <returns></returns>
         internal static uint ReportSNIError(SNIProviders provider, uint nativeError, uint sniError, string errorMessage)
         {
-            return ReportSNIError(new SNIError(provider, nativeError, sniError, errorMessage));
+            return ReportSNIError(CreateSNIError(provider, nativeError, sniError, errorMessage));
         }
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace System.Data.SqlClient.SNI
         /// <returns></returns>
         internal static uint ReportSNIError(SNIProviders provider, uint sniError, Exception sniException)
         {
-            return ReportSNIError(new SNIError(provider, sniError, sniException));
+            return ReportSNIError(CreateSNIError(provider, sniError, sniException));
         }
 
         /// <summary>
@@ -216,6 +216,17 @@ namespace System.Data.SqlClient.SNI
         {
             SNILoadHandle.SingletonInstance.LastError = error;
             return TdsEnums.SNI_ERROR;
+        }
+
+
+        internal static SNIError CreateSNIError(SNIProviders provider, uint nativeError, uint sniError, string errorMessage)
+        {
+            return new SNIError(provider, nativeError, sniError, errorMessage);
+        }
+
+        internal static SNIError CreateSNIError(SNIProviders provider, uint sniError, Exception sniException)
+        {
+            return new SNIError(provider, sniError, sniException);
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/dotnet/corefx/issues/25742

SNITcpHandle currently uses synchronous dns queries and socket open calls in the ctor which causes blocking behaviour which can be long running. This PR changes the ctor to initiate an async task to establish the connection and then makes sure that the task is correctly cleaned up and the status resolved when any sync apis request that information. async dns and connect are used where possible. This should allow more connections to be started concurrently by changing wait characteristics to non-blocking.

Notes:
* Various logic in the library expects sync behaviour and it would be a major undertaking to remove that assumption. I have attempted to leave the resolution of status as late as possible by putting the new `ResolveConnectionStatus` on the two paths that are always used to check the status but this method has to intersect the sync and async worlds and must be serialized so that only one completion is possible, lock and async aren't compatible so it uses a sync wait on an async task. I don't like this but I don't have a better way
* I can't test any of the parallel code path. it compiles and the logic is unchanged but it will need validation by someone with access to enterprise style test infrastructure. I find the code on this path slightly baffling.
* the SNIProxy singleton feels like a really bad idea for async. Again it would be a major rewrite to remove it.

/cc owners @afsanehr, @tarikulsabbir, @Gary-Zh , @david-engel and interested people @divega @saurabh500 