### PR TITLE
Copy json dependency to test out dir

### DIFF
--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -53,6 +53,8 @@
     <Compile Include="..\src\System\Text\Json\BitStack.cs" Link="BitStack.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="Newtonsoft.Json" />
+    <ReferenceFromRuntime Include="Newtonsoft.Json" />    
+    <!-- Copy external dependency into the test output directory. -->
+    <SupplementalTestData Include="$(RuntimePath)Newtonsoft.Json.dll" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Mono let us know that this is the only case where an external dependency is not included in the test archive that we upload: https://github.com/dotnet/corefx/issues/34957#issuecomment-481334190