### PR TITLE
Nullable: Most libraries that reference corelib

### DIFF
--- a/eng/DefaultGenApiDocIds.txt
+++ b/eng/DefaultGenApiDocIds.txt
@@ -20,8 +20,9 @@ T:System.IO.IODescriptionAttribute
 T:System.Runtime.CompilerServices.AsyncStateMachineAttribute
 T:System.Runtime.CompilerServices.CompilerGeneratedAttribute
 T:System.Runtime.CompilerServices.IteratorStateMachineAttribute
-T:System.Runtime.CompilerServices.TypeForwardedFromAttribute
 T:System.Runtime.CompilerServices.MethodImpl
+T:System.Runtime.CompilerServices.NullableAttribute
+T:System.Runtime.CompilerServices.TypeForwardedFromAttribute
 T:System.Runtime.ConstrainedExecution.ReliabilityContractAttribute
 T:System.Runtime.InteropServices.ClassInterfaceAttribute
 T:System.Runtime.InteropServices.ComDefaultInterfaceAttribute

--- a/src/Common/src/System/Buffers/ArrayBufferWriter.cs
+++ b/src/Common/src/System/Buffers/ArrayBufferWriter.cs
@@ -176,7 +176,7 @@ namespace System.Buffers
 
                 int newSize = checked(_buffer.Length + growBy);
 
-                Array.Resize(ref _buffer, newSize);
+                Array.Resize(ref _buffer!, newSize); // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
             }
 
             Debug.Assert(FreeCapacity > 0 && FreeCapacity >= sizeHint);

--- a/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
+++ b/src/Common/src/System/Collections/Generic/EnumerableHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 namespace System.Collections.Generic
 {
     /// <summary>
@@ -73,7 +74,7 @@ namespace System.Collections.Generic
                                     newLength = MaxArrayLength <= count ? count + 1 : MaxArrayLength;
                                 }
 
-                                Array.Resize(ref arr, newLength);
+                                Array.Resize(ref arr!, newLength); // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
                             }
 
                             arr[count++] = en.Current;

--- a/src/Common/src/System/HResults.cs
+++ b/src/Common/src/System/HResults.cs
@@ -10,8 +10,6 @@
 //
 //===========================================================================*/
 
