### PR TITLE
Update testdata versions

### DIFF
--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -44,14 +44,14 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 
     <!-- Test Data -->
-    <PackageReference Include="System.IO.Compression.TestData" Version="1.0.7-prerelease" />
-    <PackageReference Include="System.IO.Packaging.TestData" Version="1.0.0-prerelease" />
-    <PackageReference Include="System.Security.Cryptography.X509Certificates.TestData" Version="1.0.2-prerelease" />
-    <PackageReference Include="System.Net.TestData" Version="1.0.1-prerelease" />
-    <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="1.0.0" />
-    <PackageReference Include="System.Drawing.Common.TestData" Version="1.0.7" />
-    <PackageReference Include="System.Text.RegularExpressions.TestData" Version="1.0.2" />
-    <PackageReference Include="System.Windows.Extensions.TestData" Version="1.0.0" />
+    <PackageReference Include="System.IO.Compression.TestData" Version="1.0.8" />
+    <PackageReference Include="System.IO.Packaging.TestData" Version="1.0.1" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates.TestData" Version="1.0.3" />
+    <PackageReference Include="System.Net.TestData" Version="1.0.2" />
+    <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="1.0.1" />
+    <PackageReference Include="System.Drawing.Common.TestData" Version="1.0.9" />
+    <PackageReference Include="System.Text.RegularExpressions.TestData" Version="1.0.3" />
+    <PackageReference Include="System.Windows.Extensions.TestData" Version="1.0.1" />
 
     <PackageToInclude Include="xunit.abstractions" />
     <PackageToInclude Include="xunit.assert" />

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -151,7 +151,7 @@
     <Compile Include="XTypeDescriptionProviderTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.componentmodel.typeconverter.testdata\1.0.0\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)system.componentmodel.typeconverter.testdata\1.0.1\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{4B93E684-0630-45F4-8F63-6C7788C9892F}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TestDataPackageVersion>1.0.7</TestDataPackageVersion>
+    <TestDataPackageVersion>1.0.9</TestDataPackageVersion>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>

--- a/src/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
+++ b/src/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
@@ -28,7 +28,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.7-prerelease\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.8\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -38,7 +38,7 @@
     <Compile Include="ZipFile.Extract.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.7-prerelease\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.8\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -49,7 +49,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.7-prerelease\content\**\*.*">
+    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.8\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Packaging/tests/System.IO.Packaging.Tests.csproj
+++ b/src/System.IO.Packaging/tests/System.IO.Packaging.Tests.csproj
@@ -7,6 +7,6 @@
     <Compile Include="Tests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.io.packaging.testdata\1.0.0-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)system.io.packaging.testdata\1.0.1\content\**\*.*" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -170,7 +170,7 @@
     <Compile Include="XUnitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.net.testdata\1.0.1-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)system.net.testdata\1.0.2\content\**\*.*" DestinationDir="TestData" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsOSX)'=='true'">
     <TestCommandLines Include="ulimit -Sn 4096" />

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -148,6 +148,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.net.testdata\1.0.1-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)system.net.testdata\1.0.2\content\**\*.*" DestinationDir="TestData" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -58,6 +58,6 @@
     <Compile Include="WebSocketHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.net.testdata\1.0.1-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)system.net.testdata\1.0.2\content\**\*.*" DestinationDir="TestData" />
   </ItemGroup>
 </Project>

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -128,6 +128,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.security.cryptography.x509certificates.testdata\1.0.2-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)system.security.cryptography.x509certificates.testdata\1.0.3\content\**\*.*" DesinationDir="TestData" />
   </ItemGroup>
 </Project>

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -128,6 +128,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.security.cryptography.x509certificates.testdata\1.0.3\content\**\*.*" DesinationDir="TestData" />
+    <SupplementalTestData Include="$(PackagesDir)system.security.cryptography.x509certificates.testdata\1.0.3\content\**\*.*" DestinationDir="TestData" />
   </ItemGroup>
 </Project>

--- a/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
+++ b/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{AC1A1515-70D8-42E4-9B19-A72F739E974C}</ProjectGuid>
     <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release</Configurations>
-    <TestDataPackageVersion>1.0.0</TestDataPackageVersion>
+    <TestDataPackageVersion>1.0.1</TestDataPackageVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="X509Certificate2UITests.cs" />


### PR DESCRIPTION
We uploaded new versions of all the test data packages to reset the versioning schema. The new package versions don't contain any changes except System.Drawing.Common.TestData (cc @Anipik)