### PR TITLE
allow Http2 loopback test be unencrypted

### DIFF
--- a/src/Common/tests/System/Net/Capability.Security.cs
+++ b/src/Common/tests/System/Net/Capability.Security.cs
@@ -37,6 +37,16 @@ namespace System.Net.Test.Common
             return !(Configuration.Security.HostsFileNamesInstalled == null);
         }
 
+        public static bool ForceUnencryptedHttp2Loopback()
+        {
+            string value = Configuration.Http.Http2ForceUnencrypted;
+            if (value != null && (value.Equals("true", StringComparison.OrdinalIgnoreCase) || value.Equals("1")))
+            {
+                return true;
+            }
+            return false;
+        }
+
         private static bool InitializeTrustedRootCertificateCapability()
         {
             using (var store = new X509Store(StoreName.Root, StoreLocation.CurrentUser))

--- a/src/Common/tests/System/Net/Capability.Security.cs
+++ b/src/Common/tests/System/Net/Capability.Security.cs
@@ -37,9 +37,9 @@ namespace System.Net.Test.Common
             return !(Configuration.Security.HostsFileNamesInstalled == null);
         }
 
-        public static bool ForceUnencryptedHttp2Loopback()
+        public static bool Http2ForceUnencryptedLoopback()
         {
-            string value = Configuration.Http.Http2ForceUnencrypted;
+            string value = Configuration.Http.Http2ForceUnencryptedLoopback;
             if (value != null && (value.Equals("true", StringComparison.OrdinalIgnoreCase) || value.Equals("1")))
             {
                 return true;

--- a/src/Common/tests/System/Net/Configuration.Http.cs
+++ b/src/Common/tests/System/Net/Configuration.Http.cs
@@ -42,6 +42,7 @@ namespace System.Net.Test.Common
             public static string RevokedCertRemoteServer => GetValue("COREFX_HTTPHOST_REVOKEDCERT", "https://revoked.badssl.com/");
 
             public static string EchoClientCertificateRemoteServer => GetValue("COREFX_HTTPHOST_ECHOCLIENTCERT", "https://corefx-net-tls.azurewebsites.net/EchoClientCertificate.ashx");
+            public static string Http2ForceUnencrypted => GetValue("COREFX_HTTP2FORCEUNENCRYPTED");
 
             private const string HttpScheme = "http";
             private const string HttpsScheme = "https";

--- a/src/Common/tests/System/Net/Configuration.Http.cs
+++ b/src/Common/tests/System/Net/Configuration.Http.cs
@@ -42,7 +42,7 @@ namespace System.Net.Test.Common
             public static string RevokedCertRemoteServer => GetValue("COREFX_HTTPHOST_REVOKEDCERT", "https://revoked.badssl.com/");
 
             public static string EchoClientCertificateRemoteServer => GetValue("COREFX_HTTPHOST_ECHOCLIENTCERT", "https://corefx-net-tls.azurewebsites.net/EchoClientCertificate.ashx");
-            public static string Http2ForceUnencrypted => GetValue("COREFX_HTTP2FORCEUNENCRYPTED");
+            public static string Http2ForceUnencryptedLoopback => GetValue("COREFX_HTTP2_FORCEUNENCRYPTEDLOOPBACK");
 
             private const string HttpScheme = "http";
             private const string HttpsScheme = "https";

--- a/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -673,7 +673,7 @@ namespace System.Net.Test.Common
     {
         public IPAddress Address { get; set; } = IPAddress.Loopback;
         public int ListenBacklog { get; set; } = 1;
-        public bool UseSsl { get; set; } = PlatformDetection.SupportsAlpn;
+        public bool UseSsl { get; set; } = PlatformDetection.SupportsAlpn && !Capability.ForceUnencryptedHttp2Loopback();
         public SslProtocols SslProtocols { get; set; } = SslProtocols.Tls12;
     }
 

--- a/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -673,7 +673,7 @@ namespace System.Net.Test.Common
     {
         public IPAddress Address { get; set; } = IPAddress.Loopback;
         public int ListenBacklog { get; set; } = 1;
-        public bool UseSsl { get; set; } = PlatformDetection.SupportsAlpn && !Capability.ForceUnencryptedHttp2Loopback();
+        public bool UseSsl { get; set; } = PlatformDetection.SupportsAlpn && !Capability.Http2ForceUnencryptedLoopback();
         public SslProtocols SslProtocols { get; set; } = SslProtocols.Tls12;
     }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
@@ -56,9 +56,10 @@ namespace System.Net.Http.Functional.Tests
                 Debug.Assert(useSocketsHttpHandler == IsSocketsHttpHandler(handler), "Unexpected handler.");
             }
 
+            TestHelper.EnsureHttp2Feature(handler, useHttp2LoopbackServer);
+
             if (useHttp2LoopbackServer)
             {
-                TestHelper.EnsureHttp2Feature(handler);
                 handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -118,7 +118,7 @@ namespace System.Net.Http.Functional.Tests
                 .Where(a => a.IsIPv6LinkLocal)
                 .FirstOrDefault();
 
-        public static void EnsureHttp2Feature(HttpClientHandler handler)
+        public static void EnsureHttp2Feature(HttpClientHandler handler, bool useHttp2LoopbackServer = true)
         {
             // All .NET Core implementations of HttpClientHandler have HTTP/2 enabled by default except when using
             // SocketsHttpHandler. Right now, the HTTP/2 feature is disabled on SocketsHttpHandler unless certain
@@ -156,11 +156,14 @@ namespace System.Net.Http.Functional.Tests
                 BindingFlags.NonPublic | BindingFlags.Instance);
             field_maxHttpVersion.SetValue(_settings, new Version(2, 0));
 
-            // Allow HTTP/2.0 via unencrypted socket if ALPN is not supported on platform.
-            FieldInfo field_allowPlainHttp2 = type_HttpConnectionSettings.GetField(
-                "_allowUnencryptedHttp2",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            field_allowPlainHttp2.SetValue(_settings, !PlatformDetection.SupportsAlpn);
+            if (useHttp2LoopbackServer && !PlatformDetection.SupportsAlpn)
+            {
+                // Allow HTTP/2.0 via unencrypted socket if ALPN is not supported on platform.
+                FieldInfo field_allowPlainHttp2 = type_HttpConnectionSettings.GetField(
+                    "_allowUnencryptedHttp2",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+                field_allowPlainHttp2.SetValue(_settings, !PlatformDetection.SupportsAlpn);
+            }
         }
 
         public static bool NativeHandlerSupportsSslConfiguration()

--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.NetworkInformation;
 using System.Net.Security;
+using System.Net.Test.Common;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -156,13 +157,13 @@ namespace System.Net.Http.Functional.Tests
                 BindingFlags.NonPublic | BindingFlags.Instance);
             field_maxHttpVersion.SetValue(_settings, new Version(2, 0));
 
-            if (useHttp2LoopbackServer && !PlatformDetection.SupportsAlpn)
+            if (useHttp2LoopbackServer && (!PlatformDetection.SupportsAlpn || Capability.ForceUnencryptedHttp2Loopback()))
             {
                 // Allow HTTP/2.0 via unencrypted socket if ALPN is not supported on platform.
                 FieldInfo field_allowPlainHttp2 = type_HttpConnectionSettings.GetField(
                     "_allowUnencryptedHttp2",
                     BindingFlags.NonPublic | BindingFlags.Instance);
-                field_allowPlainHttp2.SetValue(_settings, !PlatformDetection.SupportsAlpn);
+                field_allowPlainHttp2.SetValue(_settings, true);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/TestHelper.cs
@@ -157,7 +157,7 @@ namespace System.Net.Http.Functional.Tests
                 BindingFlags.NonPublic | BindingFlags.Instance);
             field_maxHttpVersion.SetValue(_settings, new Version(2, 0));
 
-            if (useHttp2LoopbackServer && (!PlatformDetection.SupportsAlpn || Capability.ForceUnencryptedHttp2Loopback()))
+            if (useHttp2LoopbackServer && (!PlatformDetection.SupportsAlpn || Capability.Http2ForceUnencryptedLoopback()))
             {
                 // Allow HTTP/2.0 via unencrypted socket if ALPN is not supported on platform.
                 FieldInfo field_allowPlainHttp2 = type_HttpConnectionSettings.GetField(


### PR DESCRIPTION
This is follow-up on #36753
This change adds environmental variable to force HTTP2 loopback test to not use SSL even of platforms where ALPN is supported. This allows to develop and debug HTTP/2 tests easier. One can run  packet capture and  see all frames decoded in Wireshark. 

This is not enabled by default and it is meant only for developers. 
Note that not all tests pass with this - updated generic and Http2 loopback tests work but not all tests are updated (yet?)