### PR TITLE
JsonSerializerOptions API update and ignore property features

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -118,9 +118,9 @@ namespace System.Text.Json
     public partial struct JsonReaderOptions
     {
         private int _dummyPrimitive;
+        public bool AllowTrailingCommas { get { throw null; } set { } }
         public System.Text.Json.JsonCommentHandling CommentHandling { get { throw null; } set { } }
         public int MaxDepth { get { throw null; } set { } }
-        public bool AllowTrailingCommas { get { throw null; } set { } }
     }
     public partial struct JsonReaderState
     {
@@ -311,6 +311,15 @@ namespace System.Text.Json
 }
 namespace System.Text.Json.Serialization
 {
+    public abstract partial class JsonAttribute : System.Attribute
+    {
+        protected JsonAttribute() { }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false)]
+    public sealed partial class JsonIgnoreAttribute : System.Text.Json.Serialization.JsonAttribute
+    {
+        public JsonIgnoreAttribute() { }
+    }
     public static partial class JsonSerializer
     {
         public static object Parse(System.ReadOnlySpan<byte> utf8Json, System.Type returnType, System.Text.Json.Serialization.JsonSerializerOptions options = null) { throw null; }
@@ -329,10 +338,12 @@ namespace System.Text.Json.Serialization
     public sealed partial class JsonSerializerOptions
     {
         public JsonSerializerOptions() { }
+        public bool AllowTrailingCommas { get { throw null; } set { } }
         public int DefaultBufferSize { get { throw null; } set { } }
-        public bool IgnoreNullPropertyValueOnRead { get { throw null; } set { } }
-        public bool IgnoreNullPropertyValueOnWrite { get { throw null; } set { } }
-        public System.Text.Json.JsonReaderOptions ReaderOptions { get { throw null; } set { } }
-        public System.Text.Json.JsonWriterOptions WriterOptions { get { throw null; } set { } }
+        public bool IgnoreNullValues { get { throw null; } set { } }
+        public bool IgnoreReadOnlyProperties { get { throw null; } set { } }
+        public int MaxDepth { get { throw null; } set { } }
+        public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
+        public bool WriteIndented { get { throw null; } set { } }
     }
 }

--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -321,4 +321,7 @@
   <data name="TrailingCommaNotAllowedBeforeObjectEnd" xml:space="preserve">
     <value>The JSON object contains a trailing comma at the end which is not supported in this mode. Change the reader options.</value>
   </data>
+  <data name="SerializerOptionsImmutable" xml:space="preserve">
+    <value>Serializer options cannot be changed once serialization or deserialization has occurred.</value>
+  </data>
 </root>

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -65,14 +65,17 @@
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterUInt16.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterUInt32.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterUInt64.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonClassInfo.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonClassInfo.AddProperty.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonEnumerableConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonIgnoreAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPropertyInfo.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPropertyInfoCommon.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPropertyInfoNotNullable.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPropertyInfoNullable.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.HandleArray.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.Helpers.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.Stream.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.HandleValue.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializer.Read.HandleObject.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderOptions.cs
@@ -15,7 +15,7 @@ namespace System.Text.Json
 
         /// <summary>
         /// Defines how the <see cref="Utf8JsonReader"/> should handle comments when reading through the JSON.
-        /// By default the reader will throw a <exception cref="JsonReaderException"/> if it encounters a comment.
+        /// By default <exception cref="JsonReaderException"/> is thrown if a comment is encountered.
         /// </summary>
         public JsonCommentHandling CommentHandling { get; set; }
 
@@ -37,8 +37,8 @@ namespace System.Text.Json
 
         /// <summary>
         /// Defines whether an extra comma at the end of a list of JSON values in an object or array
-        /// are allowed (and ignored) within the JSON payload being read.
-        /// By default, it's set to false, and the reader will throw a <exception cref="JsonReaderException"/> if it encounters a trailing comma.
+        /// is allowed (and ignored) within the JSON payload being read.
+        /// By default, it's set to false, and <exception cref="JsonReaderException"/> is thrown if a trailing comma is encountered.
         /// </summary>
         public bool AllowTrailingCommas { get; set; }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonAttribute.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonAttribute.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// The base class of serialization attributes.
+    /// </summary>
+    public abstract class JsonAttribute : Attribute { }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonIgnoreAttribute.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonIgnoreAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// Prevents a property from being serialized or deserialized.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public sealed class JsonIgnoreAttribute : JsonAttribute
+    {
+        public JsonIgnoreAttribute() { }
+    }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json.Serialization.Converters;
 using System.Text.Json.Serialization.Policies;
