### PR TITLE
Added code for removing oleHeader

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -51,7 +51,7 @@
     <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="1.0.1" />
     <PackageReference Include="System.Drawing.Common.TestData" Version="1.0.9" />
     <PackageReference Include="System.Text.RegularExpressions.TestData" Version="1.0.3" />
-    <PackageReference Include="System.Windows.Extensions.TestData" Version="1.0.1" />
+    <PackageReference Include="System.Windows.Extensions.TestData" Version="1.0.2" />
 
     <PackageToInclude Include="xunit.abstractions" />
     <PackageToInclude Include="xunit.assert" />

--- a/src/System.Windows.Extensions/src/System/Drawing/ImageConverter.cs
+++ b/src/System.Windows.Extensions/src/System/Drawing/ImageConverter.cs
@@ -110,7 +110,7 @@ namespace System.Drawing
             {
                 short signature = MemoryMarshal.Read<short>(rawData);
 
-                if (signature != 0x1c15 || rawData.Length < sizeof(OBJECTHEADER))
+                if (signature != 0x1c15)
                 {
                     return null;
                 }

--- a/src/System.Windows.Extensions/src/System/Drawing/ImageConverter.cs
+++ b/src/System.Windows.Extensions/src/System/Drawing/ImageConverter.cs
@@ -3,14 +3,21 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Drawing
 {
     public class ImageConverter : TypeConverter
     {
+        private static ReadOnlySpan<byte> PBrush => new byte[] { (byte)'P', (byte)'B', (byte)'r', (byte)'u', (byte)'s', (byte)'h' };
+
+        private static ReadOnlySpan<byte> BMBytes => new byte[] { (byte)'B', (byte)'M' };
+
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             return sourceType == typeof(byte[]);
@@ -23,7 +30,17 @@ namespace System.Drawing
 
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            return value is byte[] bytes ? Image.FromStream(new MemoryStream(bytes)) : base.ConvertFrom(context, culture, value);
+            if (value is byte[] bytes)
+            {
+                Debug.Assert(value != null, "value is null.");
+                // Try to get memory stream for images with ole header.
+                Stream memStream = GetBitmapStream(bytes) ?? new MemoryStream(bytes);
+                return Image.FromStream(memStream);
+            }
+            else
+            {
+                return base.ConvertFrom(context, culture, value);
+            }
         }
 
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
@@ -86,5 +103,57 @@ namespace System.Drawing
         }
 
         public override bool GetPropertiesSupported(ITypeDescriptorContext context) => true;
+
+        private unsafe Stream GetBitmapStream(ReadOnlySpan<byte> rawData)
+        {
+            try
+            {
+                // The data is in the form of OBJECTHEADER. It's an encoded format that Access uses to push imagesinto the DB.
+                OBJECTHEADER pHeader = MemoryMarshal.Read<OBJECTHEADER>(rawData);
+
+                // pHeader.signature will always be 0x1c15.
+                // "PBrush" should be the 6 chars after position 12 as well.
+                if (pHeader.signature != 0x1c15 ||
+                    rawData.Length <= pHeader.headersize + 18 ||
+                    !rawData.Slice(pHeader.headersize + 12, 6).SequenceEqual(PBrush))
+                {
+                    return null;
+                }
+
+                // We can safely trust that we've got a bitmap.
+                // search for "BM" in the data which is the start of our bitmap data.
+                // 18 is from (12+6) above.
+                ReadOnlySpan<byte> rawDataWithoutHeader = rawData.Slice(pHeader.headersize + 18);
+                int index = rawDataWithoutHeader.IndexOf(BMBytes);
+
+                if (index >= 0 && index < pHeader.headersize + 510)
+                {
+                    return new MemoryStream(rawDataWithoutHeader.Slice(index).ToArray());
+                }
+            }
+            catch (OutOfMemoryException) // This exception may be caused by creating a new MemoryStream.
+            {
+            }
+            catch (ArgumentOutOfRangeException) // This exception may get thrown when input array size is less than the size of the OBJECTHEADER.
+            {
+            }
+
+            return null;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct OBJECTHEADER
+        {
+            public short signature; // it's always 0x1c15
+            public short headersize;
+            public short objectType;
+            public short nameLen;
+            public short classLen;
+            public short nameOffset;
+            public short classOffset;
+            public short width;
+            public short height;
+            public IntPtr pInfo;
+        }
     }
 }

--- a/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
+++ b/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <ProjectGuid>{AC1A1515-70D8-42E4-9B19-A72F739E974C}</ProjectGuid>
     <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release</Configurations>
