### PR TITLE
SocketPal.Unix: replace DangerousGetHandle with SafeHandle marshalling

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReceiveMessage")]
-        internal static extern unsafe Error ReceiveMessage(IntPtr socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
+        internal static extern unsafe Error ReceiveMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
@@ -11,6 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SendMessage")]
-        internal static extern unsafe Error SendMessage(IntPtr socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
+        internal static extern unsafe Error SendMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
     }
 }

--- a/src/Common/src/Interop/Windows/WinSock/Interop.WSARecv.cs
+++ b/src/Common/src/Interop/Windows/WinSock/Interop.WSARecv.cs
@@ -14,6 +14,16 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         internal static unsafe extern SocketError WSARecv(
+            SafeHandle socketHandle,
+            WSABuffer* buffer,
+            int bufferCount,
+            out int bytesTransferred,
+            ref SocketFlags socketFlags,
+            NativeOverlapped* overlapped,
+            IntPtr completionRoutine);
+
+        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
+        internal static unsafe extern SocketError WSARecv(
             IntPtr socketHandle,
             WSABuffer* buffer,
             int bufferCount,
@@ -23,7 +33,7 @@ internal static partial class Interop
             IntPtr completionRoutine);
 
         internal static unsafe SocketError WSARecv(
-            IntPtr socketHandle,
+            SafeHandle socketHandle,
             ref WSABuffer buffer,
             int bufferCount,
             out int bytesTransferred,
@@ -36,6 +46,22 @@ internal static partial class Interop
             // The WSABuffer struct should be unchanged anyway.
             WSABuffer localBuffer = buffer;
             return WSARecv(socketHandle, &localBuffer, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
+        }
+
+        internal static unsafe SocketError WSARecv(
+            SafeHandle socketHandle,
+            Span<WSABuffer> buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            ref SocketFlags socketFlags,
+            NativeOverlapped* overlapped,
+            IntPtr completionRoutine)
+        {
+            Debug.Assert(!buffers.IsEmpty);
+            fixed (WSABuffer* buffersPtr = &MemoryMarshal.GetReference(buffers))
+            {
+                return WSARecv(socketHandle, buffersPtr, bufferCount, out bytesTransferred, ref socketFlags, overlapped, completionRoutine);
+            }
         }
 
         internal static unsafe SocketError WSARecv(

--- a/src/Common/src/Interop/Windows/WinSock/Interop.WSARecvFrom.cs
+++ b/src/Common/src/Interop/Windows/WinSock/Interop.WSARecvFrom.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         private static unsafe extern SocketError WSARecvFrom(
-            IntPtr socketHandle,
+            SafeHandle socketHandle,
             WSABuffer* buffers,
             int bufferCount,
             out int bytesTransferred,
@@ -25,7 +25,7 @@ internal static partial class Interop
             IntPtr completionRoutine);
 
         internal static unsafe SocketError WSARecvFrom(
-            IntPtr socketHandle,
+            SafeHandle socketHandle,
             ref WSABuffer buffer,
             int bufferCount,
             out int bytesTransferred,
@@ -43,7 +43,7 @@ internal static partial class Interop
         }
 
         internal static unsafe SocketError WSARecvFrom(
-            IntPtr socketHandle,
+            SafeHandle socketHandle,
             WSABuffer[] buffers,
             int bufferCount,
             out int bytesTransferred,

--- a/src/Common/src/Interop/Windows/WinSock/Interop.WSASend.cs
+++ b/src/Common/src/Interop/Windows/WinSock/Interop.WSASend.cs
@@ -22,8 +22,18 @@ internal static partial class Interop
             NativeOverlapped* overlapped,
             IntPtr completionRoutine);
 
+        [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
+        internal static extern unsafe SocketError WSASend(
+            SafeHandle socketHandle,
+            WSABuffer* buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            SocketFlags socketFlags,
+            NativeOverlapped* overlapped,
+            IntPtr completionRoutine);
+
         internal static unsafe SocketError WSASend(
-            IntPtr socketHandle,
+            SafeHandle socketHandle,
             ref WSABuffer buffer,
             int bufferCount,
             out int bytesTransferred,
@@ -36,6 +46,22 @@ internal static partial class Interop
             // The WSABuffer struct should be unchanged anyway.
             WSABuffer localBuffer = buffer;
             return WSASend(socketHandle, &localBuffer, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);
+        }
+
+        internal static unsafe SocketError WSASend(
+            SafeHandle socketHandle,
+            Span<WSABuffer> buffers,
+            int bufferCount,
+            out int bytesTransferred,
+            SocketFlags socketFlags,
+            NativeOverlapped* overlapped,
+            IntPtr completionRoutine)
+        {
+            Debug.Assert(!buffers.IsEmpty);
+            fixed (WSABuffer* buffersPtr = &MemoryMarshal.GetReference(buffers))
+            {
+                return WSASend(socketHandle, buffersPtr, bufferCount, out bytesTransferred, socketFlags, overlapped, completionRoutine);
+            }
         }
 
         internal static unsafe SocketError WSASend(

--- a/src/Common/src/Interop/Windows/WinSock/Interop.WSASendTo.cs
+++ b/src/Common/src/Interop/Windows/WinSock/Interop.WSASendTo.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
     {
         [DllImport(Interop.Libraries.Ws2_32, SetLastError = true)]
         private static unsafe extern SocketError WSASendTo(
-            IntPtr socketHandle,
+            SafeHandle socketHandle,
             WSABuffer* buffers,
             int bufferCount,
             out int bytesTransferred,
@@ -25,7 +25,7 @@ internal static partial class Interop
             IntPtr completionRoutine);
 
         internal static unsafe SocketError WSASendTo(
-            IntPtr socketHandle,
+            SafeHandle socketHandle,
             ref WSABuffer buffer,
             int bufferCount,
             out int bytesTransferred,
@@ -43,7 +43,7 @@ internal static partial class Interop
         }
 
         internal static unsafe SocketError WSASendTo(
-            IntPtr socketHandle,
+            SafeHandle socketHandle,
             WSABuffer[] buffers,
             int bufferCount,
             [Out] out int bytesTransferred,

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -342,14 +342,13 @@ namespace System.Net.Sockets
 
                     SocketFlags flags = _socketFlags;
                     SocketError socketError = Interop.Winsock.WSARecv(
-                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                        handle,
                         ref wsaBuffer,
                         1,
                         out int bytesTransferred,
                         ref flags,
                         overlapped,
                         IntPtr.Zero);
-                    GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                     return ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred, overlapped, cancellationToken);
                 }
@@ -369,14 +368,13 @@ namespace System.Net.Sockets
             {
                 SocketFlags flags = _socketFlags;
                 SocketError socketError = Interop.Winsock.WSARecv(
-                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    handle,
                     _wsaBufferArray,
                     _bufferListInternal.Count,
                     out int bytesTransferred,
                     ref flags,
                     overlapped,
                     IntPtr.Zero);
-                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred, overlapped);
             }
@@ -414,7 +412,7 @@ namespace System.Net.Sockets
 
                     SocketFlags flags = _socketFlags;
                     SocketError socketError = Interop.Winsock.WSARecvFrom(
-                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                        handle,
                         ref wsaBuffer,
                         1,
                         out int bytesTransferred,
@@ -423,7 +421,6 @@ namespace System.Net.Sockets
                         PtrSocketAddressBufferSize,
                         overlapped,
                         IntPtr.Zero);
-                    GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                     return ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred, overlapped);
                 }
@@ -443,7 +440,7 @@ namespace System.Net.Sockets
             {
                 SocketFlags flags = _socketFlags;
                 SocketError socketError = Interop.Winsock.WSARecvFrom(
-                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    handle,
                     _wsaBufferArray,
                     _bufferListInternal.Count,
                     out int bytesTransferred,
@@ -452,7 +449,6 @@ namespace System.Net.Sockets
                     PtrSocketAddressBufferSize,
                     overlapped,
                     IntPtr.Zero);
-                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred, overlapped);
             }
