### PR TITLE
Fix official builds failing due to LinuxNoTest matrix being empty

### DIFF
--- a/.azure-ci.yml
+++ b/.azure-ci.yml
@@ -69,7 +69,6 @@ jobs:
           - WindowsNoTest
           - AllConfigurations
           - LinuxTest
-          - LinuxNoTest
           - MacOS
           - RedHat6
           # - FreeBSD

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -113,6 +113,7 @@ jobs:
           - linuxDefaultQueues: Centos.7.Amd64.Open+RedHat.7.Amd64.Open+Debian.8.Amd64.Open+Ubuntu.1604.Amd64.Open+Ubuntu.1804.Amd64.Open+OpenSuse.42.Amd64.Open+\(Fedora.28.Amd64\)ubuntu.1604.amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-45b1fa2-20190402012449
           - linuxArm64Queues: \(Ubuntu.1604.Arm64\)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm64v8-b049512-20190321153539
           - alpineQueues: \(Alpine.38.Amd64\)ubuntu.1604.amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-45b1fa2-20190327215821
+
         - ${{ if eq(parameters.isOfficialBuild, 'true') }}:
           - linuxDefaultQueues: Centos.7.Amd64+RedHat.7.Amd64+Debian.8.Amd64+Debian.9.Amd64+Ubuntu.1604.Amd64+Ubuntu.1804.Amd64+Ubuntu.1810.Amd64+OpenSuse.42.Amd64+SLES.12.Amd64+SLES.15.Amd64+\(Fedora.28.Amd64\)ubuntu.1604.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-28-helix-45b1fa2-20190402012449+\(Fedora.29.Amd64\)ubuntu.1604.amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-29-helix-c6dc5e6-20190402012449
           - linuxArm64Queues: \(Ubuntu.1604.Arm64\)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm64v8-b049512-20190321153539
@@ -121,28 +122,27 @@ jobs:
           - alpineArm64Queues: \(Alpine.38.Arm64\)Ubuntu.1604.Arm64.Docker@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.8-helix-arm64v8-46e69dd-20190327215724
 
     # Legs without helix testing
-    # There is no point of running legs without outerloop tests, when in an outerloop build.
-    - ${{ if eq(parameters.isOuterloopBuild, 'false') }}:
+    # Only run this leg in PRs.
+    - ${{ if and(eq(parameters.isOfficialBuild, 'false'), eq(parameters.isOuterloopBuild, 'false')) }}:
       - job: LinuxNoTest
         displayName: Linux
         strategy:
           matrix:
-            ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-              arm_Release:
-                _BuildConfig: Release
-                _architecture: arm
-                _framework: netcoreapp
-                _buildExtraArguments: /p:RuntimeOS=ubuntu.16.04 -warnAsError false
-                _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm '
-                _dockerContainer: ubuntu_1604_arm_cross_container
+            arm_Release:
+              _BuildConfig: Release
+              _architecture: arm
+              _framework: netcoreapp
+              _buildExtraArguments: /p:RuntimeOS=ubuntu.16.04 -warnAsError false
+              _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm '
+              _dockerContainer: ubuntu_1604_arm_cross_container
 
-              musl_arm64_Release:
-                _BuildConfig: Release
-                _architecture: arm64
-                _framework: netcoreapp
-                _dockerContainer: alpine_37_arm64_container
-                _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
-                _buildExtraArguments: -warnAsError false /p:BuildNativeClang=--clang5.0 /p:RuntimeOS=linux-musl
+            musl_arm64_Release:
+              _BuildConfig: Release
+              _architecture: arm64
+              _framework: netcoreapp
+              _dockerContainer: alpine_37_arm64_container
+              _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
+              _buildExtraArguments: -warnAsError false /p:BuildNativeClang=--clang5.0 /p:RuntimeOS=linux-musl
 
         pool:
           name: Hosted Ubuntu 1604


### PR DESCRIPTION
This got broken when we moved alpine arm legs to run tests in official builds. That was the last leg running on official builds without any tests causing them to fail due to matrix being empty and container variable also because of not being set by the matrix.

