### PR TITLE
write Host header first if we need to add it

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -434,6 +434,13 @@ namespace System.Net.Http
                     }
                 }
 
+                // Write special additional headers.  If a host isn't in the headers list, then a Host header
+                // wasn't sent, so as it's required by HTTP 1.1 spec, send one based on the Request Uri.
+                if (!request.HasHeaders || request.Headers.Host == null)
+                {
+                    await WriteHostHeaderAsync(request.RequestUri).ConfigureAwait(false);
+                }
+
                 // Write request headers
                 if (request.HasHeaders || cookiesFromContainer != null)
                 {
@@ -453,13 +460,6 @@ namespace System.Net.Http
                 {
                     // Write content headers
                     await WriteHeadersAsync(request.Content.Headers, cookiesFromContainer: null).ConfigureAwait(false);
-                }
-
-                // Write special additional headers.  If a host isn't in the headers list, then a Host header
-                // wasn't sent, so as it's required by HTTP 1.1 spec, send one based on the Request Uri.
-                if (!request.HasHeaders || request.Headers.Host == null)
-                {
-                    await WriteHostHeaderAsync(request.RequestUri).ConfigureAwait(false);
                 }
 
                 // CRLF for end of headers.

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http1.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http1.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Test.Common;
-//using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -14,7 +13,7 @@ using Xunit.Abstractions;
 namespace System.Net.Http.Functional.Tests
 {
     // This class is dedicated to SocketHttpHandler tests specific to HTTP/1.x.
-    public abstract class HttpClientHandlerTest_Http1 : HttpClientHandlerTestBase
+    public class HttpClientHandlerTest_Http1 : HttpClientHandlerTestBase
     {
         protected override bool UseSocketsHttpHandler => true;
         protected override bool UseHttp2LoopbackServer => false;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http1.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http1.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Test.Common;
+//using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    // This class is dedicated to SocketHttpHandler tests specific to HTTP/1.x.
+    public abstract class HttpClientHandlerTest_Http1 : HttpClientHandlerTestBase
+    {
+        protected override bool UseSocketsHttpHandler => true;
+        protected override bool UseHttp2LoopbackServer => false;
+
+        public HttpClientHandlerTest_Http1(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public async Task SendAsync_HostHeader_First()
+        {
+            // RFC 7230  3.2.2.  Field Order
+            await LoopbackServer.CreateServerAsync(async (server, url) =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Headers.Add("X-foo", "bar");
+
+                    Task sendTask = client.SendAsync(request);
+
+                    string[] headers = (await server.AcceptConnectionSendResponseAndCloseAsync()).ToArray();
+                    await sendTask;
+
+                    Assert.True(headers[1].StartsWith("Host"));
+                }
+            });
+        }
+    }
+}
+

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1677,12 +1677,6 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    public sealed class SocketsHttpHandlerTest_Http1 : HttpClientHandlerTest_Http1
-    {
-        public SocketsHttpHandlerTest_Http1(ITestOutputHelper output) : base(output) { }
-        protected override bool UseSocketsHttpHandler => true;
-    }
-
     public sealed class SocketsHttpHandlerTest_Http2 : HttpClientHandlerTest_Http2
     {
         public SocketsHttpHandlerTest_Http2(ITestOutputHelper output) : base(output) { }

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1677,6 +1677,12 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
+    public sealed class SocketsHttpHandlerTest_Http1 : HttpClientHandlerTest_Http1
+    {
+        public SocketsHttpHandlerTest_Http1(ITestOutputHelper output) : base(output) { }
+        protected override bool UseSocketsHttpHandler => true;
+    }
+
     public sealed class SocketsHttpHandlerTest_Http2 : HttpClientHandlerTest_Http2
     {
         public SocketsHttpHandlerTest_Http2(ITestOutputHelper output) : base(output) { }

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -147,6 +147,7 @@
     <Compile Include="NtAuthTests.cs" />
     <Compile Include="ReadOnlyMemoryContentTest.cs" />
     <Compile Include="SocketsHttpHandlerTest.cs" />
+    <Compile Include="HttpClientHandlerTest.Http1.cs" />
     <Compile Include="HttpClientHandlerTest.Http2.cs" />
     <Compile Include="$(CommonTestPath)\System\Net\Http\Http2Frames.cs">
       <Link>Common\System\Net\Http\Http2Frames.cs</Link>


### PR DESCRIPTION
Issue reported in #36135 is technically server bug as order of headers is irrelevant. However as @davidsh pointed out, rfc suggests to write "control data" headers first. If we follow that recommendation the reported site loads correctly and we behave as other HTTP implementations. 

fixes #36135 

Note that I decided to create new new test file. 
With overloads for Http2 and Platform it is getting harder to find place for tests covering only specific scenario. My plan is to slowly cleanup HttpClientHandlerTest to avoid running unnecessary tests.

 
 