### PR TITLE
Improve System.Native build experience for new platforms

### DIFF
--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -93,7 +93,7 @@ jobs:
               _helixQueues: $(alpineArm64Queues)
               _dockerContainer: alpine_37_arm64_container
               _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
-              _buildExtraArguments: -warnAsError false /p:BuildNativeClang=--clang5.0 /p:RuntimeOS=linux-musl
+              _buildExtraArguments: -warnAsError false /p:BuildNativeCompiler=--clang5.0 /p:RuntimeOS=linux-musl
 
       pool:
         name: Hosted Ubuntu 1604
@@ -142,7 +142,7 @@ jobs:
               _framework: netcoreapp
               _dockerContainer: alpine_37_arm64_container
               _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
-              _buildExtraArguments: -warnAsError false /p:BuildNativeClang=--clang5.0 /p:RuntimeOS=linux-musl
+              _buildExtraArguments: -warnAsError false /p:BuildNativeCompiler=--clang5.0 /p:RuntimeOS=linux-musl
 
         pool:
           name: Hosted Ubuntu 1604

--- a/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -14,7 +14,11 @@ if(CMAKE_STATIC_LIB_LINK)
    set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
 endif(CMAKE_STATIC_LIB_LINK)
 
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL)
+if(NOT OPENSSL_FOUND)
+    message(FATAL_ERROR "!!! Cannot find libssl and System.Security.Cryptography.Native cannot build without it. Try installing libssl-dev (or the appropriate package for your platform) !!!")
+endif(NOT OPENSSL_FOUND)
+
 include_directories(${OPENSSL_INCLUDE_DIR})
 
 set(NATIVECRYPTO_SOURCES

--- a/src/Native/build-native.proj
+++ b/src/Native/build-native.proj
@@ -24,12 +24,12 @@
       <_PortableBuildArg Condition="'$(PortableBuild)' == 'true'"> -portable</_PortableBuildArg>
 
       <!--
-        BuildNativeClang is a pass-through argument, to pass an argument to build-native.sh. It is intended to be
-        used to force a specific clang toolset.
+        BuildNativeCompiler is a pass-through argument, to pass an argument to build-native.sh. It is intended to be
+        used to force a specific compiler toolset.
       -->
-      <_BuildNativeClangArg Condition="'$(BuildNativeClang)' != ''"> $(BuildNativeClang)</_BuildNativeClangArg>
+      <_BuildNativeCompilerArg Condition="'$(BuildNativeCompiler)' != ''"> $(BuildNativeCompiler)</_BuildNativeCompilerArg>
 
-      <_BuildNativeUnixArgs>$(_BuildNativeArgs)$(_ProcessCountArg)$(_StripSymbolsArg)$(_PortableBuildArg)$(_BuildNativeClangArg)</_BuildNativeUnixArgs>
+      <_BuildNativeUnixArgs>$(_BuildNativeArgs)$(_ProcessCountArg)$(_StripSymbolsArg)$(_PortableBuildArg)$(_BuildNativeCompilerArg)</_BuildNativeUnixArgs>
     </PropertyGroup>
 
     <Message Text="$(MSBuildProjectDirectory)/build-native.sh $(_BuildNativeUnixArgs)" Importance="High"/>


### PR DESCRIPTION
1. From top-level script, we can pass (only*) one extra argument to `build-native.sh` via `BuildNativeClang` as MSBuild property; `/p:BuildNativeClang`. This PR renames it to `BuildNativeCompiler` so it doesn't look confusing when selecting GCC compiler: `corefx/build.sh /p:BuildNativeCompiler=-gcc`.
2. When libssl devel package is not installed on the system, the default CMake's "library not found" message is unhelpful. This patch aligns the error handling of `NOT OPENSSL_FOUND` with those of KRB5 and CURL etc., so user knows which missing package to install.

---
\* Currently there is no way to pass more than one arguments via `BuildNativeCompiler`, as they get stripped somewhere in `eng` directory in `corefx/build.sh -> ... -> corefx/src/Native/build-native.sh` call chain. For example, we cannot do:

> ./build.sh /p:BuildNativeCompiler="cmakeargs -DSOME_CLR_PROPERTY=SomeValue cmakeargs -DCMAKE_C_FLAGS=-march=native" release cross arm64

because a pass-through script strips away the quotes.