### PR TITLE
SqlClient Allow specifying a UDT SqlParameter value as bytes

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -7489,7 +7489,29 @@ namespace System.Data.SqlClient
 
                     if (!isNull)
                     {
-                        udtVal = _connHandler.Connection.GetBytes(value, out format, out maxsize);
+                        if (value is byte[] rawBytes)
+                        {
+                            udtVal = rawBytes;
+                        }
+                        else if (value is SqlBytes sqlBytes)
+                        {
+                            switch (sqlBytes.Storage)
+                            {
+                                case StorageState.Buffer:
+                                    // use the buffer directly, the only way to create it is with the correctly sized byte array
+                                    udtVal = sqlBytes.Buffer;
+                                    break;
+                                case StorageState.Stream:
+                                case StorageState.UnmanagedBuffer:
+                                    // allocate a new byte array to store the data
+                                    udtVal = sqlBytes.Value;
+                                    break;
+                            }
+                        }
+                        else
+                        {
+                            udtVal = _connHandler.Connection.GetBytes(value, out format, out maxsize);
+                        }
 
                         Debug.Assert(null != udtVal, "GetBytes returned null instance. Make sure that it always returns non-null value");
                         size = udtVal.Length;


### PR DESCRIPTION
Closes https://github.com/dotnet/corefx/issues/35470

Adds special casing when writing UDT parameter values to the TDS stream so that if the value is `byte[]` or `SqlBytes` the value is sent to the server and not rejected as invalid. This allows users to handle serialization and deserialization logic without having to have SqlClient be aware of the types and without using inefficient text representations.

Two new tests are added to verify the behaviour. Functional and manual tests pass.
/cc area owners @afsanehr, @tarikulsabbir, @Gary-Zh , @david-engel and requester @bricelam 