### PR TITLE
Manual darc update from build '20190418.2'

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,69 +30,69 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>1f9b84a0804e868c7e0f37a3c10fbaf7c735ae14</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.1.0-prerelease.19217.2">
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>25538d60f7f4c2c79cf098f2b808907d87b516a7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SourceRewriter" Version="1.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.SourceRewriter" Version="1.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="1.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="1.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="2.4.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="2.4.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="1.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="1.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="1.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="1.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="1.0.0-beta.19216.2">
+    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="1.0.0-beta.19218.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>09e01af076175a6dbf19e442707722e751a7163b</Sha>
+      <Sha>b7e6007d3aed917433eff4c834081fec8a9f144e</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.IBC.CoreFx" Version="99.99.99-master-20190313.3">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,19 +23,19 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19216.2</MicrosoftDotNetApiCompatPackageVersion>
-    <MicrosoftDotNetSourceRewriterPackageVersion>1.0.0-beta.19216.2</MicrosoftDotNetSourceRewriterPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19216.2</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19216.2</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19216.2</MicrosoftDotNetGenFacadesPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.0-beta.19216.2</MicrosoftDotNetXUnitExtensionsPackageVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.5.1-beta.19216.2</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19216.2</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19216.2</MicrosoftDotNetCoreFxTestingPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>1.0.0-beta.19216.2</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19216.2</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19216.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftDotNetVersionToolsTasksPackageVersion>1.0.0-beta.19216.2</MicrosoftDotNetVersionToolsTasksPackageVersion>
+    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19218.2</MicrosoftDotNetApiCompatPackageVersion>
+    <MicrosoftDotNetSourceRewriterPackageVersion>1.0.0-beta.19218.2</MicrosoftDotNetSourceRewriterPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19218.2</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19218.2</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19218.2</MicrosoftDotNetGenFacadesPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.0-beta.19218.2</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.5.1-beta.19218.2</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
+    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19218.2</MicrosoftDotNetBuildTasksPackagingPackageVersion>
+    <MicrosoftDotNetCoreFxTestingPackageVersion>1.0.0-beta.19218.2</MicrosoftDotNetCoreFxTestingPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>1.0.0-beta.19218.2</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetBuildTasksConfigurationPackageVersion>1.0.0-beta.19218.2</MicrosoftDotNetBuildTasksConfigurationPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19218.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetVersionToolsTasksPackageVersion>1.0.0-beta.19218.2</MicrosoftDotNetVersionToolsTasksPackageVersion>
     <!-- Core-setup dependencies -->
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview5-27618-02</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostPackageVersion>3.0.0-preview5-27618-02</MicrosoftNETCoreDotNetHostPackageVersion>

--- a/global.json
+++ b/global.json
@@ -3,8 +3,8 @@
     "dotnet": "3.0.100-preview3-010431"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19216.2",
-    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19216.2",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19218.2",
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19218.2",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview5-27617-73"
   }
 }


### PR DESCRIPTION
Consume changes from CoreFxTesting to allow the new rsp option: `/p:TestRspFile=...`.