@@ -11,15 +12,20 @@ namespace System.Text.Json.Serialization
 {
     internal abstract class JsonPropertyInfo
     {
+        // Cache the array and enumerable converters so they don't get created for every enumerable property.
+        private static readonly JsonEnumerableConverter s_jsonArrayConverter = new DefaultArrayConverter();
+        private static readonly JsonEnumerableConverter s_jsonEnumerableConverter = new DefaultEnumerableConverter();
+
         internal ClassType ClassType;
 
         internal byte[] _name = default;
         internal byte[] _escapedName = default;
 
-        protected bool HasGetter { get; set; }
-        protected bool HasSetter { get; set; }
-        protected bool UseGetter { get; private set; }
-        protected bool UseSetter { get; private set; }
+        internal bool HasGetter { get; set; }
+        internal bool HasSetter { get; set; }
+        internal bool ShouldSerialize { get; private set; }
+        internal bool ShouldDeserialize { get; private set; }
+
         internal bool IgnoreNullValues { get; private set; }
 
         public ReadOnlySpan<byte> Name => _name;
@@ -45,6 +51,7 @@ namespace System.Text.Json.Serialization
             ClassType = JsonClassInfo.GetClassType(runtimePropertyType);
             if (elementType != null)
             {
+                Debug.Assert(ClassType == ClassType.Enumerable);
                 ElementClassInfo = options.GetOrAddClass(elementType);
             }
 
@@ -68,26 +75,73 @@ namespace System.Text.Json.Serialization
 
         internal virtual void GetPolicies(JsonSerializerOptions options)
         {
-            if (RuntimePropertyType.IsArray)
-            {
-                EnumerableConverter = new DefaultArrayConverter();
-            }
-            else if (typeof(IEnumerable).IsAssignableFrom(RuntimePropertyType))
-            {
-                Type elementType = JsonClassInfo.GetElementType(RuntimePropertyType);
+            DetermineSerializationCapabilities(options);
+            IgnoreNullValues = options.IgnoreNullValues;
+        }
 
-                if (RuntimePropertyType.IsAssignableFrom(typeof(JsonEnumerableT<>).MakeGenericType(elementType)))
-                {
-                    EnumerableConverter = new DefaultEnumerableConverter();
-                }
-            }
-
+        private void DetermineSerializationCapabilities(JsonSerializerOptions options)
+        {
             bool hasIgnoreAttribute = (GetAttribute<JsonIgnoreAttribute>() != null);
 
-            UseGetter = HasGetter && !hasIgnoreAttribute && (HasSetter || !options.IgnoreReadOnlyProperties);
-            UseSetter = HasSetter && !hasIgnoreAttribute;
+            if (hasIgnoreAttribute)
+            {
+                // We don't serialize or deserialize.
+                return;
+            }
 
-            IgnoreNullValues = options.IgnoreNullValues;
+            if (ClassType != ClassType.Enumerable)
+            {
+                // We serialize if there is a getter + no [Ignore] attribute + not ignoring readonly properties.
+                ShouldSerialize = HasGetter && (HasSetter || !options.IgnoreReadOnlyProperties);
+
+                // We deserialize if there is a setter + no [Ignore] attribute. 
+                ShouldDeserialize = HasSetter;
+            }
+            else
+            {
+                if (HasGetter)
+                {
+                    if (HasSetter)
+                    {
+                        ShouldDeserialize = true;
+                    }
+                    else if (RuntimePropertyType.IsAssignableFrom(typeof(IList)))
+                    {
+                        ShouldDeserialize = true;
+                    }
+                    //else
+                    //{
+                    //    // todo: future feature that allows non-List types (e.g. from System.Collections.Immutable) to have converters.
+                    //}
+                }
+                //else if (HasSetter)
+                //{
+                //    // todo: Special case where there is no getter but a setter (and an EnumerableConverter)
+                //}
+
+                if (ShouldDeserialize)
+                {
+                    ShouldSerialize = HasGetter;
+
+                    if (RuntimePropertyType.IsArray)
+                    {
+                        EnumerableConverter = s_jsonArrayConverter;
+                    }
+                    else if (typeof(IEnumerable).IsAssignableFrom(RuntimePropertyType))
+                    {
+                        Type elementType = JsonClassInfo.GetElementType(RuntimePropertyType);
+
+                        if (RuntimePropertyType.IsAssignableFrom(typeof(JsonEnumerableT<>).MakeGenericType(elementType)))
+                        {
+                            EnumerableConverter = s_jsonEnumerableConverter;
+                        }
+                    }
+                }
+                else
+                {
+                    ShouldSerialize = HasGetter && !options.IgnoreReadOnlyProperties;
+                }
+            }
         }
 
         internal abstract object GetValueAsObject(object obj, JsonSerializerOptions options);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -78,7 +78,7 @@ namespace System.Text.Json.Serialization
             Debug.Assert(Set != null);
             TDeclaredProperty typedValue = (TDeclaredProperty)value;
 
-            if (typedValue != null || !IgnoreNullPropertyValueOnWrite(options))
+            if (typedValue != null || !IgnoreNullValues)
             {
                 Set((TClass)obj, (TDeclaredProperty)value);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
@@ -36,7 +36,7 @@ namespace System.Text.Json.Serialization
                 JsonPropertyInfo propertyInfo = ElementClassInfo.GetPolicyProperty();
                 propertyInfo.ReadEnumerable(tokenType, options, ref state, ref reader);
             }
-            else if (HasSetter)
+            else if (UseSetter)
             {
                 if (ValueConverter != null)
                 {
@@ -48,7 +48,7 @@ namespace System.Text.Json.Serialization
                         }
                         else
                         {
-                            if (value != null || !IgnoreNullPropertyValueOnRead(options))
+                            if (value != null || !IgnoreNullValues)
                             {
                                 Set((TClass)state.Current.ReturnValue, value);
                             }
@@ -85,7 +85,7 @@ namespace System.Text.Json.Serialization
                 JsonPropertyInfo propertyInfo = ElementClassInfo.GetPolicyProperty();
                 propertyInfo.WriteEnumerable(options, ref current, ref writer);
             }
-            else if (HasGetter)
+            else if (UseGetter)
             {
                 TRuntimeProperty value;
                 if (_isPropertyPolicy)
@@ -103,7 +103,7 @@ namespace System.Text.Json.Serialization
                     {
                         writer.WriteNullValue();
                     }
-                    else if (!IgnoreNullPropertyValueOnWrite(options))
+                    else if (!IgnoreNullValues)
                     {
                         writer.WriteNull(_escapedName);
                     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
@@ -36,7 +36,7 @@ namespace System.Text.Json.Serialization
                 JsonPropertyInfo propertyInfo = ElementClassInfo.GetPolicyProperty();
                 propertyInfo.ReadEnumerable(tokenType, options, ref state, ref reader);
             }
-            else if (UseSetter)
+            else if (ShouldDeserialize)
             {
                 if (ValueConverter != null)
                 {
@@ -48,10 +48,10 @@ namespace System.Text.Json.Serialization
                         }
                         else
                         {
-                            if (value != null || !IgnoreNullValues)
-                            {
-                                Set((TClass)state.Current.ReturnValue, value);
-                            }
+                            // Null values were already handled.
+                            Debug.Assert(value != null);
+
+                            Set((TClass)state.Current.ReturnValue, value);
                         }
 
                         return;
@@ -85,7 +85,7 @@ namespace System.Text.Json.Serialization
                 JsonPropertyInfo propertyInfo = ElementClassInfo.GetPolicyProperty();
                 propertyInfo.WriteEnumerable(options, ref current, ref writer);
             }
-            else if (UseGetter)
+            else if (ShouldSerialize)
             {
                 TRuntimeProperty value;
                 if (_isPropertyPolicy)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
@@ -36,7 +36,7 @@ namespace System.Text.Json.Serialization
                 JsonPropertyInfo propertyInfo = ElementClassInfo.GetPolicyProperty();
                 propertyInfo.ReadEnumerable(tokenType, options, ref state, ref reader);
             }
-            else if (HasSetter)
+            else if (UseSetter)
             {
                 if (ValueConverter != null)
                 {
@@ -82,7 +82,7 @@ namespace System.Text.Json.Serialization
                 JsonPropertyInfo propertyInfo = ElementClassInfo.GetPolicyProperty();
                 propertyInfo.WriteEnumerable(options, ref current, ref writer);
             }
-            else if (HasGetter)
+            else if (UseGetter)
             {
                 TProperty? value;
                 if (_isPropertyPolicy)
@@ -100,7 +100,7 @@ namespace System.Text.Json.Serialization
                     {
                         writer.WriteNullValue();
                     }
-                    else if (!IgnoreNullPropertyValueOnWrite(options))
+                    else if (!IgnoreNullValues)
                     {
                         writer.WriteNull(_escapedName);
                     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
@@ -36,7 +36,7 @@ namespace System.Text.Json.Serialization
                 JsonPropertyInfo propertyInfo = ElementClassInfo.GetPolicyProperty();
                 propertyInfo.ReadEnumerable(tokenType, options, ref state, ref reader);
             }
-            else if (UseSetter)
+            else if (ShouldDeserialize)
             {
                 if (ValueConverter != null)
                 {
@@ -82,7 +82,7 @@ namespace System.Text.Json.Serialization
                 JsonPropertyInfo propertyInfo = ElementClassInfo.GetPolicyProperty();
                 propertyInfo.WriteEnumerable(options, ref current, ref writer);
             }
-            else if (UseGetter)
+            else if (ShouldSerialize)
             {
                 TProperty? value;
                 if (_isPropertyPolicy)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -15,7 +15,10 @@ namespace System.Text.Json.Serialization
             ref Utf8JsonReader reader,
             ref ReadStack state)
         {
-            if (state.Current.Skip())
+            JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
+
+            bool skip = jsonPropertyInfo != null && !jsonPropertyInfo.ShouldDeserialize;
+            if (skip || state.Current.Skip())
             {
                 // The array is not being applied to the object.
                 state.Push();
@@ -23,7 +26,6 @@ namespace System.Text.Json.Serialization
                 return;
             }
 
-            JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
             if (jsonPropertyInfo == null || state.Current.JsonClassInfo.ClassType == ClassType.Unknown)
             {
                 jsonPropertyInfo = state.Current.JsonClassInfo.CreatePolymorphicProperty(jsonPropertyInfo, typeof(object), options);
@@ -53,8 +55,10 @@ namespace System.Text.Json.Serialization
                     state.Current.EnumerableCreated = true;
                 }
 
+                jsonPropertyInfo = state.Current.JsonPropertyInfo;
+
                 // If current property is already set (from a constructor, for example) leave as-is
-                if (state.Current.JsonPropertyInfo.GetValueAsObject(state.Current.ReturnValue, options) == null)
+                if (jsonPropertyInfo.GetValueAsObject(state.Current.ReturnValue, options) == null)
                 {
                     // Create the enumerable.
                     object value = ReadStackFrame.CreateEnumerableValue(ref reader, ref state, options);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -41,7 +41,7 @@ namespace System.Text.Json.Serialization
                 return true;
             }
 
-            if (!propertyInfo.IgnoreNullPropertyValueOnRead(options))
+            if (!propertyInfo.IgnoreNullValues)
             {
                 state.Current.JsonPropertyInfo.SetValueAsObject(state.Current.ReturnValue, null, options);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
@@ -11,8 +11,7 @@ namespace System.Text.Json.Serialization
             JsonSerializerOptions options,
             ref Utf8JsonReader reader)
         {
-            if (options == null)
-                options = JsonSerializerOptions.s_defaultOptions;
+            options ??= JsonSerializerOptions.s_defaultOptions;
 
             ReadStack state = default;
             state.Current.Initialize(returnType, options);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.Json.Serialization
+{
+    public static partial class JsonSerializer
+    {
+        private static object ReadCore(
+            Type returnType,
+            JsonSerializerOptions options,
+            ref Utf8JsonReader reader)
+        {
+            if (options == null)
+                options = JsonSerializerOptions.s_defaultOptions;
+
+            ReadStack state = default;
+            state.Current.Initialize(returnType, options);
+
+            ReadCore(options, ref reader, ref state);
+
+            return state.Current.ReturnValue;
+        }
+    }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -49,9 +49,9 @@ namespace System.Text.Json.Serialization
         private static object ParseCore(ReadOnlySpan<byte> utf8Json, Type returnType, JsonSerializerOptions options)
         {
             if (options == null)
-                options = s_defaultSettings;
+                options = JsonSerializerOptions.s_defaultOptions;
 
-            var readerState = new JsonReaderState(options: options.ReaderOptions);
+            var readerState = new JsonReaderState(options.GetReaderOptions());
             var reader = new Utf8JsonReader(utf8Json, isFinalBlock: true, readerState);
             object result = ReadCore(returnType, options, ref reader);
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -48,8 +48,7 @@ namespace System.Text.Json.Serialization
 
         private static object ParseCore(ReadOnlySpan<byte> utf8Json, Type returnType, JsonSerializerOptions options)
         {
-            if (options == null)
-                options = JsonSerializerOptions.s_defaultOptions;
+            options ??= JsonSerializerOptions.s_defaultOptions;
 
             var readerState = new JsonReaderState(options.GetReaderOptions());
             var reader = new Utf8JsonReader(utf8Json, isFinalBlock: true, readerState);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -78,12 +78,12 @@ namespace System.Text.Json.Serialization
             JsonSerializerOptions options = null,
             CancellationToken cancellationToken = default)
         {
-            options ??= s_defaultSettings;
+            options ??= JsonSerializerOptions.s_defaultOptions;
 
             ReadStack state = default;
             state.Current.Initialize(returnType, options);
 
-            var readerState = new JsonReaderState(options.ReaderOptions);
+            var readerState = new JsonReaderState(options.GetReaderOptions());
 
             // todo: switch to ArrayBuffer implementation to handle and simplify the allocs?
             byte[] buffer = ArrayPool<byte>.Shared.Rent(options.DefaultBufferSize);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -62,12 +62,11 @@ namespace System.Text.Json.Serialization
 
         private static object ParseCore(string json, Type returnType, JsonSerializerOptions options = null)
         {
-            if (options == null)
-                options = s_defaultSettings;
+            options ??= JsonSerializerOptions.s_defaultOptions;
 
             // todo: use an array pool here for smaller requests to avoid the alloc?
             byte[] jsonBytes = JsonReaderHelper.s_utf8Encoding.GetBytes(json);
-            var readerState = new JsonReaderState(options: options.ReaderOptions);
+            var readerState = new JsonReaderState(options.GetReaderOptions());
             var reader = new Utf8JsonReader(jsonBytes, isFinalBlock: true, readerState);
             object result = ReadCore(returnType, options, ref reader);
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -14,23 +14,6 @@ namespace System.Text.Json.Serialization
     public static partial class JsonSerializer
     {
         internal static readonly JsonPropertyInfo s_missingProperty = new JsonPropertyInfoNotNullable<object, object, object>();
-        private static readonly JsonSerializerOptions s_defaultSettings = new JsonSerializerOptions();
-
-        private static object ReadCore(
-            Type returnType,
-            JsonSerializerOptions options,
-            ref Utf8JsonReader reader)
-        {
-            if (options == null)
-                options = s_defaultSettings;
-
-            ReadStack state = default;
-            state.Current.Initialize(returnType, options);
-
-            ReadCore(options, ref reader, ref state);
-
-            return state.Current.ReturnValue;
-        }
 
         // todo: for readability, refactor this method to split by ClassType(Enumerable, Object, or Value) like Write()
         private static void ReadCore(

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleEnumerable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleEnumerable.cs
@@ -26,6 +26,11 @@ namespace System.Text.Json.Serialization
             Debug.Assert(state.Current.JsonPropertyInfo.ClassType == ClassType.Enumerable);
 
             JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
+            if (!jsonPropertyInfo.ShouldSerialize)
+            {
+                // Ignore writing this property.
+                return true;
+            }
 
             if (state.Current.Enumerator == null)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
@@ -114,7 +114,7 @@ namespace System.Text.Json.Serialization
             }
             else
             {
-                if (!jsonPropertyInfo.IgnoreNullPropertyValueOnWrite(options))
+                if (!jsonPropertyInfo.IgnoreNullValues)
                 {
                     writer.WriteNull(jsonPropertyInfo._escapedName);
                 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -66,8 +66,7 @@ namespace System.Text.Json.Serialization
 
         private static byte[] WriteCoreBytes(object value, Type type, JsonSerializerOptions options)
         {
-            if (options == null)
-                options = s_defaultSettings;
+            options ??= JsonSerializerOptions.s_defaultOptions;
 
             byte[] result;
 
@@ -82,9 +81,7 @@ namespace System.Text.Json.Serialization
 
         private static string WriteCoreString(object value, Type type, JsonSerializerOptions options)
         {
-            if (options == null)
-                options = s_defaultSettings;
-
+            options ??= JsonSerializerOptions.s_defaultOptions;
             string result;
 
             using (var output = new ArrayBufferWriter<byte>(options.DefaultBufferSize))
@@ -100,7 +97,7 @@ namespace System.Text.Json.Serialization
         {
             Debug.Assert(type != null || value == null);
 
-            var writerState = new JsonWriterState(options.WriterOptions);
+            var writerState = new JsonWriterState(options.GetWriterOptions());
             var writer = new Utf8JsonWriter(output, writerState);
 
             if (value == null)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -45,10 +45,9 @@ namespace System.Text.Json.Serialization
 
         private static async Task WriteAsyncCore(object value, Type type, Stream utf8Json, JsonSerializerOptions options, CancellationToken cancellationToken)
         {
-            if (options == null)
-                options = s_defaultSettings;
+            options ??= JsonSerializerOptions.s_defaultOptions;
 
-            var writerState = new JsonWriterState(options.WriterOptions);
+            var writerState = new JsonWriterState(options.GetWriterOptions());
 
             using (var bufferWriter = new ArrayBufferWriter<byte>(options.DefaultBufferSize))
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 
 namespace System.Text.Json.Serialization
 {
@@ -13,43 +14,53 @@ namespace System.Text.Json.Serialization
     {
         internal const int BufferSizeDefault = 16 * 1024;
 
-        private ClassMaterializer _classMaterializerStrategy;
-        private int _defaultBufferSize = BufferSizeDefault;
+        internal static readonly JsonSerializerOptions s_defaultOptions = new JsonSerializerOptions();
 
-        private static readonly ConcurrentDictionary<Type, JsonClassInfo> s_classes = new ConcurrentDictionary<Type, JsonClassInfo>();
+        private readonly ConcurrentDictionary<Type, JsonClassInfo> _classes = new ConcurrentDictionary<Type, JsonClassInfo>();
+        private ClassMaterializer _classMaterializerStrategy;
+        private JsonCommentHandling _readCommentHandling;
+        private int _defaultBufferSize = BufferSizeDefault;
+        private int _maxDepth;
+        private bool _allowTrailingCommas;
+        private bool _haveTypesBeenCreated;
+        private bool _ignoreNullValues;
+        private bool _ignoreReadOnlyProperties;
+        private bool _writeIndented;
 
         /// <summary>
         /// Constructs a new <see cref="JsonSerializerOptions"/> instance.
         /// </summary>
         public JsonSerializerOptions() { }
 
-        internal JsonClassInfo GetOrAddClass(Type classType)
+        /// <summary>
+        /// Defines whether an extra comma at the end of a list of JSON values in an object or array
+        /// are allowed (and ignored) within the JSON payload being read.
+        /// By default, it's set to false, and the reader will throw a <exception cref="JsonReaderException"/> if it encounters a trailing comma.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is set after serialization or deserialization has occurred.
+        /// </exception>
+        public bool AllowTrailingCommas
         {
-            JsonClassInfo result;
-
-            if (!s_classes.TryGetValue(classType, out result))
+            get
             {
-                result = s_classes.GetOrAdd(classType, new JsonClassInfo(classType, this));
+                return _allowTrailingCommas;
             }
-
-            return result;
+            set
+            {
+                VerifyMutable();
+                _allowTrailingCommas = value;
+            }
         }
-
-        /// <summary>
-        /// Options to control the <see cref="Utf8JsonReader"/>.
-        /// </summary>
-        public JsonReaderOptions ReaderOptions { get; set; }
-
-        /// <summary>
-        /// Options to control the <see cref="Utf8JsonWriter"/>.
-        /// </summary>
-        public JsonWriterOptions WriterOptions { get; set; }
 
         /// <summary>
         /// The default buffer size in bytes used when creating temporary buffers.
         /// </summary>
         /// <remarks>The default size is 16K.</remarks>
         /// <exception cref="System.ArgumentException">Thrown when the buffer size is less than 1.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is set after serialization or deserialization has occurred.
+        /// </exception>
         public int DefaultBufferSize
         {
             get
@@ -58,6 +69,8 @@ namespace System.Text.Json.Serialization
             }
             set
             {
+                VerifyMutable();
+
                 if (value < 1)
                 {
                     throw new ArgumentException(SR.SerializationInvalidBufferSize);
@@ -68,14 +81,106 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// Determines whether null values of properties are ignored or whether they are written to the JSON.
+        /// Determines whether null values are ignored during serialization and deserialization.
+        /// The default value is false.
         /// </summary>
-        public bool IgnoreNullPropertyValueOnWrite { get; set; }
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is set after serialization or deserialization has occurred.
+        /// </exception>
+        public bool IgnoreNullValues
+        {
+            get
+            {
+                return _ignoreNullValues;
+            }
+            set
+            {
+                VerifyMutable();
+                _ignoreNullValues = value;
+            }
+        }
 
         /// <summary>
-        /// Determines whether null values in the JSON are ignored or whether they are set on properties.
+        /// Determines whether read-only properties are ignored during serialization and deserialization.
+        /// A property is read-only if it contains a public getter but not a public setter.
+        /// The default value is false.
         /// </summary>
-        public bool IgnoreNullPropertyValueOnRead { get; set; }
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is set after serialization or deserialization has occurred.
+        /// </exception>
+        public bool IgnoreReadOnlyProperties
+        {
+            get
+            {
+                return _ignoreReadOnlyProperties;
+            }
+            set
+            {
+                VerifyMutable();
+                _ignoreReadOnlyProperties = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum depth allowed when reading or writing JSON, with the default (i.e. 0) indicating a max depth of 64.
+        /// Reading past this depth will throw a <exception cref="JsonReaderException"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is set after serialization or deserialization has occurred.
+        /// </exception>
+        public int MaxDepth
+        {
+            get
+            {
+                return _maxDepth;
+            }
+            set
+            {
+                VerifyMutable();
+                _maxDepth = value;
+            }
+        }
+
+        /// <summary>
+        /// Defines how the <see cref="Utf8JsonReader"/> should handle comments when reading through the JSON.
+        /// By default the reader will throw a <exception cref="JsonReaderException"/> if it encounters a comment.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is set after serialization or deserialization has occurred.
+        /// </exception>
+        public JsonCommentHandling ReadCommentHandling
+        {
+            get
+            {
+                return _readCommentHandling;
+            }
+            set
+            {
+                VerifyMutable();
+                _readCommentHandling = value;
+            }
+        }
+
+        /// <summary>
+        /// Defines whether the <see cref="Utf8JsonWriter"/> should pretty print the JSON which includes:
+        /// indenting nested JSON tokens, adding new lines, and adding white space between property names and values.
+        /// By default, the JSON is written without any extra white space.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is set after serialization or deserialization has occurred.
+        /// </exception>
+        public bool WriteIndented
+        {
+            get
+            {
+                return _writeIndented;
+            }
+            set
+            {
+                VerifyMutable();
+                _writeIndented = value;
+            }
+        }
 
         internal ClassMaterializer ClassMaterializerStrategy
         {
@@ -92,6 +197,48 @@ namespace System.Text.Json.Serialization
                 }
 
                 return _classMaterializerStrategy;
+            }
+        }
+
+        internal JsonClassInfo GetOrAddClass(Type classType)
+        {
+            _haveTypesBeenCreated = true;
+
+            // todo: for performance, consider obtaining the type from s_defaultOptions and then cloning.
+            if (!_classes.TryGetValue(classType, out JsonClassInfo result))
+            {
+                result = _classes.GetOrAdd(classType, new JsonClassInfo(classType, this));
+            }
+
+            return result;
+        }
+
+        internal JsonReaderOptions GetReaderOptions()
+        {
+            return new JsonReaderOptions
+            {
+                AllowTrailingCommas = AllowTrailingCommas,
+                CommentHandling = ReadCommentHandling,
+                MaxDepth = MaxDepth
+            };
+        }
+
+        internal JsonWriterOptions GetWriterOptions()
+        {
+            return new JsonWriterOptions
+            {
+                Indented = WriteIndented
+            };
+        }
+
+        private void VerifyMutable()
+        {
+            // The default options are hidden and thus should be immutable.
+            Debug.Assert(this != s_defaultOptions);
+
+            if (_haveTypesBeenCreated)
+            {
+                ThrowHelper.ThrowInvalidOperationException_SerializerOptionsImmutable();
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -34,8 +34,8 @@ namespace System.Text.Json.Serialization
 
         /// <summary>
         /// Defines whether an extra comma at the end of a list of JSON values in an object or array
-        /// are allowed (and ignored) within the JSON payload being read.
-        /// By default, it's set to false, and the reader will throw a <exception cref="JsonReaderException"/> if it encounters a trailing comma.
+        /// is allowed (and ignored) within the JSON payload being read.
+        /// By default, it's set to false, and <exception cref="JsonReaderException"/> is thrown if a trailing comma is encountered.
         /// </summary>
         /// <exception cref="InvalidOperationException">
         /// Thrown if this property is set after serialization or deserialization has occurred.
@@ -142,8 +142,8 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// Defines how the <see cref="Utf8JsonReader"/> should handle comments when reading through the JSON.
-        /// By default the reader will throw a <exception cref="JsonReaderException"/> if it encounters a comment.
+        /// Defines how the comments are handled during deserialization.
+        /// By default <exception cref="JsonReaderException"/> is thrown if a comment is encountered.
         /// </summary>
         /// <exception cref="InvalidOperationException">
         /// Thrown if this property is set after serialization or deserialization has occurred.
@@ -162,7 +162,7 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
-        /// Defines whether the <see cref="Utf8JsonWriter"/> should pretty print the JSON which includes:
+        /// Defines whether JSON should pretty print which includes:
         /// indenting nested JSON tokens, adding new lines, and adding white space between property names and values.
         /// By default, the JSON is written without any extra white space.
         /// </summary>

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -22,12 +22,6 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowJsonReaderException_DeserializeUnableToConvertValue(Type propertyType, in ReadStack state)
-        {
-            throw new JsonReaderException(SR.Format(SR.DeserializeUnableToConvertValue, state.PropertyPath, propertyType), 0 , 0);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonReaderException_DeserializeCannotBeNull(in Utf8JsonReader reader, in ReadStack state)
         {
             throw new JsonReaderException(SR.Format(SR.DeserializeCannotBeNull, state.PropertyPath), reader.CurrentState);
@@ -37,6 +31,12 @@ namespace System.Text.Json
         public static void ThrowObjectDisposedException(string name)
         {
             throw new ObjectDisposedException(name);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_SerializerOptionsImmutable()
+        {
+            throw new InvalidOperationException(SR.SerializerOptionsImmutable);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -2,12 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
 {
     public static partial class ArrayTests
     {
+        [Fact]
+        public static void ReadEmpty()
+        {
+            SimpleTestClass[] arr = JsonSerializer.Parse<SimpleTestClass[]>("[]");
+            Assert.Equal(0, arr.Length);
+
+            List<SimpleTestClass> list = JsonSerializer.Parse<List<SimpleTestClass>>("[]");
+            Assert.Equal(0, list.Count);
+        }
+
         [Fact]
         public static void ReadClassWithStringArray()
         {

--- a/src/System.Text.Json/tests/Serialization/Array.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.WriteTests.cs
@@ -2,12 +2,23 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
 {
     public static partial class ArrayTests
     {
+        [Fact]
+        public static void WriteEmpty()
+        {
+            string json = JsonSerializer.ToString(new SimpleTestClass[] { });
+            Assert.Equal("[]", json);
+
+            json = JsonSerializer.ToString(new List<SimpleTestClass>());
+            Assert.Equal("[]", json);
+        }
+
         [Fact]
         public static void WriteClassWithStringArray()
         {

--- a/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
@@ -38,10 +38,10 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void OverrideReadOnOption()
+        public static void IgnoreNullValuesOnOptionsWithRead()
         {
             var options = new JsonSerializerOptions();
-            options.IgnoreNullPropertyValueOnRead = true;
+            options.IgnoreNullValues = true;
 
             TestClassWithNullButInitialized obj = JsonSerializer.Parse<TestClassWithNullButInitialized>(TestClassWithNullButInitialized.s_json, options);
             Assert.Equal("Hello", obj.MyString);

--- a/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
@@ -30,20 +30,20 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void DefaultReadValue()
+        public static void DefaultIgnoreNullValuesOnRead()
         {
-            TestClassWithNullButInitialized obj = JsonSerializer.Parse<TestClassWithNullButInitialized>(TestClassWithNullButInitialized.s_json);
+            TestClassWithInitializedProperties obj = JsonSerializer.Parse<TestClassWithInitializedProperties>(TestClassWithInitializedProperties.s_null_json);
             Assert.Equal(null, obj.MyString);
             Assert.Equal(null, obj.MyInt);
         }
 
         [Fact]
-        public static void IgnoreNullValuesOnOptionsWithRead()
+        public static void EnableIgnoreNullValuesOnRead()
         {
             var options = new JsonSerializerOptions();
             options.IgnoreNullValues = true;
 
-            TestClassWithNullButInitialized obj = JsonSerializer.Parse<TestClassWithNullButInitialized>(TestClassWithNullButInitialized.s_json, options);
+            TestClassWithInitializedProperties obj = JsonSerializer.Parse<TestClassWithInitializedProperties>(TestClassWithInitializedProperties.s_null_json, options);
             Assert.Equal("Hello", obj.MyString);
             Assert.Equal(1, obj.MyInt);
         }

--- a/src/System.Text.Json/tests/Serialization/Null.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.WriteTests.cs
@@ -9,21 +9,28 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class NullTests
     {
         [Fact]
-        public static void DefaultWriteOptions()
+        public static void DefaultIgnoreNullValuesOnWrite()
         {
-            var input = new TestClassWithNull();
-            string json = JsonSerializer.ToString(input);
-            Assert.Equal(@"{""MyString"":null}", json);
+            var obj = new TestClassWithInitializedProperties();
+            obj.MyString = null;
+            obj.MyInt = null;
+
+            string json = JsonSerializer.ToString(obj);
+            Assert.Contains(@"""MyString"":null", json);
+            Assert.Contains(@"""MyInt"":null", json);
         }
 
         [Fact]
-        public static void IgnoreNullValuesOnOptionsWithWrite()
+        public static void EnableIgnoreNullValuesOnWrite()
         {
             JsonSerializerOptions options = new JsonSerializerOptions();
             options.IgnoreNullValues = true;
 
-            var input = new TestClassWithNull();
-            string json = JsonSerializer.ToString(input, options);
+            var obj = new TestClassWithInitializedProperties();
+            obj.MyString = null;
+            obj.MyInt = null;
+
+            string json = JsonSerializer.ToString(obj, options);
             Assert.Equal(@"{}", json);
         }
 

--- a/src/System.Text.Json/tests/Serialization/Null.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.WriteTests.cs
@@ -17,10 +17,10 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void OverrideWriteOnOption()
+        public static void IgnoreNullValuesOnOptionsWithWrite()
         {
             JsonSerializerOptions options = new JsonSerializerOptions();
-            options.IgnoreNullPropertyValueOnWrite = true;
+            options.IgnoreNullValues = true;
 
             var input = new TestClassWithNull();
             string json = JsonSerializer.ToString(input, options);

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -16,6 +16,13 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ReadEmpty()
+        {
+            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>("{}");
+            Assert.NotNull(obj);
+        }
+
+        [Fact]
         public static void EmptyClassWithRandomData()
         {
             JsonSerializer.Parse<EmptyClass>(SimpleTestClass.s_json);

--- a/src/System.Text.Json/tests/Serialization/OptionsTests.cs
+++ b/src/System.Text.Json/tests/Serialization/OptionsTests.cs
@@ -9,6 +9,30 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class OptionsTests
     {
         [Fact]
+        public static void SetOptionsFail()
+        {
+            var options = new JsonSerializerOptions();
+
+            JsonSerializer.Parse<int>("1", options);
+
+            // Verify defaults and ensure getters do not throw.
+            Assert.False(options.AllowTrailingCommas);
+            Assert.Equal(16 * 1024, options.DefaultBufferSize);
+            Assert.False(options.IgnoreNullValues);
+            Assert.Equal(0, options.MaxDepth);
+            Assert.Equal(JsonCommentHandling.Disallow, options.ReadCommentHandling);
+            Assert.False(options.WriteIndented);
+
+            // Setters should throw
+            Assert.Throws<InvalidOperationException>(() => options.AllowTrailingCommas = options.AllowTrailingCommas);
+            Assert.Throws<InvalidOperationException>(() => options.DefaultBufferSize = options.DefaultBufferSize);
+            Assert.Throws<InvalidOperationException>(() => options.IgnoreNullValues = options.IgnoreNullValues);
+            Assert.Throws<InvalidOperationException>(() => options.MaxDepth = options.MaxDepth);
+            Assert.Throws<InvalidOperationException>(() => options.ReadCommentHandling = options.ReadCommentHandling);
+            Assert.Throws<InvalidOperationException>(() => options.WriteIndented = options.WriteIndented);
+        }
+
+        [Fact]
         public static void DefaultBufferSizeFail()
         {
             Assert.Throws<ArgumentException>(() => new JsonSerializerOptions().DefaultBufferSize = 0);
@@ -24,6 +48,70 @@ namespace System.Text.Json.Serialization.Tests
 
             options.DefaultBufferSize = 1;
             Assert.Equal(1, options.DefaultBufferSize);
+        }
+
+        [Fact]
+        public static void AllowTrailingCommas()
+        {
+            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<int[]>("[1,]"));
+
+            var options = new JsonSerializerOptions();
+            options.AllowTrailingCommas = true;
+
+            int[] value = JsonSerializer.Parse<int[]>("[1,]", options);
+            Assert.Equal(1, value[0]);
+        }
+
+        [Fact]
+        public static void WriteIndented()
+        {
+            var obj = new BasicCompany();
+            obj.Initialize();
+
+            // Verify default value.
+            string json = JsonSerializer.ToString(obj);
+            Assert.DoesNotContain("\r", json);
+
+            // Verify default value on options.
+            var options = new JsonSerializerOptions();
+            json = JsonSerializer.ToString(obj, options);
+            Assert.DoesNotContain("\r", json);
+
+            // Change the value on options.
+            options = new JsonSerializerOptions();
+            options.WriteIndented = true;
+            json = JsonSerializer.ToString(obj, options);
+            Assert.Contains("\r", json);
+        }
+
+        [Fact]
+        public static void ReadCommentHandling()
+        {
+            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<object>("/* commment */"));
+
+            var options = new JsonSerializerOptions();
+
+            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<object>("/* commment */", options));
+
+            options = new JsonSerializerOptions();
+            options.ReadCommentHandling = JsonCommentHandling.Allow;
+
+            JsonSerializer.Parse<object>("/* commment */", options);
+        }
+
+        [Fact]
+        public static void MaxDepthRead()
+        {
+            JsonSerializer.Parse<BasicCompany>(BasicCompany.s_data);
+
+            var options = new JsonSerializerOptions();
+
+            JsonSerializer.Parse<BasicCompany>(BasicCompany.s_data, options);
+
+            options = new JsonSerializerOptions();
+            options.MaxDepth = 1;
+
+            Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<BasicCompany>(BasicCompany.s_data, options));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/OptionsTests.cs
+++ b/src/System.Text.Json/tests/Serialization/OptionsTests.cs
@@ -70,18 +70,18 @@ namespace System.Text.Json.Serialization.Tests
 
             // Verify default value.
             string json = JsonSerializer.ToString(obj);
-            Assert.DoesNotContain("\r", json);
+            Assert.DoesNotContain(Environment.NewLine, json);
 
             // Verify default value on options.
             var options = new JsonSerializerOptions();
             json = JsonSerializer.ToString(obj, options);
-            Assert.DoesNotContain("\r", json);
+            Assert.DoesNotContain(Environment.NewLine, json);
 
             // Change the value on options.
             options = new JsonSerializerOptions();
             options.WriteIndented = true;
             json = JsonSerializer.ToString(obj, options);
-            Assert.Contains("\r", json);
+            Assert.Contains(Environment.NewLine, json);
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
@@ -181,7 +181,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Contains(@"""NullableInt"":null", json);
 
             JsonSerializerOptions options = new JsonSerializerOptions();
-            options.IgnoreNullPropertyValueOnWrite = true;
+            options.IgnoreNullValues = true;
             json = JsonSerializer.ToString(obj, options);
             Assert.DoesNotContain(@"""NullableInt"":null", json);
         }

--- a/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -21,6 +21,18 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void IgnoreReadOnlyProperties()
+        {
+            var options = new JsonSerializerOptions();
+            options.IgnoreReadOnlyProperties = true;
+
+            var obj = new ClassWithNoSetter();
+
+            string json = JsonSerializer.ToString(obj, options);
+            Assert.Equal(@"{}", json);
+        }
+
+        [Fact]
         public static void NoGetter()
         {
             var objNoSetter = new ClassWithNoSetter();
@@ -51,7 +63,37 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Null(objCopy.GetMyString());
         }
 
+        [Fact]
+        public static void JsonIgnoreAttribute()
+        {
+            var obj = new ClassWithIgnoreAttributeProperty();
+            Assert.Equal(@"DefaultValue", obj.MyString);
+
+            // Verify serialize.
+            string json = JsonSerializer.ToString(obj);
+            Assert.Equal(@"{}", json);
+
+            // Verify deserialize is also ignored.
+            obj = JsonSerializer.Parse<ClassWithIgnoreAttributeProperty>(@"{""MyString"":""Hello""}");
+            Assert.Equal(@"DefaultValue", obj.MyString);
+        }
+
         // Todo: add tests with missing object property and missing collection property.
+
+        public class ClassWithPrivateSetterAndGetter
+        {
+            private string MyString { get; set; }
+
+            public string GetMyString()
+            {
+                return MyString;
+            }
+
+            public void SetMyString(string value)
+            {
+                MyString = value;
+            }
+        }
 
         public class ClassWithNoSetter
         {
@@ -81,19 +123,15 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
-        public class ClassWithPrivateSetterAndGetter
+        public class ClassWithIgnoreAttributeProperty
         {
-            private string MyString { get; set; }
-
-            public string GetMyString()
+            public ClassWithIgnoreAttributeProperty()
             {
-                return MyString;
+                MyString = "DefaultValue";
             }
 
-            public void SetMyString(string value)
-            {
-                MyString = value;
-            }
+            [JsonIgnore]
+            public string MyString { get; set; }
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.cs
@@ -555,17 +555,17 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
-    public class TestClassWithNullButInitialized
+    public class TestClassWithInitializedProperties
     {
         public string MyString { get; set; } = "Hello";
         public int? MyInt { get; set; } = 1;
-        public static readonly string s_json =
+        public static readonly string s_null_json =
                 @"{" +
                 @"""MyString"" : null," +
                 @"""MyInt"" : null" +
                 @"}";
 
-        public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
+        public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_null_json);
     }
 
     public class TestClassWithNestedObjectInner : ITestClass

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -254,6 +254,14 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ReadEmptyObjectArray()
+        {
+            SimpleTestClass[] data = JsonSerializer.Parse<SimpleTestClass[]>("[{}]");
+            Assert.Equal(1, data.Length);
+            Assert.NotNull(data[0]);
+        }
+
+        [Fact]
         public static void ReadPrimitiveJaggedArray()
         {
             int[][] i = JsonSerializer.Parse<int[][]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
@@ -84,6 +84,15 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void WriteEmptyObjectArray()
+        {
+            object[] arr = new object[]{new object()};
+
+            string json = JsonSerializer.ToString(arr);
+            Assert.Equal("[{}]", json);
+        }
+
+        [Fact]
         public static void WritePrimitiveJaggedArray()
         {
             var input = new int[2][];


### PR DESCRIPTION
Apply the approved API changes. Includes some new functionality including an [Ignore] that can be applied to properties and ability to ignore just read-only properties on serialization via options.IgnoreReadOnlyProperties.

Fixes https://github.com/dotnet/corefx/issues/34372