@@ -609,14 +605,13 @@ namespace System.Net.Sockets
                     var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
 
                     SocketError socketError = Interop.Winsock.WSASend(
-                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                        handle,
                         ref wsaBuffer,
                         1,
                         out int bytesTransferred,
                         _socketFlags,
                         overlapped,
                         IntPtr.Zero);
-                    GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                     return ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred, overlapped, cancellationToken);
                 }
@@ -635,14 +630,13 @@ namespace System.Net.Sockets
             try
             {
                 SocketError socketError = Interop.Winsock.WSASend(
-                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    handle,
                     _wsaBufferArray,
                     _bufferListInternal.Count,
                     out int bytesTransferred,
                     _socketFlags,
                     overlapped,
                     IntPtr.Zero);
-                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred, overlapped);
             }
@@ -779,7 +773,7 @@ namespace System.Net.Sockets
                     var wsaBuffer = new WSABuffer { Length = _count, Pointer = (IntPtr)(bufferPtr + _offset) };
 
                     SocketError socketError = Interop.Winsock.WSASendTo(
-                        handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                        handle,
                         ref wsaBuffer,
                         1,
                         out int bytesTransferred,
@@ -788,7 +782,6 @@ namespace System.Net.Sockets
                         _socketAddress.Size,
                         overlapped,
                         IntPtr.Zero);
-                    GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                     return ProcessIOCPResultWithSingleBufferHandle(socketError, bytesTransferred, overlapped);
                 }
