### PR TITLE
Remove NETStandard Test Suite

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -216,7 +216,6 @@
   <!-- set properties for each vertical -->
   <PropertyGroup>
     <BuildingNETCoreAppVertical Condition="'$(BuildingNETCoreAppVertical)' == '' AND ('$(_bc_TargetGroup)'=='netcoreapp' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingNETCoreAppVertical>
-    <BuildingNETStandardVertical Condition="'$(BuildingNETStandardVertical)' == '' AND ('$(_bc_TargetGroup)'=='netstandard' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingNETStandardVertical>
     <BuildingNETFxVertical Condition="'$(BuildingNETFxVertical)' == '' AND ('$(_bc_TargetGroup)'=='netfx' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingNETFxVertical>
     <BuildingUAPVertical Condition="'$(BuildingUAPVertical)' == '' AND ('$(_bc_TargetGroup)'=='uap' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingUAPVertical>
     <BuildingUAPAOTVertical Condition="'$(BuildingUAPAOTVertical)' == '' AND ('$(_bc_TargetGroup)'=='uapaot' OR '$(BuildAllConfigurations)' == 'true')">true</BuildingUAPAOTVertical>
@@ -379,7 +378,6 @@
     <UAPAOTPackageRuntimePath>$(ArtifactsBinDir)pkg\uapaot\lib</UAPAOTPackageRuntimePath>
     <NetFxPackageRefPath>$(ArtifactsBinDir)pkg\netfx\ref</NetFxPackageRefPath>
     <NetFxPackageRuntimePath>$(ArtifactsBinDir)pkg\netfx\lib</NetFxPackageRuntimePath>
-    <NETStandardTestSuiteOutputPath>$(ArtifactsBinDir)NetStandardTestSuite\</NETStandardTestSuiteOutputPath>
 
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
     <BinPlaceTestSharedFramework Condition="'$(_bc_TargetGroup)' == 'netcoreapp' AND '$(BuildTests)'!='false'">true</BinPlaceTestSharedFramework>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -94,11 +94,6 @@
       <RuntimePath>$(TestHostRootPath)</RuntimePath>
     </BinPlaceConfiguration>
 
-    <!-- binplace netstandard test suite -->
-    <BinPlaceConfiguration Condition="'$(BuildingNETStandardVertical)' == 'true' AND '$(IsTestProject)' == 'true'" Include="netstandard-$(_bc_OSGroup)">
-      <TestPath>$(NETStandardTestSuiteOutputPath)$(AssemblyName)/</TestPath>
-    </BinPlaceConfiguration>
-
     <!-- binplace targeting packs which may be different from BuildConfiguration -->
     <BinPlaceConfiguration Include="netstandard">
       <RefPath>$(RefRootPath)netstandard/</RefPath>

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -190,16 +190,6 @@ jobs:
                     $(_windowsOfficialBuildArguments)
                     $(_msbuildCommonParameters)
             displayName: Build Packages and Tests
-          - ${{ if eq(parameters.isOfficialBuild, 'false') }}:
-            - script: build.cmd
-                      -restore
-                      -build
-                      -configuration $(_BuildConfig)
-                      -ci
-                      -buildtests
-                      -framework netstandard
-                      -arch $(_architecture)
-              displayName: Build Netstandard Test Suite
 
       # TODO: UAPAOT official builds should send to helix using continuation runner.
       # Legs without HELIX testing

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -35,15 +35,5 @@
     <Project Include="$(RepoRoot)pkg\test\testPackages.proj" />
   </ItemGroup>
 
-  <Target Name="BinPlaceXUnitRuntimeForNetstandardSuite"
-          Condition="'$(TargetGroup)' == 'netstandard'"
-          BeforeTargets="BuildAllProjects">
-    <!-- Ensure that we binplace all of the xunit assemblies on the netstandard runtime path in order to be able to build netstandard test suite -->
-    <MSBuild Projects="$(MSBuildThisFileDirectory)../external/test-runtime/XUnit.Runtime.depproj"
-             Properties="TargetGroup=$(TargetGroup)"
-             RemoveProperties="Configuration"
-             ContinueOnError="ErrorAndStop" />
-  </Target>
-
   <Import Project="$(RepositoryEngineeringDir)dir.traversal.targets" />
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/36743

I left the netstandard changes in System.IO.Pipelines as they allow a broader test matrix.