### PR TITLE
Removed heap allocations from OdbcDataReader

### DIFF
--- a/src/System.Data.Odbc/src/System.Data.Odbc.csproj
+++ b/src/System.Data.Odbc/src/System.Data.Odbc.csproj
@@ -155,6 +155,7 @@
     <Reference Include="System.Diagnostics.TraceSource" />
     <Reference Include="System.Globalization" />
     <Reference Include="System.Linq" />
+    <Reference Include="System.Memory" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />


### PR DESCRIPTION
Removed allocations from when data is being parsed into managed structures within the ODBCDataReader.

|       Method  | MeanCurr  | MeanNew   | AllocCurr   |   AllocNew  |  AllocDiff  |
|-------------- |---------:|---------:|-----------:|-----------:|-----------:|
| GetDateTime() | 48.18 ms  | 48.39 ms  |  862.66 KB  |  470.59 KB  |    - 45.45%  |
| GetString()   | 63.45 ms  | 63.51 ms  |  1333.2 KB  |  941.13 KB  |    - 29.4%  |
| GetDecimal()  | 80.82 ms  | 80.38 ms  | 2117.38 KB  | 1725.31 KB  |    - 18.5%  |

<p align="center">
  [Benchmarking results of iterating through 10000 rows in a MariaDB database]
</p>

Notes:
1. This does use an unsafe an code block to copy from the IntPtr into the Span, as there is no other way of doing this.
Related issue: https://github.com/dotnet/corefx/issues/18946

2. There are two unused internal methods in DbBuffer.cs, I marked them with a comment, in case they should be removed.

3. Furthermore, the new Read/Write-Numeric implementation is not quite optimal yet, as there is no way for one to create/read a decimal from/into a Span\<byte\>. Though I am not quite sure if it is used at all, as GetDecimal() does not seem to rely on that function.
Related issue: https://github.com/dotnet/corefx/issues/35877