### PR TITLE
Run IBCMerge on Linux build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -264,8 +264,13 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <!-- Embed IBC data on Windows release builds, if IBCMerge isn't available this will just log the commandline -->
-    <EnablePartialNgenOptimization Condition="'$(EnablePartialNgenOptimization)' == '' and '$(OS)' == 'Windows_NT' and '$(ConfigurationGroup)' == 'Release'">true</EnablePartialNgenOptimization>
+    <!-- Embed IBC data on release builds, if IBCMerge isn't available this will just log the commandline -->
+    <EnablePartialNgenOptimization Condition="'$(EnablePartialNgenOptimization)' == '' and '$(ConfigurationGroup)' == 'Release'">true</EnablePartialNgenOptimization>
+
+    <WindowsCoreFxOptimizationDataPackageId>optimization.windows_nt-x64.IBC.CoreFx</WindowsCoreFxOptimizationDataPackageId>
+    <WindowsCoreFxOptimizationDataVersion>$(optimizationwindows_ntx64IBCCoreFxPackageVersion)</WindowsCoreFxOptimizationDataVersion>
+    <LinuxCoreFxOptimizationDataPackageId>optimization.linux-x64.IBC.CoreFx</LinuxCoreFxOptimizationDataPackageId>
+    <LinuxCoreFxOptimizationDataVersion>$(optimizationwindows_ntx64IBCCoreFxPackageVersion)</LinuxCoreFxOptimizationDataVersion>
   </PropertyGroup>
 
   <!-- Set up Default symbol and optimization for Configuration -->

--- a/eng/codeOptimization.targets
+++ b/eng/codeOptimization.targets
@@ -10,8 +10,8 @@
           Condition="'$(IsEligibleForNgenOptimization)' == 'true'"
           BeforeTargets="CoreCompile">
     <PropertyGroup>
-      <IbcOptimizationDataDir Condition="'$(OSGroup)' == 'Unix'">$(IbcOptimizationDataDir)$(LinuxCoreFxOptimizationDataPackageId)\</IbcOptimizationDataDir>
-      <IbcOptimizationDataDir Condition="'$(OSGroup)' != 'Unix'">$(IbcOptimizationDataDir)$(WindowsCoreFxOptimizationDataPackageId)\</IbcOptimizationDataDir>
+      <IbcOptimizationDataDir Condition="'$(OSGroup)' == 'Unix' or '$(OSGroup)' == 'Linux'">$(IbcOptimizationDataDir)$(LinuxCoreFxOptimizationDataPackageId)\</IbcOptimizationDataDir>
+      <IbcOptimizationDataDir Condition="'$(OSGroup)' != 'Unix' and '$(OSGroup)' != 'Linux'">$(IbcOptimizationDataDir)$(WindowsCoreFxOptimizationDataPackageId)\</IbcOptimizationDataDir>
     </PropertyGroup>
     <ItemGroup>
       <_optimizationDataAssembly Include="$(IbcOptimizationDataDir)**\$(TargetFileName)" />

--- a/eng/codeOptimization.targets
+++ b/eng/codeOptimization.targets
@@ -9,6 +9,10 @@
   <Target Name="SetApplyNgenOptimization"
           Condition="'$(IsEligibleForNgenOptimization)' == 'true'"
           BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <IbcOptimizationDataDir Condition="'$(OSGroup)' == 'Unix'">$(IbcOptimizationDataDir)$(LinuxCoreFxOptimizationDataPackageId)\</IbcOptimizationDataDir>
+      <IbcOptimizationDataDir Condition="'$(OSGroup)' != 'Unix'">$(IbcOptimizationDataDir)$(WindowsCoreFxOptimizationDataPackageId)\</IbcOptimizationDataDir>
+    </PropertyGroup>
     <ItemGroup>
       <_optimizationDataAssembly Include="$(IbcOptimizationDataDir)**\$(TargetFileName)" />
     </ItemGroup>

--- a/external/optimizationData/optimizationData.depproj
+++ b/external/optimizationData/optimizationData.depproj
@@ -3,14 +3,11 @@
     <!-- Copy to IBC directory -->
     <OutputPath>$(IbcOptimizationDataDir)</OutputPath>
     <EnableBinPlacing>false</EnableBinPlacing>
-
-    <CoreFxOptimizationDataPackageId>optimization.windows_nt-x64.IBC.CoreFx</CoreFxOptimizationDataPackageId>
-    <CoreFxOptimizationDataPackageId Condition="'$(IBCTarget)'=='Linux'">optimization.linux-x64.IBC.CoreFx</CoreFxOptimizationDataPackageId>
-    <CoreFxOptimizationDataVersion>$(optimizationwindows_ntx64IBCCoreFxPackageVersion)</CoreFxOptimizationDataVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- IBC data -->
-    <IBCPackage Include="$(CoreFxOptimizationDataPackageId)" Version="$(CoreFxOptimizationDataVersion)" />
+    <IBCPackage Include="$(WindowsCoreFxOptimizationDataPackageId)" Version="$(WindowsCoreFxOptimizationDataVersion)" />
+    <IBCPackage Include="$(LinuxCoreFxOptimizationDataPackageId)" Version="$(LinuxCoreFxOptimizationDataVersion)" />
     <PackageReference Include="@(IBCPackage)" GeneratePathProperty="true" />
   </ItemGroup>
   


### PR DESCRIPTION
* Restores IBC data for both Linux and Windows on all platforms
* Chooses the right IBC data based on the target OS
* When target OS isn't anything specific (like, e.g. System.Linq and other assemblies that are not OS specific), embeds Windows IBC data