### PR TITLE
Removing the explicit MicrosoftNetCompilersToolsetVersion definition so we get automatic updates from arcade.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -36,7 +36,6 @@
     <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19205.6</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19205.6</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftDotNetVersionToolsTasksPackageVersion>1.0.0-beta.19205.6</MicrosoftDotNetVersionToolsTasksPackageVersion>
-    <MicrosoftNetCompilersToolsetVersion>3.1.0-beta1-19172-05</MicrosoftNetCompilersToolsetVersion>
     <!-- Core-setup dependencies -->
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview5-27606-01</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostPackageVersion>3.0.0-preview5-27606-01</MicrosoftNETCoreDotNetHostPackageVersion>


### PR DESCRIPTION
This was already approved and merged in https://github.com/dotnet/corefx/pull/36662.

However, it was immediately reverted (likely by accident) in https://github.com/dotnet/corefx/pull/36656 as part of a merge conflict resolution.

I plan on merging as soon as CI passes.

CC. @safern, @stephentoub as an FYI.