@@ -807,7 +800,7 @@ namespace System.Net.Sockets
             try
             {
                 SocketError socketError = Interop.Winsock.WSASendTo(
-                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    handle,
                     _wsaBufferArray,
                     _bufferListInternal.Count,
                     out int bytesTransferred,
@@ -816,7 +809,6 @@ namespace System.Net.Sockets
                     _socketAddress.Size,
                     overlapped,
                     IntPtr.Zero);
-                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return ProcessIOCPResult(socketError == SocketError.Success, bytesTransferred, overlapped);
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -85,11 +85,10 @@ namespace System.Net.Sockets
                 };
 
                 errno = Interop.Sys.ReceiveMessage(
-                    socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    socket,
                     &messageHeader,
                     flags,
                     &received);
-                GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 receivedFlags = messageHeader.Flags;
                 sockAddrLen = messageHeader.SocketAddressLen;
@@ -126,11 +125,10 @@ namespace System.Net.Sockets
 
                 long bytesSent = 0;
                 errno = Interop.Sys.SendMessage(
-                    socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    socket,
                     &messageHeader,
                     flags,
                     &bytesSent);
-                GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 sent = checked((int)bytesSent);
             }
@@ -189,11 +187,10 @@ namespace System.Net.Sockets
 
                     long bytesSent = 0;
                     errno = Interop.Sys.SendMessage(
-                        socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                        socket,
                         &messageHeader,
                         flags,
                         &bytesSent);
-                    GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                     sent = checked((int)bytesSent);
                 }
@@ -312,11 +309,10 @@ namespace System.Net.Sockets
                     };
 
                     errno = Interop.Sys.ReceiveMessage(
-                        socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                        socket,
                         &messageHeader,
                         flags,
                         &received);
-                    GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                     receivedFlags = messageHeader.Flags;
                     sockAddrLen = messageHeader.SocketAddressLen;
@@ -373,11 +369,10 @@ namespace System.Net.Sockets
                 };
 
                 errno = Interop.Sys.ReceiveMessage(
-                    socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    socket,
                     &messageHeader,
                     flags,
                     &received);
-                GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 receivedFlags = messageHeader.Flags;
                 sockAddrLen = messageHeader.SocketAddressLen;
@@ -436,11 +431,10 @@ namespace System.Net.Sockets
 
                     long received = 0;
                     errno = Interop.Sys.ReceiveMessage(
-                        socket.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                        socket,
                         &messageHeader,
                         flags,
                         &received);
-                    GC.KeepAlive(socket); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                     receivedFlags = messageHeader.Flags;
                     int sockAddrLen = messageHeader.SocketAddressLen;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -919,14 +919,13 @@ namespace System.Net.Sockets
             {
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSASend(
-                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    handle,
                     ref asyncResult._singleBuffer,
                     1, // There is only ever 1 buffer being sent.
                     out bytesTransferred,
                     socketFlags,
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
-                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }
@@ -945,14 +944,13 @@ namespace System.Net.Sockets
             {
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSASend(
-                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    handle,
                     asyncResult._wsaBuffers,
                     asyncResult._wsaBuffers.Length,
                     out bytesTransferred,
                     socketFlags,
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
-                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }
@@ -1026,7 +1024,7 @@ namespace System.Net.Sockets
             {
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSASendTo(
-                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    handle,
                     ref asyncResult._singleBuffer,
                     1, // There is only ever 1 buffer being sent.
                     out bytesTransferred,
@@ -1035,7 +1033,6 @@ namespace System.Net.Sockets
                     asyncResult.SocketAddress.Size,
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
-                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }
@@ -1054,14 +1051,13 @@ namespace System.Net.Sockets
             {
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSARecv(
-                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    handle,
                     ref asyncResult._singleBuffer,
                     1,
                     out bytesTransferred,
                     ref socketFlags,
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
-                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }
@@ -1080,14 +1076,13 @@ namespace System.Net.Sockets
             {
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSARecv(
-                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    handle,
                     asyncResult._wsaBuffers,
                     asyncResult._wsaBuffers.Length,
                     out bytesTransferred,
                     ref socketFlags,
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
-                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }
@@ -1106,7 +1101,7 @@ namespace System.Net.Sockets
             {
                 int bytesTransferred;
                 SocketError errorCode = Interop.Winsock.WSARecvFrom(
-                    handle.DangerousGetHandle(), // to minimize chances of handle recycling from misuse, this should use DangerousAddRef/Release, but it adds too much overhead
+                    handle,
                     ref asyncResult._singleBuffer,
                     1,
                     out bytesTransferred,
@@ -1115,7 +1110,6 @@ namespace System.Net.Sockets
                     asyncResult.GetSocketAddressSizePtr(),
                     asyncResult.DangerousOverlappedPointer, // SafeHandle was just created in SetUnmanagedStructures
                     IntPtr.Zero);
-                GC.KeepAlive(handle); // small extra safe guard against handle getting collected/finalized while P/Invoke in progress
 
                 return asyncResult.ProcessOverlappedResult(errorCode == SocketError.Success, bytesTransferred);
             }


### PR DESCRIPTION
DangerousGetHandle was used here for performance. SafeHandle marshalling is
faster now, and preferable to avoid using invalid handles.