### PR TITLE
Use dotnet CLI 2.2.203

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "2.2.103"
+    "dotnet": "2.2.203"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19207.1",


### PR DESCRIPTION
Fixes official build restore errors:

```
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'System.Net.Sockets 4.3.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'MicroBuild.Core 0.2.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'vswhere 2.5.2' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'System.Runtime.InteropServices.Analyzers 1.1.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'Desktop.Analyzers 1.1.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'Microsoft.CodeAnalysis.FxCopAnalyzers 1.1.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'System.Security.Cryptography.Hashing.Algorithms.Analyzers 1.1.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'Microsoft.CodeAnalysis.Common 2.9.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'Microsoft.AnalyzerPowerPack 1.0.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'System.Collections.Immutable 1.5.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'Microsoft.CodeAnalysis.CSharp 2.9.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'System.Reflection.Metadata 1.6.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'Microsoft.CodeAnalysis.Analyzers 2.6.1' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'System.Security.Cryptography.Algorithms 4.3.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
F:\workspace\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19207.1\tools\Tools.proj : error NU3004: Package 'System.Threading.Tasks.Parallel 4.3.0' from source 'https://api.nuget.org/v3/index.json': This repository indicated that all its packages are repository signed; however, this package is unsigned.
```

Related https://github.com/dotnet/arcade/issues/2008#issuecomment-461986074