### PR TITLE
 Add support for trailing commas within Utf8JsonReader

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -119,6 +119,7 @@ namespace System.Text.Json
         private int _dummyPrimitive;
         public System.Text.Json.JsonCommentHandling CommentHandling { get { throw null; } set { } }
         public int MaxDepth { get { throw null; } set { } }
+        public bool AllowTrailingCommas { get { throw null; } set { } }
     }
     public partial struct JsonReaderState
     {

--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -312,4 +312,13 @@
   <data name="FormatGuid" xml:space="preserve">
     <value>The JSON value is not in a supported Guid format.</value>
   </data>
+  <data name="ExpectedStartOfPropertyOrValueAfterComment" xml:space="preserve">
+    <value>'{0}' is an invalid start of a property name or value, after a comment.</value>
+  </data>
+  <data name="TrailingCommaNotAllowedBeforeArrayEnd" xml:space="preserve">
+    <value>The JSON array contains a trailing comma at the end which is not supported in this mode. Change the reader options.</value>
+  </data>
+  <data name="TrailingCommaNotAllowedBeforeObjectEnd" xml:space="preserve">
+    <value>The JSON object contains a trailing comma at the end which is not supported in this mode. Change the reader options.</value>
+  </data>
 </root>

--- a/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderOptions.cs
@@ -34,5 +34,12 @@ namespace System.Text.Json
                 _maxDepth = value;
             }
         }
+
+        /// <summary>
+        /// Defines whether an extra comma at the end of a list of JSON values in an object or array
+        /// are allowed (and ignored) within the JSON payload being read.
+        /// By default, it's set to false, and the reader will throw a <exception cref="JsonReaderException"/> if it encounters a trailing comma.
+        /// </summary>
+        public bool AllowTrailingCommas { get; set; }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderState.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderState.cs
@@ -21,6 +21,7 @@ namespace System.Text.Json
         internal bool _isNotPrimitive;
         internal char _numberFormat;
         internal bool _stringHasEscaping;
+        internal bool _trailingCommaBeforeComment;
         internal JsonTokenType _tokenType;
         internal JsonTokenType _previousTokenType;
         internal JsonReaderOptions _readerOptions;
@@ -64,6 +65,7 @@ namespace System.Text.Json
             _isNotPrimitive = default;
             _numberFormat = default;
             _stringHasEscaping = default;
+            _trailingCommaBeforeComment = default;
             _tokenType = default;
             _previousTokenType = default;
             _readerOptions = options;

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -53,6 +53,7 @@ namespace System.Text.Json
             _sequence = jsonData;
             HasValueSequence = false;
             ValueSequence = ReadOnlySequence<byte>.Empty;
+            _trailingCommaBeforeComment = false;
 
             if (jsonData.IsSingleSegment)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -36,6 +36,7 @@ namespace System.Text.Json
             _isNotPrimitive = state._isNotPrimitive;
             _numberFormat = state._numberFormat;
             _stringHasEscaping = state._stringHasEscaping;
+            _trailingCommaBeforeComment = state._trailingCommaBeforeComment;
             _tokenType = state._tokenType;
             _previousTokenType = state._previousTokenType;
             _readerOptions = state._readerOptions;
@@ -53,7 +54,6 @@ namespace System.Text.Json
             _sequence = jsonData;
             HasValueSequence = false;
             ValueSequence = ReadOnlySequence<byte>.Empty;
-            _trailingCommaBeforeComment = false;
 
             if (jsonData.IsSingleSegment)
             {
@@ -1538,6 +1538,7 @@ namespace System.Text.Json
             long prevLineNumber = _lineNumber;
             JsonTokenType prevTokenType = _tokenType;
             SequencePosition prevSequencePosition = _currentPosition;
+            bool prevTrailingCommaBeforeComment = _trailingCommaBeforeComment;
             ConsumeTokenResult result = ConsumeNextTokenMultiSegment(marker);
             if (result == ConsumeTokenResult.Success)
             {
@@ -1551,6 +1552,7 @@ namespace System.Text.Json
                 _lineNumber = prevLineNumber;
                 _totalConsumed = prevTotalConsumed;
                 _currentPosition = prevSequencePosition;
+                _trailingCommaBeforeComment = prevTrailingCommaBeforeComment;
             }
             return false;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -535,7 +535,7 @@ namespace System.Text.Json
             {
                 if (!_readerOptions.AllowTrailingCommas)
                 {
-                    ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.MismatchedObjectArray, JsonConstants.CloseBrace); //TODO: Fix the message
+                    ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeObjectEnd);
                 }
                 _trailingCommaBeforeComment = false;
             }
@@ -569,7 +569,7 @@ namespace System.Text.Json
             {
                 if (!_readerOptions.AllowTrailingCommas)
                 {
-                    ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.MismatchedObjectArray, JsonConstants.CloseBrace); //TODO: Fix the message
+                    ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeArrayEnd);
                 }
                 _trailingCommaBeforeComment = false;
             }
