### PR TITLE
Fix StackTrace.ToString with null frame test

### DIFF
--- a/src/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -318,10 +318,11 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void ToString_NullFrame_ThrowsNullReferenceException()
         {
             var stackTrace = new StackTrace((StackFrame)null);
-            Assert.Throws<NullReferenceException>(() => stackTrace.ToString());
+            Assert.Equal(Environment.NewLine, stackTrace.ToString());
         }
 
         private static StackTrace NoParameters() => new StackTrace();


### PR DESCRIPTION
Update test to react to change to avoid a NullReferenceException when passing down a null `StrackFrame`

Depends on: https://github.com/dotnet/coreclr/pull/23762

We will need to cherry-pick this whenever the coreclr update PR contains the above PR.