### PR TITLE
Fix ODBC issues with UTF-16

### DIFF
--- a/src/Common/src/Interop/Interop.Odbc.cs
+++ b/src/Common/src/Interop/Interop.Odbc.cs
@@ -97,16 +97,12 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLColumnsW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In]
             /*SQLCHAR* */string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In]
             /*SQLCHAR* */string TableName,
             /*SQLSMALLINT*/short NameLen3,
-            [In]
             /*SQLCHAR* */string ColumnName,
             /*SQLSMALLINT*/short NameLen4);
 
@@ -118,7 +114,6 @@ internal static partial class Interop
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLDriverConnectW(
             /*SQLHDBC*/OdbcConnectionHandle hdbc,
             /*SQLHWND*/IntPtr hwnd,
-            [In]
             /*SQLCHAR* */string connectionstring,
             /*SQLSMALLINT*/short cbConnectionstring,
             /*SQLCHAR* */IntPtr connectionstringout,
@@ -135,7 +130,6 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLExecDirectW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In]
             /*SQLCHAR* */string   StatementText,
             /*SQLINTEGER*/int TextLength);
 
@@ -251,43 +245,39 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLPrepareW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In]
             /*SQLCHAR* */string   StatementText,
             /*SQLINTEGER*/int TextLength);
 
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLPrimaryKeysW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In]
             /*SQLCHAR* */ string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In]
             /*SQLCHAR* */string TableName,
             /*SQLSMALLINT*/short NameLen3);
 
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLProcedureColumnsW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In] /*SQLCHAR* */ string CatalogName,
+            /*SQLCHAR* */ string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In] /*SQLCHAR* */ string SchemaName,
+            /*SQLCHAR* */ string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In] /*SQLCHAR* */ string ProcName,
+            /*SQLCHAR* */ string ProcName,
             /*SQLSMALLINT*/short NameLen3,
-            [In] /*SQLCHAR* */ string ColumnName,
+            /*SQLCHAR* */ string ColumnName,
             /*SQLSMALLINT*/short NameLen4);
 
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLProceduresW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In] /*SQLCHAR* */ string CatalogName,
+            /*SQLCHAR* */ string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In] /*SQLCHAR* */ string SchemaName,
+            /*SQLCHAR* */ string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In] /*SQLCHAR* */ string ProcName,
+            /*SQLCHAR* */ string ProcName,
             /*SQLSMALLINT*/short NameLen3);
 
         [DllImport(Interop.Libraries.Odbc32)]
@@ -358,13 +348,10 @@ internal static partial class Interop
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLSpecialColumnsW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
             /*SQLUSMALLINT*/ODBC32.SQL_SPECIALCOLS IdentifierType,
-            [In]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In]
             /*SQLCHAR* */string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In]
             /*SQLCHAR* */string TableName,
             /*SQLSMALLINT*/short NameLen3,
             /*SQLUSMALLINT*/ODBC32.SQL_SCOPE Scope,
@@ -373,13 +360,10 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLStatisticsW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In]
             /*SQLCHAR* */string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In]
             /*SQLCHAR* */IntPtr TableName, // IntPtr instead of string because callee may mutate contents
             /*SQLSMALLINT*/short NameLen3,
             /*SQLUSMALLINT*/short Unique,
@@ -388,16 +372,12 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLTablesW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In]
             /*SQLCHAR* */string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In]
             /*SQLCHAR* */string TableName,
             /*SQLSMALLINT*/short NameLen3,
-            [In]
             /*SQLCHAR* */string TableType,
             /*SQLSMALLINT*/short NameLen4);
     }

--- a/src/Common/src/Interop/Interop.Odbc.cs
+++ b/src/Common/src/Interop/Interop.Odbc.cs
@@ -200,7 +200,6 @@ internal static partial class Interop
            /*SQLHANDLE*/   OdbcHandle Handle,
            /*SQLSMALLINT*/ short RecNumber,
            /*SQLSMALLINT*/ short DiagIdentifier,
-           [MarshalAs(UnmanagedType.LPWStr)]
            /*SQLPOINTER*/  [Out] StringBuilder rchState,
            /*SQLSMALLINT*/ short BufferLength,
            /*SQLSMALLINT* */ out short StringLength);

--- a/src/Common/src/Interop/Interop.Odbc.cs
+++ b/src/Common/src/Interop/Interop.Odbc.cs
@@ -399,6 +399,7 @@ internal static partial class Interop
             /*SQLCHAR* */string TableName,
             /*SQLSMALLINT*/short NameLen3,
             [In]
+            /*SQLCHAR* */string TableType,
             /*SQLSMALLINT*/short NameLen4);
     }
 }

--- a/src/Common/src/Interop/Interop.Odbc.cs
+++ b/src/Common/src/Interop/Interop.Odbc.cs
@@ -97,6 +97,7 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLColumnsW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
+            [In]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
             [In]