@@ -821,6 +821,7 @@ namespace System.Text.Json
                 Debug.Assert((_trailingCommaBeforeComment && _readerOptions.CommentHandling == JsonCommentHandling.Allow) || !_trailingCommaBeforeComment);
                 Debug.Assert((_trailingCommaBeforeComment && marker != JsonConstants.Slash) || !_trailingCommaBeforeComment);
                 _trailingCommaBeforeComment = false;
+
                 if (marker == JsonConstants.Quote)
                 {
                     return ConsumeString();
@@ -1559,10 +1560,14 @@ namespace System.Text.Json
                 {
                     if (first != JsonConstants.Quote)
                     {
-                        if (_readerOptions.AllowTrailingCommas && first == JsonConstants.CloseBrace)
+                        if (first == JsonConstants.CloseBrace)
                         {
-                            EndObject();
-                            return ConsumeTokenResult.Success;
+                            if (_readerOptions.AllowTrailingCommas)
+                            {
+                                EndObject();
+                                return ConsumeTokenResult.Success;
+                            }
+                            ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeObjectEnd);
                         }
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfPropertyNotFound, first);
                     }
@@ -1570,10 +1575,14 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    if (_readerOptions.AllowTrailingCommas && first == JsonConstants.CloseBracket)
+                    if (first == JsonConstants.CloseBracket)
                     {
-                        EndArray();
-                        return ConsumeTokenResult.Success;
+                        if (_readerOptions.AllowTrailingCommas)
+                        {
+                            EndArray();
+                            return ConsumeTokenResult.Success;
+                        }
+                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeArrayEnd);
                     }
                     return ConsumeValue(first) ? ConsumeTokenResult.Success : ConsumeTokenResult.NotEnoughDataRollBackState;
                 }
@@ -1639,7 +1648,7 @@ namespace System.Text.Json
                 // A comma without some JSON value preceding it is invalid
                 if (_previousTokenType <= JsonTokenType.StartObject || _previousTokenType == JsonTokenType.StartArray || _trailingCommaBeforeComment)
                 {
-                    ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfPropertyOrValueNotFound);
+                    ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfPropertyOrValueAfterComment, first);
                 }
 
                 _consumed++;
@@ -1686,12 +1695,16 @@ namespace System.Text.Json
                 {
                     if (first != JsonConstants.Quote)
                     {
-                        if (_readerOptions.AllowTrailingCommas && first == JsonConstants.CloseBrace)
+                        if (first == JsonConstants.CloseBrace)
                         {
-                            EndObject();
-                            goto Done;
+                            if (_readerOptions.AllowTrailingCommas)
+                            {
+                                EndObject();
+                                goto Done;
+                            }
+                            ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeObjectEnd);
                         }
-                        
+
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfPropertyNotFound, first);
                     }
                     if (ConsumePropertyName())
@@ -1705,10 +1718,14 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    if (_readerOptions.AllowTrailingCommas && first == JsonConstants.CloseBracket)
+                    if (first == JsonConstants.CloseBracket)
                     {
-                        EndArray();
-                        goto Done;
+                        if (_readerOptions.AllowTrailingCommas)
+                        {
+                            EndArray();
+                            goto Done;
+                        }
+                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeArrayEnd);
                     }
 
                     if (ConsumeValue(first))
@@ -1975,10 +1992,14 @@ namespace System.Text.Json
                 {
                     if (marker != JsonConstants.Quote)
                     {
-                        if (_readerOptions.AllowTrailingCommas && marker == JsonConstants.CloseBrace)
+                        if (marker == JsonConstants.CloseBrace)
                         {
-                            EndObject();
-                            goto Done;
+                            if (_readerOptions.AllowTrailingCommas)
+                            {
+                                EndObject();
+                                goto Done;
+                            }
+                            ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeObjectEnd);
                         }
 
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfPropertyNotFound, marker);
@@ -1987,10 +2008,14 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    if (_readerOptions.AllowTrailingCommas && marker == JsonConstants.CloseBracket)
+                    if (marker == JsonConstants.CloseBracket)
                     {
-                        EndArray();
-                        goto Done;
+                        if (_readerOptions.AllowTrailingCommas)
+                        {
+                            EndArray();
+                            goto Done;
+                        }
+                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.TrailingCommaNotAllowedBeforeArrayEnd);
                     }
 
                     return ConsumeValue(marker) ? ConsumeTokenResult.Success : ConsumeTokenResult.NotEnoughDataRollBackState;

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -155,6 +155,7 @@ namespace System.Text.Json
             _isNotPrimitive = _isNotPrimitive,
             _numberFormat = _numberFormat,
             _stringHasEscaping = _stringHasEscaping,
