### PR TITLE
Adding default encoder as png for MemoryBmp

### DIFF
--- a/src/System.Windows.Extensions/tests/System/Drawing/ImageConverterTests.cs
+++ b/src/System.Windows.Extensions/tests/System/Drawing/ImageConverterTests.cs
@@ -152,6 +152,15 @@ namespace System.ComponentModel.TypeConverterTests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void ConvertTo_FromBitmapToByteArray()
+        {
+            Bitmap value = new Bitmap(64, 64);
+            ImageConverter converter = new ImageConverter();
+            byte[] converted = (byte[])converter.ConvertTo(value, typeof(byte[]));
+            Assert.NotNull(converted);
+        }
+
+        [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ConvertTo_ThrowsNotSupportedException()
         {
             Assert.Throws<NotSupportedException>(() => _imgConv.ConvertTo(null, CultureInfo.InvariantCulture, _image, typeof(Rectangle)));


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/34771, https://github.com/dotnet/corefx/issues/36525
There is no encoder for the byte array which results in argument null exception.
Adding the a default png encoder if we are not able to get the encoder from destination type. (similar to .net Framework)