### PR TITLE
Improve HttpClient POST tests stability

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Http.cs
+++ b/src/Common/tests/System/Net/Configuration.Http.cs
@@ -61,6 +61,7 @@ namespace System.Net.Test.Common
             public static readonly Uri RemoteVerifyUploadServer = new Uri("http://" + Host + "/" + VerifyUploadHandler);
             public static readonly Uri SecureRemoteVerifyUploadServer = new Uri("https://" + SecureHost + "/" + VerifyUploadHandler);
             public static readonly Uri Http2RemoteVerifyUploadServer = new Uri("https://" + Http2Host + "/" + VerifyUploadHandler);
+            public static readonly Uri[] VerifyUploadServerList = new Uri[] { RemoteVerifyUploadServer, SecureRemoteVerifyUploadServer, Http2RemoteVerifyUploadServer };
 
             public static readonly Uri RemoteEmptyContentServer = new Uri("http://" + Host + "/" + EmptyContentHandler);
             public static readonly Uri RemoteDeflateServer = new Uri("http://" + Host + "/" + DeflateHandler);


### PR DESCRIPTION
Several of the HttpClient POST scenario tests were failing with HTTP status code 500. This was caused
by the Azure remote endpoint generating OutOfMemoryException at times. The tests are sending large
amounts of request body data to the Echo endpoint. That endpoint will respond back with all the
headers and request body data serialized into a JSON payload. The OOM exceptions were coming from the
Newtonsoft JSON serialization code currently used by the server endpoint.

These tests don't really require that the request body data be sent back. The purpose of the tests is
to verify that the request body payload was correctly sent by the client. We already have an endpoint,
VerifyUpload, that can do that without echo'ing back the large request body data.

This PR modifies the tests to use that endpoint. This should mitigate the OOM exceptions currently being
generated in the server-side code. Additional mitigations/fixes will be done later on the server-side code
to improve robustness. But fixing the tests to be more streamlined is goodness and will result in these
tests being faster and more stable.

Closes #36782