+            _trailingCommaBeforeComment = _trailingCommaBeforeComment,
             _tokenType = _tokenType,
             _previousTokenType = _previousTokenType,
             _readerOptions = _readerOptions,
@@ -188,6 +189,7 @@ namespace System.Text.Json
             _isNotPrimitive = state._isNotPrimitive;
             _numberFormat = state._numberFormat;
             _stringHasEscaping = state._stringHasEscaping;
+            _trailingCommaBeforeComment = state._trailingCommaBeforeComment;
             _tokenType = state._tokenType;
             _previousTokenType = state._previousTokenType;
             _readerOptions = state._readerOptions;
@@ -201,7 +203,6 @@ namespace System.Text.Json
             _totalConsumed = 0;
             _isLastSegment = _isFinalBlock;
             _isMultiSegment = false;
-            _trailingCommaBeforeComment = false;
 
             ValueSpan = ReadOnlySpan<byte>.Empty;
 
@@ -1475,6 +1476,7 @@ namespace System.Text.Json
             long prevPosition = _bytePositionInLine;
             long prevLineNumber = _lineNumber;
             JsonTokenType prevTokenType = _tokenType;
+            bool prevTrailingCommaBeforeComment = _trailingCommaBeforeComment;
             ConsumeTokenResult result = ConsumeNextToken(marker);
             if (result == ConsumeTokenResult.Success)
             {
@@ -1486,6 +1488,7 @@ namespace System.Text.Json
                 _tokenType = prevTokenType;
                 _bytePositionInLine = prevPosition;
                 _lineNumber = prevLineNumber;
+                _trailingCommaBeforeComment = prevTrailingCommaBeforeComment;
             }
             return false;
         }

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -258,6 +258,12 @@ namespace System.Text.Json
                 case ExceptionResource.MismatchedObjectArray:
                     message = SR.Format(SR.MismatchedObjectArray, character);
                     break;
+                case ExceptionResource.TrailingCommaNotAllowedBeforeArrayEnd:
+                    message = SR.TrailingCommaNotAllowedBeforeArrayEnd;
+                    break;
+                case ExceptionResource.TrailingCommaNotAllowedBeforeObjectEnd:
+                    message = SR.TrailingCommaNotAllowedBeforeObjectEnd;
+                    break;
                 case ExceptionResource.EndOfStringNotFound:
                     message = SR.EndOfStringNotFound;
                     break;
@@ -287,6 +293,9 @@ namespace System.Text.Json
                     break;
                 case ExceptionResource.ExpectedStartOfPropertyOrValueNotFound:
                     message = SR.ExpectedStartOfPropertyOrValueNotFound;
+                    break;
+                case ExceptionResource.ExpectedStartOfPropertyOrValueAfterComment:
+                    message = SR.Format(SR.ExpectedStartOfPropertyOrValueAfterComment, character);
                     break;
                 case ExceptionResource.ExpectedStartOfValueNotFound:
                     message = SR.Format(SR.ExpectedStartOfValueNotFound, character);
@@ -506,6 +515,7 @@ namespace System.Text.Json
         ExpectedSeparatorAfterPropertyNameNotFound,
         ExpectedStartOfPropertyNotFound,
         ExpectedStartOfPropertyOrValueNotFound,
+        ExpectedStartOfPropertyOrValueAfterComment,
         ExpectedStartOfValueNotFound,
         ExpectedTrue,
         ExpectedValueAfterPropertyNameNotFound,
@@ -525,7 +535,9 @@ namespace System.Text.Json
         FailedToGetMinimumSizeSpan,
         FailedToGetLargerSpan,
         CannotWritePropertyWithinArray,
-        ExpectedJsonTokens
+        ExpectedJsonTokens,
+        TrailingCommaNotAllowedBeforeArrayEnd,
+        TrailingCommaNotAllowedBeforeObjectEnd,
     }
 
     internal enum NumericType

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -746,26 +746,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("{\"name\": \"value\",}")]
-        [InlineData("{\"name\": [],}")]
-        [InlineData("{\"name\": 1,}")]
-        [InlineData("{\"name\": true,}")]
-        [InlineData("{\"name\": false,}")]
-        [InlineData("{\"name\": null,}")]
-        [InlineData("{\"name\": [{},],}")]
-        [InlineData("{\"first\" : \"value\", \"name\": [{},], \"last\":2 ,}")]
-        [InlineData("{\"prop\":{\"name\": 1,\"last\":2,},}")]
-        [InlineData("{\"prop\":[1,2,],}")]
-        [InlineData("[\"value\",]")]
-        [InlineData("[1,]")]
-        [InlineData("[true,]")]
-        [InlineData("[false,]")]
-        [InlineData("[null,]")]
-        [InlineData("[{},]")]
-        [InlineData("[{\"name\": [],},]")]
-        [InlineData("[1, {\"name\": [],},2 , ]")]
-        [InlineData("[[1,2,],]")]
-        [InlineData("[{\"name\": 1,\"last\":2,},]")]
+        [MemberData(nameof(JsonWithValidTrailingCommas))]
         public static void JsonWithTrailingCommasMultiSegment_Valid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
