### PR TITLE
Use NativeLibrary.[Try]Load for netcoreapp3

### DIFF
--- a/src/Common/src/System/Runtime/InteropServices/FunctionWrapper.cs
+++ b/src/Common/src/System/Runtime/InteropServices/FunctionWrapper.cs
@@ -65,6 +65,7 @@ namespace System.Runtime.InteropServices
                     return new FunctionLoadResult<T>(FunctionLoadResultKind.LibraryNotFound, null);
                 }
 
+#if netcoreapp20
                 IntPtr funcPtr = LoadFunctionPointer(nativeLibraryHandle, funcName);
                 if (funcPtr == IntPtr.Zero)
                 {
@@ -74,6 +75,11 @@ namespace System.Runtime.InteropServices
                 {
                     return new FunctionLoadResult<T>(FunctionLoadResultKind.Success, Marshal.GetDelegateForFunctionPointer<T>(funcPtr));
                 }
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+                return NativeLibrary.TryGetExport(nativeLibraryHandle, funcName, out var funcPtr)
+                    ? new FunctionLoadResult<T>(FunctionLoadResultKind.Success, Marshal.GetDelegateForFunctionPointer<T>(funcPtr))
+                    : new FunctionLoadResult<T>(FunctionLoadResultKind.FunctionNotFound, null);
+#endif
             });
 
             return new FunctionWrapper<T>(lazyDelegate, libName, funcName);

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.Unix.cs
@@ -65,19 +65,19 @@ namespace System
 
         public static bool IsDrawingSupported { get; } =
             RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-#if netcoreapp30
-                ? NativeLibrary.TryLoad("libgdiplus.dylib", out _)
-                : NativeLibrary.TryLoad("libgdiplus.so", out _) || NativeLibrary.TryLoad("libgdiplus.so.0", out _);
-#else
+#if netcoreapp20
                 ? dlopen("libgdiplus.dylib", RTLD_LAZY) != IntPtr.Zero
                 : dlopen("libgdiplus.so", RTLD_LAZY) != IntPtr.Zero || dlopen("libgdiplus.so.0", RTLD_LAZY) != IntPtr.Zero;
-
-        public static bool IsInContainer => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists("/.dockerenv");
 
         [DllImport("libdl")]
         private static extern IntPtr dlopen(string libName, int flags);
         private const int RTLD_LAZY = 0x001;
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+                ? NativeLibrary.TryLoad("libgdiplus.dylib", out _)
+                : NativeLibrary.TryLoad("libgdiplus.so", out _) || NativeLibrary.TryLoad("libgdiplus.so.0", out _);
 #endif
+
+        public static bool IsInContainer => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists("/.dockerenv");
 
         public static bool IsSoundPlaySupported { get; } = false;
 

--- a/src/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
+++ b/src/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
@@ -20,7 +20,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\libdl\Interop.dlopen.cs">
+    <Compile Include="$(CommonPath)\Interop\Unix\libdl\Interop.dlopen.cs" Condition="'$(TargetGroup)' == 'netcoreapp2.0'">
       <Link>Common\Interop\Unix\libdl\Interop.dlopen.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -337,6 +337,11 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
+    <EmbeddedResource Include="Resources\System\Drawing\Error.ico">
+      <LogicalName>placeholder.ico</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp2.0' AND '$(TargetsUnix)' == 'true'">
     <Compile Include="$(CommonPath)\Interop\Unix\libdl\Interop.dlopen.cs">
       <Link>Common\Interop\Unix\libdl\Interop.dlopen.cs</Link>
     </Compile>
@@ -346,9 +351,6 @@
     <Compile Include="$(CommonPath)\System\Runtime\InteropServices\FunctionWrapper.Unix.cs">
       <Link>Common\System\Runtime\InteropServices\FunctionWrapper.Unix.cs</Link>
     </Compile>
-    <EmbeddedResource Include="Resources\System\Drawing\Error.ico">
-      <LogicalName>placeholder.ico</LogicalName>
-    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true'">
     <Reference Include="Microsoft.Win32.Primitives" />

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/LibcupsNative.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/LibcupsNative.cs
@@ -15,12 +15,18 @@ namespace System.Drawing.Printing
         private static IntPtr LoadLibcups()
         {
             // We allow both "libcups.so" and "libcups.so.2" to be loaded.
+#if netcoreapp20
             IntPtr lib = Interop.Libdl.dlopen("libcups.so", Interop.Libdl.RTLD_LAZY);
             if (lib == IntPtr.Zero)
             {
                 lib = Interop.Libdl.dlopen("libcups.so.2", Interop.Libdl.RTLD_LAZY);
             }
-
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+            if (!NativeLibrary.TryLoad("libcups.so", out IntPtr lib))
+            {
+                NativeLibrary.TryLoad("libcups.so.2", out lib);
+            }
+#endif
             return lib;
         }
 


### PR DESCRIPTION
Follow up on #35548
Contributes to: #24538

FreeBSD has `dlopen` in libc, instead of `libdl`. By switching to `NativeLibrary` load methods in .NET Core 3, we can abstract this disparity at call-sites.