### PR TITLE
Remove `Partial` from `EnablePartialNgenOptimization`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -267,7 +267,7 @@
 
   <PropertyGroup>
     <!-- Embed IBC data on release builds, if IBCMerge isn't available this will just log the commandline -->
-    <EnablePartialNgenOptimization Condition="'$(EnablePartialNgenOptimization)' == '' and '$(ConfigurationGroup)' == 'Release'">true</EnablePartialNgenOptimization>
+    <EnableNgenOptimization Condition="'$(EnableNgenOptimization)' == '' and '$(ConfigurationGroup)' == 'Release'">true</EnableNgenOptimization>
 
     <WindowsCoreFxOptimizationDataPackageId>optimization.windows_nt-x64.IBC.CoreFx</WindowsCoreFxOptimizationDataPackageId>
     <WindowsCoreFxOptimizationDataVersion>$(optimizationwindows_ntx64IBCCoreFxPackageVersion)</WindowsCoreFxOptimizationDataVersion>

--- a/external/dir.proj
+++ b/external/dir.proj
@@ -17,7 +17,7 @@
     <Project Include="harvestPackages/harvestPackages.depproj" />
     <Project Include="binplacePackages/binplacePackages.depproj" />
     <Project Include="docs/docs.depproj" Condition="'$(DotNetBuildFromSource)' != 'true'" />
-    <Project Include="optimizationData/optimizationData.depproj" Condition="'$(EnablePartialNgenOptimization)' == 'true' AND '$(DotNetBuildFromSource)' != 'true'" />
+    <Project Include="optimizationData/optimizationData.depproj" Condition="'$(EnableNgenOptimization)' == 'true' AND '$(DotNetBuildFromSource)' != 'true'" />
     <Project Condition="'$(ILLinkTrimAssembly)' != 'false'" Include="ILLink/ILLink.depproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Ngen optimizations are controlled with two properties - one is EnableNgen, the other is ApplyNgen. We were already using the ApplyNgen property with value of `full` (as of #36450), so this was already doing full Ngen, but we still used EnablePartialNgen to control the EnableNgen property. It's a roundabout way to EnableNgen, but does the same thing. This pull request removes the indirection.