@@ -785,31 +766,15 @@ namespace System.Text.Json.Tests
             {
                 var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling });
                 TrailingCommasHelper(sequence, state, allow: false, expectThrow: true);
-            }
 
-            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
-            {
                 bool allowTrailingCommas = true;
-                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
                 TrailingCommasHelper(sequence, state, allowTrailingCommas, expectThrow: false);
             }
         }
 
         [Theory]
-        [InlineData(",")]
-        [InlineData("   ,   ")]
-        [InlineData("{},")]
-        [InlineData("[],")]
-        [InlineData("1,")]
-        [InlineData("true,")]
-        [InlineData("false,")]
-        [InlineData("null,")]
-        [InlineData("{,}")]
-        [InlineData("{\"name\": 1,,}")]
-        [InlineData("{\"name\": 1,,\"last\":2,}")]
-        [InlineData("[,]")]
-        [InlineData("[1,,]")]
-        [InlineData("[1,,2,]")]
+        [MemberData(nameof(JsonWithInvalidTrailingCommas))]
         public static void JsonWithTrailingCommasMultiSegment_Invalid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
@@ -819,88 +784,57 @@ namespace System.Text.Json.Tests
             {
                 var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling });
                 TrailingCommasHelper(sequence, state, allow: false, expectThrow: true);
-            }
 
-            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
-            {
                 bool allowTrailingCommas = true;
-                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
                 TrailingCommasHelper(sequence, state, allowTrailingCommas, expectThrow: true);
             }
         }
 
         [Theory]
-        [InlineData("{\"name\": \"value\"/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": []/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": 1/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": true/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": false/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": null/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": [{},]/*comment*/,/*comment*/}")]
-        [InlineData("{\"first\" : \"value\", \"name\": [{},], \"last\":2 /*comment*/,/*comment*/}")]
-        [InlineData("{\"prop\":{\"name\": 1,\"last\":2,}/*comment*/,}")]
-        [InlineData("{\"prop\":[1,2,]/*comment*/,}")]
-        [InlineData("[\"value\"/*comment*/,/*comment*/]")]
-        [InlineData("[1/*comment*/,/*comment*/]")]
-        [InlineData("[true/*comment*/,/*comment*/]")]
-        [InlineData("[false/*comment*/,/*comment*/]")]
-        [InlineData("[null/*comment*/,/*comment*/]")]
-        [InlineData("[{}/*comment*/,/*comment*/]")]
-        [InlineData("[{\"name\": [],}/*comment*/,/*comment*/]")]
-        [InlineData("[1, {\"name\": [],},2 /*comment*/,/*comment*/ ]")]
-        [InlineData("[[1,2,]/*comment*/,]")]
-        [InlineData("[{\"name\": 1,\"last\":2,}/*comment*/,]")]
+        [MemberData(nameof(JsonWithValidTrailingCommasAndComments))]
         public static void JsonWithTrailingCommasAndCommentsMultiSegment_Valid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
             ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8, 1);
 
-            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
-            TrailingCommasHelper(sequence, state, allow: false, expectThrow: true);
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                if (commentHandling == JsonCommentHandling.Disallow)
+                {
+                    continue;
+                }
 
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip });
-            TrailingCommasHelper(sequence, state, allow: false, expectThrow: true);
+                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling });
+                TrailingCommasHelper(sequence, state, allow: false, expectThrow: true);
 
-            bool allowTrailingCommas = true;
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow, AllowTrailingCommas = allowTrailingCommas });
-            TrailingCommasHelper(sequence, state, allowTrailingCommas, expectThrow: false);
-
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = allowTrailingCommas });
-            TrailingCommasHelper(sequence, state, allowTrailingCommas, expectThrow: false);
+                bool allowTrailingCommas = true;
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
+                TrailingCommasHelper(sequence, state, allowTrailingCommas, expectThrow: false);
+            }
         }
 
         [Theory]
-        [InlineData("/*comment*/ ,/*comment*/")]
-        [InlineData("   /*comment*/ ,  /*comment*/ ")]
-        [InlineData("{}/*comment*/,/*comment*/")]
-        [InlineData("[]/*comment*/,/*comment*/")]
-        [InlineData("1/*comment*/,/*comment*/")]
-        [InlineData("true/*comment*/,/*comment*/")]
-        [InlineData("false/*comment*/,/*comment*/")]
-        [InlineData("null/*comment*/,/*comment*/")]
-        [InlineData("{/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": 1/*comment*/,/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": 1,/*comment*/,\"last\":2,}")]
-        [InlineData("[/*comment*/,/*comment*/]")]
-        [InlineData("[1/*comment*/,/*comment*/,/*comment*/]")]
-        [InlineData("[1,/*comment*/,2,]")]
+        [MemberData(nameof(JsonWithInvalidTrailingCommasAndComments))]
         public static void JsonWithTrailingCommasAndCommentsMultiSegment_Invalid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
             ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8, 1);
 