-using System;
-
 namespace System
 {
     // Note: FACILITY_URT is defined as 0x13 (0x8013xxxx).  Within that

--- a/src/Common/src/System/SR.cs
+++ b/src/Common/src/System/SR.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
 using System.Resources;
 using System.Runtime.CompilerServices;
 
@@ -18,14 +19,14 @@ namespace System
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool UsingResourceKeys() => false;
 
-        internal static string GetResourceString(string resourceKey, string defaultString = null)
+        internal static string GetResourceString(string resourceKey, string? defaultString = null)
         {
             if (UsingResourceKeys())
             {
                 return defaultString ?? resourceKey;
             }
 
-            string resourceString = null;
+            string? resourceString = null;
             try
             {
                 resourceString = ResourceManager.GetString(resourceKey);
@@ -37,10 +38,10 @@ namespace System
                 return defaultString;
             }
 
-            return resourceString;
+            return resourceString!; // only null if missing resources
         }
 
-        internal static string Format(string resourceFormat, object p1)
+        internal static string Format(string resourceFormat, object? p1)
         {
             if (UsingResourceKeys())
             {
@@ -50,7 +51,7 @@ namespace System
             return string.Format(resourceFormat, p1);
         }
 
-        internal static string Format(string resourceFormat, object p1, object p2)
+        internal static string Format(string resourceFormat, object? p1, object? p2)
         {
             if (UsingResourceKeys())
             {
@@ -60,7 +61,7 @@ namespace System
             return string.Format(resourceFormat, p1, p2);
         }
 
-        internal static string Format(string resourceFormat, object p1, object p2, object p3)
+        internal static string Format(string resourceFormat, object? p1, object? p2, object? p3)
         {
             if (UsingResourceKeys())
             {
@@ -70,7 +71,7 @@ namespace System
             return string.Format(resourceFormat, p1, p2, p3);
         }
 
-        internal static string Format(string resourceFormat, params object[] args)
+        internal static string Format(string resourceFormat, params object?[]? args)
         {
             if (args != null)
             {
@@ -85,7 +86,7 @@ namespace System
             return resourceFormat;
         }
 
-        internal static string Format(IFormatProvider provider, string resourceFormat, object p1)
+        internal static string Format(IFormatProvider? provider, string resourceFormat, object? p1)
         {
             if (UsingResourceKeys())
             {
@@ -95,7 +96,7 @@ namespace System
             return string.Format(provider, resourceFormat, p1);
         }
 
-        internal static string Format(IFormatProvider provider, string resourceFormat, object p1, object p2)
+        internal static string Format(IFormatProvider? provider, string resourceFormat, object? p1, object? p2)
         {
             if (UsingResourceKeys())
             {
@@ -105,7 +106,7 @@ namespace System
             return string.Format(provider, resourceFormat, p1, p2);
         }
 
-        internal static string Format(IFormatProvider provider, string resourceFormat, object p1, object p2, object p3)
+        internal static string Format(IFormatProvider? provider, string resourceFormat, object? p1, object? p2, object? p3)
         {
             if (UsingResourceKeys())
             {
@@ -115,7 +116,7 @@ namespace System
             return string.Format(provider, resourceFormat, p1, p2, p3);
         }
 
-        internal static string Format(IFormatProvider provider, string resourceFormat, params object[] args)
+        internal static string Format(IFormatProvider? provider, string resourceFormat, params object?[]? args)
         {
             if (args != null)
             {

--- a/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
+++ b/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>System.Collections.Concurrent</AssemblyName>
     <RootNamespace>System.Collections.Concurrent</RootNamespace>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <NullableContextOptions>enable</NullableContextOptions>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/OrderablePartitioner.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/OrderablePartitioner.cs
@@ -230,7 +230,7 @@ namespace System.Collections.Concurrent
             }
             public void Dispose()
             {
-                IDisposable d = _source as IDisposable;
+                IDisposable? d = _source as IDisposable;
                 if (d != null)
                 {
                     d.Dispose();
@@ -256,7 +256,7 @@ namespace System.Collections.Concurrent
                     return _source.Current.Value;
                 }
             }
-            object IEnumerator.Current
+            object? IEnumerator.Current
             {
                 get
                 {

--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <ItemGroup>

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -548,7 +548,7 @@ namespace System.Collections
                 if (newints > m_array.Length || newints + _ShrinkThreshold < m_array.Length)
                 {
                     // grow or shrink (if wasting more than _ShrinkThreshold ints)
-                    Array.Resize(ref m_array, newints);
+                    Array.Resize(ref m_array!, newints); // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
                 }
 
                 if (value > m_length)
@@ -781,7 +781,9 @@ namespace System.Collections
                 return false;
             }
 
+#pragma warning disable CS8612 // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/23268
             public virtual object Current
+#pragma warning restore CS8612
             {
                 get
                 {

--- a/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/System.Collections/src/System/Collections/Generic/CollectionExtensions.cs
@@ -6,12 +6,12 @@ namespace System.Collections.Generic
 {
     public static class CollectionExtensions
     {
-        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key) where TKey : object
         {
-            return dictionary.GetValueOrDefault(key, default(TValue));
+            return dictionary.GetValueOrDefault(key, default(TValue)!); // TODO-NULLABLE-GENERIC
         }
 
-        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
+        public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue) where TKey : object
         {
             if (dictionary == null)
             {
@@ -22,7 +22,7 @@ namespace System.Collections.Generic
             return dictionary.TryGetValue(key, out value) ? value : defaultValue;
         }
 
-        public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value) where TKey : object
         {
             if (dictionary == null)
             {
@@ -38,7 +38,7 @@ namespace System.Collections.Generic
             return false;
         }
 
-        public static bool Remove<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, out TValue value)
+        public static bool Remove<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, out TValue value) where TKey : object // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
         {
             if (dictionary == null)
             {
@@ -51,7 +51,7 @@ namespace System.Collections.Generic
                 return true;
             }
 
-            value = default(TValue);
+            value = default(TValue)!; // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
             return false;
         }
     }

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -69,15 +69,15 @@ namespace System.Collections.Generic
         private const string ComparerName = "Comparer"; // Do not rename (binary serialization)
         private const string VersionName = "Version"; // Do not rename (binary serialization)
 
-        private int[] _buckets;
-        private Slot[] _slots;
+        private int[]? _buckets;
+        private Slot[] _slots = default!; // TODO-NULLABLE: This should be Slot[]?, but the resulting annotations causes GenPartialFacadeSource to blow up: error : Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Syntax.CompilationUnitSyntax' to type 'Microsoft.CodeAnalysis.CSharp.Syntax.BaseTypeDeclarationSyntax'
         private int _count;
         private int _lastIndex;
         private int _freeList;
-        private IEqualityComparer<T> _comparer;
+        private IEqualityComparer<T> _comparer = default!;
         private int _version;
 
-        private SerializationInfo _siInfo; // temporary variable needed during deserialization
+        private SerializationInfo? _siInfo; // temporary variable needed during deserialization
 
         #region Constructors
 
@@ -85,7 +85,7 @@ namespace System.Collections.Generic
             : this(EqualityComparer<T>.Default)
         { }
 
-        public HashSet(IEqualityComparer<T> comparer)
+        public HashSet(IEqualityComparer<T>? comparer)
         {
             if (comparer == null)
             {
@@ -114,7 +114,7 @@ namespace System.Collections.Generic
         /// </summary>
         /// <param name="collection"></param>
         /// <param name="comparer"></param>
-        public HashSet(IEnumerable<T> collection, IEqualityComparer<T> comparer)
+        public HashSet(IEnumerable<T> collection, IEqualityComparer<T>? comparer)
             : this(comparer)
         {
             if (collection == null)
@@ -132,7 +132,7 @@ namespace System.Collections.Generic
                 // to avoid excess resizes, first set size based on collection's count. Collection
                 // may contain duplicates, so call TrimExcess if resulting hashset is larger than
                 // threshold
-                ICollection<T> coll = collection as ICollection<T>;
+                ICollection<T>? coll = collection as ICollection<T>;
                 int suggestedCapacity = coll == null ? 0 : coll.Count;
                 Initialize(suggestedCapacity);
 
@@ -167,7 +167,7 @@ namespace System.Collections.Generic
                 return;
             }
 
-            int capacity = source._buckets.Length;
+            int capacity = source._buckets!.Length;
             int threshold = HashHelpers.ExpandPrime(count + 1);
 
             if (threshold >= capacity)
@@ -321,7 +321,7 @@ namespace System.Collections.Generic
                         slots[i].hashCode = -1;
                         if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                         {
-                            slots[i].value = default(T);
+                            slots[i].value = default!;
                         }
                         slots[i].next = _freeList;
 
@@ -424,7 +424,7 @@ namespace System.Collections.Generic
             }
 
             int capacity = _siInfo.GetInt32(CapacityName);
-            _comparer = (IEqualityComparer<T>)_siInfo.GetValue(ComparerName, typeof(IEqualityComparer<T>));
+            _comparer = (IEqualityComparer<T>)_siInfo.GetValue(ComparerName, typeof(IEqualityComparer<T>))!;
             _freeList = -1;
 
             if (capacity != 0)
@@ -432,7 +432,7 @@ namespace System.Collections.Generic
                 _buckets = new int[capacity];
                 _slots = new Slot[capacity];
 
-                T[] array = (T[])_siInfo.GetValue(ElementsName, typeof(T[]));
+                T[]? array = (T[]?)_siInfo.GetValue(ElementsName, typeof(T[]));
 
                 if (array == null)
                 {
@@ -481,7 +481,7 @@ namespace System.Collections.Generic
         /// a value that has more complete data than the value you currently have, although their
         /// comparer functions indicate they are equal.
         /// </remarks>
-        public bool TryGetValue(T equalValue, out T actualValue)
+        public bool TryGetValue(T equalValue, out T actualValue) // TODO-NULLABLE-GENERIC
         {
             if (_buckets != null)
             {
@@ -492,7 +492,7 @@ namespace System.Collections.Generic
                     return true;
                 }
             }
-            actualValue = default(T);
+            actualValue = default!; // TODO-NULLABLE-GENERIC
             return false;
         }
 
@@ -552,7 +552,7 @@ namespace System.Collections.Generic
 
             // if other is empty, intersection is empty set; remove all elements and we're done
             // can only figure this out if implements ICollection<T>. (IEnumerable<T> has no count)
-            ICollection<T> otherAsCollection = other as ICollection<T>;
+            ICollection<T>? otherAsCollection = other as ICollection<T>;
             if (otherAsCollection != null)
             {
                 if (otherAsCollection.Count == 0)
@@ -561,7 +561,7 @@ namespace System.Collections.Generic
                     return;
                 }
 
-                HashSet<T> otherAsSet = other as HashSet<T>;
+                HashSet<T>? otherAsSet = other as HashSet<T>;
                 // faster if other is a hashset using same equality comparer; so check 
                 // that other is a hashset using the same equality comparer.
                 if (otherAsSet != null && AreEqualityComparersEqual(this, otherAsSet))
@@ -630,7 +630,7 @@ namespace System.Collections.Generic
                 return;
             }
 
-            HashSet<T> otherAsSet = other as HashSet<T>;
+            HashSet<T>? otherAsSet = other as HashSet<T>;
             // If other is a HashSet, it has unique elements according to its equality comparer,
             // but if they're using different equality comparers, then assumption of uniqueness
             // will fail. So first check if other is a hashset using the same equality comparer;
@@ -679,7 +679,7 @@ namespace System.Collections.Generic
                 return true;
             }
 
-            HashSet<T> otherAsSet = other as HashSet<T>;
+            HashSet<T>? otherAsSet = other as HashSet<T>;
             // faster if other has unique elements according to this equality comparer; so check 
             // that other is a hashset using the same equality comparer.
             if (otherAsSet != null && AreEqualityComparersEqual(this, otherAsSet))
@@ -729,7 +729,7 @@ namespace System.Collections.Generic
                 return false;
             }
 
-            ICollection<T> otherAsCollection = other as ICollection<T>;
+            ICollection<T>? otherAsCollection = other as ICollection<T>;
             if (otherAsCollection != null)
             {
                 // no set is a proper subset of an empty set
@@ -743,7 +743,7 @@ namespace System.Collections.Generic
                 {
                     return otherAsCollection.Count > 0;
                 }
-                HashSet<T> otherAsSet = other as HashSet<T>;
+                HashSet<T>? otherAsSet = other as HashSet<T>;
                 // faster if other is a hashset (and we're using same equality comparer)
                 if (otherAsSet != null && AreEqualityComparersEqual(this, otherAsSet))
                 {
@@ -788,7 +788,7 @@ namespace System.Collections.Generic
             }
 
             // try to fall out early based on counts
-            ICollection<T> otherAsCollection = other as ICollection<T>;
+            ICollection<T>? otherAsCollection = other as ICollection<T>;
             if (otherAsCollection != null)
             {
                 // if other is the empty set then this is a superset
@@ -796,7 +796,7 @@ namespace System.Collections.Generic
                 {
                     return true;
                 }
-                HashSet<T> otherAsSet = other as HashSet<T>;
+                HashSet<T>? otherAsSet = other as HashSet<T>;
                 // try to compare based on counts alone if other is a hashset with
                 // same equality comparer
                 if (otherAsSet != null && AreEqualityComparersEqual(this, otherAsSet))
@@ -850,7 +850,7 @@ namespace System.Collections.Generic
                 return false;
             }
 
-            ICollection<T> otherAsCollection = other as ICollection<T>;
+            ICollection<T>? otherAsCollection = other as ICollection<T>;
             if (otherAsCollection != null)
             {
                 // if other is the empty set then this is a superset
@@ -859,7 +859,7 @@ namespace System.Collections.Generic
                     // note that this has at least one element, based on above check
                     return true;
                 }
-                HashSet<T> otherAsSet = other as HashSet<T>;
+                HashSet<T>? otherAsSet = other as HashSet<T>;
                 // faster if other is a hashset with the same equality comparer
                 if (otherAsSet != null && AreEqualityComparersEqual(this, otherAsSet))
                 {
@@ -928,7 +928,7 @@ namespace System.Collections.Generic
                 return true;
             }
 
-            HashSet<T> otherAsSet = other as HashSet<T>;
+            HashSet<T>? otherAsSet = other as HashSet<T>;
             // faster if other is a hashset and we're using same equality comparer
             if (otherAsSet != null && AreEqualityComparersEqual(this, otherAsSet))
             {
@@ -945,7 +945,7 @@ namespace System.Collections.Generic
             }
             else
             {
-                ICollection<T> otherAsCollection = other as ICollection<T>;
+                ICollection<T>? otherAsCollection = other as ICollection<T>;
                 if (otherAsCollection != null)
                 {
                     // if this count is 0 but other contains at least one element, they can't be equal
@@ -1083,7 +1083,7 @@ namespace System.Collections.Generic
             {
                 // if count is zero, clear references
                 _buckets = null;
-                _slots = null;
+                _slots = null!;
                 _version++;
             }
             else
@@ -1213,7 +1213,7 @@ namespace System.Collections.Generic
             }
 
             int hashCode = InternalGetHashCode(value);
-            int bucket = hashCode % _buckets.Length;
+            int bucket = hashCode % _buckets!.Length;
             int collisionCount = 0;
             Slot[] slots = _slots;
             for (int i = _buckets[bucket] - 1; i >= 0; i = slots[i].next)
@@ -1263,7 +1263,7 @@ namespace System.Collections.Generic
         // when constructing from another HashSet.
         private void AddValue(int index, int hashCode, T value)
         {
-            int bucket = hashCode % _buckets.Length;
+            int bucket = hashCode % _buckets!.Length;
 
 #if DEBUG
             Debug.Assert(InternalGetHashCode(value) == hashCode);
@@ -1662,7 +1662,7 @@ namespace System.Collections.Generic
         /// <param name="set2"></param>
         /// <param name="comparer"></param>
         /// <returns></returns>
-        internal static bool HashSetEquals(HashSet<T> set1, HashSet<T> set2, IEqualityComparer<T> comparer)
+        internal static bool HashSetEquals(HashSet<T>? set1, HashSet<T>? set2, IEqualityComparer<T> comparer)
         {
             // handle null cases first
             if (set1 == null)
@@ -1769,7 +1769,7 @@ namespace System.Collections.Generic
                 _set = set;
                 _index = 0;
                 _version = set._version;
-                _current = default(T);
+                _current = default!; // TODO-NULLABLE-GENERIC
             }
 
             public void Dispose()
@@ -1794,7 +1794,7 @@ namespace System.Collections.Generic
                     _index++;
                 }
                 _index = _set._lastIndex + 1;
-                _current = default(T);
+                _current = default!; // TODO-NULLABLE-GENERIC
                 return false;
             }
 
@@ -1806,7 +1806,7 @@ namespace System.Collections.Generic
                 }
             }
 
-            object IEnumerator.Current
+            object? IEnumerator.Current
             {
                 get
                 {
@@ -1826,7 +1826,7 @@ namespace System.Collections.Generic
                 }
 
                 _index = 0;
-                _current = default(T);
+                _current = default!; // TODO-NULLABLE-GENERIC
             }
         }
     }

--- a/src/System.Collections/src/System/Collections/Generic/HashSetEqualityComparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSetEqualityComparer.cs
@@ -2,18 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-
 namespace System.Collections.Generic
 {
-
     /// <summary>
     /// Equality comparer for hashsets of hashsets
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal sealed class HashSetEqualityComparer<T> : IEqualityComparer<HashSet<T>>
+    internal sealed class HashSetEqualityComparer<T> : IEqualityComparer<HashSet<T>?>
     {
         private readonly IEqualityComparer<T> _comparer;
 
@@ -23,12 +18,12 @@ namespace System.Collections.Generic
         }
 
         // using m_comparer to keep equals properties in tact; don't want to choose one of the comparers
-        public bool Equals(HashSet<T> x, HashSet<T> y)
+        public bool Equals(HashSet<T>? x, HashSet<T>? y)
         {
             return HashSet<T>.HashSetEquals(x, y, _comparer);
         }
 
-        public int GetHashCode(HashSet<T> obj)
+        public int GetHashCode(HashSet<T>? obj)
         {
             int hashCode = 0;
             if (obj != null)
@@ -41,10 +36,10 @@ namespace System.Collections.Generic
             return hashCode;
         }
 
-        // Equals method for the comparer itself. 
-        public override bool Equals(object obj)
+        // Equals method for the comparer itself.
+        public override bool Equals(object? obj)
         {
-            HashSetEqualityComparer<T> comparer = obj as HashSetEqualityComparer<T>;
+            HashSetEqualityComparer<T>? comparer = obj as HashSetEqualityComparer<T>;
             if (comparer == null)
             {
                 return false;
@@ -58,4 +53,3 @@ namespace System.Collections.Generic
         }
     }
 }
-

--- a/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/LinkedList.cs
@@ -15,10 +15,10 @@ namespace System.Collections.Generic
     public class LinkedList<T> : ICollection<T>, ICollection, IReadOnlyCollection<T>, ISerializable, IDeserializationCallback
     {
         // This LinkedList is a doubly-Linked circular list.
-        internal LinkedListNode<T> head;
+        internal LinkedListNode<T>? head;
         internal int count;
         internal int version;
-        private SerializationInfo _siInfo; //A temporary variable which we need during deserialization.  
+        private SerializationInfo? _siInfo; //A temporary variable which we need during deserialization.  
 
         // names for serialization
         private const string VersionName = "Version"; // Do not rename (binary serialization)
@@ -52,12 +52,12 @@ namespace System.Collections.Generic
             get { return count; }
         }
 
-        public LinkedListNode<T> First
+        public LinkedListNode<T>? First
         {
             get { return head; }
         }
 
-        public LinkedListNode<T> Last
+        public LinkedListNode<T>? Last
         {
             get { return head == null ? null : head.prev; }
         }
@@ -75,8 +75,8 @@ namespace System.Collections.Generic
         public LinkedListNode<T> AddAfter(LinkedListNode<T> node, T value)
         {
             ValidateNode(node);
-            LinkedListNode<T> result = new LinkedListNode<T>(node.list, value);
-            InternalInsertNodeBefore(node.next, result);
+            LinkedListNode<T> result = new LinkedListNode<T>(node.list!, value);
+            InternalInsertNodeBefore(node.next!, result);
             return result;
         }
 
@@ -84,14 +84,14 @@ namespace System.Collections.Generic
         {
             ValidateNode(node);
             ValidateNewNode(newNode);
-            InternalInsertNodeBefore(node.next, newNode);
+            InternalInsertNodeBefore(node.next!, newNode);
             newNode.list = this;
         }
 
         public LinkedListNode<T> AddBefore(LinkedListNode<T> node, T value)
         {
             ValidateNode(node);
-            LinkedListNode<T> result = new LinkedListNode<T>(node.list, value);
+            LinkedListNode<T> result = new LinkedListNode<T>(node.list!, value);
             InternalInsertNodeBefore(node, result);
             if (node == head)
             {
@@ -174,7 +174,7 @@ namespace System.Collections.Generic
 
         public void Clear()
         {
-            LinkedListNode<T> current = head;
+            LinkedListNode<T>? current = head;
             while (current != null)
             {
                 LinkedListNode<T> temp = current;
@@ -214,20 +214,20 @@ namespace System.Collections.Generic
                 throw new ArgumentException(SR.Arg_InsufficientSpace);
             }
 
-            LinkedListNode<T> node = head;
+            LinkedListNode<T>? node = head;
             if (node != null)
             {
                 do
                 {
-                    array[index++] = node.item;
+                    array[index++] = node!.item;
                     node = node.next;
                 } while (node != head);
             }
         }
 
-        public LinkedListNode<T> Find(T value)
+        public LinkedListNode<T>? Find(T value)
         {
-            LinkedListNode<T> node = head;
+            LinkedListNode<T>? node = head;
             EqualityComparer<T> c = EqualityComparer<T>.Default;
             if (node != null)
             {
@@ -235,7 +235,7 @@ namespace System.Collections.Generic
                 {
                     do
                     {
-                        if (c.Equals(node.item, value))
+                        if (c.Equals(node!.item, value))
                         {
                             return node;
                         }
@@ -246,7 +246,7 @@ namespace System.Collections.Generic
                 {
                     do
                     {
-                        if (node.item == null)
+                        if (node!.item == null)
                         {
                             return node;
                         }
@@ -257,12 +257,12 @@ namespace System.Collections.Generic
             return null;
         }
 
-        public LinkedListNode<T> FindLast(T value)
+        public LinkedListNode<T>? FindLast(T value)
         {
             if (head == null) return null;
 
-            LinkedListNode<T> last = head.prev;
-            LinkedListNode<T> node = last;
+            LinkedListNode<T>? last = head.prev;
+            LinkedListNode<T>? node = last;
             EqualityComparer<T> c = EqualityComparer<T>.Default;
             if (node != null)
             {
@@ -270,7 +270,7 @@ namespace System.Collections.Generic
                 {
                     do
                     {
-                        if (c.Equals(node.item, value))
+                        if (c.Equals(node!.item, value))
                         {
                             return node;
                         }
@@ -282,7 +282,7 @@ namespace System.Collections.Generic
                 {
                     do
                     {
-                        if (node.item == null)
+                        if (node!.item == null)
                         {
                             return node;
                         }
@@ -305,7 +305,7 @@ namespace System.Collections.Generic
 
         public bool Remove(T value)
         {
-            LinkedListNode<T> node = Find(value);
+            LinkedListNode<T>? node = Find(value);
             if (node != null)
             {
                 InternalRemoveNode(node);
@@ -329,7 +329,7 @@ namespace System.Collections.Generic
         public void RemoveLast()
         {
             if (head == null) { throw new InvalidOperationException(SR.LinkedListEmpty); }
-            InternalRemoveNode(head.prev);
+            InternalRemoveNode(head.prev!);
         }
 
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -365,7 +365,7 @@ namespace System.Collections.Generic
 
             if (count != 0)
             {
-                T[] array = (T[])_siInfo.GetValue(ValuesName, typeof(T[]));
+                T[]? array = (T[]?)_siInfo.GetValue(ValuesName, typeof(T[]));
 
                 if (array == null)
                 {
@@ -389,7 +389,7 @@ namespace System.Collections.Generic
         {
             newNode.next = node;
             newNode.prev = node.prev;
-            node.prev.next = newNode;
+            node.prev!.next = newNode;
             node.prev = newNode;
             version++;
             count++;
@@ -416,8 +416,8 @@ namespace System.Collections.Generic
             }
             else
             {
-                node.next.prev = node.prev;
-                node.prev.next = node.next;
+                node.next!.prev = node.prev;
+                node.prev!.next = node.next;
                 if (head == node)
                 {
                     head = node.next;
@@ -488,7 +488,7 @@ namespace System.Collections.Generic
                 throw new ArgumentException(SR.Arg_InsufficientSpace);
             }
 
-            T[] tArray = array as T[];
+            T[]? tArray = array as T[];
             if (tArray != null)
             {
                 CopyTo(tArray, index);
@@ -497,19 +497,19 @@ namespace System.Collections.Generic
             {
                 // No need to use reflection to verify that the types are compatible because it isn't 100% correct and we can rely 
                 // on the runtime validation during the cast that happens below (i.e. we will get an ArrayTypeMismatchException).
-                object[] objects = array as object[];
+                object?[]? objects = array as object[];
                 if (objects == null)
                 {
                     throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
                 }
-                LinkedListNode<T> node = head;
+                LinkedListNode<T>? node = head;
                 try
                 {
                     if (node != null)
                     {
                         do
                         {
-                            objects[index++] = node.item;
+                            objects[index++] = node!.item;
                             node = node.next;
                         } while (node != head);
                     }
@@ -530,7 +530,7 @@ namespace System.Collections.Generic
         public struct Enumerator : IEnumerator<T>, IEnumerator, ISerializable, IDeserializationCallback
         {
             private LinkedList<T> _list;
-            private LinkedListNode<T> _node;
+            private LinkedListNode<T>? _node;
             private int _version;
             private T _current;
             private int _index;
@@ -545,7 +545,7 @@ namespace System.Collections.Generic
                 _list = list;
                 _version = list.version;
                 _node = list.head;
-                _current = default(T);
+                _current = default!; // TODO-NULLABLE-GENERIC
                 _index = 0;
             }
 
@@ -554,7 +554,7 @@ namespace System.Collections.Generic
                 get { return _current; }
             }
 
-            object IEnumerator.Current
+            object? IEnumerator.Current
             {
                 get
                 {
@@ -597,7 +597,7 @@ namespace System.Collections.Generic
                     throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
                 }
 
-                _current = default(T);
+                _current = default!; // TODO-NULLABLE-GENERIC
                 _node = _list.head;
                 _index = 0;
             }
@@ -621,9 +621,9 @@ namespace System.Collections.Generic
     // Note following class is not serializable since we customized the serialization of LinkedList. 
     public sealed class LinkedListNode<T>
     {
-        internal LinkedList<T> list;
-        internal LinkedListNode<T> next;
-        internal LinkedListNode<T> prev;
+        internal LinkedList<T>? list;
+        internal LinkedListNode<T>? next;
+        internal LinkedListNode<T>? prev;
         internal T item;
 
         public LinkedListNode(T value)
@@ -637,19 +637,19 @@ namespace System.Collections.Generic
             item = value;
         }
 
-        public LinkedList<T> List
+        public LinkedList<T>? List
         {
             get { return list; }
         }
 
-        public LinkedListNode<T> Next
+        public LinkedListNode<T>? Next
         {
-            get { return next == null || next == list.head ? null : next; }
+            get { return next == null || next == list!.head ? null : next; }
         }
 
-        public LinkedListNode<T> Previous
+        public LinkedListNode<T>? Previous
         {
-            get { return prev == null || this == list.head ? null : prev; }
+            get { return prev == null || this == list!.head ? null : prev; }
         }
 
         public T Value

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -233,7 +233,7 @@ namespace System.Collections.Generic
             T removed = array[head];
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                array[head] = default;
+                array[head] = default!;
             }
             MoveNext(ref _head);
             _size--;
@@ -241,21 +241,21 @@ namespace System.Collections.Generic
             return removed;
         }
 
-        public bool TryDequeue(out T result)
+        public bool TryDequeue(out T result) // TODO-NULLABLE-GENERIC
         {
             int head = _head;
             T[] array = _array;
 
             if (_size == 0)
             {
-            	result = default;
-            	return false;
+            	result = default!; // TODO-NULLABLE-GENERIC
+                return false;
             }
 
             result = array[head];
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                array[head] = default;
+                array[head] = default!;
             }
             MoveNext(ref _head);
             _size--;
@@ -276,12 +276,12 @@ namespace System.Collections.Generic
             return _array[_head];
         }
 
-        public bool TryPeek(out T result)
+        public bool TryPeek(out T result) // TODO-NULLABLE-GENERIC
         {
             if (_size == 0)
             {
-            	result = default(T);
-            	return false;
+            	result = default!; // TODO-NULLABLE-GENERIC
+                return false;
             }
 
             result = _array[_head];
@@ -404,13 +404,13 @@ namespace System.Collections.Generic
                 _q = q;
                 _version = q._version;
                 _index = -1;
-                _currentElement = default(T);
+                _currentElement = default!; // TODO-NULLABLE-GENERIC
             }
 
             public void Dispose()
             {
                 _index = -2;
-                _currentElement = default(T);
+                _currentElement = default!; // TODO-NULLABLE-GENERIC
             }
 
             public bool MoveNext()
@@ -426,7 +426,7 @@ namespace System.Collections.Generic
                 {
                     // We've run past the last element
                     _index = -2;
-                    _currentElement = default(T);
+                    _currentElement = default!; // TODO-NULLABLE-GENERIC
                     return false;
                 }
 
@@ -469,7 +469,7 @@ namespace System.Collections.Generic
                 throw new InvalidOperationException(_index == -1 ? SR.InvalidOperation_EnumNotStarted : SR.InvalidOperation_EnumEnded);
             }
 
-            object IEnumerator.Current
+            object? IEnumerator.Current
             {
                 get { return Current; }
             }
@@ -478,7 +478,7 @@ namespace System.Collections.Generic
             {
                 if (_version != _q._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
                 _index = -1;
-                _currentElement = default(T);
+                _currentElement = default!; // TODO-NULLABLE-GENERIC
             }
         }
     }

--- a/src/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -12,16 +12,16 @@ namespace System.Collections.Generic
     [DebuggerDisplay("Count = {Count}")]
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-    public class SortedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
+    public class SortedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue> where TKey : object
     {
         [NonSerialized]
-        private KeyCollection _keys;
+        private KeyCollection? _keys;
         [NonSerialized]
-        private ValueCollection _values;
+        private ValueCollection? _values;
 
         private TreeSet<KeyValuePair<TKey, TValue>> _set; // Do not rename (binary serialization)
 
-        public SortedDictionary() : this((IComparer<TKey>)null)
+        public SortedDictionary() : this((IComparer<TKey>?)null)
         {
         }
 
@@ -29,7 +29,7 @@ namespace System.Collections.Generic
         {
         }
 
-        public SortedDictionary(IDictionary<TKey, TValue> dictionary, IComparer<TKey> comparer)
+        public SortedDictionary(IDictionary<TKey, TValue> dictionary, IComparer<TKey>? comparer)
         {
             if (dictionary == null)
             {
@@ -44,7 +44,7 @@ namespace System.Collections.Generic
             }
         }
 
-        public SortedDictionary(IComparer<TKey> comparer)
+        public SortedDictionary(IComparer<TKey>? comparer)
         {
             _set = new TreeSet<KeyValuePair<TKey, TValue>>(new KeyValuePairComparer(comparer));
         }
@@ -56,7 +56,7 @@ namespace System.Collections.Generic
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair)
         {
-            TreeSet<KeyValuePair<TKey, TValue>>.Node node = _set.FindNode(keyValuePair);
+            TreeSet<KeyValuePair<TKey, TValue>>.Node? node = _set.FindNode(keyValuePair);
             if (node == null)
             {
                 return false;
@@ -74,7 +74,7 @@ namespace System.Collections.Generic
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)
         {
-            TreeSet<KeyValuePair<TKey, TValue>>.Node node = _set.FindNode(keyValuePair);
+            TreeSet<KeyValuePair<TKey, TValue>>.Node? node = _set.FindNode(keyValuePair);
             if (node == null)
             {
                 return false;
@@ -105,7 +105,7 @@ namespace System.Collections.Generic
                     throw new ArgumentNullException(nameof(key));
                 }
 
-                TreeSet<KeyValuePair<TKey, TValue>>.Node node = _set.FindNode(new KeyValuePair<TKey, TValue>(key, default(TValue)));
+                TreeSet<KeyValuePair<TKey, TValue>>.Node? node = _set.FindNode(new KeyValuePair<TKey, TValue>(key, default(TValue)!)); // TODO-NULLABLE-GENERIC
                 if (node == null)
                 {
                     throw new KeyNotFoundException(SR.Format(SR.Arg_KeyNotFoundWithKey, key.ToString()));
@@ -120,7 +120,7 @@ namespace System.Collections.Generic
                     throw new ArgumentNullException(nameof(key));
                 }
 
-                TreeSet<KeyValuePair<TKey, TValue>>.Node node = _set.FindNode(new KeyValuePair<TKey, TValue>(key, default(TValue)));
+                TreeSet<KeyValuePair<TKey, TValue>>.Node? node = _set.FindNode(new KeyValuePair<TKey, TValue>(key, default(TValue)!)); // TODO-NULLABLE-GENERIC
                 if (node == null)
                 {
                     _set.Add(new KeyValuePair<TKey, TValue>(key, value));
@@ -220,7 +220,7 @@ namespace System.Collections.Generic
                 throw new ArgumentNullException(nameof(key));
             }
 
-            return _set.Contains(new KeyValuePair<TKey, TValue>(key, default(TValue)));
+            return _set.Contains(new KeyValuePair<TKey, TValue>(key, default(TValue)!)); // TODO-NULLABLE-GENERIC
         }
 
         public bool ContainsValue(TValue value)
@@ -276,20 +276,20 @@ namespace System.Collections.Generic
                 throw new ArgumentNullException(nameof(key));
             }
 
-            return _set.Remove(new KeyValuePair<TKey, TValue>(key, default(TValue)));
+            return _set.Remove(new KeyValuePair<TKey, TValue>(key, default(TValue)!)); // TODO-NULLABLE-GENERIC
         }
 
-        public bool TryGetValue(TKey key, out TValue value)
+        public bool TryGetValue(TKey key, out TValue value) // TODO-NULLABLE-GENERIC
         {
             if (key == null)
             {
                 throw new ArgumentNullException(nameof(key));
             }
 
-            TreeSet<KeyValuePair<TKey, TValue>>.Node node = _set.FindNode(new KeyValuePair<TKey, TValue>(key, default(TValue)));
+            TreeSet<KeyValuePair<TKey, TValue>>.Node? node = _set.FindNode(new KeyValuePair<TKey, TValue>(key, default(TValue)!)); // TODO-NULLABLE-GENERIC
             if (node == null)
             {
-                value = default(TValue);
+                value = default(TValue)!; // TODO-NULLABLE-GENERIC
                 return false;
             }
             value = node.Item.Value;
@@ -321,7 +321,7 @@ namespace System.Collections.Generic
             get { return (ICollection)Values; }
         }
 
-        object IDictionary.this[object key]
+        object? IDictionary.this[object key]
         {
             get
             {
@@ -343,7 +343,7 @@ namespace System.Collections.Generic
                     throw new ArgumentNullException(nameof(key));
                 }
 
-                if (value == null && !(default(TValue) == null))
+                if (value == null && !(default(TValue)! == null)) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/34757
                     throw new ArgumentNullException(nameof(value));
 
                 try
@@ -351,7 +351,7 @@ namespace System.Collections.Generic
                     TKey tempKey = (TKey)key;
                     try
                     {
-                        this[tempKey] = (TValue)value;
+                        this[tempKey] = (TValue)value!;
                     }
                     catch (InvalidCastException)
                     {
@@ -365,14 +365,14 @@ namespace System.Collections.Generic
             }
         }
 
-        void IDictionary.Add(object key, object value)
+        void IDictionary.Add(object key, object? value)
         {
             if (key == null)
             {
                 throw new ArgumentNullException(nameof(key));
             }
 
-            if (value == null && !(default(TValue) == null))
+            if (value == null && !(default(TValue)! == null)) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/34757
                 throw new ArgumentNullException(nameof(value));
 
             try
@@ -381,7 +381,7 @@ namespace System.Collections.Generic
 
                 try
                 {
-                    Add(tempKey, (TValue)value);
+                    Add(tempKey, (TValue)value!); // TODO-NULLABLE-GENERIC
                 }
                 catch (InvalidCastException)
                 {
@@ -493,7 +493,7 @@ namespace System.Collections.Generic
                 _treeEnum.Reset();
             }
 
-            object IEnumerator.Current
+            object? IEnumerator.Current
             {
                 get
                 {
@@ -526,7 +526,7 @@ namespace System.Collections.Generic
                 }
             }
 
-            object IDictionaryEnumerator.Value
+            object? IDictionaryEnumerator.Value
             {
                 get
                 {
@@ -630,7 +630,7 @@ namespace System.Collections.Generic
                     throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
                 }
 
-                TKey[] keys = array as TKey[];
+                TKey[]? keys = array as TKey[];
                 if (keys != null)
                 {
                     CopyTo(keys, index);
@@ -717,7 +717,7 @@ namespace System.Collections.Generic
                     }
                 }
 
-                object IEnumerator.Current
+                object? IEnumerator.Current
                 {
                     get
                     {
@@ -814,7 +814,7 @@ namespace System.Collections.Generic
                     throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
                 }
 
-                TValue[] values = array as TValue[];
+                TValue[]? values = array as TValue[];
                 if (values != null)
                 {
                     CopyTo(values, index);
@@ -823,7 +823,7 @@ namespace System.Collections.Generic
                 {
                     try
                     {
-                        object[] objects = (object[])array;
+                        object?[] objects = (object?[])array;
                         _dictionary._set.InOrderTreeWalk(delegate (TreeSet<KeyValuePair<TKey, TValue>>.Node node) { objects[index++] = node.Item.Value; return true; });
                     }
                     catch (ArrayTypeMismatchException)
@@ -901,7 +901,7 @@ namespace System.Collections.Generic
                     }
                 }
 
-                object IEnumerator.Current
+                object? IEnumerator.Current
                 {
                     get
                     {
@@ -926,7 +926,7 @@ namespace System.Collections.Generic
         {
             internal IComparer<TKey> keyComparer; // Do not rename (binary serialization)
 
-            public KeyValuePairComparer(IComparer<TKey> keyComparer)
+            public KeyValuePairComparer(IComparer<TKey>? keyComparer)
             {
                 if (keyComparer == null)
                 {
@@ -963,7 +963,7 @@ namespace System.Collections.Generic
             : base()
         { }
 
-        public TreeSet(IComparer<T> comparer) : base(comparer) { }
+        public TreeSet(IComparer<T>? comparer) : base(comparer) { }
 
         private TreeSet(SerializationInfo siInfo, StreamingContext context) : base(siInfo, context) { }
 

--- a/src/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -52,15 +52,15 @@ namespace System.Collections.Generic
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class SortedList<TKey, TValue> :
-        IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
+        IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue> where TKey : object
     {
         private TKey[] keys; // Do not rename (binary serialization)
         private TValue[] values; // Do not rename (binary serialization)
         private int _size; // Do not rename (binary serialization)
         private int version; // Do not rename (binary serialization)
         private IComparer<TKey> comparer; // Do not rename (binary serialization)
-        private KeyList keyList; // Do not rename (binary serialization)
-        private ValueList valueList; // Do not rename (binary serialization)
+        private KeyList? keyList; // Do not rename (binary serialization)
+        private ValueList? valueList; // Do not rename (binary serialization)
 
         private const int DefaultCapacity = 4;
 
@@ -104,7 +104,7 @@ namespace System.Collections.Generic
         // interface, which in that case must be implemented by the keys of all
         // entries added to the sorted list.
         // 
-        public SortedList(IComparer<TKey> comparer)
+        public SortedList(IComparer<TKey>? comparer)
             : this()
         {
             if (comparer != null)
@@ -122,7 +122,7 @@ namespace System.Collections.Generic
         // the IComparable interface, which in that case must be implemented
         // by the keys of all entries added to the sorted list.
         // 
-        public SortedList(int capacity, IComparer<TKey> comparer)
+        public SortedList(int capacity, IComparer<TKey>? comparer)
             : this(comparer)
         {
             Capacity = capacity;
@@ -147,7 +147,7 @@ namespace System.Collections.Generic
         // by the keys of all entries in the given dictionary as well as keys
         // subsequently added to the sorted list.
         // 
-        public SortedList(IDictionary<TKey, TValue> dictionary, IComparer<TKey> comparer)
+        public SortedList(IDictionary<TKey, TValue> dictionary, IComparer<TKey>? comparer)
             : this((dictionary != null ? dictionary.Count : 0), comparer)
         {
             if (dictionary == null)
@@ -265,12 +265,12 @@ namespace System.Collections.Generic
             }
         }
 
-        void IDictionary.Add(object key, object value)
+        void IDictionary.Add(object key, object? value)
         {
             if (key == null)
                 throw new ArgumentNullException(nameof(key));
 
-            if (value == null && !(default(TValue) == null))    // null is an invalid value for Value types
+            if (value == null && !(default(TValue)! == null))    // null is an invalid value for Value types // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/34757
                 throw new ArgumentNullException(nameof(value));
 
             if (!(key is TKey))
@@ -279,7 +279,7 @@ namespace System.Collections.Generic
             if (!(value is TValue) && value != null)            // null is a valid value for Reference Types
                 throw new ArgumentException(SR.Format(SR.Arg_WrongType, value, typeof(TValue)), nameof(value));
 
-            Add((TKey)key, (TValue)value);
+            Add((TKey)key, (TValue)value!);
         }
 
         // Returns the number of entries in this sorted list.
@@ -493,7 +493,7 @@ namespace System.Collections.Generic
                 throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
             }
 
-            KeyValuePair<TKey, TValue>[] keyValuePairArray = array as KeyValuePair<TKey, TValue>[];
+            KeyValuePair<TKey, TValue>[]? keyValuePairArray = array as KeyValuePair<TKey, TValue>[];
             if (keyValuePairArray != null)
             {
                 for (int i = 0; i < Count; i++)
@@ -503,7 +503,7 @@ namespace System.Collections.Generic
             }
             else
             {
-                object[] objects = array as object[];
+                object[]? objects = array as object[];
                 if (objects == null)
                 {
                     throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
@@ -601,7 +601,7 @@ namespace System.Collections.Generic
             }
         }
 
-        object IDictionary.this[object key]
+        object? IDictionary.this[object key]
         {
             get
             {
@@ -623,13 +623,13 @@ namespace System.Collections.Generic
                     throw new ArgumentNullException(nameof(key));
                 }
 
-                if (value == null && !(default(TValue) == null))
+                if (value == null && !(default(TValue)! == null)) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/34757
                     throw new ArgumentNullException(nameof(value));
 
                 TKey tempKey = (TKey)key;
                 try
                 {
-                    this[tempKey] = (TValue)value;
+                    this[tempKey] = (TValue)value!;
                 }
                 catch (InvalidCastException)
                 {
@@ -677,7 +677,7 @@ namespace System.Collections.Generic
             version++;
         }
 
-        public bool TryGetValue(TKey key, out TValue value)
+        public bool TryGetValue(TKey key, out TValue value) // TODO-NULLABLE-GENERIC
         {
             int i = IndexOfKey(key);
             if (i >= 0)
@@ -686,7 +686,7 @@ namespace System.Collections.Generic
                 return true;
             }
 
-            value = default(TValue);
+            value = default(TValue)!; // TODO-NULLABLE-GENERIC
             return false;
         }
 
@@ -704,11 +704,11 @@ namespace System.Collections.Generic
             }
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
             {
-                keys[_size] = default(TKey);
+                keys[_size] = default(TKey)!;
             }
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
             {
-                values[_size] = default(TValue);
+                values[_size] = default(TValue)!;
             }
             version++;
         }
@@ -777,15 +777,15 @@ namespace System.Collections.Generic
                 _index = 0;
                 _version = _sortedList.version;
                 _getEnumeratorRetType = getEnumeratorRetType;
-                _key = default(TKey);
-                _value = default(TValue);
+                _key = default(TKey)!; // TODO-NULLABLE-GENERIC
+                _value = default(TValue)!; // TODO-NULLABLE-GENERIC
             }
 
             public void Dispose()
             {
                 _index = 0;
-                _key = default(TKey);
-                _value = default(TValue);
+                _key = default(TKey)!; // TODO-NULLABLE-GENERIC
+                _value = default(TValue)!; // TODO-NULLABLE-GENERIC
             }
 
             object IDictionaryEnumerator.Key
@@ -814,8 +814,8 @@ namespace System.Collections.Generic
                 }
 
                 _index = _sortedList.Count + 1;
-                _key = default(TKey);
-                _value = default(TValue);
+                _key = default(TKey)!; // TODO-NULLABLE-GENERIC
+                _value = default(TValue)!; // TODO-NULLABLE-GENERIC
                 return false;
             }
 
@@ -840,7 +840,7 @@ namespace System.Collections.Generic
                 }
             }
 
-            object IEnumerator.Current
+            object? IEnumerator.Current
             {
                 get
                 {
@@ -860,7 +860,7 @@ namespace System.Collections.Generic
                 }
             }
 
-            object IDictionaryEnumerator.Value
+            object? IDictionaryEnumerator.Value
             {
                 get
                 {
@@ -881,8 +881,8 @@ namespace System.Collections.Generic
                 }
 
                 _index = 0;
-                _key = default(TKey);
-                _value = default(TValue);
+                _key = default(TKey)!; // TODO-NULLABLE-GENERIC
+                _value = default(TValue)!; // TODO-NULLABLE-GENERIC
             }
         }
 
@@ -891,7 +891,7 @@ namespace System.Collections.Generic
             private SortedList<TKey, TValue> _sortedList;
             private int _index;
             private int _version;
-            private TKey _currentKey;
+            private TKey _currentKey = default!;
 
             internal SortedListKeyEnumerator(SortedList<TKey, TValue> sortedList)
             {
@@ -902,7 +902,7 @@ namespace System.Collections.Generic
             public void Dispose()
             {
                 _index = 0;
-                _currentKey = default(TKey);
+                _currentKey = default(TKey)!; // TODO-NULLABLE-GENERIC
             }
 
             public bool MoveNext()
@@ -920,7 +920,7 @@ namespace System.Collections.Generic
                 }
 
                 _index = _sortedList.Count + 1;
-                _currentKey = default(TKey);
+                _currentKey = default(TKey)!; // TODO-NULLABLE-GENERIC
                 return false;
             }
 
@@ -932,7 +932,7 @@ namespace System.Collections.Generic
                 }
             }
 
-            object IEnumerator.Current
+            object? IEnumerator.Current
             {
                 get
                 {
@@ -952,7 +952,7 @@ namespace System.Collections.Generic
                     throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
                 }
                 _index = 0;
-                _currentKey = default(TKey);
+                _currentKey = default(TKey)!; // TODO-NULLABLE-GENERIC
             }
         }
 
@@ -961,7 +961,7 @@ namespace System.Collections.Generic
             private SortedList<TKey, TValue> _sortedList;
             private int _index;
             private int _version;
-            private TValue _currentValue;
+            private TValue _currentValue = default!;
 
             internal SortedListValueEnumerator(SortedList<TKey, TValue> sortedList)
             {
@@ -972,7 +972,7 @@ namespace System.Collections.Generic
             public void Dispose()
             {
                 _index = 0;
-                _currentValue = default(TValue);
+                _currentValue = default(TValue)!; // TODO-NULLABLE-GENERIC
             }
 
             public bool MoveNext()
@@ -990,7 +990,7 @@ namespace System.Collections.Generic
                 }
 
                 _index = _sortedList.Count + 1;
-                _currentValue = default(TValue);
+                _currentValue = default(TValue)!; // TODO-NULLABLE-GENERIC
                 return false;
             }
 
@@ -1002,7 +1002,7 @@ namespace System.Collections.Generic
                 }
             }
 
-            object IEnumerator.Current
+            object? IEnumerator.Current
             {
                 get
                 {
@@ -1022,7 +1022,7 @@ namespace System.Collections.Generic
                     throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
                 }
                 _index = 0;
-                _currentValue = default(TValue);
+                _currentValue = default(TValue)!; // TODO-NULLABLE-GENERIC
             }
         }
 
@@ -1087,7 +1087,7 @@ namespace System.Collections.Generic
                 try
                 {
                     // defer error checking to Array.Copy
-                    Array.Copy(_dict.keys, 0, array, arrayIndex, _dict.Count);
+                    Array.Copy(_dict.keys, 0, array!, arrayIndex, _dict.Count);
                 }
                 catch (ArrayTypeMismatchException)
                 {
@@ -1206,7 +1206,7 @@ namespace System.Collections.Generic
                 try
                 {
                     // defer error checking to Array.Copy
-                    Array.Copy(_dict.values, 0, array, index, _dict.Count);
+                    Array.Copy(_dict.values, 0, array!, index, _dict.Count);
                 }
                 catch (ArrayTypeMismatchException)
                 {

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -125,8 +125,8 @@ namespace System.Collections.Generic
             {
                 get
                 {
-                    Node current = root;
-                    T result = default(T);
+                    Node? current = root;
+                    T result = default(T)!;
 
                     while (current != null)
                     {
@@ -155,8 +155,8 @@ namespace System.Collections.Generic
             {
                 get
                 {
-                    Node current = root;
-                    T result = default(T);
+                    Node? current = root;
+                    T result = default(T)!;
 
                     while (current != null)
                     {
@@ -192,7 +192,7 @@ namespace System.Collections.Generic
                 // The maximum height of a red-black tree is 2*lg(n+1).
                 // See page 264 of "Introduction to algorithms" by Thomas H. Cormen
                 Stack<Node> stack = new Stack<Node>(2 * (int)SortedSet<T>.Log2(count + 1)); // this is not exactly right if count is out of date, but the stack can grow
-                Node current = root;
+                Node? current = root;
                 while (current != null)
                 {
                     if (IsWithinRange(current.Item))
@@ -218,7 +218,7 @@ namespace System.Collections.Generic
                         return false;
                     }
 
-                    Node node = current.Right;
+                    Node? node = current.Right;
                     while (node != null)
                     {
                         if (IsWithinRange(node.Item))
@@ -271,7 +271,7 @@ namespace System.Collections.Generic
                 return true;
             }
 
-            internal override SortedSet<T>.Node FindNode(T item)
+            internal override SortedSet<T>.Node? FindNode(T item)
             {
                 if (!IsWithinRange(item))
                 {

--- a/src/System.Collections/src/System/Collections/Generic/SortedSetEqualityComparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSetEqualityComparer.cs
@@ -12,7 +12,7 @@ namespace System.Collections.Generic
         private readonly IComparer<T> _comparer;
         private readonly IEqualityComparer<T> _memberEqualityComparer;
 
-        public SortedSetEqualityComparer(IEqualityComparer<T> memberEqualityComparer)
+        public SortedSetEqualityComparer(IEqualityComparer<T>? memberEqualityComparer)
             : this(comparer: null, memberEqualityComparer: memberEqualityComparer)
         { }
 
@@ -20,7 +20,7 @@ namespace System.Collections.Generic
         /// Create a new SetEqualityComparer, given a comparer for member order and another for member equality (these
         /// must be consistent in their definition of equality)
         /// </summary>        
-        private SortedSetEqualityComparer(IComparer<T> comparer, IEqualityComparer<T> memberEqualityComparer)
+        private SortedSetEqualityComparer(IComparer<T>? comparer, IEqualityComparer<T>? memberEqualityComparer)
         {
             _comparer = comparer ?? Comparer<T>.Default;
             _memberEqualityComparer = memberEqualityComparer ?? EqualityComparer<T>.Default;
@@ -45,9 +45,9 @@ namespace System.Collections.Generic
         }
 
         // Equals method for the comparer itself. 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            SortedSetEqualityComparer<T> comparer = obj as SortedSetEqualityComparer<T>;
+            SortedSetEqualityComparer<T>? comparer = obj as SortedSetEqualityComparer<T>;
             return comparer != null && _comparer == comparer._comparer;
         }
 

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -181,7 +181,7 @@ namespace System.Collections.Generic
             int threshold = (int)(((double)_array.Length) * 0.9);
             if (_size < threshold)
             {
-                Array.Resize(ref _array, _size);
+                Array.Resize(ref _array!, _size); // TODO-NULLABLE: https://github.com/dotnet/csharplang/issues/538
                 _version++;
             }
         }
@@ -201,14 +201,14 @@ namespace System.Collections.Generic
             return array[size];
         }
 
-        public bool TryPeek(out T result)
+        public bool TryPeek(out T result) // TODO-NULLABLE-GENERIC
         {
             int size = _size - 1;
             T[] array = _array;
 
             if ((uint)size >= (uint)array.Length)
             {
-                result = default;
+                result = default!; // TODO-NULLABLE-GENERIC
                 return false;
             }
             result = array[size];
@@ -235,19 +235,19 @@ namespace System.Collections.Generic
             T item = array[size];
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                array[size] = default;     // Free memory quicker.
+                array[size] = default!;     // Free memory quicker.
             }
             return item;
         }
 
-        public bool TryPop(out T result)
+        public bool TryPop(out T result) // TODO-NULLABLE-GENERIC
         {
             int size = _size - 1;
             T[] array = _array;
 
             if ((uint)size >= (uint)array.Length)
             {
-                result = default;
+                result = default!; // TODO-NULLABLE-GENERIC
                 return false;
             }
 
@@ -256,7 +256,7 @@ namespace System.Collections.Generic
             result = array[size];
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                array[size] = default;     // Free memory quicker.
+                array[size] = default!; // Free memory quicker.
             }
             return true;
         }
@@ -283,7 +283,7 @@ namespace System.Collections.Generic
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void PushWithResize(T item)
         {
-            Array.Resize(ref _array, (_array.Length == 0) ? DefaultCapacity : 2 * _array.Length);
+            Array.Resize(ref _array!, (_array.Length == 0) ? DefaultCapacity : 2 * _array.Length); // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
             _array[_size] = item;
             _version++;
             _size++;
@@ -324,7 +324,7 @@ namespace System.Collections.Generic
                 _stack = stack;
                 _version = stack._version;
                 _index = -2;
-                _currentElement = default(T);
+                _currentElement = default!; // TODO-NULLABLE-GENERIC
             }
 
             public void Dispose()
@@ -353,7 +353,7 @@ namespace System.Collections.Generic
                 if (retval)
                     _currentElement = _stack._array[_index];
                 else
-                    _currentElement = default(T);
+                    _currentElement = default!; // TODO-NULLABLE-GENERIC
                 return retval;
             }
 
@@ -373,7 +373,7 @@ namespace System.Collections.Generic
                 throw new InvalidOperationException(_index == -2 ? SR.InvalidOperation_EnumNotStarted : SR.InvalidOperation_EnumEnded);
             }
             
-            object System.Collections.IEnumerator.Current
+            object? System.Collections.IEnumerator.Current
             {
                 get { return Current; }
             }
@@ -382,7 +382,7 @@ namespace System.Collections.Generic
             {
                 if (_version != _stack._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
                 _index = -2;
-                _currentElement = default(T);
+                _currentElement = default!; // TODO-NULLABLE-GENERIC
             }
         }
     }

--- a/src/System.Collections/src/System/Collections/StructuralComparisons.cs
+++ b/src/System.Collections/src/System/Collections/StructuralComparisons.cs
@@ -8,14 +8,14 @@ namespace System.Collections
 {
     public static class StructuralComparisons
     {
-        private static volatile IComparer s_StructuralComparer;
-        private static volatile IEqualityComparer s_StructuralEqualityComparer;
+        private static volatile IComparer? s_StructuralComparer;
+        private static volatile IEqualityComparer? s_StructuralEqualityComparer;
 
         public static IComparer StructuralComparer
         {
             get
             {
-                IComparer comparer = s_StructuralComparer;
+                IComparer? comparer = s_StructuralComparer;
                 if (comparer == null)
                 {
                     comparer = new StructuralComparer();
@@ -29,7 +29,7 @@ namespace System.Collections
         {
             get
             {
-                IEqualityComparer comparer = s_StructuralEqualityComparer;
+                IEqualityComparer? comparer = s_StructuralEqualityComparer;
                 if (comparer == null)
                 {
                     comparer = new StructuralEqualityComparer();
@@ -42,11 +42,11 @@ namespace System.Collections
 
     internal sealed class StructuralEqualityComparer : IEqualityComparer
     {
-        public new bool Equals(object x, object y)
+        public new bool Equals(object? x, object? y)
         {
             if (x != null)
             {
-                IStructuralEquatable seObj = x as IStructuralEquatable;
+                IStructuralEquatable? seObj = x as IStructuralEquatable;
 
                 if (seObj != null)
                 {
@@ -70,7 +70,7 @@ namespace System.Collections
         {
             if (obj == null) return 0;
 
-            IStructuralEquatable seObj = obj as IStructuralEquatable;
+            IStructuralEquatable? seObj = obj as IStructuralEquatable;
 
             if (seObj != null)
             {
@@ -83,12 +83,12 @@ namespace System.Collections
 
     internal sealed class StructuralComparer : IComparer
     {
-        public int Compare(object x, object y)
+        public int Compare(object? x, object? y)
         {
             if (x == null) return y == null ? 0 : -1;
             if (y == null) return 1;
 
-            IStructuralComparable scX = x as IStructuralComparable;
+            IStructuralComparable? scX = x as IStructuralComparable;
 
             if (scX != null)
             {

--- a/src/System.Diagnostics.StackTrace/src/System.Diagnostics.StackTrace.csproj
+++ b/src/System.Diagnostics.StackTrace/src/System.Diagnostics.StackTrace.csproj
@@ -4,6 +4,7 @@
     <ProjectGuid>{02304469-722E-4723-92A1-820B9A37D275}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <NullableContextOptions>enable</NullableContextOptions>
     <!-- Disable 1685 (aka multiple type definitions) warning so it doesn't turn into an error -->
     <NoWarn>$(NoWarn);1685</NoWarn>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>

--- a/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/ISymbolBinder.cs
+++ b/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/ISymbolBinder.cs
@@ -9,11 +9,11 @@ namespace System.Diagnostics.SymbolStore
         // The importer parameter should be an IntPtr, not an int. This interface can not be modified without
         // a breaking change, and so ISymbolBinderEx.GetReader() has been added with the correct marshalling layout.
         [Obsolete("The recommended alternative is ISymbolBinder1.GetReader. ISymbolBinder1.GetReader takes the importer interface pointer as an IntPtr instead of an Int32, and thus works on both 32-bit and 64-bit architectures. https://go.microsoft.com/fwlink/?linkid=14202=14202")]
-        ISymbolReader GetReader(int importer, string filename, string searchPath);
+        ISymbolReader? GetReader(int importer, string filename, string searchPath);
     }
  
     public interface ISymbolBinder1
     {
-        ISymbolReader GetReader(IntPtr importer, string filename, string searchPath);
+        ISymbolReader? GetReader(IntPtr importer, string filename, string searchPath);
     }
 }

--- a/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/ISymbolMethod.cs
+++ b/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/ISymbolMethod.cs
@@ -19,12 +19,12 @@ namespace System.Diagnostics.SymbolStore
         // GetSequencePoints will verify the size of each array and place
         // the sequence point information into each. If any array is NULL,
         // then the data for that array is simply not returned.
-        void GetSequencePoints(int[] offsets,
-                               ISymbolDocument[] documents,
-                               int[] lines,
-                               int[] columns,
-                               int[] endLines,
-                               int[] endColumns);
+        void GetSequencePoints(int[]? offsets,
+                               ISymbolDocument[]? documents,
+                               int[]? lines,
+                               int[]? columns,
+                               int[]? endLines,
+                               int[]? endColumns);
     
         // Get the root lexical scope for this method. This scope encloses
         // the entire method.
@@ -62,8 +62,8 @@ namespace System.Diagnostics.SymbolStore
         // method. The first array position is the start while the second
         // is the end. Returns true if positions were defined, false
         // otherwise.
-        bool GetSourceStartEnd(ISymbolDocument[] docs,
-                               int[] lines,
-                               int[] columns);
+        bool GetSourceStartEnd(ISymbolDocument[]? docs,
+                               int[]? lines,
+                               int[]? columns);
     }
 }

--- a/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/ISymbolReader.cs
+++ b/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/ISymbolReader.cs
@@ -8,7 +8,7 @@ namespace System.Diagnostics.SymbolStore
     {
         // Find a document. Language, vendor, and document type are
         // optional.
-        ISymbolDocument GetDocument(string url,
+        ISymbolDocument? GetDocument(string url,
                                     Guid language,
                                     Guid languageVendor,
                                     Guid documentType);
@@ -23,12 +23,12 @@ namespace System.Diagnostics.SymbolStore
         SymbolToken UserEntryPoint { get; }
     
         // Get a symbol reader method given the id of a method.
-        ISymbolMethod GetMethod(SymbolToken method);
+        ISymbolMethod? GetMethod(SymbolToken method);
     
         // Get a symbol reader method given the id of a method and an E&C
         // version number. Version numbers start a 1 and are incremented
         // each time the method is changed due to an E&C operation.
-        ISymbolMethod GetMethod(SymbolToken method, int version);
+        ISymbolMethod? GetMethod(SymbolToken method, int version);
     
         // Return a non-local variable given its parent and name.
         ISymbolVariable[] GetVariables(SymbolToken parent);

--- a/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/SymbolToken.cs
+++ b/src/System.Diagnostics.StackTrace/src/System/Diagnostics/SymbolStore/SymbolToken.cs
@@ -17,7 +17,7 @@ namespace System.Diagnostics.SymbolStore
         
         public override int GetHashCode() => _token;
         
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is SymbolToken)
                 return Equals((SymbolToken)obj);

--- a/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
+++ b/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>System.Diagnostics.Tools</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <DefineConstants>$(DefineConstants);SYSTEM_DIAGNOSTICS_TOOLS</DefineConstants>
+    <NullableContextOptions>enable</NullableContextOptions>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Diagnostics.Tools/src/System/CodeDom/Compiler/GeneratedCodeAttribute.cs
+++ b/src/System.Diagnostics.Tools/src/System/CodeDom/Compiler/GeneratedCodeAttribute.cs
@@ -7,21 +7,21 @@ namespace System.CodeDom.Compiler
     [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = false)]
     public sealed class GeneratedCodeAttribute : Attribute
     {
-        private readonly string _tool;
-        private readonly string _version;
+        private readonly string? _tool;
+        private readonly string? _version;
 
-        public GeneratedCodeAttribute(string tool, string version)
+        public GeneratedCodeAttribute(string? tool, string? version)
         {
             _tool = tool;
             _version = version;
         }
 
-        public string Tool
+        public string? Tool
         {
             get { return _tool; }
         }
 
-        public string Version
+        public string? Version
         {
             get { return _version; }
         }

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -3,6 +3,7 @@
     <ProjectGuid>{4BBC8F69-D03E-4432-AA8A-D458FA5B235A}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <NullableContextOptions>enable</NullableContextOptions>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
     <!-- ArrayBufferWriter is publicly exposed from the System.Memory ref and only it should define this constant as true.  -->
     <DefineConstants>$(DefineConstants);MAKE_ABW_PUBLIC</DefineConstants>

--- a/src/System.Memory/src/System/Buffers/ArrayMemoryPool.ArrayMemoryPoolBuffer.cs
+++ b/src/System.Memory/src/System/Buffers/ArrayMemoryPool.ArrayMemoryPoolBuffer.cs
@@ -8,7 +8,7 @@ namespace System.Buffers
     {
         private sealed class ArrayMemoryPoolBuffer : IMemoryOwner<T>
         {
-            private T[] _array;
+            private T[]? _array;
 
             public ArrayMemoryPoolBuffer(int size)
             {
@@ -19,19 +19,19 @@ namespace System.Buffers
             {
                 get
                 {
-                    T[] array = _array;
+                    T[]? array = _array;
                     if (array == null)
                     {
                         ThrowHelper.ThrowObjectDisposedException_ArrayMemoryPoolBuffer();
                     }
 
-                    return new Memory<T>(array);
+                    return new Memory<T>(array!); // TODO-NULLABLE: https://github.com/dotnet/csharplang/issues/538
                 }
             }
 
             public void Dispose()
             {
-                T[] array = _array;
+                T[]? array = _array;
                 if (array != null)
                 {
                     _array = null;

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequenceSegment.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequenceSegment.cs
@@ -17,7 +17,7 @@ namespace System.Buffers
         /// <summary>
         /// The next node.
         /// </summary>
-        public ReadOnlySequenceSegment<T> Next { get; protected set; }
+        public ReadOnlySequenceSegment<T>? Next { get; protected set; }
 
         /// <summary>
         /// The sum of node length before current.

--- a/src/System.Memory/src/System/Runtime/InteropServices/SequenceMarshal.cs
+++ b/src/System.Memory/src/System/Runtime/InteropServices/SequenceMarshal.cs
@@ -16,10 +16,10 @@ namespace System.Runtime.InteropServices
         /// If unable to get the <see cref="ReadOnlySequenceSegment{T}"/>, return false.
         /// </summary>
         public static bool TryGetReadOnlySequenceSegment<T>(ReadOnlySequence<T> sequence,
-            out ReadOnlySequenceSegment<T> startSegment,
+            out ReadOnlySequenceSegment<T>? startSegment,
             out int startIndex,
-            out ReadOnlySequenceSegment<T> endSegment,
-            out int endIndex)
+            out ReadOnlySequenceSegment<T>? endSegment,
+            out int endIndex) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
         {
             return sequence.TryGetReadOnlySequenceSegment(out startSegment, out startIndex, out endSegment, out endIndex);
         }
@@ -53,7 +53,7 @@ namespace System.Runtime.InteropServices
         /// Get <see cref="string"/> from the underlying <see cref="ReadOnlySequence{T}"/>.
         /// If unable to get the <see cref="string"/>, return false.
         /// </summary>
-        internal static bool TryGetString(ReadOnlySequence<char> sequence, out string text, out int start, out int length)
+        internal static bool TryGetString(ReadOnlySequence<char> sequence, out string? text, out int start, out int length) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
         {
             return sequence.TryGetString(out text, out start, out length);
         }

--- a/src/System.Memory/src/System/SequencePosition.cs
+++ b/src/System.Memory/src/System/SequencePosition.cs
@@ -13,13 +13,13 @@ namespace System
     /// </summary>
     public readonly struct SequencePosition : IEquatable<SequencePosition>
     {
-        private readonly object _object;
+        private readonly object? _object;
         private readonly int _integer;
 
         /// <summary>
         /// Creates new <see cref="SequencePosition"/>
         /// </summary>
-        public SequencePosition(object @object, int integer)
+        public SequencePosition(object? @object, int integer)
         {
             _object = @object;
             _integer = integer;
@@ -29,7 +29,7 @@ namespace System
         /// Returns object part of this <see cref="SequencePosition"/>
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public object GetObject() => _object;
+        public object? GetObject() => _object;
 
         /// <summary>
         /// Returns integer part of this <see cref="SequencePosition"/>
@@ -48,7 +48,7 @@ namespace System
         /// <see cref="SequencePosition"/> equality does not guarantee that they point to the same location in <see cref="System.Buffers.ReadOnlySequence{T}" />
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object obj) => obj is SequencePosition other && this.Equals(other);
+        public override bool Equals(object? obj) => obj is SequencePosition other && this.Equals(other);
 
         /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/System.Memory/src/System/ThrowHelper.cs
+++ b/src/System.Memory/src/System/ThrowHelper.cs
@@ -55,10 +55,10 @@ namespace System
         //
         // ReadOnlySequence .ctor validation Throws coalesced to enable inlining of the .ctor
         //
-        public static void ThrowArgumentValidationException<T>(ReadOnlySequenceSegment<T> startSegment, int startIndex, ReadOnlySequenceSegment<T> endSegment)
+        public static void ThrowArgumentValidationException<T>(ReadOnlySequenceSegment<T>? startSegment, int startIndex, ReadOnlySequenceSegment<T>? endSegment)
             => throw CreateArgumentValidationException(startSegment, startIndex, endSegment);
 
-        private static Exception CreateArgumentValidationException<T>(ReadOnlySequenceSegment<T> startSegment, int startIndex, ReadOnlySequenceSegment<T> endSegment)
+        private static Exception CreateArgumentValidationException<T>(ReadOnlySequenceSegment<T>? startSegment, int startIndex, ReadOnlySequenceSegment<T>? endSegment)
         {
             if (startSegment == null)
                 return CreateArgumentNullException(ExceptionArgument.startSegment);
@@ -72,10 +72,10 @@ namespace System
                 return CreateArgumentOutOfRangeException(ExceptionArgument.endIndex);
         }
 
-        public static void ThrowArgumentValidationException(Array array, int start)
+        public static void ThrowArgumentValidationException(Array? array, int start)
             => throw CreateArgumentValidationException(array, start);
 
-        private static Exception CreateArgumentValidationException(Array array, int start)
+        private static Exception CreateArgumentValidationException(Array? array, int start)
         {
             if (array == null)
                 return CreateArgumentNullException(ExceptionArgument.array);

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -7,6 +7,7 @@
     <HasIntrinsics Condition="'$(TargetsNetCoreApp)'=='true'">true</HasIntrinsics>
     <DefineConstants Condition="'$(HasIntrinsics)'=='true'">$(DefineConstants);HAS_INTRINSICS</DefineConstants>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
   <!-- Shared -->
   <ItemGroup>

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix3x2.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix3x2.cs
@@ -771,7 +771,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this matrix; False otherwise.</returns>
-        public override readonly bool Equals(object obj)
+        public override readonly bool Equals(object? obj)
         {
             if (obj is Matrix3x2)
             {

--- a/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Matrix4x4.cs
@@ -2186,7 +2186,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this matrix; False otherwise.</returns>
-        public override readonly bool Equals(object obj) => (obj is Matrix4x4 other) && (this == other);
+        public override readonly bool Equals(object? obj) => (obj is Matrix4x4 other) && (this == other);
 
         /// <summary>
         /// Returns a String representing this matrix instance.

--- a/src/System.Numerics.Vectors/src/System/Numerics/Plane.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Plane.cs
@@ -335,7 +335,7 @@ namespace System.Numerics
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this Plane; False otherwise.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override readonly bool Equals(object obj)
+        public override readonly bool Equals(object? obj)
         {
             if (obj is Plane)
             {

--- a/src/System.Numerics.Vectors/src/System/Numerics/Quaternion.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Quaternion.cs
@@ -761,7 +761,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this Quaternion; False otherwise.</returns>
-        public override readonly bool Equals(object obj)
+        public override readonly bool Equals(object? obj)
         {
             if (obj is Quaternion)
             {

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector2.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector2.cs
@@ -65,7 +65,7 @@ namespace System.Numerics
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this Vector2; False otherwise.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override readonly bool Equals(object obj)
+        public override readonly bool Equals(object? obj)
         {
             if (!(obj is Vector2))
                 return false;
@@ -98,7 +98,7 @@ namespace System.Numerics
         /// <param name="format">The format of individual elements.</param>
         /// <param name="formatProvider">The format provider to use when formatting elements.</param>
         /// <returns>The string representation.</returns>
-        public readonly string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector3.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector3.cs
@@ -71,7 +71,7 @@ namespace System.Numerics
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this Vector3; False otherwise.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override readonly bool Equals(object obj)
+        public override readonly bool Equals(object? obj)
         {
             if (!(obj is Vector3))
                 return false;
@@ -104,7 +104,7 @@ namespace System.Numerics
         /// <param name="format">The format of individual elements.</param>
         /// <param name="formatProvider">The format provider to use when formatting elements.</param>
         /// <returns>The string representation.</returns>
-        public readonly string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector4.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector4.cs
@@ -75,7 +75,7 @@ namespace System.Numerics
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this Vector4; False otherwise.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override readonly bool Equals(object obj)
+        public override readonly bool Equals(object? obj)
         {
             if (!(obj is Vector4))
                 return false;
@@ -108,7 +108,7 @@ namespace System.Numerics
         /// <param name="format">The format of individual elements.</param>
         /// <param name="formatProvider">The format provider to use when formatting elements.</param>
         /// <returns>The string representation.</returns>
-        public readonly string ToString(string format, IFormatProvider formatProvider)
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
             StringBuilder sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -8,6 +8,7 @@
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetsAOT)'=='true' OR '$(TargetGroup)' == 'uap'">true</GenFacadesIgnoreMissingTypes>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\AppDomainUnloadedException.cs" />

--- a/src/System.Runtime.Extensions/src/System/AppDomainUnloadedException.cs
+++ b/src/System.Runtime.Extensions/src/System/AppDomainUnloadedException.cs
@@ -17,13 +17,13 @@ namespace System
             HResult = COR_E_APPDOMAINUNLOADED;
         }
 
-        public AppDomainUnloadedException(string message)
+        public AppDomainUnloadedException(string? message)
             : base(message)
         {
             HResult = COR_E_APPDOMAINUNLOADED;
         }
 
-        public AppDomainUnloadedException(string message, Exception innerException)
+        public AppDomainUnloadedException(string? message, Exception? innerException)
             : base(message, innerException)
         {
             HResult = COR_E_APPDOMAINUNLOADED;

--- a/src/System.Runtime.Extensions/src/System/ApplicationId.cs
+++ b/src/System.Runtime.Extensions/src/System/ApplicationId.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
-using System.Reflection;
-using System.Runtime.ExceptionServices;
 using System.Text;
 
 namespace System
@@ -13,7 +10,7 @@ namespace System
     {
         private readonly byte[] _publicKeyToken;
 
-        public ApplicationId(byte[] publicKeyToken, string name, Version version, string processorArchitecture, string culture)
+        public ApplicationId(byte[] publicKeyToken, string name, Version version, string? processorArchitecture, string? culture)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
             if (name.Length == 0) throw new ArgumentException(SR.Argument_EmptyApplicationName);
@@ -27,11 +24,11 @@ namespace System
             Culture = culture;
         }
 
-        public string Culture { get; }
+        public string? Culture { get; }
 
         public string Name { get; }
 
-        public string ProcessorArchitecture { get; }
+        public string? ProcessorArchitecture { get; }
 
         public Version Version { get; }
 
@@ -39,7 +36,9 @@ namespace System
 
         public ApplicationId Copy() => new ApplicationId(_publicKeyToken, Name, Version, ProcessorArchitecture, Culture);
 
-        public override string ToString ()
+#pragma warning disable CS8609 // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/23268
+        public override string ToString()
+#pragma warning restore CS8609
         {
             Span<char> charSpan = stackalloc char[128];
             var sb = new ValueStringBuilder(charSpan);
@@ -83,9 +82,9 @@ namespace System
                 (char)((num < 10) ? (num + '0') : (num + ('A' - 10)));
         }
 
-        public override bool Equals (object o)
+        public override bool Equals(object? o)
         {
-            ApplicationId other = (o as ApplicationId);
+            ApplicationId? other = o as ApplicationId;
             if (other == null)
                 return false;
  

--- a/src/System.Runtime.Extensions/src/System/CodeDom/Compiler/IndentedTextWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/CodeDom/Compiler/IndentedTextWriter.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Globalization;
@@ -30,7 +29,7 @@ namespace System.CodeDom.Compiler
 
         public override Encoding Encoding => _writer.Encoding;
 
-        public override string NewLine
+        public override string? NewLine // TODO-NULLABLE: https://github.com/dotnet/csharplang/issues/2384
         {
             get { return _writer.NewLine; }
             set { _writer.NewLine = value; }
@@ -60,7 +59,7 @@ namespace System.CodeDom.Compiler
             }
         }
 
-        public override void Write(string s)
+        public override void Write(string? s)
         {
             OutputTabs();
             _writer.Write(s);
@@ -78,7 +77,7 @@ namespace System.CodeDom.Compiler
             _writer.Write(value);
         }
 
-        public override void Write(char[] buffer)
+        public override void Write(char[]? buffer)
         {
             OutputTabs();
             _writer.Write(buffer);
@@ -114,36 +113,36 @@ namespace System.CodeDom.Compiler
             _writer.Write(value);
         }
 
-        public override void Write(object value)
+        public override void Write(object? value)
         {
             OutputTabs();
             _writer.Write(value);
         }
 
-        public override void Write(string format, object arg0)
+        public override void Write(string format, object? arg0)
         {
             OutputTabs();
             _writer.Write(format, arg0);
         }
 
-        public override void Write(string format, object arg0, object arg1)
+        public override void Write(string format, object? arg0, object? arg1)
         {
             OutputTabs();
             _writer.Write(format, arg0, arg1);
         }
 
-        public override void Write(string format, params object[] arg)
+        public override void Write(string format, params object?[] arg)
         {
             OutputTabs();
             _writer.Write(format, arg);
         }
 
-        public void WriteLineNoTabs(string s)
+        public void WriteLineNoTabs(string? s)
         {
             _writer.WriteLine(s);
         }
 
-        public override void WriteLine(string s)
+        public override void WriteLine(string? s)
         {
             OutputTabs();
             _writer.WriteLine(s);
@@ -171,7 +170,7 @@ namespace System.CodeDom.Compiler
             _tabsPending = true;
         }
 
-        public override void WriteLine(char[] buffer)
+        public override void WriteLine(char[]? buffer)
         {
             OutputTabs();
             _writer.WriteLine(buffer);
@@ -213,28 +212,28 @@ namespace System.CodeDom.Compiler
             _tabsPending = true;
         }
 
-        public override void WriteLine(object value)
+        public override void WriteLine(object? value)
         {
             OutputTabs();
             _writer.WriteLine(value);
             _tabsPending = true;
         }
 
-        public override void WriteLine(string format, object arg0)
+        public override void WriteLine(string format, object? arg0)
         {
             OutputTabs();
             _writer.WriteLine(format, arg0);
             _tabsPending = true;
         }
 
-        public override void WriteLine(string format, object arg0, object arg1)
+        public override void WriteLine(string format, object? arg0, object? arg1)
         {
             OutputTabs();
             _writer.WriteLine(format, arg0, arg1);
             _tabsPending = true;
         }
 
-        public override void WriteLine(string format, params object[] arg)
+        public override void WriteLine(string format, params object?[] arg)
         {
             OutputTabs();
             _writer.WriteLine(format, arg);

--- a/src/System.Runtime.Extensions/src/System/Context.cs
+++ b/src/System.Runtime.Extensions/src/System/Context.cs
@@ -6,7 +6,7 @@ using System.Runtime.Serialization;
 
 namespace System
 {
-    public abstract class ContextBoundObject : System.MarshalByRefObject
+    public abstract class ContextBoundObject : MarshalByRefObject
     {
         protected ContextBoundObject() { }
     }
@@ -19,11 +19,11 @@ namespace System
         {
         }
 
-        public ContextMarshalException(string message) : this(message, null)
+        public ContextMarshalException(string? message) : this(message, null)
         {
         }
 
-        public ContextMarshalException(string message, Exception inner) : base(message, inner)
+        public ContextMarshalException(string? message, Exception? inner) : base(message, inner)
         {
             HResult = HResults.COR_E_CONTEXTMARSHAL;
         }
@@ -34,7 +34,7 @@ namespace System
     }
 
     [AttributeUsage(AttributeTargets.Field, Inherited = false)]
-    public partial class ContextStaticAttribute : System.Attribute
+    public partial class ContextStaticAttribute : Attribute
     {
         public ContextStaticAttribute() { }
     }

--- a/src/System.Runtime.Extensions/src/System/IO/InvalidDataException.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/InvalidDataException.cs
@@ -15,12 +15,12 @@ namespace System.IO
         {
         }
 
-        public InvalidDataException(string message)
+        public InvalidDataException(string? message)
             : base(message)
         {
         }
 
-        public InvalidDataException(string message, Exception innerException)
+        public InvalidDataException(string? message, Exception? innerException)
             : base(message, innerException)
         {
         }

--- a/src/System.Runtime.Extensions/src/System/IO/StringReader.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StringReader.cs
@@ -10,18 +10,13 @@ namespace System.IO
     // This class implements a text reader that reads from a string.
     public class StringReader : TextReader
     {
-        private string _s;
+        private string? _s;
         private int _pos;
         private int _length;
 
         public StringReader(string s)
         {
-            if (s == null)
-            {
-                throw new ArgumentNullException(nameof(s));
-            }
-
-            _s = s;
+            _s = s ?? throw new ArgumentNullException(nameof(s));
             _length = s.Length;
         }
 
@@ -174,7 +169,7 @@ namespace System.IO
         // contain the terminating carriage return and/or line feed. The returned
         // value is null if the end of the underlying string has been reached.
         //
-        public override string ReadLine()
+        public override string? ReadLine()
         {
             if (_s == null)
             {
@@ -211,7 +206,7 @@ namespace System.IO
         }
 
         #region Task based Async APIs
-        public override Task<string> ReadLineAsync()
+        public override Task<string?> ReadLineAsync()
         {
             return Task.FromResult(ReadLine());
         }

--- a/src/System.Runtime.Extensions/src/System/IO/StringWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/StringWriter.cs
@@ -13,7 +13,7 @@ namespace System.IO
     // the resulting sequence of characters to be presented as a string.
     public class StringWriter : TextWriter
     {
-        private static volatile UnicodeEncoding s_encoding = null;
+        private static volatile UnicodeEncoding? s_encoding = null;
 
         private StringBuilder _sb;
         private bool _isOpen;
@@ -25,7 +25,7 @@ namespace System.IO
         {
         }
 
-        public StringWriter(IFormatProvider formatProvider)
+        public StringWriter(IFormatProvider? formatProvider)
             : this(new StringBuilder(), formatProvider)
         {
         }
@@ -36,7 +36,7 @@ namespace System.IO
         {
         }
 
-        public StringWriter(StringBuilder sb, IFormatProvider formatProvider) : base(formatProvider)
+        public StringWriter(StringBuilder sb, IFormatProvider? formatProvider) : base(formatProvider)
         {
             if (sb == null)
             {
@@ -146,7 +146,7 @@ namespace System.IO
         // Writes a string to the underlying string buffer. If the given string is
         // null, nothing is written.
         //
-        public override void Write(string value)
+        public override void Write(string? value)
         {
             if (!_isOpen)
             {
@@ -159,7 +159,7 @@ namespace System.IO
             }
         }
 
-        public override void Write(StringBuilder value)
+        public override void Write(StringBuilder? value)
         {
             if (GetType() != typeof(StringWriter))
             {
@@ -196,7 +196,7 @@ namespace System.IO
             WriteLine();
         }
 
-        public override void WriteLine(StringBuilder value)
+        public override void WriteLine(StringBuilder? value)
         {
             if (GetType() != typeof(StringWriter))
             {
@@ -223,7 +223,7 @@ namespace System.IO
             return Task.CompletedTask;
         }
 
-        public override Task WriteAsync(string value)
+        public override Task WriteAsync(string? value)
         {
             Write(value);
             return Task.CompletedTask;
@@ -246,7 +246,7 @@ namespace System.IO
             return Task.CompletedTask;
         }
 
-        public override Task WriteAsync(StringBuilder value, CancellationToken cancellationToken = default)
+        public override Task WriteAsync(StringBuilder? value, CancellationToken cancellationToken = default)
         {            
             if (GetType() != typeof(StringWriter))
             {
@@ -275,13 +275,13 @@ namespace System.IO
             return Task.CompletedTask;
         }
 
-        public override Task WriteLineAsync(string value)
+        public override Task WriteLineAsync(string? value)
         {
             WriteLine(value);
             return Task.CompletedTask;
         }
 
-        public override Task WriteLineAsync(StringBuilder value, CancellationToken cancellationToken = default)
+        public override Task WriteLineAsync(StringBuilder? value, CancellationToken cancellationToken = default)
         {
             if (GetType() != typeof(StringWriter))
             {
@@ -326,13 +326,13 @@ namespace System.IO
         {
             return Task.CompletedTask;
         }
-        
+
         #endregion
 
-        // Returns a string containing the characters written to this TextWriter
-        // so far.
-        //
+        // Returns a string containing the characters written to this TextWriter so far.
+#pragma warning disable CS8609 // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/23268
         public override string ToString()
+#pragma warning restore CS8609
         {
             return _sb.ToString();
         }

--- a/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/src/System/Net/WebUtility.cs
@@ -5,8 +5,6 @@
 // Don't entity encode high chars (160 to 256)
 #define ENTITY_ENCODE_HIGH_ASCII_CHARS
 
-using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -32,7 +30,7 @@ namespace System.Net
 
         #region HtmlEncode / HtmlDecode methods
 
-        public static string HtmlEncode(string value)
+        public static string? HtmlEncode(string? value) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
         {
             if (string.IsNullOrEmpty(value))
             {
@@ -66,7 +64,7 @@ namespace System.Net
             return sb.ToString();
         }
 
-        public static void HtmlEncode(string value, TextWriter output)
+        public static void HtmlEncode(string? value, TextWriter output)
         {
             if (output == null)
             {
@@ -184,7 +182,7 @@ namespace System.Net
             }
         }
 
-        public static string HtmlDecode(string value)
+        public static string? HtmlDecode(string? value) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
         {
             if (string.IsNullOrEmpty(value))
             {
@@ -214,7 +212,7 @@ namespace System.Net
             return sb.ToString();
         }
 
-        public static void HtmlDecode(string value, TextWriter output)
+        public static void HtmlDecode(string? value, TextWriter output)
         {
             if (output == null)
             {
@@ -405,7 +403,7 @@ namespace System.Net
         #region UrlEncode public methods
 
         [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "Already shipped public API; code moved here as part of API consolidation")]
-        public static string UrlEncode(string value)
+        public static string? UrlEncode(string? value) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
         {
             if (string.IsNullOrEmpty(value))
                 return value;
@@ -456,7 +454,7 @@ namespace System.Net
             return Encoding.UTF8.GetString(newBytes);
         }
 
-        public static byte[] UrlEncodeToBytes(byte[] value, int offset, int count)
+        public static byte[]? UrlEncodeToBytes(byte[]? value, int offset, int count) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
         {
             if (!ValidateUrlEncodingParameters(value, offset, count))
             {
@@ -469,7 +467,7 @@ namespace System.Net
             // count them first
             for (int i = 0; i < count; i++)
             {
-                char ch = (char)value[offset + i];
+                char ch = (char)value![offset + i];
 
                 if (ch == ' ')
                     foundSpaces = true;
@@ -481,13 +479,13 @@ namespace System.Net
             if (!foundSpaces && unsafeCount == 0)
             {
                 var subarray = new byte[count];
-                Buffer.BlockCopy(value, offset, subarray, 0, count);
+                Buffer.BlockCopy(value!, offset, subarray, 0, count);
                 return subarray;
             }
 
             // expand not 'safe' characters into %XX, spaces to +s
             byte[] expandedBytes = new byte[count + unsafeCount * 2];
-            GetEncodedBytes(value, offset, count, expandedBytes);
+            GetEncodedBytes(value!, offset, count, expandedBytes);
             return expandedBytes;
         }
 
@@ -495,7 +493,7 @@ namespace System.Net
 
         #region UrlDecode implementation
 
-        private static string UrlDecodeInternal(string value, Encoding encoding)
+        private static string? UrlDecodeInternal(string? value, Encoding encoding) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
         {
             if (string.IsNullOrEmpty(value))
             {
@@ -557,7 +555,7 @@ namespace System.Net
             return helper.GetString();
         }
 
-        private static byte[] UrlDecodeInternal(byte[] bytes, int offset, int count)
+        private static byte[]? UrlDecodeInternal(byte[]? bytes, int offset, int count) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
         {
             if (!ValidateUrlEncodingParameters(bytes, offset, count))
             {
@@ -570,7 +568,7 @@ namespace System.Net
             for (int i = 0; i < count; i++)
             {
                 int pos = offset + i;
-                byte b = bytes[pos];
+                byte b = bytes![pos];
 
                 if (b == '+')
                 {
@@ -593,7 +591,7 @@ namespace System.Net
 
             if (decodedBytesCount < decodedBytes.Length)
             {
-                Array.Resize(ref decodedBytes, decodedBytesCount);
+                Array.Resize(ref decodedBytes!, decodedBytesCount); // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
             }
 
             return decodedBytes;
@@ -605,12 +603,12 @@ namespace System.Net
 
 
         [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "Already shipped public API; code moved here as part of API consolidation")]
-        public static string UrlDecode(string encodedValue)
+        public static string? UrlDecode(string? encodedValue) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
         {
             return UrlDecodeInternal(encodedValue, Encoding.UTF8);
         }
 
-        public static byte[] UrlDecodeToBytes(byte[] encodedValue, int offset, int count)
+        public static byte[]? UrlDecodeToBytes(byte[]? encodedValue, int offset, int count) // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/26761
         {
             return UrlDecodeInternal(encodedValue, offset, count);
         }
@@ -719,7 +717,7 @@ namespace System.Net
             }
         }
 
-        private static bool ValidateUrlEncodingParameters(byte[] bytes, int offset, int count)
+        private static bool ValidateUrlEncodingParameters(byte[]? bytes, int offset, int count)
         {
             if (bytes == null && count == 0)
                 return false;
@@ -763,11 +761,11 @@ namespace System.Net
 
             // Accumulate characters in a special array
             private int _numChars;
-            private char[] _charBuffer;
+            private char[]? _charBuffer;
 
             // Accumulate bytes for decoding into characters in a special array
             private int _numBytes;
-            private byte[] _byteBuffer;
+            private byte[]? _byteBuffer;
 
             // Encoding to convert chars to bytes
             private Encoding _encoding;
@@ -778,7 +776,7 @@ namespace System.Net
                 if (_charBuffer == null)
                     _charBuffer = new char[_bufferSize];
 
-                _numChars += _encoding.GetChars(_byteBuffer, 0, _numBytes, _charBuffer, _numChars);
+                _numChars += _encoding.GetChars(_byteBuffer!, 0, _numBytes, _charBuffer, _numChars);
                 _numBytes = 0;
             }
 
@@ -819,7 +817,7 @@ namespace System.Net
                     FlushBytes();
 
                 Debug.Assert(_numChars > 0);
-                return new string(_charBuffer, 0, _numChars);
+                return new string(_charBuffer!, 0, _numChars);
             }
         }
 

--- a/src/System.Runtime.Extensions/src/System/Reflection/AssemblyNameProxy.cs
+++ b/src/System.Runtime.Extensions/src/System/Reflection/AssemblyNameProxy.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace System.Reflection {
-    using System;
-    using System.Runtime.Versioning;
-
+namespace System.Reflection
+{
     public class AssemblyNameProxy : MarshalByRefObject
     {
         public AssemblyName GetAssemblyName(string assemblyFile)

--- a/src/System.Runtime.Extensions/src/System/Runtime/CompilerServices/SwitchExpressionException.cs
+++ b/src/System.Runtime.Extensions/src/System/Runtime/CompilerServices/SwitchExpressionException.cs
@@ -17,10 +17,10 @@ namespace System.Runtime.CompilerServices
         public SwitchExpressionException()
             : base(SR.Arg_SwitchExpressionException) { }
 
-        public SwitchExpressionException(Exception innerException) :
+        public SwitchExpressionException(Exception? innerException) :
             base(SR.Arg_SwitchExpressionException, innerException) { }
 
-        public SwitchExpressionException(object unmatchedValue) : this()
+        public SwitchExpressionException(object? unmatchedValue) : this()
         {
             UnmatchedValue = unmatchedValue;
         }
@@ -31,12 +31,12 @@ namespace System.Runtime.CompilerServices
             UnmatchedValue = info.GetValue(nameof(UnmatchedValue), typeof(object));
         }
 
-        public SwitchExpressionException(string message) : base(message) { }
+        public SwitchExpressionException(string? message) : base(message) { }
 
-        public SwitchExpressionException(string message, Exception innerException)
+        public SwitchExpressionException(string? message, Exception? innerException)
             : base(message, innerException) { }
 
-        public object UnmatchedValue { get; }
+        public object? UnmatchedValue { get; }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -52,6 +52,7 @@ namespace System.Runtime.CompilerServices
                 {
                     return base.Message;
                 }
+
                 string valueMessage = SR.Format(SR.SwitchExpressionException_UnmatchedValue, UnmatchedValue);
                 return base.Message + Environment.NewLine + valueMessage;
             }

--- a/src/System.Runtime.Extensions/src/System/Runtime/Versioning/FrameworkName.cs
+++ b/src/System.Runtime.Extensions/src/System/Runtime/Versioning/FrameworkName.cs
@@ -6,12 +6,12 @@ using System.Diagnostics;
 
 namespace System.Runtime.Versioning
 {
-    public sealed class FrameworkName : IEquatable<FrameworkName>
+    public sealed class FrameworkName : IEquatable<FrameworkName?>
     {
         private readonly string _identifier;
-        private readonly Version _version;
+        private readonly Version _version = null!;
         private readonly string _profile;
-        private string _fullName;
+        private string? _fullName;
 
         private const char ComponentSeparator = ',';
         private const char KeyValueSeparator = '=';
@@ -71,19 +71,20 @@ namespace System.Runtime.Versioning
                             Profile;
                     }
                 }
+
                 Debug.Assert(_fullName != null);
                 return _fullName;
             }
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return Equals(obj as FrameworkName);
         }
 
-        public bool Equals(FrameworkName other)
+        public bool Equals(FrameworkName? other)
         {
-            if (object.ReferenceEquals(other, null))
+            if (other is null)
             {
                 return false;
             }
@@ -98,7 +99,9 @@ namespace System.Runtime.Versioning
             return Identifier.GetHashCode() ^ Version.GetHashCode() ^ Profile.GetHashCode();
         }
 
+#pragma warning disable CS8609 // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/23268
         public override string ToString()
+#pragma warning restore CS8609
         {
             return FullName;
         }
@@ -108,7 +111,7 @@ namespace System.Runtime.Versioning
         {
         }
 
-        public FrameworkName(string identifier, Version version, string profile)
+        public FrameworkName(string identifier, Version version, string? profile)
         {
             if (identifier == null)
             {
@@ -227,16 +230,17 @@ namespace System.Runtime.Versioning
             }
         }
 
-        public static bool operator ==(FrameworkName left, FrameworkName right)
+        public static bool operator ==(FrameworkName? left, FrameworkName? right)
         {
-            if (object.ReferenceEquals(left, null))
+            if (left is null)
             {
-                return object.ReferenceEquals(right, null);
+                return right is null;
             }
+
             return left.Equals(right);
         }
 
-        public static bool operator !=(FrameworkName left, FrameworkName right)
+        public static bool operator !=(FrameworkName? left, FrameworkName? right)
         {
             return !(left == right);
         }

--- a/src/System.Runtime.Extensions/src/System/Runtime/Versioning/VersioningHelper.cs
+++ b/src/System.Runtime.Extensions/src/System/Runtime/Versioning/VersioningHelper.cs
@@ -25,12 +25,12 @@ namespace System.Runtime.Versioning
         private const ResourceScope ResTypeMask = ResourceScope.Machine | ResourceScope.Process | ResourceScope.AppDomain | ResourceScope.Library;
         private const ResourceScope VisibilityMask = ResourceScope.Private | ResourceScope.Assembly;
 
-        public static string MakeVersionSafeName(string name, ResourceScope from, ResourceScope to)
+        public static string MakeVersionSafeName(string? name, ResourceScope from, ResourceScope to)
         {
-            return MakeVersionSafeName(name, from, to, null);
+            return MakeVersionSafeName(name, from, to, type: null);
         }
 
-        public static string MakeVersionSafeName(string name, ResourceScope from, ResourceScope to, Type type)
+        public static string MakeVersionSafeName(string? name, ResourceScope from, ResourceScope to, Type? type)
         {
             ResourceScope fromResType = from & ResTypeMask;
             ResourceScope toResType = to & ResTypeMask;
@@ -68,12 +68,12 @@ namespace System.Runtime.Versioning
             if ((requires & SxSRequirements.TypeName) != 0)
             {
                 safeName.Append(separator);
-                safeName.Append(type.Name);
+                safeName.Append(type!.Name);
             }
             if ((requires & SxSRequirements.AssemblyName) != 0)
             {
                 safeName.Append(separator);
-                safeName.Append(type.Assembly.FullName);
+                safeName.Append(type!.Assembly.FullName);
             }
             return safeName.ToString();
         }

--- a/src/System.Runtime.Extensions/src/System/Security/Permissions/SecurityAttribute.cs
+++ b/src/System.Runtime.Extensions/src/System/Security/Permissions/SecurityAttribute.cs
@@ -10,6 +10,6 @@ namespace System.Security.Permissions
         protected SecurityAttribute(SecurityAction action) { }
         public SecurityAction Action { get; set; }
         public bool Unrestricted { get; set; }
-        public abstract IPermission CreatePermission();
+        public abstract IPermission? CreatePermission();
     }
 }

--- a/src/System.Runtime.Extensions/src/System/Security/Permissions/SecurityPermissionAttribute.cs
+++ b/src/System.Runtime.Extensions/src/System/Security/Permissions/SecurityPermissionAttribute.cs
@@ -23,6 +23,6 @@ namespace System.Security.Permissions
         public bool SerializationFormatter { get; set; }
         public bool SkipVerification { get; set; }
         public bool UnmanagedCode { get; set; }
-        public override IPermission CreatePermission() { return default(IPermission); }
+        public override IPermission? CreatePermission() { return null; }
     }
 }

--- a/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
+++ b/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
@@ -7,6 +7,7 @@
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetsAOT)' == 'true'">true</GenFacadesIgnoreMissingTypes>
     <NoWarn Condition="'$(TargetsAOT)' == 'true'">$(NoWarn);0436;3001</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NullableContextOptions>enable</NullableContextOptions>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Runtime.InteropServices/src/System/Runtime/CompilerServices/IDispatchConstantAttribute.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/CompilerServices/IDispatchConstantAttribute.cs
@@ -11,6 +11,8 @@ namespace System.Runtime.CompilerServices
     {
         public IDispatchConstantAttribute() { }
 
+#pragma warning disable CS8608 // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/23268
         public override object Value => new DispatchWrapper(null);
+#pragma warning restore CS8608
     }
 }

--- a/src/System.Runtime.InteropServices/src/System/Runtime/CompilerServices/IUnknownConstantAttribute.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/CompilerServices/IUnknownConstantAttribute.cs
@@ -11,6 +11,8 @@ namespace System.Runtime.CompilerServices
     {
         public IUnknownConstantAttribute() { }
 
+#pragma warning disable CS8608 // TODO-NULLABLE: https://github.com/dotnet/roslyn/issues/23268
         public override object Value => new UnknownWrapper(null);
+#pragma warning restore CS8608
     }
 }

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComAwareEventInfo.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComAwareEventInfo.cs
@@ -4,7 +4,10 @@
 
 using System.Collections.Generic;
 using System.Reflection;
-using System.Security;
+
+// This type is obsolete, and is expected to be used in very specific ways or it may
+// throw null reference exceptions.
+#pragma warning disable CS8610
 
 namespace System.Runtime.InteropServices
 {
@@ -14,7 +17,7 @@ namespace System.Runtime.InteropServices
 
         public ComAwareEventInfo(Type type, string eventName)
         {
-            _innerEventInfo = type.GetEvent(eventName);
+            _innerEventInfo = type.GetEvent(eventName)!;
         }
 
         public override void AddEventHandler(object target, Delegate handler)
@@ -50,15 +53,15 @@ namespace System.Runtime.InteropServices
 
         public override EventAttributes Attributes => _innerEventInfo.Attributes;
 
-        public override MethodInfo GetAddMethod(bool nonPublic) => _innerEventInfo.GetAddMethod(nonPublic);
+        public override MethodInfo? GetAddMethod(bool nonPublic) => _innerEventInfo.GetAddMethod(nonPublic);
 
-        public override MethodInfo[] GetOtherMethods(bool nonPublic) => _innerEventInfo.GetOtherMethods(nonPublic);
+        public override MethodInfo[]? GetOtherMethods(bool nonPublic) => _innerEventInfo.GetOtherMethods(nonPublic);
 
-        public override MethodInfo GetRaiseMethod(bool nonPublic) => _innerEventInfo.GetRaiseMethod(nonPublic);
+        public override MethodInfo? GetRaiseMethod(bool nonPublic) => _innerEventInfo.GetRaiseMethod(nonPublic);
 
-        public override MethodInfo GetRemoveMethod(bool nonPublic) => _innerEventInfo.GetRemoveMethod(nonPublic);
+        public override MethodInfo? GetRemoveMethod(bool nonPublic) => _innerEventInfo.GetRemoveMethod(nonPublic);
 
-        public override Type DeclaringType => _innerEventInfo.DeclaringType;
+        public override Type? DeclaringType => _innerEventInfo.DeclaringType;
 
         public override object[] GetCustomAttributes(Type attributeType, bool inherit)
         {
@@ -83,11 +86,11 @@ namespace System.Runtime.InteropServices
 
         public override string Name => _innerEventInfo.Name;
 
-        public override Type ReflectedType => _innerEventInfo.ReflectedType;
+        public override Type? ReflectedType => _innerEventInfo.ReflectedType;
 
         private static void GetDataForComInvocation(EventInfo eventInfo, out Guid sourceIid, out int dispid)
         {
-            object[] comEventInterfaces = eventInfo.DeclaringType.GetCustomAttributes(typeof(ComEventInterfaceAttribute), inherit: false);
+            object[] comEventInterfaces = eventInfo.DeclaringType!.GetCustomAttributes(typeof(ComEventInterfaceAttribute), inherit: false);
 
             if (comEventInterfaces == null || comEventInterfaces.Length == 0)
             {
@@ -102,8 +105,8 @@ namespace System.Runtime.InteropServices
             Type sourceInterface = ((ComEventInterfaceAttribute)comEventInterfaces[0]).SourceInterface;
             Guid guid = sourceInterface.GUID;
 
-            MethodInfo methodInfo = sourceInterface.GetMethod(eventInfo.Name);
-            Attribute dispIdAttribute = Attribute.GetCustomAttribute(methodInfo, typeof(DispIdAttribute));
+            MethodInfo methodInfo = sourceInterface.GetMethod(eventInfo.Name)!;
+            Attribute? dispIdAttribute = Attribute.GetCustomAttribute(methodInfo, typeof(DispIdAttribute));
             if (dispIdAttribute == null)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_NoDispIdAttribute);

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComTypes/IDataObject.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComTypes/IDataObject.cs
@@ -83,6 +83,6 @@ namespace System.Runtime.InteropServices.ComTypes
         ///     Creates an object that can be used to enumerate the current advisory connections.
         /// </summary>
         [PreserveSig]
-        int EnumDAdvise(out IEnumSTATDATA enumAdvise);
+        int EnumDAdvise(out IEnumSTATDATA? enumAdvise);
     }
 }

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComTypes/STGMEDIUM.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/ComTypes/STGMEDIUM.cs
@@ -9,6 +9,6 @@ namespace System.Runtime.InteropServices.ComTypes
         public TYMED tymed;
         public IntPtr unionmember;
         [MarshalAs(UnmanagedType.IUnknown)]
-        public object pUnkForRelease;
+        public object? pUnkForRelease;
     }
 }

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/HandleCollector.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/HandleCollector.cs
@@ -16,12 +16,12 @@ namespace System.Runtime.InteropServices
         private int[] _gcCounts = new int[3];
         private int _gcGeneration = 0;
 
-        public HandleCollector(string name, int initialThreshold) :
+        public HandleCollector(string? name, int initialThreshold) :
             this(name, initialThreshold, int.MaxValue)
         {
         }
 
-        public HandleCollector(string name, int initialThreshold, int maximumThreshold)
+        public HandleCollector(string? name, int initialThreshold, int maximumThreshold)
         {
             if (initialThreshold < 0)
             {

--- a/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
+++ b/src/System.Runtime.InteropServices/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
@@ -15,7 +15,7 @@ namespace System.Runtime.InteropServices
 
         public static string GetRuntimeDirectory()
         {
-            string runtimeDirectory = typeof(object).Assembly.Location;
+            string? runtimeDirectory = typeof(object).Assembly.Location;
             if (!Path.IsPathRooted(runtimeDirectory))
             {
                 runtimeDirectory = AppDomain.CurrentDomain.BaseDirectory;

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -5,6 +5,7 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetsAOT)'=='true' OR '$(TargetGroup)' == 'uap'">true</GenFacadesIgnoreMissingTypes>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
   <ItemGroup>
     <!-- Compiler throws error if you try to use System.Void and instructs you to use void keyword instead. So we have manually added a typeforward for this type. -->  

--- a/src/System.Runtime/src/System/LazyOfTTMetadata.cs
+++ b/src/System.Runtime/src/System/LazyOfTTMetadata.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 
 namespace System

--- a/src/System.Runtime/src/System/Reflection/RuntimeReflectionExtensions.cs
+++ b/src/System.Runtime/src/System/Reflection/RuntimeReflectionExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Reflection
@@ -47,7 +46,7 @@ namespace System.Reflection
             return type.GetEvents(Everything);
         }
 
-        public static FieldInfo GetRuntimeField(this Type type, string name)
+        public static FieldInfo? GetRuntimeField(this Type type, string name)
         {
             if (type == null) 
             {
@@ -56,7 +55,7 @@ namespace System.Reflection
             return type.GetField(name);
         }
 
-        public static MethodInfo GetRuntimeMethod(this Type type, string name, Type[] parameters)
+        public static MethodInfo? GetRuntimeMethod(this Type type, string name, Type[] parameters)
         {
             if (type == null) 
             {
@@ -65,7 +64,7 @@ namespace System.Reflection
             return type.GetMethod(name, parameters);
         }
 
-        public static PropertyInfo GetRuntimeProperty(this Type type, string name)
+        public static PropertyInfo? GetRuntimeProperty(this Type type, string name)
         {
             if (type == null) 
             {
@@ -74,7 +73,7 @@ namespace System.Reflection
             return type.GetProperty(name);
         }
 
-        public static EventInfo GetRuntimeEvent(this Type type, string name)
+        public static EventInfo? GetRuntimeEvent(this Type type, string name)
         {
             if (type == null) 
             {
@@ -83,7 +82,7 @@ namespace System.Reflection
             return type.GetEvent(name);
         }
 
-        public static MethodInfo GetRuntimeBaseDefinition(this MethodInfo method)
+        public static MethodInfo? GetRuntimeBaseDefinition(this MethodInfo method)
         {
             if (method == null) 
             {
@@ -101,7 +100,7 @@ namespace System.Reflection
             return typeInfo.GetInterfaceMap(interfaceType);
         }
 
-        public static MethodInfo GetMethodInfo(this Delegate del)
+        public static MethodInfo? GetMethodInfo(this Delegate del)
         {
             if (del == null) 
             {

--- a/src/System.Runtime/src/System/Runtime/NgenServicingAttributes.cs
+++ b/src/System.Runtime/src/System/Runtime/NgenServicingAttributes.cs
@@ -2,16 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Runtime
 {
     [AttributeUsage(AttributeTargets.Assembly, Inherited = false)]
     public sealed class AssemblyTargetedPatchBandAttribute : Attribute
     {
-        public string TargetedPatchBand { get; }
+        public string? TargetedPatchBand { get; }
 
-        public AssemblyTargetedPatchBandAttribute(string targetedPatchBand)
+        public AssemblyTargetedPatchBandAttribute(string? targetedPatchBand)
         {
             TargetedPatchBand = targetedPatchBand;
         }
@@ -20,9 +18,9 @@ namespace System.Runtime
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
     public sealed class TargetedPatchingOptOutAttribute : Attribute
     {
-        public string Reason { get; }
+        public string? Reason { get; }
 
-        public TargetedPatchingOptOutAttribute(string reason)
+        public TargetedPatchingOptOutAttribute(string? reason)
         {
             Reason = reason;
         }

--- a/src/System.Runtime/src/System/System.Runtime.Typeforwards.cs
+++ b/src/System.Runtime/src/System/System.Runtime.Typeforwards.cs
@@ -1,1 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(void))]

--- a/src/System.Runtime/src/System/Threading/WaitHandleExtensions.cs
+++ b/src/System.Runtime/src/System/Threading/WaitHandleExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Win32.SafeHandles;
-using System.Security;
 
 namespace System.Threading
 {
@@ -14,7 +13,7 @@ namespace System.Threading
         /// </summary>
         /// <param name="waitHandle">The <see cref="System.Threading.WaitHandle"/> to operate on.</param>
         /// <returns>A <see cref="System.Runtime.InteropServices.SafeHandle"/> representing the native operating system handle.</returns>
-        public static SafeWaitHandle GetSafeWaitHandle(this WaitHandle waitHandle)
+        public static SafeWaitHandle? GetSafeWaitHandle(this WaitHandle waitHandle)
         {
             if (waitHandle == null)
             {
@@ -29,7 +28,7 @@ namespace System.Threading
         /// </summary>
         /// <param name="waitHandle">The <see cref="System.Threading.WaitHandle"/> to operate on.</param>
         /// <param name="value">A <see cref="System.Runtime.InteropServices.SafeHandle"/> representing the native operating system handle.</param>
-        public static void SetSafeWaitHandle(this WaitHandle waitHandle, SafeWaitHandle value)
+        public static void SetSafeWaitHandle(this WaitHandle waitHandle, SafeWaitHandle? value)
         {
             if (waitHandle == null)
             {

--- a/src/System.Security.Principal/src/System.Security.Principal.csproj
+++ b/src/System.Security.Principal/src/System.Security.Principal.csproj
@@ -4,6 +4,7 @@
     <ProjectGuid>{FBE16BC8-AE2D-422C-861E-861814F53AF7}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <NullableContextOptions>enable</NullableContextOptions>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->

--- a/src/System.Threading.Thread/src/System.Threading.Thread.csproj
+++ b/src/System.Threading.Thread/src/System.Threading.Thread.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <ProjectGuid>{06197EED-FF48-43F3-976D-463839D43E8C}</ProjectGuid>
+    <NullableContextOptions>enable</NullableContextOptions>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Threading/src/System.Threading.csproj
+++ b/src/System.Threading/src/System.Threading.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Threading\Barrier.cs" />

--- a/src/System.Threading/src/System/Threading/Barrier.cs
+++ b/src/System.Threading/src/System/Threading/Barrier.cs
@@ -28,7 +28,7 @@ namespace System.Threading
         /// Initializes a new instance of the <see cref="BarrierPostPhaseException"/> class.
         /// </summary>
         public BarrierPostPhaseException()
-            : this((string)null)
+            : this((string?)null)
         {
         }
 
@@ -36,7 +36,7 @@ namespace System.Threading
         /// Initializes a new instance of the <see cref="BarrierPostPhaseException"/> class with the specified inner exception.
         /// </summary>
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
-        public BarrierPostPhaseException(Exception innerException)
+        public BarrierPostPhaseException(Exception? innerException)
             : this(null, innerException)
         {
         }
@@ -45,7 +45,7 @@ namespace System.Threading
         /// Initializes a new instance of the <see cref="BarrierPostPhaseException"/> class with a specified error message.
         /// </summary>
         /// <param name="message">A string that describes the exception.</param>
-        public BarrierPostPhaseException(string message)
+        public BarrierPostPhaseException(string? message)
             : this(message, null)
         {
         }
@@ -55,7 +55,7 @@ namespace System.Threading
         /// </summary>
         /// <param name="message">A string that describes the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
-        public BarrierPostPhaseException(string message, Exception innerException)
+        public BarrierPostPhaseException(string? message, Exception? innerException)
             : base(message == null ? SR.BarrierPostPhaseException : message, innerException)
         {
         }
@@ -130,16 +130,16 @@ namespace System.Threading
         private ManualResetEventSlim _evenEvent;
 
         // The execution context of the creator thread
-        private ExecutionContext _ownerThreadContext;
+        private ExecutionContext? _ownerThreadContext;
 
         // The EC callback that invokes the post phase action
-        private static ContextCallback s_invokePostPhaseAction;
+        private static ContextCallback? s_invokePostPhaseAction;
 
         // Post phase action after each phase
-        private Action<Barrier> _postPhaseAction;
+        private Action<Barrier>? _postPhaseAction;
 
         // In case the post phase action throws an exception, wraps it in BarrierPostPhaseException
-        private Exception _exception;
+        private Exception? _exception;
 
         // This is the ManagedThreadID of the postPhaseAction caller thread, this is used to determine if the SignalAndWait, Dispose or Add/RemoveParticipant caller thread is
         // the same thread as the postPhaseAction thread which means this method was called from the postPhaseAction which is illegal.
@@ -213,7 +213,7 @@ namespace System.Threading
         /// will not be released to the next phase until the postPhaseAction delegate
         /// has completed execution.
         /// </remarks>
-        public Barrier(int participantCount, Action<Barrier> postPhaseAction)
+        public Barrier(int participantCount, Action<Barrier>? postPhaseAction)
         {
             // the count must be non negative value
             if (participantCount < 0 || participantCount > MAX_PARTICIPANTS)
@@ -766,7 +766,7 @@ namespace System.Threading
                     {
                         var currentContext = _ownerThreadContext;
 
-                        ContextCallback handler = s_invokePostPhaseAction;
+                        ContextCallback? handler = s_invokePostPhaseAction;
                         if (handler == null)
                         {
                             s_invokePostPhaseAction = handler = InvokePostPhaseAction;
@@ -802,10 +802,10 @@ namespace System.Threading
         /// Helper method to call the post phase action
         /// </summary>
         /// <param name="obj"></param>
-        private static void InvokePostPhaseAction(object obj)
+        private static void InvokePostPhaseAction(object? obj)
         {
-            var thisBarrier = (Barrier)obj;
-            thisBarrier._postPhaseAction(thisBarrier);
+            var thisBarrier = (Barrier)obj!;
+            thisBarrier._postPhaseAction!(thisBarrier);
         }
 
         /// <summary>

--- a/src/System.Threading/src/System/Threading/HostExecutionContext.cs
+++ b/src/System.Threading/src/System/Threading/HostExecutionContext.cs
@@ -10,12 +10,12 @@ namespace System.Threading
         {
         }
 
-        public HostExecutionContext(object state)
+        public HostExecutionContext(object? state)
         {
             State = state;
         }
 
-        protected internal object State
+        protected internal object? State
         {
             get;
             set;

--- a/src/System.Threading/src/System/Threading/HostExecutionContextManager.cs
+++ b/src/System.Threading/src/System/Threading/HostExecutionContextManager.cs
@@ -12,9 +12,9 @@ namespace System.Threading
         /// separating itself from the <see cref="ExecutionContext"/> to minimize unnecessary additions there.
         /// </summary>
         [ThreadStatic]
-        private static HostExecutionContext t_currentContext;
+        private static HostExecutionContext? t_currentContext;
 
-        public virtual HostExecutionContext Capture()
+        public virtual HostExecutionContext? Capture()
         {
             // Not hosted, so always capture null
             return null;
@@ -55,7 +55,7 @@ namespace System.Threading
         private sealed class HostExecutionContextSwitcher
         {
             public readonly HostExecutionContext _currentContext;
-            public AsyncLocal<bool> _asyncLocal;
+            public AsyncLocal<bool>? _asyncLocal;
 
             public HostExecutionContextSwitcher(HostExecutionContext currentContext)
             {

--- a/src/System.Threading/src/System/Threading/LockCookie.cs
+++ b/src/System.Threading/src/System/Threading/LockCookie.cs
@@ -20,7 +20,7 @@ namespace System.Threading
             return (int)_flags + _readerLevel + _writerLevel + _threadID;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is LockCookie && Equals((LockCookie)obj);
         }


### PR DESCRIPTION
Some of our corefx libraries implement some functionality and type-forward the rest to implementations in corelib.  For nullability annotations, we want to be able to annotate whole ref assemblies.  Since we're primarily annotating corelib right now, this annotates the bulk of the types in such partial assemblies (I believe the main one I'm missing here is System.Collections.)

I've made this a draft PR, because there are almost certainly going to be a lot of new warnings once corefx consumes an updated coreclr with a lot more annotations than are currently in the one being used.