### PR TITLE
Fix bad null check in pal_dsa.c

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.c
@@ -20,10 +20,15 @@ void CryptoNative_DsaDestroy(DSA* dsa)
 
 int32_t CryptoNative_DsaGenerateKey(DSA** dsa, int32_t bits)
 {
-    *dsa = DSA_new();
     if (!dsa)
     {
         assert(false);
+        return 0;
+    }
+
+    *dsa = DSA_new();
+    if (!(*dsa))
+    {
         return 0;
     }
 


### PR DESCRIPTION
The code calls DSA_new() and then tries to check if it returned a valid
pointer. Unfortunately, it looks at the wrong pointer when trying to
check the pointer from DSA_new() and ends up testing the argument passed
to the current function. The function argument is assumed to never be
null since we dereference it before getting to the check. So a compiler
can remove the entire check.