-            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
-            TrailingCommasHelper(sequence, state, allow: false, expectThrow: true);
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                if (commentHandling == JsonCommentHandling.Disallow)
+                {
+                    continue;
+                }
 
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip });
-            TrailingCommasHelper(sequence, state, allow: false, expectThrow: true);
+                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling });
+                TrailingCommasHelper(sequence, state, allow: false, expectThrow: true);
 
-            bool allowTrailingCommas = true;
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow, AllowTrailingCommas = allowTrailingCommas });
-            TrailingCommasHelper(sequence, state, allowTrailingCommas, expectThrow: true);
-
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = allowTrailingCommas });
-            TrailingCommasHelper(sequence, state, allowTrailingCommas, expectThrow: true);
+                bool allowTrailingCommas = true;
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
+                TrailingCommasHelper(sequence, state, allowTrailingCommas, expectThrow: true);
+            }
         }
 
         private static void TrailingCommasHelper(ReadOnlySequence<byte> utf8, JsonReaderState state, bool allow, bool expectThrow)

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -2122,26 +2122,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("{\"name\": \"value\",}")]
-        [InlineData("{\"name\": [],}")]
-        [InlineData("{\"name\": 1,}")]
-        [InlineData("{\"name\": true,}")]
-        [InlineData("{\"name\": false,}")]
-        [InlineData("{\"name\": null,}")]
-        [InlineData("{\"name\": [{},],}")]
-        [InlineData("{\"first\" : \"value\", \"name\": [{},], \"last\":2 ,}")]
-        [InlineData("{\"prop\":{\"name\": 1,\"last\":2,},}")]
-        [InlineData("{\"prop\":[1,2,],}")]
-        [InlineData("[\"value\",]")]
-        [InlineData("[1,]")]
-        [InlineData("[true,]")]
-        [InlineData("[false,]")]
-        [InlineData("[null,]")]
-        [InlineData("[{},]")]
-        [InlineData("[{\"name\": [],},]")]
-        [InlineData("[1, {\"name\": [],},2 , ]")]
-        [InlineData("[[1,2,],]")]
-        [InlineData("[{\"name\": 1,\"last\":2,},]")]
+        [MemberData(nameof(JsonWithValidTrailingCommas))]
         public static void JsonWithTrailingCommas_Valid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
@@ -2160,31 +2141,15 @@ namespace System.Text.Json.Tests
             {
                 var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling });
                 TrailingCommasHelper(utf8, state, allow: false, expectThrow: true);
-            }
 
-            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
-            {
                 bool allowTrailingCommas = true;
-                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
                 TrailingCommasHelper(utf8, state, allowTrailingCommas, expectThrow: false);
             }
         }
 
         [Theory]
-        [InlineData(",")]
-        [InlineData("   ,   ")]
-        [InlineData("{},")]
-        [InlineData("[],")]
-        [InlineData("1,")]
-        [InlineData("true,")]
-        [InlineData("false,")]
-        [InlineData("null,")]
-        [InlineData("{,}")]
-        [InlineData("{\"name\": 1,,}")]
-        [InlineData("{\"name\": 1,,\"last\":2,}")]
-        [InlineData("[,]")]
-        [InlineData("[1,,]")]
-        [InlineData("[1,,2,]")]
+        [MemberData(nameof(JsonWithInvalidTrailingCommas))]
         public static void JsonWithTrailingCommas_Invalid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
@@ -2193,86 +2158,55 @@ namespace System.Text.Json.Tests
             {
                 var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling });
                 TrailingCommasHelper(utf8, state, allow: false, expectThrow: true);
-            }
 
-            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
-            {
                 bool allowTrailingCommas = true;
-                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
                 TrailingCommasHelper(utf8, state, allowTrailingCommas, expectThrow: true);
             }
         }
 
         [Theory]
