### PR TITLE
Performance improvements in EmailAddressAttribute

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
@@ -31,27 +31,11 @@ namespace System.ComponentModel.DataAnnotations
             // only return true if there is only 1 '@' character
             // and it is neither the first nor the last character
             int index = valueAsString.IndexOf('@');
-           
-            if (index == 0) //cannot be the first char
-            {
-                return false;
-            }
-            else if (index == -1) //char not found
-            {
-                return false;
-            }
-            else if (index != valueAsString.LastIndexOf('@')) //only one char
-            {
-                return false;
-            }
-            else if (index == valueAsString.Length - 1) //cannot be the last char
-            {
-                return false;
-            }
-            else
-            {
-                return true;
-            }
+            
+            return
+                index > 0 &&
+                index != valueAsString.Length - 1 &&
+                index == valueAsString.LastIndexOf('@');
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
@@ -30,20 +30,28 @@ namespace System.ComponentModel.DataAnnotations
 
             // only return true if there is only 1 '@' character
             // and it is neither the first nor the last character
-            bool found = false;
-            for (int i = 0; i < valueAsString.Length; i++)
+            var index = valueAsString.IndexOf('@');
+           
+            if (index == 0) //cannot be the first char
             {
-                if (valueAsString[i] == '@')
-                {
-                    if (found || i == 0 || i == valueAsString.Length - 1)
-                    {
-                        return false;
-                    }
-                    found = true;
-                }
+                return false;
             }
-
-            return found;
+            else if (index == -1) //char not found
+            {
+                return false;
+            }
+            else if (index != valueAsString.LastIndexOf('@')) //only one char
+            {
+                return false;
+            }
+            else if (index == valueAsString.Length - 1) //cannot be the last char
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
@@ -30,7 +30,7 @@ namespace System.ComponentModel.DataAnnotations
 
             // only return true if there is only 1 '@' character
             // and it is neither the first nor the last character
-            var index = valueAsString.IndexOf('@');
+            int index = valueAsString.IndexOf('@');
            
             if (index == 0) //cannot be the first char
             {


### PR DESCRIPTION
Edit: My apologies, I made a mistake in the perf evaluation but that is corrected and does not change the proposed changes. Snapshots and text below have been adapted accordingly.

I get a perf improvement by using `IndexOf` which ranges from a factor of 1 for an email address having 20 char to nearly 3 for 60 char.
For a 20 char email
![Email20Char](https://user-images.githubusercontent.com/19961806/56381482-443a0880-6215-11e9-82e8-f68886588652.PNG)

For a 60 char email
![Email60Char](https://user-images.githubusercontent.com/19961806/56381489-49975300-6215-11e9-8840-1869fbe48570.PNG)

