### PR TITLE
Embed generated files into pdbs

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DisableImplicitFrameworkDefines>true</DisableImplicitFrameworkDefines>
     <DisableImplicitConfigurationDefines>true</DisableImplicitConfigurationDefines>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/1885
SourceLink currently is not able to track the generated files such as SR.cs and *notSupported.cs
So we are enbedding these generated files directly into pdbs.

Current output with official Sdk
```
C:\git\arcade\src\Microsoft.DotNet.GitSync>SourceLink test E:\sdkmastersymbols\System.Transactions.Local.pdb
1 Documents with errors:
402e899a094c5807b522d8908de97f46ac67721f1cecf62441fda588e1b782e6 sha256 csharp F:\workspace\_work\1\s\artifacts\obj\System.Transactions.Local\netcoreapp-Release\System.SR.cs
https://raw.githubusercontent.com/dotnet/corefx/7b7345665ec28a85084b3ad2932e03f7641d6151/artifacts/obj/System.Transactions.Local/netcoreapp-Release/System.SR.cs
error: url failed NotFound: Not Found
sourcelink test failed
```

After Change
```

C:\git\corefx>SourceLink test artifacts\bin\System.Transactions.Local\netcoreapp-Debug\System.Transactions.Local.pdb
sourcelink test passed: artifacts\bin\System.Transactions.Local\netcoreapp-Debug\System.Transactions.Local.pdb
```