-        [InlineData("{\"name\": \"value\"/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": []/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": 1/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": true/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": false/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": null/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": [{},]/*comment*/,/*comment*/}")]
-        [InlineData("{\"first\" : \"value\", \"name\": [{},], \"last\":2 /*comment*/,/*comment*/}")]
-        [InlineData("{\"prop\":{\"name\": 1,\"last\":2,}/*comment*/,}")]
-        [InlineData("{\"prop\":[1,2,]/*comment*/,}")]
-        [InlineData("[\"value\"/*comment*/,/*comment*/]")]
-        [InlineData("[1/*comment*/,/*comment*/]")]
-        [InlineData("[true/*comment*/,/*comment*/]")]
-        [InlineData("[false/*comment*/,/*comment*/]")]
-        [InlineData("[null/*comment*/,/*comment*/]")]
-        [InlineData("[{}/*comment*/,/*comment*/]")]
-        [InlineData("[{\"name\": [],}/*comment*/,/*comment*/]")]
-        [InlineData("[1, {\"name\": [],},2 /*comment*/,/*comment*/ ]")]
-        [InlineData("[[1,2,]/*comment*/,]")]
-        [InlineData("[{\"name\": 1,\"last\":2,}/*comment*/,]")]
+        [MemberData(nameof(JsonWithValidTrailingCommasAndComments))]
         public static void JsonWithTrailingCommasAndComments_Valid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
 
-            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
-            TrailingCommasHelper(utf8, state, allow: false, expectThrow: true);
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                if (commentHandling == JsonCommentHandling.Disallow)
+                {
+                    continue;
+                }
 
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip });
-            TrailingCommasHelper(utf8, state, allow: false, expectThrow: true);
+                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling });
+                TrailingCommasHelper(utf8, state, allow: false, expectThrow: true);
 
-            bool allowTrailingCommas = true;
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow, AllowTrailingCommas = allowTrailingCommas });
-            TrailingCommasHelper(utf8, state, allowTrailingCommas, expectThrow: false);
-            
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = allowTrailingCommas });
-            TrailingCommasHelper(utf8, state, allowTrailingCommas, expectThrow: false);
+                bool allowTrailingCommas = true;
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
+                TrailingCommasHelper(utf8, state, allowTrailingCommas, expectThrow: false);
+            }
         }
 
         [Theory]
-        [InlineData("/*comment*/ ,/*comment*/")]
-        [InlineData("   /*comment*/ ,  /*comment*/ ")]
-        [InlineData("{}/*comment*/,/*comment*/")]
-        [InlineData("[]/*comment*/,/*comment*/")]
-        [InlineData("1/*comment*/,/*comment*/")]
-        [InlineData("true/*comment*/,/*comment*/")]
-        [InlineData("false/*comment*/,/*comment*/")]
-        [InlineData("null/*comment*/,/*comment*/")]
-        [InlineData("{/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": 1/*comment*/,/*comment*/,/*comment*/}")]
-        [InlineData("{\"name\": 1,/*comment*/,\"last\":2,}")]
-        [InlineData("[/*comment*/,/*comment*/]")]
-        [InlineData("[1/*comment*/,/*comment*/,/*comment*/]")]
-        [InlineData("[1,/*comment*/,2,]")]
+        [MemberData(nameof(JsonWithInvalidTrailingCommasAndComments))]
         public static void JsonWithTrailingCommasAndComments_Invalid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
 
-            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
-            TrailingCommasHelper(utf8, state, allow: false, expectThrow: true);
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                if (commentHandling == JsonCommentHandling.Disallow)
+                {
+                    continue;
+                }
 
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip });
-            TrailingCommasHelper(utf8, state, allow: false, expectThrow: true);
+                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling });
+                TrailingCommasHelper(utf8, state, allow: false, expectThrow: true);
 
-            bool allowTrailingCommas = true;
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow, AllowTrailingCommas = allowTrailingCommas });
-            TrailingCommasHelper(utf8, state, allowTrailingCommas, expectThrow: true);
-
-            state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = allowTrailingCommas });
-            TrailingCommasHelper(utf8, state, allowTrailingCommas, expectThrow: true);
+                bool allowTrailingCommas = true;
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = allowTrailingCommas });
+                TrailingCommasHelper(utf8, state, allowTrailingCommas, expectThrow: true);
+            }
         }
 
         private static void TrailingCommasHelper(byte[] utf8, JsonReaderState state, bool allow, bool expectThrow)