-    <TestDataPackageVersion>1.0.1</TestDataPackageVersion>
+    <SystemComponentmodelTypeconverterTestdataVersion>1.0.1</SystemComponentmodelTypeconverterTestdataVersion>
+    <SystemWindowsExtensionsTestdataVersion>1.0.2</SystemWindowsExtensionsTestdataVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="X509Certificate2UITests.cs" />
@@ -24,10 +25,10 @@
     <Compile Include="System\Media\SystemSoundsTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.componentmodel.typeconverter.testdata\$(TestDataPackageVersion)\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)system.componentmodel.typeconverter.testdata\$(SystemComponentmodelTypeconverterTestdataVersion)\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
-    <SupplementalTestData Include="$(PackagesDir)system.windows.extensions.testdata\$(TestDataPackageVersion)\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)system.windows.extensions.testdata\$(SystemWindowsExtensionsTestdataVersion)\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.Windows.Extensions/tests/System/Drawing/ImageConverterTests.cs
+++ b/src/System.Windows.Extensions/tests/System/Drawing/ImageConverterTests.cs
@@ -34,6 +34,22 @@ namespace System.ComponentModel.TypeConverterTests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void ImageWithOleHeader()
+        {
+            string path = Path.Combine("bitmaps", "TestImageWithOleHeader.bmp");
+            using (FileStream fileStream = File.Open(path, FileMode.Open))
+            {              
+                using (var ms = new MemoryStream())
+                {
+                    fileStream.CopyTo(ms);
+                    var converter = new ImageConverter();
+                    object image = converter.ConvertFrom(ms.ToArray());
+                    Assert.NotNull(image);
+                }
+            }
+        }
+
+        [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TestCanConvertFrom()
         {
             Assert.True(_imgConv.CanConvertFrom(typeof(byte[])), "byte[] (no context)");


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/36439
Related test data PR https://github.com/dotnet/corefx-testdata/pull/31

Before
```
      System.ComponentModel.TypeConverterTests.ImageConverterTest.ImageWithOleHeader [FAIL]
        System.ArgumentException : Parameter is not valid.
        Stack Trace:
          C:\git\corefx\src\System.Drawing.Common\src\System\Drawing\Gdiplus.cs(259,0): at System.Drawing.SafeNativeMethods.Gdip.CheckStatus(Int32 status)
          C:\git\corefx\src\System.Drawing.Common\src\System\Drawing\Image.Windows.cs(67,0): at System.Drawing.Image.FromStream(Stream stream, Boolean useEmbeddedColorManagement, Boolean validateImageData)
          C:\git\corefx\src\System.Drawing.Common\src\System\Drawing\Image.cs(107,0): at System.Drawing.Image.FromStream(Stream stream, Boolean useEmbeddedColorManagement)
          C:\git\corefx\src\System.Drawing.Common\src\System\Drawing\Image.cs(105,0): at System.Drawing.Image.FromStream(Stream stream)
          C:\git\corefx\src\System.Windows.Extensions\src\System\Drawing\ImageConverter.cs(32,0): at System.Drawing.ImageConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
          C:\git\corefx\src\System.ComponentModel.TypeConverter\src\System\ComponentModel\TypeConverter.cs(48,0): at System.ComponentModel.TypeConverter.ConvertFrom(Object value)
          C:\git\corefx\src\System.Windows.Extensions\tests\System\Drawing\ImageConverterTests.cs(46,0): at System.ComponentModel.TypeConverterTests.ImageConverterTest.ImageWithOleHeader()
    Finished:    System.Windows.Extensions.Tests
  === TEST EXECUTION SUMMARY ===
     System.Windows.Extensions.Tests  Total: 81, Errors: 0, Failed: 1, Skipped: 2, Time: 0.421s
```

After
```
    Discovering: System.Windows.Extensions.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Windows.Extensions.Tests (found 65 of 76 test cases)
    Starting:    System.Windows.Extensions.Tests (parallel test collections = on, max threads = 12)
      System.Security.Cryptography.X509Certificates.Tests.X509Certificate2UIManualTests.DisplayCertificateTest [SKIP]
        Condition(s) not met: "ManualTestsEnabled"
      System.Security.Cryptography.X509Certificates.Tests.X509Certificate2UIManualTests.SelectCertificateSingleSelectionTest [SKIP]
        Condition(s) not met: "ManualTestsEnabled"
    Finished:    System.Windows.Extensions.Tests
  === TEST EXECUTION SUMMARY ===
     System.Windows.Extensions.Tests  Total: 81, Errors: 0, Failed: 0, Skipped: 2, Time: 0.356s
  ----- end 11:38:26.31 ----- exit code 0 ---------------------------------------------------------
```


code taken from https://referencesource.microsoft.com/#System.Drawing/commonui/System/Drawing/ImageConverter.cs,181