### PR TITLE
Fix Linux process names

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -128,10 +128,17 @@ namespace System.Diagnostics
         {
             int pid = procFsStat.pid;
 
+            // Get long process name if possible, otherwise use a fall back method.
+            string procName = Path.GetFileName(Process.GetExePath(pid));
+            if (String.IsNullOrEmpty(procName))
+            {
+                procName = procFsStat.comm;
+            }
+
             var pi = new ProcessInfo()
             {
                 ProcessId = pid,
-                ProcessName = procFsStat.comm,
+                ProcessName = procName,
                 BasePriority = (int)procFsStat.nice,
                 VirtualBytes = (long)procFsStat.vsize,
                 WorkingSet = procFsStat.rss * Environment.SystemPageSize,

--- a/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -101,7 +101,7 @@ namespace System.Diagnostics.Tests
         /// <returns></returns>
         protected static bool IsProgramInstalled(string program)
         {
-            return !(GetProgramPath(program) is null);
+            return GetProgramPath(program) != null;
         }
 
         /// <summary>

--- a/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -101,6 +101,16 @@ namespace System.Diagnostics.Tests
         /// <returns></returns>
         protected static bool IsProgramInstalled(string program)
         {
+            return !(GetProgramPath(program) is null);
+        }
+
+        /// <summary>
+        /// Return program path
+        /// </summary>
+        /// <param name="program"></param>
+        /// <returns></returns>
+        protected static string GetProgramPath(string program)
+        {
             string path;
             string pathEnvVar = Environment.GetEnvironmentVariable("PATH");
             char separator = PlatformDetection.IsWindows ? ';' : ':';
@@ -113,11 +123,11 @@ namespace System.Diagnostics.Tests
                     path = Path.Combine(subPath, program);
                     if (File.Exists(path))
                     {
-                        return true;
+                        return path;
                     }
                 }
             }
-            return false;
+            return null;
         }
     }
 }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -59,53 +59,6 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        public void GetProcesses_LongProcessName()
