### PR TITLE
Fix TypeInfoTests.GenericParameterConstraints() test

### DIFF
--- a/src/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/System.Reflection/tests/TypeInfoTests.cs
@@ -984,8 +984,8 @@ namespace System.Reflection.Tests
             Assert.Equal(expected, type.GetTypeInfo().GetElementType());
         }
 
-        [Theory]
-        public void GenericParameterConstraints(Type type)
+        [Fact]
+        public void GenericParameterConstraints()
         {
             Type[] genericTypeParameters = typeof(MethodClassWithConstraints<,>).GetTypeInfo().GenericTypeParameters;
             Assert.Equal(2, genericTypeParameters.Length);


### PR DESCRIPTION
It was a Theory instead of a Fact and the method parameter wasn't being used.

We noticed this when running the test on Xamarin.Android (I assume because we use a different xunit runner?) which gave the following error:

```
 Failed tests:
 1)    Test name: System.Reflection.Tests.TypeInfoTests.GenericParameterConstraints
    Assembly:  [monodroid_corlib_xunit-test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756]
    Exception messages: System.InvalidOperationException : No data found for System.Reflection.Tests.TypeInfoTests.GenericParameterConstraints 
```