### PR TITLE
Close the socket if bind() fails

### DIFF
--- a/src/Native/Unix/System.Native/pal_networkchange.c
+++ b/src/Native/Unix/System.Native/pal_networkchange.c
@@ -35,7 +35,9 @@ Error SystemNative_CreateNetworkChangeListenerSocket(int32_t* retSocket)
     if (bind(sock, (struct sockaddr*)(&sa), sizeof(sa)) != 0)
     {
         *retSocket = -1;
-        return (Error)(SystemNative_ConvertErrorPlatformToPal(errno));
+        Error palError = (Error)(SystemNative_ConvertErrorPlatformToPal(errno));
+        close(sock);
+        return palError;
     }
 
     *retSocket = sock;


### PR DESCRIPTION
When using a socket with bind() and bind fails, close the socket to free
up the resources associated with the socket.