### PR TITLE
Fixing the Min/Max and MinMagnitude/MaxMagnitude for System.Math and System.MathF to expect NaN propagation

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/System.Runtime.Extensions/tests/System/Math.cs
@@ -1080,7 +1080,7 @@ namespace System.Tests
         [InlineData(-0.0, 0.0, 0.0)]
         [InlineData(2.0, -3.0, 2.0)]
         [InlineData(3.0, -2.0, 3.0)]
-        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.NaN)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Max_Double_NotNetFramework(double x, double y, double expectedResult)
         {
@@ -1133,7 +1133,7 @@ namespace System.Tests
         [InlineData(-0.0f, 0.0f, 0.0f)]
         [InlineData(2.0f, -3.0f, 2.0f)]
         [InlineData(3.0f, -2.0f, 3.0f)]
-        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.NaN)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Max_Single_NotNetFramework(float x, float y, float expectedResult)
         {
@@ -1193,7 +1193,7 @@ namespace System.Tests
         [InlineData(-0.0, 0.0, -0.0)]
         [InlineData(2.0, -3.0, -3.0)]
         [InlineData(3.0, -2.0, -2.0)]
-        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.NaN)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Min_Double_NotNetFramework(double x, double y, double expectedResult)
         {
@@ -1246,7 +1246,7 @@ namespace System.Tests
         [InlineData(-0.0f, 0.0f, -0.0f)]
         [InlineData(2.0f, -3.0f, -3.0f)]
         [InlineData(3.0f, -2.0f, -2.0f)]
-        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.NaN)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public static void Min_Single_NotNetFramework(float x, float y, float expectedResult)
         {

--- a/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathF.netcoreapp.cs
@@ -1208,7 +1208,7 @@ namespace System.Tests
         [InlineData(-0.0f, 0.0f, 0.0f)]
         [InlineData(2.0f, -3.0f, 2.0f)]
         [InlineData(3.0f, -2.0f, 3.0f)]
-        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.NaN)]
         public static void Max(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.Max(x, y), 0.0f);
@@ -1221,7 +1221,7 @@ namespace System.Tests
         [InlineData(-0.0f, 0.0f, 0.0f)]
         [InlineData(2.0f, -3.0f, -3.0f)]
         [InlineData(3.0f, -2.0f, 3.0f)]
-        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.NaN)]
         public static void MaxMagnitude(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.MaxMagnitude(x, y), 0.0f);
@@ -1234,7 +1234,7 @@ namespace System.Tests
         [InlineData(-0.0f, 0.0f, -0.0f)]
         [InlineData(2.0f, -3.0f, -3.0f)]
         [InlineData(3.0f, -2.0f, -2.0f)]
-        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.NaN)]
         public static void Min(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.Min(x, y), 0.0f);
@@ -1247,7 +1247,7 @@ namespace System.Tests
         [InlineData(-0.0f, 0.0f, -0.0f)]
         [InlineData(2.0f, -3.0f, 2.0f)]
         [InlineData(3.0f, -2.0f, -2.0f)]
-        [InlineData(float.PositiveInfinity, float.NaN, float.PositiveInfinity)]
+        [InlineData(float.PositiveInfinity, float.NaN, float.NaN)]
         public static void MinMagnitude(float x, float y, float expectedResult)
         {
             AssertEqual(expectedResult, MathF.MinMagnitude(x, y), 0.0f);

--- a/src/System.Runtime.Extensions/tests/System/MathTests.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/MathTests.netcoreapp.cs
@@ -599,7 +599,7 @@ namespace System.Tests
         [InlineData(-0.0, 0.0, 0.0)]
         [InlineData(2.0, -3.0, -3.0)]
         [InlineData(3.0, -2.0, 3.0)]
-        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.NaN)]
         public static void MaxMagnitude(double x, double y, double expectedResult)
         {
             AssertEqual(expectedResult, Math.MaxMagnitude(x, y), 0.0);
@@ -612,7 +612,7 @@ namespace System.Tests
         [InlineData(-0.0, 0.0, -0.0)]
         [InlineData(2.0, -3.0, 2.0)]
         [InlineData(3.0, -2.0, -2.0)]
-        [InlineData(double.PositiveInfinity, double.NaN, double.PositiveInfinity)]
+        [InlineData(double.PositiveInfinity, double.NaN, double.NaN)]
         public static void MinMagnitude(double x, double y, double expectedResult)
         {
             AssertEqual(expectedResult, Math.MinMagnitude(x, y), 0.0);


### PR DESCRIPTION
This resolves https://github.com/dotnet/corefx/issues/36931