### PR TITLE
This should fix the flaky test

### DIFF
--- a/src/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
@@ -69,14 +69,16 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public async Task MultiSegmentWritesUntilFailure()
         {
-            using (var pool = new TestMemoryPool())
+            using (var pool = new DisposeTrackingBufferPool())
             {
-                var pipe = new Pipe(s_testOptions);
-                pipe.Writer.WriteEmpty(pool.MaxBufferSize);
-                pipe.Writer.WriteEmpty(pool.MaxBufferSize);
-                pipe.Writer.WriteEmpty(pool.MaxBufferSize);
+                var pipe = new Pipe(new PipeOptions(pool, readerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));
+                pipe.Writer.WriteEmpty(4096);
+                pipe.Writer.WriteEmpty(4096);
+                pipe.Writer.WriteEmpty(4096);
                 await pipe.Writer.FlushAsync();
                 pipe.Writer.Complete();
+
+                Assert.Equal(3, pool.CurrentlyRentedBlocks);
 
                 var stream = new ThrowAfterNWritesStream(2);
                 try
@@ -91,9 +93,15 @@ namespace System.IO.Pipelines.Tests
 
                 Assert.Equal(2, stream.Writes);
 
+                Assert.Equal(1, pool.CurrentlyRentedBlocks);
+                Assert.Equal(2, pool.DisposedBlocks);
+
                 ReadResult result = await pipe.Reader.ReadAsync();
                 Assert.Equal(4096, result.Buffer.Length);
                 pipe.Reader.Complete();
+
+                Assert.Equal(0, pool.CurrentlyRentedBlocks);
+                Assert.Equal(3, pool.DisposedBlocks);
             }
         }
 


### PR DESCRIPTION
- The pool in the test wasn't being used (This was changed in a previous commit)
- Use the DisposeTrackingBufferPool to make sure we allocated the number of segments we expect