@@ -2295,6 +2229,123 @@ namespace System.Text.Json.Tests
                 while (reader.Read())
                     ;
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(JsonWithValidTrailingCommas))]
+        public static void PartialJsonWithTrailingCommas_Valid(string jsonString)
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            {
+                JsonReaderState state = default;
+                TrailingCommasHelperPartial(utf8, state, expectThrow: true);
+            }
+
+            {
+                var state = new JsonReaderState(options: default);
+                TrailingCommasHelperPartial(utf8, state, expectThrow: true);
+            }
+
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = false });
+                TrailingCommasHelperPartial(utf8, state, expectThrow: true);
+
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = true });
+                TrailingCommasHelperPartial(utf8, state, expectThrow: false);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(JsonWithValidTrailingCommasAndComments))]
+        public static void PartialJsonWithTrailingCommasAndComments_Valid(string jsonString)
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                if (commentHandling == JsonCommentHandling.Disallow)
+                {
+                    continue;
+                }
+
+                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = false });
+                TrailingCommasHelperPartial(utf8, state, expectThrow: true);
+
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = true });
+                TrailingCommasHelperPartial(utf8, state, expectThrow: false);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(JsonWithInvalidTrailingCommas))]
+        public static void PartialJsonWithTrailingCommas_Invalid(string jsonString)
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = false });
+                TrailingCommasHelperPartial(utf8, state, expectThrow: true);
+
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = true });
+                TrailingCommasHelperPartial(utf8, state, expectThrow: true);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(JsonWithInvalidTrailingCommasAndComments))]
+        public static void PartialJsonWithTrailingCommasAndComments_Invalid(string jsonString)
+        {
+            byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            foreach (JsonCommentHandling commentHandling in Enum.GetValues(typeof(JsonCommentHandling)))
+            {
+                if (commentHandling == JsonCommentHandling.Disallow)
+                {
+                    continue;
+                }
+
+                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = false });
+                TrailingCommasHelperPartial(utf8, state, expectThrow: true);
+
+                state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = commentHandling, AllowTrailingCommas = true });
+                TrailingCommasHelperPartial(utf8, state, expectThrow: true);
+            }
+        }
+
+        private static void TrailingCommasHelperPartial(byte[] utf8, JsonReaderState state, bool expectThrow)
+        {
+            if (expectThrow)
+            {
+                Assert.Throws<JsonReaderException>(() => PartialReaderLoop(utf8, state));
+            }
+            else
+            {
+                PartialReaderLoop(utf8, state);
+            }
+        }
+
+        private static void PartialReaderLoop(byte[] utf8, JsonReaderState state)
+        {
+            for (int i = 0; i < utf8.Length; i++)
+            {
+                JsonReaderState stateCopy = state;
+                PartialReaderLoop(utf8, stateCopy, i);
+            }
+        }
+
+        private static void PartialReaderLoop(byte[] utf8, JsonReaderState state, int splitLocation)
+        {
+            var reader = new Utf8JsonReader(utf8.AsSpan(0, splitLocation), isFinalBlock: false, state);
+            while (reader.Read())
+                ;
+
+            long consumed = reader.BytesConsumed;
+            reader = new Utf8JsonReader(utf8.AsSpan((int)consumed), isFinalBlock: true, reader.CurrentState);
+            while (reader.Read())
+                ;
         }
 
         public static IEnumerable<object[]> TestCases
