### PR TITLE
Change charsets to explicitly unicode in System.Drawing.Common

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/NativeStructs.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/NativeStructs.Unix.cs
@@ -34,7 +34,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Drawing
 {
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct LOGFONT
     {
         internal int lfHeight;

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -820,7 +820,6 @@ namespace System.Drawing.Tests
             }
         }
 
-        //[ActiveIssue(36683)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ToLogFont_DisposedGraphics_ThrowsArgumentException()
         {

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -820,7 +820,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue(36683)]
+        //[ActiveIssue(36683)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ToLogFont_DisposedGraphics_ThrowsArgumentException()
         {
@@ -835,7 +835,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         public class LOGFONT
         {
             public int lfHeight;


### PR DESCRIPTION
This struct was depending on the old behavior of `CharSet.Auto`. As a result, when Auto changed to mean UTF-8 on Unix, then the native code was writing past the end of the in-place buffer, corrupting the native heap.

Fixes #36683 