### PR TITLE
Implement Trace.TraceCritical

### DIFF
--- a/src/System.Diagnostics.TraceSource/ref/System.Diagnostics.TraceSource.cs
+++ b/src/System.Diagnostics.TraceSource/ref/System.Diagnostics.TraceSource.cs
@@ -122,6 +122,10 @@ namespace System.Diagnostics
         public static void Indent() { }
         public static void Refresh() { }
         [System.Diagnostics.ConditionalAttribute("TRACE")]
+        public static void TraceCritical(string message) { }
+        [System.Diagnostics.ConditionalAttribute("TRACE")]
+        public static void TraceCritical(string format, params object[] args) { }
+        [System.Diagnostics.ConditionalAttribute("TRACE")]
         public static void TraceError(string message) { }
         [System.Diagnostics.ConditionalAttribute("TRACE")]
         public static void TraceError(string format, params object[] args) { }

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/Trace.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/Trace.cs
@@ -207,17 +207,17 @@ namespace System.Diagnostics
         {
             TraceInternal.TraceEvent(TraceEventType.Error, 0, format, args);
         }
-        
+
         [System.Diagnostics.Conditional("TRACE")]
         public static void TraceCritical(string message)
         {
-            TraceInternal.TraceCritical(TraceEventType.Critical, 0, message, null);
+            TraceInternal.TraceEvent(TraceEventType.Critical, 0, message, null);
         }
 
         [System.Diagnostics.Conditional("TRACE")]
         public static void TraceCritical(string format, params object[] args)
         {
-            TraceInternal.TraceCritical(TraceEventType.Critical, 0, format, args);
+            TraceInternal.TraceEvent(TraceEventType.Critical, 0, format, args);
         }
 
         /// <devdoc>

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/Trace.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/Trace.cs
@@ -207,6 +207,18 @@ namespace System.Diagnostics
         {
             TraceInternal.TraceEvent(TraceEventType.Error, 0, format, args);
         }
+        
+        [System.Diagnostics.Conditional("TRACE")]
+        public static void TraceCritical(string message)
+        {
+            TraceInternal.TraceCritical(TraceEventType.Critical, 0, message, null);
+        }
+
+        [System.Diagnostics.Conditional("TRACE")]
+        public static void TraceCritical(string format, params object[] args)
+        {
+            TraceInternal.TraceCritical(TraceEventType.Critical, 0, format, args);
+        }
 
         /// <devdoc>
         /// <para>Writes a message to the trace listeners in the <see cref='System.Diagnostics.Trace.Listeners'/>

--- a/src/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
@@ -331,7 +331,9 @@ namespace System.Diagnostics.TraceSourceTests
             Trace.IndentSize = 2;
             Trace.IndentLevel = 2;
             Trace.Write("This message should be indented.");
-            Trace.TraceError("This error not be indented.");
+            Trace.TraceCritical("This critical error should not be indented.");
+            Trace.TraceCritical("{0}", "This critical error is indented");
+            Trace.TraceError("This error is indented.");
             Trace.TraceError("{0}", "This error is indented");
             Trace.TraceWarning("This warning is indented");
             Trace.TraceWarning("{0}", "This warning is also indented");
@@ -344,7 +346,7 @@ namespace System.Diagnostics.TraceSourceTests
             string newLine = Environment.NewLine;
             var expected =
                 string.Format(
-                    "Message start." + newLine + "    This message should be indented.{0} Error: 0 : This error not be indented." + newLine + "    {0} Error: 0 : This error is indented" + newLine + "    {0} Warning: 0 : This warning is indented" + newLine + "    {0} Warning: 0 : This warning is also indented" + newLine + "    {0} Information: 0 : This information in indented" + newLine + "    {0} Information: 0 : This information is also indented" + newLine + "Message end." + newLine + "",
+                    "Message start." + newLine + "    This message should be indented.{0} Critical: 0 : This critical error should not be indented." + newLine + "    {0} Critical: 0 : This critical error is indented" + newLine + "    {0} Error: 0 : This error is indented." + newLine + "    {0} Error: 0 : This error is indented" + newLine + "    {0} Warning: 0 : This warning is indented" + newLine + "    {0} Warning: 0 : This warning is also indented" + newLine + "    {0} Information: 0 : This information in indented" + newLine + "    {0} Information: 0 : This information is also indented" + newLine + "Message end." + newLine + "",
                     TestRunnerAssemblyName
                 );
 


### PR DESCRIPTION
Exposes the static method TraceCritical so that callers can easily trace at the critical TrraceEventType