@@ -2518,6 +2569,116 @@ namespace System.Text.Json.Tests
                     new object[] {"  { },  /* comment */ true "},
                     new object[] {"  { },  /* comment */ \"hello\" "},
                     new object[] {"  { },  // comment \n \"hello\" "},
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> JsonWithValidTrailingCommas
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] {"{\"name\": \"value\",}"},
+                    new object[] {"{\"name\": [],}"},
+                    new object[] {"{\"name\": 1,}"},
+                    new object[] {"{\"name\": true,}"},
+                    new object[] {"{\"name\": false,}"},
+                    new object[] {"{\"name\": null,}"},
+                    new object[] {"{\"name\": [{},],}"},
+                    new object[] {"{\"first\" : \"value\", \"name\": [{},], \"last\":2 ,}"},
+                    new object[] {"{\"prop\":{\"name\": 1,\"last\":2,},}"},
+                    new object[] {"{\"prop\":[1,2,],}"},
+                    new object[] {"[\"value\",]"},
+                    new object[] {"[1,]"},
+                    new object[] {"[true,]"},
+                    new object[] {"[false,]"},
+                    new object[] {"[null,]"},
+                    new object[] {"[{},]"},
+                    new object[] {"[{\"name\": [],},]"},
+                    new object[] {"[1, {\"name\": [],},2 , ]"},
+                    new object[] {"[[1,2,],]"},
+                    new object[] {"[{\"name\": 1,\"last\":2,},]"},
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> JsonWithValidTrailingCommasAndComments
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] {"{\"name\": \"value\"/*comment*/,/*comment*/}"},
+                    new object[] {"{\"name\": []/*comment*/,/*comment*/}"},
+                    new object[] {"{\"name\": 1/*comment*/,/*comment*/}"},
+                    new object[] {"{\"name\": true/*comment*/,/*comment*/}"},
+                    new object[] {"{\"name\": false/*comment*/,/*comment*/}"},
+                    new object[] {"{\"name\": null/*comment*/,/*comment*/}"},
+                    new object[] {"{\"name\": [{},]/*comment*/,/*comment*/}"},
+                    new object[] {"{\"first\" : \"value\", \"name\": [{},], \"last\":2 /*comment*/,/*comment*/}"},
+                    new object[] {"{\"prop\":{\"name\": 1,\"last\":2,}/*comment*/,}"},
+                    new object[] {"{\"prop\":[1,2,]/*comment*/,}"},
+                    new object[] {"{\"prop\":1,/*comment*/}"},
+                    new object[] {"[\"value\"/*comment*/,/*comment*/]"},
+                    new object[] {"[1/*comment*/,/*comment*/]"},
+                    new object[] {"[true/*comment*/,/*comment*/]"},
+                    new object[] {"[false/*comment*/,/*comment*/]"},
+                    new object[] {"[null/*comment*/,/*comment*/]"},
+                    new object[] {"[{}/*comment*/,/*comment*/]"},
+                    new object[] {"[{\"name\": [],}/*comment*/,/*comment*/]"},
+                    new object[] {"[1, {\"name\": [],},2 /*comment*/,/*comment*/ ]"},
+                    new object[] {"[[1,2,]/*comment*/,]"},
+                    new object[] {"[{\"name\": 1,\"last\":2,}/*comment*/,]"},
+                    new object[] {"[1,/*comment*/]"},
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> JsonWithInvalidTrailingCommas
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] {","},
+                    new object[] {"   ,   "},
+                    new object[] {"{},"},
+                    new object[] {"[],"},
+                    new object[] {"1,"},
+                    new object[] {"true,"},
+                    new object[] {"false,"},
+                    new object[] {"null,"},
+                    new object[] {"{,}"},
+                    new object[] {"{\"name\": 1,,}"},
+                    new object[] {"{\"name\": 1,,\"last\":2,}"},
+                    new object[] {"[,]"},
+                    new object[] {"[1,,]"},
+                    new object[] {"[1,,2,]"},
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> JsonWithInvalidTrailingCommasAndComments
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] {"/*comment*/ ,/*comment*/"},
+                    new object[] {"   /*comment*/ ,  /*comment*/ "},
+                    new object[] {"{}/*comment*/,/*comment*/"},
+                    new object[] {"[]/*comment*/,/*comment*/"},
+                    new object[] {"1/*comment*/,/*comment*/"},
+                    new object[] {"true/*comment*/,/*comment*/"},
+                    new object[] {"false/*comment*/,/*comment*/"},
+                    new object[] {"null/*comment*/,/*comment*/"},
+                    new object[] {"{/*comment*/,/*comment*/}"},
+                    new object[] {"{\"name\": 1/*comment*/,/*comment*/,/*comment*/}"},
+                    new object[] {"{\"name\": 1,/*comment*/,\"last\":2,}"},
+                    new object[] {"[/*comment*/,/*comment*/]"},
+                    new object[] {"[1/*comment*/,/*comment*/,/*comment*/]"},
+                    new object[] {"[1,/*comment*/,2,]"},
                 };
             }
         }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -2142,7 +2142,7 @@ namespace System.Text.Json.Tests
         [InlineData("[1, {\"name\": [],},2 , ]")]
         [InlineData("[[1,2,],]")]
         [InlineData("[{\"name\": 1,\"last\":2,},]")]
-        public static void JsonWithValidCommas(string jsonString)
+        public static void JsonWithTrailingCommas_Valid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
 
@@ -2185,7 +2185,7 @@ namespace System.Text.Json.Tests
         [InlineData("[,]")]
         [InlineData("[1,,]")]
         [InlineData("[1,,2,]")]
-        public static void JsonWithInvalidCommas(string jsonString)
+        public static void JsonWithTrailingCommas_Invalid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
 
@@ -2224,7 +2224,7 @@ namespace System.Text.Json.Tests
         [InlineData("[1, {\"name\": [],},2 /*comment*/,/*comment*/ ]")]
         [InlineData("[[1,2,]/*comment*/,]")]
         [InlineData("[{\"name\": 1,\"last\":2,}/*comment*/,]")]
-        public static void JsonWithValidCommasWithComments(string jsonString)
+        public static void JsonWithTrailingCommasAndComments_Valid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
 
@@ -2257,7 +2257,7 @@ namespace System.Text.Json.Tests
         [InlineData("[/*comment*/,/*comment*/]")]
         [InlineData("[1/*comment*/,/*comment*/,/*comment*/]")]
         [InlineData("[1,/*comment*/,2,]")]
-        public static void JsonWithInvalidCommasWithComments(string jsonString)
+        public static void JsonWithTrailingCommasAndComments_Invalid(string jsonString)
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(jsonString);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/34794.

Note that: `"[,]"` is still considered **invalid** (just like `"{,}"`). Json.NET allows `"[,]"`, specifically, but that did not seem consistent to me.

Please review the test cases, specifically, for expected behavior: https://github.com/dotnet/corefx/blob/76a2a65d8ee9f98842973ed15b422338a05e506e/src/System.Text.Json/tests/Utf8JsonReaderTests.cs#L2576-L2684

Only trailing commas **within** an object/array are allowed.

cc @JamesNK, @bartonjs 