@@ -117,6 +118,7 @@ internal static partial class Interop
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLDriverConnectW(
             /*SQLHDBC*/OdbcConnectionHandle hdbc,
             /*SQLHWND*/IntPtr hwnd,
+            [In]
             /*SQLCHAR* */string connectionstring,
             /*SQLSMALLINT*/short cbConnectionstring,
             /*SQLCHAR* */IntPtr connectionstringout,
@@ -133,6 +135,7 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLExecDirectW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
+            [In]
             /*SQLCHAR* */string   StatementText,
             /*SQLINTEGER*/int TextLength);
 
@@ -249,12 +252,14 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLPrepareW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
+            [In]
             /*SQLCHAR* */string   StatementText,
             /*SQLINTEGER*/int TextLength);
 
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLPrimaryKeysW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
+            [In]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
             [In]
@@ -354,6 +359,7 @@ internal static partial class Interop
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLSpecialColumnsW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
             /*SQLUSMALLINT*/ODBC32.SQL_SPECIALCOLS IdentifierType,
+            [In]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
             [In]
@@ -368,6 +374,7 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLStatisticsW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
+            [In]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
             [In]
@@ -382,6 +389,7 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLTablesW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
+            [In]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
             [In]

--- a/src/Common/src/Interop/Interop.Odbc.cs
+++ b/src/Common/src/Interop/Interop.Odbc.cs
@@ -94,19 +94,18 @@ internal static partial class Interop
         //            SQLSMALLINT *StringLength, SQLPOINTER NumericAttribute);
         // #endif
 
-        [DllImport(Interop.Libraries.Odbc32)]
+        [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLColumnsW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
+            [In]
             /*SQLCHAR* */string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
+            [In]
             /*SQLCHAR* */string TableName,
             /*SQLSMALLINT*/short NameLen3,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
+            [In]
             /*SQLCHAR* */string ColumnName,
             /*SQLSMALLINT*/short NameLen4);
 
@@ -118,8 +117,7 @@ internal static partial class Interop
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLDriverConnectW(
             /*SQLHDBC*/OdbcConnectionHandle hdbc,
             /*SQLHWND*/IntPtr hwnd,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
-            /*SQLCHAR* */string               connectionstring,
+            /*SQLCHAR* */string connectionstring,
             /*SQLSMALLINT*/short cbConnectionstring,
             /*SQLCHAR* */IntPtr connectionstringout,
             /*SQLSMALLINT*/short cbConnectionstringoutMax,
@@ -135,7 +133,6 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLExecDirectW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
             /*SQLCHAR* */string   StatementText,
             /*SQLINTEGER*/int TextLength);
 
@@ -172,7 +169,7 @@ internal static partial class Interop
             /*SQLSMALLINT*/ODBC32.SQL_C TargetType,
             /*SQLPOINTER*/CNativeBuffer TargetValue,
             /*SQLLEN*/IntPtr BufferLength, // sql.h differs from MSDN
-                                           /*SQLLEN* */out IntPtr StrLen_or_Ind);
+            /*SQLLEN* */out IntPtr StrLen_or_Ind);
 
         [DllImport(Interop.Libraries.Odbc32)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLGetDescFieldW(
@@ -252,43 +249,41 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLPrepareW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
             /*SQLCHAR* */string   StatementText,
             /*SQLINTEGER*/int TextLength);
 
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLPrimaryKeysW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
+            [In]
             /*SQLCHAR* */ string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
+            [In]
             /*SQLCHAR* */string TableName,
             /*SQLSMALLINT*/short NameLen3);
 
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLProcedureColumnsW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In, MarshalAs(UnmanagedType.LPWStr)] /*SQLCHAR* */ string CatalogName,
+            [In] /*SQLCHAR* */ string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In, MarshalAs(UnmanagedType.LPWStr)] /*SQLCHAR* */ string SchemaName,
+            [In] /*SQLCHAR* */ string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In, MarshalAs(UnmanagedType.LPWStr)] /*SQLCHAR* */ string ProcName,
+            [In] /*SQLCHAR* */ string ProcName,
             /*SQLSMALLINT*/short NameLen3,
-            [In, MarshalAs(UnmanagedType.LPWStr)] /*SQLCHAR* */ string ColumnName,
+            [In] /*SQLCHAR* */ string ColumnName,
             /*SQLSMALLINT*/short NameLen4);
 
-        [DllImport(Interop.Libraries.Odbc32)]
+        [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLProceduresW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In, MarshalAs(UnmanagedType.LPWStr)] /*SQLCHAR* */ string CatalogName,
+            [In)] /*SQLCHAR* */ string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In, MarshalAs(UnmanagedType.LPWStr)] /*SQLCHAR* */ string SchemaName,
+            [In)] /*SQLCHAR* */ string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In, MarshalAs(UnmanagedType.LPWStr)] /*SQLCHAR* */ string ProcName,
+            [In] /*SQLCHAR* */ string ProcName,
             /*SQLSMALLINT*/short NameLen3);
 
         [DllImport(Interop.Libraries.Odbc32)]
