### PR TITLE
System.Linq.Expressions: Skip tests if DebuggerTypeProxy attribute isn't available

### DIFF
--- a/src/System.Linq.Expressions/tests/DebuggerTypeProxy/ExpressionDebuggerTypeProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/DebuggerTypeProxy/ExpressionDebuggerTypeProxyTests.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -32,7 +33,11 @@ namespace System.Linq.Expressions.Tests
         {
             var att =
                 (DebuggerTypeProxyAttribute)
-                    type.GetCustomAttributes().Single(at => at.TypeId.Equals(typeof(DebuggerTypeProxyAttribute)));
+                    type.GetCustomAttributes().SingleOrDefault(at => at.TypeId.Equals(typeof(DebuggerTypeProxyAttribute)));
+            if (att == null)
+            {
+                return null;
+            }
             string proxyName = att.ProxyTypeName;
             proxyName = proxyName.Substring(0, proxyName.IndexOf(','));
             return type.GetTypeInfo().Assembly.GetType(proxyName);
@@ -77,6 +82,10 @@ namespace System.Linq.Expressions.Tests
         {
             Type type = obj.GetType();
             Type viewType = GetDebugViewType(type);
+            if (viewType == null)
+            {
+                throw new SkipTestException($"Didn't find DebuggerTypeProxyAttribute on {type}.");
+            }
             object view = viewType.GetConstructors().Single().Invoke(new[] {obj});
             IEnumerable<PropertyInfo> properties =
                 type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy)
@@ -160,6 +169,10 @@ namespace System.Linq.Expressions.Tests
         {
             Type type = sourceObject.GetType();
             Type viewType = GetDebugViewType(type);
+            if (viewType == null)
+            {
+                throw new SkipTestException($"Didn't find DebuggerTypeProxyAttribute on {type}.");
+            }
             ConstructorInfo ctor = viewType.GetConstructors().Single();
             TargetInvocationException tie = Assert.Throws<TargetInvocationException>(() => ctor.Invoke(new object[] { null }));
             ArgumentNullException ane = (ArgumentNullException)tie.InnerException;

--- a/src/System.Linq.Expressions/tests/DebuggerTypeProxy/ExpressionDebuggerTypeProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/DebuggerTypeProxy/ExpressionDebuggerTypeProxyTests.cs
@@ -51,7 +51,7 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<NotSupportedException>(() => collection.Remove(default(T)));
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(BinaryExpressionProxy))]
         [MemberData(nameof(BlockExpressionProxy))]
         [MemberData(nameof(CatchBlockProxy))]
@@ -164,7 +164,7 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
-        [Theory, MemberData(nameof(OnePerType))]
+        [ConditionalTheory, MemberData(nameof(OnePerType))]
         public void ThrowOnNullToCtor(object sourceObject)
         {
             Type type = sourceObject.GetType();

--- a/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/BindingRestrictionsProxyTests.cs
@@ -67,7 +67,7 @@ namespace System.Dynamic.Tests
         private static BindingRestrictionsProxyProxy GetDebugViewObject(object obj)
             => new BindingRestrictionsProxyProxy(BindingRestrictionsProxyCtor.Invoke(new[] {obj}));
 
-        [Fact]
+        [ConditionalFact]
         public void EmptyRestiction()
         {
             if (BindingRestrictionsDebugViewType == null)
@@ -84,7 +84,7 @@ namespace System.Dynamic.Tests
             Assert.Equal(empty.ToExpression().ToString(), view.ToString());
         }
 
-        [Fact]
+        [ConditionalFact]
         public void CustomRestriction()
         {
             if (BindingRestrictionsDebugViewType == null)
@@ -103,7 +103,7 @@ namespace System.Dynamic.Tests
             Assert.Equal(exp.ToString(), view.ToString());
         }
 
-        [Fact]
+        [ConditionalFact]
         public void MergedRestrictionsProperties()
         {
             var exps = new Expression[]
@@ -138,7 +138,7 @@ namespace System.Dynamic.Tests
             Assert.True(viewedRestrictions.All(r => restrictions.Contains(r)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public void MergedRestrictionsExpressions()
         {
             var exps = new Expression[]
@@ -195,7 +195,7 @@ namespace System.Dynamic.Tests
             Assert.True(notAndAlso.All(ex => exps.Contains(ex)));
         }
 
-        [Fact]
+        [ConditionalFact]
         public void ThrowOnNullToCtor()
         {
             if (BindingRestrictionsDebugViewType == null)

--- a/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectProxyTests.cs
+++ b/src/System.Linq.Expressions/tests/Dynamic/ExpandoObjectProxyTests.cs
@@ -81,7 +81,7 @@ namespace System.Dynamic.Tests
                 Assert.Contains(item, expected);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(KeyCollections))]
         [MemberData(nameof(ValueCollections))]
         public void ItemsAreRootHidden(object eo)
@@ -96,7 +96,7 @@ namespace System.Dynamic.Tests
             Assert.Equal(DebuggerBrowsableState.RootHidden, browsable.State);
         }
 
-        [Theory, MemberData(nameof(KeyCollections))]
+        [ConditionalTheory, MemberData(nameof(KeyCollections))]
         public void KeyCollectionCorrectlyViewed(ICollection<string> keys)
         {
             object view = GetDebugViewObject(keys);
@@ -109,7 +109,7 @@ namespace System.Dynamic.Tests
             AssertSameCollectionIgnoreOrder(keys, items);
         }
 
-        [Theory, MemberData(nameof(ValueCollections))]
+        [ConditionalTheory, MemberData(nameof(ValueCollections))]
         public void ValueCollectionCorrectlyViewed(ICollection<object> keys)
         {
             object view = GetDebugViewObject(keys);
@@ -122,7 +122,7 @@ namespace System.Dynamic.Tests
             AssertSameCollectionIgnoreOrder(keys, items);
         }
 
-        [Theory, MemberData(nameof(OneOfEachCollection))]
+        [ConditionalTheory, MemberData(nameof(OneOfEachCollection))]
         public void ViewTypeThrowsOnNull(object collection)
         {
             Type debugViewType = GetDebugViewType(collection.GetType());


### PR DESCRIPTION
These tests failed on Xamarin.iOS since the linker strips out most Debugger* attributes in release builds.

We can gracefully handle this case and simply skip the tests instead.

/cc @ViktorHofer 