### PR TITLE
Fix build after #36775

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ssl.c
@@ -364,6 +364,7 @@ int32_t CryptoNative_SetCiphers(SSL_CTX* ctx, const char* cipherList, const char
 
 const char* CryptoNative_GetOpenSslCipherSuiteName(SSL* ssl, int32_t cipherSuite, int32_t* isTls12OrLower)
 {
+#if HAVE_OPENSSL_SET_CIPHERSUITES
     unsigned char cs[2];
     const SSL_CIPHER* cipher;
     const char* ret;
@@ -413,6 +414,12 @@ const char* CryptoNative_GetOpenSslCipherSuiteName(SSL* ssl, int32_t cipherSuite
     }
 
     return ret;
+#else
+    (void)ssl;
+    (void)cipherSuite;
+    *isTls12OrLower = 0;
+    return NULL;
+#endif
 }
 
 int32_t CryptoNative_Tls13Supported()


### PR DESCRIPTION
I believe this should fix the build break introduced by https://github.com/dotnet/corefx/pull/36775

This probably happened on machine which doesn't have OpenSSL 1.1.1 installed and is using native component build with `./build-native.sh` (without `-portable` switch)
cc: @safern @ViktorHofer 