### PR TITLE
Implement server-side of NegotiateStream on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
@@ -90,7 +90,8 @@ internal static partial class Interop
             ref SafeGssContextHandle acceptContextHandle,
             byte[] inputBytes,
             int inputLength,
-            ref GssBuffer token);
+            ref GssBuffer token,
+            out uint retFlags);
 
         [DllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_DeleteSecContext")]
         internal static extern Status DeleteSecContext(

--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
@@ -98,6 +98,12 @@ internal static partial class Interop
             out Status minorStatus,
             ref IntPtr contextHandle);
 
+        [DllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_GetUser")]
+        internal static extern Status GetUser(
+            out Status minorStatus,
+            SafeGssContextHandle acceptContextHandle,
+            ref GssBuffer token);
+
         [DllImport(Interop.Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_Wrap")]
         private static extern Status Wrap(
             out Status minorStatus,

--- a/src/Common/src/System/Net/NTAuthentication.Common.cs
+++ b/src/Common/src/System/Net/NTAuthentication.Common.cs
@@ -293,7 +293,7 @@ namespace System.Net
 
             // The return value will tell us correctly if the handshake is over or not
             if (statusCode.ErrorCode == SecurityStatusPalErrorCode.OK
-                || statusCode.ErrorCode == SecurityStatusPalErrorCode.CompleteNeeded) // Server only
+                || (_isServer && statusCode.ErrorCode == SecurityStatusPalErrorCode.CompleteNeeded))
             {
                 // Success.
                 _isCompleted = true;

--- a/src/Common/src/System/Net/NTAuthentication.Common.cs
+++ b/src/Common/src/System/Net/NTAuthentication.Common.cs
@@ -292,7 +292,8 @@ namespace System.Net
             }
 
             // The return value will tell us correctly if the handshake is over or not
-            if (statusCode.ErrorCode == SecurityStatusPalErrorCode.OK)
+            if (statusCode.ErrorCode == SecurityStatusPalErrorCode.OK
+                || statusCode.ErrorCode == SecurityStatusPalErrorCode.CompleteNeeded) // Server only
             {
                 // Success.
                 _isCompleted = true;

--- a/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -125,8 +125,10 @@ namespace System.Net.Security
             // EstablishSecurityContext is called multiple times in a session.
             // In each call, we need to pass the context handle from the previous call.
             // For the first call, the context handle will be null.
+            bool newContext = false;
             if (context == null)
             {
+                newContext = true;
                 context = new SafeGssContextHandle();
             }
 
@@ -153,6 +155,11 @@ namespace System.Net.Security
                 if ((status != Interop.NetSecurityNative.Status.GSS_S_COMPLETE) &&
                     (status != Interop.NetSecurityNative.Status.GSS_S_CONTINUE_NEEDED))
                 {
+                    if (newContext)
+                    {
+                        context.Dispose();
+                        context = null;
+                    }
                     throw new Interop.NetSecurityNative.GssApiException(status, minorStatus);
                 }
 
@@ -172,8 +179,10 @@ namespace System.Net.Security
             out byte[] outputBuffer,
             out uint outFlags)
         {
+            bool newContext = false;
             if (context == null)
             {
+                newContext = true;
                 context = new SafeGssContextHandle();
             }
 
@@ -193,6 +202,11 @@ namespace System.Net.Security
                 if ((status != Interop.NetSecurityNative.Status.GSS_S_COMPLETE) &&
                     (status != Interop.NetSecurityNative.Status.GSS_S_CONTINUE_NEEDED))
                 {
+                    if (newContext)
+                    {
+                        context.Dispose();
+                        context = null;
+                    }
                     throw new Interop.NetSecurityNative.GssApiException(status, minorStatus);
                 }
 
@@ -213,9 +227,10 @@ namespace System.Net.Security
 
             try
             {
-                var status = Interop.NetSecurityNative.GetUser(out var minorStatus,
-                                                               context,
-                                                               ref token);
+                Interop.NetSecurityNative.Status status
+                    = Interop.NetSecurityNative.GetUser(out var minorStatus,
+                                                        context,
+                                                        ref token);
 
                 if (status != Interop.NetSecurityNative.Status.GSS_S_COMPLETE)
                 {

--- a/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -222,7 +222,7 @@ namespace System.Net.Security
                     throw new Interop.NetSecurityNative.GssApiException(status, minorStatus);
                 }
 
-                return Encoding.ASCII.GetString(token.ToByteArray());
+                return Encoding.UTF8.GetString(token.ToByteArray());
             }
             finally
             {

--- a/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -314,11 +314,6 @@ namespace System.Net.Security
 
         internal static SafeFreeCredentials AcquireCredentialsHandle(string package, bool isServer, NetworkCredential credential)
         {
-            if (isServer)
-            {
-                throw new PlatformNotSupportedException(SR.net_nego_server_not_supported);
-            }
-
             bool isEmptyCredential = string.IsNullOrWhiteSpace(credential.UserName) ||
                                      string.IsNullOrWhiteSpace(credential.Password);
             bool ntlmOnly = string.Equals(package, NegotiationInfoClass.NTLM, StringComparison.OrdinalIgnoreCase);

--- a/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -168,7 +168,8 @@ namespace System.Net.Security
         private static bool GssAcceptSecurityContext(
             ref SafeGssContextHandle context,
             byte[] buffer,
-            out byte[] outputBuffer)
+            out byte[] outputBuffer,
+            out uint outFlags)
         {
             // do we need to initalize this?
             if (context == null)
@@ -183,10 +184,11 @@ namespace System.Net.Security
             {
                 Interop.NetSecurityNative.Status minorStatus;
                 status = Interop.NetSecurityNative.AcceptSecContext(out minorStatus,
-                                                          ref context,
-                                                          buffer,
-                                                          buffer?.Length ?? 0,
-                                                          ref token);
+                                                                    ref context,
+                                                                    buffer,
+                                                                    buffer?.Length ?? 0,
+                                                                    ref token,
+                                                                    out outFlags);
 
                 if ((status != Interop.NetSecurityNative.Status.GSS_S_COMPLETE) &&
                     (status != Interop.NetSecurityNative.Status.GSS_S_CONTINUE_NEEDED))
@@ -366,7 +368,8 @@ namespace System.Net.Security
                 bool done = GssAcceptSecurityContext(
                    ref contextHandle,
                    incomingBlob,
-                   out resultBlob);
+                   out resultBlob,
+                   out uint outputFlags);
 /*
                 if (done)
                 {
@@ -390,6 +393,8 @@ namespace System.Net.Security
                     negoContext.SetGssContext(contextHandle);
                 }
 
+                contextFlags = ContextFlagsAdapterPal.GetContextFlagsPalFromInterop(
+                    (Interop.NetSecurityNative.GssFlags)outputFlags, isServer: true);
                 SecurityStatusPalErrorCode errorCode = done ?
                     (negoContext.IsNtlmUsed && resultBlob.Length > 0 ? SecurityStatusPalErrorCode.OK : SecurityStatusPalErrorCode.CompleteNeeded) :
                     SecurityStatusPalErrorCode.ContinueNeeded;

--- a/src/Common/src/System/Net/Security/Unix/SafeDeleteNegoContext.cs
+++ b/src/Common/src/System/Net/Security/Unix/SafeDeleteNegoContext.cs
@@ -32,10 +32,15 @@ namespace System.Net.Security
             get { return _context; }
         }
 
-        public SafeDeleteNegoContext(SafeFreeNegoCredentials credential, string targetName)
+        public SafeDeleteNegoContext(SafeFreeNegoCredentials credential)
             : base(credential)
         {
             Debug.Assert((null != credential), "Null credential in SafeDeleteNegoContext");
+        }
+
+        public SafeDeleteNegoContext(SafeFreeNegoCredentials credential, string targetName)
+            : this(credential)
+        {
             try
             {
                 // Convert any "SERVICE/HOST" style of targetName to use "SERVICE@HOST" style.

--- a/src/Common/tests/System/Net/Capability.Security.cs
+++ b/src/Common/tests/System/Net/Capability.Security.cs
@@ -27,6 +27,12 @@ namespace System.Net.Test.Common
             return !string.IsNullOrWhiteSpace(Configuration.Security.ActiveDirectoryName);
         }
 
+        public static bool IsNegotiateClientAvailable()
+        {
+            return !(Configuration.Security.NegotiateClient == null)
+                && !(Configuration.Security.NegotiateClientUser == null);
+        }
+
         public static bool IsNegotiateServerAvailable()
         {
             return !(Configuration.Security.NegotiateServer == null);

--- a/src/Common/tests/System/Net/Configuration.Security.cs
+++ b/src/Common/tests/System/Net/Configuration.Security.cs
@@ -22,6 +22,10 @@ namespace System.Net.Test.Common
 
             public static Uri NegotiateServer => GetUriValue("COREFX_NET_SECURITY_NEGOSERVERURI");
 
+            public static Uri NegotiateClient => GetUriValue("COREFX_NET_SECURITY_NEGOCLIENTURI");
+
+            public static string NegotiateClientUser => GetValue("COREFX_NET_SECURITY_NEGOCLIENTUSER");
+
             public static string TlsRenegotiationServer => GetValue("COREFX_NET_SECURITY_TLSREGOTIATIONSERVER", "corefx-net-tls.azurewebsites.net");
 
             // This should be set if hostnames for all certificates within corefx-testdata have been set to point to 127.0.0.1.

--- a/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs
+++ b/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs
@@ -25,33 +25,39 @@ namespace System.Threading.Tasks
             }
         }
 
-        public static async Task TimeoutAfter(this Task task, int millisecondsTimeout)
+        public static Task TimeoutAfter(this Task task, int millisecondsTimeout)
+            => task.TimeoutAfter(TimeSpan.FromMilliseconds(millisecondsTimeout));
+
+        public static async Task TimeoutAfter(this Task task, TimeSpan timeout)
         {
             var cts = new CancellationTokenSource();
 
-            if (task == await Task.WhenAny(task, Task.Delay(millisecondsTimeout, cts.Token)).ConfigureAwait(false))
+            if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)).ConfigureAwait(false))
             {
                 cts.Cancel();
                 await task.ConfigureAwait(false);
             }
             else
             {
-                throw new TimeoutException($"Task timed out after {millisecondsTimeout}ms");
+                throw new TimeoutException($"Task timed out after {timeout}");
             }
         }
 
-        public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, int millisecondsTimeout)
+        public static Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, int millisecondsTimeout)
+            => task.TimeoutAfter(TimeSpan.FromMilliseconds(millisecondsTimeout));
+
+        public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, TimeSpan timeout)
         {
             var cts = new CancellationTokenSource();
 
-            if (task == await Task<TResult>.WhenAny(task, Task<TResult>.Delay(millisecondsTimeout, cts.Token)).ConfigureAwait(false))
+            if (task == await Task<TResult>.WhenAny(task, Task<TResult>.Delay(timeout, cts.Token)).ConfigureAwait(false))
             {
                 cts.Cancel();
                 return await task.ConfigureAwait(false);
             }
             else
             {
-                throw new TimeoutException($"Task timed out after {millisecondsTimeout}ms");
+                throw new TimeoutException($"Task timed out after {timeout}");
             }
         }
 

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
@@ -247,7 +247,8 @@ uint32_t NetSecurityNative_AcceptSecContext(uint32_t* minorStatus,
                                             GssCtxId** contextHandle,
                                             uint8_t* inputBytes,
                                             uint32_t inputLength,
-                                            PAL_GssBuffer* outBuffer)
+                                            PAL_GssBuffer* outBuffer,
+                                            uint32_t* retFlags)
 {
     assert(minorStatus != NULL);
     assert(contextHandle != NULL);
@@ -266,7 +267,7 @@ uint32_t NetSecurityNative_AcceptSecContext(uint32_t* minorStatus,
                                                   NULL,
                                                   NULL,
                                                   &gssBuffer,
-                                                  0,
+                                                  retFlags,
                                                   NULL,
                                                   NULL);
 

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.c
@@ -275,6 +275,44 @@ uint32_t NetSecurityNative_AcceptSecContext(uint32_t* minorStatus,
     return majorStatus;
 }
 
+uint32_t NetSecurityNative_GetUser(uint32_t* minorStatus,
+                                   GssCtxId* contextHandle,
+                                   PAL_GssBuffer* outBuffer)
+{
+    assert(minorStatus != NULL);
+    assert(contextHandle != NULL);
+    assert(outBuffer != NULL);
+
+    gss_name_t srcName = GSS_C_NO_NAME;
+
+    uint32_t majorStatus = gss_inquire_context(minorStatus,
+                                               contextHandle,
+                                               &srcName,
+                                               NULL,
+                                               NULL,
+                                               NULL,
+                                               NULL,
+                                               NULL,
+                                               NULL);
+
+    if (majorStatus == GSS_S_COMPLETE)
+    {
+        GssBuffer gssBuffer = {.length = 0, .value = NULL};
+        majorStatus = gss_display_name(minorStatus, srcName, &gssBuffer, NULL);
+        if (majorStatus == GSS_S_COMPLETE)
+        {
+            NetSecurityNative_MoveBuffer(&gssBuffer, outBuffer);
+        }
+    }
+
+    if (srcName != NULL)
+    {
+        majorStatus = gss_release_name(minorStatus, &srcName);
+    }
+
+    return majorStatus;
+}
+
 uint32_t NetSecurityNative_ReleaseCred(uint32_t* minorStatus, GssCredId** credHandle)
 {
     assert(minorStatus != NULL);

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.h
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.h
@@ -168,3 +168,10 @@ DLLEXPORT uint32_t NetSecurityNative_InitiateCredWithPassword(uint32_t* minorSta
 Shims the gss_indicate_mechs method to detect if NTLM mech is installed.
 */
 DLLEXPORT uint32_t NetSecurityNative_IsNtlmInstalled(void);
+
+/*
+Shims gss_inquire_context and gss_display_name to get the remote user principal name.
+*/
+DLLEXPORT uint32_t NetSecurityNative_GetUser(uint32_t* minorStatus,
+                                             GssCtxId* contextHandle,
+                                             PAL_GssBuffer* outBuffer);

--- a/src/Native/Unix/System.Net.Security.Native/pal_gssapi.h
+++ b/src/Native/Unix/System.Net.Security.Native/pal_gssapi.h
@@ -124,7 +124,8 @@ DLLEXPORT uint32_t NetSecurityNative_AcceptSecContext(uint32_t* minorStatus,
                                                       GssCtxId** contextHandle,
                                                       uint8_t* inputBytes,
                                                       uint32_t inputLength,
-                                                      PAL_GssBuffer* outBuffer);
+                                                      PAL_GssBuffer* outBuffer,
+                                                      uint32_t* retFlags);
 
 /*
 

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -33,7 +33,7 @@ namespace System.Net.Security
                 var safeContext = context.GetContext(out var status);
                 if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
                 {
-                    throw new Exception(status.ErrorCode.ToString()); // TODO?
+                    throw new Win32Exception((int)status.ErrorCode);
                 }
                 name = GetUser(ref safeContext);
             }

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -24,7 +24,7 @@ namespace System.Net.Security
     {
         internal static IIdentity GetIdentity(NTAuthentication context)
         {
-            Debug.Assert(!context.IsServer, "GetIdentity: Server is not supported");
+            if (context.IsServer) throw new PlatformNotSupportedException("GetIdentity: Server is not supported");
 
             string name = context.Spn;
             string protocol = context.ProtocolName;

--- a/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -3,14 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Security;
-using System.Security.Principal;
-using System.Threading;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Net.Security
@@ -24,10 +25,18 @@ namespace System.Net.Security
     {
         internal static IIdentity GetIdentity(NTAuthentication context)
         {
-            if (context.IsServer) throw new PlatformNotSupportedException("GetIdentity: Server is not supported");
-
             string name = context.Spn;
             string protocol = context.ProtocolName;
+
+            if (context.IsServer)
+            {
+                var safeContext = context.GetContext(out var status);
+                if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
+                {
+                    throw new Exception(status.ErrorCode.ToString()); // TODO?
+                }
+                name = GetUser(ref safeContext);
+            }
 
             return new GenericIdentity(name, protocol);
 

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
@@ -25,6 +25,9 @@ namespace System.Net.Security.Tests
     {
         public static bool IsServerAndDomainAvailable => 
             Capability.IsDomainAvailable() && Capability.IsNegotiateServerAvailable();
+
+        public static bool IsClientAvailable =>
+            Capability.IsNegotiateClientAvailable();
         
         public static IEnumerable<object[]> GoodCredentialsData
         {
@@ -162,9 +165,8 @@ namespace System.Net.Security.Tests
         }
 
         [OuterLoop]
-        // [Fact]
-        // [ConditionalFact(nameof(IsServerAndDomainAvailable))]
-        public async Task NegotiateStream_RemoteServerAuthentication_Success()
+        [ConditionalFact(nameof(IsClientAvailable))]
+        public async Task NegotiateStream_ServerAuthenticationRemote_Success()
         {
             string expectedUser = Configuration.Security.NegotiateClientUser;
             

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
@@ -122,7 +122,7 @@ namespace System.Net.Security.Tests
             bool isLocalhost = await IsLocalHost(serverName);
             
             string expectedAuthenticationType = "Kerberos";
-            bool mutualAuthenitcated = true;
+            bool mutuallyAuthenticated = true;
 
             if (credential == CredentialCache.DefaultNetworkCredentials && isLocalhost)
             {
@@ -133,7 +133,7 @@ namespace System.Net.Security.Tests
             {
                 // Anonymous authentication.
                 expectedAuthenticationType = "NTLM";
-                mutualAuthenitcated = false;
+                mutuallyAuthenticated = false;
             }
 
             using (var client = new TcpClient())
@@ -154,7 +154,7 @@ namespace System.Net.Security.Tests
 
                     Assert.Equal(true, auth.IsAuthenticated);
                     Assert.Equal(true, auth.IsEncrypted);
-                    Assert.Equal(mutualAuthenitcated, auth.IsMutuallyAuthenticated);
+                    Assert.Equal(mutuallyAuthenticated, auth.IsMutuallyAuthenticated);
                     Assert.Equal(true, auth.IsSigned);
 
                     // Send a message to the server. Encode the test data into a byte array.
@@ -171,7 +171,7 @@ namespace System.Net.Security.Tests
             string expectedUser = Configuration.Security.NegotiateClientUser;
             
             string expectedAuthenticationType = "Kerberos";
-            bool mutualAuthenitcated = true;
+            bool mutuallyAuthenticated = true;
 
             using (var controlClient = new TcpClient())
             {
@@ -192,7 +192,7 @@ namespace System.Net.Security.Tests
                     Assert.True(serverAuth.IsAuthenticated, "IsAuthenticated");
                     Assert.True(serverAuth.IsEncrypted, "IsEncrypted");
                     Assert.True(serverAuth.IsSigned, "IsSigned");
-                    Assert.Equal(mutualAuthenitcated, serverAuth.IsMutuallyAuthenticated);
+                    Assert.Equal(mutuallyAuthenticated, serverAuth.IsMutuallyAuthenticated);
 
                     Assert.Equal(expectedAuthenticationType, serverAuth.RemoteIdentity.AuthenticationType);
                     Assert.Equal(expectedUser, serverAuth.RemoteIdentity.Name);

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
@@ -181,9 +181,9 @@ namespace System.Net.Security.Tests
 
         private async Task VerifyLocalServerAuthentication(NetworkCredential credential)
         {
-            string serverName = "CHRROSS-UDESK.CRKERBEROS.COM";// Configuration.Security.NegotiateServer.Host;
+            string serverName = "chrross-udesk.crkerberos.com";// Configuration.Security.NegotiateServer.Host;
             int port = 54321;// Configuration.Security.NegotiateServer.Port;
-            string serverSPN = "host/" + serverName;
+            string serverSPN = "HTTP/" + serverName;
             
             string expectedAuthenticationType = "Kerberos";
             bool mutualAuthenitcated = true;
@@ -212,6 +212,13 @@ namespace System.Net.Security.Tests
 
                     var serverConnection = await acceptTask;
                     var serverStream = serverConnection.GetStream();
+
+            var loop = true;
+            while (loop)
+            {
+                await Task.Delay(1000);
+            }
+
                     using (var serverAuth = new NegotiateStream(serverStream, leaveInnerStreamOpen: false))
                     {
                         var clientStream = client.GetStream();
@@ -221,7 +228,7 @@ namespace System.Net.Security.Tests
                             var clientAuthTask = clientAuth.AuthenticateAsClientAsync(
                                 credential,
                                 serverSPN,
-                                ProtectionLevel.EncryptAndSign,
+                                ProtectionLevel.None,
                                 System.Security.Principal.TokenImpersonationLevel.Identification);
 
                             await serverAuthTask;

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
@@ -332,7 +332,7 @@ namespace System.Net.Security.Tests
                     Assert.Equal(mutualAuthenitcated, serverAuth.IsMutuallyAuthenticated);
 
                     Assert.Equal(expectedAuthenticationType, serverAuth.RemoteIdentity.AuthenticationType);
-                    Assert.Equal(serverSPN, serverAuth.RemoteIdentity.Name);
+                    Assert.Equal("Administrator@CRKERBEROS.COM", serverAuth.RemoteIdentity.Name);
 
                     // Send a message to the server. Encode the test data into a byte array.
                     byte[] message = Encoding.UTF8.GetBytes("Hello from the server.");

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
@@ -267,7 +267,7 @@ namespace System.Net.Security.Tests
         }
 
         [OuterLoop]
-        [Theory]
+        // [Theory]
         // [ConditionalTheory(nameof(IsServerAndDomainAvailable))]
         [MemberData(nameof(GoodCredentialsData))]
         public async Task NegotiateStream_RemoteServerAuthentication_Success(object credentialObject)

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamKerberosTest.cs
@@ -323,16 +323,16 @@ namespace System.Net.Security.Tests
                 {
                     serverAuth.AuthenticateAsServer(
                         CredentialCache.DefaultNetworkCredentials,
-                        ProtectionLevel.None,
+                        ProtectionLevel.EncryptAndSign,
                         TokenImpersonationLevel.Identification);
-
-                    Assert.Equal(expectedAuthenticationType, serverAuth.RemoteIdentity.AuthenticationType);
-                    Assert.Equal(serverSPN, serverAuth.RemoteIdentity.Name);
 
                     Assert.True(serverAuth.IsAuthenticated, "IsAuthenticated");
                     Assert.True(serverAuth.IsEncrypted, "IsEncrypted");
                     Assert.True(serverAuth.IsSigned, "IsSigned");
                     Assert.Equal(mutualAuthenitcated, serverAuth.IsMutuallyAuthenticated);
+
+                    Assert.Equal(expectedAuthenticationType, serverAuth.RemoteIdentity.AuthenticationType);
+                    Assert.Equal(serverSPN, serverAuth.RemoteIdentity.Name);
 
                     // Send a message to the server. Encode the test data into a byte array.
                     byte[] message = Encoding.UTF8.GetBytes("Hello from the server.");

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -13,9 +13,11 @@ using Xunit;
 
 namespace System.Net.Security.Tests
 {
-    [PlatformSpecific(TestPlatforms.Windows)] // NegotiateStream only supports client-side functionality on Unix
+    [PlatformSpecific(TestPlatforms.Windows)] // NegotiateStream client needs explicit credentials or SPNs on unix.
     public abstract class NegotiateStreamStreamToStreamTest
     {
+        public static bool IsNtlmInstalled => Capability.IsNtlmInstalled();
+
         private const int PartialBytesToRead = 5;
         private static readonly byte[] s_sampleMsg = Encoding.UTF8.GetBytes("Sample Test Message");
 
@@ -26,7 +28,7 @@ namespace System.Net.Security.Tests
         protected abstract Task AuthenticateAsClientAsync(NegotiateStream client, NetworkCredential credential, string targetName);
         protected abstract Task AuthenticateAsServerAsync(NegotiateStream server);
 
-        [Fact]
+        [ConditionalFact(nameof(IsNtlmInstalled))]
         public async Task NegotiateStream_StreamToStream_Authentication_Success()
         {
             VirtualNetwork network = new VirtualNetwork();
@@ -76,7 +78,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNtlmInstalled))]
         public async Task NegotiateStream_StreamToStream_Authentication_TargetName_Success()
         {
             string targetName = "testTargetName";
@@ -132,7 +134,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNtlmInstalled))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core difference in behavior: https://github.com/dotnet/corefx/issues/5241")]
         public async Task NegotiateStream_StreamToStream_Authentication_EmptyCredentials_Fails()
         {
@@ -195,7 +197,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNtlmInstalled))]
         public async Task NegotiateStream_StreamToStream_Successive_ClientWrite_Sync_Success()
         {
             byte[] recvBuf = new byte[s_sampleMsg.Length];
@@ -234,7 +236,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNtlmInstalled))]
         public async Task NegotiateStream_StreamToStream_Successive_ClientWrite_Async_Success()
         {
             byte[] recvBuf = new byte[s_sampleMsg.Length];
@@ -273,7 +275,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNtlmInstalled))]
         public async Task NegotiateStream_ReadWriteLongMsgSync_Success()
         {
             byte[] recvBuf = new byte[s_longMsg.Length];
@@ -300,7 +302,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNtlmInstalled))]
         public async Task NegotiateStream_ReadWriteLongMsgAsync_Success()
         {
             byte[] recvBuf = new byte[s_longMsg.Length];
@@ -327,7 +329,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNtlmInstalled))]
         public void NegotiateStream_StreamToStream_Flush_Propagated()
         {
             VirtualNetwork network = new VirtualNetwork();
@@ -341,7 +343,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(IsNtlmInstalled))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Relies on FlushAsync override not available in desktop")]
         public void NegotiateStream_StreamToStream_FlushAsync_Propagated()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -110,6 +110,15 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="IdentityValidator.Unix.cs" />
+    <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.Unix.cs">
+      <Link>Common\System\Net\Capability.Security.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs">
+      <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.NetSecurityNative.IsNtlmInstalled.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">
     <None Include="..\Scripts\Unix\setup-kdc.sh">
@@ -130,9 +139,6 @@
     <Compile Include="NegotiateStreamTest.Linux.cs" />
     <Compile Include="UnixGssFakeNegotiateStream.cs" />
     <Compile Include="UnixGssFakeStreamFramer.cs" />
-    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
-      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs">
       <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.GssApiException.cs</Link>
     </Compile>

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -107,6 +107,9 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="IdentityValidator.Windows.cs" />
+    <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.Windows.cs">
+      <Link>Common\System\Net\Capability.Security.Windows.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="IdentityValidator.Unix.cs" />


### PR DESCRIPTION
#8221 @davidsh I'm starting this draft PR to show you the scope of the changes needed for this feature. I'll follow up with you offline.

The current code works end-to-end using a Windows client to authenticate via Kerberos to a Linux server that has been linked to the Windows domain. Ignore the tests, they were there there for manual verification and debugging. We'll need to discuss what's possible to automate with the given infrastructure.

We also need to work out what variants need to be supported and tested, and which should be blocked with explicit checks and error messages? E.g. NTLM, non-default credentials, Mac, etc.. cc: @blowdart 

I'm not including here an new public APIs for AspNetCore, nor have I tested the HTTP scenario, but that should follow easily from this foundational work.