-        {
-            string commandName = "sleep";
-
-            // sleep program doesn't exist on some distros
-            if (IsProgramInstalled(commandName))
-            {
-                string tmpDir = Path.Combine(TestDirectory, GetTestFileName());
-                try
-                {
-                    // create tmp folder and copy sleep command inside it renamed
-                    Directory.CreateDirectory(tmpDir);
-                    string longProcessName = "123456789012345678901234567890";
-                    string sleepCommandPathFileName = Path.Combine(tmpDir, longProcessName);
-                    File.Copy(GetProgramPath(commandName), sleepCommandPathFileName);
-                    Assert.True(File.Exists(sleepCommandPathFileName));
-
-                    // start sleep program and wait for some seconds
-                    using (Process px = Process.Start(new ProcessStartInfo { FileName = sleepCommandPathFileName , Arguments = "5s", UseShellExecute = true}))
-                    {
-                        bool processFound = false;
-                        foreach(Process process in Process.GetProcesses())
-                        {
-                            if (process.ProcessName == longProcessName)
-                            {
-                                processFound = true;
-                                break;
-                            }
-                        }
-                        px.Kill();
-                        px.WaitForExit();
-                        Assert.True(px.HasExited);
-
-                        Assert.True(processFound, $"Process named '{longProcessName}' not found");
-                    }
-                }
-                finally
-                {
-                    if (Directory.Exists(tmpDir))
-                    {
-                        Directory.Delete(tmpDir, true);
-                    }
-                }
-            }
-        }
-
-        [Fact]
         public void TestRootGetProcessById()
         {
             Process p = Process.GetProcessById(1);

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -59,6 +59,53 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        public void GetProcesses_LongProcessName()
+        {
+            string commandName = "sleep";
+
+            // sleep program doesn't exist on some distros
+            if (IsProgramInstalled(commandName))
+            {
+                string tmpDir = Path.Combine(TestDirectory, GetTestFileName());
+                try
+                {
+                    // create tmp folder and copy sleep command inside it renamed
+                    Directory.CreateDirectory(tmpDir);
+                    string longProcessName = "123456789012345678901234567890";
+                    string sleepCommandPathFileName = Path.Combine(tmpDir, longProcessName);
+                    File.Copy(GetProgramPath(commandName), sleepCommandPathFileName);
+                    Assert.True(File.Exists(sleepCommandPathFileName));
+
+                    // start sleep program and wait for some seconds
+                    using (Process px = Process.Start(new ProcessStartInfo { FileName = sleepCommandPathFileName , Arguments = "5s", UseShellExecute = true}))
+                    {
+                        bool processFound = false;
+                        foreach(Process process in Process.GetProcesses())
+                        {
+                            if (process.ProcessName == longProcessName)
+                            {
+                                processFound = true;
+                                break;
+                            }
+                        }
+                        px.Kill();
+                        px.WaitForExit();
+                        Assert.True(px.HasExited);
+
+                        Assert.True(processFound, $"Process named '{longProcessName}' not found");
+                    }
+                }
+                finally
+                {
+                    if (Directory.Exists(tmpDir))
+                    {
+                        Directory.Delete(tmpDir, true);
+                    }
+                }
+            }
+        }
+
+        [Fact]
         public void TestRootGetProcessById()
         {
             Process p = Process.GetProcessById(1);

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1891,7 +1891,7 @@ namespace System.Diagnostics.Tests
             File.Copy(GetProgramPath(commandName), sleepCommandPathFileName);
 
             // start sleep program and wait for some seconds
-            using (Process px = Process.Start(new ProcessStartInfo { FileName = sleepCommandPathFileName , Arguments = "30s", UseShellExecute = true}))
+            using (Process px = Process.Start(new ProcessStartInfo { FileName = sleepCommandPathFileName , Arguments = "30", UseShellExecute = true}))
             {
                 bool processFound = false;
                 foreach (Process process in Process.GetProcesses())

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1875,6 +1875,41 @@ namespace System.Diagnostics.Tests
             Assert.True(p.HasExited);
         }
 
+       [Fact]
+        public void GetProcesses_LongProcessName()
+        {
+            string commandName = "sleep";
+
+            // sleep program doesn't exist on some flavor
+            if (!IsProgramInstalled(commandName))
+            {
+                return;
+            }
+
+            string longProcessName = "123456789012345678901234567890";
+            string sleepCommandPathFileName = Path.Combine(TestDirectory, longProcessName);
+            File.Copy(GetProgramPath(commandName), sleepCommandPathFileName);
+
+            // start sleep program and wait for some seconds
+            using (Process px = Process.Start(new ProcessStartInfo { FileName = sleepCommandPathFileName , Arguments = "30s", UseShellExecute = true}))
+            {
+                bool processFound = false;
+                foreach (Process process in Process.GetProcesses())
+                {
+                    if (process.ProcessName == longProcessName)
+                    {
+                        processFound = true;
+                        break;
+                    }
+                }
+                px.Kill();
+                px.WaitForExit();
+                Assert.True(px.HasExited);
+
+                Assert.True(processFound, $"Process named '{longProcessName}' not found");
+            }
+        }
+
         private string GetCurrentProcessName()
         {
             return $"{Process.GetCurrentProcess().ProcessName}.exe";

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1875,7 +1875,7 @@ namespace System.Diagnostics.Tests
             Assert.True(p.HasExited);
         }
 
-       [Fact]
+        [Fact]
         public void GetProcesses_LongProcessName()
         {
             string commandName = "sleep";


### PR DESCRIPTION
Replacement of https://github.com/dotnet/corefx/pull/35809 
I moved changes to new PR for convenience(few line of code) and added a test.
If it's not ok (the solution is of @2E0PGS I only added test)  please tell me how I can move commit from another forked branch to mine(so I don't waste time scrubbing on internet), I neved did it.

Fixes https://github.com/dotnet/corefx/issues/34437

/cc @2E0PGS @danmosemsft @krwq @wtgodbe

Output without changes:
```
~/repos/corefx/artifacts/bin/tests/System.Diagnostics.Process.Tests/netcoreapp-Linux-Debug-x64 ~/repos/corefx/src/System.Diagnostics.Process/tests
    Discovering: System.Diagnostics.Process.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Diagnostics.Process.Tests (found 1 of 273 test case)
    Starting:    System.Diagnostics.Process.Tests (parallel test collections = on, max threads = 4)
      System.Diagnostics.Tests.ProcessTests.GetProcesses_LongProcessName [FAIL]
        Process named '123456789012345678901234567890' not found
        Expected: True
        Actual:   False
        Stack Trace:
          /home/marco/repos/corefx/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs(95,0): at System.Diagnostics.Tests.ProcessTests.GetProcesses_LongProcessName()
    Finished:    System.Diagnostics.Process.Tests
  === TEST EXECUTION SUMMARY ===
     System.Diagnostics.Process.Tests  Total: 1, Errors: 0, Failed: 1, Skipped: 0, Time: 0.453s
  ~/repos/corefx/src/System.Diagnostics.Process/tests
  ----- end 16:34:01 ----- exit code 1 ----------------------------------------------------------
  Looking around for any Linux dump...
  ... found no dump in /home/marco/repos/corefx/artifacts/bin/tests/System.Diagnostics.Process.Tests/netcoreapp-Linux-Debug-x64

```