@@ -319,7 +314,7 @@ internal static partial class Interop
 
         [DllImport(Interop.Libraries.Odbc32)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLSetConnectAttrW( // used only for AutoCommitOn
-                                                                               /*SQLHBDC*/IntPtr ConnectionHandle,
+            /*SQLHBDC*/IntPtr ConnectionHandle,
             /*SQLINTEGER*/ODBC32.SQL_ATTR Attribute,
             /*SQLPOINTER*/IntPtr Value,
             /*SQLINTEGER*/int StringLength);
@@ -359,13 +354,12 @@ internal static partial class Interop
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLSpecialColumnsW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
             /*SQLUSMALLINT*/ODBC32.SQL_SPECIALCOLS IdentifierType,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
+            [In]
             /*SQLCHAR* */string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
+            [In]
             /*SQLCHAR* */string TableName,
             /*SQLSMALLINT*/short NameLen3,
             /*SQLUSMALLINT*/ODBC32.SQL_SCOPE Scope,
@@ -374,10 +368,9 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLStatisticsW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
+            [In]
             /*SQLCHAR* */string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
             [In]
@@ -386,20 +379,18 @@ internal static partial class Interop
             /*SQLUSMALLINT*/short Unique,
             /*SQLUSMALLINT*/short Reserved);
 
-        [DllImport(Interop.Libraries.Odbc32)]
+        [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLTablesW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
             /*SQLCHAR* */string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
+            [In]
             /*SQLCHAR* */string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
+            [In]
             /*SQLCHAR* */string TableName,
             /*SQLSMALLINT*/short NameLen3,
-            [In, MarshalAs(UnmanagedType.LPWStr)]
-            /*SQLCHAR* */string TableType,
+            [In]
             /*SQLSMALLINT*/short NameLen4);
     }
 }

--- a/src/Common/src/Interop/Interop.Odbc.cs
+++ b/src/Common/src/Interop/Interop.Odbc.cs
@@ -283,9 +283,9 @@ internal static partial class Interop
         [DllImport(Interop.Libraries.Odbc32, CharSet = CharSet.Unicode)]
         internal static extern /*SQLRETURN*/ODBC32.RetCode SQLProceduresW(
             /*SQLHSTMT*/OdbcStatementHandle StatementHandle,
-            [In)] /*SQLCHAR* */ string CatalogName,
+            [In] /*SQLCHAR* */ string CatalogName,
             /*SQLSMALLINT*/short NameLen1,
-            [In)] /*SQLCHAR* */ string SchemaName,
+            [In] /*SQLCHAR* */ string SchemaName,
             /*SQLSMALLINT*/short NameLen2,
             [In] /*SQLCHAR* */ string ProcName,
             /*SQLSMALLINT*/short NameLen3);

--- a/src/System.Data.Odbc/src/System/Data/Odbc/OdbcConnection.cs
+++ b/src/System.Data.Odbc/src/System/Data/Odbc/OdbcConnection.cs
@@ -394,7 +394,7 @@ namespace System.Data.Odbc
                 }
                 if ((ODBC32.RetCode.SUCCESS == retcode) || (ODBC32.RetCode.SUCCESS_WITH_INFO == retcode))
                 {
-                    value = Encoding.Unicode.GetString(buffer, 0, Math.Min(cbActual, buffer.Length));
+                    value = (BitConverter.IsLittleEndian ? Encoding.Unicode : Encoding.BigEndianUnicode).GetString(buffer, 0, Math.Min(cbActual, buffer.Length));
                 }
                 else if (retcode == ODBC32.RetCode.ERROR)
                 {
@@ -497,7 +497,7 @@ namespace System.Data.Odbc
                 }
                 if (retcode == ODBC32.RetCode.SUCCESS || retcode == ODBC32.RetCode.SUCCESS_WITH_INFO)
                 {
-                    value = Encoding.Unicode.GetString(buffer, 0, Math.Min(cbActual, buffer.Length));
+                    value = (BitConverter.IsLittleEndian ? Encoding.Unicode : Encoding.BigEndianUnicode).GetString(buffer, 0, Math.Min(cbActual, buffer.Length));
                 }
                 else if (handleError)
                 {


### PR DESCRIPTION
* Make the usage of UTF-16 in calling conventions more consistent and explicit after marshaling rule changes to be more consistent with Mono.

* Fix manual string marshaling on big endian platforms, using the proper encoding object. This fixes ODBC on Mono for IBM i.

cc @filipnavara 