### PR TITLE
Fix outerloop linux build missing container resource

### DIFF
--- a/eng/pipelines/outerloop.yml
+++ b/eng/pipelines/outerloop.yml
@@ -8,6 +8,9 @@ resources:
   - container: ubuntu_1604_arm64_cross_container
     image: microsoft/dotnet-buildtools-prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921
 
+  - container: alpine_36_container
+    image: microsoft/dotnet-buildtools-prereqs:alpine-3.6-WithNode-f4d3fe3-20181213005010
+
 jobs:
   # Windows outerloop legs
   - ${{ if endsWith(variables['Build.DefinitionName'], 'windows') }}:


### PR DESCRIPTION
Fixes: #36771 

This is another regression of when we added the musl legs to run tests.

cc: @vcsjones 