### PR TITLE
SqlClient fix SqlEnvChangePool thread safety bug

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -1937,7 +1937,7 @@ namespace System.Data.SqlClient
                                 }
                                 SqlEnvChange head = env;
                                 env = env.Next;
-                                SqlEnvChangePool.Release(head);
+                                head.Clear();
                                 head = null;
                             }
                             break;
@@ -2187,7 +2187,7 @@ namespace System.Data.SqlClient
 
             while (tokenLength > processedLength)
             {
-                SqlEnvChange env = SqlEnvChangePool.Allocate();
+                var env = new SqlEnvChange();
 
                 if (!stateObj.TryReadByte(out env.type))
                 {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
@@ -326,7 +326,7 @@ namespace System.Data.SqlClient
                     return item;
                 }
             }
-            // if we didn't find an item in the pool we've either never craete any or we're under pressure 
+            // if we didn't find an item in the pool we've either never create any or we're under pressure 
             // so just create a new one and let the caller get on with their work
             return new SqlEnvChange();
         }
@@ -347,7 +347,7 @@ namespace System.Data.SqlClient
                     break;
                 }
             }
-            // if we didn't add the item to the cache just let the go to the GC
+            // if we didn't add the item to the cache just let it go to the GC
         }
     }
 


### PR DESCRIPTION
In PR https://github.com/dotnet/corefx/pull/34573 a static pool of `SqlEnvChange` objects was added. This pool has been found to be unsafe causing a client crash. 

Under high load while running the data access benchmark at https://github.com/aspnet/DataAccessPerformance an exception occurred which I tracked back to newBinValue being null on line 276. 
https://github.com/dotnet/corefx/blob/7b320a0ad1ea83670f561a6ef9231916465bb4b4/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs#L271-L279

The object is not accessed from multiple threads and it is not possible to invoke the Clear method on the same object twice unless it has been returned to two different callers which means the pool is not safe. 

It has been replaced with a simpler version inspired by the ObjectPool in aspnet which doesn't count it just uses interlocks throughout. This version does not crash under load. The functional and manual tests all pass but they passed before. This is a bug fix and it is important to get in integrated quickly if possible.

/cc @afsanehr, @tarikulsabbir, @Gary-Zh , @david-engelh @saurabh500 