### PR TITLE
Fix IDN Tests to support Unicode 11

### DIFF
--- a/src/System.Globalization.Extensions/tests/IdnMapping/Data/Factory.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/Data/Factory.cs
@@ -29,11 +29,13 @@ namespace System.Globalization.Tests
             string fileName = null;
             if (PlatformDetection.IsWindows7)
                 fileName = "IdnaTest_Win7.txt";
+            else if (PlatformDetection.IsWindows10Version1903OrGreater)
+                fileName = "IdnaTest_11.txt";
             else if (PlatformDetection.IsWindows10Version1703OrGreater)
                 fileName = "IdnaTest_9.txt";
             else
                 fileName = "IdnaTest_6.txt";
-            
+
             // test file 'IdnaTest.txt' is included as an embedded resource
             var name = typeof(Factory).GetTypeInfo().Assembly.GetManifestResourceNames().First(n => n.EndsWith(fileName, StringComparison.Ordinal));
             return typeof(Factory).GetTypeInfo().Assembly.GetManifestResourceStream(name);
@@ -60,6 +62,8 @@ namespace System.Globalization.Tests
         {
             if (PlatformDetection.IsWindows7)
                 return new Unicode_Win7_IdnaTest(line, lineCount);
+            else if (PlatformDetection.IsWindows10Version1903OrGreater)
+                return new Unicode_11_0_IdnaTest(line, lineCount);
             else if (PlatformDetection.IsWindows10Version1703OrGreater)
                 return new Unicode_9_0_IdnaTest(line, lineCount);
             else
@@ -69,9 +73,9 @@ namespace System.Globalization.Tests
         /// <summary>
         /// Abstracts retrieving the dataset so this can be changed depending on platform support, such as
         /// when the IDNA implementation is updated to a newer version of Unicode.  Windows 10 up to 1607 supports
-        /// and uses 6.0 in IDNA processing. Windows 10 1703 and greater currently uses 9.0 in IDNA processing. 
-        /// 
-        /// This method retrieves the dataset to be used by the test.  Windows implementation uses transitional 
+        /// and uses 6.0 in IDNA processing. Windows 10 1703 and greater currently uses 9.0 in IDNA processing.
+        ///
+        /// This method retrieves the dataset to be used by the test.  Windows implementation uses transitional
         /// mappings, which only affect 4 characters, known as deviations.  See the description at
         /// http://www.unicode.org/reports/tr46/#Deviations for more information.  Windows also throws an error
         /// when an empty string is given, so we want to filter that from the IDNA test set

--- a/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_11_0/IdnaTest_11.txt
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_11_0/IdnaTest_11.txt
@@ -1,0 +1,6331 @@
+# IdnaTestV2.txt
+# Date: 2018-05-22, 05:53:13 GMT
+# © 2018 Unicode®, Inc.
+# Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+# For terms of use, see http://www.unicode.org/terms_of_use.html
+# Contains test cases for verifying UTS #46 conformance. For more information,
+# see http://www.unicode.org/reports/tr46/
+#
+# FORMAT:
+#
+# This file is in UTF-8, where characters may be escaped using the \uXXXX or \x{XXXX}
+# convention where they could otherwise have a confusing display.
+# These characters include control codes and combining marks.
+# 
+# Columns (c1, c2,...) are separated by semicolons.
+# Leading and trailing spaces and tabs in each column are ignored.
+# Comments are indicated with hash marks.
+#
+# Column 1: source -          The source string to be tested
+# Column 2: toUnicode -       The result of applying toUnicode to the source,
+#                             with Transitional_Processing=false.
+#                             A blank value means the same as the source value.
+# Column 3: toUnicodeStatus - A set of status codes, each corresponding to a particular test.
+#                             A blank value means [] (no errors).
+# Column 4: toAsciiN -        The result of applying toASCII to the source,
+#                             with Transitional_Processing=false.
+#                             A blank value means the same as the toUnicode value.
+# Column 5: toAsciiNStatus -  A set of status codes, each corresponding to a particular test.
+#                             A blank value means the same as the toUnicodeStatus value.
+#                             An explicit [] means no errors.
+# Column 6: toAsciiT -        The result of applying toASCII to the source,
+#                             with Transitional_Processing=true.
+#                             A blank value means the same as the toAsciiN value.
+# Column 7: toAsciiTStatus -  A set of status codes, each corresponding to a particular test.
+#                             A blank value means the same as the toAsciiNStatus value.
+#                             An explicit [] means no errors.
+#
+# The line comments currently show visible characters that have been escaped. 
+# 
+# CONFORMANCE:
+#
+# To test for conformance to UTS #46, an implementation will perform the toUnicode, toAsciiN, and
+# toAsciiT operations on the source string, then verify the resulting strings and relevant status 
+# values.
+#
+# If the implementation converts illegal code points into U+FFFD (as per
+# http://www.unicode.org/reports/tr46/proposed.html#Processing) then the string comparisons need to
+# account for that by treating U+FFFD in the actual value as a wildcard when comparing to the 
+# expected value in the test file.
+#
+# A status in toUnicode, toAsciiN or toAsciiT is indicated by a value in square brackets,
+# such as "[B5 B6]". In such a case, the contents is a list of status codes based on the step 
+# numbers in UTS #46 and IDNA2008, with the following formats.
+#
+#   Pn for Section 4 Processing step n
+#   Vn for 4.1 Validity Criteria step n
+#   U1 for UseSTD3ASCIIRules
+#   An for 4.2 ToASCII step n
+#   Bn for Bidi (in IDNA2008)
+#   Cn for ContextJ (in IDNA2008)
+#   Xn for toUnicode issues (see below)
+#
+# Thus C1 = Appendix A.1. ZERO WIDTH NON-JOINER, and C2 = Appendix A.2. ZERO WIDTH JOINER. 
+# (The CONTEXTO tests are optional for client software, and not tested here.)
+#
+# Implementations that allow values of particular input flags to be false would ignore
+# the corresponding status codes listed in the table below when testing for errors.
+#
+# VerifyDnsLength:   P4
+# CheckHyphens:      V2, V3
+# CheckBidi:         V8
+# CheckJoiners:      V7
+# UseSTD3ASCIIRules: U1
+#
+# Implementations may be more strict than the default settings for UTS #46.
+# In particular, an implementation conformant to IDNA2008 would disallow the input for lines
+# marked with NV8.
+#
+# Implementations need only record that there is an error: they need not reproduce the
+# precise status codes (after removing the ignored status values).
+#
+# Compatibility errors
+#
+# The special error codes X3 and X4_2 are now returned where a toASCII error code
+# was formerly being generated in toUnicode due to an empty label.
+#
+# A3 was being generated in the following cases (in addition to its normal usage).
+#   • an empty label in toUnicode. In this case, it is replaced by X3.
+#
+# A4_2 was being generated in the following case (in addition to its normal usage).
+#   • an empty label in V8 (CheckBidi). In this case, it is being replaced by X4_2.
+# ============================================================================================
+fass.de; ; ; ; ; ;  # fass.de
+faß.de; ; ; xn--fa-hia.de; ; fass.de;  # faß.de
+Faß.de; faß.de; ; xn--fa-hia.de; ; fass.de;  # faß.de
+xn--fa-hia.de; faß.de; ; xn--fa-hia.de; ; ;  # faß.de
+
+# BIDI TESTS
+
+àא; ; [B5, B6]; xn--0ca24w; ; ;  # àא
+àא; àא; [B5, B6]; xn--0ca24w; ; ;  # àא
+Àא; àא; [B5, B6]; xn--0ca24w; ; ;  # àא
+Àא; àא; [B5, B6]; xn--0ca24w; ; ;  # àא
+xn--0ca24w; àא; [B5, B6]; xn--0ca24w; ; ;  # àא
+0à.א; ; [B1]; xn--0-sfa.xn--4db; ; ;  # 0à.א
+0à.א; 0à.א; [B1]; xn--0-sfa.xn--4db; ; ;  # 0à.א
+0À.א; 0à.א; [B1]; xn--0-sfa.xn--4db; ; ;  # 0à.א
+0À.א; 0à.א; [B1]; xn--0-sfa.xn--4db; ; ;  # 0à.א
+xn--0-sfa.xn--4db; 0à.א; [B1]; xn--0-sfa.xn--4db; ; ;  # 0à.א
+à.א̈; ; ; xn--0ca.xn--ssa73l; ; ;  # à.א̈
+à.א̈; à.א̈; ; xn--0ca.xn--ssa73l; ; ;  # à.א̈
+À.א̈; à.א̈; ; xn--0ca.xn--ssa73l; ; ;  # à.א̈
+À.א̈; à.א̈; ; xn--0ca.xn--ssa73l; ; ;  # à.א̈
+xn--0ca.xn--ssa73l; à.א̈; ; xn--0ca.xn--ssa73l; ; ;  # à.א̈
+à.א0٠א; ; [B4]; xn--0ca.xn--0-zhcb98c; ; ;  # à.א0٠א
+à.א0٠א; à.א0٠א; [B4]; xn--0ca.xn--0-zhcb98c; ; ;  # à.א0٠א
+À.א0٠א; à.א0٠א; [B4]; xn--0ca.xn--0-zhcb98c; ; ;  # à.א0٠א
+À.א0٠א; à.א0٠א; [B4]; xn--0ca.xn--0-zhcb98c; ; ;  # à.א0٠א
+xn--0ca.xn--0-zhcb98c; à.א0٠א; [B4]; xn--0ca.xn--0-zhcb98c; ; ;  # à.א0٠א
+̈.א; ; [B1, B3, B6, V5]; xn--ssa.xn--4db; ; ;  # ̈.א
+xn--ssa.xn--4db; ̈.א; [B1, B3, B6, V5]; xn--ssa.xn--4db; ; ;  # ̈.א
+à.א0٠; ; [B4]; xn--0ca.xn--0-zhc74b; ; ;  # à.א0٠
+à.א0٠; à.א0٠; [B4]; xn--0ca.xn--0-zhc74b; ; ;  # à.א0٠
+À.א0٠; à.א0٠; [B4]; xn--0ca.xn--0-zhc74b; ; ;  # à.א0٠
+À.א0٠; à.א0٠; [B4]; xn--0ca.xn--0-zhc74b; ; ;  # à.א0٠
+xn--0ca.xn--0-zhc74b; à.א0٠; [B4]; xn--0ca.xn--0-zhc74b; ; ;  # à.א0٠
+àˇ.א; ; [B6]; xn--0ca88g.xn--4db; ; ;  # àˇ.א
+àˇ.א; àˇ.א; [B6]; xn--0ca88g.xn--4db; ; ;  # àˇ.א
+Àˇ.א; àˇ.א; [B6]; xn--0ca88g.xn--4db; ; ;  # àˇ.א
+Àˇ.א; àˇ.א; [B6]; xn--0ca88g.xn--4db; ; ;  # àˇ.א
+xn--0ca88g.xn--4db; àˇ.א; [B6]; xn--0ca88g.xn--4db; ; ;  # àˇ.א
+à̈.א; ; ; xn--0ca81i.xn--4db; ; ;  # à̈.א
+à̈.א; à̈.א; ; xn--0ca81i.xn--4db; ; ;  # à̈.א
+À̈.א; à̈.א; ; xn--0ca81i.xn--4db; ; ;  # à̈.א
+À̈.א; à̈.א; ; xn--0ca81i.xn--4db; ; ;  # à̈.א
+xn--0ca81i.xn--4db; à̈.א; ; xn--0ca81i.xn--4db; ; ;  # à̈.א
+
+# CONTEXT TESTS
+
+a‌b; ; [C1]; xn--ab-j1t; ; ab; [] # ab
+A‌B; a‌b; [C1]; xn--ab-j1t; ; ab; [] # ab
+A‌b; a‌b; [C1]; xn--ab-j1t; ; ab; [] # ab
+ab; ; ; ; ; ;  # ab
+xn--ab-j1t; a‌b; [C1]; xn--ab-j1t; ; ;  # ab
+a्‌b; ; ; xn--ab-fsf604u; ; xn--ab-fsf;  # a्b
+A्‌B; a्‌b; ; xn--ab-fsf604u; ; xn--ab-fsf;  # a्b
+A्‌b; a्‌b; ; xn--ab-fsf604u; ; xn--ab-fsf;  # a्b
+xn--ab-fsf; a्b; ; xn--ab-fsf; ; ;  # a्b
+a्b; ; ; xn--ab-fsf; ; ;  # a्b
+A्B; a्b; ; xn--ab-fsf; ; ;  # a्b
+A्b; a्b; ; xn--ab-fsf; ; ;  # a्b
+xn--ab-fsf604u; a्‌b; ; xn--ab-fsf604u; ; ;  # a्b
+̈‌̈بb; ; [B1, C1, V5]; xn--b-bcba413a2w8b; ; xn--b-bcba413a; [B1, V5] # ̈̈بb
+̈‌̈بB; ̈‌̈بb; [B1, C1, V5]; xn--b-bcba413a2w8b; ; xn--b-bcba413a; [B1, V5] # ̈̈بb
+xn--b-bcba413a; ̈̈بb; [B1, V5]; xn--b-bcba413a; ; ;  # ̈̈بb
+xn--b-bcba413a2w8b; ̈‌̈بb; [B1, C1, V5]; xn--b-bcba413a2w8b; ; ;  # ̈̈بb
+aب̈‌̈; ; [B5, B6, C1]; xn--a-ccba213a5w8b; ; xn--a-ccba213a; [B5, B6] # aب̈̈
+Aب̈‌̈; aب̈‌̈; [B5, B6, C1]; xn--a-ccba213a5w8b; ; xn--a-ccba213a; [B5, B6] # aب̈̈
+xn--a-ccba213a; aب̈̈; [B5, B6]; xn--a-ccba213a; ; ;  # aب̈̈
+xn--a-ccba213a5w8b; aب̈‌̈; [B5, B6, C1]; xn--a-ccba213a5w8b; ; ;  # aب̈̈
+aب̈‌̈بb; ; [B5]; xn--ab-uuba211bca8057b; ; xn--ab-uuba211bca;  # aب̈̈بb
+Aب̈‌̈بB; aب̈‌̈بb; [B5]; xn--ab-uuba211bca8057b; ; xn--ab-uuba211bca;  # aب̈̈بb
+Aب̈‌̈بb; aب̈‌̈بb; [B5]; xn--ab-uuba211bca8057b; ; xn--ab-uuba211bca;  # aب̈̈بb
+xn--ab-uuba211bca; aب̈̈بb; [B5]; xn--ab-uuba211bca; ; ;  # aب̈̈بb
+xn--ab-uuba211bca8057b; aب̈‌̈بb; [B5]; xn--ab-uuba211bca8057b; ; ;  # aب̈̈بb
+a‍b; ; [C2]; xn--ab-m1t; ; ab; [] # ab
+A‍B; a‍b; [C2]; xn--ab-m1t; ; ab; [] # ab
+A‍b; a‍b; [C2]; xn--ab-m1t; ; ab; [] # ab
+xn--ab-m1t; a‍b; [C2]; xn--ab-m1t; ; ;  # ab
+a्‍b; ; ; xn--ab-fsf014u; ; xn--ab-fsf;  # a्b
+A्‍B; a्‍b; ; xn--ab-fsf014u; ; xn--ab-fsf;  # a्b
+A्‍b; a्‍b; ; xn--ab-fsf014u; ; xn--ab-fsf;  # a्b
+xn--ab-fsf014u; a्‍b; ; xn--ab-fsf014u; ; ;  # a्b
+̈‍̈بb; ; [B1, C2, V5]; xn--b-bcba413a7w8b; ; xn--b-bcba413a; [B1, V5] # ̈̈بb
+̈‍̈بB; ̈‍̈بb; [B1, C2, V5]; xn--b-bcba413a7w8b; ; xn--b-bcba413a; [B1, V5] # ̈̈بb
+xn--b-bcba413a7w8b; ̈‍̈بb; [B1, C2, V5]; xn--b-bcba413a7w8b; ; ;  # ̈̈بb
+aب̈‍̈; ; [B5, B6, C2]; xn--a-ccba213abx8b; ; xn--a-ccba213a; [B5, B6] # aب̈̈
+Aب̈‍̈; aب̈‍̈; [B5, B6, C2]; xn--a-ccba213abx8b; ; xn--a-ccba213a; [B5, B6] # aب̈̈
+xn--a-ccba213abx8b; aب̈‍̈; [B5, B6, C2]; xn--a-ccba213abx8b; ; ;  # aب̈̈
+aب̈‍̈بb; ; [B5, C2]; xn--ab-uuba211bca5157b; ; xn--ab-uuba211bca; [B5] # aب̈̈بb
+Aب̈‍̈بB; aب̈‍̈بb; [B5, C2]; xn--ab-uuba211bca5157b; ; xn--ab-uuba211bca; [B5] # aب̈̈بb
+Aب̈‍̈بb; aب̈‍̈بb; [B5, C2]; xn--ab-uuba211bca5157b; ; xn--ab-uuba211bca; [B5] # aب̈̈بb
+xn--ab-uuba211bca5157b; aب̈‍̈بb; [B5, C2]; xn--ab-uuba211bca5157b; ; ;  # aب̈̈بb
+
+# SELECTED TESTS
+
+¡; ; ; xn--7a; ; ;  # ¡
+xn--7a; ¡; ; xn--7a; ; ;  # ¡
+᧚; ; ; xn--pkf; ; ;  # ᧚
+xn--pkf; ᧚; ; xn--pkf; ; ;  # ᧚
+。; .; [X4_2]; ; [A4_2]; ;  # .
+.; ; [X4_2]; ; [A4_2]; ;  # .
+ꭠ; ; ; xn--3y9a; ; ;  # ꭠ
+xn--3y9a; ꭠ; ; xn--3y9a; ; ;  # ꭠ
+1234567890ä1234567890123456789012345678901234567890123456; ; ; xn--12345678901234567890123456789012345678901234567890123456-fxe; [A4_2]; ;  # 1234567890ä1234567890123456789012345678901234567890123456
+1234567890ä1234567890123456789012345678901234567890123456; 1234567890ä1234567890123456789012345678901234567890123456; ; xn--12345678901234567890123456789012345678901234567890123456-fxe; [A4_2]; ;  # 1234567890ä1234567890123456789012345678901234567890123456
+1234567890Ä1234567890123456789012345678901234567890123456; 1234567890ä1234567890123456789012345678901234567890123456; ; xn--12345678901234567890123456789012345678901234567890123456-fxe; [A4_2]; ;  # 1234567890ä1234567890123456789012345678901234567890123456
+1234567890Ä1234567890123456789012345678901234567890123456; 1234567890ä1234567890123456789012345678901234567890123456; ; xn--12345678901234567890123456789012345678901234567890123456-fxe; [A4_2]; ;  # 1234567890ä1234567890123456789012345678901234567890123456
+xn--12345678901234567890123456789012345678901234567890123456-fxe; 1234567890ä1234567890123456789012345678901234567890123456; ; xn--12345678901234567890123456789012345678901234567890123456-fxe; [A4_2]; ;  # 1234567890ä1234567890123456789012345678901234567890123456
+www.eXample.cOm; www.example.com; ; ; ; ;  # www.example.com
+Bücher.de; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+Bücher.de; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+bücher.de; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+bücher.de; ; ; xn--bcher-kva.de; ; ;  # bücher.de
+BÜCHER.DE; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+BÜCHER.DE; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+xn--bcher-kva.de; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+ÖBB; öbb; ; xn--bb-eka; ; ;  # öbb
+ÖBB; öbb; ; xn--bb-eka; ; ;  # öbb
+öbb; öbb; ; xn--bb-eka; ; ;  # öbb
+öbb; ; ; xn--bb-eka; ; ;  # öbb
+Öbb; öbb; ; xn--bb-eka; ; ;  # öbb
+Öbb; öbb; ; xn--bb-eka; ; ;  # öbb
+xn--bb-eka; öbb; ; xn--bb-eka; ; ;  # öbb
+βόλος.com; ; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
+βόλος.com; βόλος.com; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
+ΒΌΛΟΣ.COM; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+ΒΌΛΟΣ.COM; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+βόλοσ.com; ; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+βόλοσ.com; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+Βόλοσ.com; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+Βόλοσ.com; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+xn--nxasmq6b.com; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+Βόλος.com; βόλος.com; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
+Βόλος.com; βόλος.com; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
+xn--nxasmm1c.com; βόλος.com; ; xn--nxasmm1c.com; ; ;  # βόλος.com
+xn--nxasmm1c; βόλος; ; xn--nxasmm1c; ; ;  # βόλος
+βόλος; ; ; xn--nxasmm1c; ; xn--nxasmq6b;  # βόλος
+βόλος; βόλος; ; xn--nxasmm1c; ; xn--nxasmq6b;  # βόλος
+ΒΌΛΟΣ; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+ΒΌΛΟΣ; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+βόλοσ; ; ; xn--nxasmq6b; ; ;  # βόλοσ
+βόλοσ; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+Βόλοσ; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+Βόλοσ; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+xn--nxasmq6b; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+Βόλος; βόλος; ; xn--nxasmm1c; ; xn--nxasmq6b;  # βόλος
+Βόλος; βόλος; ; xn--nxasmm1c; ; xn--nxasmq6b;  # βόλος
+www.ශ්‍රී.com; ; ; www.xn--10cl1a0b660p.com; ; www.xn--10cl1a0b.com;  # www.ශ්රී.com
+WWW.ශ්‍රී.COM; www.ශ්‍රී.com; ; www.xn--10cl1a0b660p.com; ; www.xn--10cl1a0b.com;  # www.ශ්රී.com
+Www.ශ්‍රී.com; www.ශ්‍රී.com; ; www.xn--10cl1a0b660p.com; ; www.xn--10cl1a0b.com;  # www.ශ්රී.com
+www.xn--10cl1a0b.com; www.ශ්රී.com; ; www.xn--10cl1a0b.com; ; ;  # www.ශ්රී.com
+www.ශ්රී.com; ; ; www.xn--10cl1a0b.com; ; ;  # www.ශ්රී.com
+WWW.ශ්රී.COM; www.ශ්රී.com; ; www.xn--10cl1a0b.com; ; ;  # www.ශ්රී.com
+Www.ශ්රී.com; www.ශ්රී.com; ; www.xn--10cl1a0b.com; ; ;  # www.ශ්රී.com
+www.xn--10cl1a0b660p.com; www.ශ්‍රී.com; ; www.xn--10cl1a0b660p.com; ; ;  # www.ශ්රී.com
+نامه‌ای; ; ; xn--mgba3gch31f060k; ; xn--mgba3gch31f;  # نامهای
+xn--mgba3gch31f; نامهای; ; xn--mgba3gch31f; ; ;  # نامهای
+نامهای; ; ; xn--mgba3gch31f; ; ;  # نامهای
+xn--mgba3gch31f060k; نامه‌ای; ; xn--mgba3gch31f060k; ; ;  # نامهای
+xn--mgba3gch31f060k.com; نامه‌ای.com; ; xn--mgba3gch31f060k.com; ; ;  # نامهای.com
+نامه‌ای.com; ; ; xn--mgba3gch31f060k.com; ; xn--mgba3gch31f.com;  # نامهای.com
+نامه‌ای.COM; نامه‌ای.com; ; xn--mgba3gch31f060k.com; ; xn--mgba3gch31f.com;  # نامهای.com
+xn--mgba3gch31f.com; نامهای.com; ; xn--mgba3gch31f.com; ; ;  # نامهای.com
+نامهای.com; ; ; xn--mgba3gch31f.com; ; ;  # نامهای.com
+نامهای.COM; نامهای.com; ; xn--mgba3gch31f.com; ; ;  # نامهای.com
+a.b．c。d｡; a.b.c.d.; ; ; ; ;  # a.b.c.d.
+a.b.c。d。; a.b.c.d.; ; ; ; ;  # a.b.c.d.
+A.B.C。D。; a.b.c.d.; ; ; ; ;  # a.b.c.d.
+A.b.c。D。; a.b.c.d.; ; ; ; ;  # a.b.c.d.
+a.b.c.d.; ; ; ; ; ;  # a.b.c.d.
+A.B．C。D｡; a.b.c.d.; ; ; ; ;  # a.b.c.d.
+A.b．c。D｡; a.b.c.d.; ; ; ; ;  # a.b.c.d.
+Ü.xn--tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.xn--tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+ü.xn--tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+ü.xn--tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.XN--TDA; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.XN--TDA; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.xn--Tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.xn--Tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+xn--tda.xn--tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+ü.ü; ; ; xn--tda.xn--tda; ; ;  # ü.ü
+ü.ü; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.Ü; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.Ü; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.ü; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.ü; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+xn--u-ccb; ü; [V1]; xn--u-ccb; ; ;  # ü
+a⒈com; ; [P1, V6]; xn--acom-0w1b; ; ;  # a⒈com
+a1.com; ; ; ; ; ;  # a1.com
+A⒈COM; a⒈com; [P1, V6]; xn--acom-0w1b; ; ;  # a⒈com
+A⒈Com; a⒈com; [P1, V6]; xn--acom-0w1b; ; ;  # a⒈com
+xn--acom-0w1b; a⒈com; [V6]; xn--acom-0w1b; ; ;  # a⒈com
+xn--a-ecp.ru; a⒈.ru; [V6]; xn--a-ecp.ru; ; ;  # a⒈.ru
+xn--0.pt; ; [P4]; ; ; ;  # xn--0.pt
+xn--a.pt; .pt; [V6]; xn--a.pt; ; ;  # .pt
+xn--a-Ä.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+xn--a-Ä.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+xn--a-ä.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+xn--a-ä.pt; ; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+XN--A-Ä.PT; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+XN--A-Ä.PT; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+Xn--A-Ä.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+Xn--A-Ä.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+xn--xn--a--gua.pt; xn--a-ä.pt; [V2]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+日本語。ＪＰ; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語。JP; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語。jp; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語。Jp; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+xn--wgv71a119e.jp; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語.jp; ; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語.JP; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語.Jp; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語。ｊｐ; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語。Ｊｐ; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+☕; ; ; xn--53h; ; ;  # ☕
+xn--53h; ☕; ; xn--53h; ; ;  # ☕
+1.aß‌‍b‌‍cßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß̂ßz; ; [C1, C2]; 1.xn--abcdexyz-qyacaaabaaaaaaabaaaaaaaaabaaaaaaaaabaaaaaaaa010ze2isb1140zba8cc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.aßbcßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß̂ßz
+1.ASS‌‍B‌‍CSSSSSSSSDΣΣSSSSSSSSSSSSSSSSESSSSSSSSSSSSSSSSSSSSXSSSSSSSSSSSSSSSSSSSSYSSSSSSSSSSSSSSSŜSSZ; 1.ass‌‍b‌‍cssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.ASS‌‍B‌‍CSSSSSSSSDΣΣSSSSSSSSSSSSSSSSESSSSSSSSSSSSSSSSSSSSXSSSSSSSSSSSSSSSSSSSSYSSSSSSSSSSSSSSSŜSSZ; 1.ass‌‍b‌‍cssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.ass‌‍b‌‍cssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.ass‌‍b‌‍cssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; 1.ass‌‍b‌‍cssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.Ass‌‍b‌‍cssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; 1.ass‌‍b‌‍cssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.Ass‌‍b‌‍cssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; 1.ass‌‍b‌‍cssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.ASSBCSSSSSSSSDΣΣSSSSSSSSSSSSSSSSESSSSSSSSSSSSSSSSSSSSXSSSSSSSSSSSSSSSSSSSSYSSSSSSSSSSSSSSSŜSSZ; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.ASSBCSSSSSSSSDΣΣSSSSSSSSSSSSSSSSESSSSSSSSSSSSSSSSSSSSXSSSSSSSSSSSSSSSSSSSSYSSSSSSSSSSSSSSSŜSSZ; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.Assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.Assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; 1.ass‌‍b‌‍cssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.Aß‌‍b‌‍cßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß̂ßz; 1.aß‌‍b‌‍cßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß̂ßz; [C1, C2]; 1.xn--abcdexyz-qyacaaabaaaaaaabaaaaaaaaabaaaaaaaaabaaaaaaaa010ze2isb1140zba8cc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.aßbcßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß̂ßz
+1.xn--abcdexyz-qyacaaabaaaaaaabaaaaaaaaabaaaaaaaaabaaaaaaaa010ze2isb1140zba8cc; 1.aß‌‍b‌‍cßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß̂ßz; [C1, C2]; 1.xn--abcdexyz-qyacaaabaaaaaaabaaaaaaaaabaaaaaaaaabaaaaaaaa010ze2isb1140zba8cc; [C1, C2, A4_2]; ;  # 1.aßbcßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß̂ßz
+‌x‍n‌-‍-bß; ; [C1, C2]; xn--xn--b-pqa5796ccahd; ; xn--bss; [] # xn--bß
+‌X‍N‌-‍-BSS; ‌x‍n‌-‍-bss; [C1, C2]; xn--xn--bss-7z6ccid; ; xn--bss; [] # xn--bss
+‌x‍n‌-‍-bss; ; [C1, C2]; xn--xn--bss-7z6ccid; ; xn--bss; [] # xn--bss
+‌X‍n‌-‍-Bss; ‌x‍n‌-‍-bss; [C1, C2]; xn--xn--bss-7z6ccid; ; xn--bss; [] # xn--bss
+xn--bss; 夙; ; xn--bss; ; ;  # 夙
+夙; ; ; xn--bss; ; ;  # 夙
+xn--xn--bss-7z6ccid; ‌x‍n‌-‍-bss; [C1, C2]; xn--xn--bss-7z6ccid; ; ;  # xn--bss
+‌X‍n‌-‍-Bß; ‌x‍n‌-‍-bß; [C1, C2]; xn--xn--b-pqa5796ccahd; ; xn--bss; [] # xn--bß
+xn--xn--b-pqa5796ccahd; ‌x‍n‌-‍-bß; [C1, C2]; xn--xn--b-pqa5796ccahd; ; ;  # xn--bß
+ˣ͏ℕ​﹣­－᠌ℬ︀ſ⁤𝔰󠇯ﬄ; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+x͏N​-­-᠌B︀s⁤s󠇯ffl; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+x͏n​-­-᠌b︀s⁤s󠇯ffl; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+X͏N​-­-᠌B︀S⁤S󠇯FFL; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+X͏n​-­-᠌B︀s⁤s󠇯ffl; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+xn--bssffl; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+夡夞夜夙; ; ; xn--bssffl; ; ;  # 夡夞夜夙
+ˣ͏ℕ​﹣­－᠌ℬ︀S⁤𝔰󠇯FFL; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+x͏N​-­-᠌B︀S⁤s󠇯FFL; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+ˣ͏ℕ​﹣­－᠌ℬ︀s⁤𝔰󠇯ffl; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; ; ; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; ; ; ; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.
+123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; ; ; ; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012
+123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; ; ; ; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890
+123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; ; ; ; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.
+123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; ; ; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+ä1234567890123456789012345678901234567890123456789012345; ; ; xn--1234567890123456789012345678901234567890123456789012345-9te; ; ;  # ä1234567890123456789012345678901234567890123456789012345
+ä1234567890123456789012345678901234567890123456789012345; ä1234567890123456789012345678901234567890123456789012345; ; xn--1234567890123456789012345678901234567890123456789012345-9te; ; ;  # ä1234567890123456789012345678901234567890123456789012345
+Ä1234567890123456789012345678901234567890123456789012345; ä1234567890123456789012345678901234567890123456789012345; ; xn--1234567890123456789012345678901234567890123456789012345-9te; ; ;  # ä1234567890123456789012345678901234567890123456789012345
+Ä1234567890123456789012345678901234567890123456789012345; ä1234567890123456789012345678901234567890123456789012345; ; xn--1234567890123456789012345678901234567890123456789012345-9te; ; ;  # ä1234567890123456789012345678901234567890123456789012345
+xn--1234567890123456789012345678901234567890123456789012345-9te; ä1234567890123456789012345678901234567890123456789012345; ; xn--1234567890123456789012345678901234567890123456789012345-9te; ; ;  # ä1234567890123456789012345678901234567890123456789012345
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.
+123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901.
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012
+123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789012
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890
+123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.
+123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890.
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901
+a.b..-q--a-.e; ; [V2, V3, X4_2]; ; [V2, V3, A4_2]; ;  # a.b..-q--a-.e
+a.b..-q--ä-.e; ; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+a.b..-q--ä-.e; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+A.B..-Q--Ä-.E; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+A.B..-Q--Ä-.E; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+A.b..-Q--Ä-.E; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+A.b..-Q--Ä-.E; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+a.b..xn---q----jra.e; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+a..c; ; [X4_2]; ; [A4_2]; ;  # a..c
+a.-b.; ; [V3]; ; ; ;  # a.-b.
+a.b-.c; ; [V3]; ; ; ;  # a.b-.c
+a.-.c; ; [V3]; ; ; ;  # a.-.c
+a.bc--de.f; ; [V2]; ; ; ;  # a.bc--de.f
+ä.­.c; ä..c; [X4_2]; xn--4ca..c; [A4_2]; ;  # ä..c
+ä.­.c; ä..c; [X4_2]; xn--4ca..c; [A4_2]; ;  # ä..c
+Ä.­.C; ä..c; [X4_2]; xn--4ca..c; [A4_2]; ;  # ä..c
+Ä.­.C; ä..c; [X4_2]; xn--4ca..c; [A4_2]; ;  # ä..c
+xn--4ca..c; ä..c; [X4_2]; xn--4ca..c; [A4_2]; ;  # ä..c
+ä.-b.; ; [V3]; xn--4ca.-b.; ; ;  # ä.-b.
+ä.-b.; ä.-b.; [V3]; xn--4ca.-b.; ; ;  # ä.-b.
+Ä.-B.; ä.-b.; [V3]; xn--4ca.-b.; ; ;  # ä.-b.
+Ä.-B.; ä.-b.; [V3]; xn--4ca.-b.; ; ;  # ä.-b.
+xn--4ca.-b.; ä.-b.; [V3]; xn--4ca.-b.; ; ;  # ä.-b.
+ä.b-.c; ; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+ä.b-.c; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+Ä.B-.C; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+Ä.B-.C; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+Ä.b-.C; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+Ä.b-.C; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+xn--4ca.b-.c; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+ä.-.c; ; [V3]; xn--4ca.-.c; ; ;  # ä.-.c
+ä.-.c; ä.-.c; [V3]; xn--4ca.-.c; ; ;  # ä.-.c
+Ä.-.C; ä.-.c; [V3]; xn--4ca.-.c; ; ;  # ä.-.c
+Ä.-.C; ä.-.c; [V3]; xn--4ca.-.c; ; ;  # ä.-.c
+xn--4ca.-.c; ä.-.c; [V3]; xn--4ca.-.c; ; ;  # ä.-.c
+ä.bc--de.f; ; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+ä.bc--de.f; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+Ä.BC--DE.F; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+Ä.BC--DE.F; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+Ä.bc--De.f; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+Ä.bc--De.f; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+xn--4ca.bc--de.f; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+a.b.̈c.d; ; [V5]; a.b.xn--c-bcb.d; ; ;  # a.b.̈c.d
+A.B.̈C.D; a.b.̈c.d; [V5]; a.b.xn--c-bcb.d; ; ;  # a.b.̈c.d
+A.b.̈c.d; a.b.̈c.d; [V5]; a.b.xn--c-bcb.d; ; ;  # a.b.̈c.d
+a.b.xn--c-bcb.d; a.b.̈c.d; [V5]; a.b.xn--c-bcb.d; ; ;  # a.b.̈c.d
+A0; a0; ; ; ; ;  # a0
+0A; 0a; ; ; ; ;  # 0a
+0A.א; 0a.א; [B1]; 0a.xn--4db; ; ;  # 0a.א
+0a.א; ; [B1]; 0a.xn--4db; ; ;  # 0a.א
+0a.xn--4db; 0a.א; [B1]; 0a.xn--4db; ; ;  # 0a.א
+c.xn--0-eha.xn--4db; c.0ü.א; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+b-.א; ; [B6, V3]; b-.xn--4db; ; ;  # b-.א
+B-.א; b-.א; [B6, V3]; b-.xn--4db; ; ;  # b-.א
+b-.xn--4db; b-.א; [B6, V3]; b-.xn--4db; ; ;  # b-.א
+d.xn----dha.xn--4db; d.ü-.א; [B6, V3]; d.xn----dha.xn--4db; ; ;  # d.ü-.א
+aא; ; [B5, B6]; xn--a-0hc; ; ;  # aא
+Aא; aא; [B5, B6]; xn--a-0hc; ; ;  # aא
+xn--a-0hc; aא; [B5, B6]; xn--a-0hc; ; ;  # aא
+אׇ; ; ; xn--vdbr; ; ;  # אׇ
+xn--vdbr; אׇ; ; xn--vdbr; ; ;  # אׇ
+א9ׇ; ; ; xn--9-ihcz; ; ;  # א9ׇ
+xn--9-ihcz; א9ׇ; ; xn--9-ihcz; ; ;  # א9ׇ
+אaׇ; ; [B2, B3]; xn--a-ihcz; ; ;  # אaׇ
+אAׇ; אaׇ; [B2, B3]; xn--a-ihcz; ; ;  # אaׇ
+xn--a-ihcz; אaׇ; [B2, B3]; xn--a-ihcz; ; ;  # אaׇ
+את; ; ; xn--4db6c; ; ;  # את
+xn--4db6c; את; ; xn--4db6c; ; ;  # את
+א׳ת; ; ; xn--4db6c0a; ; ;  # א׳ת
+xn--4db6c0a; א׳ת; ; xn--4db6c0a; ; ;  # א׳ת
+aאTz; aאtz; [B5]; xn--atz-qpe; ; ;  # aאtz
+aאtz; ; [B5]; xn--atz-qpe; ; ;  # aאtz
+AאTZ; aאtz; [B5]; xn--atz-qpe; ; ;  # aאtz
+Aאtz; aאtz; [B5]; xn--atz-qpe; ; ;  # aאtz
+xn--atz-qpe; aאtz; [B5]; xn--atz-qpe; ; ;  # aאtz
+אTת; אtת; [B2]; xn--t-zhc3f; ; ;  # אtת
+אtת; ; [B2]; xn--t-zhc3f; ; ;  # אtת
+xn--t-zhc3f; אtת; [B2]; xn--t-zhc3f; ; ;  # אtת
+א7ת; ; ; xn--7-zhc3f; ; ;  # א7ת
+xn--7-zhc3f; א7ת; ; xn--7-zhc3f; ; ;  # א7ת
+א٧ת; ; ; xn--4db6c6t; ; ;  # א٧ת
+xn--4db6c6t; א٧ת; ; xn--4db6c6t; ; ;  # א٧ת
+a7٧z; ; [B5]; xn--a7z-06e; ; ;  # a7٧z
+A7٧Z; a7٧z; [B5]; xn--a7z-06e; ; ;  # a7٧z
+A7٧z; a7٧z; [B5]; xn--a7z-06e; ; ;  # a7٧z
+xn--a7z-06e; a7٧z; [B5]; xn--a7z-06e; ; ;  # a7٧z
+א7٧ת; ; [B4]; xn--7-zhc3fty; ; ;  # א7٧ת
+xn--7-zhc3fty; א7٧ת; [B4]; xn--7-zhc3fty; ; ;  # א7٧ת
+ஹ்‍; ; ; xn--dmc4b194h; ; xn--dmc4b;  # ஹ்
+xn--dmc4b; ஹ்; ; xn--dmc4b; ; ;  # ஹ்
+ஹ்; ; ; xn--dmc4b; ; ;  # ஹ்
+xn--dmc4b194h; ஹ்‍; ; xn--dmc4b194h; ; ;  # ஹ்
+ஹ‍; ; [C2]; xn--dmc225h; ; xn--dmc; [] # ஹ
+xn--dmc; ஹ; ; xn--dmc; ; ;  # ஹ
+ஹ; ; ; xn--dmc; ; ;  # ஹ
+xn--dmc225h; ஹ‍; [C2]; xn--dmc225h; ; ;  # ஹ
+‍; ; [C2]; xn--1ug; ; ; [A4_2] # 
+; ; [X4_2]; ; [A4_2]; ;  # 
+xn--1ug; ‍; [C2]; xn--1ug; ; ;  # 
+ஹ்‌; ; ; xn--dmc4by94h; ; xn--dmc4b;  # ஹ்
+xn--dmc4by94h; ஹ்‌; ; xn--dmc4by94h; ; ;  # ஹ்
+ஹ‌; ; [C1]; xn--dmc025h; ; xn--dmc; [] # ஹ
+xn--dmc025h; ஹ‌; [C1]; xn--dmc025h; ; ;  # ஹ
+‌; ; [C1]; xn--0ug; ; ; [A4_2] # 
+xn--0ug; ‌; [C1]; xn--0ug; ; ;  # 
+لٰ‌ۭۯ; ; ; xn--ghb2gxqia7523a; ; xn--ghb2gxqia;  # لٰۭۯ
+xn--ghb2gxqia; لٰۭۯ; ; xn--ghb2gxqia; ; ;  # لٰۭۯ
+لٰۭۯ; ; ; xn--ghb2gxqia; ; ;  # لٰۭۯ
+xn--ghb2gxqia7523a; لٰ‌ۭۯ; ; xn--ghb2gxqia7523a; ; ;  # لٰۭۯ
+لٰ‌ۯ; ; ; xn--ghb2g3qq34f; ; xn--ghb2g3q;  # لٰۯ
+xn--ghb2g3q; لٰۯ; ; xn--ghb2g3q; ; ;  # لٰۯ
+لٰۯ; ; ; xn--ghb2g3q; ; ;  # لٰۯ
+xn--ghb2g3qq34f; لٰ‌ۯ; ; xn--ghb2g3qq34f; ; ;  # لٰۯ
+ل‌ۭۯ; ; ; xn--ghb25aga828w; ; xn--ghb25aga;  # لۭۯ
+xn--ghb25aga; لۭۯ; ; xn--ghb25aga; ; ;  # لۭۯ
+لۭۯ; ; ; xn--ghb25aga; ; ;  # لۭۯ
+xn--ghb25aga828w; ل‌ۭۯ; ; xn--ghb25aga828w; ; ;  # لۭۯ
+ل‌ۯ; ; ; xn--ghb65a953d; ; xn--ghb65a;  # لۯ
+xn--ghb65a; لۯ; ; xn--ghb65a; ; ;  # لۯ
+لۯ; ; ; xn--ghb65a; ; ;  # لۯ
+xn--ghb65a953d; ل‌ۯ; ; xn--ghb65a953d; ; ;  # لۯ
+لٰ‌ۭ; ; [B3, C1]; xn--ghb2gxqy34f; ; xn--ghb2gxq; [] # لٰۭ
+xn--ghb2gxq; لٰۭ; ; xn--ghb2gxq; ; ;  # لٰۭ
+لٰۭ; ; ; xn--ghb2gxq; ; ;  # لٰۭ
+xn--ghb2gxqy34f; لٰ‌ۭ; [B3, C1]; xn--ghb2gxqy34f; ; ;  # لٰۭ
+ۯ‌ۯ; ; [C1]; xn--cmba004q; ; xn--cmba; [] # ۯۯ
+xn--cmba; ۯۯ; ; xn--cmba; ; ;  # ۯۯ
+ۯۯ; ; ; xn--cmba; ; ;  # ۯۯ
+xn--cmba004q; ۯ‌ۯ; [C1]; xn--cmba004q; ; ;  # ۯۯ
+ل‌; ; [B3, C1]; xn--ghb413k; ; xn--ghb; [] # ل
+xn--ghb; ل; ; xn--ghb; ; ;  # ل
+ل; ; ; xn--ghb; ; ;  # ل
+xn--ghb413k; ل‌; [B3, C1]; xn--ghb413k; ; ;  # ل
+a。。b; a..b; [X4_2]; ; [A4_2]; ;  # a..b
+A。。B; a..b; [X4_2]; ; [A4_2]; ;  # a..b
+a..b; ; [X4_2]; ; [A4_2]; ;  # a..b
+‍。。ڹ‌; ‍..ڹ‌; [B1, B3, C1, C2, X4_2]; xn--1ug..xn--skb080k; [B1, B3, C1, C2, A4_2]; ..xn--skb; [A4_2] # ..ڹ
+..xn--skb; ..ڹ; [X4_2]; ..xn--skb; [A4_2]; ;  # ..ڹ
+xn--1ug..xn--skb080k; ‍..ڹ‌; [B1, B3, C1, C2, X4_2]; xn--1ug..xn--skb080k; [B1, B3, C1, C2, A4_2]; ;  # ..ڹ
+א0٠; ; [B4]; xn--0-zhc74b; ; ;  # א0٠
+xn--0-zhc74b; א0٠; [B4]; xn--0-zhc74b; ; ;  # א0٠
+$; ; [P1, V6]; ; ; ;  # $
+
+# RANDOMIZED TESTS
+
+c.0ü.א; ; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+c.0ü.א; c.0ü.א; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+C.0Ü.א; c.0ü.א; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+C.0Ü.א; c.0ü.א; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+C.0ü.א; c.0ü.א; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+C.0ü.א; c.0ü.א; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+⒕∝ٟ򓤦．-󠄯; ⒕∝ٟ򓤦.-; [P1, V3, V6]; xn--7hb713lfwbi1311b.-; ; ;  # ⒕∝ٟ.-
+14.∝ٟ򓤦.-󠄯; 14.∝ٟ򓤦.-; [P1, V3, V6]; 14.xn--7hb713l3v90n.-; ; ;  # 14.∝ٟ.-
+14.xn--7hb713l3v90n.-; 14.∝ٟ򓤦.-; [V3, V6]; 14.xn--7hb713l3v90n.-; ; ;  # 14.∝ٟ.-
+xn--7hb713lfwbi1311b.-; ⒕∝ٟ򓤦.-; [V3, V6]; xn--7hb713lfwbi1311b.-; ; ;  # ⒕∝ٟ.-
+ꡣ.ߏ; ; ; xn--8c9a.xn--qsb; ; ;  # ꡣ.ߏ
+xn--8c9a.xn--qsb; ꡣ.ߏ; ; xn--8c9a.xn--qsb; ; ;  # ꡣ.ߏ
+≯؃｡-; ≯؃.-; [B1, P1, V3, V6]; xn--lfb566l.-; ; ;  # ≯.-
+≯؃｡-; ≯؃.-; [B1, P1, V3, V6]; xn--lfb566l.-; ; ;  # ≯.-
+≯؃。-; ≯؃.-; [B1, P1, V3, V6]; xn--lfb566l.-; ; ;  # ≯.-
+≯؃。-; ≯؃.-; [B1, P1, V3, V6]; xn--lfb566l.-; ; ;  # ≯.-
+xn--lfb566l.-; ≯؃.-; [B1, V3, V6]; xn--lfb566l.-; ; ;  # ≯.-
+⾛𐹧⾕.ᅟ󠗰ςႭ; 走𐹧谷.ᅟ󠗰ςႭ; [B5, P1, V6]; xn--6g3a1x434z.xn--3xa827dhpae6345i; ; xn--6g3a1x434z.xn--4xa627dhpae6345i;  # 走𐹧谷.ςႭ
+走𐹧谷.ᅟ󠗰ςႭ; ; [B5, P1, V6]; xn--6g3a1x434z.xn--3xa827dhpae6345i; ; xn--6g3a1x434z.xn--4xa627dhpae6345i;  # 走𐹧谷.ςႭ
+走𐹧谷.ᅟ󠗰ςⴍ; ; [B5, P1, V6]; xn--6g3a1x434z.xn--3xa380eotvh7453a; ; xn--6g3a1x434z.xn--4xa180eotvh7453a;  # 走𐹧谷.ςⴍ
+走𐹧谷.ᅟ󠗰ΣႭ; 走𐹧谷.ᅟ󠗰σႭ; [B5, P1, V6]; xn--6g3a1x434z.xn--4xa627dhpae6345i; ; ;  # 走𐹧谷.σႭ
+走𐹧谷.ᅟ󠗰σⴍ; ; [B5, P1, V6]; xn--6g3a1x434z.xn--4xa180eotvh7453a; ; ;  # 走𐹧谷.σⴍ
+走𐹧谷.ᅟ󠗰Σⴍ; 走𐹧谷.ᅟ󠗰σⴍ; [B5, P1, V6]; xn--6g3a1x434z.xn--4xa180eotvh7453a; ; ;  # 走𐹧谷.σⴍ
+xn--6g3a1x434z.xn--4xa180eotvh7453a; 走𐹧谷.ᅟ󠗰σⴍ; [B5, V6]; xn--6g3a1x434z.xn--4xa180eotvh7453a; ; ;  # 走𐹧谷.σⴍ
+xn--6g3a1x434z.xn--4xa627dhpae6345i; 走𐹧谷.ᅟ󠗰σႭ; [B5, V6]; xn--6g3a1x434z.xn--4xa627dhpae6345i; ; ;  # 走𐹧谷.σႭ
+xn--6g3a1x434z.xn--3xa380eotvh7453a; 走𐹧谷.ᅟ󠗰ςⴍ; [B5, V6]; xn--6g3a1x434z.xn--3xa380eotvh7453a; ; ;  # 走𐹧谷.ςⴍ
+xn--6g3a1x434z.xn--3xa827dhpae6345i; 走𐹧谷.ᅟ󠗰ςႭ; [B5, V6]; xn--6g3a1x434z.xn--3xa827dhpae6345i; ; ;  # 走𐹧谷.ςႭ
+⾛𐹧⾕.ᅟ󠗰ςⴍ; 走𐹧谷.ᅟ󠗰ςⴍ; [B5, P1, V6]; xn--6g3a1x434z.xn--3xa380eotvh7453a; ; xn--6g3a1x434z.xn--4xa180eotvh7453a;  # 走𐹧谷.ςⴍ
+⾛𐹧⾕.ᅟ󠗰ΣႭ; 走𐹧谷.ᅟ󠗰σႭ; [B5, P1, V6]; xn--6g3a1x434z.xn--4xa627dhpae6345i; ; ;  # 走𐹧谷.σႭ
+⾛𐹧⾕.ᅟ󠗰σⴍ; 走𐹧谷.ᅟ󠗰σⴍ; [B5, P1, V6]; xn--6g3a1x434z.xn--4xa180eotvh7453a; ; ;  # 走𐹧谷.σⴍ
+⾛𐹧⾕.ᅟ󠗰Σⴍ; 走𐹧谷.ᅟ󠗰σⴍ; [B5, P1, V6]; xn--6g3a1x434z.xn--4xa180eotvh7453a; ; ;  # 走𐹧谷.σⴍ
+‍≠ᢙ≯.솣-ᡴႠ; ; [C2, P1, V6]; xn--jbf929a90b0b.xn----6zg521d196p; ; xn--jbf911clb.xn----6zg521d196p; [P1, V6] # ≠ᢙ≯.솣-ᡴႠ
+‍≠ᢙ≯.솣-ᡴႠ; ‍≠ᢙ≯.솣-ᡴႠ; [C2, P1, V6]; xn--jbf929a90b0b.xn----6zg521d196p; ; xn--jbf911clb.xn----6zg521d196p; [P1, V6] # ≠ᢙ≯.솣-ᡴႠ
+‍≠ᢙ≯.솣-ᡴⴀ; ‍≠ᢙ≯.솣-ᡴⴀ; [C2, P1, V6]; xn--jbf929a90b0b.xn----p9j493ivi4l; ; xn--jbf911clb.xn----p9j493ivi4l; [P1, V6] # ≠ᢙ≯.솣-ᡴⴀ
+‍≠ᢙ≯.솣-ᡴⴀ; ; [C2, P1, V6]; xn--jbf929a90b0b.xn----p9j493ivi4l; ; xn--jbf911clb.xn----p9j493ivi4l; [P1, V6] # ≠ᢙ≯.솣-ᡴⴀ
+xn--jbf911clb.xn----p9j493ivi4l; ≠ᢙ≯.솣-ᡴⴀ; [V6]; xn--jbf911clb.xn----p9j493ivi4l; ; ;  # ≠ᢙ≯.솣-ᡴⴀ
+xn--jbf929a90b0b.xn----p9j493ivi4l; ‍≠ᢙ≯.솣-ᡴⴀ; [C2, V6]; xn--jbf929a90b0b.xn----p9j493ivi4l; ; ;  # ≠ᢙ≯.솣-ᡴⴀ
+xn--jbf911clb.xn----6zg521d196p; ≠ᢙ≯.솣-ᡴႠ; [V6]; xn--jbf911clb.xn----6zg521d196p; ; ;  # ≠ᢙ≯.솣-ᡴႠ
+xn--jbf929a90b0b.xn----6zg521d196p; ‍≠ᢙ≯.솣-ᡴႠ; [C2, V6]; xn--jbf929a90b0b.xn----6zg521d196p; ; ;  # ≠ᢙ≯.솣-ᡴႠ
+񯞜．𐿇ྡྷݽ؀; 񯞜.𐿇ྡྷݽ؀; [P1, V6]; xn--gw68a.xn--ifb57ev2psc6027m; ; ;  # .ྡྷݽ
+񯞜．𐿇ྡྷݽ؀; 񯞜.𐿇ྡྷݽ؀; [P1, V6]; xn--gw68a.xn--ifb57ev2psc6027m; ; ;  # .ྡྷݽ
+񯞜.𐿇ྡྷݽ؀; ; [P1, V6]; xn--gw68a.xn--ifb57ev2psc6027m; ; ;  # .ྡྷݽ
+xn--gw68a.xn--ifb57ev2psc6027m; 񯞜.𐿇ྡྷݽ؀; [V6]; xn--gw68a.xn--ifb57ev2psc6027m; ; ;  # .ྡྷݽ
+𣳔̃.𑓂; ; [V5]; xn--nsa95820a.xn--wz1d; ; ;  # 𣳔̃.𑓂
+xn--nsa95820a.xn--wz1d; 𣳔̃.𑓂; [V5]; xn--nsa95820a.xn--wz1d; ; ;  # 𣳔̃.𑓂
+𞤀𞥅񘐱。󠄌Ⴣꡥ; 𞤢𞥅񘐱.Ⴣꡥ; [B2, B3, P1, V6]; xn--9d6hgcy3556a.xn--7nd0578e; ; ;  # 𞤢𞥅.Ⴣꡥ
+𞤢𞥅񘐱。󠄌ⴣꡥ; 𞤢𞥅񘐱.ⴣꡥ; [B2, B3, P1, V6]; xn--9d6hgcy3556a.xn--rlju750b; ; ;  # 𞤢𞥅.ⴣꡥ
+xn--9d6hgcy3556a.xn--rlju750b; 𞤢𞥅񘐱.ⴣꡥ; [B2, B3, V6]; xn--9d6hgcy3556a.xn--rlju750b; ; ;  # 𞤢𞥅.ⴣꡥ
+xn--9d6hgcy3556a.xn--7nd0578e; 𞤢𞥅񘐱.Ⴣꡥ; [B2, B3, V6]; xn--9d6hgcy3556a.xn--7nd0578e; ; ;  # 𞤢𞥅.Ⴣꡥ
+𞤀𞥅񘐱。󠄌ⴣꡥ; 𞤢𞥅񘐱.ⴣꡥ; [B2, B3, P1, V6]; xn--9d6hgcy3556a.xn--rlju750b; ; ;  # 𞤢𞥅.ⴣꡥ
+࣢𑁿ς𖬱。󠅡렧; ࣢𑁿ς𖬱.렧; [B1, P1, V6]; xn--3xa73xp48ys2xc.xn--kn2b; ; xn--4xa53xp48ys2xc.xn--kn2b;  # 𑁿ς𖬱.렧
+࣢𑁿ς𖬱。󠅡렧; ࣢𑁿ς𖬱.렧; [B1, P1, V6]; xn--3xa73xp48ys2xc.xn--kn2b; ; xn--4xa53xp48ys2xc.xn--kn2b;  # 𑁿ς𖬱.렧
+࣢𑁿Σ𖬱。󠅡렧; ࣢𑁿σ𖬱.렧; [B1, P1, V6]; xn--4xa53xp48ys2xc.xn--kn2b; ; ;  # 𑁿σ𖬱.렧
+࣢𑁿Σ𖬱。󠅡렧; ࣢𑁿σ𖬱.렧; [B1, P1, V6]; xn--4xa53xp48ys2xc.xn--kn2b; ; ;  # 𑁿σ𖬱.렧
+࣢𑁿σ𖬱。󠅡렧; ࣢𑁿σ𖬱.렧; [B1, P1, V6]; xn--4xa53xp48ys2xc.xn--kn2b; ; ;  # 𑁿σ𖬱.렧
+࣢𑁿σ𖬱。󠅡렧; ࣢𑁿σ𖬱.렧; [B1, P1, V6]; xn--4xa53xp48ys2xc.xn--kn2b; ; ;  # 𑁿σ𖬱.렧
+xn--4xa53xp48ys2xc.xn--kn2b; ࣢𑁿σ𖬱.렧; [B1, V6]; xn--4xa53xp48ys2xc.xn--kn2b; ; ;  # 𑁿σ𖬱.렧
+xn--3xa73xp48ys2xc.xn--kn2b; ࣢𑁿ς𖬱.렧; [B1, V6]; xn--3xa73xp48ys2xc.xn--kn2b; ; ;  # 𑁿ς𖬱.렧
+-‍。𞤍‌‍⒈; -‍.𞤯‌‍⒈; [B1, C1, C2, P1, V3, V6]; xn----ugn.xn--0ugc555aiv51d; ; -.xn--tsh3666n; [B1, P1, V3, V6] # -.𞤯⒈
+-‍。𞤍‌‍1.; -‍.𞤯‌‍1.; [B1, C1, C2, V3]; xn----ugn.xn--1-rgnd61297b.; ; -.xn--1-0i8r.; [B1, V3] # -.𞤯1.
+-‍。𞤯‌‍1.; -‍.𞤯‌‍1.; [B1, C1, C2, V3]; xn----ugn.xn--1-rgnd61297b.; ; -.xn--1-0i8r.; [B1, V3] # -.𞤯1.
+-.xn--1-0i8r.; -.𞤯1.; [B1, V3]; -.xn--1-0i8r.; ; ;  # -.𞤯1.
+xn----ugn.xn--1-rgnd61297b.; -‍.𞤯‌‍1.; [B1, C1, C2, V3]; xn----ugn.xn--1-rgnd61297b.; ; ;  # -.𞤯1.
+-‍。𞤯‌‍⒈; -‍.𞤯‌‍⒈; [B1, C1, C2, P1, V3, V6]; xn----ugn.xn--0ugc555aiv51d; ; -.xn--tsh3666n; [B1, P1, V3, V6] # -.𞤯⒈
+-.xn--tsh3666n; -.𞤯⒈; [B1, V3, V6]; -.xn--tsh3666n; ; ;  # -.𞤯⒈
+xn----ugn.xn--0ugc555aiv51d; -‍.𞤯‌‍⒈; [B1, C1, C2, V3, V6]; xn----ugn.xn--0ugc555aiv51d; ; ;  # -.𞤯⒈
+‌򅎭.Ⴒ𑇀; ; [C1, P1, V6]; xn--0ug15083f.xn--qnd6272k; ; xn--bn95b.xn--qnd6272k; [P1, V6] # .Ⴒ𑇀
+‌򅎭.ⴒ𑇀; ; [C1, P1, V6]; xn--0ug15083f.xn--9kj2034e; ; xn--bn95b.xn--9kj2034e; [P1, V6] # .ⴒ𑇀
+xn--bn95b.xn--9kj2034e; 򅎭.ⴒ𑇀; [V6]; xn--bn95b.xn--9kj2034e; ; ;  # .ⴒ𑇀
+xn--0ug15083f.xn--9kj2034e; ‌򅎭.ⴒ𑇀; [C1, V6]; xn--0ug15083f.xn--9kj2034e; ; ;  # .ⴒ𑇀
+xn--bn95b.xn--qnd6272k; 򅎭.Ⴒ𑇀; [V6]; xn--bn95b.xn--qnd6272k; ; ;  # .Ⴒ𑇀
+xn--0ug15083f.xn--qnd6272k; ‌򅎭.Ⴒ𑇀; [C1, V6]; xn--0ug15083f.xn--qnd6272k; ; ;  # .Ⴒ𑇀
+繱𑖿‍.８︒; 繱𑖿‍.8︒; [P1, V6]; xn--1ug6928ac48e.xn--8-o89h; ; xn--gl0as212a.xn--8-o89h;  # 繱𑖿.8︒
+繱𑖿‍.8。; 繱𑖿‍.8.; ; xn--1ug6928ac48e.8.; ; xn--gl0as212a.8.;  # 繱𑖿.8.
+xn--gl0as212a.8.; 繱𑖿.8.; ; xn--gl0as212a.8.; ; ;  # 繱𑖿.8.
+繱𑖿.8.; ; ; xn--gl0as212a.8.; ; ;  # 繱𑖿.8.
+xn--1ug6928ac48e.8.; 繱𑖿‍.8.; ; xn--1ug6928ac48e.8.; ; ;  # 繱𑖿.8.
+繱𑖿‍.8.; ; ; xn--1ug6928ac48e.8.; ; xn--gl0as212a.8.;  # 繱𑖿.8.
+xn--gl0as212a.xn--8-o89h; 繱𑖿.8︒; [V6]; xn--gl0as212a.xn--8-o89h; ; ;  # 繱𑖿.8︒
+xn--1ug6928ac48e.xn--8-o89h; 繱𑖿‍.8︒; [V6]; xn--1ug6928ac48e.xn--8-o89h; ; ;  # 繱𑖿.8︒
+󠆾．𞀈; .𞀈; [V5, X4_2]; .xn--ph4h; [V5, A4_2]; ;  # .𞀈
+󠆾.𞀈; .𞀈; [V5, X4_2]; .xn--ph4h; [V5, A4_2]; ;  # .𞀈
+.xn--ph4h; .𞀈; [V5, X4_2]; .xn--ph4h; [V5, A4_2]; ;  # .𞀈
+ß۫。‍; ß۫.‍; [C2]; xn--zca012a.xn--1ug; ; xn--ss-59d.; [] # ß۫.
+SS۫。‍; ss۫.‍; [C2]; xn--ss-59d.xn--1ug; ; xn--ss-59d.; [] # ss۫.
+ss۫。‍; ss۫.‍; [C2]; xn--ss-59d.xn--1ug; ; xn--ss-59d.; [] # ss۫.
+Ss۫。‍; ss۫.‍; [C2]; xn--ss-59d.xn--1ug; ; xn--ss-59d.; [] # ss۫.
+xn--ss-59d.; ss۫.; ; xn--ss-59d.; ; ;  # ss۫.
+ss۫.; ; ; xn--ss-59d.; ; ;  # ss۫.
+SS۫.; ss۫.; ; xn--ss-59d.; ; ;  # ss۫.
+Ss۫.; ss۫.; ; xn--ss-59d.; ; ;  # ss۫.
+xn--ss-59d.xn--1ug; ss۫.‍; [C2]; xn--ss-59d.xn--1ug; ; ;  # ss۫.
+xn--zca012a.xn--1ug; ß۫.‍; [C2]; xn--zca012a.xn--1ug; ; ;  # ß۫.
+󠐵‌⒈．󠎇; 󠐵‌⒈.󠎇; [C1, P1, V6]; xn--0ug88o47900b.xn--tv36e; ; xn--tshz2001k.xn--tv36e; [P1, V6] # ⒈.
+󠐵‌1..󠎇; ; [C1, P1, V6, X4_2]; xn--1-rgn37671n..xn--tv36e; [C1, P1, V6, A4_2]; xn--1-bs31m..xn--tv36e; [P1, V6, A4_2] # 1..
+xn--1-bs31m..xn--tv36e; 󠐵1..󠎇; [V6, X4_2]; xn--1-bs31m..xn--tv36e; [V6, A4_2]; ;  # 1..
+xn--1-rgn37671n..xn--tv36e; 󠐵‌1..󠎇; [C1, V6, X4_2]; xn--1-rgn37671n..xn--tv36e; [C1, V6, A4_2]; ;  # 1..
+xn--tshz2001k.xn--tv36e; 󠐵⒈.󠎇; [V6]; xn--tshz2001k.xn--tv36e; ; ;  # ⒈.
+xn--0ug88o47900b.xn--tv36e; 󠐵‌⒈.󠎇; [C1, V6]; xn--0ug88o47900b.xn--tv36e; ; ;  # ⒈.
+󟈣ٟꪲß。󌓧; 󟈣ٟꪲß.󌓧; [P1, V6]; xn--zca92z0t7n5w96j.xn--bb79d; ; xn--ss-3xd2839nncy1m.xn--bb79d;  # ٟꪲß.
+󟈣ٟꪲSS。󌓧; 󟈣ٟꪲss.󌓧; [P1, V6]; xn--ss-3xd2839nncy1m.xn--bb79d; ; ;  # ٟꪲss.
+󟈣ٟꪲss。󌓧; 󟈣ٟꪲss.󌓧; [P1, V6]; xn--ss-3xd2839nncy1m.xn--bb79d; ; ;  # ٟꪲss.
+󟈣ٟꪲSs。󌓧; 󟈣ٟꪲss.󌓧; [P1, V6]; xn--ss-3xd2839nncy1m.xn--bb79d; ; ;  # ٟꪲss.
+xn--ss-3xd2839nncy1m.xn--bb79d; 󟈣ٟꪲss.󌓧; [V6]; xn--ss-3xd2839nncy1m.xn--bb79d; ; ;  # ٟꪲss.
+xn--zca92z0t7n5w96j.xn--bb79d; 󟈣ٟꪲß.󌓧; [V6]; xn--zca92z0t7n5w96j.xn--bb79d; ; ;  # ٟꪲß.
+ݴ‌𞤿。𽘐䉜‍񿤼; ݴ‌𞤿.𽘐䉜‍񿤼; [C1, C2, P1, V6]; xn--4pb607jjt73a.xn--1ug236ke314donv1a; ; xn--4pb2977v.xn--z0nt555ukbnv; [P1, V6] # ݴ𞤿.䉜
+ݴ‌𞤝。𽘐䉜‍񿤼; ݴ‌𞤿.𽘐䉜‍񿤼; [C1, C2, P1, V6]; xn--4pb607jjt73a.xn--1ug236ke314donv1a; ; xn--4pb2977v.xn--z0nt555ukbnv; [P1, V6] # ݴ𞤿.䉜
+xn--4pb2977v.xn--z0nt555ukbnv; ݴ𞤿.𽘐䉜񿤼; [V6]; xn--4pb2977v.xn--z0nt555ukbnv; ; ;  # ݴ𞤿.䉜
+xn--4pb607jjt73a.xn--1ug236ke314donv1a; ݴ‌𞤿.𽘐䉜‍񿤼; [C1, C2, V6]; xn--4pb607jjt73a.xn--1ug236ke314donv1a; ; ;  # ݴ𞤿.䉜
+򔭜ςᡱ⒈.≮𑄳‍𐮍; ; [B1, P1, V6]; xn--3xa407hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # ςᡱ⒈.≮𑄳𐮍
+򔭜ςᡱ⒈.≮𑄳‍𐮍; 򔭜ςᡱ⒈.≮𑄳‍𐮍; [B1, P1, V6]; xn--3xa407hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # ςᡱ⒈.≮𑄳𐮍
+򔭜ςᡱ1..≮𑄳‍𐮍; ; [B1, P1, V6, X4_2]; xn--1-xmb999meq63t..xn--1ug85gn777ahze; [B1, P1, V6, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # ςᡱ1..≮𑄳𐮍
+򔭜ςᡱ1..≮𑄳‍𐮍; 򔭜ςᡱ1..≮𑄳‍𐮍; [B1, P1, V6, X4_2]; xn--1-xmb999meq63t..xn--1ug85gn777ahze; [B1, P1, V6, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # ςᡱ1..≮𑄳𐮍
+򔭜Σᡱ1..≮𑄳‍𐮍; 򔭜σᡱ1..≮𑄳‍𐮍; [B1, P1, V6, X4_2]; xn--1-zmb699meq63t..xn--1ug85gn777ahze; [B1, P1, V6, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # σᡱ1..≮𑄳𐮍
+򔭜Σᡱ1..≮𑄳‍𐮍; 򔭜σᡱ1..≮𑄳‍𐮍; [B1, P1, V6, X4_2]; xn--1-zmb699meq63t..xn--1ug85gn777ahze; [B1, P1, V6, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # σᡱ1..≮𑄳𐮍
+򔭜σᡱ1..≮𑄳‍𐮍; ; [B1, P1, V6, X4_2]; xn--1-zmb699meq63t..xn--1ug85gn777ahze; [B1, P1, V6, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # σᡱ1..≮𑄳𐮍
+򔭜σᡱ1..≮𑄳‍𐮍; 򔭜σᡱ1..≮𑄳‍𐮍; [B1, P1, V6, X4_2]; xn--1-zmb699meq63t..xn--1ug85gn777ahze; [B1, P1, V6, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # σᡱ1..≮𑄳𐮍
+xn--1-zmb699meq63t..xn--gdh5392g6sd; 򔭜σᡱ1..≮𑄳𐮍; [B1, V6, X4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd; [B1, V6, A4_2]; ;  # σᡱ1..≮𑄳𐮍
+xn--1-zmb699meq63t..xn--1ug85gn777ahze; 򔭜σᡱ1..≮𑄳‍𐮍; [B1, V6, X4_2]; xn--1-zmb699meq63t..xn--1ug85gn777ahze; [B1, V6, A4_2]; ;  # σᡱ1..≮𑄳𐮍
+xn--1-xmb999meq63t..xn--1ug85gn777ahze; 򔭜ςᡱ1..≮𑄳‍𐮍; [B1, V6, X4_2]; xn--1-xmb999meq63t..xn--1ug85gn777ahze; [B1, V6, A4_2]; ;  # ςᡱ1..≮𑄳𐮍
+򔭜Σᡱ⒈.≮𑄳‍𐮍; 򔭜σᡱ⒈.≮𑄳‍𐮍; [B1, P1, V6]; xn--4xa207hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # σᡱ⒈.≮𑄳𐮍
+򔭜Σᡱ⒈.≮𑄳‍𐮍; 򔭜σᡱ⒈.≮𑄳‍𐮍; [B1, P1, V6]; xn--4xa207hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # σᡱ⒈.≮𑄳𐮍
+򔭜σᡱ⒈.≮𑄳‍𐮍; ; [B1, P1, V6]; xn--4xa207hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # σᡱ⒈.≮𑄳𐮍
+򔭜σᡱ⒈.≮𑄳‍𐮍; 򔭜σᡱ⒈.≮𑄳‍𐮍; [B1, P1, V6]; xn--4xa207hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # σᡱ⒈.≮𑄳𐮍
+xn--4xa207hkzinr77u.xn--gdh5392g6sd; 򔭜σᡱ⒈.≮𑄳𐮍; [B1, V6]; xn--4xa207hkzinr77u.xn--gdh5392g6sd; ; ;  # σᡱ⒈.≮𑄳𐮍
+xn--4xa207hkzinr77u.xn--1ug85gn777ahze; 򔭜σᡱ⒈.≮𑄳‍𐮍; [B1, V6]; xn--4xa207hkzinr77u.xn--1ug85gn777ahze; ; ;  # σᡱ⒈.≮𑄳𐮍
+xn--3xa407hkzinr77u.xn--1ug85gn777ahze; 򔭜ςᡱ⒈.≮𑄳‍𐮍; [B1, V6]; xn--3xa407hkzinr77u.xn--1ug85gn777ahze; ; ;  # ςᡱ⒈.≮𑄳𐮍
+ㅤ्Ⴀ័.᠋; ㅤ्Ⴀ័.; [P1, V6]; xn--n3b468azngju2a.; ; ;  # ्Ⴀ័.
+ᅠ्Ⴀ័.᠋; ᅠ्Ⴀ័.; [P1, V6]; xn--n3b468aoqa89r.; ; ;  # ्Ⴀ័.
+ᅠ्ⴀ័.᠋; ᅠ्ⴀ័.; [P1, V6]; xn--n3b742bkqf4ty.; ; ;  # ्ⴀ័.
+xn--n3b742bkqf4ty.; ᅠ्ⴀ័.; [V6]; xn--n3b742bkqf4ty.; ; ;  # ्ⴀ័.
+xn--n3b468aoqa89r.; ᅠ्Ⴀ័.; [V6]; xn--n3b468aoqa89r.; ; ;  # ्Ⴀ័.
+ㅤ्ⴀ័.᠋; ㅤ्ⴀ័.; [P1, V6]; xn--n3b445e53po6d.; ; ;  # ्ⴀ័.
+xn--n3b445e53po6d.; ㅤ्ⴀ័.; [V6]; xn--n3b445e53po6d.; ; ;  # ्ⴀ័.
+xn--n3b468azngju2a.; ㅤ्Ⴀ័.; [V6]; xn--n3b468azngju2a.; ; ;  # ्Ⴀ័.
+❣‍．্𑰽ؒꤩ; ❣‍.্𑰽ؒꤩ; [C2, V5]; xn--1ugy10a.xn--0fb32q3w7q2g4d; ; xn--pei.xn--0fb32q3w7q2g4d; [V5] # ❣.্𑰽ؒꤩ
+❣‍.্𑰽ؒꤩ; ; [C2, V5]; xn--1ugy10a.xn--0fb32q3w7q2g4d; ; xn--pei.xn--0fb32q3w7q2g4d; [V5] # ❣.্𑰽ؒꤩ
+xn--pei.xn--0fb32q3w7q2g4d; ❣.্𑰽ؒꤩ; [V5]; xn--pei.xn--0fb32q3w7q2g4d; ; ;  # ❣.্𑰽ؒꤩ
+xn--1ugy10a.xn--0fb32q3w7q2g4d; ❣‍.্𑰽ؒꤩ; [C2, V5]; xn--1ugy10a.xn--0fb32q3w7q2g4d; ; ;  # ❣.্𑰽ؒꤩ
+≮𐳺𐹄.≯񪮸ꡅ; ; [B1, P1, V6]; xn--gdh7943gk2a.xn--hdh1383c5e36c; ; ;  # ≮𐳺.≯ꡅ
+≮𐳺𐹄.≯񪮸ꡅ; ≮𐳺𐹄.≯񪮸ꡅ; [B1, P1, V6]; xn--gdh7943gk2a.xn--hdh1383c5e36c; ; ;  # ≮𐳺.≯ꡅ
+xn--gdh7943gk2a.xn--hdh1383c5e36c; ≮𐳺𐹄.≯񪮸ꡅ; [B1, V6]; xn--gdh7943gk2a.xn--hdh1383c5e36c; ; ;  # ≮𐳺.≯ꡅ
+ೌ𐧅𐳏󠲺｡್ᠦ; ೌ𐧅𐳏󠲺.್ᠦ; [B1, P1, V5, V6]; xn--7tc6360ky5bn2732c.xn--8tc429c; ; ;  # ೌ𐧅𐳏.್ᠦ
+ೌ𐧅𐳏󠲺。್ᠦ; ೌ𐧅𐳏󠲺.್ᠦ; [B1, P1, V5, V6]; xn--7tc6360ky5bn2732c.xn--8tc429c; ; ;  # ೌ𐧅𐳏.್ᠦ
+ೌ𐧅𐲏󠲺。್ᠦ; ೌ𐧅𐳏󠲺.್ᠦ; [B1, P1, V5, V6]; xn--7tc6360ky5bn2732c.xn--8tc429c; ; ;  # ೌ𐧅𐳏.್ᠦ
+xn--7tc6360ky5bn2732c.xn--8tc429c; ೌ𐧅𐳏󠲺.್ᠦ; [B1, V5, V6]; xn--7tc6360ky5bn2732c.xn--8tc429c; ; ;  # ೌ𐧅𐳏.್ᠦ
+ೌ𐧅𐲏󠲺｡್ᠦ; ೌ𐧅𐳏󠲺.್ᠦ; [B1, P1, V5, V6]; xn--7tc6360ky5bn2732c.xn--8tc429c; ; ;  # ೌ𐧅𐳏.್ᠦ
+͉。𧡫; ͉.𧡫; [V5]; xn--nua.xn--bc6k; ; ;  # ͉.𧡫
+xn--nua.xn--bc6k; ͉.𧡫; [V5]; xn--nua.xn--bc6k; ; ;  # ͉.𧡫
+𑰿󠅦．ᅠ; 𑰿.ᅠ; [P1, V5, V6]; xn--ok3d.xn--psd; ; ;  # 𑰿.
+𑰿󠅦.ᅠ; 𑰿.ᅠ; [P1, V5, V6]; xn--ok3d.xn--psd; ; ;  # 𑰿.
+xn--ok3d.xn--psd; 𑰿.ᅠ; [V5, V6]; xn--ok3d.xn--psd; ; ;  # 𑰿.
+-𞤆‍。󸼄𞳒; -𞤨‍.󸼄𞳒; [B1, B5, B6, C2, P1, V3, V6]; xn----ugnx367r.xn--846h96596c; ; xn----ni8r.xn--846h96596c; [B1, B5, B6, P1, V3, V6] # -𞤨.
+-𞤨‍。󸼄𞳒; -𞤨‍.󸼄𞳒; [B1, B5, B6, C2, P1, V3, V6]; xn----ugnx367r.xn--846h96596c; ; xn----ni8r.xn--846h96596c; [B1, B5, B6, P1, V3, V6] # -𞤨.
+xn----ni8r.xn--846h96596c; -𞤨.󸼄𞳒; [B1, B5, B6, V3, V6]; xn----ni8r.xn--846h96596c; ; ;  # -𞤨.
+xn----ugnx367r.xn--846h96596c; -𞤨‍.󸼄𞳒; [B1, B5, B6, C2, V3, V6]; xn----ugnx367r.xn--846h96596c; ; ;  # -𞤨.
+ꡏ󠇶≯𳾽。᷽⾇滸𐹰; ꡏ󠇶≯𳾽.᷽舛滸𐹰; [B1, P1, V5, V6]; xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ; ;  # ꡏ≯.᷽舛滸𐹰
+ꡏ󠇶≯𳾽。᷽⾇滸𐹰; ꡏ󠇶≯𳾽.᷽舛滸𐹰; [B1, P1, V5, V6]; xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ; ;  # ꡏ≯.᷽舛滸𐹰
+ꡏ󠇶≯𳾽。᷽舛滸𐹰; ꡏ󠇶≯𳾽.᷽舛滸𐹰; [B1, P1, V5, V6]; xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ; ;  # ꡏ≯.᷽舛滸𐹰
+ꡏ󠇶≯𳾽。᷽舛滸𐹰; ꡏ󠇶≯𳾽.᷽舛滸𐹰; [B1, P1, V5, V6]; xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ; ;  # ꡏ≯.᷽舛滸𐹰
+xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ꡏ󠇶≯𳾽.᷽舛滸𐹰; [B1, V5, V6]; xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ; ;  # ꡏ≯.᷽舛滸𐹰
+蔏｡𑰺; 蔏.𑰺; [V5]; xn--uy1a.xn--jk3d; ; ;  # 蔏.𑰺
+蔏。𑰺; 蔏.𑰺; [V5]; xn--uy1a.xn--jk3d; ; ;  # 蔏.𑰺
+xn--uy1a.xn--jk3d; 蔏.𑰺; [V5]; xn--uy1a.xn--jk3d; ; ;  # 蔏.𑰺
+𝟿𐮋。󠄊; 9𐮋.; [B1]; xn--9-rv5i.; ; ;  # 9𐮋.
+9𐮋。󠄊; 9𐮋.; [B1]; xn--9-rv5i.; ; ;  # 9𐮋.
+xn--9-rv5i.; 9𐮋.; [B1]; xn--9-rv5i.; ; ;  # 9𐮋.
+󟇇-䟖F。ߋ⒈٢; 󟇇-䟖f.ߋ⒈٢; [B4, P1, V6]; xn---f-mz8b08788k.xn--bib53ev44d; ; ;  # -䟖f.ߋ⒈٢
+󟇇-䟖F。ߋ1.٢; 󟇇-䟖f.ߋ1.٢; [B1, P1, V6]; xn---f-mz8b08788k.xn--1-ybd.xn--bib; ; ;  # -䟖f.ߋ1.٢
+󟇇-䟖f。ߋ1.٢; 󟇇-䟖f.ߋ1.٢; [B1, P1, V6]; xn---f-mz8b08788k.xn--1-ybd.xn--bib; ; ;  # -䟖f.ߋ1.٢
+xn---f-mz8b08788k.xn--1-ybd.xn--bib; 󟇇-䟖f.ߋ1.٢; [B1, V6]; xn---f-mz8b08788k.xn--1-ybd.xn--bib; ; ;  # -䟖f.ߋ1.٢
+󟇇-䟖f。ߋ⒈٢; 󟇇-䟖f.ߋ⒈٢; [B4, P1, V6]; xn---f-mz8b08788k.xn--bib53ev44d; ; ;  # -䟖f.ߋ⒈٢
+xn---f-mz8b08788k.xn--bib53ev44d; 󟇇-䟖f.ߋ⒈٢; [B4, V6]; xn---f-mz8b08788k.xn--bib53ev44d; ; ;  # -䟖f.ߋ⒈٢
+‌｡𐹺; ‌.𐹺; [B1, C1]; xn--0ug.xn--yo0d; ; .xn--yo0d; [B1, A4_2] # .𐹺
+‌。𐹺; ‌.𐹺; [B1, C1]; xn--0ug.xn--yo0d; ; .xn--yo0d; [B1, A4_2] # .𐹺
+.xn--yo0d; .𐹺; [B1, X4_2]; .xn--yo0d; [B1, A4_2]; ;  # .𐹺
+xn--0ug.xn--yo0d; ‌.𐹺; [B1, C1]; xn--0ug.xn--yo0d; ; ;  # .𐹺
+𐡆.≯‌-𞥀; ; [B1, C1, P1, V6]; xn--le9c.xn----rgn40iy359e; ; xn--le9c.xn----ogo9956r; [B1, P1, V6] # 𐡆.≯-𞥀
+𐡆.≯‌-𞥀; 𐡆.≯‌-𞥀; [B1, C1, P1, V6]; xn--le9c.xn----rgn40iy359e; ; xn--le9c.xn----ogo9956r; [B1, P1, V6] # 𐡆.≯-𞥀
+𐡆.≯‌-𞤞; 𐡆.≯‌-𞥀; [B1, C1, P1, V6]; xn--le9c.xn----rgn40iy359e; ; xn--le9c.xn----ogo9956r; [B1, P1, V6] # 𐡆.≯-𞥀
+𐡆.≯‌-𞤞; 𐡆.≯‌-𞥀; [B1, C1, P1, V6]; xn--le9c.xn----rgn40iy359e; ; xn--le9c.xn----ogo9956r; [B1, P1, V6] # 𐡆.≯-𞥀
+xn--le9c.xn----ogo9956r; 𐡆.≯-𞥀; [B1, V6]; xn--le9c.xn----ogo9956r; ; ;  # 𐡆.≯-𞥀
+xn--le9c.xn----rgn40iy359e; 𐡆.≯‌-𞥀; [B1, C1, V6]; xn--le9c.xn----rgn40iy359e; ; ;  # 𐡆.≯-𞥀
+󠁀-。≠ﳗ; 󠁀-.≠هج; [B1, P1, V3, V6]; xn----f411m.xn--rgb7c611j; ; ;  # -.≠هج
+󠁀-。≠ﳗ; 󠁀-.≠هج; [B1, P1, V3, V6]; xn----f411m.xn--rgb7c611j; ; ;  # -.≠هج
+󠁀-。≠هج; 󠁀-.≠هج; [B1, P1, V3, V6]; xn----f411m.xn--rgb7c611j; ; ;  # -.≠هج
+󠁀-。≠هج; 󠁀-.≠هج; [B1, P1, V3, V6]; xn----f411m.xn--rgb7c611j; ; ;  # -.≠هج
+xn----f411m.xn--rgb7c611j; 󠁀-.≠هج; [B1, V3, V6]; xn----f411m.xn--rgb7c611j; ; ;  # -.≠هج
+񻬹𑈵。‍𞨶; 񻬹𑈵.‍𞨶; [B1, C2, P1, V6]; xn--8g1d12120a.xn--1ug6651p; ; xn--8g1d12120a.xn--5l6h; [P1, V6] # 𑈵.
+xn--8g1d12120a.xn--5l6h; 񻬹𑈵.𞨶; [V6]; xn--8g1d12120a.xn--5l6h; ; ;  # 𑈵.
+xn--8g1d12120a.xn--1ug6651p; 񻬹𑈵.‍𞨶; [B1, C2, V6]; xn--8g1d12120a.xn--1ug6651p; ; ;  # 𑈵.
+𑋧꧀2｡㧉򒖄; 𑋧꧀2.㧉򒖄; [P1, V5, V6]; xn--2-5z4eu89y.xn--97l02706d; ; ;  # 𑋧꧀2.㧉
+𑋧꧀2。㧉򒖄; 𑋧꧀2.㧉򒖄; [P1, V5, V6]; xn--2-5z4eu89y.xn--97l02706d; ; ;  # 𑋧꧀2.㧉
+xn--2-5z4eu89y.xn--97l02706d; 𑋧꧀2.㧉򒖄; [V5, V6]; xn--2-5z4eu89y.xn--97l02706d; ; ;  # 𑋧꧀2.㧉
+‌𽬄𐹴𞩥。≯6; ‌𽬄𐹴𞩥.≯6; [B1, C1, P1, V6]; xn--0ug7105gf5wfxepq.xn--6-ogo; ; xn--so0du768aim9m.xn--6-ogo; [B1, B5, B6, P1, V6] # 𐹴.≯6
+‌𽬄𐹴𞩥。≯6; ‌𽬄𐹴𞩥.≯6; [B1, C1, P1, V6]; xn--0ug7105gf5wfxepq.xn--6-ogo; ; xn--so0du768aim9m.xn--6-ogo; [B1, B5, B6, P1, V6] # 𐹴.≯6
+xn--so0du768aim9m.xn--6-ogo; 𽬄𐹴𞩥.≯6; [B1, B5, B6, V6]; xn--so0du768aim9m.xn--6-ogo; ; ;  # 𐹴.≯6
+xn--0ug7105gf5wfxepq.xn--6-ogo; ‌𽬄𐹴𞩥.≯6; [B1, C1, V6]; xn--0ug7105gf5wfxepq.xn--6-ogo; ; ;  # 𐹴.≯6
+𑁿．𐹦𻞵-‍; 𑁿.𐹦𻞵-‍; [B1, B3, B6, C2, P1, V5, V6]; xn--q30d.xn----ugn1088hfsxv; ; xn--q30d.xn----i26i1299n; [B1, B3, B6, P1, V3, V5, V6] # 𑁿.𐹦-
+𑁿.𐹦𻞵-‍; ; [B1, B3, B6, C2, P1, V5, V6]; xn--q30d.xn----ugn1088hfsxv; ; xn--q30d.xn----i26i1299n; [B1, B3, B6, P1, V3, V5, V6] # 𑁿.𐹦-
+xn--q30d.xn----i26i1299n; 𑁿.𐹦𻞵-; [B1, B3, B6, V3, V5, V6]; xn--q30d.xn----i26i1299n; ; ;  # 𑁿.𐹦-
+xn--q30d.xn----ugn1088hfsxv; 𑁿.𐹦𻞵-‍; [B1, B3, B6, C2, V5, V6]; xn--q30d.xn----ugn1088hfsxv; ; ;  # 𑁿.𐹦-
+⤸ς𺱀｡ﾠ; ⤸ς𺱀.ﾠ; [P1, V6]; xn--3xa392qmp03d.xn--cl7c; ; xn--4xa192qmp03d.xn--cl7c;  # ⤸ς.
+⤸ς𺱀。ᅠ; ⤸ς𺱀.ᅠ; [P1, V6]; xn--3xa392qmp03d.xn--psd; ; xn--4xa192qmp03d.xn--psd;  # ⤸ς.
+⤸Σ𺱀。ᅠ; ⤸σ𺱀.ᅠ; [P1, V6]; xn--4xa192qmp03d.xn--psd; ; ;  # ⤸σ.
+⤸σ𺱀。ᅠ; ⤸σ𺱀.ᅠ; [P1, V6]; xn--4xa192qmp03d.xn--psd; ; ;  # ⤸σ.
+xn--4xa192qmp03d.xn--psd; ⤸σ𺱀.ᅠ; [V6]; xn--4xa192qmp03d.xn--psd; ; ;  # ⤸σ.
+xn--3xa392qmp03d.xn--psd; ⤸ς𺱀.ᅠ; [V6]; xn--3xa392qmp03d.xn--psd; ; ;  # ⤸ς.
+⤸Σ𺱀｡ﾠ; ⤸σ𺱀.ﾠ; [P1, V6]; xn--4xa192qmp03d.xn--cl7c; ; ;  # ⤸σ.
+⤸σ𺱀｡ﾠ; ⤸σ𺱀.ﾠ; [P1, V6]; xn--4xa192qmp03d.xn--cl7c; ; ;  # ⤸σ.
+xn--4xa192qmp03d.xn--cl7c; ⤸σ𺱀.ﾠ; [V6]; xn--4xa192qmp03d.xn--cl7c; ; ;  # ⤸σ.
+xn--3xa392qmp03d.xn--cl7c; ⤸ς𺱀.ﾠ; [V6]; xn--3xa392qmp03d.xn--cl7c; ; ;  # ⤸ς.
+ݥဵ𐫔ە.𐦬𑋪Ⴃ; ; [B2, B3, P1, V6]; xn--llb10as9tqp5y.xn--bnd9168j21f; ; ;  # ݥဵ𐫔ە.𐦬𑋪Ⴃ
+ݥဵ𐫔ە.𐦬𑋪ⴃ; ; [B2, B3]; xn--llb10as9tqp5y.xn--ukj7371e21f; ; ;  # ݥဵ𐫔ە.𐦬𑋪ⴃ
+xn--llb10as9tqp5y.xn--ukj7371e21f; ݥဵ𐫔ە.𐦬𑋪ⴃ; [B2, B3]; xn--llb10as9tqp5y.xn--ukj7371e21f; ; ;  # ݥဵ𐫔ە.𐦬𑋪ⴃ
+xn--llb10as9tqp5y.xn--bnd9168j21f; ݥဵ𐫔ە.𐦬𑋪Ⴃ; [B2, B3, V6]; xn--llb10as9tqp5y.xn--bnd9168j21f; ; ;  # ݥဵ𐫔ە.𐦬𑋪Ⴃ
+١᭄-킼.᮪ؖ٬≯; ; [B1, B5, B6, P1, V5, V6]; xn----9pc551nk39n.xn--4fb6o571degg; ; ;  # ١᭄-킼.᮪ؖ٬≯
+١᭄-킼.᮪ؖ٬≯; ١᭄-킼.᮪ؖ٬≯; [B1, B5, B6, P1, V5, V6]; xn----9pc551nk39n.xn--4fb6o571degg; ; ;  # ١᭄-킼.᮪ؖ٬≯
+xn----9pc551nk39n.xn--4fb6o571degg; ١᭄-킼.᮪ؖ٬≯; [B1, B5, B6, V5, V6]; xn----9pc551nk39n.xn--4fb6o571degg; ; ;  # ١᭄-킼.᮪ؖ٬≯
+-。ۂ؄򅖡𑓂; -.ۂ؄򅖡𑓂; [B1, B2, B3, P1, V3, V6]; -.xn--mfb39a7208dzgs3d; ; ;  # -.ۂ𑓂
+-。ۂ؄򅖡𑓂; -.ۂ؄򅖡𑓂; [B1, B2, B3, P1, V3, V6]; -.xn--mfb39a7208dzgs3d; ; ;  # -.ۂ𑓂
+-.xn--mfb39a7208dzgs3d; -.ۂ؄򅖡𑓂; [B1, B2, B3, V3, V6]; -.xn--mfb39a7208dzgs3d; ; ;  # -.ۂ𑓂
+‍󯑖󠁐．ֽ𙮰ꡝ𐋡; ‍󯑖󠁐.ֽ𙮰ꡝ𐋡; [C2, P1, V5, V6]; xn--1ug66101lt8me.xn--ldb8734fg0qcyzzg; ; xn--b726ey18m.xn--ldb8734fg0qcyzzg; [P1, V5, V6] # .ֽꡝ𐋡
+‍󯑖󠁐.ֽ𙮰ꡝ𐋡; ; [C2, P1, V5, V6]; xn--1ug66101lt8me.xn--ldb8734fg0qcyzzg; ; xn--b726ey18m.xn--ldb8734fg0qcyzzg; [P1, V5, V6] # .ֽꡝ𐋡
+xn--b726ey18m.xn--ldb8734fg0qcyzzg; 󯑖󠁐.ֽ𙮰ꡝ𐋡; [V5, V6]; xn--b726ey18m.xn--ldb8734fg0qcyzzg; ; ;  # .ֽꡝ𐋡
+xn--1ug66101lt8me.xn--ldb8734fg0qcyzzg; ‍󯑖󠁐.ֽ𙮰ꡝ𐋡; [C2, V5, V6]; xn--1ug66101lt8me.xn--ldb8734fg0qcyzzg; ; ;  # .ֽꡝ𐋡
+︒􃈵ς񀠇｡𐮈; ︒􃈵ς񀠇.𐮈; [B1, P1, V6]; xn--3xa3729jwz5t7gl5f.xn--f29c; ; xn--4xa1729jwz5t7gl5f.xn--f29c;  # ︒ς.𐮈
+。􃈵ς񀠇。𐮈; .􃈵ς񀠇.𐮈; [P1, V6, X4_2]; .xn--3xa88573c7n64d.xn--f29c; [P1, V6, A4_2]; .xn--4xa68573c7n64d.xn--f29c;  # .ς.𐮈
+。􃈵Σ񀠇。𐮈; .􃈵σ񀠇.𐮈; [P1, V6, X4_2]; .xn--4xa68573c7n64d.xn--f29c; [P1, V6, A4_2]; ;  # .σ.𐮈
+。􃈵σ񀠇。𐮈; .􃈵σ񀠇.𐮈; [P1, V6, X4_2]; .xn--4xa68573c7n64d.xn--f29c; [P1, V6, A4_2]; ;  # .σ.𐮈
+.xn--4xa68573c7n64d.xn--f29c; .􃈵σ񀠇.𐮈; [V6, X4_2]; .xn--4xa68573c7n64d.xn--f29c; [V6, A4_2]; ;  # .σ.𐮈
+.xn--3xa88573c7n64d.xn--f29c; .􃈵ς񀠇.𐮈; [V6, X4_2]; .xn--3xa88573c7n64d.xn--f29c; [V6, A4_2]; ;  # .ς.𐮈
+︒􃈵Σ񀠇｡𐮈; ︒􃈵σ񀠇.𐮈; [B1, P1, V6]; xn--4xa1729jwz5t7gl5f.xn--f29c; ; ;  # ︒σ.𐮈
+︒􃈵σ񀠇｡𐮈; ︒􃈵σ񀠇.𐮈; [B1, P1, V6]; xn--4xa1729jwz5t7gl5f.xn--f29c; ; ;  # ︒σ.𐮈
+xn--4xa1729jwz5t7gl5f.xn--f29c; ︒􃈵σ񀠇.𐮈; [B1, V6]; xn--4xa1729jwz5t7gl5f.xn--f29c; ; ;  # ︒σ.𐮈
+xn--3xa3729jwz5t7gl5f.xn--f29c; ︒􃈵ς񀠇.𐮈; [B1, V6]; xn--3xa3729jwz5t7gl5f.xn--f29c; ; ;  # ︒ς.𐮈
+ߙ．ۮ󆾃≯󠅲; ߙ.ۮ󆾃≯; [B2, B3, P1, V6]; xn--0sb.xn--bmb691l0524t; ; ;  # ߙ.ۮ≯
+ߙ．ۮ󆾃≯󠅲; ߙ.ۮ󆾃≯; [B2, B3, P1, V6]; xn--0sb.xn--bmb691l0524t; ; ;  # ߙ.ۮ≯
+ߙ.ۮ󆾃≯󠅲; ߙ.ۮ󆾃≯; [B2, B3, P1, V6]; xn--0sb.xn--bmb691l0524t; ; ;  # ߙ.ۮ≯
+ߙ.ۮ󆾃≯󠅲; ߙ.ۮ󆾃≯; [B2, B3, P1, V6]; xn--0sb.xn--bmb691l0524t; ; ;  # ߙ.ۮ≯
+xn--0sb.xn--bmb691l0524t; ߙ.ۮ󆾃≯; [B2, B3, V6]; xn--0sb.xn--bmb691l0524t; ; ;  # ߙ.ۮ≯
+ᩳ󚙸.𐭍; ; [B1, P1, V5, V6]; xn--2of22352n.xn--q09c; ; ;  # ᩳ.𐭍
+xn--2of22352n.xn--q09c; ᩳ󚙸.𐭍; [B1, V5, V6]; xn--2of22352n.xn--q09c; ; ;  # ᩳ.𐭍
+⒉󠊓≠｡Ⴟ⬣Ⴈ; ⒉󠊓≠.Ⴟ⬣Ⴈ; [P1, V6]; xn--1ch07f91401d.xn--gnd9b297j; ; ;  # ⒉≠.Ⴟ⬣Ⴈ
+⒉󠊓≠｡Ⴟ⬣Ⴈ; ⒉󠊓≠.Ⴟ⬣Ⴈ; [P1, V6]; xn--1ch07f91401d.xn--gnd9b297j; ; ;  # ⒉≠.Ⴟ⬣Ⴈ
+2.󠊓≠。Ⴟ⬣Ⴈ; 2.󠊓≠.Ⴟ⬣Ⴈ; [P1, V6]; 2.xn--1chz4101l.xn--gnd9b297j; ; ;  # 2.≠.Ⴟ⬣Ⴈ
+2.󠊓≠。Ⴟ⬣Ⴈ; 2.󠊓≠.Ⴟ⬣Ⴈ; [P1, V6]; 2.xn--1chz4101l.xn--gnd9b297j; ; ;  # 2.≠.Ⴟ⬣Ⴈ
+2.󠊓≠。ⴟ⬣ⴈ; 2.󠊓≠.ⴟ⬣ⴈ; [P1, V6]; 2.xn--1chz4101l.xn--45iz7d6b; ; ;  # 2.≠.ⴟ⬣ⴈ
+2.󠊓≠。ⴟ⬣ⴈ; 2.󠊓≠.ⴟ⬣ⴈ; [P1, V6]; 2.xn--1chz4101l.xn--45iz7d6b; ; ;  # 2.≠.ⴟ⬣ⴈ
+2.xn--1chz4101l.xn--45iz7d6b; 2.󠊓≠.ⴟ⬣ⴈ; [V6]; 2.xn--1chz4101l.xn--45iz7d6b; ; ;  # 2.≠.ⴟ⬣ⴈ
+2.xn--1chz4101l.xn--gnd9b297j; 2.󠊓≠.Ⴟ⬣Ⴈ; [V6]; 2.xn--1chz4101l.xn--gnd9b297j; ; ;  # 2.≠.Ⴟ⬣Ⴈ
+⒉󠊓≠｡ⴟ⬣ⴈ; ⒉󠊓≠.ⴟ⬣ⴈ; [P1, V6]; xn--1ch07f91401d.xn--45iz7d6b; ; ;  # ⒉≠.ⴟ⬣ⴈ
+⒉󠊓≠｡ⴟ⬣ⴈ; ⒉󠊓≠.ⴟ⬣ⴈ; [P1, V6]; xn--1ch07f91401d.xn--45iz7d6b; ; ;  # ⒉≠.ⴟ⬣ⴈ
+xn--1ch07f91401d.xn--45iz7d6b; ⒉󠊓≠.ⴟ⬣ⴈ; [V6]; xn--1ch07f91401d.xn--45iz7d6b; ; ;  # ⒉≠.ⴟ⬣ⴈ
+xn--1ch07f91401d.xn--gnd9b297j; ⒉󠊓≠.Ⴟ⬣Ⴈ; [V6]; xn--1ch07f91401d.xn--gnd9b297j; ; ;  # ⒉≠.Ⴟ⬣Ⴈ
+-󠉱ྸჅ。-𐹽ݴ𞣑; -󠉱ྸჅ.-𐹽ݴ𞣑; [B1, P1, V3, V6]; xn----xmg12fm2555h.xn----05c4213ryr0g; ; ;  # -ྸჅ.-𐹽ݴ𞣑
+-󠉱ྸⴥ。-𐹽ݴ𞣑; -󠉱ྸⴥ.-𐹽ݴ𞣑; [B1, P1, V3, V6]; xn----xmg317tgv352a.xn----05c4213ryr0g; ; ;  # -ྸⴥ.-𐹽ݴ𞣑
+xn----xmg317tgv352a.xn----05c4213ryr0g; -󠉱ྸⴥ.-𐹽ݴ𞣑; [B1, V3, V6]; xn----xmg317tgv352a.xn----05c4213ryr0g; ; ;  # -ྸⴥ.-𐹽ݴ𞣑
+xn----xmg12fm2555h.xn----05c4213ryr0g; -󠉱ྸჅ.-𐹽ݴ𞣑; [B1, V3, V6]; xn----xmg12fm2555h.xn----05c4213ryr0g; ; ;  # -ྸჅ.-𐹽ݴ𞣑
+ٙ。𑄴︒اߝ; ٙ.𑄴︒اߝ; [B1, B3, B6, P1, V5, V6]; xn--1hb.xn--mgb09fp820c08pa; ; ;  # ٙ.𑄴︒اߝ
+ٙ。𑄴。اߝ; ٙ.𑄴.اߝ; [B1, B3, B6, V5]; xn--1hb.xn--w80d.xn--mgb09f; ; ;  # ٙ.𑄴.اߝ
+xn--1hb.xn--w80d.xn--mgb09f; ٙ.𑄴.اߝ; [B1, B3, B6, V5]; xn--1hb.xn--w80d.xn--mgb09f; ; ;  # ٙ.𑄴.اߝ
+xn--1hb.xn--mgb09fp820c08pa; ٙ.𑄴︒اߝ; [B1, B3, B6, V5, V6]; xn--1hb.xn--mgb09fp820c08pa; ; ;  # ٙ.𑄴︒اߝ
+Ⴙظ.󠆓‍; Ⴙظ.‍; [B1, B5, B6, C2, P1, V6]; xn--3gb194c.xn--1ug; ; xn--3gb194c.; [B5, B6, P1, V6] # Ⴙظ.
+ⴙظ.󠆓‍; ⴙظ.‍; [B1, B5, B6, C2]; xn--3gb910r.xn--1ug; ; xn--3gb910r.; [B5, B6] # ⴙظ.
+xn--3gb910r.; ⴙظ.; [B5, B6]; xn--3gb910r.; ; ;  # ⴙظ.
+xn--3gb910r.xn--1ug; ⴙظ.‍; [B1, B5, B6, C2]; xn--3gb910r.xn--1ug; ; ;  # ⴙظ.
+xn--3gb194c.; Ⴙظ.; [B5, B6, V6]; xn--3gb194c.; ; ;  # Ⴙظ.
+xn--3gb194c.xn--1ug; Ⴙظ.‍; [B1, B5, B6, C2, V6]; xn--3gb194c.xn--1ug; ; ;  # Ⴙظ.
+󠆸｡₆０𐺧ݖ; .60𐺧ݖ; [B1, P1, V6, X4_2]; .xn--60-cke9470y; [B1, P1, V6, A4_2]; ;  # .60ݖ
+󠆸。60𐺧ݖ; .60𐺧ݖ; [B1, P1, V6, X4_2]; .xn--60-cke9470y; [B1, P1, V6, A4_2]; ;  # .60ݖ
+.xn--60-cke9470y; .60𐺧ݖ; [B1, V6, X4_2]; .xn--60-cke9470y; [B1, V6, A4_2]; ;  # .60ݖ
+6ࡏ｡-𑈴; 6ࡏ.-𑈴; [B1, V3]; xn--6-jjd.xn----6n8i; ; ;  # 6ࡏ.-𑈴
+6ࡏ。-𑈴; 6ࡏ.-𑈴; [B1, V3]; xn--6-jjd.xn----6n8i; ; ;  # 6ࡏ.-𑈴
+xn--6-jjd.xn----6n8i; 6ࡏ.-𑈴; [B1, V3]; xn--6-jjd.xn----6n8i; ; ;  # 6ࡏ.-𑈴
+‍񋌿𐹰｡્ς𞰎ࣖ; ‍񋌿𐹰.્ς𞰎ࣖ; [B1, C2, P1, V5, V6]; xn--1ugx105gq26y.xn--3xa41xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, P1, V5, V6] # 𐹰.્ςࣖ
+‍񋌿𐹰。્ς𞰎ࣖ; ‍񋌿𐹰.્ς𞰎ࣖ; [B1, C2, P1, V5, V6]; xn--1ugx105gq26y.xn--3xa41xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, P1, V5, V6] # 𐹰.્ςࣖ
+‍񋌿𐹰。્Σ𞰎ࣖ; ‍񋌿𐹰.્σ𞰎ࣖ; [B1, C2, P1, V5, V6]; xn--1ugx105gq26y.xn--4xa21xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, P1, V5, V6] # 𐹰.્σࣖ
+‍񋌿𐹰。્σ𞰎ࣖ; ‍񋌿𐹰.્σ𞰎ࣖ; [B1, C2, P1, V5, V6]; xn--1ugx105gq26y.xn--4xa21xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, P1, V5, V6] # 𐹰.્σࣖ
+xn--oo0d1330n.xn--4xa21xcwbfz15g; 񋌿𐹰.્σ𞰎ࣖ; [B1, B5, B6, V5, V6]; xn--oo0d1330n.xn--4xa21xcwbfz15g; ; ;  # 𐹰.્σࣖ
+xn--1ugx105gq26y.xn--4xa21xcwbfz15g; ‍񋌿𐹰.્σ𞰎ࣖ; [B1, C2, V5, V6]; xn--1ugx105gq26y.xn--4xa21xcwbfz15g; ; ;  # 𐹰.્σࣖ
+xn--1ugx105gq26y.xn--3xa41xcwbfz15g; ‍񋌿𐹰.્ς𞰎ࣖ; [B1, C2, V5, V6]; xn--1ugx105gq26y.xn--3xa41xcwbfz15g; ; ;  # 𐹰.્ςࣖ
+‍񋌿𐹰｡્Σ𞰎ࣖ; ‍񋌿𐹰.્σ𞰎ࣖ; [B1, C2, P1, V5, V6]; xn--1ugx105gq26y.xn--4xa21xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, P1, V5, V6] # 𐹰.્σࣖ
+‍񋌿𐹰｡્σ𞰎ࣖ; ‍񋌿𐹰.્σ𞰎ࣖ; [B1, C2, P1, V5, V6]; xn--1ugx105gq26y.xn--4xa21xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, P1, V5, V6] # 𐹰.્σࣖ
+⒈񟄜Ⴓ⒪．්򘘶ࢋ𐹢; ⒈񟄜Ⴓ⒪.්򘘶ࢋ𐹢; [B1, P1, V5, V6]; xn--rnd762h7cx3027d.xn--3xb99xpx1yoes3e; ; ;  # ⒈Ⴓ⒪.්𐹢
+1.񟄜Ⴓ(o).්򘘶ࢋ𐹢; ; [B1, B6, P1, V5, V6]; 1.xn--(o)-7sn88849j.xn--3xb99xpx1yoes3e; ; ;  # 1.Ⴓ(o).්𐹢
+1.񟄜ⴓ(o).්򘘶ࢋ𐹢; ; [B1, B6, P1, V5, V6]; 1.xn--(o)-ej1bu5389e.xn--3xb99xpx1yoes3e; ; ;  # 1.ⴓ(o).්𐹢
+1.񟄜Ⴓ(O).්򘘶ࢋ𐹢; 1.񟄜Ⴓ(o).්򘘶ࢋ𐹢; [B1, B6, P1, V5, V6]; 1.xn--(o)-7sn88849j.xn--3xb99xpx1yoes3e; ; ;  # 1.Ⴓ(o).්𐹢
+1.xn--(o)-7sn88849j.xn--3xb99xpx1yoes3e; 1.񟄜Ⴓ(o).්򘘶ࢋ𐹢; [B1, B6, P1, V5, V6]; 1.xn--(o)-7sn88849j.xn--3xb99xpx1yoes3e; ; ;  # 1.Ⴓ(o).්𐹢
+1.xn--(o)-ej1bu5389e.xn--3xb99xpx1yoes3e; 1.񟄜ⴓ(o).්򘘶ࢋ𐹢; [B1, B6, P1, V5, V6]; 1.xn--(o)-ej1bu5389e.xn--3xb99xpx1yoes3e; ; ;  # 1.ⴓ(o).්𐹢
+⒈񟄜ⴓ⒪．්򘘶ࢋ𐹢; ⒈񟄜ⴓ⒪.්򘘶ࢋ𐹢; [B1, P1, V5, V6]; xn--tsh0ds63atl31n.xn--3xb99xpx1yoes3e; ; ;  # ⒈ⴓ⒪.්𐹢
+xn--tsh0ds63atl31n.xn--3xb99xpx1yoes3e; ⒈񟄜ⴓ⒪.්򘘶ࢋ𐹢; [B1, V5, V6]; xn--tsh0ds63atl31n.xn--3xb99xpx1yoes3e; ; ;  # ⒈ⴓ⒪.්𐹢
+xn--rnd762h7cx3027d.xn--3xb99xpx1yoes3e; ⒈񟄜Ⴓ⒪.්򘘶ࢋ𐹢; [B1, V5, V6]; xn--rnd762h7cx3027d.xn--3xb99xpx1yoes3e; ; ;  # ⒈Ⴓ⒪.්𐹢
+𞤷.𐮐𞢁𐹠ؤ; ; ; xn--ve6h.xn--jgb1694kz0b2176a; ; ;  # 𞤷.𐮐𞢁𐹠ؤ
+𞤷.𐮐𞢁𐹠ؤ; 𞤷.𐮐𞢁𐹠ؤ; ; xn--ve6h.xn--jgb1694kz0b2176a; ; ;  # 𞤷.𐮐𞢁𐹠ؤ
+𞤕.𐮐𞢁𐹠ؤ; 𞤷.𐮐𞢁𐹠ؤ; ; xn--ve6h.xn--jgb1694kz0b2176a; ; ;  # 𞤷.𐮐𞢁𐹠ؤ
+𞤕.𐮐𞢁𐹠ؤ; 𞤷.𐮐𞢁𐹠ؤ; ; xn--ve6h.xn--jgb1694kz0b2176a; ; ;  # 𞤷.𐮐𞢁𐹠ؤ
+xn--ve6h.xn--jgb1694kz0b2176a; 𞤷.𐮐𞢁𐹠ؤ; ; xn--ve6h.xn--jgb1694kz0b2176a; ; ;  # 𞤷.𐮐𞢁𐹠ؤ
+𐲈-｡𑄳񢌻; 𐳈-.𑄳񢌻; [B1, B3, P1, V3, V5, V6]; xn----ue6i.xn--v80d6662t; ; ;  # 𐳈-.𑄳
+𐲈-。𑄳񢌻; 𐳈-.𑄳񢌻; [B1, B3, P1, V3, V5, V6]; xn----ue6i.xn--v80d6662t; ; ;  # 𐳈-.𑄳
+𐳈-。𑄳񢌻; 𐳈-.𑄳񢌻; [B1, B3, P1, V3, V5, V6]; xn----ue6i.xn--v80d6662t; ; ;  # 𐳈-.𑄳
+xn----ue6i.xn--v80d6662t; 𐳈-.𑄳񢌻; [B1, B3, V3, V5, V6]; xn----ue6i.xn--v80d6662t; ; ;  # 𐳈-.𑄳
+𐳈-｡𑄳񢌻; 𐳈-.𑄳񢌻; [B1, B3, P1, V3, V5, V6]; xn----ue6i.xn--v80d6662t; ; ;  # 𐳈-.𑄳
+-󠉖ꡧ．󠊂񇆃🄉; -󠉖ꡧ.󠊂񇆃🄉; [P1, V3, V6]; xn----hg4ei0361g.xn--207ht163h7m94c; ; ;  # -ꡧ.🄉
+-󠉖ꡧ.󠊂񇆃8,; ; [P1, V3, V6]; xn----hg4ei0361g.xn--8,-k362evu488a; ; ;  # -ꡧ.8,
+xn----hg4ei0361g.xn--8,-k362evu488a; -󠉖ꡧ.󠊂񇆃8,; [P1, V3, V6]; xn----hg4ei0361g.xn--8,-k362evu488a; ; ;  # -ꡧ.8,
+xn----hg4ei0361g.xn--207ht163h7m94c; -󠉖ꡧ.󠊂񇆃🄉; [V3, V6]; xn----hg4ei0361g.xn--207ht163h7m94c; ; ;  # -ꡧ.🄉
+󠾛󠈴臯𧔤.ݨ𝟝; 󠾛󠈴臯𧔤.ݨ5; [B1, P1, V6]; xn--zb1at733hm579ddhla.xn--5-b5c; ; ;  # 臯𧔤.ݨ5
+󠾛󠈴臯𧔤.ݨ5; ; [B1, P1, V6]; xn--zb1at733hm579ddhla.xn--5-b5c; ; ;  # 臯𧔤.ݨ5
+xn--zb1at733hm579ddhla.xn--5-b5c; 󠾛󠈴臯𧔤.ݨ5; [B1, V6]; xn--zb1at733hm579ddhla.xn--5-b5c; ; ;  # 臯𧔤.ݨ5
+≮𐹣．𝨿; ≮𐹣.𝨿; [B1, B3, B6, P1, V5, V6]; xn--gdh1504g.xn--e92h; ; ;  # ≮𐹣.𝨿
+≮𐹣．𝨿; ≮𐹣.𝨿; [B1, B3, B6, P1, V5, V6]; xn--gdh1504g.xn--e92h; ; ;  # ≮𐹣.𝨿
+≮𐹣.𝨿; ; [B1, B3, B6, P1, V5, V6]; xn--gdh1504g.xn--e92h; ; ;  # ≮𐹣.𝨿
+≮𐹣.𝨿; ≮𐹣.𝨿; [B1, B3, B6, P1, V5, V6]; xn--gdh1504g.xn--e92h; ; ;  # ≮𐹣.𝨿
+xn--gdh1504g.xn--e92h; ≮𐹣.𝨿; [B1, B3, B6, V5, V6]; xn--gdh1504g.xn--e92h; ; ;  # ≮𐹣.𝨿
+𐹯ᯛ੍｡脥; 𐹯ᯛ੍.脥; [B1]; xn--ybc101g3m1p.xn--740a; ; ;  # 𐹯ᯛ੍.脥
+𐹯ᯛ੍。脥; 𐹯ᯛ੍.脥; [B1]; xn--ybc101g3m1p.xn--740a; ; ;  # 𐹯ᯛ੍.脥
+xn--ybc101g3m1p.xn--740a; 𐹯ᯛ੍.脥; [B1]; xn--ybc101g3m1p.xn--740a; ; ;  # 𐹯ᯛ੍.脥
+᭄ᅟ𞷿򃀍.-; ; [B1, B5, P1, V3, V5, V6]; xn--osd971cpx70btgt8b.-; ; ;  # ᭄.-
+xn--osd971cpx70btgt8b.-; ᭄ᅟ𞷿򃀍.-; [B1, B5, V3, V5, V6]; xn--osd971cpx70btgt8b.-; ; ;  # ᭄.-
+‌｡͔; ‌.͔; [C1, V5]; xn--0ug.xn--yua; ; .xn--yua; [V5, A4_2] # .͔
+‌。͔; ‌.͔; [C1, V5]; xn--0ug.xn--yua; ; .xn--yua; [V5, A4_2] # .͔
+.xn--yua; .͔; [V5, X4_2]; .xn--yua; [V5, A4_2]; ;  # .͔
+xn--0ug.xn--yua; ‌.͔; [C1, V5]; xn--0ug.xn--yua; ; ;  # .͔
+𞤥󠅮．ᡄႮ; 𞤥.ᡄႮ; [P1, V6]; xn--de6h.xn--mnd799a; ; ;  # 𞤥.ᡄႮ
+𞤥󠅮.ᡄႮ; 𞤥.ᡄႮ; [P1, V6]; xn--de6h.xn--mnd799a; ; ;  # 𞤥.ᡄႮ
+𞤥󠅮.ᡄⴎ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤃󠅮.ᡄႮ; 𞤥.ᡄႮ; [P1, V6]; xn--de6h.xn--mnd799a; ; ;  # 𞤥.ᡄႮ
+𞤃󠅮.ᡄⴎ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+xn--de6h.xn--37e857h; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤥.ᡄⴎ; ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤃.ᡄႮ; 𞤥.ᡄႮ; [P1, V6]; xn--de6h.xn--mnd799a; ; ;  # 𞤥.ᡄႮ
+𞤃.ᡄⴎ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+xn--de6h.xn--mnd799a; 𞤥.ᡄႮ; [V6]; xn--de6h.xn--mnd799a; ; ;  # 𞤥.ᡄႮ
+𞤥󠅮．ᡄⴎ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤃󠅮．ᡄႮ; 𞤥.ᡄႮ; [P1, V6]; xn--de6h.xn--mnd799a; ; ;  # 𞤥.ᡄႮ
+𞤃󠅮．ᡄⴎ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤥.ᡄႮ; ; [P1, V6]; xn--de6h.xn--mnd799a; ; ;  # 𞤥.ᡄႮ
+𞤧𝨨Ξ．𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤧𝨨Ξ.𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤧𝨨ξ.𪺏㛨❸; ; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤅𝨨Ξ.𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤅𝨨ξ.𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+xn--zxa5691vboja.xn--bfi293ci119b; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤧𝨨ξ．𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤅𝨨Ξ．𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤅𝨨ξ．𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+᠆몆‌-｡Ⴛ𐦅︒; ᠆몆‌-.Ⴛ𐦅︒; [B1, B5, B6, C1, P1, V3, V6]; xn----e3j425bsk1o.xn--znd2362jhgh; ; xn----e3j6620g.xn--znd2362jhgh; [B1, B5, B6, P1, V3, V6] # ᠆몆-.Ⴛ𐦅︒
+᠆몆‌-｡Ⴛ𐦅︒; ᠆몆‌-.Ⴛ𐦅︒; [B1, B5, B6, C1, P1, V3, V6]; xn----e3j425bsk1o.xn--znd2362jhgh; ; xn----e3j6620g.xn--znd2362jhgh; [B1, B5, B6, P1, V3, V6] # ᠆몆-.Ⴛ𐦅︒
+᠆몆‌-。Ⴛ𐦅。; ᠆몆‌-.Ⴛ𐦅.; [B1, B5, B6, C1, P1, V3, V6]; xn----e3j425bsk1o.xn--znd4948j.; ; xn----e3j6620g.xn--znd4948j.; [B1, B5, B6, P1, V3, V6] # ᠆몆-.Ⴛ𐦅.
+᠆몆‌-。Ⴛ𐦅。; ᠆몆‌-.Ⴛ𐦅.; [B1, B5, B6, C1, P1, V3, V6]; xn----e3j425bsk1o.xn--znd4948j.; ; xn----e3j6620g.xn--znd4948j.; [B1, B5, B6, P1, V3, V6] # ᠆몆-.Ⴛ𐦅.
+᠆몆‌-。ⴛ𐦅。; ᠆몆‌-.ⴛ𐦅.; [B1, B5, B6, C1, P1, V3, V6]; xn----e3j425bsk1o.xn--jlju661e.; ; xn----e3j6620g.xn--jlju661e.; [B1, B5, B6, P1, V3, V6] # ᠆몆-.ⴛ𐦅.
+᠆몆‌-。ⴛ𐦅。; ᠆몆‌-.ⴛ𐦅.; [B1, B5, B6, C1, P1, V3, V6]; xn----e3j425bsk1o.xn--jlju661e.; ; xn----e3j6620g.xn--jlju661e.; [B1, B5, B6, P1, V3, V6] # ᠆몆-.ⴛ𐦅.
+xn----e3j6620g.xn--jlju661e.; ᠆몆-.ⴛ𐦅.; [B1, B5, B6, V3, V6]; xn----e3j6620g.xn--jlju661e.; ; ;  # ᠆몆-.ⴛ𐦅.
+xn----e3j425bsk1o.xn--jlju661e.; ᠆몆‌-.ⴛ𐦅.; [B1, B5, B6, C1, V3, V6]; xn----e3j425bsk1o.xn--jlju661e.; ; ;  # ᠆몆-.ⴛ𐦅.
+xn----e3j6620g.xn--znd4948j.; ᠆몆-.Ⴛ𐦅.; [B1, B5, B6, V3, V6]; xn----e3j6620g.xn--znd4948j.; ; ;  # ᠆몆-.Ⴛ𐦅.
+xn----e3j425bsk1o.xn--znd4948j.; ᠆몆‌-.Ⴛ𐦅.; [B1, B5, B6, C1, V3, V6]; xn----e3j425bsk1o.xn--znd4948j.; ; ;  # ᠆몆-.Ⴛ𐦅.
+᠆몆‌-｡ⴛ𐦅︒; ᠆몆‌-.ⴛ𐦅︒; [B1, B5, B6, C1, P1, V3, V6]; xn----e3j425bsk1o.xn--jlj4997dhgh; ; xn----e3j6620g.xn--jlj4997dhgh; [B1, B5, B6, P1, V3, V6] # ᠆몆-.ⴛ𐦅︒
+᠆몆‌-｡ⴛ𐦅︒; ᠆몆‌-.ⴛ𐦅︒; [B1, B5, B6, C1, P1, V3, V6]; xn----e3j425bsk1o.xn--jlj4997dhgh; ; xn----e3j6620g.xn--jlj4997dhgh; [B1, B5, B6, P1, V3, V6] # ᠆몆-.ⴛ𐦅︒
+xn----e3j6620g.xn--jlj4997dhgh; ᠆몆-.ⴛ𐦅︒; [B1, B5, B6, V3, V6]; xn----e3j6620g.xn--jlj4997dhgh; ; ;  # ᠆몆-.ⴛ𐦅︒
+xn----e3j425bsk1o.xn--jlj4997dhgh; ᠆몆‌-.ⴛ𐦅︒; [B1, B5, B6, C1, V3, V6]; xn----e3j425bsk1o.xn--jlj4997dhgh; ; ;  # ᠆몆-.ⴛ𐦅︒
+xn----e3j6620g.xn--znd2362jhgh; ᠆몆-.Ⴛ𐦅︒; [B1, B5, B6, V3, V6]; xn----e3j6620g.xn--znd2362jhgh; ; ;  # ᠆몆-.Ⴛ𐦅︒
+xn----e3j425bsk1o.xn--znd2362jhgh; ᠆몆‌-.Ⴛ𐦅︒; [B1, B5, B6, C1, V3, V6]; xn----e3j425bsk1o.xn--znd2362jhgh; ; ;  # ᠆몆-.Ⴛ𐦅︒
+󠾳.︒⥱‌𐹬; ; [B1, C1, P1, V6]; xn--uf66e.xn--0ugz28axl3pqxna; ; xn--uf66e.xn--qtiz073e3ik; [B1, P1, V6] # .︒⥱𐹬
+󠾳.。⥱‌𐹬; 󠾳..⥱‌𐹬; [B1, C1, P1, V6, X4_2]; xn--uf66e..xn--0ugz28as66q; [B1, C1, P1, V6, A4_2]; xn--uf66e..xn--qti2829e; [B1, P1, V6, A4_2] # ..⥱𐹬
+xn--uf66e..xn--qti2829e; 󠾳..⥱𐹬; [B1, V6, X4_2]; xn--uf66e..xn--qti2829e; [B1, V6, A4_2]; ;  # ..⥱𐹬
+xn--uf66e..xn--0ugz28as66q; 󠾳..⥱‌𐹬; [B1, C1, V6, X4_2]; xn--uf66e..xn--0ugz28as66q; [B1, C1, V6, A4_2]; ;  # ..⥱𐹬
+xn--uf66e.xn--qtiz073e3ik; 󠾳.︒⥱𐹬; [B1, V6]; xn--uf66e.xn--qtiz073e3ik; ; ;  # .︒⥱𐹬
+xn--uf66e.xn--0ugz28axl3pqxna; 󠾳.︒⥱‌𐹬; [B1, C1, V6]; xn--uf66e.xn--0ugz28axl3pqxna; ; ;  # .︒⥱𐹬
+𐯖.𐹠Ⴑ񚇜𐫊; ; [B1, P1, V6]; xn--n49c.xn--pnd4619jwicl862o; ; ;  # .𐹠Ⴑ𐫊
+𐯖.𐹠ⴑ񚇜𐫊; ; [B1, P1, V6]; xn--n49c.xn--8kj8702ewicl862o; ; ;  # .𐹠ⴑ𐫊
+xn--n49c.xn--8kj8702ewicl862o; 𐯖.𐹠ⴑ񚇜𐫊; [B1, V6]; xn--n49c.xn--8kj8702ewicl862o; ; ;  # .𐹠ⴑ𐫊
+xn--n49c.xn--pnd4619jwicl862o; 𐯖.𐹠Ⴑ񚇜𐫊; [B1, V6]; xn--n49c.xn--pnd4619jwicl862o; ; ;  # .𐹠Ⴑ𐫊
+ྤ񱤯．𝟭Ⴛ; ྤ񱤯.1Ⴛ; [P1, V5, V6]; xn--0fd40533g.xn--1-q1g; ; ;  # ྤ.1Ⴛ
+ྤ񱤯.1Ⴛ; ; [P1, V5, V6]; xn--0fd40533g.xn--1-q1g; ; ;  # ྤ.1Ⴛ
+ྤ񱤯.1ⴛ; ; [P1, V5, V6]; xn--0fd40533g.xn--1-tws; ; ;  # ྤ.1ⴛ
+xn--0fd40533g.xn--1-tws; ྤ񱤯.1ⴛ; [V5, V6]; xn--0fd40533g.xn--1-tws; ; ;  # ྤ.1ⴛ
+xn--0fd40533g.xn--1-q1g; ྤ񱤯.1Ⴛ; [V5, V6]; xn--0fd40533g.xn--1-q1g; ; ;  # ྤ.1Ⴛ
+ྤ񱤯．𝟭ⴛ; ྤ񱤯.1ⴛ; [P1, V5, V6]; xn--0fd40533g.xn--1-tws; ; ;  # ྤ.1ⴛ
+-ࠦ齀。릿𐸋; -ࠦ齀.릿𐸋; [B1, B5, B6, P1, V3, V6]; xn----6gd0617i.xn--7y2bm55m; ; ;  # -ࠦ齀.릿
+-ࠦ齀。릿𐸋; -ࠦ齀.릿𐸋; [B1, B5, B6, P1, V3, V6]; xn----6gd0617i.xn--7y2bm55m; ; ;  # -ࠦ齀.릿
+xn----6gd0617i.xn--7y2bm55m; -ࠦ齀.릿𐸋; [B1, B5, B6, V3, V6]; xn----6gd0617i.xn--7y2bm55m; ; ;  # -ࠦ齀.릿
+󠔊ܜ鹝꾗。񾵐‍‍⏃; 󠔊ܜ鹝꾗.񾵐‍‍⏃; [B1, B6, C2, P1, V6]; xn--mnb6558e91kyq533a.xn--1uga46zs309y; ; xn--mnb6558e91kyq533a.xn--6mh27269e; [B1, B6, P1, V6] # ܜ鹝꾗.⏃
+󠔊ܜ鹝꾗。񾵐‍‍⏃; 󠔊ܜ鹝꾗.񾵐‍‍⏃; [B1, B6, C2, P1, V6]; xn--mnb6558e91kyq533a.xn--1uga46zs309y; ; xn--mnb6558e91kyq533a.xn--6mh27269e; [B1, B6, P1, V6] # ܜ鹝꾗.⏃
+xn--mnb6558e91kyq533a.xn--6mh27269e; 󠔊ܜ鹝꾗.񾵐⏃; [B1, B6, V6]; xn--mnb6558e91kyq533a.xn--6mh27269e; ; ;  # ܜ鹝꾗.⏃
+xn--mnb6558e91kyq533a.xn--1uga46zs309y; 󠔊ܜ鹝꾗.񾵐‍‍⏃; [B1, B6, C2, V6]; xn--mnb6558e91kyq533a.xn--1uga46zs309y; ; ;  # ܜ鹝꾗.⏃
+≮．-܈--; ≮.-܈--; [B1, P1, V2, V3, V6]; xn--gdh.xn------eqf; ; ;  # ≮.-܈--
+≮．-܈--; ≮.-܈--; [B1, P1, V2, V3, V6]; xn--gdh.xn------eqf; ; ;  # ≮.-܈--
+≮.-܈--; ; [B1, P1, V2, V3, V6]; xn--gdh.xn------eqf; ; ;  # ≮.-܈--
+≮.-܈--; ≮.-܈--; [B1, P1, V2, V3, V6]; xn--gdh.xn------eqf; ; ;  # ≮.-܈--
+xn--gdh.xn------eqf; ≮.-܈--; [B1, V2, V3, V6]; xn--gdh.xn------eqf; ; ;  # ≮.-܈--
+𐹸󠋳。‍ς𝟩; 𐹸󠋳.‍ς7; [B1, C2, P1, V6]; xn--wo0di5177c.xn--7-xmb248s; ; xn--wo0di5177c.xn--7-zmb; [B1, P1, V6] # 𐹸.ς7
+𐹸󠋳。‍ς7; 𐹸󠋳.‍ς7; [B1, C2, P1, V6]; xn--wo0di5177c.xn--7-xmb248s; ; xn--wo0di5177c.xn--7-zmb; [B1, P1, V6] # 𐹸.ς7
+𐹸󠋳。‍Σ7; 𐹸󠋳.‍σ7; [B1, C2, P1, V6]; xn--wo0di5177c.xn--7-zmb938s; ; xn--wo0di5177c.xn--7-zmb; [B1, P1, V6] # 𐹸.σ7
+𐹸󠋳。‍σ7; 𐹸󠋳.‍σ7; [B1, C2, P1, V6]; xn--wo0di5177c.xn--7-zmb938s; ; xn--wo0di5177c.xn--7-zmb; [B1, P1, V6] # 𐹸.σ7
+xn--wo0di5177c.xn--7-zmb; 𐹸󠋳.σ7; [B1, V6]; xn--wo0di5177c.xn--7-zmb; ; ;  # 𐹸.σ7
+xn--wo0di5177c.xn--7-zmb938s; 𐹸󠋳.‍σ7; [B1, C2, V6]; xn--wo0di5177c.xn--7-zmb938s; ; ;  # 𐹸.σ7
+xn--wo0di5177c.xn--7-xmb248s; 𐹸󠋳.‍ς7; [B1, C2, V6]; xn--wo0di5177c.xn--7-xmb248s; ; ;  # 𐹸.ς7
+𐹸󠋳。‍Σ𝟩; 𐹸󠋳.‍σ7; [B1, C2, P1, V6]; xn--wo0di5177c.xn--7-zmb938s; ; xn--wo0di5177c.xn--7-zmb; [B1, P1, V6] # 𐹸.σ7
+𐹸󠋳。‍σ𝟩; 𐹸󠋳.‍σ7; [B1, C2, P1, V6]; xn--wo0di5177c.xn--7-zmb938s; ; xn--wo0di5177c.xn--7-zmb; [B1, P1, V6] # 𐹸.σ7
+ς򅜌８.𞭤; ς򅜌8.𞭤; [P1, V6]; xn--8-xmb44974n.xn--su6h; ; xn--8-zmb14974n.xn--su6h;  # ς8.
+ς򅜌8.𞭤; ; [P1, V6]; xn--8-xmb44974n.xn--su6h; ; xn--8-zmb14974n.xn--su6h;  # ς8.
+Σ򅜌8.𞭤; σ򅜌8.𞭤; [P1, V6]; xn--8-zmb14974n.xn--su6h; ; ;  # σ8.
+σ򅜌8.𞭤; ; [P1, V6]; xn--8-zmb14974n.xn--su6h; ; ;  # σ8.
+xn--8-zmb14974n.xn--su6h; σ򅜌8.𞭤; [V6]; xn--8-zmb14974n.xn--su6h; ; ;  # σ8.
+xn--8-xmb44974n.xn--su6h; ς򅜌8.𞭤; [V6]; xn--8-xmb44974n.xn--su6h; ; ;  # ς8.
+Σ򅜌８.𞭤; σ򅜌8.𞭤; [P1, V6]; xn--8-zmb14974n.xn--su6h; ; ;  # σ8.
+σ򅜌８.𞭤; σ򅜌8.𞭤; [P1, V6]; xn--8-zmb14974n.xn--su6h; ; ;  # σ8.
+‌ᡑ🄀ڄ．-𐫄𑲤; ‌ᡑ🄀ڄ.-𐫄𑲤; [B1, C1, P1, V3, V6]; xn--9ib722gvtfi563c.xn----ek5i065b; ; xn--9ib722gbw95a.xn----ek5i065b; [B1, B5, B6, P1, V3, V6] # ᡑ🄀ڄ.-𐫄𑲤
+‌ᡑ0.ڄ.-𐫄𑲤; ; [B1, C1, V3]; xn--0-o7j263b.xn--9ib.xn----ek5i065b; ; xn--0-o7j.xn--9ib.xn----ek5i065b; [B1, V3] # ᡑ0.ڄ.-𐫄𑲤
+xn--0-o7j.xn--9ib.xn----ek5i065b; ᡑ0.ڄ.-𐫄𑲤; [B1, V3]; xn--0-o7j.xn--9ib.xn----ek5i065b; ; ;  # ᡑ0.ڄ.-𐫄𑲤
+xn--0-o7j263b.xn--9ib.xn----ek5i065b; ‌ᡑ0.ڄ.-𐫄𑲤; [B1, C1, V3]; xn--0-o7j263b.xn--9ib.xn----ek5i065b; ; ;  # ᡑ0.ڄ.-𐫄𑲤
+xn--9ib722gbw95a.xn----ek5i065b; ᡑ🄀ڄ.-𐫄𑲤; [B1, B5, B6, V3, V6]; xn--9ib722gbw95a.xn----ek5i065b; ; ;  # ᡑ🄀ڄ.-𐫄𑲤
+xn--9ib722gvtfi563c.xn----ek5i065b; ‌ᡑ🄀ڄ.-𐫄𑲤; [B1, C1, V3, V6]; xn--9ib722gvtfi563c.xn----ek5i065b; ; ;  # ᡑ🄀ڄ.-𐫄𑲤
+𖠍。𐪿넯򞵲; 𖠍.𐪿넯򞵲; [B2, B3, P1, V6]; xn--4e9e.xn--l60bj21opd57g; ; ;  # 𖠍.넯
+𖠍。𐪿넯򞵲; 𖠍.𐪿넯򞵲; [B2, B3, P1, V6]; xn--4e9e.xn--l60bj21opd57g; ; ;  # 𖠍.넯
+xn--4e9e.xn--l60bj21opd57g; 𖠍.𐪿넯򞵲; [B2, B3, V6]; xn--4e9e.xn--l60bj21opd57g; ; ;  # 𖠍.넯
+᠇Ⴘ。؃Ⴈ𝆊; ᠇Ⴘ.؃Ⴈ𝆊; [B1, P1, V6]; xn--wnd558a.xn--lfb465c1v87a; ; ;  # ᠇Ⴘ.Ⴈ𝆊
+᠇ⴘ。؃ⴈ𝆊; ᠇ⴘ.؃ⴈ𝆊; [B1, P1, V6]; xn--d6e009h.xn--lfb290rfu3z; ; ;  # ᠇ⴘ.ⴈ𝆊
+xn--d6e009h.xn--lfb290rfu3z; ᠇ⴘ.؃ⴈ𝆊; [B1, V6]; xn--d6e009h.xn--lfb290rfu3z; ; ;  # ᠇ⴘ.ⴈ𝆊
+xn--wnd558a.xn--lfb465c1v87a; ᠇Ⴘ.؃Ⴈ𝆊; [B1, V6]; xn--wnd558a.xn--lfb465c1v87a; ; ;  # ᠇Ⴘ.Ⴈ𝆊
+⒚󠋑𞤰。牣٧Ⴜᣥ; ⒚󠋑𞤰.牣٧Ⴜᣥ; [B1, B5, P1, V6]; xn--cthy466n29j3e.xn--gib404ccxgh00h; ; ;  # ⒚𞤰.牣٧Ⴜᣥ
+19.󠋑𞤰。牣٧Ⴜᣥ; 19.󠋑𞤰.牣٧Ⴜᣥ; [B1, B5, P1, V6]; 19.xn--oe6h75760c.xn--gib404ccxgh00h; ; ;  # 19.𞤰.牣٧Ⴜᣥ
+19.󠋑𞤰。牣٧ⴜᣥ; 19.󠋑𞤰.牣٧ⴜᣥ; [B1, B5, P1, V6]; 19.xn--oe6h75760c.xn--gib285gtxo2l9d; ; ;  # 19.𞤰.牣٧ⴜᣥ
+19.󠋑𞤎。牣٧Ⴜᣥ; 19.󠋑𞤰.牣٧Ⴜᣥ; [B1, B5, P1, V6]; 19.xn--oe6h75760c.xn--gib404ccxgh00h; ; ;  # 19.𞤰.牣٧Ⴜᣥ
+19.󠋑𞤎。牣٧ⴜᣥ; 19.󠋑𞤰.牣٧ⴜᣥ; [B1, B5, P1, V6]; 19.xn--oe6h75760c.xn--gib285gtxo2l9d; ; ;  # 19.𞤰.牣٧ⴜᣥ
+19.xn--oe6h75760c.xn--gib285gtxo2l9d; 19.󠋑𞤰.牣٧ⴜᣥ; [B1, B5, V6]; 19.xn--oe6h75760c.xn--gib285gtxo2l9d; ; ;  # 19.𞤰.牣٧ⴜᣥ
+19.xn--oe6h75760c.xn--gib404ccxgh00h; 19.󠋑𞤰.牣٧Ⴜᣥ; [B1, B5, V6]; 19.xn--oe6h75760c.xn--gib404ccxgh00h; ; ;  # 19.𞤰.牣٧Ⴜᣥ
+⒚󠋑𞤰。牣٧ⴜᣥ; ⒚󠋑𞤰.牣٧ⴜᣥ; [B1, B5, P1, V6]; xn--cthy466n29j3e.xn--gib285gtxo2l9d; ; ;  # ⒚𞤰.牣٧ⴜᣥ
+⒚󠋑𞤎。牣٧Ⴜᣥ; ⒚󠋑𞤰.牣٧Ⴜᣥ; [B1, B5, P1, V6]; xn--cthy466n29j3e.xn--gib404ccxgh00h; ; ;  # ⒚𞤰.牣٧Ⴜᣥ
+⒚󠋑𞤎。牣٧ⴜᣥ; ⒚󠋑𞤰.牣٧ⴜᣥ; [B1, B5, P1, V6]; xn--cthy466n29j3e.xn--gib285gtxo2l9d; ; ;  # ⒚𞤰.牣٧ⴜᣥ
+xn--cthy466n29j3e.xn--gib285gtxo2l9d; ⒚󠋑𞤰.牣٧ⴜᣥ; [B1, B5, V6]; xn--cthy466n29j3e.xn--gib285gtxo2l9d; ; ;  # ⒚𞤰.牣٧ⴜᣥ
+xn--cthy466n29j3e.xn--gib404ccxgh00h; ⒚󠋑𞤰.牣٧Ⴜᣥ; [B1, B5, V6]; xn--cthy466n29j3e.xn--gib404ccxgh00h; ; ;  # ⒚𞤰.牣٧Ⴜᣥ
+-𐋱𐰽⒈.Ⴓ; ; [B1, P1, V3, V6]; xn----ecp0206g90h.xn--rnd; ; ;  # -𐋱𐰽⒈.Ⴓ
+-𐋱𐰽1..Ⴓ; ; [B1, P1, V3, V6, X4_2]; xn---1-895nq11a..xn--rnd; [B1, P1, V3, V6, A4_2]; ;  # -𐋱𐰽1..Ⴓ
+-𐋱𐰽1..ⴓ; ; [B1, V3, X4_2]; xn---1-895nq11a..xn--blj; [B1, V3, A4_2]; ;  # -𐋱𐰽1..ⴓ
+xn---1-895nq11a..xn--blj; -𐋱𐰽1..ⴓ; [B1, V3, X4_2]; xn---1-895nq11a..xn--blj; [B1, V3, A4_2]; ;  # -𐋱𐰽1..ⴓ
+xn---1-895nq11a..xn--rnd; -𐋱𐰽1..Ⴓ; [B1, V3, V6, X4_2]; xn---1-895nq11a..xn--rnd; [B1, V3, V6, A4_2]; ;  # -𐋱𐰽1..Ⴓ
+-𐋱𐰽⒈.ⴓ; ; [B1, P1, V3, V6]; xn----ecp0206g90h.xn--blj; ; ;  # -𐋱𐰽⒈.ⴓ
+xn----ecp0206g90h.xn--blj; -𐋱𐰽⒈.ⴓ; [B1, V3, V6]; xn----ecp0206g90h.xn--blj; ; ;  # -𐋱𐰽⒈.ⴓ
+xn----ecp0206g90h.xn--rnd; -𐋱𐰽⒈.Ⴓ; [B1, V3, V6]; xn----ecp0206g90h.xn--rnd; ; ;  # -𐋱𐰽⒈.Ⴓ
+‌긃.榶-; ; [C1, V3]; xn--0ug3307c.xn----d87b; ; xn--ej0b.xn----d87b; [V3] # 긃.榶-
+‌긃.榶-; ‌긃.榶-; [C1, V3]; xn--0ug3307c.xn----d87b; ; xn--ej0b.xn----d87b; [V3] # 긃.榶-
+xn--ej0b.xn----d87b; 긃.榶-; [V3]; xn--ej0b.xn----d87b; ; ;  # 긃.榶-
+xn--0ug3307c.xn----d87b; ‌긃.榶-; [C1, V3]; xn--0ug3307c.xn----d87b; ; ;  # 긃.榶-
+뉓泓𜵽.্‍; ; [P1, V5, V6]; xn--lwwp69lqs7m.xn--b7b605i; ; xn--lwwp69lqs7m.xn--b7b;  # 뉓泓.্
+뉓泓𜵽.্‍; 뉓泓𜵽.্‍; [P1, V5, V6]; xn--lwwp69lqs7m.xn--b7b605i; ; xn--lwwp69lqs7m.xn--b7b;  # 뉓泓.্
+xn--lwwp69lqs7m.xn--b7b; 뉓泓𜵽.্; [V5, V6]; xn--lwwp69lqs7m.xn--b7b; ; ;  # 뉓泓.্
+xn--lwwp69lqs7m.xn--b7b605i; 뉓泓𜵽.্‍; [V5, V6]; xn--lwwp69lqs7m.xn--b7b605i; ; ;  # 뉓泓.্
+‍𐹴ß｡ິ⭵񪅌; ‍𐹴ß.ິ⭵񪅌; [B1, C2, P1, V5, V6]; xn--zca770nip7n.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, P1, V5, V6] # 𐹴ß.ິ
+‍𐹴ß。ິ⭵񪅌; ‍𐹴ß.ິ⭵񪅌; [B1, C2, P1, V5, V6]; xn--zca770nip7n.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, P1, V5, V6] # 𐹴ß.ິ
+‍𐹴SS。ິ⭵񪅌; ‍𐹴ss.ິ⭵񪅌; [B1, C2, P1, V5, V6]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, P1, V5, V6] # 𐹴ss.ິ
+‍𐹴ss。ິ⭵񪅌; ‍𐹴ss.ິ⭵񪅌; [B1, C2, P1, V5, V6]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, P1, V5, V6] # 𐹴ss.ິ
+‍𐹴Ss。ິ⭵񪅌; ‍𐹴ss.ິ⭵񪅌; [B1, C2, P1, V5, V6]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, P1, V5, V6] # 𐹴ss.ິ
+xn--ss-ti3o.xn--57c638l8774i; 𐹴ss.ິ⭵񪅌; [B1, V5, V6]; xn--ss-ti3o.xn--57c638l8774i; ; ;  # 𐹴ss.ິ
+xn--ss-l1t5169j.xn--57c638l8774i; ‍𐹴ss.ິ⭵񪅌; [B1, C2, V5, V6]; xn--ss-l1t5169j.xn--57c638l8774i; ; ;  # 𐹴ss.ິ
+xn--zca770nip7n.xn--57c638l8774i; ‍𐹴ß.ິ⭵񪅌; [B1, C2, V5, V6]; xn--zca770nip7n.xn--57c638l8774i; ; ;  # 𐹴ß.ິ
+‍𐹴SS｡ິ⭵񪅌; ‍𐹴ss.ິ⭵񪅌; [B1, C2, P1, V5, V6]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, P1, V5, V6] # 𐹴ss.ິ
+‍𐹴ss｡ິ⭵񪅌; ‍𐹴ss.ິ⭵񪅌; [B1, C2, P1, V5, V6]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, P1, V5, V6] # 𐹴ss.ິ
+‍𐹴Ss｡ິ⭵񪅌; ‍𐹴ss.ິ⭵񪅌; [B1, C2, P1, V5, V6]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, P1, V5, V6] # 𐹴ss.ິ
+᭄．᮪-≮≠; ᭄.᮪-≮≠; [P1, V5, V6]; xn--1uf.xn----nmlz65aub; ; ;  # ᭄.᮪-≮≠
+᭄．᮪-≮≠; ᭄.᮪-≮≠; [P1, V5, V6]; xn--1uf.xn----nmlz65aub; ; ;  # ᭄.᮪-≮≠
+᭄.᮪-≮≠; ; [P1, V5, V6]; xn--1uf.xn----nmlz65aub; ; ;  # ᭄.᮪-≮≠
+᭄.᮪-≮≠; ᭄.᮪-≮≠; [P1, V5, V6]; xn--1uf.xn----nmlz65aub; ; ;  # ᭄.᮪-≮≠
+xn--1uf.xn----nmlz65aub; ᭄.᮪-≮≠; [V5, V6]; xn--1uf.xn----nmlz65aub; ; ;  # ᭄.᮪-≮≠
+᯳Ⴑᅟ．𑄴Ⅎ; ᯳Ⴑᅟ.𑄴Ⅎ; [P1, V5, V6]; xn--pnd26a55x.xn--f3g7465g; ; ;  # ᯳Ⴑ.𑄴Ⅎ
+᯳Ⴑᅟ.𑄴Ⅎ; ; [P1, V5, V6]; xn--pnd26a55x.xn--f3g7465g; ; ;  # ᯳Ⴑ.𑄴Ⅎ
+᯳ⴑᅟ.𑄴ⅎ; ; [P1, V5, V6]; xn--osd925cvyn.xn--73g3065g; ; ;  # ᯳ⴑ.𑄴ⅎ
+᯳Ⴑᅟ.𑄴ⅎ; ; [P1, V5, V6]; xn--pnd26a55x.xn--73g3065g; ; ;  # ᯳Ⴑ.𑄴ⅎ
+xn--pnd26a55x.xn--73g3065g; ᯳Ⴑᅟ.𑄴ⅎ; [V5, V6]; xn--pnd26a55x.xn--73g3065g; ; ;  # ᯳Ⴑ.𑄴ⅎ
+xn--osd925cvyn.xn--73g3065g; ᯳ⴑᅟ.𑄴ⅎ; [V5, V6]; xn--osd925cvyn.xn--73g3065g; ; ;  # ᯳ⴑ.𑄴ⅎ
+xn--pnd26a55x.xn--f3g7465g; ᯳Ⴑᅟ.𑄴Ⅎ; [V5, V6]; xn--pnd26a55x.xn--f3g7465g; ; ;  # ᯳Ⴑ.𑄴Ⅎ
+᯳ⴑᅟ．𑄴ⅎ; ᯳ⴑᅟ.𑄴ⅎ; [P1, V5, V6]; xn--osd925cvyn.xn--73g3065g; ; ;  # ᯳ⴑ.𑄴ⅎ
+᯳Ⴑᅟ．𑄴ⅎ; ᯳Ⴑᅟ.𑄴ⅎ; [P1, V5, V6]; xn--pnd26a55x.xn--73g3065g; ; ;  # ᯳Ⴑ.𑄴ⅎ
+𜉆。Ⴃ𐴣𐹹똯; 𜉆.Ⴃ𐴣𐹹똯; [B5, P1, V6]; xn--187g.xn--bnd4785f8r8bdeb; ; ;  # .Ⴃ𐴣𐹹똯
+𜉆。Ⴃ𐴣𐹹똯; 𜉆.Ⴃ𐴣𐹹똯; [B5, P1, V6]; xn--187g.xn--bnd4785f8r8bdeb; ; ;  # .Ⴃ𐴣𐹹똯
+𜉆。ⴃ𐴣𐹹똯; 𜉆.ⴃ𐴣𐹹똯; [B5, P1, V6]; xn--187g.xn--ukjy205b8rscdeb; ; ;  # .ⴃ𐴣𐹹똯
+𜉆。ⴃ𐴣𐹹똯; 𜉆.ⴃ𐴣𐹹똯; [B5, P1, V6]; xn--187g.xn--ukjy205b8rscdeb; ; ;  # .ⴃ𐴣𐹹똯
+xn--187g.xn--ukjy205b8rscdeb; 𜉆.ⴃ𐴣𐹹똯; [B5, V6]; xn--187g.xn--ukjy205b8rscdeb; ; ;  # .ⴃ𐴣𐹹똯
+xn--187g.xn--bnd4785f8r8bdeb; 𜉆.Ⴃ𐴣𐹹똯; [B5, V6]; xn--187g.xn--bnd4785f8r8bdeb; ; ;  # .Ⴃ𐴣𐹹똯
+𐫀｡⳻󠙾󠄷ㅤ; 𐫀.⳻󠙾ㅤ; [B1, P1, V6]; xn--pw9c.xn--mkj83l4v899a; ; ;  # 𐫀.⳻
+𐫀。⳻󠙾󠄷ᅠ; 𐫀.⳻󠙾ᅠ; [B1, P1, V6]; xn--pw9c.xn--psd742lxt32w; ; ;  # 𐫀.⳻
+xn--pw9c.xn--psd742lxt32w; 𐫀.⳻󠙾ᅠ; [B1, V6]; xn--pw9c.xn--psd742lxt32w; ; ;  # 𐫀.⳻
+xn--pw9c.xn--mkj83l4v899a; 𐫀.⳻󠙾ㅤ; [B1, V6]; xn--pw9c.xn--mkj83l4v899a; ; ;  # 𐫀.⳻
+ޚ⾇．ܞ-𐋰; ޚ舛.ܞ-𐋰; [B2, B3]; xn--7qb6383d.xn----20c3154q; ; ;  # ޚ舛.ܞ-𐋰
+ޚ舛.ܞ-𐋰; ; [B2, B3]; xn--7qb6383d.xn----20c3154q; ; ;  # ޚ舛.ܞ-𐋰
+xn--7qb6383d.xn----20c3154q; ޚ舛.ܞ-𐋰; [B2, B3]; xn--7qb6383d.xn----20c3154q; ; ;  # ޚ舛.ܞ-𐋰
+Ⴉ猕󹛫≮．︒; Ⴉ猕󹛫≮.︒; [P1, V6]; xn--hnd212gz32d54x5r.xn--y86c; ; ;  # Ⴉ猕≮.︒
+Ⴉ猕󹛫≮．︒; Ⴉ猕󹛫≮.︒; [P1, V6]; xn--hnd212gz32d54x5r.xn--y86c; ; ;  # Ⴉ猕≮.︒
+Ⴉ猕󹛫≮.。; Ⴉ猕󹛫≮..; [P1, V6, X4_2]; xn--hnd212gz32d54x5r..; [P1, V6, A4_2]; ;  # Ⴉ猕≮..
+Ⴉ猕󹛫≮.。; Ⴉ猕󹛫≮..; [P1, V6, X4_2]; xn--hnd212gz32d54x5r..; [P1, V6, A4_2]; ;  # Ⴉ猕≮..
+ⴉ猕󹛫≮.。; ⴉ猕󹛫≮..; [P1, V6, X4_2]; xn--gdh892bbz0d5438s..; [P1, V6, A4_2]; ;  # ⴉ猕≮..
+ⴉ猕󹛫≮.。; ⴉ猕󹛫≮..; [P1, V6, X4_2]; xn--gdh892bbz0d5438s..; [P1, V6, A4_2]; ;  # ⴉ猕≮..
+xn--gdh892bbz0d5438s..; ⴉ猕󹛫≮..; [V6, X4_2]; xn--gdh892bbz0d5438s..; [V6, A4_2]; ;  # ⴉ猕≮..
+xn--hnd212gz32d54x5r..; Ⴉ猕󹛫≮..; [V6, X4_2]; xn--hnd212gz32d54x5r..; [V6, A4_2]; ;  # Ⴉ猕≮..
+ⴉ猕󹛫≮．︒; ⴉ猕󹛫≮.︒; [P1, V6]; xn--gdh892bbz0d5438s.xn--y86c; ; ;  # ⴉ猕≮.︒
+ⴉ猕󹛫≮．︒; ⴉ猕󹛫≮.︒; [P1, V6]; xn--gdh892bbz0d5438s.xn--y86c; ; ;  # ⴉ猕≮.︒
+xn--gdh892bbz0d5438s.xn--y86c; ⴉ猕󹛫≮.︒; [V6]; xn--gdh892bbz0d5438s.xn--y86c; ; ;  # ⴉ猕≮.︒
+xn--hnd212gz32d54x5r.xn--y86c; Ⴉ猕󹛫≮.︒; [V6]; xn--hnd212gz32d54x5r.xn--y86c; ; ;  # Ⴉ猕≮.︒
+🏮｡ث鳳ߢ󠅉; 🏮.ث鳳ߢ; [B1, B2]; xn--8m8h.xn--qgb29f6z90a; ; ;  # 🏮.ث鳳ߢ
+🏮。ث鳳ߢ󠅉; 🏮.ث鳳ߢ; [B1, B2]; xn--8m8h.xn--qgb29f6z90a; ; ;  # 🏮.ث鳳ߢ
+xn--8m8h.xn--qgb29f6z90a; 🏮.ث鳳ߢ; [B1, B2]; xn--8m8h.xn--qgb29f6z90a; ; ;  # 🏮.ث鳳ߢ
+‍𐹶。ß; ‍𐹶.ß; [B1, C2]; xn--1ug9105g.xn--zca; ; xn--uo0d.ss; [B1] # 𐹶.ß
+‍𐹶。SS; ‍𐹶.ss; [B1, C2]; xn--1ug9105g.ss; ; xn--uo0d.ss; [B1] # 𐹶.ss
+‍𐹶。ss; ‍𐹶.ss; [B1, C2]; xn--1ug9105g.ss; ; xn--uo0d.ss; [B1] # 𐹶.ss
+‍𐹶。Ss; ‍𐹶.ss; [B1, C2]; xn--1ug9105g.ss; ; xn--uo0d.ss; [B1] # 𐹶.ss
+xn--uo0d.ss; 𐹶.ss; [B1]; xn--uo0d.ss; ; ;  # 𐹶.ss
+xn--1ug9105g.ss; ‍𐹶.ss; [B1, C2]; xn--1ug9105g.ss; ; ;  # 𐹶.ss
+xn--1ug9105g.xn--zca; ‍𐹶.ß; [B1, C2]; xn--1ug9105g.xn--zca; ; ;  # 𐹶.ß
+Å둄-．‌; å둄-.‌; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3] # å둄-.
+Å둄-．‌; å둄-.‌; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3] # å둄-.
+Å둄-.‌; å둄-.‌; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3] # å둄-.
+Å둄-.‌; å둄-.‌; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3] # å둄-.
+å둄-.‌; å둄-.‌; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3] # å둄-.
+å둄-.‌; ; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3] # å둄-.
+xn----1fa1788k.; å둄-.; [V3]; xn----1fa1788k.; ; ;  # å둄-.
+xn----1fa1788k.xn--0ug; å둄-.‌; [C1, V3]; xn----1fa1788k.xn--0ug; ; ;  # å둄-.
+å둄-．‌; å둄-.‌; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3] # å둄-.
+å둄-．‌; å둄-.‌; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3] # å둄-.
+゙򬎑ᷗ𞤀.򱲢-॓; ゙򬎑ᷗ𞤢.򱲢-॓; [B1, B6, P1, V5, V6]; xn--veg121fwg63altj9d.xn----eyd92688s; ; ;  # ゙ᷗ𞤢.-॓
+゙򬎑ᷗ𞤢.򱲢-॓; ; [B1, B6, P1, V5, V6]; xn--veg121fwg63altj9d.xn----eyd92688s; ; ;  # ゙ᷗ𞤢.-॓
+xn--veg121fwg63altj9d.xn----eyd92688s; ゙򬎑ᷗ𞤢.򱲢-॓; [B1, B6, V5, V6]; xn--veg121fwg63altj9d.xn----eyd92688s; ; ;  # ゙ᷗ𞤢.-॓
+ς.ß񴱄۝⵿; ; [B5, B6, P1, V6]; xn--3xa.xn--zca281az71b8x73m; ; xn--4xa.xn--ss-y8d4760biv60n;  # ς.ß⵿
+Σ.SS񴱄۝⵿; σ.ss񴱄۝⵿; [B5, B6, P1, V6]; xn--4xa.xn--ss-y8d4760biv60n; ; ;  # σ.ss⵿
+σ.ss񴱄۝⵿; ; [B5, B6, P1, V6]; xn--4xa.xn--ss-y8d4760biv60n; ; ;  # σ.ss⵿
+Σ.ss񴱄۝⵿; σ.ss񴱄۝⵿; [B5, B6, P1, V6]; xn--4xa.xn--ss-y8d4760biv60n; ; ;  # σ.ss⵿
+xn--4xa.xn--ss-y8d4760biv60n; σ.ss񴱄۝⵿; [B5, B6, V6]; xn--4xa.xn--ss-y8d4760biv60n; ; ;  # σ.ss⵿
+Σ.ß񴱄۝⵿; σ.ß񴱄۝⵿; [B5, B6, P1, V6]; xn--4xa.xn--zca281az71b8x73m; ; xn--4xa.xn--ss-y8d4760biv60n;  # σ.ß⵿
+σ.ß񴱄۝⵿; ; [B5, B6, P1, V6]; xn--4xa.xn--zca281az71b8x73m; ; xn--4xa.xn--ss-y8d4760biv60n;  # σ.ß⵿
+xn--4xa.xn--zca281az71b8x73m; σ.ß񴱄۝⵿; [B5, B6, V6]; xn--4xa.xn--zca281az71b8x73m; ; ;  # σ.ß⵿
+xn--3xa.xn--zca281az71b8x73m; ς.ß񴱄۝⵿; [B5, B6, V6]; xn--3xa.xn--zca281az71b8x73m; ; ;  # ς.ß⵿
+ꡀ𞀟｡٫֙; ꡀ𞀟.٫֙; [B1]; xn--8b9a1720d.xn--kcb33b; ; ;  # ꡀ𞀟.٫֙
+ꡀ𞀟。٫֙; ꡀ𞀟.٫֙; [B1]; xn--8b9a1720d.xn--kcb33b; ; ;  # ꡀ𞀟.٫֙
+xn--8b9a1720d.xn--kcb33b; ꡀ𞀟.٫֙; [B1]; xn--8b9a1720d.xn--kcb33b; ; ;  # ꡀ𞀟.٫֙
+򈛉‌ࢩ｡⧅񘘡-𐭡; 򈛉‌ࢩ.⧅񘘡-𐭡; [B1, B5, B6, C1, P1, V6]; xn--yyb780jll63m.xn----zir1232guu71b; ; xn--yyb56242i.xn----zir1232guu71b; [B1, B5, B6, P1, V6] # ࢩ.⧅-𐭡
+򈛉‌ࢩ。⧅񘘡-𐭡; 򈛉‌ࢩ.⧅񘘡-𐭡; [B1, B5, B6, C1, P1, V6]; xn--yyb780jll63m.xn----zir1232guu71b; ; xn--yyb56242i.xn----zir1232guu71b; [B1, B5, B6, P1, V6] # ࢩ.⧅-𐭡
+xn--yyb56242i.xn----zir1232guu71b; 򈛉ࢩ.⧅񘘡-𐭡; [B1, B5, B6, V6]; xn--yyb56242i.xn----zir1232guu71b; ; ;  # ࢩ.⧅-𐭡
+xn--yyb780jll63m.xn----zir1232guu71b; 򈛉‌ࢩ.⧅񘘡-𐭡; [B1, B5, B6, C1, V6]; xn--yyb780jll63m.xn----zir1232guu71b; ; ;  # ࢩ.⧅-𐭡
+룱‍𰍨‌。𝨖︒; 룱‍𰍨‌.𝨖︒; [C1, C2, P1, V5, V6]; xn--0ugb3358ili2v.xn--y86cl899a; ; xn--ct2b0738h.xn--y86cl899a; [P1, V5, V6] # 룱.𝨖︒
+룱‍𰍨‌。𝨖︒; 룱‍𰍨‌.𝨖︒; [C1, C2, P1, V5, V6]; xn--0ugb3358ili2v.xn--y86cl899a; ; xn--ct2b0738h.xn--y86cl899a; [P1, V5, V6] # 룱.𝨖︒
+룱‍𰍨‌。𝨖。; 룱‍𰍨‌.𝨖.; [C1, C2, P1, V5, V6]; xn--0ugb3358ili2v.xn--772h.; ; xn--ct2b0738h.xn--772h.; [P1, V5, V6] # 룱.𝨖.
+룱‍𰍨‌。𝨖。; 룱‍𰍨‌.𝨖.; [C1, C2, P1, V5, V6]; xn--0ugb3358ili2v.xn--772h.; ; xn--ct2b0738h.xn--772h.; [P1, V5, V6] # 룱.𝨖.
+xn--ct2b0738h.xn--772h.; 룱𰍨.𝨖.; [V5, V6]; xn--ct2b0738h.xn--772h.; ; ;  # 룱.𝨖.
+xn--0ugb3358ili2v.xn--772h.; 룱‍𰍨‌.𝨖.; [C1, C2, V5, V6]; xn--0ugb3358ili2v.xn--772h.; ; ;  # 룱.𝨖.
+xn--ct2b0738h.xn--y86cl899a; 룱𰍨.𝨖︒; [V5, V6]; xn--ct2b0738h.xn--y86cl899a; ; ;  # 룱.𝨖︒
+xn--0ugb3358ili2v.xn--y86cl899a; 룱‍𰍨‌.𝨖︒; [C1, C2, V5, V6]; xn--0ugb3358ili2v.xn--y86cl899a; ; ;  # 룱.𝨖︒
+🄄．᳜⒈ß; 🄄.᳜⒈ß; [P1, V5, V6]; xn--x07h.xn--zca344lmif; ; xn--x07h.xn--ss-k1r094b;  # 🄄.᳜⒈ß
+3,.᳜1.ß; ; [P1, V5, V6]; 3,.xn--1-43l.xn--zca; ; 3,.xn--1-43l.ss;  # 3,.᳜1.ß
+3,.᳜1.SS; 3,.᳜1.ss; [P1, V5, V6]; 3,.xn--1-43l.ss; ; ;  # 3,.᳜1.ss
+3,.᳜1.ss; ; [P1, V5, V6]; 3,.xn--1-43l.ss; ; ;  # 3,.᳜1.ss
+3,.᳜1.Ss; 3,.᳜1.ss; [P1, V5, V6]; 3,.xn--1-43l.ss; ; ;  # 3,.᳜1.ss
+3,.xn--1-43l.ss; 3,.᳜1.ss; [P1, V5, V6]; 3,.xn--1-43l.ss; ; ;  # 3,.᳜1.ss
+3,.xn--1-43l.xn--zca; 3,.᳜1.ß; [P1, V5, V6]; 3,.xn--1-43l.xn--zca; ; ;  # 3,.᳜1.ß
+🄄．᳜⒈SS; 🄄.᳜⒈ss; [P1, V5, V6]; xn--x07h.xn--ss-k1r094b; ; ;  # 🄄.᳜⒈ss
+🄄．᳜⒈ss; 🄄.᳜⒈ss; [P1, V5, V6]; xn--x07h.xn--ss-k1r094b; ; ;  # 🄄.᳜⒈ss
+🄄．᳜⒈Ss; 🄄.᳜⒈ss; [P1, V5, V6]; xn--x07h.xn--ss-k1r094b; ; ;  # 🄄.᳜⒈ss
+xn--x07h.xn--ss-k1r094b; 🄄.᳜⒈ss; [V5, V6]; xn--x07h.xn--ss-k1r094b; ; ;  # 🄄.᳜⒈ss
+xn--x07h.xn--zca344lmif; 🄄.᳜⒈ß; [V5, V6]; xn--x07h.xn--zca344lmif; ; ;  # 🄄.᳜⒈ß
+񇌍⵿｡𞼓򡄨𑐺; 񇌍⵿.𞼓򡄨𑐺; [B2, B3, P1, V6]; xn--eoj16016a.xn--0v1d3848a3lr0d; ; ;  # ⵿.𑐺
+񇌍⵿。𞼓򡄨𑐺; 񇌍⵿.𞼓򡄨𑐺; [B2, B3, P1, V6]; xn--eoj16016a.xn--0v1d3848a3lr0d; ; ;  # ⵿.𑐺
+xn--eoj16016a.xn--0v1d3848a3lr0d; 񇌍⵿.𞼓򡄨𑐺; [B2, B3, V6]; xn--eoj16016a.xn--0v1d3848a3lr0d; ; ;  # ⵿.𑐺
+်्᷽．≠‍㇛; ်्᷽.≠‍㇛; [C2, P1, V5, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; xn--n3b956a9zm.xn--1ch912d; [P1, V5, V6] # ်्᷽.≠㇛
+်्᷽．≠‍㇛; ်्᷽.≠‍㇛; [C2, P1, V5, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; xn--n3b956a9zm.xn--1ch912d; [P1, V5, V6] # ်्᷽.≠㇛
+်्᷽．≠‍㇛; ်्᷽.≠‍㇛; [C2, P1, V5, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; xn--n3b956a9zm.xn--1ch912d; [P1, V5, V6] # ်्᷽.≠㇛
+်्᷽.≠‍㇛; ; [C2, P1, V5, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; xn--n3b956a9zm.xn--1ch912d; [P1, V5, V6] # ်्᷽.≠㇛
+်्᷽.≠‍㇛; ်्᷽.≠‍㇛; [C2, P1, V5, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; xn--n3b956a9zm.xn--1ch912d; [P1, V5, V6] # ်्᷽.≠㇛
+xn--n3b956a9zm.xn--1ch912d; ်्᷽.≠㇛; [V5, V6]; xn--n3b956a9zm.xn--1ch912d; ; ;  # ်्᷽.≠㇛
+xn--n3b956a9zm.xn--1ug63gz5w; ်्᷽.≠‍㇛; [C2, V5, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; ;  # ်्᷽.≠㇛
+Ⴁ𐋨娤.‍̼٢𑖿; ; [B1, C2, P1, V6]; xn--8md2578ag21g.xn--9ta62ngt6aou8t; ; xn--8md2578ag21g.xn--9ta62nrv36a; [B1, P1, V5, V6] # Ⴁ𐋨娤.̼٢𑖿
+ⴁ𐋨娤.‍̼٢𑖿; ; [B1, C2]; xn--skjw75lg29h.xn--9ta62ngt6aou8t; ; xn--skjw75lg29h.xn--9ta62nrv36a; [B1, V5] # ⴁ𐋨娤.̼٢𑖿
+xn--skjw75lg29h.xn--9ta62nrv36a; ⴁ𐋨娤.̼٢𑖿; [B1, V5]; xn--skjw75lg29h.xn--9ta62nrv36a; ; ;  # ⴁ𐋨娤.̼٢𑖿
+xn--skjw75lg29h.xn--9ta62ngt6aou8t; ⴁ𐋨娤.‍̼٢𑖿; [B1, C2]; xn--skjw75lg29h.xn--9ta62ngt6aou8t; ; ;  # ⴁ𐋨娤.̼٢𑖿
+xn--8md2578ag21g.xn--9ta62nrv36a; Ⴁ𐋨娤.̼٢𑖿; [B1, V5, V6]; xn--8md2578ag21g.xn--9ta62nrv36a; ; ;  # Ⴁ𐋨娤.̼٢𑖿
+xn--8md2578ag21g.xn--9ta62ngt6aou8t; Ⴁ𐋨娤.‍̼٢𑖿; [B1, C2, V6]; xn--8md2578ag21g.xn--9ta62ngt6aou8t; ; ;  # Ⴁ𐋨娤.̼٢𑖿
+🄀Ⴄ٩ࠠ。⒈ྶß; 🄀Ⴄ٩ࠠ.⒈ྶß; [B1, P1, V6]; xn--iib29f26o6n43c.xn--zca117e3vp; ; xn--iib29f26o6n43c.xn--ss-1sj588o;  # 🄀Ⴄ٩ࠠ.⒈ྶß
+0.Ⴄ٩ࠠ。1.ྶß; 0.Ⴄ٩ࠠ.1.ྶß; [B1, B5, B6, P1, V5, V6]; 0.xn--iib29f26o.1.xn--zca117e; ; 0.xn--iib29f26o.1.xn--ss-1sj;  # 0.Ⴄ٩ࠠ.1.ྶß
+0.ⴄ٩ࠠ。1.ྶß; 0.ⴄ٩ࠠ.1.ྶß; [B1, B5, B6, V5]; 0.xn--iib29fp25e.1.xn--zca117e; ; 0.xn--iib29fp25e.1.xn--ss-1sj;  # 0.ⴄ٩ࠠ.1.ྶß
+0.Ⴄ٩ࠠ。1.ྶSS; 0.Ⴄ٩ࠠ.1.ྶss; [B1, B5, B6, P1, V5, V6]; 0.xn--iib29f26o.1.xn--ss-1sj; ; ;  # 0.Ⴄ٩ࠠ.1.ྶss
+0.ⴄ٩ࠠ。1.ྶss; 0.ⴄ٩ࠠ.1.ྶss; [B1, B5, B6, V5]; 0.xn--iib29fp25e.1.xn--ss-1sj; ; ;  # 0.ⴄ٩ࠠ.1.ྶss
+0.Ⴄ٩ࠠ。1.ྶSs; 0.Ⴄ٩ࠠ.1.ྶss; [B1, B5, B6, P1, V5, V6]; 0.xn--iib29f26o.1.xn--ss-1sj; ; ;  # 0.Ⴄ٩ࠠ.1.ྶss
+0.xn--iib29f26o.1.xn--ss-1sj; 0.Ⴄ٩ࠠ.1.ྶss; [B1, B5, B6, V5, V6]; 0.xn--iib29f26o.1.xn--ss-1sj; ; ;  # 0.Ⴄ٩ࠠ.1.ྶss
+0.xn--iib29fp25e.1.xn--ss-1sj; 0.ⴄ٩ࠠ.1.ྶss; [B1, B5, B6, V5]; 0.xn--iib29fp25e.1.xn--ss-1sj; ; ;  # 0.ⴄ٩ࠠ.1.ྶss
+0.xn--iib29fp25e.1.xn--zca117e; 0.ⴄ٩ࠠ.1.ྶß; [B1, B5, B6, V5]; 0.xn--iib29fp25e.1.xn--zca117e; ; ;  # 0.ⴄ٩ࠠ.1.ྶß
+0.xn--iib29f26o.1.xn--zca117e; 0.Ⴄ٩ࠠ.1.ྶß; [B1, B5, B6, V5, V6]; 0.xn--iib29f26o.1.xn--zca117e; ; ;  # 0.Ⴄ٩ࠠ.1.ྶß
+🄀ⴄ٩ࠠ。⒈ྶß; 🄀ⴄ٩ࠠ.⒈ྶß; [B1, P1, V6]; xn--iib29fp25e0219a.xn--zca117e3vp; ; xn--iib29fp25e0219a.xn--ss-1sj588o;  # 🄀ⴄ٩ࠠ.⒈ྶß
+🄀Ⴄ٩ࠠ。⒈ྶSS; 🄀Ⴄ٩ࠠ.⒈ྶss; [B1, P1, V6]; xn--iib29f26o6n43c.xn--ss-1sj588o; ; ;  # 🄀Ⴄ٩ࠠ.⒈ྶss
+🄀ⴄ٩ࠠ。⒈ྶss; 🄀ⴄ٩ࠠ.⒈ྶss; [B1, P1, V6]; xn--iib29fp25e0219a.xn--ss-1sj588o; ; ;  # 🄀ⴄ٩ࠠ.⒈ྶss
+🄀Ⴄ٩ࠠ。⒈ྶSs; 🄀Ⴄ٩ࠠ.⒈ྶss; [B1, P1, V6]; xn--iib29f26o6n43c.xn--ss-1sj588o; ; ;  # 🄀Ⴄ٩ࠠ.⒈ྶss
+xn--iib29f26o6n43c.xn--ss-1sj588o; 🄀Ⴄ٩ࠠ.⒈ྶss; [B1, V6]; xn--iib29f26o6n43c.xn--ss-1sj588o; ; ;  # 🄀Ⴄ٩ࠠ.⒈ྶss
+xn--iib29fp25e0219a.xn--ss-1sj588o; 🄀ⴄ٩ࠠ.⒈ྶss; [B1, V6]; xn--iib29fp25e0219a.xn--ss-1sj588o; ; ;  # 🄀ⴄ٩ࠠ.⒈ྶss
+xn--iib29fp25e0219a.xn--zca117e3vp; 🄀ⴄ٩ࠠ.⒈ྶß; [B1, V6]; xn--iib29fp25e0219a.xn--zca117e3vp; ; ;  # 🄀ⴄ٩ࠠ.⒈ྶß
+xn--iib29f26o6n43c.xn--zca117e3vp; 🄀Ⴄ٩ࠠ.⒈ྶß; [B1, V6]; xn--iib29f26o6n43c.xn--zca117e3vp; ; ;  # 🄀Ⴄ٩ࠠ.⒈ྶß
+≠.‌-٫; ; [B1, C1, P1, V6]; xn--1ch.xn----vqc597q; ; xn--1ch.xn----vqc; [B1, P1, V3, V6] # ≠.-٫
+≠.‌-٫; ≠.‌-٫; [B1, C1, P1, V6]; xn--1ch.xn----vqc597q; ; xn--1ch.xn----vqc; [B1, P1, V3, V6] # ≠.-٫
+xn--1ch.xn----vqc; ≠.-٫; [B1, V3, V6]; xn--1ch.xn----vqc; ; ;  # ≠.-٫
+xn--1ch.xn----vqc597q; ≠.‌-٫; [B1, C1, V6]; xn--1ch.xn----vqc597q; ; ;  # ≠.-٫
+٠۱｡󠳶𞠁٥; ٠۱.󠳶𞠁٥; [B1, P1, V6]; xn--8hb40a.xn--eib7967vner3e; ; ;  # ٠۱.𞠁٥
+٠۱。󠳶𞠁٥; ٠۱.󠳶𞠁٥; [B1, P1, V6]; xn--8hb40a.xn--eib7967vner3e; ; ;  # ٠۱.𞠁٥
+xn--8hb40a.xn--eib7967vner3e; ٠۱.󠳶𞠁٥; [B1, V6]; xn--8hb40a.xn--eib7967vner3e; ; ;  # ٠۱.𞠁٥
+‌٣⒖。󱅉𽷛᯳; ‌٣⒖.󱅉𽷛᯳; [B1, C1, P1, V6]; xn--cib152kwgd.xn--1zf13512buy41d; ; xn--cib675m.xn--1zf13512buy41d; [B1, P1, V6] # ٣⒖.᯳
+‌٣15.。󱅉𽷛᯳; ‌٣15..󱅉𽷛᯳; [B1, C1, P1, V6, X4_2]; xn--15-gyd983x..xn--1zf13512buy41d; [B1, C1, P1, V6, A4_2]; xn--15-gyd..xn--1zf13512buy41d; [B1, P1, V6, A4_2] # ٣15..᯳
+xn--15-gyd..xn--1zf13512buy41d; ٣15..󱅉𽷛᯳; [B1, V6, X4_2]; xn--15-gyd..xn--1zf13512buy41d; [B1, V6, A4_2]; ;  # ٣15..᯳
+xn--15-gyd983x..xn--1zf13512buy41d; ‌٣15..󱅉𽷛᯳; [B1, C1, V6, X4_2]; xn--15-gyd983x..xn--1zf13512buy41d; [B1, C1, V6, A4_2]; ;  # ٣15..᯳
+xn--cib675m.xn--1zf13512buy41d; ٣⒖.󱅉𽷛᯳; [B1, V6]; xn--cib675m.xn--1zf13512buy41d; ; ;  # ٣⒖.᯳
+xn--cib152kwgd.xn--1zf13512buy41d; ‌٣⒖.󱅉𽷛᯳; [B1, C1, V6]; xn--cib152kwgd.xn--1zf13512buy41d; ; ;  # ٣⒖.᯳
+᯳.-逋񳦭󙙮; ; [P1, V3, V5, V6]; xn--1zf.xn----483d46987byr50b; ; ;  # ᯳.-逋
+xn--1zf.xn----483d46987byr50b; ᯳.-逋񳦭󙙮; [V3, V5, V6]; xn--1zf.xn----483d46987byr50b; ; ;  # ᯳.-逋
+ݖ。ㅤ‍ς; ݖ.ㅤ‍ς; [C2, P1, V6]; xn--9ob.xn--3xa995lq2l; ; xn--9ob.xn--4xa574u; [P1, V6] # ݖ.ς
+ݖ。ᅠ‍ς; ݖ.ᅠ‍ς; [C2, P1, V6]; xn--9ob.xn--3xa580ebol; ; xn--9ob.xn--4xa380e; [P1, V6] # ݖ.ς
+ݖ。ᅠ‍Σ; ݖ.ᅠ‍σ; [C2, P1, V6]; xn--9ob.xn--4xa380ebol; ; xn--9ob.xn--4xa380e; [P1, V6] # ݖ.σ
+ݖ。ᅠ‍σ; ݖ.ᅠ‍σ; [C2, P1, V6]; xn--9ob.xn--4xa380ebol; ; xn--9ob.xn--4xa380e; [P1, V6] # ݖ.σ
+xn--9ob.xn--4xa380e; ݖ.ᅠσ; [V6]; xn--9ob.xn--4xa380e; ; ;  # ݖ.σ
+xn--9ob.xn--4xa380ebol; ݖ.ᅠ‍σ; [C2, V6]; xn--9ob.xn--4xa380ebol; ; ;  # ݖ.σ
+xn--9ob.xn--3xa580ebol; ݖ.ᅠ‍ς; [C2, V6]; xn--9ob.xn--3xa580ebol; ; ;  # ݖ.ς
+ݖ。ㅤ‍Σ; ݖ.ㅤ‍σ; [C2, P1, V6]; xn--9ob.xn--4xa795lq2l; ; xn--9ob.xn--4xa574u; [P1, V6] # ݖ.σ
+ݖ。ㅤ‍σ; ݖ.ㅤ‍σ; [C2, P1, V6]; xn--9ob.xn--4xa795lq2l; ; xn--9ob.xn--4xa574u; [P1, V6] # ݖ.σ
+xn--9ob.xn--4xa574u; ݖ.ㅤσ; [V6]; xn--9ob.xn--4xa574u; ; ;  # ݖ.σ
+xn--9ob.xn--4xa795lq2l; ݖ.ㅤ‍σ; [C2, V6]; xn--9ob.xn--4xa795lq2l; ; ;  # ݖ.σ
+xn--9ob.xn--3xa995lq2l; ݖ.ㅤ‍ς; [C2, V6]; xn--9ob.xn--3xa995lq2l; ; ;  # ݖ.ς
+ᡆႣ｡󞢧̕‍‍; ᡆႣ.󞢧̕‍‍; [C2, P1, V6]; xn--bnd320b.xn--5sa649la993427a; ; xn--bnd320b.xn--5sa98523p; [P1, V6] # ᡆႣ.̕
+ᡆႣ。󞢧̕‍‍; ᡆႣ.󞢧̕‍‍; [C2, P1, V6]; xn--bnd320b.xn--5sa649la993427a; ; xn--bnd320b.xn--5sa98523p; [P1, V6] # ᡆႣ.̕
+ᡆⴃ。󞢧̕‍‍; ᡆⴃ.󞢧̕‍‍; [C2, P1, V6]; xn--57e237h.xn--5sa649la993427a; ; xn--57e237h.xn--5sa98523p; [P1, V6] # ᡆⴃ.̕
+xn--57e237h.xn--5sa98523p; ᡆⴃ.󞢧̕; [V6]; xn--57e237h.xn--5sa98523p; ; ;  # ᡆⴃ.̕
+xn--57e237h.xn--5sa649la993427a; ᡆⴃ.󞢧̕‍‍; [C2, V6]; xn--57e237h.xn--5sa649la993427a; ; ;  # ᡆⴃ.̕
+xn--bnd320b.xn--5sa98523p; ᡆႣ.󞢧̕; [V6]; xn--bnd320b.xn--5sa98523p; ; ;  # ᡆႣ.̕
+xn--bnd320b.xn--5sa649la993427a; ᡆႣ.󞢧̕‍‍; [C2, V6]; xn--bnd320b.xn--5sa649la993427a; ; ;  # ᡆႣ.̕
+ᡆⴃ｡󞢧̕‍‍; ᡆⴃ.󞢧̕‍‍; [C2, P1, V6]; xn--57e237h.xn--5sa649la993427a; ; xn--57e237h.xn--5sa98523p; [P1, V6] # ᡆⴃ.̕
+㭄‍ࡏ𑚵．ς𐮮‌‍; 㭄‍ࡏ𑚵.ς𐮮‌‍; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--3xa895lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.ς𐮮
+㭄‍ࡏ𑚵.ς𐮮‌‍; ; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--3xa895lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.ς𐮮
+㭄‍ࡏ𑚵.Σ𐮮‌‍; 㭄‍ࡏ𑚵.σ𐮮‌‍; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--4xa695lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.σ𐮮
+㭄‍ࡏ𑚵.σ𐮮‌‍; ; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--4xa695lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.σ𐮮
+xn--ewb302xhu1l.xn--4xa0426k; 㭄ࡏ𑚵.σ𐮮; [B5, B6]; xn--ewb302xhu1l.xn--4xa0426k; ; ;  # 㭄ࡏ𑚵.σ𐮮
+xn--ewb962jfitku4r.xn--4xa695lda6932v; 㭄‍ࡏ𑚵.σ𐮮‌‍; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--4xa695lda6932v; ; ;  # 㭄ࡏ𑚵.σ𐮮
+xn--ewb962jfitku4r.xn--3xa895lda6932v; 㭄‍ࡏ𑚵.ς𐮮‌‍; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--3xa895lda6932v; ; ;  # 㭄ࡏ𑚵.ς𐮮
+㭄‍ࡏ𑚵．Σ𐮮‌‍; 㭄‍ࡏ𑚵.σ𐮮‌‍; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--4xa695lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.σ𐮮
+㭄‍ࡏ𑚵．σ𐮮‌‍; 㭄‍ࡏ𑚵.σ𐮮‌‍; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--4xa695lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.σ𐮮
+឵。𞯸ꡀ🄋; ឵.𞯸ꡀ🄋; [B1, B2, B3, B6, P1, V5, V6]; xn--03e.xn--8b9ar252dngd; ; ;  # .ꡀ🄋
+xn--03e.xn--8b9ar252dngd; ឵.𞯸ꡀ🄋; [B1, B2, B3, B6, V5, V6]; xn--03e.xn--8b9ar252dngd; ; ;  # .ꡀ🄋
+󐪺暑．⾑٨; 󐪺暑.襾٨; [B5, B6, P1, V6]; xn--tlvq3513e.xn--hib9228d; ; ;  # 暑.襾٨
+󐪺暑.襾٨; ; [B5, B6, P1, V6]; xn--tlvq3513e.xn--hib9228d; ; ;  # 暑.襾٨
+xn--tlvq3513e.xn--hib9228d; 󐪺暑.襾٨; [B5, B6, V6]; xn--tlvq3513e.xn--hib9228d; ; ;  # 暑.襾٨
+󠄚≯ꡢ。࢑᷿; ≯ꡢ.࢑᷿; [B1, P1, V6]; xn--hdh7783c.xn--9xb680i; ; ;  # ≯ꡢ.᷿
+󠄚≯ꡢ。࢑᷿; ≯ꡢ.࢑᷿; [B1, P1, V6]; xn--hdh7783c.xn--9xb680i; ; ;  # ≯ꡢ.᷿
+xn--hdh7783c.xn--9xb680i; ≯ꡢ.࢑᷿; [B1, V6]; xn--hdh7783c.xn--9xb680i; ; ;  # ≯ꡢ.᷿
+ﷃ𮁱୍𐨿.󐧤Ⴗ; كمم𮁱୍𐨿.󐧤Ⴗ; [B2, B3, P1, V6]; xn--fhbea662czx68a2tju.xn--vnd55511o; ; ;  # كمم𮁱୍𐨿.Ⴗ
+كمم𮁱୍𐨿.󐧤Ⴗ; ; [B2, B3, P1, V6]; xn--fhbea662czx68a2tju.xn--vnd55511o; ; ;  # كمم𮁱୍𐨿.Ⴗ
+كمم𮁱୍𐨿.󐧤ⴗ; ; [B2, B3, P1, V6]; xn--fhbea662czx68a2tju.xn--fljz2846h; ; ;  # كمم𮁱୍𐨿.ⴗ
+xn--fhbea662czx68a2tju.xn--fljz2846h; كمم𮁱୍𐨿.󐧤ⴗ; [B2, B3, V6]; xn--fhbea662czx68a2tju.xn--fljz2846h; ; ;  # كمم𮁱୍𐨿.ⴗ
+xn--fhbea662czx68a2tju.xn--vnd55511o; كمم𮁱୍𐨿.󐧤Ⴗ; [B2, B3, V6]; xn--fhbea662czx68a2tju.xn--vnd55511o; ; ;  # كمم𮁱୍𐨿.Ⴗ
+ﷃ𮁱୍𐨿.󐧤ⴗ; كمم𮁱୍𐨿.󐧤ⴗ; [B2, B3, P1, V6]; xn--fhbea662czx68a2tju.xn--fljz2846h; ; ;  # كمم𮁱୍𐨿.ⴗ
+𞀨｡᭄򡛨𞎇; 𞀨.᭄򡛨𞎇; [P1, V5, V6]; xn--mi4h.xn--1uf6843smg20c; ; ;  # 𞀨.᭄
+𞀨。᭄򡛨𞎇; 𞀨.᭄򡛨𞎇; [P1, V5, V6]; xn--mi4h.xn--1uf6843smg20c; ; ;  # 𞀨.᭄
+xn--mi4h.xn--1uf6843smg20c; 𞀨.᭄򡛨𞎇; [V5, V6]; xn--mi4h.xn--1uf6843smg20c; ; ;  # 𞀨.᭄
+󠣼‌．𐺰‌ᡟ; 󠣼‌.𐺰‌ᡟ; [B1, B2, B3, C1, P1, V6]; xn--0ug18531l.xn--v8e340bp21t; ; xn--q046e.xn--v8e7227j; [B1, B2, B3, P1, V6] # .ᡟ
+󠣼‌.𐺰‌ᡟ; ; [B1, B2, B3, C1, P1, V6]; xn--0ug18531l.xn--v8e340bp21t; ; xn--q046e.xn--v8e7227j; [B1, B2, B3, P1, V6] # .ᡟ
+xn--q046e.xn--v8e7227j; 󠣼.𐺰ᡟ; [B1, B2, B3, V6]; xn--q046e.xn--v8e7227j; ; ;  # .ᡟ
+xn--0ug18531l.xn--v8e340bp21t; 󠣼‌.𐺰‌ᡟ; [B1, B2, B3, C1, V6]; xn--0ug18531l.xn--v8e340bp21t; ; ;  # .ᡟ
+ᢛ󨅟ß.ጧ; ; [P1, V6]; xn--zca562jc642x.xn--p5d; ; xn--ss-7dp66033t.xn--p5d;  # ᢛß.ጧ
+ᢛ󨅟SS.ጧ; ᢛ󨅟ss.ጧ; [P1, V6]; xn--ss-7dp66033t.xn--p5d; ; ;  # ᢛss.ጧ
+ᢛ󨅟ss.ጧ; ; [P1, V6]; xn--ss-7dp66033t.xn--p5d; ; ;  # ᢛss.ጧ
+ᢛ󨅟Ss.ጧ; ᢛ󨅟ss.ጧ; [P1, V6]; xn--ss-7dp66033t.xn--p5d; ; ;  # ᢛss.ጧ
+xn--ss-7dp66033t.xn--p5d; ᢛ󨅟ss.ጧ; [V6]; xn--ss-7dp66033t.xn--p5d; ; ;  # ᢛss.ጧ
+xn--zca562jc642x.xn--p5d; ᢛ󨅟ß.ጧ; [V6]; xn--zca562jc642x.xn--p5d; ; ;  # ᢛß.ጧ
+⮒‌.񒚗‌; ; [C1, P1, V6]; xn--0ugx66b.xn--0ugz2871c; ; xn--b9i.xn--5p9y; [P1, V6] # ⮒.
+xn--b9i.xn--5p9y; ⮒.񒚗; [V6]; xn--b9i.xn--5p9y; ; ;  # ⮒.
+xn--0ugx66b.xn--0ugz2871c; ⮒‌.񒚗‌; [C1, V6]; xn--0ugx66b.xn--0ugz2871c; ; ;  # ⮒.
+𞤂񹞁𐹯。Ⴜ; 𞤤񹞁𐹯.Ⴜ; [B2, P1, V6]; xn--no0dr648a51o3b.xn--0nd; ; ;  # 𞤤𐹯.Ⴜ
+𞤤񹞁𐹯。ⴜ; 𞤤񹞁𐹯.ⴜ; [B2, P1, V6]; xn--no0dr648a51o3b.xn--klj; ; ;  # 𞤤𐹯.ⴜ
+xn--no0dr648a51o3b.xn--klj; 𞤤񹞁𐹯.ⴜ; [B2, V6]; xn--no0dr648a51o3b.xn--klj; ; ;  # 𞤤𐹯.ⴜ
+xn--no0dr648a51o3b.xn--0nd; 𞤤񹞁𐹯.Ⴜ; [B2, V6]; xn--no0dr648a51o3b.xn--0nd; ; ;  # 𞤤𐹯.Ⴜ
+𞤂񹞁𐹯。ⴜ; 𞤤񹞁𐹯.ⴜ; [B2, P1, V6]; xn--no0dr648a51o3b.xn--klj; ; ;  # 𞤤𐹯.ⴜ
+𐹵⮣‌𑄰｡񷴿ﲷ; 𐹵⮣‌𑄰.񷴿ضم; [B1, B5, B6, C1, P1, V6]; xn--0ug586bcj8p7jc.xn--1gb4a66004i; ; xn--s9i5458e7yb.xn--1gb4a66004i; [B1, B5, B6, P1, V6] # 𐹵⮣𑄰.ضم
+𐹵⮣‌𑄰。񷴿ضم; 𐹵⮣‌𑄰.񷴿ضم; [B1, B5, B6, C1, P1, V6]; xn--0ug586bcj8p7jc.xn--1gb4a66004i; ; xn--s9i5458e7yb.xn--1gb4a66004i; [B1, B5, B6, P1, V6] # 𐹵⮣𑄰.ضم
+xn--s9i5458e7yb.xn--1gb4a66004i; 𐹵⮣𑄰.񷴿ضم; [B1, B5, B6, V6]; xn--s9i5458e7yb.xn--1gb4a66004i; ; ;  # 𐹵⮣𑄰.ضم
+xn--0ug586bcj8p7jc.xn--1gb4a66004i; 𐹵⮣‌𑄰.񷴿ضم; [B1, B5, B6, C1, V6]; xn--0ug586bcj8p7jc.xn--1gb4a66004i; ; ;  # 𐹵⮣𑄰.ضم
+Ⴒ。デß𞤵్; Ⴒ.デß𞤵్; [B5, B6, P1, V6]; xn--qnd.xn--zca669cmr3a0f28a; ; xn--qnd.xn--ss-9nh3648ahh20b;  # Ⴒ.デß𞤵్
+Ⴒ。デß𞤵్; Ⴒ.デß𞤵్; [B5, B6, P1, V6]; xn--qnd.xn--zca669cmr3a0f28a; ; xn--qnd.xn--ss-9nh3648ahh20b;  # Ⴒ.デß𞤵్
+ⴒ。デß𞤵్; ⴒ.デß𞤵్; [B5, B6]; xn--9kj.xn--zca669cmr3a0f28a; ; xn--9kj.xn--ss-9nh3648ahh20b;  # ⴒ.デß𞤵్
+ⴒ。デß𞤵్; ⴒ.デß𞤵్; [B5, B6]; xn--9kj.xn--zca669cmr3a0f28a; ; xn--9kj.xn--ss-9nh3648ahh20b;  # ⴒ.デß𞤵్
+Ⴒ。デSS𞤓్; Ⴒ.デss𞤵్; [B5, B6, P1, V6]; xn--qnd.xn--ss-9nh3648ahh20b; ; ;  # Ⴒ.デss𞤵్
+Ⴒ。デSS𞤓్; Ⴒ.デss𞤵్; [B5, B6, P1, V6]; xn--qnd.xn--ss-9nh3648ahh20b; ; ;  # Ⴒ.デss𞤵్
+ⴒ。デss𞤵్; ⴒ.デss𞤵్; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+ⴒ。デss𞤵్; ⴒ.デss𞤵్; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+Ⴒ。デSs𞤵్; Ⴒ.デss𞤵్; [B5, B6, P1, V6]; xn--qnd.xn--ss-9nh3648ahh20b; ; ;  # Ⴒ.デss𞤵్
+Ⴒ。デSs𞤵్; Ⴒ.デss𞤵్; [B5, B6, P1, V6]; xn--qnd.xn--ss-9nh3648ahh20b; ; ;  # Ⴒ.デss𞤵్
+xn--qnd.xn--ss-9nh3648ahh20b; Ⴒ.デss𞤵్; [B5, B6, V6]; xn--qnd.xn--ss-9nh3648ahh20b; ; ;  # Ⴒ.デss𞤵్
+xn--9kj.xn--ss-9nh3648ahh20b; ⴒ.デss𞤵్; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+xn--9kj.xn--zca669cmr3a0f28a; ⴒ.デß𞤵్; [B5, B6]; xn--9kj.xn--zca669cmr3a0f28a; ; ;  # ⴒ.デß𞤵్
+xn--qnd.xn--zca669cmr3a0f28a; Ⴒ.デß𞤵్; [B5, B6, V6]; xn--qnd.xn--zca669cmr3a0f28a; ; ;  # Ⴒ.デß𞤵్
+Ⴒ。デSS𞤵్; Ⴒ.デss𞤵్; [B5, B6, P1, V6]; xn--qnd.xn--ss-9nh3648ahh20b; ; ;  # Ⴒ.デss𞤵్
+Ⴒ。デSS𞤵్; Ⴒ.デss𞤵్; [B5, B6, P1, V6]; xn--qnd.xn--ss-9nh3648ahh20b; ; ;  # Ⴒ.デss𞤵్
+𑁿്．７-ߒ; 𑁿്.7-ߒ; [B1, B3, B6, V5]; xn--wxc1283k.xn--7--yue; ; ;  # 𑁿്.7-ߒ
+𑁿്.7-ߒ; ; [B1, B3, B6, V5]; xn--wxc1283k.xn--7--yue; ; ;  # 𑁿്.7-ߒ
+xn--wxc1283k.xn--7--yue; 𑁿്.7-ߒ; [B1, B3, B6, V5]; xn--wxc1283k.xn--7--yue; ; ;  # 𑁿്.7-ߒ
+≯𑜫󠭇.᜴񒞤𑍬ᢧ; ; [P1, V5, V6]; xn--hdhx157g68o0g.xn--c0e65eu616c34o7a; ; ;  # ≯𑜫.᜴𑍬ᢧ
+≯𑜫󠭇.᜴񒞤𑍬ᢧ; ≯𑜫󠭇.᜴񒞤𑍬ᢧ; [P1, V5, V6]; xn--hdhx157g68o0g.xn--c0e65eu616c34o7a; ; ;  # ≯𑜫.᜴𑍬ᢧ
+xn--hdhx157g68o0g.xn--c0e65eu616c34o7a; ≯𑜫󠭇.᜴񒞤𑍬ᢧ; [V5, V6]; xn--hdhx157g68o0g.xn--c0e65eu616c34o7a; ; ;  # ≯𑜫.᜴𑍬ᢧ
+ᷛ򎐙Ⴗ쏔。ށ; ᷛ򎐙Ⴗ쏔.ށ; [B1, P1, V5, V6]; xn--vnd148d733ky6n9e.xn--iqb; ; ;  # ᷛႷ쏔.ށ
+ᷛ򎐙Ⴗ쏔。ށ; ᷛ򎐙Ⴗ쏔.ށ; [B1, P1, V5, V6]; xn--vnd148d733ky6n9e.xn--iqb; ; ;  # ᷛႷ쏔.ށ
+ᷛ򎐙ⴗ쏔。ށ; ᷛ򎐙ⴗ쏔.ށ; [B1, P1, V5, V6]; xn--zegy26dw47iy6w2f.xn--iqb; ; ;  # ᷛⴗ쏔.ށ
+ᷛ򎐙ⴗ쏔。ށ; ᷛ򎐙ⴗ쏔.ށ; [B1, P1, V5, V6]; xn--zegy26dw47iy6w2f.xn--iqb; ; ;  # ᷛⴗ쏔.ށ
+xn--zegy26dw47iy6w2f.xn--iqb; ᷛ򎐙ⴗ쏔.ށ; [B1, V5, V6]; xn--zegy26dw47iy6w2f.xn--iqb; ; ;  # ᷛⴗ쏔.ށ
+xn--vnd148d733ky6n9e.xn--iqb; ᷛ򎐙Ⴗ쏔.ށ; [B1, V5, V6]; xn--vnd148d733ky6n9e.xn--iqb; ; ;  # ᷛႷ쏔.ށ
+ß｡𐋳Ⴌྸ; ß.𐋳Ⴌྸ; [P1, V6]; xn--zca.xn--lgd10cu829c; ; ss.xn--lgd10cu829c;  # ß.𐋳Ⴌྸ
+ß。𐋳Ⴌྸ; ß.𐋳Ⴌྸ; [P1, V6]; xn--zca.xn--lgd10cu829c; ; ss.xn--lgd10cu829c;  # ß.𐋳Ⴌྸ
+ß。𐋳ⴌྸ; ß.𐋳ⴌྸ; ; xn--zca.xn--lgd921mvv0m; ; ss.xn--lgd921mvv0m;  # ß.𐋳ⴌྸ
+SS。𐋳Ⴌྸ; ss.𐋳Ⴌྸ; [P1, V6]; ss.xn--lgd10cu829c; ; ;  # ss.𐋳Ⴌྸ
+ss。𐋳ⴌྸ; ss.𐋳ⴌྸ; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+Ss。𐋳Ⴌྸ; ss.𐋳Ⴌྸ; [P1, V6]; ss.xn--lgd10cu829c; ; ;  # ss.𐋳Ⴌྸ
+ss.xn--lgd10cu829c; ss.𐋳Ⴌྸ; [V6]; ss.xn--lgd10cu829c; ; ;  # ss.𐋳Ⴌྸ
+ss.xn--lgd921mvv0m; ss.𐋳ⴌྸ; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+ss.𐋳ⴌྸ; ; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+SS.𐋳Ⴌྸ; ss.𐋳Ⴌྸ; [P1, V6]; ss.xn--lgd10cu829c; ; ;  # ss.𐋳Ⴌྸ
+Ss.𐋳Ⴌྸ; ss.𐋳Ⴌྸ; [P1, V6]; ss.xn--lgd10cu829c; ; ;  # ss.𐋳Ⴌྸ
+xn--zca.xn--lgd921mvv0m; ß.𐋳ⴌྸ; ; xn--zca.xn--lgd921mvv0m; ; ;  # ß.𐋳ⴌྸ
+ß.𐋳ⴌྸ; ; ; xn--zca.xn--lgd921mvv0m; ; ss.xn--lgd921mvv0m;  # ß.𐋳ⴌྸ
+xn--zca.xn--lgd10cu829c; ß.𐋳Ⴌྸ; [V6]; xn--zca.xn--lgd10cu829c; ; ;  # ß.𐋳Ⴌྸ
+ß｡𐋳ⴌྸ; ß.𐋳ⴌྸ; ; xn--zca.xn--lgd921mvv0m; ; ss.xn--lgd921mvv0m;  # ß.𐋳ⴌྸ
+SS｡𐋳Ⴌྸ; ss.𐋳Ⴌྸ; [P1, V6]; ss.xn--lgd10cu829c; ; ;  # ss.𐋳Ⴌྸ
+ss｡𐋳ⴌྸ; ss.𐋳ⴌྸ; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+Ss｡𐋳Ⴌྸ; ss.𐋳Ⴌྸ; [P1, V6]; ss.xn--lgd10cu829c; ; ;  # ss.𐋳Ⴌྸ
+-ڞ𐶡.‌⾝্; -ڞ𐶡.‌身্; [B1, C1, P1, V3, V6]; xn----stc7013r.xn--b7b305imj2f; ; xn----stc7013r.xn--b7b1419d; [B1, P1, V3, V6] # -ڞ.身্
+-ڞ𐶡.‌身্; ; [B1, C1, P1, V3, V6]; xn----stc7013r.xn--b7b305imj2f; ; xn----stc7013r.xn--b7b1419d; [B1, P1, V3, V6] # -ڞ.身্
+xn----stc7013r.xn--b7b1419d; -ڞ𐶡.身্; [B1, V3, V6]; xn----stc7013r.xn--b7b1419d; ; ;  # -ڞ.身্
+xn----stc7013r.xn--b7b305imj2f; -ڞ𐶡.‌身্; [B1, C1, V3, V6]; xn----stc7013r.xn--b7b305imj2f; ; ;  # -ڞ.身্
+😮ݤ𑈵𞀖.💅‍; 😮ݤ𑈵𞀖.💅‍; [B1, C2]; xn--opb4277kuc7elqsa.xn--1ug5265p; ; xn--opb4277kuc7elqsa.xn--kr8h; [B1] # 😮ݤ𑈵𞀖.💅
+😮ݤ𑈵𞀖.💅‍; ; [B1, C2]; xn--opb4277kuc7elqsa.xn--1ug5265p; ; xn--opb4277kuc7elqsa.xn--kr8h; [B1] # 😮ݤ𑈵𞀖.💅
+xn--opb4277kuc7elqsa.xn--kr8h; 😮ݤ𑈵𞀖.💅; [B1]; xn--opb4277kuc7elqsa.xn--kr8h; ; ;  # 😮ݤ𑈵𞀖.💅
+xn--opb4277kuc7elqsa.xn--1ug5265p; 😮ݤ𑈵𞀖.💅‍; [B1, C2]; xn--opb4277kuc7elqsa.xn--1ug5265p; ; ;  # 😮ݤ𑈵𞀖.💅
+ࣲ‍꙳ܒ.ᢏ‌󠍄; ; [B1, B6, C1, C2, P1, V5, V6]; xn--cnb37g904be26j.xn--89e849ax9363a; ; xn--cnb37gdy00a.xn--89e02253p; [B1, B6, P1, V5, V6] # ࣲ꙳ܒ.ᢏ
+xn--cnb37gdy00a.xn--89e02253p; ࣲ꙳ܒ.ᢏ󠍄; [B1, B6, V5, V6]; xn--cnb37gdy00a.xn--89e02253p; ; ;  # ࣲ꙳ܒ.ᢏ
+xn--cnb37g904be26j.xn--89e849ax9363a; ࣲ‍꙳ܒ.ᢏ‌󠍄; [B1, B6, C1, C2, V5, V6]; xn--cnb37g904be26j.xn--89e849ax9363a; ; ;  # ࣲ꙳ܒ.ᢏ
+Ⴑ．ڿ𞯓ᠲ; Ⴑ.ڿ𞯓ᠲ; [B2, B3, P1, V6]; xn--pnd.xn--ykb840gd555a; ; ;  # Ⴑ.ڿᠲ
+Ⴑ.ڿ𞯓ᠲ; ; [B2, B3, P1, V6]; xn--pnd.xn--ykb840gd555a; ; ;  # Ⴑ.ڿᠲ
+ⴑ.ڿ𞯓ᠲ; ; [B2, B3, P1, V6]; xn--8kj.xn--ykb840gd555a; ; ;  # ⴑ.ڿᠲ
+xn--8kj.xn--ykb840gd555a; ⴑ.ڿ𞯓ᠲ; [B2, B3, V6]; xn--8kj.xn--ykb840gd555a; ; ;  # ⴑ.ڿᠲ
+xn--pnd.xn--ykb840gd555a; Ⴑ.ڿ𞯓ᠲ; [B2, B3, V6]; xn--pnd.xn--ykb840gd555a; ; ;  # Ⴑ.ڿᠲ
+ⴑ．ڿ𞯓ᠲ; ⴑ.ڿ𞯓ᠲ; [B2, B3, P1, V6]; xn--8kj.xn--ykb840gd555a; ; ;  # ⴑ.ڿᠲ
+ᩚ𛦝్。𚝬𝟵; ᩚ𛦝్.𚝬9; [P1, V5, V6]; xn--lqc703ebm93a.xn--9-000p; ; ;  # ᩚ్.9
+ᩚ𛦝్。𚝬9; ᩚ𛦝్.𚝬9; [P1, V5, V6]; xn--lqc703ebm93a.xn--9-000p; ; ;  # ᩚ్.9
+xn--lqc703ebm93a.xn--9-000p; ᩚ𛦝్.𚝬9; [V5, V6]; xn--lqc703ebm93a.xn--9-000p; ; ;  # ᩚ్.9
+‌ڠ𿺆𝟗｡Ⴣ꒘ﳐ񐘖; ‌ڠ𿺆9.Ⴣ꒘مخ񐘖; [B1, B5, C1, P1, V6]; xn--9-vtc736qts91g.xn--tgb9bz61cfn8mw3t2c; ; xn--9-vtc42319e.xn--tgb9bz61cfn8mw3t2c; [B2, B5, P1, V6] # ڠ9.Ⴣ꒘مخ
+‌ڠ𿺆9。Ⴣ꒘مخ񐘖; ‌ڠ𿺆9.Ⴣ꒘مخ񐘖; [B1, B5, C1, P1, V6]; xn--9-vtc736qts91g.xn--tgb9bz61cfn8mw3t2c; ; xn--9-vtc42319e.xn--tgb9bz61cfn8mw3t2c; [B2, B5, P1, V6] # ڠ9.Ⴣ꒘مخ
+‌ڠ𿺆9。ⴣ꒘مخ񐘖; ‌ڠ𿺆9.ⴣ꒘مخ񐘖; [B1, B5, C1, P1, V6]; xn--9-vtc736qts91g.xn--tgb9bz87p833hw316c; ; xn--9-vtc42319e.xn--tgb9bz87p833hw316c; [B2, B5, P1, V6] # ڠ9.ⴣ꒘مخ
+xn--9-vtc42319e.xn--tgb9bz87p833hw316c; ڠ𿺆9.ⴣ꒘مخ񐘖; [B2, B5, V6]; xn--9-vtc42319e.xn--tgb9bz87p833hw316c; ; ;  # ڠ9.ⴣ꒘مخ
+xn--9-vtc736qts91g.xn--tgb9bz87p833hw316c; ‌ڠ𿺆9.ⴣ꒘مخ񐘖; [B1, B5, C1, V6]; xn--9-vtc736qts91g.xn--tgb9bz87p833hw316c; ; ;  # ڠ9.ⴣ꒘مخ
+xn--9-vtc42319e.xn--tgb9bz61cfn8mw3t2c; ڠ𿺆9.Ⴣ꒘مخ񐘖; [B2, B5, V6]; xn--9-vtc42319e.xn--tgb9bz61cfn8mw3t2c; ; ;  # ڠ9.Ⴣ꒘مخ
+xn--9-vtc736qts91g.xn--tgb9bz61cfn8mw3t2c; ‌ڠ𿺆9.Ⴣ꒘مخ񐘖; [B1, B5, C1, V6]; xn--9-vtc736qts91g.xn--tgb9bz61cfn8mw3t2c; ; ;  # ڠ9.Ⴣ꒘مخ
+‌ڠ𿺆𝟗｡ⴣ꒘ﳐ񐘖; ‌ڠ𿺆9.ⴣ꒘مخ񐘖; [B1, B5, C1, P1, V6]; xn--9-vtc736qts91g.xn--tgb9bz87p833hw316c; ; xn--9-vtc42319e.xn--tgb9bz87p833hw316c; [B2, B5, P1, V6] # ڠ9.ⴣ꒘مخ
+ᡖ｡̟񗛨ஂ-; ᡖ.̟񗛨ஂ-; [P1, V3, V5, V6]; xn--m8e.xn----mdb555dkk71m; ; ;  # ᡖ.̟ஂ-
+ᡖ。̟񗛨ஂ-; ᡖ.̟񗛨ஂ-; [P1, V3, V5, V6]; xn--m8e.xn----mdb555dkk71m; ; ;  # ᡖ.̟ஂ-
+xn--m8e.xn----mdb555dkk71m; ᡖ.̟񗛨ஂ-; [V3, V5, V6]; xn--m8e.xn----mdb555dkk71m; ; ;  # ᡖ.̟ஂ-
+𞠠浘。絧𞀀; 𞠠浘.絧𞀀; [B2, B3]; xn--e0wp491f.xn--ud0a3573e; ; ;  # 𞠠浘.絧𞀀
+xn--e0wp491f.xn--ud0a3573e; 𞠠浘.絧𞀀; [B2, B3]; xn--e0wp491f.xn--ud0a3573e; ; ;  # 𞠠浘.絧𞀀
+֖Ⴋ．𝟳≯︒︊; ֖Ⴋ.7≯︒; [P1, V5, V6]; xn--hcb887c.xn--7-pgoy530h; ; ;  # ֖Ⴋ.7≯︒
+֖Ⴋ．𝟳≯︒︊; ֖Ⴋ.7≯︒; [P1, V5, V6]; xn--hcb887c.xn--7-pgoy530h; ; ;  # ֖Ⴋ.7≯︒
+֖Ⴋ.7≯。︊; ֖Ⴋ.7≯.; [P1, V5, V6]; xn--hcb887c.xn--7-pgo.; ; ;  # ֖Ⴋ.7≯.
+֖Ⴋ.7≯。︊; ֖Ⴋ.7≯.; [P1, V5, V6]; xn--hcb887c.xn--7-pgo.; ; ;  # ֖Ⴋ.7≯.
+֖ⴋ.7≯。︊; ֖ⴋ.7≯.; [P1, V5, V6]; xn--hcb613r.xn--7-pgo.; ; ;  # ֖ⴋ.7≯.
+֖ⴋ.7≯。︊; ֖ⴋ.7≯.; [P1, V5, V6]; xn--hcb613r.xn--7-pgo.; ; ;  # ֖ⴋ.7≯.
+xn--hcb613r.xn--7-pgo.; ֖ⴋ.7≯.; [V5, V6]; xn--hcb613r.xn--7-pgo.; ; ;  # ֖ⴋ.7≯.
+xn--hcb887c.xn--7-pgo.; ֖Ⴋ.7≯.; [V5, V6]; xn--hcb887c.xn--7-pgo.; ; ;  # ֖Ⴋ.7≯.
+֖ⴋ．𝟳≯︒︊; ֖ⴋ.7≯︒; [P1, V5, V6]; xn--hcb613r.xn--7-pgoy530h; ; ;  # ֖ⴋ.7≯︒
+֖ⴋ．𝟳≯︒︊; ֖ⴋ.7≯︒; [P1, V5, V6]; xn--hcb613r.xn--7-pgoy530h; ; ;  # ֖ⴋ.7≯︒
+xn--hcb613r.xn--7-pgoy530h; ֖ⴋ.7≯︒; [V5, V6]; xn--hcb613r.xn--7-pgoy530h; ; ;  # ֖ⴋ.7≯︒
+xn--hcb887c.xn--7-pgoy530h; ֖Ⴋ.7≯︒; [V5, V6]; xn--hcb887c.xn--7-pgoy530h; ; ;  # ֖Ⴋ.7≯︒
+‍F𑓂。󠺨︒ݾ𐹢; ‍f𑓂.󠺨︒ݾ𐹢; [B1, C2, P1, V6]; xn--f-tgn9761i.xn--fqb1637j8hky9452a; ; xn--f-kq9i.xn--fqb1637j8hky9452a; [B1, P1, V6] # f𑓂.︒ݾ𐹢
+‍F𑓂。󠺨。ݾ𐹢; ‍f𑓂.󠺨.ݾ𐹢; [B1, C2, P1, V6]; xn--f-tgn9761i.xn--7656e.xn--fqb4175k; ; xn--f-kq9i.xn--7656e.xn--fqb4175k; [B1, P1, V6] # f𑓂..ݾ𐹢
+‍f𑓂。󠺨。ݾ𐹢; ‍f𑓂.󠺨.ݾ𐹢; [B1, C2, P1, V6]; xn--f-tgn9761i.xn--7656e.xn--fqb4175k; ; xn--f-kq9i.xn--7656e.xn--fqb4175k; [B1, P1, V6] # f𑓂..ݾ𐹢
+xn--f-kq9i.xn--7656e.xn--fqb4175k; f𑓂.󠺨.ݾ𐹢; [B1, V6]; xn--f-kq9i.xn--7656e.xn--fqb4175k; ; ;  # f𑓂..ݾ𐹢
+xn--f-tgn9761i.xn--7656e.xn--fqb4175k; ‍f𑓂.󠺨.ݾ𐹢; [B1, C2, V6]; xn--f-tgn9761i.xn--7656e.xn--fqb4175k; ; ;  # f𑓂..ݾ𐹢
+‍f𑓂。󠺨︒ݾ𐹢; ‍f𑓂.󠺨︒ݾ𐹢; [B1, C2, P1, V6]; xn--f-tgn9761i.xn--fqb1637j8hky9452a; ; xn--f-kq9i.xn--fqb1637j8hky9452a; [B1, P1, V6] # f𑓂.︒ݾ𐹢
+xn--f-kq9i.xn--fqb1637j8hky9452a; f𑓂.󠺨︒ݾ𐹢; [B1, V6]; xn--f-kq9i.xn--fqb1637j8hky9452a; ; ;  # f𑓂.︒ݾ𐹢
+xn--f-tgn9761i.xn--fqb1637j8hky9452a; ‍f𑓂.󠺨︒ݾ𐹢; [B1, C2, V6]; xn--f-tgn9761i.xn--fqb1637j8hky9452a; ; ;  # f𑓂.︒ݾ𐹢
+ࡅ🄇𐼗︒｡𐹻𑜫; ࡅ🄇𐼗︒.𐹻𑜫; [B1, B3, P1, V6]; xn--3vb4696jpxkjh7s.xn--zo0di2m; ; ;  # ࡅ🄇𐼗︒.𐹻𑜫
+ࡅ6,𐼗。。𐹻𑜫; ࡅ6,𐼗..𐹻𑜫; [B1, P1, V6, X4_2]; xn--6,-r4e4420y..xn--zo0di2m; [B1, P1, V6, A4_2]; ;  # ࡅ6,𐼗..𐹻𑜫
+xn--6,-r4e4420y..xn--zo0di2m; ࡅ6,𐼗..𐹻𑜫; [B1, P1, V6, X4_2]; xn--6,-r4e4420y..xn--zo0di2m; [B1, P1, V6, A4_2]; ;  # ࡅ6,𐼗..𐹻𑜫
+xn--3vb4696jpxkjh7s.xn--zo0di2m; ࡅ🄇𐼗︒.𐹻𑜫; [B1, B3, V6]; xn--3vb4696jpxkjh7s.xn--zo0di2m; ; ;  # ࡅ🄇𐼗︒.𐹻𑜫
+𐹈.᷀𑈱𐦭; ; [B1, P1, V5, V6]; xn--jn0d.xn--7dg0871h3lf; ; ;  # .᷀𑈱𐦭
+xn--jn0d.xn--7dg0871h3lf; 𐹈.᷀𑈱𐦭; [B1, V5, V6]; xn--jn0d.xn--7dg0871h3lf; ; ;  # .᷀𑈱𐦭
+Ⴂ䠺。𞤃񅏎󙮦ړ; Ⴂ䠺.𞤥񅏎󙮦ړ; [B2, P1, V6]; xn--9md875z.xn--pjb9818vg4xno967d; ; ;  # Ⴂ䠺.𞤥ړ
+ⴂ䠺。𞤥񅏎󙮦ړ; ⴂ䠺.𞤥񅏎󙮦ړ; [B2, P1, V6]; xn--tkj638f.xn--pjb9818vg4xno967d; ; ;  # ⴂ䠺.𞤥ړ
+xn--tkj638f.xn--pjb9818vg4xno967d; ⴂ䠺.𞤥񅏎󙮦ړ; [B2, V6]; xn--tkj638f.xn--pjb9818vg4xno967d; ; ;  # ⴂ䠺.𞤥ړ
+xn--9md875z.xn--pjb9818vg4xno967d; Ⴂ䠺.𞤥񅏎󙮦ړ; [B2, V6]; xn--9md875z.xn--pjb9818vg4xno967d; ; ;  # Ⴂ䠺.𞤥ړ
+ⴂ䠺。𞤃񅏎󙮦ړ; ⴂ䠺.𞤥񅏎󙮦ړ; [B2, P1, V6]; xn--tkj638f.xn--pjb9818vg4xno967d; ; ;  # ⴂ䠺.𞤥ړ
+🄇伐︒.𜙚꣄; ; [P1, V6]; xn--woqs083bel0g.xn--0f9ao925c; ; ;  # 🄇伐︒.꣄
+6,伐。.𜙚꣄; 6,伐..𜙚꣄; [P1, V6, X4_2]; xn--6,-7i3c..xn--0f9ao925c; [P1, V6, A4_2]; ;  # 6,伐..꣄
+xn--6,-7i3c..xn--0f9ao925c; 6,伐..𜙚꣄; [P1, V6, X4_2]; xn--6,-7i3c..xn--0f9ao925c; [P1, V6, A4_2]; ;  # 6,伐..꣄
+xn--woqs083bel0g.xn--0f9ao925c; 🄇伐︒.𜙚꣄; [V6]; xn--woqs083bel0g.xn--0f9ao925c; ; ;  # 🄇伐︒.꣄
+‍𐹠꯭￻。‍𐫓Ⴚ𑂹; ‍𐹠꯭￻.‍𐫓Ⴚ𑂹; [B1, C2, P1, V6]; xn--1ugz126coy7bdbm.xn--ynd959evs1pv6e; ; xn--429az70n29i.xn--ynd3619jqyd; [B1, B2, B3, P1, V6] # 𐹠꯭.𐫓Ⴚ𑂹
+‍𐹠꯭￻。‍𐫓ⴚ𑂹; ‍𐹠꯭￻.‍𐫓ⴚ𑂹; [B1, C2, P1, V6]; xn--1ugz126coy7bdbm.xn--1ug062chv7ov6e; ; xn--429az70n29i.xn--ilj7702eqyd; [B1, B2, B3, P1, V6] # 𐹠꯭.𐫓ⴚ𑂹
+xn--429az70n29i.xn--ilj7702eqyd; 𐹠꯭￻.𐫓ⴚ𑂹; [B1, B2, B3, V6]; xn--429az70n29i.xn--ilj7702eqyd; ; ;  # 𐹠꯭.𐫓ⴚ𑂹
+xn--1ugz126coy7bdbm.xn--1ug062chv7ov6e; ‍𐹠꯭￻.‍𐫓ⴚ𑂹; [B1, C2, V6]; xn--1ugz126coy7bdbm.xn--1ug062chv7ov6e; ; ;  # 𐹠꯭.𐫓ⴚ𑂹
+xn--429az70n29i.xn--ynd3619jqyd; 𐹠꯭￻.𐫓Ⴚ𑂹; [B1, B2, B3, V6]; xn--429az70n29i.xn--ynd3619jqyd; ; ;  # 𐹠꯭.𐫓Ⴚ𑂹
+xn--1ugz126coy7bdbm.xn--ynd959evs1pv6e; ‍𐹠꯭￻.‍𐫓Ⴚ𑂹; [B1, C2, V6]; xn--1ugz126coy7bdbm.xn--ynd959evs1pv6e; ; ;  # 𐹠꯭.𐫓Ⴚ𑂹
+󠆠．񷐴󌟈; .񷐴󌟈; [P1, V6, X4_2]; .xn--rx21bhv12i; [P1, V6, A4_2]; ;  # .
+󠆠.񷐴󌟈; .񷐴󌟈; [P1, V6, X4_2]; .xn--rx21bhv12i; [P1, V6, A4_2]; ;  # .
+.xn--rx21bhv12i; .񷐴󌟈; [V6, X4_2]; .xn--rx21bhv12i; [V6, A4_2]; ;  # .
+𐫃‌Ⴆ.≠𞷙; ; [B1, B2, B3, C1, P1, V6]; xn--end799ekr1p.xn--1ch2802p; ; xn--end1719j.xn--1ch2802p; [B1, B2, B3, P1, V6] # 𐫃Ⴆ.≠
+𐫃‌Ⴆ.≠𞷙; 𐫃‌Ⴆ.≠𞷙; [B1, B2, B3, C1, P1, V6]; xn--end799ekr1p.xn--1ch2802p; ; xn--end1719j.xn--1ch2802p; [B1, B2, B3, P1, V6] # 𐫃Ⴆ.≠
+𐫃‌ⴆ.≠𞷙; 𐫃‌ⴆ.≠𞷙; [B1, B2, B3, C1, P1, V6]; xn--0ug132csv7o.xn--1ch2802p; ; xn--xkjz802e.xn--1ch2802p; [B1, B2, B3, P1, V6] # 𐫃ⴆ.≠
+𐫃‌ⴆ.≠𞷙; ; [B1, B2, B3, C1, P1, V6]; xn--0ug132csv7o.xn--1ch2802p; ; xn--xkjz802e.xn--1ch2802p; [B1, B2, B3, P1, V6] # 𐫃ⴆ.≠
+xn--xkjz802e.xn--1ch2802p; 𐫃ⴆ.≠𞷙; [B1, B2, B3, V6]; xn--xkjz802e.xn--1ch2802p; ; ;  # 𐫃ⴆ.≠
+xn--0ug132csv7o.xn--1ch2802p; 𐫃‌ⴆ.≠𞷙; [B1, B2, B3, C1, V6]; xn--0ug132csv7o.xn--1ch2802p; ; ;  # 𐫃ⴆ.≠
+xn--end1719j.xn--1ch2802p; 𐫃Ⴆ.≠𞷙; [B1, B2, B3, V6]; xn--end1719j.xn--1ch2802p; ; ;  # 𐫃Ⴆ.≠
+xn--end799ekr1p.xn--1ch2802p; 𐫃‌Ⴆ.≠𞷙; [B1, B2, B3, C1, V6]; xn--end799ekr1p.xn--1ch2802p; ; ;  # 𐫃Ⴆ.≠
+󠁲𙩢𝟥ꘌ．ࡁ; 󠁲𙩢3ꘌ.ࡁ; [B1, P1, V6]; xn--3-0g3es485d8i15h.xn--zvb; ; ;  # 3ꘌ.ࡁ
+󠁲𙩢3ꘌ.ࡁ; ; [B1, P1, V6]; xn--3-0g3es485d8i15h.xn--zvb; ; ;  # 3ꘌ.ࡁ
+xn--3-0g3es485d8i15h.xn--zvb; 󠁲𙩢3ꘌ.ࡁ; [B1, V6]; xn--3-0g3es485d8i15h.xn--zvb; ; ;  # 3ꘌ.ࡁ
+-.ᢆ󡲣-; ; [P1, V3, V5, V6]; -.xn----pbkx6497q; ; ;  # -.ᢆ-
+-.xn----pbkx6497q; -.ᢆ󡲣-; [V3, V5, V6]; -.xn----pbkx6497q; ; ;  # -.ᢆ-
+󲚗‌｡‌𞰆ς; 󲚗‌.‌𞰆ς; [B1, B6, C1, P1, V6]; xn--0ug76062m.xn--3xa795lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, P1, V6] # .ς
+󲚗‌。‌𞰆ς; 󲚗‌.‌𞰆ς; [B1, B6, C1, P1, V6]; xn--0ug76062m.xn--3xa795lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, P1, V6] # .ς
+󲚗‌。‌𞰆Σ; 󲚗‌.‌𞰆σ; [B1, B6, C1, P1, V6]; xn--0ug76062m.xn--4xa595lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, P1, V6] # .σ
+󲚗‌。‌𞰆σ; 󲚗‌.‌𞰆σ; [B1, B6, C1, P1, V6]; xn--0ug76062m.xn--4xa595lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, P1, V6] # .σ
+xn--qp42f.xn--4xa3011w; 󲚗.𞰆σ; [B2, B3, V6]; xn--qp42f.xn--4xa3011w; ; ;  # .σ
+xn--0ug76062m.xn--4xa595lhn92a; 󲚗‌.‌𞰆σ; [B1, B6, C1, V6]; xn--0ug76062m.xn--4xa595lhn92a; ; ;  # .σ
+xn--0ug76062m.xn--3xa795lhn92a; 󲚗‌.‌𞰆ς; [B1, B6, C1, V6]; xn--0ug76062m.xn--3xa795lhn92a; ; ;  # .ς
+󲚗‌｡‌𞰆Σ; 󲚗‌.‌𞰆σ; [B1, B6, C1, P1, V6]; xn--0ug76062m.xn--4xa595lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, P1, V6] # .σ
+󲚗‌｡‌𞰆σ; 󲚗‌.‌𞰆σ; [B1, B6, C1, P1, V6]; xn--0ug76062m.xn--4xa595lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, P1, V6] # .σ
+堕𑓂ᬂ。𐮇𞤽‌-; 堕𑓂ᬂ.𐮇𞤽‌-; [B3, C1, V3]; xn--5sf345zdk8h.xn----rgnt157hwl9g; ; xn--5sf345zdk8h.xn----iv5iw606c; [B3, V3] # 堕𑓂ᬂ.𐮇𞤽-
+堕𑓂ᬂ。𐮇𞤛‌-; 堕𑓂ᬂ.𐮇𞤽‌-; [B3, C1, V3]; xn--5sf345zdk8h.xn----rgnt157hwl9g; ; xn--5sf345zdk8h.xn----iv5iw606c; [B3, V3] # 堕𑓂ᬂ.𐮇𞤽-
+xn--5sf345zdk8h.xn----iv5iw606c; 堕𑓂ᬂ.𐮇𞤽-; [B3, V3]; xn--5sf345zdk8h.xn----iv5iw606c; ; ;  # 堕𑓂ᬂ.𐮇𞤽-
+xn--5sf345zdk8h.xn----rgnt157hwl9g; 堕𑓂ᬂ.𐮇𞤽‌-; [B3, C1, V3]; xn--5sf345zdk8h.xn----rgnt157hwl9g; ; ;  # 堕𑓂ᬂ.𐮇𞤽-
+𐹶𑁆ᡕ𞤢｡ᡥςتς; 𐹶𑁆ᡕ𞤢.ᡥςتς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xaa16plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥςتς
+𐹶𑁆ᡕ𞤢。ᡥςتς; 𐹶𑁆ᡕ𞤢.ᡥςتς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xaa16plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥςتς
+𐹶𑁆ᡕ𞤀。ᡥΣتΣ; 𐹶𑁆ᡕ𞤢.ᡥσتσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢。ᡥσتσ; 𐹶𑁆ᡕ𞤢.ᡥσتσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+xn--l8e1317j1ebz456b.xn--4xaa85plx4a; 𐹶𑁆ᡕ𞤢.ᡥσتσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+xn--l8e1317j1ebz456b.xn--3xaa16plx4a; 𐹶𑁆ᡕ𞤢.ᡥςتς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xaa16plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥςتς
+𐹶𑁆ᡕ𞤀｡ᡥΣتΣ; 𐹶𑁆ᡕ𞤢.ᡥσتσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢｡ᡥσتσ; 𐹶𑁆ᡕ𞤢.ᡥσتσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢。ᡥΣتΣ; 𐹶𑁆ᡕ𞤢.ᡥσتσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢。ᡥΣتσ; 𐹶𑁆ᡕ𞤢.ᡥσتσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢。ᡥΣتς; 𐹶𑁆ᡕ𞤢.ᡥσتς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xab95plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥσتς
+𐹶𑁆ᡕ𞤢。ᡥσتς; 𐹶𑁆ᡕ𞤢.ᡥσتς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xab95plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥσتς
+xn--l8e1317j1ebz456b.xn--3xab95plx4a; 𐹶𑁆ᡕ𞤢.ᡥσتς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xab95plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتς
+𐹶𑁆ᡕ𞤢｡ᡥΣتΣ; 𐹶𑁆ᡕ𞤢.ᡥσتσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢｡ᡥΣتσ; 𐹶𑁆ᡕ𞤢.ᡥσتσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢｡ᡥΣتς; 𐹶𑁆ᡕ𞤢.ᡥσتς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xab95plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥσتς
+𐹶𑁆ᡕ𞤢｡ᡥσتς; 𐹶𑁆ᡕ𞤢.ᡥσتς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xab95plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥσتς
+󏒰．-𝟻ß; 󏒰.-5ß; [P1, V3, V6]; xn--t960e.xn---5-hia; ; xn--t960e.-5ss;  # .-5ß
+󏒰.-5ß; ; [P1, V3, V6]; xn--t960e.xn---5-hia; ; xn--t960e.-5ss;  # .-5ß
+󏒰.-5SS; 󏒰.-5ss; [P1, V3, V6]; xn--t960e.-5ss; ; ;  # .-5ss
+󏒰.-5ss; ; [P1, V3, V6]; xn--t960e.-5ss; ; ;  # .-5ss
+xn--t960e.-5ss; 󏒰.-5ss; [V3, V6]; xn--t960e.-5ss; ; ;  # .-5ss
+xn--t960e.xn---5-hia; 󏒰.-5ß; [V3, V6]; xn--t960e.xn---5-hia; ; ;  # .-5ß
+󏒰．-𝟻SS; 󏒰.-5ss; [P1, V3, V6]; xn--t960e.-5ss; ; ;  # .-5ss
+󏒰．-𝟻ss; 󏒰.-5ss; [P1, V3, V6]; xn--t960e.-5ss; ; ;  # .-5ss
+󏒰．-𝟻Ss; 󏒰.-5ss; [P1, V3, V6]; xn--t960e.-5ss; ; ;  # .-5ss
+󏒰.-5Ss; 󏒰.-5ss; [P1, V3, V6]; xn--t960e.-5ss; ; ;  # .-5ss
+‍𐨿.🤒Ⴥ򑮶; ; [C2, P1, V6]; xn--1ug9533g.xn--9nd3211w0gz4b; ; xn--0s9c.xn--9nd3211w0gz4b; [P1, V5, V6] # 𐨿.🤒Ⴥ
+‍𐨿.🤒ⴥ򑮶; ; [C2, P1, V6]; xn--1ug9533g.xn--tljz038l0gz4b; ; xn--0s9c.xn--tljz038l0gz4b; [P1, V5, V6] # 𐨿.🤒ⴥ
+xn--0s9c.xn--tljz038l0gz4b; 𐨿.🤒ⴥ򑮶; [V5, V6]; xn--0s9c.xn--tljz038l0gz4b; ; ;  # 𐨿.🤒ⴥ
+xn--1ug9533g.xn--tljz038l0gz4b; ‍𐨿.🤒ⴥ򑮶; [C2, V6]; xn--1ug9533g.xn--tljz038l0gz4b; ; ;  # 𐨿.🤒ⴥ
+xn--0s9c.xn--9nd3211w0gz4b; 𐨿.🤒Ⴥ򑮶; [V5, V6]; xn--0s9c.xn--9nd3211w0gz4b; ; ;  # 𐨿.🤒Ⴥ
+xn--1ug9533g.xn--9nd3211w0gz4b; ‍𐨿.🤒Ⴥ򑮶; [C2, V6]; xn--1ug9533g.xn--9nd3211w0gz4b; ; ;  # 𐨿.🤒Ⴥ
+𵋅。ß𬵩‍; 𵋅.ß𬵩‍; [C2, P1, V6]; xn--ey1p.xn--zca870nz438b; ; xn--ey1p.xn--ss-eq36b; [P1, V6] # .ß𬵩
+𵋅。SS𬵩‍; 𵋅.ss𬵩‍; [C2, P1, V6]; xn--ey1p.xn--ss-n1tx0508a; ; xn--ey1p.xn--ss-eq36b; [P1, V6] # .ss𬵩
+𵋅。ss𬵩‍; 𵋅.ss𬵩‍; [C2, P1, V6]; xn--ey1p.xn--ss-n1tx0508a; ; xn--ey1p.xn--ss-eq36b; [P1, V6] # .ss𬵩
+𵋅。Ss𬵩‍; 𵋅.ss𬵩‍; [C2, P1, V6]; xn--ey1p.xn--ss-n1tx0508a; ; xn--ey1p.xn--ss-eq36b; [P1, V6] # .ss𬵩
+xn--ey1p.xn--ss-eq36b; 𵋅.ss𬵩; [V6]; xn--ey1p.xn--ss-eq36b; ; ;  # .ss𬵩
+xn--ey1p.xn--ss-n1tx0508a; 𵋅.ss𬵩‍; [C2, V6]; xn--ey1p.xn--ss-n1tx0508a; ; ;  # .ss𬵩
+xn--ey1p.xn--zca870nz438b; 𵋅.ß𬵩‍; [C2, V6]; xn--ey1p.xn--zca870nz438b; ; ;  # .ß𬵩
+‌𭉝。߱́𞹻; ‌𭉝.߱́غ; [B1, C1, V5]; xn--0ugy003y.xn--lsa46nuub; ; xn--634m.xn--lsa46nuub; [B1, V5] # 𭉝.߱́غ
+‌𭉝。߱́غ; ‌𭉝.߱́غ; [B1, C1, V5]; xn--0ugy003y.xn--lsa46nuub; ; xn--634m.xn--lsa46nuub; [B1, V5] # 𭉝.߱́غ
+xn--634m.xn--lsa46nuub; 𭉝.߱́غ; [B1, V5]; xn--634m.xn--lsa46nuub; ; ;  # 𭉝.߱́غ
+xn--0ugy003y.xn--lsa46nuub; ‌𭉝.߱́غ; [B1, C1, V5]; xn--0ugy003y.xn--lsa46nuub; ; ;  # 𭉝.߱́غ
+𞼌‌𑈶。𐹡; 𞼌‌𑈶.𐹡; [B1, B3, C1, P1, V6]; xn--0ug7946gzpxf.xn--8n0d; ; xn--9g1d1288a.xn--8n0d; [B1, P1, V6] # 𑈶.𐹡
+xn--9g1d1288a.xn--8n0d; 𞼌𑈶.𐹡; [B1, V6]; xn--9g1d1288a.xn--8n0d; ; ;  # 𑈶.𐹡
+xn--0ug7946gzpxf.xn--8n0d; 𞼌‌𑈶.𐹡; [B1, B3, C1, V6]; xn--0ug7946gzpxf.xn--8n0d; ; ;  # 𑈶.𐹡
+󠅯򇽭‌🜭｡𑖿᪻ς≠; 򇽭‌🜭.𑖿᪻ς≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻ς≠
+󠅯򇽭‌🜭｡𑖿᪻ς≠; 򇽭‌🜭.𑖿᪻ς≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻ς≠
+󠅯򇽭‌🜭。𑖿᪻ς≠; 򇽭‌🜭.𑖿᪻ς≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻ς≠
+󠅯򇽭‌🜭。𑖿᪻ς≠; 򇽭‌🜭.𑖿᪻ς≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻ς≠
+󠅯򇽭‌🜭。𑖿᪻Σ≠; 򇽭‌🜭.𑖿᪻σ≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻σ≠
+󠅯򇽭‌🜭。𑖿᪻Σ≠; 򇽭‌🜭.𑖿᪻σ≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻σ≠
+󠅯򇽭‌🜭。𑖿᪻σ≠; 򇽭‌🜭.𑖿᪻σ≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻σ≠
+󠅯򇽭‌🜭。𑖿᪻σ≠; 򇽭‌🜭.𑖿᪻σ≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻σ≠
+xn--zb9h5968x.xn--4xa378i1mfjw7y; 򇽭🜭.𑖿᪻σ≠; [V5, V6]; xn--zb9h5968x.xn--4xa378i1mfjw7y; ; ;  # 🜭.𑖿᪻σ≠
+xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; 򇽭‌🜭.𑖿᪻σ≠; [C1, V5, V6]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; ;  # 🜭.𑖿᪻σ≠
+xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; 򇽭‌🜭.𑖿᪻ς≠; [C1, V5, V6]; xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; ; ;  # 🜭.𑖿᪻ς≠
+󠅯򇽭‌🜭｡𑖿᪻Σ≠; 򇽭‌🜭.𑖿᪻σ≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻σ≠
+󠅯򇽭‌🜭｡𑖿᪻Σ≠; 򇽭‌🜭.𑖿᪻σ≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻σ≠
+󠅯򇽭‌🜭｡𑖿᪻σ≠; 򇽭‌🜭.𑖿᪻σ≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻σ≠
+󠅯򇽭‌🜭｡𑖿᪻σ≠; 򇽭‌🜭.𑖿᪻σ≠; [C1, P1, V5, V6]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [P1, V5, V6] # 🜭.𑖿᪻σ≠
+⒋｡⒈‍򳴢; ⒋.⒈‍򳴢; [C2, P1, V6]; xn--wsh.xn--1ug58o74922a; ; xn--wsh.xn--tsh07994h; [P1, V6] # ⒋.⒈
+4.。1.‍򳴢; 4..1.‍򳴢; [C2, P1, V6, X4_2]; 4..1.xn--1ug64613i; [C2, P1, V6, A4_2]; 4..1.xn--sf51d; [P1, V6, A4_2] # 4..1.
+4..1.xn--sf51d; 4..1.򳴢; [V6, X4_2]; 4..1.xn--sf51d; [V6, A4_2]; ;  # 4..1.
+4..1.xn--1ug64613i; 4..1.‍򳴢; [C2, V6, X4_2]; 4..1.xn--1ug64613i; [C2, V6, A4_2]; ;  # 4..1.
+xn--wsh.xn--tsh07994h; ⒋.⒈򳴢; [V6]; xn--wsh.xn--tsh07994h; ; ;  # ⒋.⒈
+xn--wsh.xn--1ug58o74922a; ⒋.⒈‍򳴢; [C2, V6]; xn--wsh.xn--1ug58o74922a; ; ;  # ⒋.⒈
+لß｡᩠𐇽򾅢𞤾; لß.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+لß｡᩠𐇽򾅢𞤾; لß.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+لß。᩠𐇽򾅢𞤾; لß.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+لSS。᩠𐇽򾅢𞤜; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لss。᩠𐇽򾅢𞤾; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لss。᩠𐇽򾅢𞤜; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+xn--ss-svd.xn--jof2298hn83fln78f; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لß。᩠𐇽򾅢𞤜; لß.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+xn--zca57y.xn--jof2298hn83fln78f; لß.᩠𐇽򾅢𞤾; [B1, B2, B3, V5, V6]; xn--zca57y.xn--jof2298hn83fln78f; ; ;  # لß.᩠𐇽𞤾
+لSS｡᩠𐇽򾅢𞤜; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لss｡᩠𐇽򾅢𞤾; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لss｡᩠𐇽򾅢𞤜; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لß｡᩠𐇽򾅢𞤜; لß.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+لSS｡᩠𐇽򾅢𞤜; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لss｡᩠𐇽򾅢𞤾; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لss｡᩠𐇽򾅢𞤜; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لß｡᩠𐇽򾅢𞤜; لß.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+لSS。᩠𐇽򾅢𞤾; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لSs。᩠𐇽򾅢𞤾; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لSS｡᩠𐇽򾅢𞤾; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لSs｡᩠𐇽򾅢𞤾; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لSS｡᩠𐇽򾅢𞤾; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+لSs｡᩠𐇽򾅢𞤾; لss.᩠𐇽򾅢𞤾; [B1, B2, B3, P1, V5, V6]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+𐹽𑄳񼜲.ᷟី꠆𑜫; ; [B1, B3, B6, P1, V5, V6]; xn--1o0di0c0652w.xn--33e362arr1l153d; ; ;  # 𐹽𑄳.ᷟី꠆𑜫
+xn--1o0di0c0652w.xn--33e362arr1l153d; 𐹽𑄳񼜲.ᷟី꠆𑜫; [B1, B3, B6, V5, V6]; xn--1o0di0c0652w.xn--33e362arr1l153d; ; ;  # 𐹽𑄳.ᷟី꠆𑜫
+Ⴓ𑜫‍򗭓．ڧ𑰶; Ⴓ𑜫‍򗭓.ڧ𑰶; [P1, V6]; xn--rnd479ep20q7x12e.xn--9jb4223l; ; xn--rnd8945ky009c.xn--9jb4223l;  # Ⴓ𑜫.ڧ𑰶
+Ⴓ𑜫‍򗭓.ڧ𑰶; ; [P1, V6]; xn--rnd479ep20q7x12e.xn--9jb4223l; ; xn--rnd8945ky009c.xn--9jb4223l;  # Ⴓ𑜫.ڧ𑰶
+ⴓ𑜫‍򗭓.ڧ𑰶; ; [P1, V6]; xn--1ugy52cym7p7xu5e.xn--9jb4223l; ; xn--blj6306ey091d.xn--9jb4223l;  # ⴓ𑜫.ڧ𑰶
+xn--blj6306ey091d.xn--9jb4223l; ⴓ𑜫򗭓.ڧ𑰶; [V6]; xn--blj6306ey091d.xn--9jb4223l; ; ;  # ⴓ𑜫.ڧ𑰶
+xn--1ugy52cym7p7xu5e.xn--9jb4223l; ⴓ𑜫‍򗭓.ڧ𑰶; [V6]; xn--1ugy52cym7p7xu5e.xn--9jb4223l; ; ;  # ⴓ𑜫.ڧ𑰶
+xn--rnd8945ky009c.xn--9jb4223l; Ⴓ𑜫򗭓.ڧ𑰶; [V6]; xn--rnd8945ky009c.xn--9jb4223l; ; ;  # Ⴓ𑜫.ڧ𑰶
+xn--rnd479ep20q7x12e.xn--9jb4223l; Ⴓ𑜫‍򗭓.ڧ𑰶; [V6]; xn--rnd479ep20q7x12e.xn--9jb4223l; ; ;  # Ⴓ𑜫.ڧ𑰶
+ⴓ𑜫‍򗭓．ڧ𑰶; ⴓ𑜫‍򗭓.ڧ𑰶; [P1, V6]; xn--1ugy52cym7p7xu5e.xn--9jb4223l; ; xn--blj6306ey091d.xn--9jb4223l;  # ⴓ𑜫.ڧ𑰶
+𐨿.🄆—; ; [P1, V5, V6]; xn--0s9c.xn--8ug8324p; ; ;  # 𐨿.🄆—
+𐨿.5,—; ; [P1, V5, V6]; xn--0s9c.xn--5,-81t; ; ;  # 𐨿.5,—
+xn--0s9c.xn--5,-81t; 𐨿.5,—; [P1, V5, V6]; xn--0s9c.xn--5,-81t; ; ;  # 𐨿.5,—
+xn--0s9c.xn--8ug8324p; 𐨿.🄆—; [V5, V6]; xn--0s9c.xn--8ug8324p; ; ;  # 𐨿.🄆—
+򔊱񁦮۸。󠾭-; 򔊱񁦮۸.󠾭-; [P1, V3, V6]; xn--lmb18944c0g2z.xn----2k81m; ; ;  # ۸.-
+xn--lmb18944c0g2z.xn----2k81m; 򔊱񁦮۸.󠾭-; [V3, V6]; xn--lmb18944c0g2z.xn----2k81m; ; ;  # ۸.-
+𼗸ߍ𐹮。۝ᡎᠴ; 𼗸ߍ𐹮.۝ᡎᠴ; [B1, B5, B6, P1, V6]; xn--osb0855kcc2r.xn--tlb299fhc; ; ;  # ߍ𐹮.ᡎᠴ
+xn--osb0855kcc2r.xn--tlb299fhc; 𼗸ߍ𐹮.۝ᡎᠴ; [B1, B5, B6, V6]; xn--osb0855kcc2r.xn--tlb299fhc; ; ;  # ߍ𐹮.ᡎᠴ
+‍ᠮႾ🄂.🚗ࡁ𮹌‌; ; [B1, C1, C2, P1, V6]; xn--2nd129ay2gnw71c.xn--zvb692j9664aic1g; ; xn--2nd129ai554b.xn--zvb3124wpkpf; [B1, P1, V6] # ᠮႾ🄂.🚗ࡁ
+‍ᠮႾ1,.🚗ࡁ𮹌‌; ; [B1, C1, C2, P1, V6]; xn--1,-ogkx89c39j.xn--zvb692j9664aic1g; ; xn--1,-ogkx89c.xn--zvb3124wpkpf; [B1, B6, P1, V6] # ᠮႾ1,.🚗ࡁ
+‍ᠮⴞ1,.🚗ࡁ𮹌‌; ; [B1, C1, C2, P1, V6]; xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ; xn--1,-v3o625k.xn--zvb3124wpkpf; [B1, B6, P1, V6] # ᠮⴞ1,.🚗ࡁ
+xn--1,-v3o625k.xn--zvb3124wpkpf; ᠮⴞ1,.🚗ࡁ𮹌; [B1, B6, P1, V6]; xn--1,-v3o625k.xn--zvb3124wpkpf; ; ;  # ᠮⴞ1,.🚗ࡁ
+xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ‍ᠮⴞ1,.🚗ࡁ𮹌‌; [B1, C1, C2, P1, V6]; xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ; ;  # ᠮⴞ1,.🚗ࡁ
+xn--1,-ogkx89c.xn--zvb3124wpkpf; ᠮႾ1,.🚗ࡁ𮹌; [B1, B6, P1, V6]; xn--1,-ogkx89c.xn--zvb3124wpkpf; ; ;  # ᠮႾ1,.🚗ࡁ
+xn--1,-ogkx89c39j.xn--zvb692j9664aic1g; ‍ᠮႾ1,.🚗ࡁ𮹌‌; [B1, C1, C2, P1, V6]; xn--1,-ogkx89c39j.xn--zvb692j9664aic1g; ; ;  # ᠮႾ1,.🚗ࡁ
+‍ᠮⴞ🄂.🚗ࡁ𮹌‌; ; [B1, C1, C2, P1, V6]; xn--h7e341b0wlbv45b.xn--zvb692j9664aic1g; ; xn--h7e438h1p44a.xn--zvb3124wpkpf; [B1, P1, V6] # ᠮⴞ🄂.🚗ࡁ
+xn--h7e438h1p44a.xn--zvb3124wpkpf; ᠮⴞ🄂.🚗ࡁ𮹌; [B1, V6]; xn--h7e438h1p44a.xn--zvb3124wpkpf; ; ;  # ᠮⴞ🄂.🚗ࡁ
+xn--h7e341b0wlbv45b.xn--zvb692j9664aic1g; ‍ᠮⴞ🄂.🚗ࡁ𮹌‌; [B1, C1, C2, V6]; xn--h7e341b0wlbv45b.xn--zvb692j9664aic1g; ; ;  # ᠮⴞ🄂.🚗ࡁ
+xn--2nd129ai554b.xn--zvb3124wpkpf; ᠮႾ🄂.🚗ࡁ𮹌; [B1, V6]; xn--2nd129ai554b.xn--zvb3124wpkpf; ; ;  # ᠮႾ🄂.🚗ࡁ
+xn--2nd129ay2gnw71c.xn--zvb692j9664aic1g; ‍ᠮႾ🄂.🚗ࡁ𮹌‌; [B1, C1, C2, V6]; xn--2nd129ay2gnw71c.xn--zvb692j9664aic1g; ; ;  # ᠮႾ🄂.🚗ࡁ
+؁ڗ．𑚶񼡷⾆; ؁ڗ.𑚶񼡷舌; [B1, P1, V5, V6]; xn--jfb41a.xn--tc1ap851axo39c; ; ;  # ڗ.𑚶舌
+؁ڗ.𑚶񼡷舌; ; [B1, P1, V5, V6]; xn--jfb41a.xn--tc1ap851axo39c; ; ;  # ڗ.𑚶舌
+xn--jfb41a.xn--tc1ap851axo39c; ؁ڗ.𑚶񼡷舌; [B1, V5, V6]; xn--jfb41a.xn--tc1ap851axo39c; ; ;  # ڗ.𑚶舌
+🞅󠳡󜍙.񲖷; ; [P1, V6]; xn--ie9hi1349bqdlb.xn--oj69a; ; ;  # 🞅.
+xn--ie9hi1349bqdlb.xn--oj69a; 🞅󠳡󜍙.񲖷; [V6]; xn--ie9hi1349bqdlb.xn--oj69a; ; ;  # 🞅.
+⃧񯡎-򫣝.4Ⴄ‌; ; [C1, P1, V5, V6]; xn----9snu5320fi76w.xn--4-f0g649i; ; xn----9snu5320fi76w.xn--4-f0g; [P1, V5, V6] # ⃧-.4Ⴄ
+⃧񯡎-򫣝.4ⴄ‌; ; [C1, P1, V5, V6]; xn----9snu5320fi76w.xn--4-sgn589c; ; xn----9snu5320fi76w.xn--4-ivs; [P1, V5, V6] # ⃧-.4ⴄ
+xn----9snu5320fi76w.xn--4-ivs; ⃧񯡎-򫣝.4ⴄ; [V5, V6]; xn----9snu5320fi76w.xn--4-ivs; ; ;  # ⃧-.4ⴄ
+xn----9snu5320fi76w.xn--4-sgn589c; ⃧񯡎-򫣝.4ⴄ‌; [C1, V5, V6]; xn----9snu5320fi76w.xn--4-sgn589c; ; ;  # ⃧-.4ⴄ
+xn----9snu5320fi76w.xn--4-f0g; ⃧񯡎-򫣝.4Ⴄ; [V5, V6]; xn----9snu5320fi76w.xn--4-f0g; ; ;  # ⃧-.4Ⴄ
+xn----9snu5320fi76w.xn--4-f0g649i; ⃧񯡎-򫣝.4Ⴄ‌; [C1, V5, V6]; xn----9snu5320fi76w.xn--4-f0g649i; ; ;  # ⃧-.4Ⴄ
+ᚭ｡𝌠ß𖫱; ᚭ.𝌠ß𖫱; ; xn--hwe.xn--zca4946pblnc; ; xn--hwe.xn--ss-ci1ub261a;  # ᚭ.𝌠ß𖫱
+ᚭ。𝌠ß𖫱; ᚭ.𝌠ß𖫱; ; xn--hwe.xn--zca4946pblnc; ; xn--hwe.xn--ss-ci1ub261a;  # ᚭ.𝌠ß𖫱
+ᚭ。𝌠SS𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ。𝌠ss𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ。𝌠Ss𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+xn--hwe.xn--ss-ci1ub261a; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ.𝌠ss𖫱; ; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ.𝌠SS𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ.𝌠Ss𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+xn--hwe.xn--zca4946pblnc; ᚭ.𝌠ß𖫱; ; xn--hwe.xn--zca4946pblnc; ; ;  # ᚭ.𝌠ß𖫱
+ᚭ.𝌠ß𖫱; ; ; xn--hwe.xn--zca4946pblnc; ; xn--hwe.xn--ss-ci1ub261a;  # ᚭ.𝌠ß𖫱
+ᚭ｡𝌠SS𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ｡𝌠ss𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ｡𝌠Ss𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+₁｡𞤫ꡪ; 1.𞤫ꡪ; [B1, B2, B3]; 1.xn--gd9al691d; ; ;  # 1.𞤫ꡪ
+1。𞤫ꡪ; 1.𞤫ꡪ; [B1, B2, B3]; 1.xn--gd9al691d; ; ;  # 1.𞤫ꡪ
+1。𞤉ꡪ; 1.𞤫ꡪ; [B1, B2, B3]; 1.xn--gd9al691d; ; ;  # 1.𞤫ꡪ
+1.xn--gd9al691d; 1.𞤫ꡪ; [B1, B2, B3]; 1.xn--gd9al691d; ; ;  # 1.𞤫ꡪ
+₁｡𞤉ꡪ; 1.𞤫ꡪ; [B1, B2, B3]; 1.xn--gd9al691d; ; ;  # 1.𞤫ꡪ
+𯻼‌.𞶞򻙤񥘇; ; [B2, B3, B6, C1, P1, V6]; xn--0ug27500a.xn--2b7hs861pl540a; ; xn--kg4n.xn--2b7hs861pl540a; [B2, B3, P1, V6] # .
+xn--kg4n.xn--2b7hs861pl540a; 𯻼.𞶞򻙤񥘇; [B2, B3, V6]; xn--kg4n.xn--2b7hs861pl540a; ; ;  # .
+xn--0ug27500a.xn--2b7hs861pl540a; 𯻼‌.𞶞򻙤񥘇; [B2, B3, B6, C1, V6]; xn--0ug27500a.xn--2b7hs861pl540a; ; ;  # .
+𑑄≯｡𑜤; 𑑄≯.𑜤; [P1, V5, V6]; xn--hdh5636g.xn--ci2d; ; ;  # 𑑄≯.𑜤
+𑑄≯｡𑜤; 𑑄≯.𑜤; [P1, V5, V6]; xn--hdh5636g.xn--ci2d; ; ;  # 𑑄≯.𑜤
+𑑄≯。𑜤; 𑑄≯.𑜤; [P1, V5, V6]; xn--hdh5636g.xn--ci2d; ; ;  # 𑑄≯.𑜤
+𑑄≯。𑜤; 𑑄≯.𑜤; [P1, V5, V6]; xn--hdh5636g.xn--ci2d; ; ;  # 𑑄≯.𑜤
+xn--hdh5636g.xn--ci2d; 𑑄≯.𑜤; [V5, V6]; xn--hdh5636g.xn--ci2d; ; ;  # 𑑄≯.𑜤
+Ⴋ≮𱲆。‍ާ𐋣; Ⴋ≮𱲆.‍ާ𐋣; [C2, P1, V6]; xn--jnd802gsm17c.xn--lrb506jqr4n; ; xn--jnd802gsm17c.xn--lrb6479j; [P1, V5, V6] # Ⴋ≮.ާ𐋣
+Ⴋ≮𱲆。‍ާ𐋣; Ⴋ≮𱲆.‍ާ𐋣; [C2, P1, V6]; xn--jnd802gsm17c.xn--lrb506jqr4n; ; xn--jnd802gsm17c.xn--lrb6479j; [P1, V5, V6] # Ⴋ≮.ާ𐋣
+ⴋ≮𱲆。‍ާ𐋣; ⴋ≮𱲆.‍ާ𐋣; [C2, P1, V6]; xn--gdhz03bxt42d.xn--lrb506jqr4n; ; xn--gdhz03bxt42d.xn--lrb6479j; [P1, V5, V6] # ⴋ≮.ާ𐋣
+ⴋ≮𱲆。‍ާ𐋣; ⴋ≮𱲆.‍ާ𐋣; [C2, P1, V6]; xn--gdhz03bxt42d.xn--lrb506jqr4n; ; xn--gdhz03bxt42d.xn--lrb6479j; [P1, V5, V6] # ⴋ≮.ާ𐋣
+xn--gdhz03bxt42d.xn--lrb6479j; ⴋ≮𱲆.ާ𐋣; [V5, V6]; xn--gdhz03bxt42d.xn--lrb6479j; ; ;  # ⴋ≮.ާ𐋣
+xn--gdhz03bxt42d.xn--lrb506jqr4n; ⴋ≮𱲆.‍ާ𐋣; [C2, V6]; xn--gdhz03bxt42d.xn--lrb506jqr4n; ; ;  # ⴋ≮.ާ𐋣
+xn--jnd802gsm17c.xn--lrb6479j; Ⴋ≮𱲆.ާ𐋣; [V5, V6]; xn--jnd802gsm17c.xn--lrb6479j; ; ;  # Ⴋ≮.ާ𐋣
+xn--jnd802gsm17c.xn--lrb506jqr4n; Ⴋ≮𱲆.‍ާ𐋣; [C2, V6]; xn--jnd802gsm17c.xn--lrb506jqr4n; ; ;  # Ⴋ≮.ާ𐋣
+្.򆽒≯; ; [P1, V5, V6]; xn--u4e.xn--hdhx0084f; ; ;  # ្.≯
+្.򆽒≯; ្.򆽒≯; [P1, V5, V6]; xn--u4e.xn--hdhx0084f; ; ;  # ្.≯
+xn--u4e.xn--hdhx0084f; ្.򆽒≯; [V5, V6]; xn--u4e.xn--hdhx0084f; ; ;  # ្.≯
+񏁇᜴．𐨺É⬓𑄴; 񏁇᜴.𐨺é⬓𑄴; [P1, V5, V6]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇᜴．𐨺É⬓𑄴; 񏁇᜴.𐨺é⬓𑄴; [P1, V5, V6]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇᜴.𐨺É⬓𑄴; 񏁇᜴.𐨺é⬓𑄴; [P1, V5, V6]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇᜴.𐨺É⬓𑄴; 񏁇᜴.𐨺é⬓𑄴; [P1, V5, V6]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇᜴.𐨺é⬓𑄴; 񏁇᜴.𐨺é⬓𑄴; [P1, V5, V6]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇᜴.𐨺é⬓𑄴; ; [P1, V5, V6]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+xn--c0e34564d.xn--9ca207st53lg3f; 񏁇᜴.𐨺é⬓𑄴; [V5, V6]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇᜴．𐨺é⬓𑄴; 񏁇᜴.𐨺é⬓𑄴; [P1, V5, V6]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇᜴．𐨺é⬓𑄴; 񏁇᜴.𐨺é⬓𑄴; [P1, V5, V6]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+ᢇ‍꣄｡︒𞤺; ᢇ‍꣄.︒𞤺; [B1, B6, C2, P1, V6]; xn--09e669a6x8j.xn--y86cv562b; ; xn--09e4694e.xn--y86cv562b; [B1, P1, V6] # ᢇ꣄.︒𞤺
+ᢇ‍꣄。。𞤺; ᢇ‍꣄..𞤺; [B6, C2, X4_2]; xn--09e669a6x8j..xn--ye6h; [B6, C2, A4_2]; xn--09e4694e..xn--ye6h; [A4_2] # ᢇ꣄..𞤺
+ᢇ‍꣄。。𞤘; ᢇ‍꣄..𞤺; [B6, C2, X4_2]; xn--09e669a6x8j..xn--ye6h; [B6, C2, A4_2]; xn--09e4694e..xn--ye6h; [A4_2] # ᢇ꣄..𞤺
+xn--09e4694e..xn--ye6h; ᢇ꣄..𞤺; [X4_2]; xn--09e4694e..xn--ye6h; [A4_2]; ;  # ᢇ꣄..𞤺
+xn--09e669a6x8j..xn--ye6h; ᢇ‍꣄..𞤺; [B6, C2, X4_2]; xn--09e669a6x8j..xn--ye6h; [B6, C2, A4_2]; ;  # ᢇ꣄..𞤺
+ᢇ‍꣄｡︒𞤘; ᢇ‍꣄.︒𞤺; [B1, B6, C2, P1, V6]; xn--09e669a6x8j.xn--y86cv562b; ; xn--09e4694e.xn--y86cv562b; [B1, P1, V6] # ᢇ꣄.︒𞤺
+xn--09e4694e.xn--y86cv562b; ᢇ꣄.︒𞤺; [B1, V6]; xn--09e4694e.xn--y86cv562b; ; ;  # ᢇ꣄.︒𞤺
+xn--09e669a6x8j.xn--y86cv562b; ᢇ‍꣄.︒𞤺; [B1, B6, C2, V6]; xn--09e669a6x8j.xn--y86cv562b; ; ;  # ᢇ꣄.︒𞤺
+𞩬򖙱᜔‌｡رު≮; 𞩬򖙱᜔‌.رު≮; [B2, B3, P1, V6]; xn--fze607b9651bjwl7c.xn--wgb86el10d; ; xn--fze3930v7hz6b.xn--wgb86el10d;  # ᜔.رު≮
+𞩬򖙱᜔‌｡رު≮; 𞩬򖙱᜔‌.رު≮; [B2, B3, P1, V6]; xn--fze607b9651bjwl7c.xn--wgb86el10d; ; xn--fze3930v7hz6b.xn--wgb86el10d;  # ᜔.رު≮
+𞩬򖙱᜔‌。رު≮; 𞩬򖙱᜔‌.رު≮; [B2, B3, P1, V6]; xn--fze607b9651bjwl7c.xn--wgb86el10d; ; xn--fze3930v7hz6b.xn--wgb86el10d;  # ᜔.رު≮
+𞩬򖙱᜔‌。رު≮; 𞩬򖙱᜔‌.رު≮; [B2, B3, P1, V6]; xn--fze607b9651bjwl7c.xn--wgb86el10d; ; xn--fze3930v7hz6b.xn--wgb86el10d;  # ᜔.رު≮
+xn--fze3930v7hz6b.xn--wgb86el10d; 𞩬򖙱᜔.رު≮; [B2, B3, V6]; xn--fze3930v7hz6b.xn--wgb86el10d; ; ;  # ᜔.رު≮
+xn--fze607b9651bjwl7c.xn--wgb86el10d; 𞩬򖙱᜔‌.رު≮; [B2, B3, V6]; xn--fze607b9651bjwl7c.xn--wgb86el10d; ; ;  # ᜔.رު≮
+Ⴣ．ٓᢤ; Ⴣ.ٓᢤ; [P1, V5, V6]; xn--7nd.xn--vhb294g; ; ;  # Ⴣ.ٓᢤ
+Ⴣ.ٓᢤ; ; [P1, V5, V6]; xn--7nd.xn--vhb294g; ; ;  # Ⴣ.ٓᢤ
+ⴣ.ٓᢤ; ; [V5]; xn--rlj.xn--vhb294g; ; ;  # ⴣ.ٓᢤ
+xn--rlj.xn--vhb294g; ⴣ.ٓᢤ; [V5]; xn--rlj.xn--vhb294g; ; ;  # ⴣ.ٓᢤ
+xn--7nd.xn--vhb294g; Ⴣ.ٓᢤ; [V5, V6]; xn--7nd.xn--vhb294g; ; ;  # Ⴣ.ٓᢤ
+ⴣ．ٓᢤ; ⴣ.ٓᢤ; [V5]; xn--rlj.xn--vhb294g; ; ;  # ⴣ.ٓᢤ
+󠄈ࠓ．싉򄆻Ⴤ򂡐; ࠓ.싉򄆻Ⴤ򂡐; [P1, V6]; xn--oub.xn--8nd9522gpe69cviva; ; ;  # ࠓ.싉Ⴤ
+󠄈ࠓ．싉򄆻Ⴤ򂡐; ࠓ.싉򄆻Ⴤ򂡐; [P1, V6]; xn--oub.xn--8nd9522gpe69cviva; ; ;  # ࠓ.싉Ⴤ
+󠄈ࠓ.싉򄆻Ⴤ򂡐; ࠓ.싉򄆻Ⴤ򂡐; [P1, V6]; xn--oub.xn--8nd9522gpe69cviva; ; ;  # ࠓ.싉Ⴤ
+󠄈ࠓ.싉򄆻Ⴤ򂡐; ࠓ.싉򄆻Ⴤ򂡐; [P1, V6]; xn--oub.xn--8nd9522gpe69cviva; ; ;  # ࠓ.싉Ⴤ
+󠄈ࠓ.싉򄆻ⴤ򂡐; ࠓ.싉򄆻ⴤ򂡐; [P1, V6]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+󠄈ࠓ.싉򄆻ⴤ򂡐; ࠓ.싉򄆻ⴤ򂡐; [P1, V6]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+xn--oub.xn--sljz109bpe25dviva; ࠓ.싉򄆻ⴤ򂡐; [V6]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+xn--oub.xn--8nd9522gpe69cviva; ࠓ.싉򄆻Ⴤ򂡐; [V6]; xn--oub.xn--8nd9522gpe69cviva; ; ;  # ࠓ.싉Ⴤ
+󠄈ࠓ．싉򄆻ⴤ򂡐; ࠓ.싉򄆻ⴤ򂡐; [P1, V6]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+󠄈ࠓ．싉򄆻ⴤ򂡐; ࠓ.싉򄆻ⴤ򂡐; [P1, V6]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+ꨬ𑲫≮．⤂; ꨬ𑲫≮.⤂; [P1, V5, V6]; xn--gdh1854cn19c.xn--kqi; ; ;  # ꨬ𑲫≮.⤂
+ꨬ𑲫≮．⤂; ꨬ𑲫≮.⤂; [P1, V5, V6]; xn--gdh1854cn19c.xn--kqi; ; ;  # ꨬ𑲫≮.⤂
+ꨬ𑲫≮.⤂; ; [P1, V5, V6]; xn--gdh1854cn19c.xn--kqi; ; ;  # ꨬ𑲫≮.⤂
+ꨬ𑲫≮.⤂; ꨬ𑲫≮.⤂; [P1, V5, V6]; xn--gdh1854cn19c.xn--kqi; ; ;  # ꨬ𑲫≮.⤂
+xn--gdh1854cn19c.xn--kqi; ꨬ𑲫≮.⤂; [V5, V6]; xn--gdh1854cn19c.xn--kqi; ; ;  # ꨬ𑲫≮.⤂
+؄𐩔≮Ⴢ．Ⴃ; ؄𐩔≮Ⴢ.Ⴃ; [B1, P1, V6]; xn--mfb416c0jox02t.xn--bnd; ; ;  # 𐩔≮Ⴢ.Ⴃ
+؄𐩔≮Ⴢ．Ⴃ; ؄𐩔≮Ⴢ.Ⴃ; [B1, P1, V6]; xn--mfb416c0jox02t.xn--bnd; ; ;  # 𐩔≮Ⴢ.Ⴃ
+؄𐩔≮Ⴢ.Ⴃ; ; [B1, P1, V6]; xn--mfb416c0jox02t.xn--bnd; ; ;  # 𐩔≮Ⴢ.Ⴃ
+؄𐩔≮Ⴢ.Ⴃ; ؄𐩔≮Ⴢ.Ⴃ; [B1, P1, V6]; xn--mfb416c0jox02t.xn--bnd; ; ;  # 𐩔≮Ⴢ.Ⴃ
+؄𐩔≮ⴢ.ⴃ; ؄𐩔≮ⴢ.ⴃ; [B1, P1, V6]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+؄𐩔≮ⴢ.ⴃ; ; [B1, P1, V6]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+؄𐩔≮Ⴢ.ⴃ; ; [B1, P1, V6]; xn--mfb416c0jox02t.xn--ukj; ; ;  # 𐩔≮Ⴢ.ⴃ
+؄𐩔≮Ⴢ.ⴃ; ؄𐩔≮Ⴢ.ⴃ; [B1, P1, V6]; xn--mfb416c0jox02t.xn--ukj; ; ;  # 𐩔≮Ⴢ.ⴃ
+xn--mfb416c0jox02t.xn--ukj; ؄𐩔≮Ⴢ.ⴃ; [B1, V6]; xn--mfb416c0jox02t.xn--ukj; ; ;  # 𐩔≮Ⴢ.ⴃ
+xn--mfb266l4khr54u.xn--ukj; ؄𐩔≮ⴢ.ⴃ; [B1, V6]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+xn--mfb416c0jox02t.xn--bnd; ؄𐩔≮Ⴢ.Ⴃ; [B1, V6]; xn--mfb416c0jox02t.xn--bnd; ; ;  # 𐩔≮Ⴢ.Ⴃ
+؄𐩔≮ⴢ．ⴃ; ؄𐩔≮ⴢ.ⴃ; [B1, P1, V6]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+؄𐩔≮ⴢ．ⴃ; ؄𐩔≮ⴢ.ⴃ; [B1, P1, V6]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+؄𐩔≮Ⴢ．ⴃ; ؄𐩔≮Ⴢ.ⴃ; [B1, P1, V6]; xn--mfb416c0jox02t.xn--ukj; ; ;  # 𐩔≮Ⴢ.ⴃ
+؄𐩔≮Ⴢ．ⴃ; ؄𐩔≮Ⴢ.ⴃ; [B1, P1, V6]; xn--mfb416c0jox02t.xn--ukj; ; ;  # 𐩔≮Ⴢ.ⴃ
+𑁅。-; 𑁅.-; [V3, V5]; xn--210d.-; ; ;  # 𑁅.-
+xn--210d.-; 𑁅.-; [V3, V5]; xn--210d.-; ; ;  # 𑁅.-
+්򕸽󠧱｡饈≠٤; ්򕸽󠧱.饈≠٤; [B1, B5, B6, P1, V5, V6]; xn--h1c25913jfwov.xn--dib144ler5f; ; ;  # ්.饈≠٤
+්򕸽󠧱｡饈≠٤; ්򕸽󠧱.饈≠٤; [B1, B5, B6, P1, V5, V6]; xn--h1c25913jfwov.xn--dib144ler5f; ; ;  # ්.饈≠٤
+්򕸽󠧱。饈≠٤; ්򕸽󠧱.饈≠٤; [B1, B5, B6, P1, V5, V6]; xn--h1c25913jfwov.xn--dib144ler5f; ; ;  # ්.饈≠٤
+්򕸽󠧱。饈≠٤; ්򕸽󠧱.饈≠٤; [B1, B5, B6, P1, V5, V6]; xn--h1c25913jfwov.xn--dib144ler5f; ; ;  # ්.饈≠٤
+xn--h1c25913jfwov.xn--dib144ler5f; ්򕸽󠧱.饈≠٤; [B1, B5, B6, V5, V6]; xn--h1c25913jfwov.xn--dib144ler5f; ; ;  # ්.饈≠٤
+𞥃ᠠ⁷｡≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2, P1, V6]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞥃ᠠ⁷｡≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2, P1, V6]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞥃ᠠ7。≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2, P1, V6]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞥃ᠠ7。≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2, P1, V6]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞤡ᠠ7。≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2, P1, V6]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞤡ᠠ7。≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2, P1, V6]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+xn--7-v4j2826w.xn--4-ogoy01bou3i; 𞥃ᠠ7.≯邅⬻4; [B1, B2, V6]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞤡ᠠ⁷｡≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2, P1, V6]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞤡ᠠ⁷｡≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2, P1, V6]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+򠿯ᡳ-𑐻.𐹴𐋫؅󑎳; ; [B1, B6, P1, V6]; xn----m9j3429kxmy7e.xn--nfb7950kdihrp812a; ; ;  # ᡳ-𑐻.𐹴𐋫
+xn----m9j3429kxmy7e.xn--nfb7950kdihrp812a; 򠿯ᡳ-𑐻.𐹴𐋫؅󑎳; [B1, B6, V6]; xn----m9j3429kxmy7e.xn--nfb7950kdihrp812a; ; ;  # ᡳ-𑐻.𐹴𐋫
+򠶆ࡅੑ.넨-󶧈; ; [B5, B6, P1, V6]; xn--3vb26hb6834b.xn----i37ez0957g; ; ;  # ࡅੑ.넨-
+򠶆ࡅੑ.넨-󶧈; 򠶆ࡅੑ.넨-󶧈; [B5, B6, P1, V6]; xn--3vb26hb6834b.xn----i37ez0957g; ; ;  # ࡅੑ.넨-
+xn--3vb26hb6834b.xn----i37ez0957g; 򠶆ࡅੑ.넨-󶧈; [B5, B6, V6]; xn--3vb26hb6834b.xn----i37ez0957g; ; ;  # ࡅੑ.넨-
+ꡦᡑ‍⒈。𐋣-; ꡦᡑ‍⒈.𐋣-; [C2, P1, V3, V6]; xn--h8e470bl0d838o.xn----381i; ; xn--h8e863drj7h.xn----381i; [P1, V3, V6] # ꡦᡑ⒈.𐋣-
+ꡦᡑ‍1.。𐋣-; ꡦᡑ‍1..𐋣-; [C2, V3, X4_2]; xn--1-o7j663bdl7m..xn----381i; [C2, V3, A4_2]; xn--1-o7j0610f..xn----381i; [V3, A4_2] # ꡦᡑ1..𐋣-
+xn--1-o7j0610f..xn----381i; ꡦᡑ1..𐋣-; [V3, X4_2]; xn--1-o7j0610f..xn----381i; [V3, A4_2]; ;  # ꡦᡑ1..𐋣-
+xn--1-o7j663bdl7m..xn----381i; ꡦᡑ‍1..𐋣-; [C2, V3, X4_2]; xn--1-o7j663bdl7m..xn----381i; [C2, V3, A4_2]; ;  # ꡦᡑ1..𐋣-
+xn--h8e863drj7h.xn----381i; ꡦᡑ⒈.𐋣-; [V3, V6]; xn--h8e863drj7h.xn----381i; ; ;  # ꡦᡑ⒈.𐋣-
+xn--h8e470bl0d838o.xn----381i; ꡦᡑ‍⒈.𐋣-; [C2, V3, V6]; xn--h8e470bl0d838o.xn----381i; ; ;  # ꡦᡑ⒈.𐋣-
+Ⴌ。􍼠ﭩ; Ⴌ.􍼠ٹ; [B5, B6, P1, V6]; xn--knd.xn--yib19191t; ; ;  # Ⴌ.ٹ
+Ⴌ。􍼠ٹ; Ⴌ.􍼠ٹ; [B5, B6, P1, V6]; xn--knd.xn--yib19191t; ; ;  # Ⴌ.ٹ
+ⴌ。􍼠ٹ; ⴌ.􍼠ٹ; [B5, B6, P1, V6]; xn--3kj.xn--yib19191t; ; ;  # ⴌ.ٹ
+xn--3kj.xn--yib19191t; ⴌ.􍼠ٹ; [B5, B6, V6]; xn--3kj.xn--yib19191t; ; ;  # ⴌ.ٹ
+xn--knd.xn--yib19191t; Ⴌ.􍼠ٹ; [B5, B6, V6]; xn--knd.xn--yib19191t; ; ;  # Ⴌ.ٹ
+ⴌ。􍼠ﭩ; ⴌ.􍼠ٹ; [B5, B6, P1, V6]; xn--3kj.xn--yib19191t; ; ;  # ⴌ.ٹ
+𐮁𐭱.྄፞-ᳺ; ; [B1, P1, V5, V6]; xn--r19c5a.xn----xjg270ag3m; ; ;  # 𐮁𐭱.྄፞-
+xn--r19c5a.xn----xjg270ag3m; 𐮁𐭱.྄፞-ᳺ; [B1, V5, V6]; xn--r19c5a.xn----xjg270ag3m; ; ;  # 𐮁𐭱.྄፞-
+⒈䰹‍-。웈; ⒈䰹‍-.웈; [C2, P1, V3, V6]; xn----tgnx5rjr6c.xn--kp5b; ; xn----dcp160o.xn--kp5b; [P1, V3, V6] # ⒈䰹-.웈
+⒈䰹‍-。웈; ⒈䰹‍-.웈; [C2, P1, V3, V6]; xn----tgnx5rjr6c.xn--kp5b; ; xn----dcp160o.xn--kp5b; [P1, V3, V6] # ⒈䰹-.웈
+1.䰹‍-。웈; 1.䰹‍-.웈; [C2, V3]; 1.xn----tgnz80r.xn--kp5b; ; 1.xn----zw5a.xn--kp5b; [V3] # 1.䰹-.웈
+1.䰹‍-。웈; 1.䰹‍-.웈; [C2, V3]; 1.xn----tgnz80r.xn--kp5b; ; 1.xn----zw5a.xn--kp5b; [V3] # 1.䰹-.웈
+1.xn----zw5a.xn--kp5b; 1.䰹-.웈; [V3]; 1.xn----zw5a.xn--kp5b; ; ;  # 1.䰹-.웈
+1.xn----tgnz80r.xn--kp5b; 1.䰹‍-.웈; [C2, V3]; 1.xn----tgnz80r.xn--kp5b; ; ;  # 1.䰹-.웈
+xn----dcp160o.xn--kp5b; ⒈䰹-.웈; [V3, V6]; xn----dcp160o.xn--kp5b; ; ;  # ⒈䰹-.웈
+xn----tgnx5rjr6c.xn--kp5b; ⒈䰹‍-.웈; [C2, V3, V6]; xn----tgnx5rjr6c.xn--kp5b; ; ;  # ⒈䰹-.웈
+て。‌󠳽߳; て.‌󠳽߳; [C1, P1, V6]; xn--m9j.xn--rtb154j9l73w; ; xn--m9j.xn--rtb10784p; [P1, V6] # て.߳
+xn--m9j.xn--rtb10784p; て.󠳽߳; [V6]; xn--m9j.xn--rtb10784p; ; ;  # て.߳
+xn--m9j.xn--rtb154j9l73w; て.‌󠳽߳; [C1, V6]; xn--m9j.xn--rtb154j9l73w; ; ;  # て.߳
+ς｡꧀ۧ; ς.꧀ۧ; [V5]; xn--3xa.xn--3lb1944f; ; xn--4xa.xn--3lb1944f;  # ς.꧀ۧ
+ς。꧀ۧ; ς.꧀ۧ; [V5]; xn--3xa.xn--3lb1944f; ; xn--4xa.xn--3lb1944f;  # ς.꧀ۧ
+Σ。꧀ۧ; σ.꧀ۧ; [V5]; xn--4xa.xn--3lb1944f; ; ;  # σ.꧀ۧ
+σ。꧀ۧ; σ.꧀ۧ; [V5]; xn--4xa.xn--3lb1944f; ; ;  # σ.꧀ۧ
+xn--4xa.xn--3lb1944f; σ.꧀ۧ; [V5]; xn--4xa.xn--3lb1944f; ; ;  # σ.꧀ۧ
+xn--3xa.xn--3lb1944f; ς.꧀ۧ; [V5]; xn--3xa.xn--3lb1944f; ; ;  # ς.꧀ۧ
+Σ｡꧀ۧ; σ.꧀ۧ; [V5]; xn--4xa.xn--3lb1944f; ; ;  # σ.꧀ۧ
+σ｡꧀ۧ; σ.꧀ۧ; [V5]; xn--4xa.xn--3lb1944f; ; ;  # σ.꧀ۧ
+்󥫅򌉑.ႢႵ; ; [P1, V5, V6]; xn--xmc83135idcxza.xn--9md2b; ; ;  # ்.ႢႵ
+்󥫅򌉑.ⴂⴕ; ; [P1, V5, V6]; xn--xmc83135idcxza.xn--tkjwb; ; ;  # ்.ⴂⴕ
+்󥫅򌉑.Ⴂⴕ; ; [P1, V5, V6]; xn--xmc83135idcxza.xn--9md086l; ; ;  # ்.Ⴂⴕ
+xn--xmc83135idcxza.xn--9md086l; ்󥫅򌉑.Ⴂⴕ; [V5, V6]; xn--xmc83135idcxza.xn--9md086l; ; ;  # ்.Ⴂⴕ
+xn--xmc83135idcxza.xn--tkjwb; ்󥫅򌉑.ⴂⴕ; [V5, V6]; xn--xmc83135idcxza.xn--tkjwb; ; ;  # ்.ⴂⴕ
+xn--xmc83135idcxza.xn--9md2b; ்󥫅򌉑.ႢႵ; [V5, V6]; xn--xmc83135idcxza.xn--9md2b; ; ;  # ்.ႢႵ
+ᰲ🄈⾛֦．‍򯥤߽; ᰲ🄈走֦.‍򯥤߽; [C2, P1, V5, V6]; xn--xcb756i493fwi5o.xn--1tb334j1197q; ; xn--xcb756i493fwi5o.xn--1tb13454l; [P1, V5, V6] # ᰲ🄈走֦.߽
+ᰲ7,走֦.‍򯥤߽; ; [C2, P1, V5, V6]; xn--7,-bid991urn3k.xn--1tb334j1197q; ; xn--7,-bid991urn3k.xn--1tb13454l; [P1, V5, V6] # ᰲ7,走֦.߽
+xn--7,-bid991urn3k.xn--1tb13454l; ᰲ7,走֦.򯥤߽; [P1, V5, V6]; xn--7,-bid991urn3k.xn--1tb13454l; ; ;  # ᰲ7,走֦.߽
+xn--7,-bid991urn3k.xn--1tb334j1197q; ᰲ7,走֦.‍򯥤߽; [C2, P1, V5, V6]; xn--7,-bid991urn3k.xn--1tb334j1197q; ; ;  # ᰲ7,走֦.߽
+xn--xcb756i493fwi5o.xn--1tb13454l; ᰲ🄈走֦.򯥤߽; [V5, V6]; xn--xcb756i493fwi5o.xn--1tb13454l; ; ;  # ᰲ🄈走֦.߽
+xn--xcb756i493fwi5o.xn--1tb334j1197q; ᰲ🄈走֦.‍򯥤߽; [C2, V5, V6]; xn--xcb756i493fwi5o.xn--1tb334j1197q; ; ;  # ᰲ🄈走֦.߽
+ᢗ｡Ӏ񝄻; ᢗ.Ӏ񝄻; [P1, V6]; xn--hbf.xn--d5a86117e; ; ;  # ᢗ.Ӏ
+ᢗ。Ӏ񝄻; ᢗ.Ӏ񝄻; [P1, V6]; xn--hbf.xn--d5a86117e; ; ;  # ᢗ.Ӏ
+ᢗ。ӏ񝄻; ᢗ.ӏ񝄻; [P1, V6]; xn--hbf.xn--s5a83117e; ; ;  # ᢗ.ӏ
+xn--hbf.xn--s5a83117e; ᢗ.ӏ񝄻; [V6]; xn--hbf.xn--s5a83117e; ; ;  # ᢗ.ӏ
+xn--hbf.xn--d5a86117e; ᢗ.Ӏ񝄻; [V6]; xn--hbf.xn--d5a86117e; ; ;  # ᢗ.Ӏ
+ᢗ｡ӏ񝄻; ᢗ.ӏ񝄻; [P1, V6]; xn--hbf.xn--s5a83117e; ; ;  # ᢗ.ӏ
+٨-。񠏇🝆ᄾ; ٨-.񠏇🝆ᄾ; [B1, P1, V3, V6]; xn----oqc.xn--qrd1699v327w; ; ;  # ٨-.🝆ᄾ
+xn----oqc.xn--qrd1699v327w; ٨-.񠏇🝆ᄾ; [B1, V3, V6]; xn----oqc.xn--qrd1699v327w; ; ;  # ٨-.🝆ᄾ
+-𐋷𖾑。󠆬; -𐋷𖾑.; [V3]; xn----991iq40y.; ; ;  # -𐋷𖾑.
+xn----991iq40y.; -𐋷𖾑.; [V3]; xn----991iq40y.; ; ;  # -𐋷𖾑.
+‌𐹳🐴멈.꯭񐡼; ; [B1, C1, P1, V5, V6]; xn--0ug6681d406b7bwk.xn--429a8682s; ; xn--422b325mqb6i.xn--429a8682s; [B1, P1, V5, V6] # 𐹳🐴멈.꯭
+‌𐹳🐴멈.꯭񐡼; ‌𐹳🐴멈.꯭񐡼; [B1, C1, P1, V5, V6]; xn--0ug6681d406b7bwk.xn--429a8682s; ; xn--422b325mqb6i.xn--429a8682s; [B1, P1, V5, V6] # 𐹳🐴멈.꯭
+xn--422b325mqb6i.xn--429a8682s; 𐹳🐴멈.꯭񐡼; [B1, V5, V6]; xn--422b325mqb6i.xn--429a8682s; ; ;  # 𐹳🐴멈.꯭
+xn--0ug6681d406b7bwk.xn--429a8682s; ‌𐹳🐴멈.꯭񐡼; [B1, C1, V5, V6]; xn--0ug6681d406b7bwk.xn--429a8682s; ; ;  # 𐹳🐴멈.꯭
+≮.ݩ؃; ; [B1, P1, V6]; xn--gdh.xn--lfb92e; ; ;  # ≮.ݩ
+≮.ݩ؃; ≮.ݩ؃; [B1, P1, V6]; xn--gdh.xn--lfb92e; ; ;  # ≮.ݩ
+xn--gdh.xn--lfb92e; ≮.ݩ؃; [B1, V6]; xn--gdh.xn--lfb92e; ; ;  # ≮.ݩ
+𐶭⾆｡‌𑚶򟱃𞰘; 𐶭舌.‌𑚶򟱃𞰘; [B1, B2, B3, C1, P1, V6]; xn--tc1ao37z.xn--0ugx728gi1nfwqz2e; ; xn--tc1ao37z.xn--6e2dw557azds2d; [B2, B3, B5, B6, P1, V5, V6] # 舌.𑚶
+𐶭舌。‌𑚶򟱃𞰘; 𐶭舌.‌𑚶򟱃𞰘; [B1, B2, B3, C1, P1, V6]; xn--tc1ao37z.xn--0ugx728gi1nfwqz2e; ; xn--tc1ao37z.xn--6e2dw557azds2d; [B2, B3, B5, B6, P1, V5, V6] # 舌.𑚶
+xn--tc1ao37z.xn--6e2dw557azds2d; 𐶭舌.𑚶򟱃𞰘; [B2, B3, B5, B6, V5, V6]; xn--tc1ao37z.xn--6e2dw557azds2d; ; ;  # 舌.𑚶
+xn--tc1ao37z.xn--0ugx728gi1nfwqz2e; 𐶭舌.‌𑚶򟱃𞰘; [B1, B2, B3, C1, V6]; xn--tc1ao37z.xn--0ugx728gi1nfwqz2e; ; ;  # 舌.𑚶
+‌Ⴠ-.𝟷ς𞴺ς; ‌Ⴠ-.1ς𞴺ς; [B1, C1, P1, V3, V6]; xn----z1g168i.xn--1-ymba92321c; ; xn----z1g.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # Ⴠ-.1ςς
+‌Ⴠ-.1ς𞴺ς; ; [B1, C1, P1, V3, V6]; xn----z1g168i.xn--1-ymba92321c; ; xn----z1g.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # Ⴠ-.1ςς
+‌ⴠ-.1ς𞴺ς; ; [B1, C1, P1, V3, V6]; xn----rgn530d.xn--1-ymba92321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # ⴠ-.1ςς
+‌Ⴠ-.1Σ𞴺Σ; ‌Ⴠ-.1σ𞴺σ; [B1, C1, P1, V3, V6]; xn----z1g168i.xn--1-0mba52321c; ; xn----z1g.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # Ⴠ-.1σσ
+‌ⴠ-.1σ𞴺σ; ; [B1, C1, P1, V3, V6]; xn----rgn530d.xn--1-0mba52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # ⴠ-.1σσ
+‌Ⴠ-.1σ𞴺Σ; ‌Ⴠ-.1σ𞴺σ; [B1, C1, P1, V3, V6]; xn----z1g168i.xn--1-0mba52321c; ; xn----z1g.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # Ⴠ-.1σσ
+xn----z1g.xn--1-0mba52321c; Ⴠ-.1σ𞴺σ; [B1, B6, V3, V6]; xn----z1g.xn--1-0mba52321c; ; ;  # Ⴠ-.1σσ
+xn----z1g168i.xn--1-0mba52321c; ‌Ⴠ-.1σ𞴺σ; [B1, C1, V3, V6]; xn----z1g168i.xn--1-0mba52321c; ; ;  # Ⴠ-.1σσ
+xn----2ws.xn--1-0mba52321c; ⴠ-.1σ𞴺σ; [B1, B6, V3, V6]; xn----2ws.xn--1-0mba52321c; ; ;  # ⴠ-.1σσ
+xn----rgn530d.xn--1-0mba52321c; ‌ⴠ-.1σ𞴺σ; [B1, C1, V3, V6]; xn----rgn530d.xn--1-0mba52321c; ; ;  # ⴠ-.1σσ
+‌Ⴠ-.1ς𞴺Σ; ‌Ⴠ-.1ς𞴺σ; [B1, C1, P1, V3, V6]; xn----z1g168i.xn--1-ymbd52321c; ; xn----z1g.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # Ⴠ-.1ςσ
+‌ⴠ-.1ς𞴺σ; ; [B1, C1, P1, V3, V6]; xn----rgn530d.xn--1-ymbd52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # ⴠ-.1ςσ
+xn----rgn530d.xn--1-ymbd52321c; ‌ⴠ-.1ς𞴺σ; [B1, C1, V3, V6]; xn----rgn530d.xn--1-ymbd52321c; ; ;  # ⴠ-.1ςσ
+xn----z1g168i.xn--1-ymbd52321c; ‌Ⴠ-.1ς𞴺σ; [B1, C1, V3, V6]; xn----z1g168i.xn--1-ymbd52321c; ; ;  # Ⴠ-.1ςσ
+xn----rgn530d.xn--1-ymba92321c; ‌ⴠ-.1ς𞴺ς; [B1, C1, V3, V6]; xn----rgn530d.xn--1-ymba92321c; ; ;  # ⴠ-.1ςς
+xn----z1g168i.xn--1-ymba92321c; ‌Ⴠ-.1ς𞴺ς; [B1, C1, V3, V6]; xn----z1g168i.xn--1-ymba92321c; ; ;  # Ⴠ-.1ςς
+‌ⴠ-.𝟷ς𞴺ς; ‌ⴠ-.1ς𞴺ς; [B1, C1, P1, V3, V6]; xn----rgn530d.xn--1-ymba92321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # ⴠ-.1ςς
+‌Ⴠ-.𝟷Σ𞴺Σ; ‌Ⴠ-.1σ𞴺σ; [B1, C1, P1, V3, V6]; xn----z1g168i.xn--1-0mba52321c; ; xn----z1g.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # Ⴠ-.1σσ
+‌ⴠ-.𝟷σ𞴺σ; ‌ⴠ-.1σ𞴺σ; [B1, C1, P1, V3, V6]; xn----rgn530d.xn--1-0mba52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # ⴠ-.1σσ
+‌Ⴠ-.𝟷σ𞴺Σ; ‌Ⴠ-.1σ𞴺σ; [B1, C1, P1, V3, V6]; xn----z1g168i.xn--1-0mba52321c; ; xn----z1g.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # Ⴠ-.1σσ
+‌Ⴠ-.𝟷ς𞴺Σ; ‌Ⴠ-.1ς𞴺σ; [B1, C1, P1, V3, V6]; xn----z1g168i.xn--1-ymbd52321c; ; xn----z1g.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # Ⴠ-.1ςσ
+‌ⴠ-.𝟷ς𞴺σ; ‌ⴠ-.1ς𞴺σ; [B1, C1, P1, V3, V6]; xn----rgn530d.xn--1-ymbd52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, P1, V3, V6] # ⴠ-.1ςσ
+𑲘󠄒𓑡｡𝟪Ⴜ; 𑲘𓑡.8Ⴜ; [P1, V5, V6]; xn--7m3d291b.xn--8-s1g; ; ;  # 𑲘.8Ⴜ
+𑲘󠄒𓑡。8Ⴜ; 𑲘𓑡.8Ⴜ; [P1, V5, V6]; xn--7m3d291b.xn--8-s1g; ; ;  # 𑲘.8Ⴜ
+𑲘󠄒𓑡。8ⴜ; 𑲘𓑡.8ⴜ; [P1, V5, V6]; xn--7m3d291b.xn--8-vws; ; ;  # 𑲘.8ⴜ
+xn--7m3d291b.xn--8-vws; 𑲘𓑡.8ⴜ; [V5, V6]; xn--7m3d291b.xn--8-vws; ; ;  # 𑲘.8ⴜ
+xn--7m3d291b.xn--8-s1g; 𑲘𓑡.8Ⴜ; [V5, V6]; xn--7m3d291b.xn--8-s1g; ; ;  # 𑲘.8Ⴜ
+𑲘󠄒𓑡｡𝟪ⴜ; 𑲘𓑡.8ⴜ; [P1, V5, V6]; xn--7m3d291b.xn--8-vws; ; ;  # 𑲘.8ⴜ
+䪏ګߠु｡뭕ᢝឹ; 䪏ګߠु.뭕ᢝឹ; [B5, B6]; xn--ekb23dj4at01n.xn--43e96bh910b; ; ;  # 䪏ګߠु.뭕ᢝឹ
+䪏ګߠु｡뭕ᢝឹ; 䪏ګߠु.뭕ᢝឹ; [B5, B6]; xn--ekb23dj4at01n.xn--43e96bh910b; ; ;  # 䪏ګߠु.뭕ᢝឹ
+䪏ګߠु。뭕ᢝឹ; 䪏ګߠु.뭕ᢝឹ; [B5, B6]; xn--ekb23dj4at01n.xn--43e96bh910b; ; ;  # 䪏ګߠु.뭕ᢝឹ
+䪏ګߠु。뭕ᢝឹ; 䪏ګߠु.뭕ᢝឹ; [B5, B6]; xn--ekb23dj4at01n.xn--43e96bh910b; ; ;  # 䪏ګߠु.뭕ᢝឹ
+xn--ekb23dj4at01n.xn--43e96bh910b; 䪏ګߠु.뭕ᢝឹ; [B5, B6]; xn--ekb23dj4at01n.xn--43e96bh910b; ; ;  # 䪏ګߠु.뭕ᢝឹ
+᮫｡🂉󠁰; ᮫.🂉󠁰; [P1, V5, V6]; xn--zxf.xn--fx7ho0250c; ; ;  # ᮫.🂉
+᮫。🂉󠁰; ᮫.🂉󠁰; [P1, V5, V6]; xn--zxf.xn--fx7ho0250c; ; ;  # ᮫.🂉
+xn--zxf.xn--fx7ho0250c; ᮫.🂉󠁰; [V5, V6]; xn--zxf.xn--fx7ho0250c; ; ;  # ᮫.🂉
+󩎃ૄ。ς‍𐹮𑈵; 󩎃ૄ.ς‍𐹮𑈵; [B5, C2, P1, V6]; xn--dfc53161q.xn--3xa006lzo7nsfd; ; xn--dfc53161q.xn--4xa8467k5mc; [B5, P1, V6] # ૄ.ς𐹮𑈵
+󩎃ૄ。Σ‍𐹮𑈵; 󩎃ૄ.σ‍𐹮𑈵; [B5, C2, P1, V6]; xn--dfc53161q.xn--4xa895lzo7nsfd; ; xn--dfc53161q.xn--4xa8467k5mc; [B5, P1, V6] # ૄ.σ𐹮𑈵
+󩎃ૄ。σ‍𐹮𑈵; 󩎃ૄ.σ‍𐹮𑈵; [B5, C2, P1, V6]; xn--dfc53161q.xn--4xa895lzo7nsfd; ; xn--dfc53161q.xn--4xa8467k5mc; [B5, P1, V6] # ૄ.σ𐹮𑈵
+xn--dfc53161q.xn--4xa8467k5mc; 󩎃ૄ.σ𐹮𑈵; [B5, V6]; xn--dfc53161q.xn--4xa8467k5mc; ; ;  # ૄ.σ𐹮𑈵
+xn--dfc53161q.xn--4xa895lzo7nsfd; 󩎃ૄ.σ‍𐹮𑈵; [B5, C2, V6]; xn--dfc53161q.xn--4xa895lzo7nsfd; ; ;  # ૄ.σ𐹮𑈵
+xn--dfc53161q.xn--3xa006lzo7nsfd; 󩎃ૄ.ς‍𐹮𑈵; [B5, C2, V6]; xn--dfc53161q.xn--3xa006lzo7nsfd; ; ;  # ૄ.ς𐹮𑈵
+𐫀ᡂ𑜫．𑘿; 𐫀ᡂ𑜫.𑘿; [B1, B2, B3, B6, V5]; xn--17e9625js1h.xn--sb2d; ; ;  # 𐫀ᡂ𑜫.𑘿
+𐫀ᡂ𑜫.𑘿; ; [B1, B2, B3, B6, V5]; xn--17e9625js1h.xn--sb2d; ; ;  # 𐫀ᡂ𑜫.𑘿
+xn--17e9625js1h.xn--sb2d; 𐫀ᡂ𑜫.𑘿; [B1, B2, B3, B6, V5]; xn--17e9625js1h.xn--sb2d; ; ;  # 𐫀ᡂ𑜫.𑘿
+󬚶󸋖򖩰-。‌; 󬚶󸋖򖩰-.‌; [C1, P1, V3, V6]; xn----7i12hu122k9ire.xn--0ug; ; xn----7i12hu122k9ire.; [P1, V3, V6] # -.
+xn----7i12hu122k9ire.; 󬚶󸋖򖩰-.; [V3, V6]; xn----7i12hu122k9ire.; ; ;  # -.
+xn----7i12hu122k9ire.xn--0ug; 󬚶󸋖򖩰-.‌; [C1, V3, V6]; xn----7i12hu122k9ire.xn--0ug; ; ;  # -.
+𐹣．߂; 𐹣.߂; [B1]; xn--bo0d.xn--dsb; ; ;  # 𐹣.߂
+𐹣.߂; ; [B1]; xn--bo0d.xn--dsb; ; ;  # 𐹣.߂
+xn--bo0d.xn--dsb; 𐹣.߂; [B1]; xn--bo0d.xn--dsb; ; ;  # 𐹣.߂
+-ߡ｡Ↄ; -ߡ.Ↄ; [B1, P1, V3, V6]; xn----8cd.xn--q5g; ; ;  # -ߡ.Ↄ
+-ߡ。Ↄ; -ߡ.Ↄ; [B1, P1, V3, V6]; xn----8cd.xn--q5g; ; ;  # -ߡ.Ↄ
+-ߡ。ↄ; -ߡ.ↄ; [B1, V3]; xn----8cd.xn--r5g; ; ;  # -ߡ.ↄ
+xn----8cd.xn--r5g; -ߡ.ↄ; [B1, V3]; xn----8cd.xn--r5g; ; ;  # -ߡ.ↄ
+xn----8cd.xn--q5g; -ߡ.Ↄ; [B1, V3, V6]; xn----8cd.xn--q5g; ; ;  # -ߡ.Ↄ
+-ߡ｡ↄ; -ߡ.ↄ; [B1, V3]; xn----8cd.xn--r5g; ; ;  # -ߡ.ↄ
+‍-︒󠄄。ß哑‌𐵿; ‍-︒.ß哑‌𐵿; [B1, B5, B6, C1, C2, P1, V6]; xn----tgnt341h.xn--zca670n5f0binyk; ; xn----o89h.xn--ss-h46c5711e; [B1, B5, B6, P1, V3, V6] # -︒.ß哑
+‍-。󠄄。ß哑‌𐵿; ‍-..ß哑‌𐵿; [B1, B5, B6, C1, C2, P1, V3, V6, X4_2]; xn----tgn..xn--zca670n5f0binyk; [B1, B5, B6, C1, C2, P1, V3, V6, A4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, P1, V3, V6, A4_2] # -..ß哑
+‍-。󠄄。SS哑‌𐵿; ‍-..ss哑‌𐵿; [B1, B5, B6, C1, C2, P1, V3, V6, X4_2]; xn----tgn..xn--ss-k1ts75zb8ym; [B1, B5, B6, C1, C2, P1, V3, V6, A4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, P1, V3, V6, A4_2] # -..ss哑
+‍-。󠄄。ss哑‌𐵿; ‍-..ss哑‌𐵿; [B1, B5, B6, C1, C2, P1, V3, V6, X4_2]; xn----tgn..xn--ss-k1ts75zb8ym; [B1, B5, B6, C1, C2, P1, V3, V6, A4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, P1, V3, V6, A4_2] # -..ss哑
+‍-。󠄄。Ss哑‌𐵿; ‍-..ss哑‌𐵿; [B1, B5, B6, C1, C2, P1, V3, V6, X4_2]; xn----tgn..xn--ss-k1ts75zb8ym; [B1, B5, B6, C1, C2, P1, V3, V6, A4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, P1, V3, V6, A4_2] # -..ss哑
+-..xn--ss-h46c5711e; -..ss哑𐵿; [B1, B5, B6, V3, V6, X4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, V3, V6, A4_2]; ;  # -..ss哑
+xn----tgn..xn--ss-k1ts75zb8ym; ‍-..ss哑‌𐵿; [B1, B5, B6, C1, C2, V3, V6, X4_2]; xn----tgn..xn--ss-k1ts75zb8ym; [B1, B5, B6, C1, C2, V3, V6, A4_2]; ;  # -..ss哑
+xn----tgn..xn--zca670n5f0binyk; ‍-..ß哑‌𐵿; [B1, B5, B6, C1, C2, V3, V6, X4_2]; xn----tgn..xn--zca670n5f0binyk; [B1, B5, B6, C1, C2, V3, V6, A4_2]; ;  # -..ß哑
+‍-︒󠄄。SS哑‌𐵿; ‍-︒.ss哑‌𐵿; [B1, B5, B6, C1, C2, P1, V6]; xn----tgnt341h.xn--ss-k1ts75zb8ym; ; xn----o89h.xn--ss-h46c5711e; [B1, B5, B6, P1, V3, V6] # -︒.ss哑
+‍-︒󠄄。ss哑‌𐵿; ‍-︒.ss哑‌𐵿; [B1, B5, B6, C1, C2, P1, V6]; xn----tgnt341h.xn--ss-k1ts75zb8ym; ; xn----o89h.xn--ss-h46c5711e; [B1, B5, B6, P1, V3, V6] # -︒.ss哑
+‍-︒󠄄。Ss哑‌𐵿; ‍-︒.ss哑‌𐵿; [B1, B5, B6, C1, C2, P1, V6]; xn----tgnt341h.xn--ss-k1ts75zb8ym; ; xn----o89h.xn--ss-h46c5711e; [B1, B5, B6, P1, V3, V6] # -︒.ss哑
+xn----o89h.xn--ss-h46c5711e; -︒.ss哑𐵿; [B1, B5, B6, V3, V6]; xn----o89h.xn--ss-h46c5711e; ; ;  # -︒.ss哑
+xn----tgnt341h.xn--ss-k1ts75zb8ym; ‍-︒.ss哑‌𐵿; [B1, B5, B6, C1, C2, V6]; xn----tgnt341h.xn--ss-k1ts75zb8ym; ; ;  # -︒.ss哑
+xn----tgnt341h.xn--zca670n5f0binyk; ‍-︒.ß哑‌𐵿; [B1, B5, B6, C1, C2, V6]; xn----tgnt341h.xn--zca670n5f0binyk; ; ;  # -︒.ß哑
+︒．𑑂︯; ︒.𑑂︯; [P1, V5, V6]; xn--y86c.xn--s96cu30b; ; ;  # ︒.𑑂︯
+︒．𑑂︯; ︒.𑑂︯; [P1, V5, V6]; xn--y86c.xn--s96cu30b; ; ;  # ︒.𑑂︯
+。.𑑂︯; ..𑑂︯; [V5, X4_2]; ..xn--s96cu30b; [V5, A4_2]; ;  # ..𑑂︯
+..xn--s96cu30b; ..𑑂︯; [V5, X4_2]; ..xn--s96cu30b; [V5, A4_2]; ;  # ..𑑂︯
+xn--y86c.xn--s96cu30b; ︒.𑑂︯; [V5, V6]; xn--y86c.xn--s96cu30b; ; ;  # ︒.𑑂︯
+꤬。‍; ꤬.‍; [C2, V5]; xn--zi9a.xn--1ug; ; xn--zi9a.; [V5] # ꤬.
+xn--zi9a.; ꤬.; [V5]; xn--zi9a.; ; ;  # ꤬.
+xn--zi9a.xn--1ug; ꤬.‍; [C2, V5]; xn--zi9a.xn--1ug; ; ;  # ꤬.
+‍󠸡｡ﳗ; ‍󠸡.هج; [B1, C2, P1, V6]; xn--1ug80651l.xn--rgb7c; ; xn--d356e.xn--rgb7c; [B1, P1, V6] # .هج
+‍󠸡。هج; ‍󠸡.هج; [B1, C2, P1, V6]; xn--1ug80651l.xn--rgb7c; ; xn--d356e.xn--rgb7c; [B1, P1, V6] # .هج
+xn--d356e.xn--rgb7c; 󠸡.هج; [B1, V6]; xn--d356e.xn--rgb7c; ; ;  # .هج
+xn--1ug80651l.xn--rgb7c; ‍󠸡.هج; [B1, C2, V6]; xn--1ug80651l.xn--rgb7c; ; ;  # .هج
+-Ⴄ𝟢٣．𑍴ς; -Ⴄ0٣.𑍴ς; [B1, P1, V3, V5, V6]; xn---0-iyd216h.xn--3xa1220l; ; xn---0-iyd216h.xn--4xa9120l;  # -Ⴄ0٣.𑍴ς
+-Ⴄ0٣.𑍴ς; ; [B1, P1, V3, V5, V6]; xn---0-iyd216h.xn--3xa1220l; ; xn---0-iyd216h.xn--4xa9120l;  # -Ⴄ0٣.𑍴ς
+-ⴄ0٣.𑍴ς; ; [B1, V3, V5]; xn---0-iyd8660b.xn--3xa1220l; ; xn---0-iyd8660b.xn--4xa9120l;  # -ⴄ0٣.𑍴ς
+-Ⴄ0٣.𑍴Σ; -Ⴄ0٣.𑍴σ; [B1, P1, V3, V5, V6]; xn---0-iyd216h.xn--4xa9120l; ; ;  # -Ⴄ0٣.𑍴σ
+-ⴄ0٣.𑍴σ; ; [B1, V3, V5]; xn---0-iyd8660b.xn--4xa9120l; ; ;  # -ⴄ0٣.𑍴σ
+xn---0-iyd8660b.xn--4xa9120l; -ⴄ0٣.𑍴σ; [B1, V3, V5]; xn---0-iyd8660b.xn--4xa9120l; ; ;  # -ⴄ0٣.𑍴σ
+xn---0-iyd216h.xn--4xa9120l; -Ⴄ0٣.𑍴σ; [B1, V3, V5, V6]; xn---0-iyd216h.xn--4xa9120l; ; ;  # -Ⴄ0٣.𑍴σ
+xn---0-iyd8660b.xn--3xa1220l; -ⴄ0٣.𑍴ς; [B1, V3, V5]; xn---0-iyd8660b.xn--3xa1220l; ; ;  # -ⴄ0٣.𑍴ς
+xn---0-iyd216h.xn--3xa1220l; -Ⴄ0٣.𑍴ς; [B1, V3, V5, V6]; xn---0-iyd216h.xn--3xa1220l; ; ;  # -Ⴄ0٣.𑍴ς
+-ⴄ𝟢٣．𑍴ς; -ⴄ0٣.𑍴ς; [B1, V3, V5]; xn---0-iyd8660b.xn--3xa1220l; ; xn---0-iyd8660b.xn--4xa9120l;  # -ⴄ0٣.𑍴ς
+-Ⴄ𝟢٣．𑍴Σ; -Ⴄ0٣.𑍴σ; [B1, P1, V3, V5, V6]; xn---0-iyd216h.xn--4xa9120l; ; ;  # -Ⴄ0٣.𑍴σ
+-ⴄ𝟢٣．𑍴σ; -ⴄ0٣.𑍴σ; [B1, V3, V5]; xn---0-iyd8660b.xn--4xa9120l; ; ;  # -ⴄ0٣.𑍴σ
+󦈄。-; 󦈄.-; [P1, V3, V6]; xn--xm38e.-; ; ;  # .-
+xn--xm38e.-; 󦈄.-; [V3, V6]; xn--xm38e.-; ; ;  # .-
+⋠𐋮．򶈮༘ß≯; ⋠𐋮.򶈮༘ß≯; [P1, V6]; xn--pgh4639f.xn--zca593eo6oc013y; ; xn--pgh4639f.xn--ss-ifj426nle504a;  # ⋠𐋮.༘ß≯
+⋠𐋮．򶈮༘ß≯; ⋠𐋮.򶈮༘ß≯; [P1, V6]; xn--pgh4639f.xn--zca593eo6oc013y; ; xn--pgh4639f.xn--ss-ifj426nle504a;  # ⋠𐋮.༘ß≯
+⋠𐋮.򶈮༘ß≯; ; [P1, V6]; xn--pgh4639f.xn--zca593eo6oc013y; ; xn--pgh4639f.xn--ss-ifj426nle504a;  # ⋠𐋮.༘ß≯
+⋠𐋮.򶈮༘ß≯; ⋠𐋮.򶈮༘ß≯; [P1, V6]; xn--pgh4639f.xn--zca593eo6oc013y; ; xn--pgh4639f.xn--ss-ifj426nle504a;  # ⋠𐋮.༘ß≯
+⋠𐋮.򶈮༘SS≯; ⋠𐋮.򶈮༘ss≯; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮.򶈮༘SS≯; ⋠𐋮.򶈮༘ss≯; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮.򶈮༘ss≯; ; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮.򶈮༘ss≯; ⋠𐋮.򶈮༘ss≯; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮.򶈮༘Ss≯; ⋠𐋮.򶈮༘ss≯; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮.򶈮༘Ss≯; ⋠𐋮.򶈮༘ss≯; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+xn--pgh4639f.xn--ss-ifj426nle504a; ⋠𐋮.򶈮༘ss≯; [V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+xn--pgh4639f.xn--zca593eo6oc013y; ⋠𐋮.򶈮༘ß≯; [V6]; xn--pgh4639f.xn--zca593eo6oc013y; ; ;  # ⋠𐋮.༘ß≯
+⋠𐋮．򶈮༘SS≯; ⋠𐋮.򶈮༘ss≯; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮．򶈮༘SS≯; ⋠𐋮.򶈮༘ss≯; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮．򶈮༘ss≯; ⋠𐋮.򶈮༘ss≯; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮．򶈮༘ss≯; ⋠𐋮.򶈮༘ss≯; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮．򶈮༘Ss≯; ⋠𐋮.򶈮༘ss≯; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮．򶈮༘Ss≯; ⋠𐋮.򶈮༘ss≯; [P1, V6]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+1𐋸٤｡󠢮ﮤ񷝊; 1𐋸٤.󠢮ۀ񷝊; [B1, P1, V6]; xn--1-hqc3905q.xn--zkb83268gqee4a; ; ;  # 1𐋸٤.ۀ
+1𐋸٤。󠢮ۀ񷝊; 1𐋸٤.󠢮ۀ񷝊; [B1, P1, V6]; xn--1-hqc3905q.xn--zkb83268gqee4a; ; ;  # 1𐋸٤.ۀ
+1𐋸٤。󠢮ۀ񷝊; 1𐋸٤.󠢮ۀ񷝊; [B1, P1, V6]; xn--1-hqc3905q.xn--zkb83268gqee4a; ; ;  # 1𐋸٤.ۀ
+xn--1-hqc3905q.xn--zkb83268gqee4a; 1𐋸٤.󠢮ۀ񷝊; [B1, V6]; xn--1-hqc3905q.xn--zkb83268gqee4a; ; ;  # 1𐋸٤.ۀ
+儭-｡𐹴Ⴢ񥳠‌; 儭-.𐹴Ⴢ񥳠‌; [B1, B6, C1, P1, V3, V6]; xn----gz7a.xn--6nd249ejl4pusr7b; ; xn----gz7a.xn--6nd5001kyw98a; [B1, B6, P1, V3, V6] # 儭-.𐹴Ⴢ
+儭-。𐹴Ⴢ񥳠‌; 儭-.𐹴Ⴢ񥳠‌; [B1, B6, C1, P1, V3, V6]; xn----gz7a.xn--6nd249ejl4pusr7b; ; xn----gz7a.xn--6nd5001kyw98a; [B1, B6, P1, V3, V6] # 儭-.𐹴Ⴢ
+儭-。𐹴ⴢ񥳠‌; 儭-.𐹴ⴢ񥳠‌; [B1, B6, C1, P1, V3, V6]; xn----gz7a.xn--0ug472cfq0pus98b; ; xn----gz7a.xn--qlj9223eywx0b; [B1, B6, P1, V3, V6] # 儭-.𐹴ⴢ
+xn----gz7a.xn--qlj9223eywx0b; 儭-.𐹴ⴢ񥳠; [B1, B6, V3, V6]; xn----gz7a.xn--qlj9223eywx0b; ; ;  # 儭-.𐹴ⴢ
+xn----gz7a.xn--0ug472cfq0pus98b; 儭-.𐹴ⴢ񥳠‌; [B1, B6, C1, V3, V6]; xn----gz7a.xn--0ug472cfq0pus98b; ; ;  # 儭-.𐹴ⴢ
+xn----gz7a.xn--6nd5001kyw98a; 儭-.𐹴Ⴢ񥳠; [B1, B6, V3, V6]; xn----gz7a.xn--6nd5001kyw98a; ; ;  # 儭-.𐹴Ⴢ
+xn----gz7a.xn--6nd249ejl4pusr7b; 儭-.𐹴Ⴢ񥳠‌; [B1, B6, C1, V3, V6]; xn----gz7a.xn--6nd249ejl4pusr7b; ; ;  # 儭-.𐹴Ⴢ
+儭-｡𐹴ⴢ񥳠‌; 儭-.𐹴ⴢ񥳠‌; [B1, B6, C1, P1, V3, V6]; xn----gz7a.xn--0ug472cfq0pus98b; ; xn----gz7a.xn--qlj9223eywx0b; [B1, B6, P1, V3, V6] # 儭-.𐹴ⴢ
+𝟺𐋷ڹ．𞤭򿍡; 4𐋷ڹ.𞤭򿍡; [B1, B2, B3, P1, V6]; xn--4-cvc5384q.xn--le6hi7322b; ; ;  # 4𐋷ڹ.𞤭
+4𐋷ڹ.𞤭򿍡; ; [B1, B2, B3, P1, V6]; xn--4-cvc5384q.xn--le6hi7322b; ; ;  # 4𐋷ڹ.𞤭
+4𐋷ڹ.𞤋򿍡; 4𐋷ڹ.𞤭򿍡; [B1, B2, B3, P1, V6]; xn--4-cvc5384q.xn--le6hi7322b; ; ;  # 4𐋷ڹ.𞤭
+xn--4-cvc5384q.xn--le6hi7322b; 4𐋷ڹ.𞤭򿍡; [B1, B2, B3, V6]; xn--4-cvc5384q.xn--le6hi7322b; ; ;  # 4𐋷ڹ.𞤭
+𝟺𐋷ڹ．𞤋򿍡; 4𐋷ڹ.𞤭򿍡; [B1, B2, B3, P1, V6]; xn--4-cvc5384q.xn--le6hi7322b; ; ;  # 4𐋷ڹ.𞤭
+≯-ꡋ𑲣.⒈𐹭; ; [B1, P1, V6]; xn----ogox061d5i8d.xn--tsh0666f; ; ;  # ≯-ꡋ𑲣.⒈𐹭
+≯-ꡋ𑲣.⒈𐹭; ≯-ꡋ𑲣.⒈𐹭; [B1, P1, V6]; xn----ogox061d5i8d.xn--tsh0666f; ; ;  # ≯-ꡋ𑲣.⒈𐹭
+≯-ꡋ𑲣.1.𐹭; ; [B1, P1, V6]; xn----ogox061d5i8d.1.xn--lo0d; ; ;  # ≯-ꡋ𑲣.1.𐹭
+≯-ꡋ𑲣.1.𐹭; ≯-ꡋ𑲣.1.𐹭; [B1, P1, V6]; xn----ogox061d5i8d.1.xn--lo0d; ; ;  # ≯-ꡋ𑲣.1.𐹭
+xn----ogox061d5i8d.1.xn--lo0d; ≯-ꡋ𑲣.1.𐹭; [B1, V6]; xn----ogox061d5i8d.1.xn--lo0d; ; ;  # ≯-ꡋ𑲣.1.𐹭
+xn----ogox061d5i8d.xn--tsh0666f; ≯-ꡋ𑲣.⒈𐹭; [B1, V6]; xn----ogox061d5i8d.xn--tsh0666f; ; ;  # ≯-ꡋ𑲣.⒈𐹭
+̰．󰜱蚀; ̰.󰜱蚀; [P1, V5, V6]; xn--xta.xn--e91aw9417e; ; ;  # ̰.蚀
+̰.󰜱蚀; ; [P1, V5, V6]; xn--xta.xn--e91aw9417e; ; ;  # ̰.蚀
+xn--xta.xn--e91aw9417e; ̰.󰜱蚀; [V5, V6]; xn--xta.xn--e91aw9417e; ; ;  # ̰.蚀
+יּႸ.𞡼𑇀ß⃗; יּႸ.𞡼𑇀ß⃗; [B2, B3, P1, V6]; xn--kdb1d867b.xn--zca284nhg9nrrxg; ; xn--kdb1d867b.xn--ss-yju5690ken9h;  # יּႸ.𞡼𑇀ß⃗
+יּႸ.𞡼𑇀ß⃗; ; [B2, B3, P1, V6]; xn--kdb1d867b.xn--zca284nhg9nrrxg; ; xn--kdb1d867b.xn--ss-yju5690ken9h;  # יּႸ.𞡼𑇀ß⃗
+יּⴘ.𞡼𑇀ß⃗; ; [B2, B3]; xn--kdb1d278n.xn--zca284nhg9nrrxg; ; xn--kdb1d278n.xn--ss-yju5690ken9h;  # יּⴘ.𞡼𑇀ß⃗
+יּႸ.𞡼𑇀SS⃗; יּႸ.𞡼𑇀ss⃗; [B2, B3, P1, V6]; xn--kdb1d867b.xn--ss-yju5690ken9h; ; ;  # יּႸ.𞡼𑇀ss⃗
+יּⴘ.𞡼𑇀ss⃗; ; [B2, B3]; xn--kdb1d278n.xn--ss-yju5690ken9h; ; ;  # יּⴘ.𞡼𑇀ss⃗
+xn--kdb1d278n.xn--ss-yju5690ken9h; יּⴘ.𞡼𑇀ss⃗; [B2, B3]; xn--kdb1d278n.xn--ss-yju5690ken9h; ; ;  # יּⴘ.𞡼𑇀ss⃗
+xn--kdb1d867b.xn--ss-yju5690ken9h; יּႸ.𞡼𑇀ss⃗; [B2, B3, V6]; xn--kdb1d867b.xn--ss-yju5690ken9h; ; ;  # יּႸ.𞡼𑇀ss⃗
+xn--kdb1d278n.xn--zca284nhg9nrrxg; יּⴘ.𞡼𑇀ß⃗; [B2, B3]; xn--kdb1d278n.xn--zca284nhg9nrrxg; ; ;  # יּⴘ.𞡼𑇀ß⃗
+xn--kdb1d867b.xn--zca284nhg9nrrxg; יּႸ.𞡼𑇀ß⃗; [B2, B3, V6]; xn--kdb1d867b.xn--zca284nhg9nrrxg; ; ;  # יּႸ.𞡼𑇀ß⃗
+יּⴘ.𞡼𑇀ß⃗; יּⴘ.𞡼𑇀ß⃗; [B2, B3]; xn--kdb1d278n.xn--zca284nhg9nrrxg; ; xn--kdb1d278n.xn--ss-yju5690ken9h;  # יּⴘ.𞡼𑇀ß⃗
+יּႸ.𞡼𑇀SS⃗; יּႸ.𞡼𑇀ss⃗; [B2, B3, P1, V6]; xn--kdb1d867b.xn--ss-yju5690ken9h; ; ;  # יּႸ.𞡼𑇀ss⃗
+יּⴘ.𞡼𑇀ss⃗; יּⴘ.𞡼𑇀ss⃗; [B2, B3]; xn--kdb1d278n.xn--ss-yju5690ken9h; ; ;  # יּⴘ.𞡼𑇀ss⃗
+יּႸ.𞡼𑇀ss⃗; ; [B2, B3, P1, V6]; xn--kdb1d867b.xn--ss-yju5690ken9h; ; ;  # יּႸ.𞡼𑇀ss⃗
+יּႸ.𞡼𑇀ss⃗; יּႸ.𞡼𑇀ss⃗; [B2, B3, P1, V6]; xn--kdb1d867b.xn--ss-yju5690ken9h; ; ;  # יּႸ.𞡼𑇀ss⃗
+ᮣ𐹰򁱓｡凬; ᮣ𐹰򁱓.凬; [B1, P1, V5, V6]; xn--rxfz314ilg20c.xn--t9q; ; ;  # ᮣ𐹰.凬
+ᮣ𐹰򁱓。凬; ᮣ𐹰򁱓.凬; [B1, P1, V5, V6]; xn--rxfz314ilg20c.xn--t9q; ; ;  # ᮣ𐹰.凬
+xn--rxfz314ilg20c.xn--t9q; ᮣ𐹰򁱓.凬; [B1, V5, V6]; xn--rxfz314ilg20c.xn--t9q; ; ;  # ᮣ𐹰.凬
+🢟🄈‍ꡎ｡྄; 🢟🄈‍ꡎ.྄; [C2, P1, V5, V6]; xn--1ug4874cfd0kbmg.xn--3ed; ; xn--nc9aq743ds0e.xn--3ed; [P1, V5, V6] # 🢟🄈ꡎ.྄
+🢟7,‍ꡎ。྄; 🢟7,‍ꡎ.྄; [C2, P1, V5, V6]; xn--7,-n1t0654eqo3o.xn--3ed; ; xn--7,-gh9hg322i.xn--3ed; [P1, V5, V6] # 🢟7,ꡎ.྄
+xn--7,-gh9hg322i.xn--3ed; 🢟7,ꡎ.྄; [P1, V5, V6]; xn--7,-gh9hg322i.xn--3ed; ; ;  # 🢟7,ꡎ.྄
+xn--7,-n1t0654eqo3o.xn--3ed; 🢟7,‍ꡎ.྄; [C2, P1, V5, V6]; xn--7,-n1t0654eqo3o.xn--3ed; ; ;  # 🢟7,ꡎ.྄
+xn--nc9aq743ds0e.xn--3ed; 🢟🄈ꡎ.྄; [V5, V6]; xn--nc9aq743ds0e.xn--3ed; ; ;  # 🢟🄈ꡎ.྄
+xn--1ug4874cfd0kbmg.xn--3ed; 🢟🄈‍ꡎ.྄; [C2, V5, V6]; xn--1ug4874cfd0kbmg.xn--3ed; ; ;  # 🢟🄈ꡎ.྄
+ꡔ。္ᢇ; ꡔ.္ᢇ; [V5]; xn--tc9a.xn--9jd663b; ; ;  # ꡔ.္ᢇ
+xn--tc9a.xn--9jd663b; ꡔ.္ᢇ; [V5]; xn--tc9a.xn--9jd663b; ; ;  # ꡔ.္ᢇ
+⃫≮.𝨖; ; [P1, V5, V6]; xn--e1g71d.xn--772h; ; ;  # ⃫≮.𝨖
+⃫≮.𝨖; ⃫≮.𝨖; [P1, V5, V6]; xn--e1g71d.xn--772h; ; ;  # ⃫≮.𝨖
+xn--e1g71d.xn--772h; ⃫≮.𝨖; [V5, V6]; xn--e1g71d.xn--772h; ; ;  # ⃫≮.𝨖
+Ⴢ≯褦．ᠪߪႾݧ; Ⴢ≯褦.ᠪߪႾݧ; [B5, B6, P1, V6]; xn--6nd461g478e.xn--rpb5x49td2h; ; ;  # Ⴢ≯褦.ᠪߪႾݧ
+Ⴢ≯褦．ᠪߪႾݧ; Ⴢ≯褦.ᠪߪႾݧ; [B5, B6, P1, V6]; xn--6nd461g478e.xn--rpb5x49td2h; ; ;  # Ⴢ≯褦.ᠪߪႾݧ
+Ⴢ≯褦.ᠪߪႾݧ; ; [B5, B6, P1, V6]; xn--6nd461g478e.xn--rpb5x49td2h; ; ;  # Ⴢ≯褦.ᠪߪႾݧ
+Ⴢ≯褦.ᠪߪႾݧ; Ⴢ≯褦.ᠪߪႾݧ; [B5, B6, P1, V6]; xn--6nd461g478e.xn--rpb5x49td2h; ; ;  # Ⴢ≯褦.ᠪߪႾݧ
+ⴢ≯褦.ᠪߪⴞݧ; ⴢ≯褦.ᠪߪⴞݧ; [B5, B6, P1, V6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+ⴢ≯褦.ᠪߪⴞݧ; ; [B5, B6, P1, V6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+Ⴢ≯褦.ᠪߪⴞݧ; ; [B5, B6, P1, V6]; xn--6nd461g478e.xn--rpb5x392bcyt; ; ;  # Ⴢ≯褦.ᠪߪⴞݧ
+Ⴢ≯褦.ᠪߪⴞݧ; Ⴢ≯褦.ᠪߪⴞݧ; [B5, B6, P1, V6]; xn--6nd461g478e.xn--rpb5x392bcyt; ; ;  # Ⴢ≯褦.ᠪߪⴞݧ
+xn--6nd461g478e.xn--rpb5x392bcyt; Ⴢ≯褦.ᠪߪⴞݧ; [B5, B6, V6]; xn--6nd461g478e.xn--rpb5x392bcyt; ; ;  # Ⴢ≯褦.ᠪߪⴞݧ
+xn--hdh433bev8e.xn--rpb5x392bcyt; ⴢ≯褦.ᠪߪⴞݧ; [B5, B6, V6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+xn--6nd461g478e.xn--rpb5x49td2h; Ⴢ≯褦.ᠪߪႾݧ; [B5, B6, V6]; xn--6nd461g478e.xn--rpb5x49td2h; ; ;  # Ⴢ≯褦.ᠪߪႾݧ
+ⴢ≯褦．ᠪߪⴞݧ; ⴢ≯褦.ᠪߪⴞݧ; [B5, B6, P1, V6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+ⴢ≯褦．ᠪߪⴞݧ; ⴢ≯褦.ᠪߪⴞݧ; [B5, B6, P1, V6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+Ⴢ≯褦．ᠪߪⴞݧ; Ⴢ≯褦.ᠪߪⴞݧ; [B5, B6, P1, V6]; xn--6nd461g478e.xn--rpb5x392bcyt; ; ;  # Ⴢ≯褦.ᠪߪⴞݧ
+Ⴢ≯褦．ᠪߪⴞݧ; Ⴢ≯褦.ᠪߪⴞݧ; [B5, B6, P1, V6]; xn--6nd461g478e.xn--rpb5x392bcyt; ; ;  # Ⴢ≯褦.ᠪߪⴞݧ
+򊉆󠆒‌꥓。𞤙ٻꡘ; 򊉆‌꥓.𞤻ٻꡘ; [B2, B3, C1, P1, V6]; xn--0ug8815chtz0e.xn--0ib8893fegvj; ; xn--3j9al6189a.xn--0ib8893fegvj; [B2, B3, P1, V6] # ꥓.𞤻ٻꡘ
+򊉆󠆒‌꥓。𞤻ٻꡘ; 򊉆‌꥓.𞤻ٻꡘ; [B2, B3, C1, P1, V6]; xn--0ug8815chtz0e.xn--0ib8893fegvj; ; xn--3j9al6189a.xn--0ib8893fegvj; [B2, B3, P1, V6] # ꥓.𞤻ٻꡘ
+xn--3j9al6189a.xn--0ib8893fegvj; 򊉆꥓.𞤻ٻꡘ; [B2, B3, V6]; xn--3j9al6189a.xn--0ib8893fegvj; ; ;  # ꥓.𞤻ٻꡘ
+xn--0ug8815chtz0e.xn--0ib8893fegvj; 򊉆‌꥓.𞤻ٻꡘ; [B2, B3, C1, V6]; xn--0ug8815chtz0e.xn--0ib8893fegvj; ; ;  # ꥓.𞤻ٻꡘ
+‌.≯; ; [C1, P1, V6]; xn--0ug.xn--hdh; ; .xn--hdh; [P1, V6, A4_2] # .≯
+‌.≯; ‌.≯; [C1, P1, V6]; xn--0ug.xn--hdh; ; .xn--hdh; [P1, V6, A4_2] # .≯
+.xn--hdh; .≯; [V6, X4_2]; .xn--hdh; [V6, A4_2]; ;  # .≯
+xn--0ug.xn--hdh; ‌.≯; [C1, V6]; xn--0ug.xn--hdh; ; ;  # .≯
+𰅧񣩠-．꯭-悜; 𰅧񣩠-.꯭-悜; [P1, V3, V5, V6]; xn----7m53aj640l.xn----8f4br83t; ; ;  # -.꯭-悜
+𰅧񣩠-.꯭-悜; ; [P1, V3, V5, V6]; xn----7m53aj640l.xn----8f4br83t; ; ;  # -.꯭-悜
+xn----7m53aj640l.xn----8f4br83t; 𰅧񣩠-.꯭-悜; [V3, V5, V6]; xn----7m53aj640l.xn----8f4br83t; ; ;  # -.꯭-悜
+ᡉ𶓧⬞ᢜ.-‍𞣑‮; ; [C2, P1, V3, V6]; xn--87e0ol04cdl39e.xn----ugn5e3763s; ; xn--87e0ol04cdl39e.xn----qinu247r; [P1, V3, V6] # ᡉ⬞ᢜ.-𞣑
+xn--87e0ol04cdl39e.xn----qinu247r; ᡉ𶓧⬞ᢜ.-𞣑‮; [V3, V6]; xn--87e0ol04cdl39e.xn----qinu247r; ; ;  # ᡉ⬞ᢜ.-𞣑
+xn--87e0ol04cdl39e.xn----ugn5e3763s; ᡉ𶓧⬞ᢜ.-‍𞣑‮; [C2, V3, V6]; xn--87e0ol04cdl39e.xn----ugn5e3763s; ; ;  # ᡉ⬞ᢜ.-𞣑
+⒐‌衃Ⴝ.ڂႴ; ; [B1, B2, B3, C1, P1, V6]; xn--1nd159ecmd785k.xn--7ib433c; ; xn--1nd362hy16e.xn--7ib433c; [B1, B2, B3, P1, V6] # ⒐衃Ⴝ.ڂႴ
+9.‌衃Ⴝ.ڂႴ; ; [B1, B2, B3, C1, P1, V6]; 9.xn--1nd159e1y2f.xn--7ib433c; ; 9.xn--1nd9032d.xn--7ib433c; [B1, B2, B3, P1, V6] # 9.衃Ⴝ.ڂႴ
+9.‌衃ⴝ.ڂⴔ; ; [B1, B2, B3, C1]; 9.xn--0ug862cbm5e.xn--7ib268q; ; 9.xn--llj1920a.xn--7ib268q; [B1, B2, B3] # 9.衃ⴝ.ڂⴔ
+9.‌衃Ⴝ.ڂⴔ; ; [B1, B2, B3, C1, P1, V6]; 9.xn--1nd159e1y2f.xn--7ib268q; ; 9.xn--1nd9032d.xn--7ib268q; [B1, B2, B3, P1, V6] # 9.衃Ⴝ.ڂⴔ
+9.xn--1nd9032d.xn--7ib268q; 9.衃Ⴝ.ڂⴔ; [B1, B2, B3, V6]; 9.xn--1nd9032d.xn--7ib268q; ; ;  # 9.衃Ⴝ.ڂⴔ
+9.xn--1nd159e1y2f.xn--7ib268q; 9.‌衃Ⴝ.ڂⴔ; [B1, B2, B3, C1, V6]; 9.xn--1nd159e1y2f.xn--7ib268q; ; ;  # 9.衃Ⴝ.ڂⴔ
+9.xn--llj1920a.xn--7ib268q; 9.衃ⴝ.ڂⴔ; [B1, B2, B3]; 9.xn--llj1920a.xn--7ib268q; ; ;  # 9.衃ⴝ.ڂⴔ
+9.xn--0ug862cbm5e.xn--7ib268q; 9.‌衃ⴝ.ڂⴔ; [B1, B2, B3, C1]; 9.xn--0ug862cbm5e.xn--7ib268q; ; ;  # 9.衃ⴝ.ڂⴔ
+9.xn--1nd9032d.xn--7ib433c; 9.衃Ⴝ.ڂႴ; [B1, B2, B3, V6]; 9.xn--1nd9032d.xn--7ib433c; ; ;  # 9.衃Ⴝ.ڂႴ
+9.xn--1nd159e1y2f.xn--7ib433c; 9.‌衃Ⴝ.ڂႴ; [B1, B2, B3, C1, V6]; 9.xn--1nd159e1y2f.xn--7ib433c; ; ;  # 9.衃Ⴝ.ڂႴ
+⒐‌衃ⴝ.ڂⴔ; ; [B1, B2, B3, C1, P1, V6]; xn--0ugx0px1izu2h.xn--7ib268q; ; xn--1shy52abz3f.xn--7ib268q; [B1, B2, B3, P1, V6] # ⒐衃ⴝ.ڂⴔ
+⒐‌衃Ⴝ.ڂⴔ; ; [B1, B2, B3, C1, P1, V6]; xn--1nd159ecmd785k.xn--7ib268q; ; xn--1nd362hy16e.xn--7ib268q; [B1, B2, B3, P1, V6] # ⒐衃Ⴝ.ڂⴔ
+xn--1nd362hy16e.xn--7ib268q; ⒐衃Ⴝ.ڂⴔ; [B1, B2, B3, V6]; xn--1nd362hy16e.xn--7ib268q; ; ;  # ⒐衃Ⴝ.ڂⴔ
+xn--1nd159ecmd785k.xn--7ib268q; ⒐‌衃Ⴝ.ڂⴔ; [B1, B2, B3, C1, V6]; xn--1nd159ecmd785k.xn--7ib268q; ; ;  # ⒐衃Ⴝ.ڂⴔ
+xn--1shy52abz3f.xn--7ib268q; ⒐衃ⴝ.ڂⴔ; [B1, B2, B3, V6]; xn--1shy52abz3f.xn--7ib268q; ; ;  # ⒐衃ⴝ.ڂⴔ
+xn--0ugx0px1izu2h.xn--7ib268q; ⒐‌衃ⴝ.ڂⴔ; [B1, B2, B3, C1, V6]; xn--0ugx0px1izu2h.xn--7ib268q; ; ;  # ⒐衃ⴝ.ڂⴔ
+xn--1nd362hy16e.xn--7ib433c; ⒐衃Ⴝ.ڂႴ; [B1, B2, B3, V6]; xn--1nd362hy16e.xn--7ib433c; ; ;  # ⒐衃Ⴝ.ڂႴ
+xn--1nd159ecmd785k.xn--7ib433c; ⒐‌衃Ⴝ.ڂႴ; [B1, B2, B3, C1, V6]; xn--1nd159ecmd785k.xn--7ib433c; ; ;  # ⒐衃Ⴝ.ڂႴ
+ߡ‌。--⸬; ߡ‌.--⸬; [B1, B3, C1, V3]; xn--8sb884j.xn-----iw2a; ; xn--8sb.xn-----iw2a; [B1, V3] # ߡ.--⸬
+xn--8sb.xn-----iw2a; ߡ.--⸬; [B1, V3]; xn--8sb.xn-----iw2a; ; ;  # ߡ.--⸬
+xn--8sb884j.xn-----iw2a; ߡ‌.--⸬; [B1, B3, C1, V3]; xn--8sb884j.xn-----iw2a; ; ;  # ߡ.--⸬
+𞥓．ܘ; 𞥓.ܘ; ; xn--of6h.xn--inb; ; ;  # 𞥓.ܘ
+𞥓.ܘ; ; ; xn--of6h.xn--inb; ; ;  # 𞥓.ܘ
+xn--of6h.xn--inb; 𞥓.ܘ; ; xn--of6h.xn--inb; ; ;  # 𞥓.ܘ
+󠄽-．-්; -.-්; [V3]; -.xn----ptf; ; ;  # -.-්
+󠄽-.-්; -.-්; [V3]; -.xn----ptf; ; ;  # -.-්
+-.xn----ptf; -.-්; [V3]; -.xn----ptf; ; ;  # -.-්
+󠇝ݛ-.ᤧ; ݛ-.ᤧ; [B1, B3, B6, V3, V5]; xn----k4c.xn--lff; ; ;  # ݛ-.ᤧ
+xn----k4c.xn--lff; ݛ-.ᤧ; [B1, B3, B6, V3, V5]; xn----k4c.xn--lff; ; ;  # ݛ-.ᤧ
+𞤴󠆹⦉𐹺.꠆⒌󘤸; 𞤴⦉𐹺.꠆⒌󘤸; [B1, P1, V5, V6]; xn--fuix729epewf.xn--xsh5029b6e77i; ; ;  # 𞤴⦉𐹺.꠆⒌
+𞤴󠆹⦉𐹺.꠆5.󘤸; 𞤴⦉𐹺.꠆5.󘤸; [B1, P1, V5, V6]; xn--fuix729epewf.xn--5-w93e.xn--7b83e; ; ;  # 𞤴⦉𐹺.꠆5.
+𞤒󠆹⦉𐹺.꠆5.󘤸; 𞤴⦉𐹺.꠆5.󘤸; [B1, P1, V5, V6]; xn--fuix729epewf.xn--5-w93e.xn--7b83e; ; ;  # 𞤴⦉𐹺.꠆5.
+xn--fuix729epewf.xn--5-w93e.xn--7b83e; 𞤴⦉𐹺.꠆5.󘤸; [B1, V5, V6]; xn--fuix729epewf.xn--5-w93e.xn--7b83e; ; ;  # 𞤴⦉𐹺.꠆5.
+𞤒󠆹⦉𐹺.꠆⒌󘤸; 𞤴⦉𐹺.꠆⒌󘤸; [B1, P1, V5, V6]; xn--fuix729epewf.xn--xsh5029b6e77i; ; ;  # 𞤴⦉𐹺.꠆⒌
+xn--fuix729epewf.xn--xsh5029b6e77i; 𞤴⦉𐹺.꠆⒌󘤸; [B1, V5, V6]; xn--fuix729epewf.xn--xsh5029b6e77i; ; ;  # 𞤴⦉𐹺.꠆⒌
+󠄸₀。𑖿‌𐦂‍; 0.𑖿‌𐦂‍; [B1, C2, V5]; 0.xn--0ugc8040p9hk; ; 0.xn--mn9cz2s; [B1, V5] # 0.𑖿𐦂
+󠄸0。𑖿‌𐦂‍; 0.𑖿‌𐦂‍; [B1, C2, V5]; 0.xn--0ugc8040p9hk; ; 0.xn--mn9cz2s; [B1, V5] # 0.𑖿𐦂
+0.xn--mn9cz2s; 0.𑖿𐦂; [B1, V5]; 0.xn--mn9cz2s; ; ;  # 0.𑖿𐦂
+0.xn--0ugc8040p9hk; 0.𑖿‌𐦂‍; [B1, C2, V5]; 0.xn--0ugc8040p9hk; ; ;  # 0.𑖿𐦂
+Ⴚ𐋸󠄄。𝟝ퟶ်; Ⴚ𐋸.5ퟶ်; [P1, V6]; xn--ynd2415j.xn--5-dug9054m; ; ;  # Ⴚ𐋸.5ퟶ်
+Ⴚ𐋸󠄄。5ퟶ်; Ⴚ𐋸.5ퟶ်; [P1, V6]; xn--ynd2415j.xn--5-dug9054m; ; ;  # Ⴚ𐋸.5ퟶ်
+ⴚ𐋸󠄄。5ퟶ်; ⴚ𐋸.5ퟶ်; ; xn--ilj2659d.xn--5-dug9054m; ; ;  # ⴚ𐋸.5ퟶ်
+xn--ilj2659d.xn--5-dug9054m; ⴚ𐋸.5ퟶ်; ; xn--ilj2659d.xn--5-dug9054m; ; ;  # ⴚ𐋸.5ퟶ်
+ⴚ𐋸.5ퟶ်; ; ; xn--ilj2659d.xn--5-dug9054m; ; ;  # ⴚ𐋸.5ퟶ်
+Ⴚ𐋸.5ퟶ်; ; [P1, V6]; xn--ynd2415j.xn--5-dug9054m; ; ;  # Ⴚ𐋸.5ퟶ်
+xn--ynd2415j.xn--5-dug9054m; Ⴚ𐋸.5ퟶ်; [V6]; xn--ynd2415j.xn--5-dug9054m; ; ;  # Ⴚ𐋸.5ퟶ်
+ⴚ𐋸󠄄。𝟝ퟶ်; ⴚ𐋸.5ퟶ်; ; xn--ilj2659d.xn--5-dug9054m; ; ;  # ⴚ𐋸.5ퟶ်
+‍-ᠹ﹪.ᷡᤢ; ; [C2, P1, V5, V6]; xn----c6j614b1z4v.xn--gff52t; ; xn----c6jx047j.xn--gff52t; [P1, V3, V5, V6] # -ᠹ﹪.ᷡᤢ
+‍-ᠹ%.ᷡᤢ; ; [C2, P1, V5, V6]; xn---%-u4oy48b.xn--gff52t; ; xn---%-u4o.xn--gff52t; [P1, V3, V5, V6] # -ᠹ%.ᷡᤢ
+xn---%-u4o.xn--gff52t; -ᠹ%.ᷡᤢ; [P1, V3, V5, V6]; xn---%-u4o.xn--gff52t; ; ;  # -ᠹ%.ᷡᤢ
+xn---%-u4oy48b.xn--gff52t; ‍-ᠹ%.ᷡᤢ; [C2, P1, V5, V6]; xn---%-u4oy48b.xn--gff52t; ; ;  # -ᠹ%.ᷡᤢ
+xn----c6jx047j.xn--gff52t; -ᠹ﹪.ᷡᤢ; [V3, V5, V6]; xn----c6jx047j.xn--gff52t; ; ;  # -ᠹ﹪.ᷡᤢ
+xn----c6j614b1z4v.xn--gff52t; ‍-ᠹ﹪.ᷡᤢ; [C2, V5, V6]; xn----c6j614b1z4v.xn--gff52t; ; ;  # -ᠹ﹪.ᷡᤢ
+≠.ᠿ; ; [P1, V6]; xn--1ch.xn--y7e; ; ;  # ≠.ᠿ
+≠.ᠿ; ≠.ᠿ; [P1, V6]; xn--1ch.xn--y7e; ; ;  # ≠.ᠿ
+xn--1ch.xn--y7e; ≠.ᠿ; [V6]; xn--1ch.xn--y7e; ; ;  # ≠.ᠿ
+ܣ֣｡㌪; ܣ֣.ハイツ; ; xn--ucb18e.xn--eck4c5a; ; ;  # ܣ֣.ハイツ
+ܣ֣。ハイツ; ܣ֣.ハイツ; ; xn--ucb18e.xn--eck4c5a; ; ;  # ܣ֣.ハイツ
+xn--ucb18e.xn--eck4c5a; ܣ֣.ハイツ; ; xn--ucb18e.xn--eck4c5a; ; ;  # ܣ֣.ハイツ
+ܣ֣.ハイツ; ; ; xn--ucb18e.xn--eck4c5a; ; ;  # ܣ֣.ハイツ
+𞷥󠆀≮.⵿-; 𞷥≮.⵿-; [B1, B3, P1, V3, V5, V6]; xn--gdhx802p.xn----i2s; ; ;  # ≮.⵿-
+𞷥󠆀≮.⵿-; 𞷥≮.⵿-; [B1, B3, P1, V3, V5, V6]; xn--gdhx802p.xn----i2s; ; ;  # ≮.⵿-
+xn--gdhx802p.xn----i2s; 𞷥≮.⵿-; [B1, B3, V3, V5, V6]; xn--gdhx802p.xn----i2s; ; ;  # ≮.⵿-
+₆榎򦖎്｡𞤅ۭﱚ󠮨; 6榎򦖎്.𞤧ۭيي󠮨; [B1, B3, P1, V6]; xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; ; ;  # 6榎്.𞤧ۭيي
+6榎򦖎്。𞤅ۭيي󠮨; 6榎򦖎്.𞤧ۭيي󠮨; [B1, B3, P1, V6]; xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; ; ;  # 6榎്.𞤧ۭيي
+6榎򦖎്。𞤧ۭيي󠮨; 6榎򦖎്.𞤧ۭيي󠮨; [B1, B3, P1, V6]; xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; ; ;  # 6榎്.𞤧ۭيي
+xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; 6榎򦖎്.𞤧ۭيي󠮨; [B1, B3, V6]; xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; ; ;  # 6榎്.𞤧ۭيي
+₆榎򦖎്｡𞤧ۭﱚ󠮨; 6榎򦖎്.𞤧ۭيي󠮨; [B1, B3, P1, V6]; xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; ; ;  # 6榎്.𞤧ۭيي
+𣩫．򌑲; 𣩫.򌑲; [P1, V6]; xn--td3j.xn--4628b; ; ;  # 𣩫.
+𣩫.򌑲; ; [P1, V6]; xn--td3j.xn--4628b; ; ;  # 𣩫.
+xn--td3j.xn--4628b; 𣩫.򌑲; [V6]; xn--td3j.xn--4628b; ; ;  # 𣩫.
+‍︒｡ڹ‌; ‍︒.ڹ‌; [B1, B3, C1, C2, P1, V6]; xn--1ug2658f.xn--skb080k; ; xn--y86c.xn--skb; [B1, P1, V6] # ︒.ڹ
+xn--y86c.xn--skb; ︒.ڹ; [B1, V6]; xn--y86c.xn--skb; ; ;  # ︒.ڹ
+xn--1ug2658f.xn--skb080k; ‍︒.ڹ‌; [B1, B3, C1, C2, V6]; xn--1ug2658f.xn--skb080k; ; ;  # ︒.ڹ
+xn--skb; ڹ; ; xn--skb; ; ;  # ڹ
+ڹ; ; ; xn--skb; ; ;  # ڹ
+𐹦‌𐹶。⁭; 𐹦‌𐹶.⁭; [B1, C1, P1, V6]; xn--0ug4994goba.xn--sxg; ; xn--eo0d6a.xn--sxg; [B1, P1, V6] # 𐹦𐹶.
+xn--eo0d6a.xn--sxg; 𐹦𐹶.⁭; [B1, V6]; xn--eo0d6a.xn--sxg; ; ;  # 𐹦𐹶.
+xn--0ug4994goba.xn--sxg; 𐹦‌𐹶.⁭; [B1, C1, V6]; xn--0ug4994goba.xn--sxg; ; ;  # 𐹦𐹶.
+్𝨾֩𝟭。-𑜨; ్𝨾֩1.-𑜨; [V3, V5]; xn--1-rfc312cdp45c.xn----nq0j; ; ;  # ్𝨾֩1.-𑜨
+్𝨾֩1。-𑜨; ్𝨾֩1.-𑜨; [V3, V5]; xn--1-rfc312cdp45c.xn----nq0j; ; ;  # ్𝨾֩1.-𑜨
+xn--1-rfc312cdp45c.xn----nq0j; ్𝨾֩1.-𑜨; [V3, V5]; xn--1-rfc312cdp45c.xn----nq0j; ; ;  # ్𝨾֩1.-𑜨
+򣿈。뙏; 򣿈.뙏; [P1, V6]; xn--ph26c.xn--281b; ; ;  # .뙏
+򣿈。뙏; 򣿈.뙏; [P1, V6]; xn--ph26c.xn--281b; ; ;  # .뙏
+xn--ph26c.xn--281b; 򣿈.뙏; [V6]; xn--ph26c.xn--281b; ; ;  # .뙏
+񕨚󠄌󑽀ᡀ.ࢶ; 񕨚󑽀ᡀ.ࢶ; [P1, V6]; xn--z7e98100evc01b.xn--czb; ; ;  # ᡀ.ࢶ
+xn--z7e98100evc01b.xn--czb; 񕨚󑽀ᡀ.ࢶ; [V6]; xn--z7e98100evc01b.xn--czb; ; ;  # ᡀ.ࢶ
+‍｡񅁛; ‍.񅁛; [C2, P1, V6]; xn--1ug.xn--6x4u; ; .xn--6x4u; [P1, V6, A4_2] # .
+‍。񅁛; ‍.񅁛; [C2, P1, V6]; xn--1ug.xn--6x4u; ; .xn--6x4u; [P1, V6, A4_2] # .
+.xn--6x4u; .񅁛; [V6, X4_2]; .xn--6x4u; [V6, A4_2]; ;  # .
+xn--1ug.xn--6x4u; ‍.񅁛; [C2, V6]; xn--1ug.xn--6x4u; ; ;  # .
+ࡋ皥．-; ࡋ皥.-; [B1, B2, B3, V3]; xn--9vb4167c.-; ; ;  # ࡋ皥.-
+ࡋ皥.-; ; [B1, B2, B3, V3]; xn--9vb4167c.-; ; ;  # ࡋ皥.-
+xn--9vb4167c.-; ࡋ皥.-; [B1, B2, B3, V3]; xn--9vb4167c.-; ; ;  # ࡋ皥.-
+𐣸̕𐮇．⒈ꡦ; 𐣸̕𐮇.⒈ꡦ; [B1, P1, V6]; xn--5sa9915kgvb.xn--tshw539b; ; ;  # ̕𐮇.⒈ꡦ
+𐣸̕𐮇.1.ꡦ; ; [B1, P1, V6]; xn--5sa9915kgvb.1.xn--cd9a; ; ;  # ̕𐮇.1.ꡦ
+xn--5sa9915kgvb.1.xn--cd9a; 𐣸̕𐮇.1.ꡦ; [B1, V6]; xn--5sa9915kgvb.1.xn--cd9a; ; ;  # ̕𐮇.1.ꡦ
+xn--5sa9915kgvb.xn--tshw539b; 𐣸̕𐮇.⒈ꡦ; [B1, V6]; xn--5sa9915kgvb.xn--tshw539b; ; ;  # ̕𐮇.⒈ꡦ
+Ⴛ‌֢‍。ﾠā𐹦; Ⴛ‌֢‍.ﾠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb597cdmmfa.xn--yda9741khjj; ; xn--tcb597c.xn--yda9741khjj; [B5, B6, P1, V6] # Ⴛ֢.ā𐹦
+Ⴛ‌֢‍。ﾠā𐹦; Ⴛ‌֢‍.ﾠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb597cdmmfa.xn--yda9741khjj; ; xn--tcb597c.xn--yda9741khjj; [B5, B6, P1, V6] # Ⴛ֢.ā𐹦
+Ⴛ‌֢‍。ᅠā𐹦; Ⴛ‌֢‍.ᅠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb597cdmmfa.xn--yda594fdn5q; ; xn--tcb597c.xn--yda594fdn5q; [B5, B6, P1, V6] # Ⴛ֢.ā𐹦
+Ⴛ‌֢‍。ᅠā𐹦; Ⴛ‌֢‍.ᅠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb597cdmmfa.xn--yda594fdn5q; ; xn--tcb597c.xn--yda594fdn5q; [B5, B6, P1, V6] # Ⴛ֢.ā𐹦
+ⴛ‌֢‍。ᅠā𐹦; ⴛ‌֢‍.ᅠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb736kea974k.xn--yda594fdn5q; ; xn--tcb323r.xn--yda594fdn5q; [B5, B6, P1, V6] # ⴛ֢.ā𐹦
+ⴛ‌֢‍。ᅠā𐹦; ⴛ‌֢‍.ᅠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb736kea974k.xn--yda594fdn5q; ; xn--tcb323r.xn--yda594fdn5q; [B5, B6, P1, V6] # ⴛ֢.ā𐹦
+Ⴛ‌֢‍。ᅠĀ𐹦; Ⴛ‌֢‍.ᅠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb597cdmmfa.xn--yda594fdn5q; ; xn--tcb597c.xn--yda594fdn5q; [B5, B6, P1, V6] # Ⴛ֢.ā𐹦
+Ⴛ‌֢‍。ᅠĀ𐹦; Ⴛ‌֢‍.ᅠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb597cdmmfa.xn--yda594fdn5q; ; xn--tcb597c.xn--yda594fdn5q; [B5, B6, P1, V6] # Ⴛ֢.ā𐹦
+xn--tcb597c.xn--yda594fdn5q; Ⴛ֢.ᅠā𐹦; [B5, B6, V6]; xn--tcb597c.xn--yda594fdn5q; ; ;  # Ⴛ֢.ā𐹦
+xn--tcb597cdmmfa.xn--yda594fdn5q; Ⴛ‌֢‍.ᅠā𐹦; [B5, B6, C1, C2, V6]; xn--tcb597cdmmfa.xn--yda594fdn5q; ; ;  # Ⴛ֢.ā𐹦
+xn--tcb323r.xn--yda594fdn5q; ⴛ֢.ᅠā𐹦; [B5, B6, V6]; xn--tcb323r.xn--yda594fdn5q; ; ;  # ⴛ֢.ā𐹦
+xn--tcb736kea974k.xn--yda594fdn5q; ⴛ‌֢‍.ᅠā𐹦; [B5, B6, C1, C2, V6]; xn--tcb736kea974k.xn--yda594fdn5q; ; ;  # ⴛ֢.ā𐹦
+ⴛ‌֢‍。ﾠā𐹦; ⴛ‌֢‍.ﾠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb736kea974k.xn--yda9741khjj; ; xn--tcb323r.xn--yda9741khjj; [B5, B6, P1, V6] # ⴛ֢.ā𐹦
+ⴛ‌֢‍。ﾠā𐹦; ⴛ‌֢‍.ﾠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb736kea974k.xn--yda9741khjj; ; xn--tcb323r.xn--yda9741khjj; [B5, B6, P1, V6] # ⴛ֢.ā𐹦
+Ⴛ‌֢‍。ﾠĀ𐹦; Ⴛ‌֢‍.ﾠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb597cdmmfa.xn--yda9741khjj; ; xn--tcb597c.xn--yda9741khjj; [B5, B6, P1, V6] # Ⴛ֢.ā𐹦
+Ⴛ‌֢‍。ﾠĀ𐹦; Ⴛ‌֢‍.ﾠā𐹦; [B5, B6, C1, C2, P1, V6]; xn--tcb597cdmmfa.xn--yda9741khjj; ; xn--tcb597c.xn--yda9741khjj; [B5, B6, P1, V6] # Ⴛ֢.ā𐹦
+xn--tcb597c.xn--yda9741khjj; Ⴛ֢.ﾠā𐹦; [B5, B6, V6]; xn--tcb597c.xn--yda9741khjj; ; ;  # Ⴛ֢.ā𐹦
+xn--tcb597cdmmfa.xn--yda9741khjj; Ⴛ‌֢‍.ﾠā𐹦; [B5, B6, C1, C2, V6]; xn--tcb597cdmmfa.xn--yda9741khjj; ; ;  # Ⴛ֢.ā𐹦
+xn--tcb323r.xn--yda9741khjj; ⴛ֢.ﾠā𐹦; [B5, B6, V6]; xn--tcb323r.xn--yda9741khjj; ; ;  # ⴛ֢.ā𐹦
+xn--tcb736kea974k.xn--yda9741khjj; ⴛ‌֢‍.ﾠā𐹦; [B5, B6, C1, C2, V6]; xn--tcb736kea974k.xn--yda9741khjj; ; ;  # ⴛ֢.ā𐹦
+￹‌｡曳⾑𐋰≯; ￹‌.曳襾𐋰≯; [C1, P1, V6]; xn--0ug2139f.xn--hdh501y8wvfs5h; ; xn--vn7c.xn--hdh501y8wvfs5h; [P1, V6] # .曳襾𐋰≯
+￹‌｡曳⾑𐋰≯; ￹‌.曳襾𐋰≯; [C1, P1, V6]; xn--0ug2139f.xn--hdh501y8wvfs5h; ; xn--vn7c.xn--hdh501y8wvfs5h; [P1, V6] # .曳襾𐋰≯
+￹‌。曳襾𐋰≯; ￹‌.曳襾𐋰≯; [C1, P1, V6]; xn--0ug2139f.xn--hdh501y8wvfs5h; ; xn--vn7c.xn--hdh501y8wvfs5h; [P1, V6] # .曳襾𐋰≯
+￹‌。曳襾𐋰≯; ￹‌.曳襾𐋰≯; [C1, P1, V6]; xn--0ug2139f.xn--hdh501y8wvfs5h; ; xn--vn7c.xn--hdh501y8wvfs5h; [P1, V6] # .曳襾𐋰≯
+xn--vn7c.xn--hdh501y8wvfs5h; ￹.曳襾𐋰≯; [V6]; xn--vn7c.xn--hdh501y8wvfs5h; ; ;  # .曳襾𐋰≯
+xn--0ug2139f.xn--hdh501y8wvfs5h; ￹‌.曳襾𐋰≯; [C1, V6]; xn--0ug2139f.xn--hdh501y8wvfs5h; ; ;  # .曳襾𐋰≯
+≯⒈。ß; ≯⒈.ß; [P1, V6]; xn--hdh84f.xn--zca; ; xn--hdh84f.ss;  # ≯⒈.ß
+≯⒈。ß; ≯⒈.ß; [P1, V6]; xn--hdh84f.xn--zca; ; xn--hdh84f.ss;  # ≯⒈.ß
+≯1.。ß; ≯1..ß; [P1, V6, X4_2]; xn--1-ogo..xn--zca; [P1, V6, A4_2]; xn--1-ogo..ss;  # ≯1..ß
+≯1.。ß; ≯1..ß; [P1, V6, X4_2]; xn--1-ogo..xn--zca; [P1, V6, A4_2]; xn--1-ogo..ss;  # ≯1..ß
+≯1.。SS; ≯1..ss; [P1, V6, X4_2]; xn--1-ogo..ss; [P1, V6, A4_2]; ;  # ≯1..ss
+≯1.。SS; ≯1..ss; [P1, V6, X4_2]; xn--1-ogo..ss; [P1, V6, A4_2]; ;  # ≯1..ss
+≯1.。ss; ≯1..ss; [P1, V6, X4_2]; xn--1-ogo..ss; [P1, V6, A4_2]; ;  # ≯1..ss
+≯1.。ss; ≯1..ss; [P1, V6, X4_2]; xn--1-ogo..ss; [P1, V6, A4_2]; ;  # ≯1..ss
+≯1.。Ss; ≯1..ss; [P1, V6, X4_2]; xn--1-ogo..ss; [P1, V6, A4_2]; ;  # ≯1..ss
+≯1.。Ss; ≯1..ss; [P1, V6, X4_2]; xn--1-ogo..ss; [P1, V6, A4_2]; ;  # ≯1..ss
+xn--1-ogo..ss; ≯1..ss; [V6, X4_2]; xn--1-ogo..ss; [V6, A4_2]; ;  # ≯1..ss
+xn--1-ogo..xn--zca; ≯1..ß; [V6, X4_2]; xn--1-ogo..xn--zca; [V6, A4_2]; ;  # ≯1..ß
+≯⒈。SS; ≯⒈.ss; [P1, V6]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+≯⒈。SS; ≯⒈.ss; [P1, V6]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+≯⒈。ss; ≯⒈.ss; [P1, V6]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+≯⒈。ss; ≯⒈.ss; [P1, V6]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+≯⒈。Ss; ≯⒈.ss; [P1, V6]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+≯⒈。Ss; ≯⒈.ss; [P1, V6]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+xn--hdh84f.ss; ≯⒈.ss; [V6]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+xn--hdh84f.xn--zca; ≯⒈.ß; [V6]; xn--hdh84f.xn--zca; ; ;  # ≯⒈.ß
+٧‍ﮖ｡ߚ-₆Ⴙ; ٧‍ڳ.ߚ-6Ⴙ; [B1, B2, B3, C2, P1, V6]; xn--gib6m343e.xn---6-lve002g; ; xn--gib6m.xn---6-lve002g; [B1, B2, B3, P1, V6] # ٧ڳ.ߚ-6Ⴙ
+٧‍ڳ。ߚ-6Ⴙ; ٧‍ڳ.ߚ-6Ⴙ; [B1, B2, B3, C2, P1, V6]; xn--gib6m343e.xn---6-lve002g; ; xn--gib6m.xn---6-lve002g; [B1, B2, B3, P1, V6] # ٧ڳ.ߚ-6Ⴙ
+٧‍ڳ。ߚ-6ⴙ; ٧‍ڳ.ߚ-6ⴙ; [B1, B2, B3, C2]; xn--gib6m343e.xn---6-lve6529a; ; xn--gib6m.xn---6-lve6529a; [B1, B2, B3] # ٧ڳ.ߚ-6ⴙ
+xn--gib6m.xn---6-lve6529a; ٧ڳ.ߚ-6ⴙ; [B1, B2, B3]; xn--gib6m.xn---6-lve6529a; ; ;  # ٧ڳ.ߚ-6ⴙ
+xn--gib6m343e.xn---6-lve6529a; ٧‍ڳ.ߚ-6ⴙ; [B1, B2, B3, C2]; xn--gib6m343e.xn---6-lve6529a; ; ;  # ٧ڳ.ߚ-6ⴙ
+xn--gib6m.xn---6-lve002g; ٧ڳ.ߚ-6Ⴙ; [B1, B2, B3, V6]; xn--gib6m.xn---6-lve002g; ; ;  # ٧ڳ.ߚ-6Ⴙ
+xn--gib6m343e.xn---6-lve002g; ٧‍ڳ.ߚ-6Ⴙ; [B1, B2, B3, C2, V6]; xn--gib6m343e.xn---6-lve002g; ; ;  # ٧ڳ.ߚ-6Ⴙ
+٧‍ﮖ｡ߚ-₆ⴙ; ٧‍ڳ.ߚ-6ⴙ; [B1, B2, B3, C2]; xn--gib6m343e.xn---6-lve6529a; ; xn--gib6m.xn---6-lve6529a; [B1, B2, B3] # ٧ڳ.ߚ-6ⴙ
+‌｡≠; ‌.≠; [C1, P1, V6]; xn--0ug.xn--1ch; ; .xn--1ch; [P1, V6, A4_2] # .≠
+‌｡≠; ‌.≠; [C1, P1, V6]; xn--0ug.xn--1ch; ; .xn--1ch; [P1, V6, A4_2] # .≠
+‌。≠; ‌.≠; [C1, P1, V6]; xn--0ug.xn--1ch; ; .xn--1ch; [P1, V6, A4_2] # .≠
+‌。≠; ‌.≠; [C1, P1, V6]; xn--0ug.xn--1ch; ; .xn--1ch; [P1, V6, A4_2] # .≠
+.xn--1ch; .≠; [V6, X4_2]; .xn--1ch; [V6, A4_2]; ;  # .≠
+xn--0ug.xn--1ch; ‌.≠; [C1, V6]; xn--0ug.xn--1ch; ; ;  # .≠
+𑖿𝨔.ᡟ𑖿ᭂ‌; ; [C1, V5]; xn--461dw464a.xn--v8e29ldzfo952a; ; xn--461dw464a.xn--v8e29loy65a; [V5] # 𑖿𝨔.ᡟ𑖿ᭂ
+xn--461dw464a.xn--v8e29loy65a; 𑖿𝨔.ᡟ𑖿ᭂ; [V5]; xn--461dw464a.xn--v8e29loy65a; ; ;  # 𑖿𝨔.ᡟ𑖿ᭂ
+xn--461dw464a.xn--v8e29ldzfo952a; 𑖿𝨔.ᡟ𑖿ᭂ‌; [C1, V5]; xn--461dw464a.xn--v8e29ldzfo952a; ; ;  # 𑖿𝨔.ᡟ𑖿ᭂ
+򔣳‍򑝱.𖬴Ↄ≠-; ; [C2, P1, V3, V5, V6]; xn--1ug15151gkb5a.xn----61n81bt713h; ; xn--6j00chy9a.xn----61n81bt713h; [P1, V3, V5, V6] # .𖬴Ↄ≠-
+򔣳‍򑝱.𖬴Ↄ≠-; 򔣳‍򑝱.𖬴Ↄ≠-; [C2, P1, V3, V5, V6]; xn--1ug15151gkb5a.xn----61n81bt713h; ; xn--6j00chy9a.xn----61n81bt713h; [P1, V3, V5, V6] # .𖬴Ↄ≠-
+򔣳‍򑝱.𖬴ↄ≠-; 򔣳‍򑝱.𖬴ↄ≠-; [C2, P1, V3, V5, V6]; xn--1ug15151gkb5a.xn----81n51bt713h; ; xn--6j00chy9a.xn----81n51bt713h; [P1, V3, V5, V6] # .𖬴ↄ≠-
+򔣳‍򑝱.𖬴ↄ≠-; ; [C2, P1, V3, V5, V6]; xn--1ug15151gkb5a.xn----81n51bt713h; ; xn--6j00chy9a.xn----81n51bt713h; [P1, V3, V5, V6] # .𖬴ↄ≠-
+xn--6j00chy9a.xn----81n51bt713h; 򔣳򑝱.𖬴ↄ≠-; [V3, V5, V6]; xn--6j00chy9a.xn----81n51bt713h; ; ;  # .𖬴ↄ≠-
+xn--1ug15151gkb5a.xn----81n51bt713h; 򔣳‍򑝱.𖬴ↄ≠-; [C2, V3, V5, V6]; xn--1ug15151gkb5a.xn----81n51bt713h; ; ;  # .𖬴ↄ≠-
+xn--6j00chy9a.xn----61n81bt713h; 򔣳򑝱.𖬴Ↄ≠-; [V3, V5, V6]; xn--6j00chy9a.xn----61n81bt713h; ; ;  # .𖬴Ↄ≠-
+xn--1ug15151gkb5a.xn----61n81bt713h; 򔣳‍򑝱.𖬴Ↄ≠-; [C2, V3, V5, V6]; xn--1ug15151gkb5a.xn----61n81bt713h; ; ;  # .𖬴Ↄ≠-
+ߢς‍𝟳。蔑򛖢; ߢς‍7.蔑򛖢; [B2, C2, P1, V6]; xn--7-xmb182aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, P1, V6] # ߢς7.蔑
+ߢς‍7。蔑򛖢; ߢς‍7.蔑򛖢; [B2, C2, P1, V6]; xn--7-xmb182aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, P1, V6] # ߢς7.蔑
+ߢΣ‍7。蔑򛖢; ߢσ‍7.蔑򛖢; [B2, C2, P1, V6]; xn--7-zmb872aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, P1, V6] # ߢσ7.蔑
+ߢσ‍7。蔑򛖢; ߢσ‍7.蔑򛖢; [B2, C2, P1, V6]; xn--7-zmb872aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, P1, V6] # ߢσ7.蔑
+xn--7-zmb872a.xn--wy1ao4929b; ߢσ7.蔑򛖢; [B2, V6]; xn--7-zmb872a.xn--wy1ao4929b; ; ;  # ߢσ7.蔑
+xn--7-zmb872aez5a.xn--wy1ao4929b; ߢσ‍7.蔑򛖢; [B2, C2, V6]; xn--7-zmb872aez5a.xn--wy1ao4929b; ; ;  # ߢσ7.蔑
+xn--7-xmb182aez5a.xn--wy1ao4929b; ߢς‍7.蔑򛖢; [B2, C2, V6]; xn--7-xmb182aez5a.xn--wy1ao4929b; ; ;  # ߢς7.蔑
+ߢΣ‍𝟳。蔑򛖢; ߢσ‍7.蔑򛖢; [B2, C2, P1, V6]; xn--7-zmb872aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, P1, V6] # ߢσ7.蔑
+ߢσ‍𝟳。蔑򛖢; ߢσ‍7.蔑򛖢; [B2, C2, P1, V6]; xn--7-zmb872aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, P1, V6] # ߢσ7.蔑
+𐹰.؀; ; [B1, P1, V6]; xn--oo0d.xn--ifb; ; ;  # 𐹰.
+xn--oo0d.xn--ifb; 𐹰.؀; [B1, V6]; xn--oo0d.xn--ifb; ; ;  # 𐹰.
+-ࢨ.𱠖; ; [B1, P1, V3, V6]; xn----mod.xn--5o9n; ; ;  # -ࢨ.
+xn----mod.xn--5o9n; -ࢨ.𱠖; [B1, V3, V6]; xn----mod.xn--5o9n; ; ;  # -ࢨ.
+≯𞱸󠇀。誆⒈; ≯𞱸.誆⒈; [B1, P1, V6]; xn--hdh7151p.xn--tsh1248a; ; ;  # ≯𞱸.誆⒈
+≯𞱸󠇀。誆⒈; ≯𞱸.誆⒈; [B1, P1, V6]; xn--hdh7151p.xn--tsh1248a; ; ;  # ≯𞱸.誆⒈
+≯𞱸󠇀。誆1.; ≯𞱸.誆1.; [B1, P1, V6]; xn--hdh7151p.xn--1-dy1d.; ; ;  # ≯𞱸.誆1.
+≯𞱸󠇀。誆1.; ≯𞱸.誆1.; [B1, P1, V6]; xn--hdh7151p.xn--1-dy1d.; ; ;  # ≯𞱸.誆1.
+xn--hdh7151p.xn--1-dy1d.; ≯𞱸.誆1.; [B1, V6]; xn--hdh7151p.xn--1-dy1d.; ; ;  # ≯𞱸.誆1.
+xn--hdh7151p.xn--tsh1248a; ≯𞱸.誆⒈; [B1, V6]; xn--hdh7151p.xn--tsh1248a; ; ;  # ≯𞱸.誆⒈
+ؖ𞥙䐊ِ．︒م↺ڜ; ؖ𞥙䐊ِ.︒م↺ڜ; [B1, P1, V5, V6]; xn--4fb0j490qjg4x.xn--hhb8o948euo5r; ; ;  # ؖ𞥙䐊ِ.︒م↺ڜ
+ؖ𞥙䐊ِ.。م↺ڜ; ؖ𞥙䐊ِ..م↺ڜ; [B1, V5, X4_2]; xn--4fb0j490qjg4x..xn--hhb8o948e; [B1, V5, A4_2]; ;  # ؖ𞥙䐊ِ..م↺ڜ
+xn--4fb0j490qjg4x..xn--hhb8o948e; ؖ𞥙䐊ِ..م↺ڜ; [B1, V5, X4_2]; xn--4fb0j490qjg4x..xn--hhb8o948e; [B1, V5, A4_2]; ;  # ؖ𞥙䐊ِ..م↺ڜ
+xn--4fb0j490qjg4x.xn--hhb8o948euo5r; ؖ𞥙䐊ِ.︒م↺ڜ; [B1, V5, V6]; xn--4fb0j490qjg4x.xn--hhb8o948euo5r; ; ;  # ؖ𞥙䐊ِ.︒م↺ڜ
+퀬-?񶳒.‌ૅ󩸤۴; ; [C1, P1, V6]; 퀬-?񶳒.xn--hmb76q48y18505a; [C1, P1, V6, A3]; 퀬-?񶳒.xn--hmb76q74166b; [P1, V5, V6, A3] # 퀬-.ૅ۴
+퀬-?񶳒.‌ૅ󩸤۴; 퀬-?񶳒.‌ૅ󩸤۴; [C1, P1, V6]; 퀬-?񶳒.xn--hmb76q48y18505a; [C1, P1, V6, A3]; 퀬-?񶳒.xn--hmb76q74166b; [P1, V5, V6, A3] # 퀬-.ૅ۴
+퀬-?񶳒.xn--hmb76q74166b; 퀬-?񶳒.ૅ󩸤۴; [P1, V5, V6]; 퀬-?񶳒.xn--hmb76q74166b; [P1, V5, V6, A3]; ;  # 퀬-.ૅ۴
+퀬-?񶳒.xn--hmb76q74166b; 퀬-?񶳒.ૅ󩸤۴; [P1, V5, V6]; 퀬-?񶳒.xn--hmb76q74166b; [P1, V5, V6, A3]; ;  # 퀬-.ૅ۴
+퀬-?񶳒.XN--HMB76Q74166B; 퀬-?񶳒.ૅ󩸤۴; [P1, V5, V6]; 퀬-?񶳒.xn--hmb76q74166b; [P1, V5, V6, A3]; ;  # 퀬-.ૅ۴
+퀬-?񶳒.XN--HMB76Q74166B; 퀬-?񶳒.ૅ󩸤۴; [P1, V5, V6]; 퀬-?񶳒.xn--hmb76q74166b; [P1, V5, V6, A3]; ;  # 퀬-.ૅ۴
+퀬-?񶳒.Xn--Hmb76q74166b; 퀬-?񶳒.ૅ󩸤۴; [P1, V5, V6]; 퀬-?񶳒.xn--hmb76q74166b; [P1, V5, V6, A3]; ;  # 퀬-.ૅ۴
+퀬-?񶳒.Xn--Hmb76q74166b; 퀬-?񶳒.ૅ󩸤۴; [P1, V5, V6]; 퀬-?񶳒.xn--hmb76q74166b; [P1, V5, V6, A3]; ;  # 퀬-.ૅ۴
+퀬-?񶳒.xn--hmb76q48y18505a; 퀬-?񶳒.‌ૅ󩸤۴; [C1, P1, V6]; 퀬-?񶳒.xn--hmb76q48y18505a; [C1, P1, V6, A3]; ;  # 퀬-.ૅ۴
+퀬-?񶳒.xn--hmb76q48y18505a; 퀬-?񶳒.‌ૅ󩸤۴; [C1, P1, V6]; 퀬-?񶳒.xn--hmb76q48y18505a; [C1, P1, V6, A3]; ;  # 퀬-.ૅ۴
+퀬-?񶳒.XN--HMB76Q48Y18505A; 퀬-?񶳒.‌ૅ󩸤۴; [C1, P1, V6]; 퀬-?񶳒.xn--hmb76q48y18505a; [C1, P1, V6, A3]; ;  # 퀬-.ૅ۴
+퀬-?񶳒.XN--HMB76Q48Y18505A; 퀬-?񶳒.‌ૅ󩸤۴; [C1, P1, V6]; 퀬-?񶳒.xn--hmb76q48y18505a; [C1, P1, V6, A3]; ;  # 퀬-.ૅ۴
+퀬-?񶳒.Xn--Hmb76q48y18505a; 퀬-?񶳒.‌ૅ󩸤۴; [C1, P1, V6]; 퀬-?񶳒.xn--hmb76q48y18505a; [C1, P1, V6, A3]; ;  # 퀬-.ૅ۴
+퀬-?񶳒.Xn--Hmb76q48y18505a; 퀬-?񶳒.‌ૅ󩸤۴; [C1, P1, V6]; 퀬-?񶳒.xn--hmb76q48y18505a; [C1, P1, V6, A3]; ;  # 퀬-.ૅ۴
+Ⴌ.𐹾︒𑁿𞾄; ; [B1, P1, V6]; xn--knd.xn--y86c030a9ob6374b; ; ;  # Ⴌ.𐹾︒𑁿
+Ⴌ.𐹾。𑁿𞾄; Ⴌ.𐹾.𑁿𞾄; [B1, P1, V5, V6]; xn--knd.xn--2o0d.xn--q30dg029a; ; ;  # Ⴌ.𐹾.𑁿
+ⴌ.𐹾。𑁿𞾄; ⴌ.𐹾.𑁿𞾄; [B1, P1, V5, V6]; xn--3kj.xn--2o0d.xn--q30dg029a; ; ;  # ⴌ.𐹾.𑁿
+xn--3kj.xn--2o0d.xn--q30dg029a; ⴌ.𐹾.𑁿𞾄; [B1, V5, V6]; xn--3kj.xn--2o0d.xn--q30dg029a; ; ;  # ⴌ.𐹾.𑁿
+xn--knd.xn--2o0d.xn--q30dg029a; Ⴌ.𐹾.𑁿𞾄; [B1, V5, V6]; xn--knd.xn--2o0d.xn--q30dg029a; ; ;  # Ⴌ.𐹾.𑁿
+ⴌ.𐹾︒𑁿𞾄; ; [B1, P1, V6]; xn--3kj.xn--y86c030a9ob6374b; ; ;  # ⴌ.𐹾︒𑁿
+xn--3kj.xn--y86c030a9ob6374b; ⴌ.𐹾︒𑁿𞾄; [B1, V6]; xn--3kj.xn--y86c030a9ob6374b; ; ;  # ⴌ.𐹾︒𑁿
+xn--knd.xn--y86c030a9ob6374b; Ⴌ.𐹾︒𑁿𞾄; [B1, V6]; xn--knd.xn--y86c030a9ob6374b; ; ;  # Ⴌ.𐹾︒𑁿
+񧞿╏。𞩕󠁾; 񧞿╏.𞩕󠁾; [B3, B6, P1, V6]; xn--iyh90030d.xn--1m6hs0260c; ; ;  # ╏.
+xn--iyh90030d.xn--1m6hs0260c; 񧞿╏.𞩕󠁾; [B3, B6, V6]; xn--iyh90030d.xn--1m6hs0260c; ; ;  # ╏.
+‍┮󠇐．ఀ్᜴‍; ‍┮.ఀ్᜴‍; [C2, V5]; xn--1ug04r.xn--eoc8m432a40i; ; xn--kxh.xn--eoc8m432a; [V5] # ┮.ఀ్᜴
+‍┮󠇐.ఀ్᜴‍; ‍┮.ఀ్᜴‍; [C2, V5]; xn--1ug04r.xn--eoc8m432a40i; ; xn--kxh.xn--eoc8m432a; [V5] # ┮.ఀ్᜴
+xn--kxh.xn--eoc8m432a; ┮.ఀ్᜴; [V5]; xn--kxh.xn--eoc8m432a; ; ;  # ┮.ఀ్᜴
+xn--1ug04r.xn--eoc8m432a40i; ‍┮.ఀ్᜴‍; [C2, V5]; xn--1ug04r.xn--eoc8m432a40i; ; ;  # ┮.ఀ్᜴
+򹚪｡🄂; 򹚪.🄂; [P1, V6]; xn--n433d.xn--v07h; ; ;  # .🄂
+򹚪。1,; 򹚪.1,; [P1, V6]; xn--n433d.1,; ; ;  # .1,
+xn--n433d.1,; 򹚪.1,; [P1, V6]; xn--n433d.1,; ; ;  # .1,
+xn--n433d.xn--v07h; 򹚪.🄂; [V6]; xn--n433d.xn--v07h; ; ;  # .🄂
+𑍨刍.🛦; ; [V5]; xn--rbry728b.xn--y88h; ; ;  # 𑍨刍.🛦
+xn--rbry728b.xn--y88h; 𑍨刍.🛦; [V5]; xn--rbry728b.xn--y88h; ; ;  # 𑍨刍.🛦
+󠌏3｡ᯱ𝟒; 󠌏3.ᯱ4; [P1, V5, V6]; xn--3-ib31m.xn--4-pql; ; ;  # 3.ᯱ4
+󠌏3。ᯱ4; 󠌏3.ᯱ4; [P1, V5, V6]; xn--3-ib31m.xn--4-pql; ; ;  # 3.ᯱ4
+xn--3-ib31m.xn--4-pql; 󠌏3.ᯱ4; [V5, V6]; xn--3-ib31m.xn--4-pql; ; ;  # 3.ᯱ4
+ڇ６Ⴔ辘.ﴢڇ‌; ڇ6Ⴔ辘.صيڇ‌; [B2, B3, C1, P1, V6]; xn--6-gsc039eqq6k.xn--0gb6bxkx18g; ; xn--6-gsc039eqq6k.xn--0gb6bxk; [B2, B3, P1, V6] # ڇ6Ⴔ辘.صيڇ
+ڇ6Ⴔ辘.صيڇ‌; ; [B2, B3, C1, P1, V6]; xn--6-gsc039eqq6k.xn--0gb6bxkx18g; ; xn--6-gsc039eqq6k.xn--0gb6bxk; [B2, B3, P1, V6] # ڇ6Ⴔ辘.صيڇ
+ڇ6ⴔ辘.صيڇ‌; ; [B2, B3, C1]; xn--6-gsc2270akm6f.xn--0gb6bxkx18g; ; xn--6-gsc2270akm6f.xn--0gb6bxk; [B2, B3] # ڇ6ⴔ辘.صيڇ
+xn--6-gsc2270akm6f.xn--0gb6bxk; ڇ6ⴔ辘.صيڇ; [B2, B3]; xn--6-gsc2270akm6f.xn--0gb6bxk; ; ;  # ڇ6ⴔ辘.صيڇ
+xn--6-gsc2270akm6f.xn--0gb6bxkx18g; ڇ6ⴔ辘.صيڇ‌; [B2, B3, C1]; xn--6-gsc2270akm6f.xn--0gb6bxkx18g; ; ;  # ڇ6ⴔ辘.صيڇ
+xn--6-gsc039eqq6k.xn--0gb6bxk; ڇ6Ⴔ辘.صيڇ; [B2, B3, V6]; xn--6-gsc039eqq6k.xn--0gb6bxk; ; ;  # ڇ6Ⴔ辘.صيڇ
+xn--6-gsc039eqq6k.xn--0gb6bxkx18g; ڇ6Ⴔ辘.صيڇ‌; [B2, B3, C1, V6]; xn--6-gsc039eqq6k.xn--0gb6bxkx18g; ; ;  # ڇ6Ⴔ辘.صيڇ
+ڇ６ⴔ辘.ﴢڇ‌; ڇ6ⴔ辘.صيڇ‌; [B2, B3, C1]; xn--6-gsc2270akm6f.xn--0gb6bxkx18g; ; xn--6-gsc2270akm6f.xn--0gb6bxk; [B2, B3] # ڇ6ⴔ辘.صيڇ
+󠄍.𐮭𞰬򻫞۹; .𐮭𞰬򻫞۹; [B2, P1, V6, X4_2]; .xn--mmb3954kd0uf1zx7f; [B2, P1, V6, A4_2]; ;  # .𐮭۹
+.xn--mmb3954kd0uf1zx7f; .𐮭𞰬򻫞۹; [B2, V6, X4_2]; .xn--mmb3954kd0uf1zx7f; [B2, V6, A4_2]; ;  # .𐮭۹
+꡽≯．򻲀򒳄; ꡽≯.򻲀򒳄; [P1, V6]; xn--hdh8193c.xn--5z40cp629b; ; ;  # ≯.
+꡽≯．򻲀򒳄; ꡽≯.򻲀򒳄; [P1, V6]; xn--hdh8193c.xn--5z40cp629b; ; ;  # ≯.
+꡽≯.򻲀򒳄; ; [P1, V6]; xn--hdh8193c.xn--5z40cp629b; ; ;  # ≯.
+꡽≯.򻲀򒳄; ꡽≯.򻲀򒳄; [P1, V6]; xn--hdh8193c.xn--5z40cp629b; ; ;  # ≯.
+xn--hdh8193c.xn--5z40cp629b; ꡽≯.򻲀򒳄; [V6]; xn--hdh8193c.xn--5z40cp629b; ; ;  # ≯.
+ςოٻ.ςܔ; ; [B5, B6]; xn--3xa80l26n.xn--3xa41o; ; xn--4xa60l26n.xn--4xa21o;  # ςოٻ.ςܔ
+ΣᲝٻ.Σܔ; σᲝٻ.σܔ; [B5, B6, P1, V6]; xn--4xa60lw94a.xn--4xa21o; ; ;  # σᲝٻ.σܔ
+σოٻ.σܔ; ; [B5, B6]; xn--4xa60l26n.xn--4xa21o; ; ;  # σოٻ.σܔ
+Σოٻ.σܔ; σოٻ.σܔ; [B5, B6]; xn--4xa60l26n.xn--4xa21o; ; ;  # σოٻ.σܔ
+xn--4xa60l26n.xn--4xa21o; σოٻ.σܔ; [B5, B6]; xn--4xa60l26n.xn--4xa21o; ; ;  # σოٻ.σܔ
+xn--4xa60lw94a.xn--4xa21o; σᲝٻ.σܔ; [B5, B6, V6]; xn--4xa60lw94a.xn--4xa21o; ; ;  # σᲝٻ.σܔ
+Σოٻ.ςܔ; σოٻ.ςܔ; [B5, B6]; xn--4xa60l26n.xn--3xa41o; ; xn--4xa60l26n.xn--4xa21o;  # σოٻ.ςܔ
+σოٻ.ςܔ; ; [B5, B6]; xn--4xa60l26n.xn--3xa41o; ; xn--4xa60l26n.xn--4xa21o;  # σოٻ.ςܔ
+xn--4xa60l26n.xn--3xa41o; σოٻ.ςܔ; [B5, B6]; xn--4xa60l26n.xn--3xa41o; ; ;  # σოٻ.ςܔ
+xn--3xa80l26n.xn--3xa41o; ςოٻ.ςܔ; [B5, B6]; xn--3xa80l26n.xn--3xa41o; ; ;  # ςოٻ.ςܔ
+Σოٻ.Σܔ; σოٻ.σܔ; [B5, B6]; xn--4xa60l26n.xn--4xa21o; ; ;  # σოٻ.σܔ
+򄖚݈𠄯ݟ｡󠛩; 򄖚݈𠄯ݟ.󠛩; [B1, B5, B6, P1, V6]; xn--vob0c4369twfv8b.xn--kl46e; ; ;  # ݈𠄯ݟ.
+򄖚݈𠄯ݟ。󠛩; 򄖚݈𠄯ݟ.󠛩; [B1, B5, B6, P1, V6]; xn--vob0c4369twfv8b.xn--kl46e; ; ;  # ݈𠄯ݟ.
+xn--vob0c4369twfv8b.xn--kl46e; 򄖚݈𠄯ݟ.󠛩; [B1, B5, B6, V6]; xn--vob0c4369twfv8b.xn--kl46e; ; ;  # ݈𠄯ݟ.
+󠳛．‍䤫≠Ⴞ; 󠳛.‍䤫≠Ⴞ; [C2, P1, V6]; xn--1t56e.xn--2nd159e9vb743e; ; xn--1t56e.xn--2nd141ghl2a; [P1, V6] # .䤫≠Ⴞ
+󠳛．‍䤫≠Ⴞ; 󠳛.‍䤫≠Ⴞ; [C2, P1, V6]; xn--1t56e.xn--2nd159e9vb743e; ; xn--1t56e.xn--2nd141ghl2a; [P1, V6] # .䤫≠Ⴞ
+󠳛.‍䤫≠Ⴞ; ; [C2, P1, V6]; xn--1t56e.xn--2nd159e9vb743e; ; xn--1t56e.xn--2nd141ghl2a; [P1, V6] # .䤫≠Ⴞ
+󠳛.‍䤫≠Ⴞ; 󠳛.‍䤫≠Ⴞ; [C2, P1, V6]; xn--1t56e.xn--2nd159e9vb743e; ; xn--1t56e.xn--2nd141ghl2a; [P1, V6] # .䤫≠Ⴞ
+󠳛.‍䤫≠ⴞ; 󠳛.‍䤫≠ⴞ; [C2, P1, V6]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [P1, V6] # .䤫≠ⴞ
+󠳛.‍䤫≠ⴞ; ; [C2, P1, V6]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [P1, V6] # .䤫≠ⴞ
+xn--1t56e.xn--1ch153bqvw; 󠳛.䤫≠ⴞ; [V6]; xn--1t56e.xn--1ch153bqvw; ; ;  # .䤫≠ⴞ
+xn--1t56e.xn--1ug73gzzpwi3a; 󠳛.‍䤫≠ⴞ; [C2, V6]; xn--1t56e.xn--1ug73gzzpwi3a; ; ;  # .䤫≠ⴞ
+xn--1t56e.xn--2nd141ghl2a; 󠳛.䤫≠Ⴞ; [V6]; xn--1t56e.xn--2nd141ghl2a; ; ;  # .䤫≠Ⴞ
+xn--1t56e.xn--2nd159e9vb743e; 󠳛.‍䤫≠Ⴞ; [C2, V6]; xn--1t56e.xn--2nd159e9vb743e; ; ;  # .䤫≠Ⴞ
+󠳛．‍䤫≠ⴞ; 󠳛.‍䤫≠ⴞ; [C2, P1, V6]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [P1, V6] # .䤫≠ⴞ
+󠳛．‍䤫≠ⴞ; 󠳛.‍䤫≠ⴞ; [C2, P1, V6]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [P1, V6] # .䤫≠ⴞ
+𐽘𑈵．𐹣🕥; 𐽘𑈵.𐹣🕥; [B1, B2, B3]; xn--bv0d02c.xn--bo0dq650b; ; ;  # 𐽘𑈵.𐹣🕥
+𐽘𑈵.𐹣🕥; ; [B1, B2, B3]; xn--bv0d02c.xn--bo0dq650b; ; ;  # 𐽘𑈵.𐹣🕥
+xn--bv0d02c.xn--bo0dq650b; 𐽘𑈵.𐹣🕥; [B1, B2, B3]; xn--bv0d02c.xn--bo0dq650b; ; ;  # 𐽘𑈵.𐹣🕥
+⒊⒈𑁄。9; ⒊⒈𑁄.9; [P1, V6]; xn--tshd3512p.9; ; ;  # ⒊⒈𑁄.9
+3.1.𑁄。9; 3.1.𑁄.9; [V5]; 3.1.xn--110d.9; ; ;  # 3.1.𑁄.9
+3.1.xn--110d.9; 3.1.𑁄.9; [V5]; 3.1.xn--110d.9; ; ;  # 3.1.𑁄.9
+xn--tshd3512p.9; ⒊⒈𑁄.9; [V6]; xn--tshd3512p.9; ; ;  # ⒊⒈𑁄.9
+-‌ⷱ≮．𐹱򭏴4₉; -‌ⷱ≮.𐹱򭏴49; [B1, C1, P1, V3, V6]; xn----sgn20i14s.xn--49-ki3om2611f; ; xn----ngo823c.xn--49-ki3om2611f; [B1, P1, V3, V6] # -ⷱ≮.𐹱49
+-‌ⷱ≮．𐹱򭏴4₉; -‌ⷱ≮.𐹱򭏴49; [B1, C1, P1, V3, V6]; xn----sgn20i14s.xn--49-ki3om2611f; ; xn----ngo823c.xn--49-ki3om2611f; [B1, P1, V3, V6] # -ⷱ≮.𐹱49
+-‌ⷱ≮.𐹱򭏴49; ; [B1, C1, P1, V3, V6]; xn----sgn20i14s.xn--49-ki3om2611f; ; xn----ngo823c.xn--49-ki3om2611f; [B1, P1, V3, V6] # -ⷱ≮.𐹱49
+-‌ⷱ≮.𐹱򭏴49; -‌ⷱ≮.𐹱򭏴49; [B1, C1, P1, V3, V6]; xn----sgn20i14s.xn--49-ki3om2611f; ; xn----ngo823c.xn--49-ki3om2611f; [B1, P1, V3, V6] # -ⷱ≮.𐹱49
+xn----ngo823c.xn--49-ki3om2611f; -ⷱ≮.𐹱򭏴49; [B1, V3, V6]; xn----ngo823c.xn--49-ki3om2611f; ; ;  # -ⷱ≮.𐹱49
+xn----sgn20i14s.xn--49-ki3om2611f; -‌ⷱ≮.𐹱򭏴49; [B1, C1, V3, V6]; xn----sgn20i14s.xn--49-ki3om2611f; ; ;  # -ⷱ≮.𐹱49
+-≯딾｡ࡇ; -≯딾.ࡇ; [B1, P1, V3, V6]; xn----pgow547d.xn--5vb; ; ;  # -≯딾.ࡇ
+-≯딾｡ࡇ; -≯딾.ࡇ; [B1, P1, V3, V6]; xn----pgow547d.xn--5vb; ; ;  # -≯딾.ࡇ
+-≯딾。ࡇ; -≯딾.ࡇ; [B1, P1, V3, V6]; xn----pgow547d.xn--5vb; ; ;  # -≯딾.ࡇ
+-≯딾。ࡇ; -≯딾.ࡇ; [B1, P1, V3, V6]; xn----pgow547d.xn--5vb; ; ;  # -≯딾.ࡇ
+xn----pgow547d.xn--5vb; -≯딾.ࡇ; [B1, V3, V6]; xn----pgow547d.xn--5vb; ; ;  # -≯딾.ࡇ
+𑙢⒈𐹠-｡󠗐‌; 𑙢⒈𐹠-.󠗐‌; [B1, C1, P1, V3, V6]; xn----dcpy090hiyg.xn--0ug23321l; ; xn----dcpy090hiyg.xn--jd46e; [B1, P1, V3, V6] # 𑙢⒈𐹠-.
+𑙢1.𐹠-。󠗐‌; 𑙢1.𐹠-.󠗐‌; [B1, C1, P1, V3, V6]; xn--1-bf0j.xn----516i.xn--0ug23321l; ; xn--1-bf0j.xn----516i.xn--jd46e; [B1, P1, V3, V6] # 𑙢1.𐹠-.
+xn--1-bf0j.xn----516i.xn--jd46e; 𑙢1.𐹠-.󠗐; [B1, V3, V6]; xn--1-bf0j.xn----516i.xn--jd46e; ; ;  # 𑙢1.𐹠-.
+xn--1-bf0j.xn----516i.xn--0ug23321l; 𑙢1.𐹠-.󠗐‌; [B1, C1, V3, V6]; xn--1-bf0j.xn----516i.xn--0ug23321l; ; ;  # 𑙢1.𐹠-.
+xn----dcpy090hiyg.xn--jd46e; 𑙢⒈𐹠-.󠗐; [B1, V3, V6]; xn----dcpy090hiyg.xn--jd46e; ; ;  # 𑙢⒈𐹠-.
+xn----dcpy090hiyg.xn--0ug23321l; 𑙢⒈𐹠-.󠗐‌; [B1, C1, V3, V6]; xn----dcpy090hiyg.xn--0ug23321l; ; ;  # 𑙢⒈𐹠-.
+͊．𐨎; ͊.𐨎; [V5]; xn--oua.xn--mr9c; ; ;  # ͊.𐨎
+͊.𐨎; ; [V5]; xn--oua.xn--mr9c; ; ;  # ͊.𐨎
+xn--oua.xn--mr9c; ͊.𐨎; [V5]; xn--oua.xn--mr9c; ; ;  # ͊.𐨎
+훉≮｡ิ; 훉≮.ิ; [P1, V5, V6]; xn--gdh2512e.xn--i4c; ; ;  # 훉≮.ิ
+훉≮｡ิ; 훉≮.ิ; [P1, V5, V6]; xn--gdh2512e.xn--i4c; ; ;  # 훉≮.ิ
+훉≮。ิ; 훉≮.ิ; [P1, V5, V6]; xn--gdh2512e.xn--i4c; ; ;  # 훉≮.ิ
+훉≮。ิ; 훉≮.ิ; [P1, V5, V6]; xn--gdh2512e.xn--i4c; ; ;  # 훉≮.ิ
+xn--gdh2512e.xn--i4c; 훉≮.ิ; [V5, V6]; xn--gdh2512e.xn--i4c; ; ;  # 훉≮.ิ
+ⷷ򞣉🃘．𴈇𝟸ٙ𞤯; ⷷ򞣉🃘.𴈇2ٙ𞤯; [B1, B5, B6, P1, V5, V6]; xn--trj8045le6s9b.xn--2-upc23918acjsj; ; ;  # ⷷ🃘.2ٙ𞤯
+ⷷ򞣉🃘.𴈇2ٙ𞤯; ; [B1, B5, B6, P1, V5, V6]; xn--trj8045le6s9b.xn--2-upc23918acjsj; ; ;  # ⷷ🃘.2ٙ𞤯
+ⷷ򞣉🃘.𴈇2ٙ𞤍; ⷷ򞣉🃘.𴈇2ٙ𞤯; [B1, B5, B6, P1, V5, V6]; xn--trj8045le6s9b.xn--2-upc23918acjsj; ; ;  # ⷷ🃘.2ٙ𞤯
+xn--trj8045le6s9b.xn--2-upc23918acjsj; ⷷ򞣉🃘.𴈇2ٙ𞤯; [B1, B5, B6, V5, V6]; xn--trj8045le6s9b.xn--2-upc23918acjsj; ; ;  # ⷷ🃘.2ٙ𞤯
+ⷷ򞣉🃘．𴈇𝟸ٙ𞤍; ⷷ򞣉🃘.𴈇2ٙ𞤯; [B1, B5, B6, P1, V5, V6]; xn--trj8045le6s9b.xn--2-upc23918acjsj; ; ;  # ⷷ🃘.2ٙ𞤯
+󗇩ßᢞ‌。٠𞷻ﳔ-; 󗇩ßᢞ‌.٠𞷻نخ-; [B1, B6, C1, P1, V3, V6]; xn--zca272jbif10059a.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, P1, V3, V6] # ßᢞ.٠نخ-
+󗇩ßᢞ‌。٠𞷻نخ-; 󗇩ßᢞ‌.٠𞷻نخ-; [B1, B6, C1, P1, V3, V6]; xn--zca272jbif10059a.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, P1, V3, V6] # ßᢞ.٠نخ-
+󗇩SSᢞ‌。٠𞷻نخ-; 󗇩ssᢞ‌.٠𞷻نخ-; [B1, B6, C1, P1, V3, V6]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, P1, V3, V6] # ssᢞ.٠نخ-
+󗇩ssᢞ‌。٠𞷻نخ-; 󗇩ssᢞ‌.٠𞷻نخ-; [B1, B6, C1, P1, V3, V6]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, P1, V3, V6] # ssᢞ.٠نخ-
+󗇩Ssᢞ‌。٠𞷻نخ-; 󗇩ssᢞ‌.٠𞷻نخ-; [B1, B6, C1, P1, V3, V6]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, P1, V3, V6] # ssᢞ.٠نخ-
+xn--ss-jepz4596r.xn----dnc5e1er384z; 󗇩ssᢞ.٠𞷻نخ-; [B1, V3, V6]; xn--ss-jepz4596r.xn----dnc5e1er384z; ; ;  # ssᢞ.٠نخ-
+xn--ss-jep006bqt765b.xn----dnc5e1er384z; 󗇩ssᢞ‌.٠𞷻نخ-; [B1, B6, C1, V3, V6]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; ;  # ssᢞ.٠نخ-
+xn--zca272jbif10059a.xn----dnc5e1er384z; 󗇩ßᢞ‌.٠𞷻نخ-; [B1, B6, C1, V3, V6]; xn--zca272jbif10059a.xn----dnc5e1er384z; ; ;  # ßᢞ.٠نخ-
+󗇩SSᢞ‌。٠𞷻ﳔ-; 󗇩ssᢞ‌.٠𞷻نخ-; [B1, B6, C1, P1, V3, V6]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, P1, V3, V6] # ssᢞ.٠نخ-
+󗇩ssᢞ‌。٠𞷻ﳔ-; 󗇩ssᢞ‌.٠𞷻نخ-; [B1, B6, C1, P1, V3, V6]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, P1, V3, V6] # ssᢞ.٠نخ-
+󗇩Ssᢞ‌。٠𞷻ﳔ-; 󗇩ssᢞ‌.٠𞷻نخ-; [B1, B6, C1, P1, V3, V6]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, P1, V3, V6] # ssᢞ.٠نخ-
+ꡆ。Ↄྵ놮-; ꡆ.Ↄྵ놮-; [P1, V3, V6]; xn--fc9a.xn----qmg787k869k; ; ;  # ꡆ.Ↄྵ놮-
+ꡆ。Ↄྵ놮-; ꡆ.Ↄྵ놮-; [P1, V3, V6]; xn--fc9a.xn----qmg787k869k; ; ;  # ꡆ.Ↄྵ놮-
+ꡆ。ↄྵ놮-; ꡆ.ↄྵ놮-; [V3]; xn--fc9a.xn----qmg097k469k; ; ;  # ꡆ.ↄྵ놮-
+ꡆ。ↄྵ놮-; ꡆ.ↄྵ놮-; [V3]; xn--fc9a.xn----qmg097k469k; ; ;  # ꡆ.ↄྵ놮-
+xn--fc9a.xn----qmg097k469k; ꡆ.ↄྵ놮-; [V3]; xn--fc9a.xn----qmg097k469k; ; ;  # ꡆ.ↄྵ놮-
+xn--fc9a.xn----qmg787k869k; ꡆ.Ↄྵ놮-; [V3, V6]; xn--fc9a.xn----qmg787k869k; ; ;  # ꡆ.Ↄྵ놮-
+ﶭ‍.񥰌ک; لمي‍.񥰌ک; [B3, B5, B6, C2, P1, V6]; xn--ghbcp494x.xn--ckb36214f; ; xn--ghbcp.xn--ckb36214f; [B5, B6, P1, V6] # لمي.ک
+لمي‍.񥰌ک; ; [B3, B5, B6, C2, P1, V6]; xn--ghbcp494x.xn--ckb36214f; ; xn--ghbcp.xn--ckb36214f; [B5, B6, P1, V6] # لمي.ک
+xn--ghbcp.xn--ckb36214f; لمي.񥰌ک; [B5, B6, V6]; xn--ghbcp.xn--ckb36214f; ; ;  # لمي.ک
+xn--ghbcp494x.xn--ckb36214f; لمي‍.񥰌ک; [B3, B5, B6, C2, V6]; xn--ghbcp494x.xn--ckb36214f; ; ;  # لمي.ک
+Ⴜᰯ𐳒≯。۠ᜲྺ; Ⴜᰯ𐳒≯.۠ᜲྺ; [B1, B3, B5, B6, P1, V5, V6]; xn--0nd679cf3eq67y.xn--wlb646b4ng; ; ;  # Ⴜᰯ𐳒≯.۠ᜲྺ
+Ⴜᰯ𐳒≯。۠ᜲྺ; Ⴜᰯ𐳒≯.۠ᜲྺ; [B1, B3, B5, B6, P1, V5, V6]; xn--0nd679cf3eq67y.xn--wlb646b4ng; ; ;  # Ⴜᰯ𐳒≯.۠ᜲྺ
+ⴜᰯ𐳒≯。۠ᜲྺ; ⴜᰯ𐳒≯.۠ᜲྺ; [B1, B3, B5, B6, P1, V5, V6]; xn--r1f68xh1jgv7u.xn--wlb646b4ng; ; ;  # ⴜᰯ𐳒≯.۠ᜲྺ
+ⴜᰯ𐳒≯。۠ᜲྺ; ⴜᰯ𐳒≯.۠ᜲྺ; [B1, B3, B5, B6, P1, V5, V6]; xn--r1f68xh1jgv7u.xn--wlb646b4ng; ; ;  # ⴜᰯ𐳒≯.۠ᜲྺ
+Ⴜᰯ𐲒≯。۠ᜲྺ; Ⴜᰯ𐳒≯.۠ᜲྺ; [B1, B3, B5, B6, P1, V5, V6]; xn--0nd679cf3eq67y.xn--wlb646b4ng; ; ;  # Ⴜᰯ𐳒≯.۠ᜲྺ
+Ⴜᰯ𐲒≯。۠ᜲྺ; Ⴜᰯ𐳒≯.۠ᜲྺ; [B1, B3, B5, B6, P1, V5, V6]; xn--0nd679cf3eq67y.xn--wlb646b4ng; ; ;  # Ⴜᰯ𐳒≯.۠ᜲྺ
+xn--0nd679cf3eq67y.xn--wlb646b4ng; Ⴜᰯ𐳒≯.۠ᜲྺ; [B1, B3, B5, B6, V5, V6]; xn--0nd679cf3eq67y.xn--wlb646b4ng; ; ;  # Ⴜᰯ𐳒≯.۠ᜲྺ
+xn--r1f68xh1jgv7u.xn--wlb646b4ng; ⴜᰯ𐳒≯.۠ᜲྺ; [B1, B3, B5, B6, V5, V6]; xn--r1f68xh1jgv7u.xn--wlb646b4ng; ; ;  # ⴜᰯ𐳒≯.۠ᜲྺ
+𐋵。ﳬ; 𐋵.كم; [B1]; xn--p97c.xn--fhbe; ; ;  # 𐋵.كم
+𐋵。كم; 𐋵.كم; [B1]; xn--p97c.xn--fhbe; ; ;  # 𐋵.كم
+xn--p97c.xn--fhbe; 𐋵.كم; [B1]; xn--p97c.xn--fhbe; ; ;  # 𐋵.كم
+𐋵.كم; ; [B1]; xn--p97c.xn--fhbe; ; ;  # 𐋵.كم
+≮𝅶．񱲁ꫬ⹈󰥭; ≮𝅶.񱲁ꫬ⹈󰥭; [P1, V6]; xn--gdh0880o.xn--4tjx101bsg00ds9pyc; ; ;  # ≮.ꫬ⹈
+≮𝅶．񱲁ꫬ⹈󰥭; ≮𝅶.񱲁ꫬ⹈󰥭; [P1, V6]; xn--gdh0880o.xn--4tjx101bsg00ds9pyc; ; ;  # ≮.ꫬ⹈
+≮𝅶.񱲁ꫬ⹈󰥭; ; [P1, V6]; xn--gdh0880o.xn--4tjx101bsg00ds9pyc; ; ;  # ≮.ꫬ⹈
+≮𝅶.񱲁ꫬ⹈󰥭; ≮𝅶.񱲁ꫬ⹈󰥭; [P1, V6]; xn--gdh0880o.xn--4tjx101bsg00ds9pyc; ; ;  # ≮.ꫬ⹈
+xn--gdh0880o.xn--4tjx101bsg00ds9pyc; ≮𝅶.񱲁ꫬ⹈󰥭; [V6]; xn--gdh0880o.xn--4tjx101bsg00ds9pyc; ; ;  # ≮.ꫬ⹈
+ⷰ͘ᢕ．͡𐹷󠴍; ⷰ͘ᢕ.͡𐹷󠴍; [B1, P1, V5, V6]; xn--2ua889htsp.xn--cva2687k2tv0g; ; ;  # ⷰ͘ᢕ.͡𐹷
+ⷰ͘ᢕ.͡𐹷󠴍; ; [B1, P1, V5, V6]; xn--2ua889htsp.xn--cva2687k2tv0g; ; ;  # ⷰ͘ᢕ.͡𐹷
+xn--2ua889htsp.xn--cva2687k2tv0g; ⷰ͘ᢕ.͡𐹷󠴍; [B1, V5, V6]; xn--2ua889htsp.xn--cva2687k2tv0g; ; ;  # ⷰ͘ᢕ.͡𐹷
+ﵹᡐ‌ڭ．𑋪ׇ; غممᡐ‌ڭ.𑋪ׇ; [B1, B2, B3, B6, V5]; xn--5gbwa03bg24eptk.xn--vdb1198k; ; xn--5gbwa03bg24e.xn--vdb1198k;  # غممᡐڭ.𑋪ׇ
+غممᡐ‌ڭ.𑋪ׇ; ; [B1, B2, B3, B6, V5]; xn--5gbwa03bg24eptk.xn--vdb1198k; ; xn--5gbwa03bg24e.xn--vdb1198k;  # غممᡐڭ.𑋪ׇ
+xn--5gbwa03bg24e.xn--vdb1198k; غممᡐڭ.𑋪ׇ; [B1, B2, B3, B6, V5]; xn--5gbwa03bg24e.xn--vdb1198k; ; ;  # غممᡐڭ.𑋪ׇ
+xn--5gbwa03bg24eptk.xn--vdb1198k; غممᡐ‌ڭ.𑋪ׇ; [B1, B2, B3, B6, V5]; xn--5gbwa03bg24eptk.xn--vdb1198k; ; ;  # غممᡐڭ.𑋪ׇ
+𑑂｡‍󥞀🞕򥁔; 𑑂.‍󥞀🞕򥁔; [C2, P1, V5, V6]; xn--8v1d.xn--1ug1386plvx1cd8vya; ; xn--8v1d.xn--ye9h41035a2qqs; [P1, V5, V6] # 𑑂.🞕
+𑑂。‍󥞀🞕򥁔; 𑑂.‍󥞀🞕򥁔; [C2, P1, V5, V6]; xn--8v1d.xn--1ug1386plvx1cd8vya; ; xn--8v1d.xn--ye9h41035a2qqs; [P1, V5, V6] # 𑑂.🞕
+xn--8v1d.xn--ye9h41035a2qqs; 𑑂.󥞀🞕򥁔; [V5, V6]; xn--8v1d.xn--ye9h41035a2qqs; ; ;  # 𑑂.🞕
+xn--8v1d.xn--1ug1386plvx1cd8vya; 𑑂.‍󥞀🞕򥁔; [C2, V5, V6]; xn--8v1d.xn--1ug1386plvx1cd8vya; ; ;  # 𑑂.🞕
+-ש。⒚; -ש.⒚; [B1, P1, V3, V6]; xn----gjc.xn--cth; ; ;  # -ש.⒚
+-ש。19.; -ש.19.; [B1, V3]; xn----gjc.19.; ; ;  # -ש.19.
+xn----gjc.19.; -ש.19.; [B1, V3]; xn----gjc.19.; ; ;  # -ש.19.
+xn----gjc.xn--cth; -ש.⒚; [B1, V3, V6]; xn----gjc.xn--cth; ; ;  # -ש.⒚
+􊾻ࡅ‌｡ᢎ‍; 􊾻ࡅ‌.ᢎ‍; [B5, B6, C1, C2, P1, V6]; xn--3vb882jz4411a.xn--79e259a; ; xn--3vb50049s.xn--79e; [B5, B6, P1, V6] # ࡅ.ᢎ
+􊾻ࡅ‌。ᢎ‍; 􊾻ࡅ‌.ᢎ‍; [B5, B6, C1, C2, P1, V6]; xn--3vb882jz4411a.xn--79e259a; ; xn--3vb50049s.xn--79e; [B5, B6, P1, V6] # ࡅ.ᢎ
+xn--3vb50049s.xn--79e; 􊾻ࡅ.ᢎ; [B5, B6, V6]; xn--3vb50049s.xn--79e; ; ;  # ࡅ.ᢎ
+xn--3vb882jz4411a.xn--79e259a; 􊾻ࡅ‌.ᢎ‍; [B5, B6, C1, C2, V6]; xn--3vb882jz4411a.xn--79e259a; ; ;  # ࡅ.ᢎ
+ßুᷭ。ؠ8₅; ßুᷭ.ؠ85; ; xn--zca266bwrr.xn--85-psd; ; xn--ss-e2f077r.xn--85-psd;  # ßুᷭ.ؠ85
+ßুᷭ。ؠ85; ßুᷭ.ؠ85; ; xn--zca266bwrr.xn--85-psd; ; xn--ss-e2f077r.xn--85-psd;  # ßুᷭ.ؠ85
+SSুᷭ。ؠ85; ssুᷭ.ؠ85; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+ssুᷭ。ؠ85; ssুᷭ.ؠ85; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+Ssুᷭ。ؠ85; ssুᷭ.ؠ85; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+xn--ss-e2f077r.xn--85-psd; ssুᷭ.ؠ85; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+ssুᷭ.ؠ85; ; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+SSুᷭ.ؠ85; ssুᷭ.ؠ85; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+Ssুᷭ.ؠ85; ssুᷭ.ؠ85; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+xn--zca266bwrr.xn--85-psd; ßুᷭ.ؠ85; ; xn--zca266bwrr.xn--85-psd; ; ;  # ßুᷭ.ؠ85
+ßুᷭ.ؠ85; ; ; xn--zca266bwrr.xn--85-psd; ; xn--ss-e2f077r.xn--85-psd;  # ßুᷭ.ؠ85
+SSুᷭ。ؠ8₅; ssুᷭ.ؠ85; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+ssুᷭ。ؠ8₅; ssুᷭ.ؠ85; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+Ssুᷭ。ؠ8₅; ssুᷭ.ؠ85; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+્҄魅𝟣．₃𐹥ß; ્҄魅1.3𐹥ß; [B1, V5]; xn--1-0xb049b102o.xn--3-qfa7018r; ; xn--1-0xb049b102o.xn--3ss-nv9t;  # ્҄魅1.3𐹥ß
+્҄魅1.3𐹥ß; ; [B1, V5]; xn--1-0xb049b102o.xn--3-qfa7018r; ; xn--1-0xb049b102o.xn--3ss-nv9t;  # ્҄魅1.3𐹥ß
+્҄魅1.3𐹥SS; ્҄魅1.3𐹥ss; [B1, V5]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+્҄魅1.3𐹥ss; ; [B1, V5]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+્҄魅1.3𐹥Ss; ્҄魅1.3𐹥ss; [B1, V5]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+xn--1-0xb049b102o.xn--3ss-nv9t; ્҄魅1.3𐹥ss; [B1, V5]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+xn--1-0xb049b102o.xn--3-qfa7018r; ્҄魅1.3𐹥ß; [B1, V5]; xn--1-0xb049b102o.xn--3-qfa7018r; ; ;  # ્҄魅1.3𐹥ß
+્҄魅𝟣．₃𐹥SS; ્҄魅1.3𐹥ss; [B1, V5]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+્҄魅𝟣．₃𐹥ss; ્҄魅1.3𐹥ss; [B1, V5]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+્҄魅𝟣．₃𐹥Ss; ્҄魅1.3𐹥ss; [B1, V5]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+ܫ｡𑓂⒈𑜫󠿻; ܫ.𑓂⒈𑜫󠿻; [B1, P1, V5, V6]; xn--1nb.xn--tsh7798f6rbrt828c; ; ;  # ܫ.𑓂⒈𑜫
+ܫ。𑓂1.𑜫󠿻; ܫ.𑓂1.𑜫󠿻; [B1, P1, V5, V6]; xn--1nb.xn--1-jq9i.xn--ji2dg9877c; ; ;  # ܫ.𑓂1.𑜫
+xn--1nb.xn--1-jq9i.xn--ji2dg9877c; ܫ.𑓂1.𑜫󠿻; [B1, V5, V6]; xn--1nb.xn--1-jq9i.xn--ji2dg9877c; ; ;  # ܫ.𑓂1.𑜫
+xn--1nb.xn--tsh7798f6rbrt828c; ܫ.𑓂⒈𑜫󠿻; [B1, V5, V6]; xn--1nb.xn--tsh7798f6rbrt828c; ; ;  # ܫ.𑓂⒈𑜫
+︍છ。嵨; છ.嵨; ; xn--6dc.xn--tot; ; ;  # છ.嵨
+xn--6dc.xn--tot; છ.嵨; ; xn--6dc.xn--tot; ; ;  # છ.嵨
+છ.嵨; ; ; xn--6dc.xn--tot; ; ;  # છ.嵨
+Ⴔ≠Ⴀ.𐹥𐹰; ; [B1, P1, V6]; xn--7md3b171g.xn--do0dwa; ; ;  # Ⴔ≠Ⴀ.𐹥𐹰
+Ⴔ≠Ⴀ.𐹥𐹰; Ⴔ≠Ⴀ.𐹥𐹰; [B1, P1, V6]; xn--7md3b171g.xn--do0dwa; ; ;  # Ⴔ≠Ⴀ.𐹥𐹰
+ⴔ≠ⴀ.𐹥𐹰; ⴔ≠ⴀ.𐹥𐹰; [B1, P1, V6]; xn--1ch603bxb.xn--do0dwa; ; ;  # ⴔ≠ⴀ.𐹥𐹰
+ⴔ≠ⴀ.𐹥𐹰; ; [B1, P1, V6]; xn--1ch603bxb.xn--do0dwa; ; ;  # ⴔ≠ⴀ.𐹥𐹰
+xn--1ch603bxb.xn--do0dwa; ⴔ≠ⴀ.𐹥𐹰; [B1, V6]; xn--1ch603bxb.xn--do0dwa; ; ;  # ⴔ≠ⴀ.𐹥𐹰
+xn--7md3b171g.xn--do0dwa; Ⴔ≠Ⴀ.𐹥𐹰; [B1, V6]; xn--7md3b171g.xn--do0dwa; ; ;  # Ⴔ≠Ⴀ.𐹥𐹰
+-‌⒙𐫥｡𝨵; -‌⒙𐫥.𝨵; [C1, P1, V3, V5, V6]; xn----sgn18r3191a.xn--382h; ; xn----ddps939g.xn--382h; [P1, V3, V5, V6] # -⒙𐫥.𝨵
+-‌18.𐫥。𝨵; -‌18.𐫥.𝨵; [C1, V3, V5]; xn---18-9m0a.xn--rx9c.xn--382h; ; -18.xn--rx9c.xn--382h; [V3, V5] # -18.𐫥.𝨵
+-18.xn--rx9c.xn--382h; -18.𐫥.𝨵; [V3, V5]; -18.xn--rx9c.xn--382h; ; ;  # -18.𐫥.𝨵
+xn---18-9m0a.xn--rx9c.xn--382h; -‌18.𐫥.𝨵; [C1, V3, V5]; xn---18-9m0a.xn--rx9c.xn--382h; ; ;  # -18.𐫥.𝨵
+xn----ddps939g.xn--382h; -⒙𐫥.𝨵; [V3, V5, V6]; xn----ddps939g.xn--382h; ; ;  # -⒙𐫥.𝨵
+xn----sgn18r3191a.xn--382h; -‌⒙𐫥.𝨵; [C1, V3, V5, V6]; xn----sgn18r3191a.xn--382h; ; ;  # -⒙𐫥.𝨵
+︒.ʌᠣ-𐹽; ; [B1, B5, B6, P1, V6]; xn--y86c.xn----73a596nuh9t; ; ;  # ︒.ʌᠣ-𐹽
+。.ʌᠣ-𐹽; ..ʌᠣ-𐹽; [B5, B6, X4_2]; ..xn----73a596nuh9t; [B5, B6, A4_2]; ;  # ..ʌᠣ-𐹽
+。.Ʌᠣ-𐹽; ..ʌᠣ-𐹽; [B5, B6, X4_2]; ..xn----73a596nuh9t; [B5, B6, A4_2]; ;  # ..ʌᠣ-𐹽
+..xn----73a596nuh9t; ..ʌᠣ-𐹽; [B5, B6, X4_2]; ..xn----73a596nuh9t; [B5, B6, A4_2]; ;  # ..ʌᠣ-𐹽
+︒.Ʌᠣ-𐹽; ︒.ʌᠣ-𐹽; [B1, B5, B6, P1, V6]; xn--y86c.xn----73a596nuh9t; ; ;  # ︒.ʌᠣ-𐹽
+xn--y86c.xn----73a596nuh9t; ︒.ʌᠣ-𐹽; [B1, B5, B6, V6]; xn--y86c.xn----73a596nuh9t; ; ;  # ︒.ʌᠣ-𐹽
+︅︒。𦀾᳠; ︒.𦀾᳠; [P1, V6]; xn--y86c.xn--t6f5138v; ; ;  # ︒.𦀾᳠
+︅。。𦀾᳠; ..𦀾᳠; [X4_2]; ..xn--t6f5138v; [A4_2]; ;  # ..𦀾᳠
+..xn--t6f5138v; ..𦀾᳠; [X4_2]; ..xn--t6f5138v; [A4_2]; ;  # ..𦀾᳠
+xn--y86c.xn--t6f5138v; ︒.𦀾᳠; [V6]; xn--y86c.xn--t6f5138v; ; ;  # ︒.𦀾᳠
+xn--t6f5138v; 𦀾᳠; ; xn--t6f5138v; ; ;  # 𦀾᳠
+𦀾᳠; ; ; xn--t6f5138v; ; ;  # 𦀾᳠
+𞮑ß􏞞。ᡁ; 𞮑ß􏞞.ᡁ; [B2, B3, P1, V6]; xn--zca9432wb989f.xn--07e; ; xn--ss-o412ac6305g.xn--07e;  # ß.ᡁ
+𞮑SS􏞞。ᡁ; 𞮑ss􏞞.ᡁ; [B2, B3, P1, V6]; xn--ss-o412ac6305g.xn--07e; ; ;  # ss.ᡁ
+𞮑ss􏞞。ᡁ; 𞮑ss􏞞.ᡁ; [B2, B3, P1, V6]; xn--ss-o412ac6305g.xn--07e; ; ;  # ss.ᡁ
+𞮑Ss􏞞。ᡁ; 𞮑ss􏞞.ᡁ; [B2, B3, P1, V6]; xn--ss-o412ac6305g.xn--07e; ; ;  # ss.ᡁ
+xn--ss-o412ac6305g.xn--07e; 𞮑ss􏞞.ᡁ; [B2, B3, V6]; xn--ss-o412ac6305g.xn--07e; ; ;  # ss.ᡁ
+xn--zca9432wb989f.xn--07e; 𞮑ß􏞞.ᡁ; [B2, B3, V6]; xn--zca9432wb989f.xn--07e; ; ;  # ß.ᡁ
+꥓‍ج٬。𱆎󻡟‌󠅆; ꥓‍ج٬.𱆎󻡟‌; [B5, B6, C1, P1, V5, V6]; xn--rgb2k500fhq9j.xn--0ug78870a5sp9d; ; xn--rgb2k6711c.xn--ec8nj3948b; [B5, B6, P1, V5, V6] # ꥓ج٬.
+xn--rgb2k6711c.xn--ec8nj3948b; ꥓ج٬.𱆎󻡟; [B5, B6, V5, V6]; xn--rgb2k6711c.xn--ec8nj3948b; ; ;  # ꥓ج٬.
+xn--rgb2k500fhq9j.xn--0ug78870a5sp9d; ꥓‍ج٬.𱆎󻡟‌; [B5, B6, C1, V5, V6]; xn--rgb2k500fhq9j.xn--0ug78870a5sp9d; ; ;  # ꥓ج٬.
+󠕏．-ß‌≠; 󠕏.-ß‌≠; [C1, P1, V3, V6]; xn--u836e.xn----qfa750ve7b; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ß≠
+󠕏．-ß‌≠; 󠕏.-ß‌≠; [C1, P1, V3, V6]; xn--u836e.xn----qfa750ve7b; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ß≠
+󠕏.-ß‌≠; ; [C1, P1, V3, V6]; xn--u836e.xn----qfa750ve7b; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ß≠
+󠕏.-ß‌≠; 󠕏.-ß‌≠; [C1, P1, V3, V6]; xn--u836e.xn----qfa750ve7b; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ß≠
+󠕏.-SS‌≠; 󠕏.-ss‌≠; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+󠕏.-SS‌≠; 󠕏.-ss‌≠; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+󠕏.-ss‌≠; ; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+󠕏.-ss‌≠; 󠕏.-ss‌≠; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+󠕏.-Ss‌≠; 󠕏.-ss‌≠; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+󠕏.-Ss‌≠; 󠕏.-ss‌≠; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+xn--u836e.xn---ss-gl2a; 󠕏.-ss≠; [V3, V6]; xn--u836e.xn---ss-gl2a; ; ;  # .-ss≠
+xn--u836e.xn---ss-cn0at5l; 󠕏.-ss‌≠; [C1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; ;  # .-ss≠
+xn--u836e.xn----qfa750ve7b; 󠕏.-ß‌≠; [C1, V3, V6]; xn--u836e.xn----qfa750ve7b; ; ;  # .-ß≠
+󠕏．-SS‌≠; 󠕏.-ss‌≠; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+󠕏．-SS‌≠; 󠕏.-ss‌≠; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+󠕏．-ss‌≠; 󠕏.-ss‌≠; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+󠕏．-ss‌≠; 󠕏.-ss‌≠; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+󠕏．-Ss‌≠; 󠕏.-ss‌≠; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+󠕏．-Ss‌≠; 󠕏.-ss‌≠; [C1, P1, V3, V6]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [P1, V3, V6] # .-ss≠
+ᡙ‌｡≯𐋲≠; ᡙ‌.≯𐋲≠; [C1, P1, V6]; xn--p8e650b.xn--1ch3a7084l; ; xn--p8e.xn--1ch3a7084l; [P1, V6] # ᡙ.≯𐋲≠
+ᡙ‌｡≯𐋲≠; ᡙ‌.≯𐋲≠; [C1, P1, V6]; xn--p8e650b.xn--1ch3a7084l; ; xn--p8e.xn--1ch3a7084l; [P1, V6] # ᡙ.≯𐋲≠
+ᡙ‌。≯𐋲≠; ᡙ‌.≯𐋲≠; [C1, P1, V6]; xn--p8e650b.xn--1ch3a7084l; ; xn--p8e.xn--1ch3a7084l; [P1, V6] # ᡙ.≯𐋲≠
+ᡙ‌。≯𐋲≠; ᡙ‌.≯𐋲≠; [C1, P1, V6]; xn--p8e650b.xn--1ch3a7084l; ; xn--p8e.xn--1ch3a7084l; [P1, V6] # ᡙ.≯𐋲≠
+xn--p8e.xn--1ch3a7084l; ᡙ.≯𐋲≠; [V6]; xn--p8e.xn--1ch3a7084l; ; ;  # ᡙ.≯𐋲≠
+xn--p8e650b.xn--1ch3a7084l; ᡙ‌.≯𐋲≠; [C1, V6]; xn--p8e650b.xn--1ch3a7084l; ; ;  # ᡙ.≯𐋲≠
+𐹧𞲄󠁭񆼩。͎🄀; 𐹧𞲄󠁭񆼩.͎🄀; [B1, P1, V5, V6]; xn--fo0dw409aq58qrn69d.xn--sua6883w; ; ;  # 𐹧𞲄.͎🄀
+𐹧𞲄󠁭񆼩。͎0.; 𐹧𞲄󠁭񆼩.͎0.; [B1, P1, V5, V6]; xn--fo0dw409aq58qrn69d.xn--0-bgb.; ; ;  # 𐹧𞲄.͎0.
+xn--fo0dw409aq58qrn69d.xn--0-bgb.; 𐹧𞲄󠁭񆼩.͎0.; [B1, V5, V6]; xn--fo0dw409aq58qrn69d.xn--0-bgb.; ; ;  # 𐹧𞲄.͎0.
+xn--fo0dw409aq58qrn69d.xn--sua6883w; 𐹧𞲄󠁭񆼩.͎🄀; [B1, V5, V6]; xn--fo0dw409aq58qrn69d.xn--sua6883w; ; ;  # 𐹧𞲄.͎🄀
+Ⴄ．‍ܡ󻣋ς; Ⴄ.‍ܡ󻣋ς; [B1, C2, P1, V6]; xn--cnd.xn--3xa93o3t5ajq467a; ; xn--cnd.xn--4xa73ob5892c; [B2, B3, P1, V6] # Ⴄ.ܡς
+Ⴄ.‍ܡ󻣋ς; ; [B1, C2, P1, V6]; xn--cnd.xn--3xa93o3t5ajq467a; ; xn--cnd.xn--4xa73ob5892c; [B2, B3, P1, V6] # Ⴄ.ܡς
+ⴄ.‍ܡ󻣋ς; ; [B1, C2, P1, V6]; xn--vkj.xn--3xa93o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, P1, V6] # ⴄ.ܡς
+Ⴄ.‍ܡ󻣋Σ; Ⴄ.‍ܡ󻣋σ; [B1, C2, P1, V6]; xn--cnd.xn--4xa73o3t5ajq467a; ; xn--cnd.xn--4xa73ob5892c; [B2, B3, P1, V6] # Ⴄ.ܡσ
+ⴄ.‍ܡ󻣋σ; ; [B1, C2, P1, V6]; xn--vkj.xn--4xa73o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, P1, V6] # ⴄ.ܡσ
+xn--vkj.xn--4xa73ob5892c; ⴄ.ܡ󻣋σ; [B2, B3, V6]; xn--vkj.xn--4xa73ob5892c; ; ;  # ⴄ.ܡσ
+xn--vkj.xn--4xa73o3t5ajq467a; ⴄ.‍ܡ󻣋σ; [B1, C2, V6]; xn--vkj.xn--4xa73o3t5ajq467a; ; ;  # ⴄ.ܡσ
+xn--cnd.xn--4xa73ob5892c; Ⴄ.ܡ󻣋σ; [B2, B3, V6]; xn--cnd.xn--4xa73ob5892c; ; ;  # Ⴄ.ܡσ
+xn--cnd.xn--4xa73o3t5ajq467a; Ⴄ.‍ܡ󻣋σ; [B1, C2, V6]; xn--cnd.xn--4xa73o3t5ajq467a; ; ;  # Ⴄ.ܡσ
+xn--vkj.xn--3xa93o3t5ajq467a; ⴄ.‍ܡ󻣋ς; [B1, C2, V6]; xn--vkj.xn--3xa93o3t5ajq467a; ; ;  # ⴄ.ܡς
+xn--cnd.xn--3xa93o3t5ajq467a; Ⴄ.‍ܡ󻣋ς; [B1, C2, V6]; xn--cnd.xn--3xa93o3t5ajq467a; ; ;  # Ⴄ.ܡς
+ⴄ．‍ܡ󻣋ς; ⴄ.‍ܡ󻣋ς; [B1, C2, P1, V6]; xn--vkj.xn--3xa93o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, P1, V6] # ⴄ.ܡς
+Ⴄ．‍ܡ󻣋Σ; Ⴄ.‍ܡ󻣋σ; [B1, C2, P1, V6]; xn--cnd.xn--4xa73o3t5ajq467a; ; xn--cnd.xn--4xa73ob5892c; [B2, B3, P1, V6] # Ⴄ.ܡσ
+ⴄ．‍ܡ󻣋σ; ⴄ.‍ܡ󻣋σ; [B1, C2, P1, V6]; xn--vkj.xn--4xa73o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, P1, V6] # ⴄ.ܡσ
+򮵛ؓ.Ⴕ; ; [P1, V6]; xn--1fb94204l.xn--tnd; ; ;  # ؓ.Ⴕ
+򮵛ؓ.ⴕ; ; [P1, V6]; xn--1fb94204l.xn--dlj; ; ;  # ؓ.ⴕ
+xn--1fb94204l.xn--dlj; 򮵛ؓ.ⴕ; [V6]; xn--1fb94204l.xn--dlj; ; ;  # ؓ.ⴕ
+xn--1fb94204l.xn--tnd; 򮵛ؓ.Ⴕ; [V6]; xn--1fb94204l.xn--tnd; ; ;  # ؓ.Ⴕ
+≯ᷳ𞤥。‌꣄󠪉‍; ≯ᷳ𞤥.‌꣄󠪉‍; [B1, C1, C2, P1, V6]; xn--ofg13qyr21c.xn--0ugc0116hix29k; ; xn--ofg13qyr21c.xn--0f9au6706d; [B1, P1, V5, V6] # ≯ᷳ𞤥.꣄
+≯ᷳ𞤥。‌꣄󠪉‍; ≯ᷳ𞤥.‌꣄󠪉‍; [B1, C1, C2, P1, V6]; xn--ofg13qyr21c.xn--0ugc0116hix29k; ; xn--ofg13qyr21c.xn--0f9au6706d; [B1, P1, V5, V6] # ≯ᷳ𞤥.꣄
+≯ᷳ𞤃。‌꣄󠪉‍; ≯ᷳ𞤥.‌꣄󠪉‍; [B1, C1, C2, P1, V6]; xn--ofg13qyr21c.xn--0ugc0116hix29k; ; xn--ofg13qyr21c.xn--0f9au6706d; [B1, P1, V5, V6] # ≯ᷳ𞤥.꣄
+≯ᷳ𞤃。‌꣄󠪉‍; ≯ᷳ𞤥.‌꣄󠪉‍; [B1, C1, C2, P1, V6]; xn--ofg13qyr21c.xn--0ugc0116hix29k; ; xn--ofg13qyr21c.xn--0f9au6706d; [B1, P1, V5, V6] # ≯ᷳ𞤥.꣄
+xn--ofg13qyr21c.xn--0f9au6706d; ≯ᷳ𞤥.꣄󠪉; [B1, V5, V6]; xn--ofg13qyr21c.xn--0f9au6706d; ; ;  # ≯ᷳ𞤥.꣄
+xn--ofg13qyr21c.xn--0ugc0116hix29k; ≯ᷳ𞤥.‌꣄󠪉‍; [B1, C1, C2, V6]; xn--ofg13qyr21c.xn--0ugc0116hix29k; ; ;  # ≯ᷳ𞤥.꣄
+‌󠄷｡򒑁; ‌.򒑁; [C1, P1, V6]; xn--0ug.xn--w720c; ; .xn--w720c; [P1, V6, A4_2] # .
+‌󠄷。򒑁; ‌.򒑁; [C1, P1, V6]; xn--0ug.xn--w720c; ; .xn--w720c; [P1, V6, A4_2] # .
+.xn--w720c; .򒑁; [V6, X4_2]; .xn--w720c; [V6, A4_2]; ;  # .
+xn--0ug.xn--w720c; ‌.򒑁; [C1, V6]; xn--0ug.xn--w720c; ; ;  # .
+⒈ූ焅.󗡙‍ꡟ; ; [C2, P1, V6]; xn--t1c337io97c.xn--1ugz184c9lw7i; ; xn--t1c337io97c.xn--4c9a21133d; [P1, V6] # ⒈ූ焅.ꡟ
+1.ූ焅.󗡙‍ꡟ; ; [C2, P1, V5, V6]; 1.xn--t1c6981c.xn--1ugz184c9lw7i; ; 1.xn--t1c6981c.xn--4c9a21133d; [P1, V5, V6] # 1.ූ焅.ꡟ
+1.xn--t1c6981c.xn--4c9a21133d; 1.ූ焅.󗡙ꡟ; [V5, V6]; 1.xn--t1c6981c.xn--4c9a21133d; ; ;  # 1.ූ焅.ꡟ
+1.xn--t1c6981c.xn--1ugz184c9lw7i; 1.ූ焅.󗡙‍ꡟ; [C2, V5, V6]; 1.xn--t1c6981c.xn--1ugz184c9lw7i; ; ;  # 1.ූ焅.ꡟ
+xn--t1c337io97c.xn--4c9a21133d; ⒈ූ焅.󗡙ꡟ; [V6]; xn--t1c337io97c.xn--4c9a21133d; ; ;  # ⒈ූ焅.ꡟ
+xn--t1c337io97c.xn--1ugz184c9lw7i; ⒈ූ焅.󗡙‍ꡟ; [C2, V6]; xn--t1c337io97c.xn--1ugz184c9lw7i; ; ;  # ⒈ූ焅.ꡟ
+᷍ς≮.ς𝪦𞤕0; ᷍ς≮.ς𝪦𞤷0; [B1, B5, P1, V5, V6]; xn--3xa744kvid.xn--0-xmb85727aggma; ; xn--4xa544kvid.xn--0-zmb55727aggma;  # ᷍ς≮.ς𝪦𞤷0
+᷍ς≮.ς𝪦𞤕0; ᷍ς≮.ς𝪦𞤷0; [B1, B5, P1, V5, V6]; xn--3xa744kvid.xn--0-xmb85727aggma; ; xn--4xa544kvid.xn--0-zmb55727aggma;  # ᷍ς≮.ς𝪦𞤷0
+᷍ς≮.ς𝪦𞤷0; ᷍ς≮.ς𝪦𞤷0; [B1, B5, P1, V5, V6]; xn--3xa744kvid.xn--0-xmb85727aggma; ; xn--4xa544kvid.xn--0-zmb55727aggma;  # ᷍ς≮.ς𝪦𞤷0
+᷍ς≮.ς𝪦𞤷0; ; [B1, B5, P1, V5, V6]; xn--3xa744kvid.xn--0-xmb85727aggma; ; xn--4xa544kvid.xn--0-zmb55727aggma;  # ᷍ς≮.ς𝪦𞤷0
+᷍Σ≮.Σ𝪦𞤕0; ᷍σ≮.σ𝪦𞤷0; [B1, B5, P1, V5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+᷍Σ≮.Σ𝪦𞤕0; ᷍σ≮.σ𝪦𞤷0; [B1, B5, P1, V5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+᷍σ≮.σ𝪦𞤷0; ᷍σ≮.σ𝪦𞤷0; [B1, B5, P1, V5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+᷍σ≮.σ𝪦𞤷0; ; [B1, B5, P1, V5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+᷍Σ≮.Σ𝪦𞤷0; ᷍σ≮.σ𝪦𞤷0; [B1, B5, P1, V5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+᷍Σ≮.Σ𝪦𞤷0; ᷍σ≮.σ𝪦𞤷0; [B1, B5, P1, V5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+xn--4xa544kvid.xn--0-zmb55727aggma; ᷍σ≮.σ𝪦𞤷0; [B1, B5, V5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+xn--3xa744kvid.xn--0-xmb85727aggma; ᷍ς≮.ς𝪦𞤷0; [B1, B5, V5, V6]; xn--3xa744kvid.xn--0-xmb85727aggma; ; ;  # ᷍ς≮.ς𝪦𞤷0
+᷍σ≮.σ𝪦𞤕0; ᷍σ≮.σ𝪦𞤷0; [B1, B5, P1, V5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+᷍σ≮.σ𝪦𞤕0; ᷍σ≮.σ𝪦𞤷0; [B1, B5, P1, V5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+򢦾ßֹ𐫙.֭ࢡ; ; [B1, B5, B6, P1, V5, V6]; xn--zca89v339zj118e.xn--4cb62m; ; xn--ss-xjd6058xlz50g.xn--4cb62m;  # ßֹ𐫙.֭ࢡ
+򢦾SSֹ𐫙.֭ࢡ; 򢦾ssֹ𐫙.֭ࢡ; [B1, B5, B6, P1, V5, V6]; xn--ss-xjd6058xlz50g.xn--4cb62m; ; ;  # ssֹ𐫙.֭ࢡ
+򢦾ssֹ𐫙.֭ࢡ; ; [B1, B5, B6, P1, V5, V6]; xn--ss-xjd6058xlz50g.xn--4cb62m; ; ;  # ssֹ𐫙.֭ࢡ
+򢦾Ssֹ𐫙.֭ࢡ; 򢦾ssֹ𐫙.֭ࢡ; [B1, B5, B6, P1, V5, V6]; xn--ss-xjd6058xlz50g.xn--4cb62m; ; ;  # ssֹ𐫙.֭ࢡ
+xn--ss-xjd6058xlz50g.xn--4cb62m; 򢦾ssֹ𐫙.֭ࢡ; [B1, B5, B6, V5, V6]; xn--ss-xjd6058xlz50g.xn--4cb62m; ; ;  # ssֹ𐫙.֭ࢡ
+xn--zca89v339zj118e.xn--4cb62m; 򢦾ßֹ𐫙.֭ࢡ; [B1, B5, B6, V5, V6]; xn--zca89v339zj118e.xn--4cb62m; ; ;  # ßֹ𐫙.֭ࢡ
+-𞣄｡⒈; -𞣄.⒈; [B1, P1, V3, V6]; xn----xc8r.xn--tsh; ; ;  # -𞣄.⒈
+-𞣄。1.; -𞣄.1.; [B1, V3]; xn----xc8r.1.; ; ;  # -𞣄.1.
+xn----xc8r.1.; -𞣄.1.; [B1, V3]; xn----xc8r.1.; ; ;  # -𞣄.1.
+xn----xc8r.xn--tsh; -𞣄.⒈; [B1, V3, V6]; xn----xc8r.xn--tsh; ; ;  # -𞣄.⒈
+񈠢𐫖𝟡。ؾ𑘿; 񈠢𐫖9.ؾ𑘿; [B5, P1, V6]; xn--9-el5iv442t.xn--9gb0830l; ; ;  # 𐫖9.ؾ𑘿
+񈠢𐫖9。ؾ𑘿; 񈠢𐫖9.ؾ𑘿; [B5, P1, V6]; xn--9-el5iv442t.xn--9gb0830l; ; ;  # 𐫖9.ؾ𑘿
+xn--9-el5iv442t.xn--9gb0830l; 񈠢𐫖9.ؾ𑘿; [B5, V6]; xn--9-el5iv442t.xn--9gb0830l; ; ;  # 𐫖9.ؾ𑘿
+٨ﲌ٨ᩝ.‍; ٨نم٨ᩝ.‍; [B1, C2]; xn--hhbb5hc956w.xn--1ug; ; xn--hhbb5hc956w.; [B1] # ٨نم٨ᩝ.
+٨نم٨ᩝ.‍; ; [B1, C2]; xn--hhbb5hc956w.xn--1ug; ; xn--hhbb5hc956w.; [B1] # ٨نم٨ᩝ.
+xn--hhbb5hc956w.; ٨نم٨ᩝ.; [B1]; xn--hhbb5hc956w.; ; ;  # ٨نم٨ᩝ.
+xn--hhbb5hc956w.xn--1ug; ٨نم٨ᩝ.‍; [B1, C2]; xn--hhbb5hc956w.xn--1ug; ; ;  # ٨نم٨ᩝ.
+𝟘．Ⴇ󀳑ﵐ񫃱; 0.Ⴇ󀳑تجم񫃱; [B1, B5, P1, V6]; 0.xn--pgbe9e344c2725svff8b; ; ;  # 0.Ⴇتجم
+0.Ⴇ󀳑تجم񫃱; ; [B1, B5, P1, V6]; 0.xn--pgbe9e344c2725svff8b; ; ;  # 0.Ⴇتجم
+0.ⴇ󀳑تجم񫃱; ; [B1, B5, P1, V6]; 0.xn--pgbe9ez79qd207lvff8b; ; ;  # 0.ⴇتجم
+0.xn--pgbe9ez79qd207lvff8b; 0.ⴇ󀳑تجم񫃱; [B1, B5, V6]; 0.xn--pgbe9ez79qd207lvff8b; ; ;  # 0.ⴇتجم
+0.xn--pgbe9e344c2725svff8b; 0.Ⴇ󀳑تجم񫃱; [B1, B5, V6]; 0.xn--pgbe9e344c2725svff8b; ; ;  # 0.Ⴇتجم
+𝟘．ⴇ󀳑ﵐ񫃱; 0.ⴇ󀳑تجم񫃱; [B1, B5, P1, V6]; 0.xn--pgbe9ez79qd207lvff8b; ; ;  # 0.ⴇتجم
+𑇀▍.⁞ᠰ; ; [V5]; xn--9zh3057f.xn--j7e103b; ; ;  # 𑇀▍.⁞ᠰ
+xn--9zh3057f.xn--j7e103b; 𑇀▍.⁞ᠰ; [V5]; xn--9zh3057f.xn--j7e103b; ; ;  # 𑇀▍.⁞ᠰ
+‍-ٺ.򏯩; ; [B1, C2, P1, V6]; xn----qrc357q.xn--ts49b; ; xn----qrc.xn--ts49b; [B1, P1, V3, V6] # -ٺ.
+xn----qrc.xn--ts49b; -ٺ.򏯩; [B1, V3, V6]; xn----qrc.xn--ts49b; ; ;  # -ٺ.
+xn----qrc357q.xn--ts49b; ‍-ٺ.򏯩; [B1, C2, V6]; xn----qrc357q.xn--ts49b; ; ;  # -ٺ.
+ᠢ𐮂𐫘寐｡‌≯✳; ᠢ𐮂𐫘寐.‌≯✳; [B1, B5, C1, P1, V6]; xn--46e6675axzzhota.xn--0ug06gu8f; ; xn--46e6675axzzhota.xn--hdh99p; [B1, B5, P1, V6] # ᠢ𐮂𐫘寐.≯✳
+ᠢ𐮂𐫘寐｡‌≯✳; ᠢ𐮂𐫘寐.‌≯✳; [B1, B5, C1, P1, V6]; xn--46e6675axzzhota.xn--0ug06gu8f; ; xn--46e6675axzzhota.xn--hdh99p; [B1, B5, P1, V6] # ᠢ𐮂𐫘寐.≯✳
+ᠢ𐮂𐫘寐。‌≯✳; ᠢ𐮂𐫘寐.‌≯✳; [B1, B5, C1, P1, V6]; xn--46e6675axzzhota.xn--0ug06gu8f; ; xn--46e6675axzzhota.xn--hdh99p; [B1, B5, P1, V6] # ᠢ𐮂𐫘寐.≯✳
+ᠢ𐮂𐫘寐。‌≯✳; ᠢ𐮂𐫘寐.‌≯✳; [B1, B5, C1, P1, V6]; xn--46e6675axzzhota.xn--0ug06gu8f; ; xn--46e6675axzzhota.xn--hdh99p; [B1, B5, P1, V6] # ᠢ𐮂𐫘寐.≯✳
+xn--46e6675axzzhota.xn--hdh99p; ᠢ𐮂𐫘寐.≯✳; [B1, B5, V6]; xn--46e6675axzzhota.xn--hdh99p; ; ;  # ᠢ𐮂𐫘寐.≯✳
+xn--46e6675axzzhota.xn--0ug06gu8f; ᠢ𐮂𐫘寐.‌≯✳; [B1, B5, C1, V6]; xn--46e6675axzzhota.xn--0ug06gu8f; ; ;  # ᠢ𐮂𐫘寐.≯✳
+‍｡󸲜ႺႴ𞨇; ‍.󸲜ႺႴ𞨇; [B1, B5, B6, C2, P1, V6]; xn--1ug.xn--sndl01647an3h1h; ; .xn--sndl01647an3h1h; [B5, B6, P1, V6, A4_2] # .ႺႴ
+‍。󸲜ႺႴ𞨇; ‍.󸲜ႺႴ𞨇; [B1, B5, B6, C2, P1, V6]; xn--1ug.xn--sndl01647an3h1h; ; .xn--sndl01647an3h1h; [B5, B6, P1, V6, A4_2] # .ႺႴ
+‍。󸲜ⴚⴔ𞨇; ‍.󸲜ⴚⴔ𞨇; [B1, B5, B6, C2, P1, V6]; xn--1ug.xn--cljl81825an3r4h; ; .xn--cljl81825an3r4h; [B5, B6, P1, V6, A4_2] # .ⴚⴔ
+‍。󸲜Ⴚⴔ𞨇; ‍.󸲜Ⴚⴔ𞨇; [B1, B5, B6, C2, P1, V6]; xn--1ug.xn--ynd036lq981an3r4h; ; .xn--ynd036lq981an3r4h; [B5, B6, P1, V6, A4_2] # .Ⴚⴔ
+.xn--ynd036lq981an3r4h; .󸲜Ⴚⴔ𞨇; [B5, B6, V6, X4_2]; .xn--ynd036lq981an3r4h; [B5, B6, V6, A4_2]; ;  # .Ⴚⴔ
+xn--1ug.xn--ynd036lq981an3r4h; ‍.󸲜Ⴚⴔ𞨇; [B1, B5, B6, C2, V6]; xn--1ug.xn--ynd036lq981an3r4h; ; ;  # .Ⴚⴔ
+.xn--cljl81825an3r4h; .󸲜ⴚⴔ𞨇; [B5, B6, V6, X4_2]; .xn--cljl81825an3r4h; [B5, B6, V6, A4_2]; ;  # .ⴚⴔ
+xn--1ug.xn--cljl81825an3r4h; ‍.󸲜ⴚⴔ𞨇; [B1, B5, B6, C2, V6]; xn--1ug.xn--cljl81825an3r4h; ; ;  # .ⴚⴔ
+.xn--sndl01647an3h1h; .󸲜ႺႴ𞨇; [B5, B6, V6, X4_2]; .xn--sndl01647an3h1h; [B5, B6, V6, A4_2]; ;  # .ႺႴ
+xn--1ug.xn--sndl01647an3h1h; ‍.󸲜ႺႴ𞨇; [B1, B5, B6, C2, V6]; xn--1ug.xn--sndl01647an3h1h; ; ;  # .ႺႴ
+‍｡󸲜ⴚⴔ𞨇; ‍.󸲜ⴚⴔ𞨇; [B1, B5, B6, C2, P1, V6]; xn--1ug.xn--cljl81825an3r4h; ; .xn--cljl81825an3r4h; [B5, B6, P1, V6, A4_2] # .ⴚⴔ
+‍｡󸲜Ⴚⴔ𞨇; ‍.󸲜Ⴚⴔ𞨇; [B1, B5, B6, C2, P1, V6]; xn--1ug.xn--ynd036lq981an3r4h; ; .xn--ynd036lq981an3r4h; [B5, B6, P1, V6, A4_2] # .Ⴚⴔ
+-3.‍ヌᢕ; ; [C2, V3]; -3.xn--fbf739aq5o; ; -3.xn--fbf115j; [V3] # -3.ヌᢕ
+-3.xn--fbf115j; -3.ヌᢕ; [V3]; -3.xn--fbf115j; ; ;  # -3.ヌᢕ
+-3.xn--fbf739aq5o; -3.‍ヌᢕ; [C2, V3]; -3.xn--fbf739aq5o; ; ;  # -3.ヌᢕ
+🂃٦ß‍。󠠂򭰍𞩒-; 🂃٦ß‍.󠠂򭰍𞩒-; [B1, C2, P1, V3, V6]; xn--zca34z68yzu83b.xn----nz8rh7531csznt; ; xn--ss-pyd98921c.xn----nz8rh7531csznt; [B1, P1, V3, V6] # 🂃٦ß.-
+🂃٦SS‍。󠠂򭰍𞩒-; 🂃٦ss‍.󠠂򭰍𞩒-; [B1, C2, P1, V3, V6]; xn--ss-pyd483x5k99b.xn----nz8rh7531csznt; ; xn--ss-pyd98921c.xn----nz8rh7531csznt; [B1, P1, V3, V6] # 🂃٦ss.-
+🂃٦ss‍。󠠂򭰍𞩒-; 🂃٦ss‍.󠠂򭰍𞩒-; [B1, C2, P1, V3, V6]; xn--ss-pyd483x5k99b.xn----nz8rh7531csznt; ; xn--ss-pyd98921c.xn----nz8rh7531csznt; [B1, P1, V3, V6] # 🂃٦ss.-
+xn--ss-pyd98921c.xn----nz8rh7531csznt; 🂃٦ss.󠠂򭰍𞩒-; [B1, V3, V6]; xn--ss-pyd98921c.xn----nz8rh7531csznt; ; ;  # 🂃٦ss.-
+xn--ss-pyd483x5k99b.xn----nz8rh7531csznt; 🂃٦ss‍.󠠂򭰍𞩒-; [B1, C2, V3, V6]; xn--ss-pyd483x5k99b.xn----nz8rh7531csznt; ; ;  # 🂃٦ss.-
+xn--zca34z68yzu83b.xn----nz8rh7531csznt; 🂃٦ß‍.󠠂򭰍𞩒-; [B1, C2, V3, V6]; xn--zca34z68yzu83b.xn----nz8rh7531csznt; ; ;  # 🂃٦ß.-
+🂃٦Ss‍。󠠂򭰍𞩒-; 🂃٦ss‍.󠠂򭰍𞩒-; [B1, C2, P1, V3, V6]; xn--ss-pyd483x5k99b.xn----nz8rh7531csznt; ; xn--ss-pyd98921c.xn----nz8rh7531csznt; [B1, P1, V3, V6] # 🂃٦ss.-
+ꇟ-𐾺ڟ。򰀺‌; ꇟ-𐾺ڟ.򰀺‌; [B5, B6, C1, P1, V6]; xn----utc4430jd3zd.xn--0ugx6670i; ; xn----utc4430jd3zd.xn--bp20d; [B5, B6, P1, V6] # ꇟ-ڟ.
+xn----utc4430jd3zd.xn--bp20d; ꇟ-𐾺ڟ.򰀺; [B5, B6, V6]; xn----utc4430jd3zd.xn--bp20d; ; ;  # ꇟ-ڟ.
+xn----utc4430jd3zd.xn--0ugx6670i; ꇟ-𐾺ڟ.򰀺‌; [B5, B6, C1, V6]; xn----utc4430jd3zd.xn--0ugx6670i; ; ;  # ꇟ-ڟ.
+٥.҄𐨗𝩋𴤃; ; [B1, P1, V5, V6]; xn--eib.xn--n3a0405kus8eft5l; ; ;  # ٥.҄𐨗𝩋
+xn--eib.xn--n3a0405kus8eft5l; ٥.҄𐨗𝩋𴤃; [B1, V5, V6]; xn--eib.xn--n3a0405kus8eft5l; ; ;  # ٥.҄𐨗𝩋
+-.񱼓ى𐨿; ; [B1, B5, B6, P1, V3, V6]; -.xn--lhb4124khbq4b; ; ;  # -.ى𐨿
+-.xn--lhb4124khbq4b; -.񱼓ى𐨿; [B1, B5, B6, V3, V6]; -.xn--lhb4124khbq4b; ; ;  # -.ى𐨿
+󾬨ς.𞶙녫ß; ; [B2, B3, P1, V6]; xn--3xa96659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # ς.녫ß
+󾬨ς.𞶙녫ß; 󾬨ς.𞶙녫ß; [B2, B3, P1, V6]; xn--3xa96659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # ς.녫ß
+󾬨Σ.𞶙녫SS; 󾬨σ.𞶙녫ss; [B2, B3, P1, V6]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫SS; 󾬨σ.𞶙녫ss; [B2, B3, P1, V6]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨σ.𞶙녫ss; ; [B2, B3, P1, V6]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨σ.𞶙녫ss; 󾬨σ.𞶙녫ss; [B2, B3, P1, V6]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫ss; 󾬨σ.𞶙녫ss; [B2, B3, P1, V6]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫ss; 󾬨σ.𞶙녫ss; [B2, B3, P1, V6]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫Ss; 󾬨σ.𞶙녫ss; [B2, B3, P1, V6]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫Ss; 󾬨σ.𞶙녫ss; [B2, B3, P1, V6]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+xn--4xa76659r.xn--ss-d64i8755h; 󾬨σ.𞶙녫ss; [B2, B3, V6]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫ß; 󾬨σ.𞶙녫ß; [B2, B3, P1, V6]; xn--4xa76659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # σ.녫ß
+󾬨Σ.𞶙녫ß; 󾬨σ.𞶙녫ß; [B2, B3, P1, V6]; xn--4xa76659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # σ.녫ß
+󾬨σ.𞶙녫ß; ; [B2, B3, P1, V6]; xn--4xa76659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # σ.녫ß
+󾬨σ.𞶙녫ß; 󾬨σ.𞶙녫ß; [B2, B3, P1, V6]; xn--4xa76659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # σ.녫ß
+xn--4xa76659r.xn--zca5051g4h4i; 󾬨σ.𞶙녫ß; [B2, B3, V6]; xn--4xa76659r.xn--zca5051g4h4i; ; ;  # σ.녫ß
+xn--3xa96659r.xn--zca5051g4h4i; 󾬨ς.𞶙녫ß; [B2, B3, V6]; xn--3xa96659r.xn--zca5051g4h4i; ; ;  # ς.녫ß
+Ⅎ្‍｡≠‍‌; Ⅎ្‍.≠‍‌; [C1, C2, P1, V6]; xn--u4e823bcza.xn--0ugb89o; ; xn--u4e319b.xn--1ch; [P1, V6] # Ⅎ្.≠
+Ⅎ្‍｡≠‍‌; Ⅎ្‍.≠‍‌; [C1, C2, P1, V6]; xn--u4e823bcza.xn--0ugb89o; ; xn--u4e319b.xn--1ch; [P1, V6] # Ⅎ្.≠
+Ⅎ្‍。≠‍‌; Ⅎ្‍.≠‍‌; [C1, C2, P1, V6]; xn--u4e823bcza.xn--0ugb89o; ; xn--u4e319b.xn--1ch; [P1, V6] # Ⅎ្.≠
+Ⅎ្‍。≠‍‌; Ⅎ្‍.≠‍‌; [C1, C2, P1, V6]; xn--u4e823bcza.xn--0ugb89o; ; xn--u4e319b.xn--1ch; [P1, V6] # Ⅎ្.≠
+ⅎ្‍。≠‍‌; ⅎ្‍.≠‍‌; [C1, C2, P1, V6]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [P1, V6] # ⅎ្.≠
+ⅎ្‍。≠‍‌; ⅎ្‍.≠‍‌; [C1, C2, P1, V6]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [P1, V6] # ⅎ្.≠
+xn--u4e969b.xn--1ch; ⅎ្.≠; [V6]; xn--u4e969b.xn--1ch; ; ;  # ⅎ្.≠
+xn--u4e823bq1a.xn--0ugb89o; ⅎ្‍.≠‍‌; [C1, C2, V6]; xn--u4e823bq1a.xn--0ugb89o; ; ;  # ⅎ្.≠
+xn--u4e319b.xn--1ch; Ⅎ្.≠; [V6]; xn--u4e319b.xn--1ch; ; ;  # Ⅎ្.≠
+xn--u4e823bcza.xn--0ugb89o; Ⅎ្‍.≠‍‌; [C1, C2, V6]; xn--u4e823bcza.xn--0ugb89o; ; ;  # Ⅎ្.≠
+ⅎ្‍｡≠‍‌; ⅎ្‍.≠‍‌; [C1, C2, P1, V6]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [P1, V6] # ⅎ្.≠
+ⅎ្‍｡≠‍‌; ⅎ្‍.≠‍‌; [C1, C2, P1, V6]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [P1, V6] # ⅎ្.≠
+𐋺꫶꥓󧦉．‌᜔ڏ; 𐋺꫶꥓󧦉.‌᜔ڏ; [B1, C1, P1, V6]; xn--3j9a14ak27osbz2o.xn--ljb175f1wg; ; xn--3j9a14ak27osbz2o.xn--ljb175f; [B1, P1, V5, V6] # 𐋺꫶꥓.᜔ڏ
+𐋺꫶꥓󧦉.‌᜔ڏ; ; [B1, C1, P1, V6]; xn--3j9a14ak27osbz2o.xn--ljb175f1wg; ; xn--3j9a14ak27osbz2o.xn--ljb175f; [B1, P1, V5, V6] # 𐋺꫶꥓.᜔ڏ
+xn--3j9a14ak27osbz2o.xn--ljb175f; 𐋺꫶꥓󧦉.᜔ڏ; [B1, V5, V6]; xn--3j9a14ak27osbz2o.xn--ljb175f; ; ;  # 𐋺꫶꥓.᜔ڏ
+xn--3j9a14ak27osbz2o.xn--ljb175f1wg; 𐋺꫶꥓󧦉.‌᜔ڏ; [B1, C1, V6]; xn--3j9a14ak27osbz2o.xn--ljb175f1wg; ; ;  # 𐋺꫶꥓.᜔ڏ
+񺔯ྨ．≯; 񺔯ྨ.≯; [P1, V6]; xn--4fd57150h.xn--hdh; ; ;  # ྨ.≯
+񺔯ྨ．≯; 񺔯ྨ.≯; [P1, V6]; xn--4fd57150h.xn--hdh; ; ;  # ྨ.≯
+񺔯ྨ.≯; ; [P1, V6]; xn--4fd57150h.xn--hdh; ; ;  # ྨ.≯
+񺔯ྨ.≯; 񺔯ྨ.≯; [P1, V6]; xn--4fd57150h.xn--hdh; ; ;  # ྨ.≯
+xn--4fd57150h.xn--hdh; 񺔯ྨ.≯; [V6]; xn--4fd57150h.xn--hdh; ; ;  # ྨ.≯
+‍𞡄Ⴓ．𐇽; ‍𞡄Ⴓ.𐇽; [B1, B3, B6, C2, P1, V5, V6]; xn--rnd379ex885a.xn--m27c; ; xn--rnd5552v.xn--m27c; [B1, B2, B3, B6, P1, V5, V6] # 𞡄Ⴓ.𐇽
+‍𞡄Ⴓ.𐇽; ; [B1, B3, B6, C2, P1, V5, V6]; xn--rnd379ex885a.xn--m27c; ; xn--rnd5552v.xn--m27c; [B1, B2, B3, B6, P1, V5, V6] # 𞡄Ⴓ.𐇽
+‍𞡄ⴓ.𐇽; ; [B1, B3, B6, C2, V5]; xn--1ugz52c4i16a.xn--m27c; ; xn--blj7492l.xn--m27c; [B1, B2, B3, B6, V5] # 𞡄ⴓ.𐇽
+xn--blj7492l.xn--m27c; 𞡄ⴓ.𐇽; [B1, B2, B3, B6, V5]; xn--blj7492l.xn--m27c; ; ;  # 𞡄ⴓ.𐇽
+xn--1ugz52c4i16a.xn--m27c; ‍𞡄ⴓ.𐇽; [B1, B3, B6, C2, V5]; xn--1ugz52c4i16a.xn--m27c; ; ;  # 𞡄ⴓ.𐇽
+xn--rnd5552v.xn--m27c; 𞡄Ⴓ.𐇽; [B1, B2, B3, B6, V5, V6]; xn--rnd5552v.xn--m27c; ; ;  # 𞡄Ⴓ.𐇽
+xn--rnd379ex885a.xn--m27c; ‍𞡄Ⴓ.𐇽; [B1, B3, B6, C2, V5, V6]; xn--rnd379ex885a.xn--m27c; ; ;  # 𞡄Ⴓ.𐇽
+‍𞡄ⴓ．𐇽; ‍𞡄ⴓ.𐇽; [B1, B3, B6, C2, V5]; xn--1ugz52c4i16a.xn--m27c; ; xn--blj7492l.xn--m27c; [B1, B2, B3, B6, V5] # 𞡄ⴓ.𐇽
+𐪒ß꣪．ᡤ; 𐪒ß꣪.ᡤ; [B2, B3]; xn--zca2517f2hvc.xn--08e; ; xn--ss-tu9hw933a.xn--08e;  # 𐪒ß꣪.ᡤ
+𐪒ß꣪.ᡤ; ; [B2, B3]; xn--zca2517f2hvc.xn--08e; ; xn--ss-tu9hw933a.xn--08e;  # 𐪒ß꣪.ᡤ
+𐪒SS꣪.ᡤ; 𐪒ss꣪.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+𐪒ss꣪.ᡤ; ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+xn--ss-tu9hw933a.xn--08e; 𐪒ss꣪.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+xn--zca2517f2hvc.xn--08e; 𐪒ß꣪.ᡤ; [B2, B3]; xn--zca2517f2hvc.xn--08e; ; ;  # 𐪒ß꣪.ᡤ
+𐪒SS꣪．ᡤ; 𐪒ss꣪.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+𐪒ss꣪．ᡤ; 𐪒ss꣪.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+𐪒Ss꣪.ᡤ; 𐪒ss꣪.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+𐪒Ss꣪．ᡤ; 𐪒ss꣪.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+𐨿󠆌鸮𑚶.ς; 𐨿鸮𑚶.ς; [V5]; xn--l76a726rt2h.xn--3xa; ; xn--l76a726rt2h.xn--4xa;  # 𐨿鸮𑚶.ς
+𐨿󠆌鸮𑚶.Σ; 𐨿鸮𑚶.σ; [V5]; xn--l76a726rt2h.xn--4xa; ; ;  # 𐨿鸮𑚶.σ
+𐨿󠆌鸮𑚶.σ; 𐨿鸮𑚶.σ; [V5]; xn--l76a726rt2h.xn--4xa; ; ;  # 𐨿鸮𑚶.σ
+xn--l76a726rt2h.xn--4xa; 𐨿鸮𑚶.σ; [V5]; xn--l76a726rt2h.xn--4xa; ; ;  # 𐨿鸮𑚶.σ
+xn--l76a726rt2h.xn--3xa; 𐨿鸮𑚶.ς; [V5]; xn--l76a726rt2h.xn--3xa; ; ;  # 𐨿鸮𑚶.ς
+⒗𞤬。-𑚶; ⒗𞤬.-𑚶; [B1, P1, V3, V6]; xn--8shw466n.xn----4j0j; ; ;  # ⒗𞤬.-𑚶
+16.𞤬。-𑚶; 16.𞤬.-𑚶; [B1, V3]; 16.xn--ke6h.xn----4j0j; ; ;  # 16.𞤬.-𑚶
+16.𞤊。-𑚶; 16.𞤬.-𑚶; [B1, V3]; 16.xn--ke6h.xn----4j0j; ; ;  # 16.𞤬.-𑚶
+16.xn--ke6h.xn----4j0j; 16.𞤬.-𑚶; [B1, V3]; 16.xn--ke6h.xn----4j0j; ; ;  # 16.𞤬.-𑚶
+⒗𞤊。-𑚶; ⒗𞤬.-𑚶; [B1, P1, V3, V6]; xn--8shw466n.xn----4j0j; ; ;  # ⒗𞤬.-𑚶
+xn--8shw466n.xn----4j0j; ⒗𞤬.-𑚶; [B1, V3, V6]; xn--8shw466n.xn----4j0j; ; ;  # ⒗𞤬.-𑚶
+ࢳ𞤿⾫｡𐹣ڏ⒈; ࢳ𞤿隹.𐹣ڏ⒈; [B1, B2, B3, P1, V6]; xn--8yb0383efiwk.xn--ljb064mol4n; ; ;  # ࢳ𞤿隹.𐹣ڏ⒈
+ࢳ𞤿隹。𐹣ڏ1.; ࢳ𞤿隹.𐹣ڏ1.; [B1, B2, B3]; xn--8yb0383efiwk.xn--1-wsc3373r.; ; ;  # ࢳ𞤿隹.𐹣ڏ1.
+ࢳ𞤝隹。𐹣ڏ1.; ࢳ𞤿隹.𐹣ڏ1.; [B1, B2, B3]; xn--8yb0383efiwk.xn--1-wsc3373r.; ; ;  # ࢳ𞤿隹.𐹣ڏ1.
+xn--8yb0383efiwk.xn--1-wsc3373r.; ࢳ𞤿隹.𐹣ڏ1.; [B1, B2, B3]; xn--8yb0383efiwk.xn--1-wsc3373r.; ; ;  # ࢳ𞤿隹.𐹣ڏ1.
+ࢳ𞤝⾫｡𐹣ڏ⒈; ࢳ𞤿隹.𐹣ڏ⒈; [B1, B2, B3, P1, V6]; xn--8yb0383efiwk.xn--ljb064mol4n; ; ;  # ࢳ𞤿隹.𐹣ڏ⒈
+xn--8yb0383efiwk.xn--ljb064mol4n; ࢳ𞤿隹.𐹣ڏ⒈; [B1, B2, B3, V6]; xn--8yb0383efiwk.xn--ljb064mol4n; ; ;  # ࢳ𞤿隹.𐹣ڏ⒈
+␳𚎛𝟧١.ᡢ8ི؀; ␳𚎛5١.ᡢ8ི؀; [B5, B6, P1, V6]; xn--5-bqc410un435a.xn--8-rkc763epjj; ; ;  # 5١.ᡢ8ི
+␳𚎛5١.ᡢ8ི؀; ; [B5, B6, P1, V6]; xn--5-bqc410un435a.xn--8-rkc763epjj; ; ;  # 5١.ᡢ8ི
+xn--5-bqc410un435a.xn--8-rkc763epjj; ␳𚎛5١.ᡢ8ི؀; [B5, B6, V6]; xn--5-bqc410un435a.xn--8-rkc763epjj; ; ;  # 5١.ᡢ8ི
+𐹠.🄀⒒-󨰈; ; [B1, P1, V6]; xn--7n0d.xn----xcp9757q1s13g; ; ;  # 𐹠.🄀⒒-
+𐹠.0.11.-󨰈; ; [B1, P1, V3, V6]; xn--7n0d.0.11.xn----8j07m; ; ;  # 𐹠.0.11.-
+xn--7n0d.0.11.xn----8j07m; 𐹠.0.11.-󨰈; [B1, V3, V6]; xn--7n0d.0.11.xn----8j07m; ; ;  # 𐹠.0.11.-
+xn--7n0d.xn----xcp9757q1s13g; 𐹠.🄀⒒-󨰈; [B1, V6]; xn--7n0d.xn----xcp9757q1s13g; ; ;  # 𐹠.🄀⒒-
+ς-。‌𝟭-; ς-.‌1-; [C1, V3]; xn----xmb.xn--1--i1t; ; xn----zmb.1-; [V3] # ς-.1-
+ς-。‌1-; ς-.‌1-; [C1, V3]; xn----xmb.xn--1--i1t; ; xn----zmb.1-; [V3] # ς-.1-
+Σ-。‌1-; σ-.‌1-; [C1, V3]; xn----zmb.xn--1--i1t; ; xn----zmb.1-; [V3] # σ-.1-
+σ-。‌1-; σ-.‌1-; [C1, V3]; xn----zmb.xn--1--i1t; ; xn----zmb.1-; [V3] # σ-.1-
+xn----zmb.1-; σ-.1-; [V3]; xn----zmb.1-; ; ;  # σ-.1-
+xn----zmb.xn--1--i1t; σ-.‌1-; [C1, V3]; xn----zmb.xn--1--i1t; ; ;  # σ-.1-
+xn----xmb.xn--1--i1t; ς-.‌1-; [C1, V3]; xn----xmb.xn--1--i1t; ; ;  # ς-.1-
+Σ-。‌𝟭-; σ-.‌1-; [C1, V3]; xn----zmb.xn--1--i1t; ; xn----zmb.1-; [V3] # σ-.1-
+σ-。‌𝟭-; σ-.‌1-; [C1, V3]; xn----zmb.xn--1--i1t; ; xn----zmb.1-; [V3] # σ-.1-
+᜴-ೢ．󠄩Ⴄ; ᜴-ೢ.Ⴄ; [P1, V5, V6]; xn----ggf830f.xn--cnd; ; ;  # ᜴-ೢ.Ⴄ
+᜴-ೢ.󠄩Ⴄ; ᜴-ೢ.Ⴄ; [P1, V5, V6]; xn----ggf830f.xn--cnd; ; ;  # ᜴-ೢ.Ⴄ
+᜴-ೢ.󠄩ⴄ; ᜴-ೢ.ⴄ; [V5]; xn----ggf830f.xn--vkj; ; ;  # ᜴-ೢ.ⴄ
+xn----ggf830f.xn--vkj; ᜴-ೢ.ⴄ; [V5]; xn----ggf830f.xn--vkj; ; ;  # ᜴-ೢ.ⴄ
+xn----ggf830f.xn--cnd; ᜴-ೢ.Ⴄ; [V5, V6]; xn----ggf830f.xn--cnd; ; ;  # ᜴-ೢ.Ⴄ
+᜴-ೢ．󠄩ⴄ; ᜴-ೢ.ⴄ; [V5]; xn----ggf830f.xn--vkj; ; ;  # ᜴-ೢ.ⴄ
+򭈗♋ڻ𐦥｡॔⒈; 򭈗♋ڻ𐦥.॔⒈; [B1, B5, B6, P1, V5, V6]; xn--ukb372n129m3rs7f.xn--u3b240l; ; ;  # ♋ڻ𐦥.॔⒈
+򭈗♋ڻ𐦥。॔1.; 򭈗♋ڻ𐦥.॔1.; [B1, B5, B6, P1, V5, V6]; xn--ukb372n129m3rs7f.xn--1-fyd.; ; ;  # ♋ڻ𐦥.॔1.
+xn--ukb372n129m3rs7f.xn--1-fyd.; 򭈗♋ڻ𐦥.॔1.; [B1, B5, B6, V5, V6]; xn--ukb372n129m3rs7f.xn--1-fyd.; ; ;  # ♋ڻ𐦥.॔1.
+xn--ukb372n129m3rs7f.xn--u3b240l; 򭈗♋ڻ𐦥.॔⒈; [B1, B5, B6, V5, V6]; xn--ukb372n129m3rs7f.xn--u3b240l; ; ;  # ♋ڻ𐦥.॔⒈
+֤．ہ᪳‌; ֤.ہ᪳‌; [B1, B3, B6, C1, V5]; xn--vcb.xn--0kb623hm1d; ; xn--vcb.xn--0kb623h; [B1, B3, B6, V5] # ֤.ہ᪳
+֤.ہ᪳‌; ; [B1, B3, B6, C1, V5]; xn--vcb.xn--0kb623hm1d; ; xn--vcb.xn--0kb623h; [B1, B3, B6, V5] # ֤.ہ᪳
+xn--vcb.xn--0kb623h; ֤.ہ᪳; [B1, B3, B6, V5]; xn--vcb.xn--0kb623h; ; ;  # ֤.ہ᪳
+xn--vcb.xn--0kb623hm1d; ֤.ہ᪳‌; [B1, B3, B6, C1, V5]; xn--vcb.xn--0kb623hm1d; ; ;  # ֤.ہ᪳
+񢭏ࡆ≮્．𞦊; 񢭏ࡆ≮્.𞦊; [B5, B6, P1, V6]; xn--4vb80kq29ayo62l.xn--8g6h; ; ;  # ࡆ≮્.
+񢭏ࡆ≮્．𞦊; 񢭏ࡆ≮્.𞦊; [B5, B6, P1, V6]; xn--4vb80kq29ayo62l.xn--8g6h; ; ;  # ࡆ≮્.
+񢭏ࡆ≮્.𞦊; ; [B5, B6, P1, V6]; xn--4vb80kq29ayo62l.xn--8g6h; ; ;  # ࡆ≮્.
+񢭏ࡆ≮્.𞦊; 񢭏ࡆ≮્.𞦊; [B5, B6, P1, V6]; xn--4vb80kq29ayo62l.xn--8g6h; ; ;  # ࡆ≮્.
+xn--4vb80kq29ayo62l.xn--8g6h; 񢭏ࡆ≮્.𞦊; [B5, B6, V6]; xn--4vb80kq29ayo62l.xn--8g6h; ; ;  # ࡆ≮્.
+‍。𞀘⒈ꡍ擉; ‍.𞀘⒈ꡍ擉; [C2, P1, V5, V6]; xn--1ug.xn--tsh026uql4bew9p; ; .xn--tsh026uql4bew9p; [P1, V5, V6, A4_2] # .𞀘⒈ꡍ擉
+‍。𞀘1.ꡍ擉; ‍.𞀘1.ꡍ擉; [C2, V5]; xn--1ug.xn--1-1p4r.xn--s7uv61m; ; .xn--1-1p4r.xn--s7uv61m; [V5, A4_2] # .𞀘1.ꡍ擉
+.xn--1-1p4r.xn--s7uv61m; .𞀘1.ꡍ擉; [V5, X4_2]; .xn--1-1p4r.xn--s7uv61m; [V5, A4_2]; ;  # .𞀘1.ꡍ擉
+xn--1ug.xn--1-1p4r.xn--s7uv61m; ‍.𞀘1.ꡍ擉; [C2, V5]; xn--1ug.xn--1-1p4r.xn--s7uv61m; ; ;  # .𞀘1.ꡍ擉
+.xn--tsh026uql4bew9p; .𞀘⒈ꡍ擉; [V5, V6, X4_2]; .xn--tsh026uql4bew9p; [V5, V6, A4_2]; ;  # .𞀘⒈ꡍ擉
+xn--1ug.xn--tsh026uql4bew9p; ‍.𞀘⒈ꡍ擉; [C2, V5, V6]; xn--1ug.xn--tsh026uql4bew9p; ; ;  # .𞀘⒈ꡍ擉
+₈ߋ．ﭤ≠; 8ߋ.ٿ≠; [B1, B3, P1, V6]; xn--8-zbd.xn--4ib883l; ; ;  # 8ߋ.ٿ≠
+₈ߋ．ﭤ≠; 8ߋ.ٿ≠; [B1, B3, P1, V6]; xn--8-zbd.xn--4ib883l; ; ;  # 8ߋ.ٿ≠
+8ߋ.ٿ≠; ; [B1, B3, P1, V6]; xn--8-zbd.xn--4ib883l; ; ;  # 8ߋ.ٿ≠
+8ߋ.ٿ≠; 8ߋ.ٿ≠; [B1, B3, P1, V6]; xn--8-zbd.xn--4ib883l; ; ;  # 8ߋ.ٿ≠
+xn--8-zbd.xn--4ib883l; 8ߋ.ٿ≠; [B1, B3, V6]; xn--8-zbd.xn--4ib883l; ; ;  # 8ߋ.ٿ≠
+ᢡߞ򹐣.⒒ق𑍦; ; [B1, B5, P1, V6]; xn--5sb596fi873t.xn--ehb336mvy7n; ; ;  # ᢡߞ.⒒ق𑍦
+ᢡߞ򹐣.11.ق𑍦; ; [B1, B5, P1, V6]; xn--5sb596fi873t.11.xn--ehb4198k; ; ;  # ᢡߞ.11.ق𑍦
+xn--5sb596fi873t.11.xn--ehb4198k; ᢡߞ򹐣.11.ق𑍦; [B1, B5, V6]; xn--5sb596fi873t.11.xn--ehb4198k; ; ;  # ᢡߞ.11.ق𑍦
+xn--5sb596fi873t.xn--ehb336mvy7n; ᢡߞ򹐣.⒒ق𑍦; [B1, B5, V6]; xn--5sb596fi873t.xn--ehb336mvy7n; ; ;  # ᢡߞ.⒒ق𑍦
+่-𐹺𝟜.ͣۡ⒏; ่-𐹺4.ͣۡ⒏; [B1, P1, V5, V6]; xn---4-owiz479s.xn--eva20pjv9a; ; ;  # ่-𐹺4.ͣۡ⒏
+่-𐹺4.ͣۡ8.; ; [B1, V5]; xn---4-owiz479s.xn--8-ihb69x.; ; ;  # ่-𐹺4.ͣۡ8.
+xn---4-owiz479s.xn--8-ihb69x.; ่-𐹺4.ͣۡ8.; [B1, V5]; xn---4-owiz479s.xn--8-ihb69x.; ; ;  # ่-𐹺4.ͣۡ8.
+xn---4-owiz479s.xn--eva20pjv9a; ่-𐹺4.ͣۡ⒏; [B1, V5, V6]; xn---4-owiz479s.xn--eva20pjv9a; ; ;  # ่-𐹺4.ͣۡ⒏
+⫐｡Ⴠ-󃐢; ⫐.Ⴠ-󃐢; [P1, V6]; xn--r3i.xn----z1g58579u; ; ;  # ⫐.Ⴠ-
+⫐。Ⴠ-󃐢; ⫐.Ⴠ-󃐢; [P1, V6]; xn--r3i.xn----z1g58579u; ; ;  # ⫐.Ⴠ-
+⫐。ⴠ-󃐢; ⫐.ⴠ-󃐢; [P1, V6]; xn--r3i.xn----2wst7439i; ; ;  # ⫐.ⴠ-
+xn--r3i.xn----2wst7439i; ⫐.ⴠ-󃐢; [V6]; xn--r3i.xn----2wst7439i; ; ;  # ⫐.ⴠ-
+xn--r3i.xn----z1g58579u; ⫐.Ⴠ-󃐢; [V6]; xn--r3i.xn----z1g58579u; ; ;  # ⫐.Ⴠ-
+⫐｡ⴠ-󃐢; ⫐.ⴠ-󃐢; [P1, V6]; xn--r3i.xn----2wst7439i; ; ;  # ⫐.ⴠ-
+𑑂◊．⦟∠; 𑑂◊.⦟∠; [V5]; xn--01h3338f.xn--79g270a; ; ;  # 𑑂◊.⦟∠
+𑑂◊.⦟∠; ; [V5]; xn--01h3338f.xn--79g270a; ; ;  # 𑑂◊.⦟∠
+xn--01h3338f.xn--79g270a; 𑑂◊.⦟∠; [V5]; xn--01h3338f.xn--79g270a; ; ;  # 𑑂◊.⦟∠
+𿌰-٢。󋸛ꡂ; 𿌰-٢.󋸛ꡂ; [B5, B6, P1, V6]; xn----dqc20828e.xn--bc9an2879c; ; ;  # -٢.ꡂ
+xn----dqc20828e.xn--bc9an2879c; 𿌰-٢.󋸛ꡂ; [B5, B6, V6]; xn----dqc20828e.xn--bc9an2879c; ; ;  # -٢.ꡂ
+ٸ。󠏬݁𞪭𐹪; يٴ.󠏬݁𞪭𐹪; [B1, P1, V6]; xn--mhb8f.xn--oob2585kfdsfsbo7h; ; ;  # يٴ.݁𐹪
+يٴ。󠏬݁𞪭𐹪; يٴ.󠏬݁𞪭𐹪; [B1, P1, V6]; xn--mhb8f.xn--oob2585kfdsfsbo7h; ; ;  # يٴ.݁𐹪
+xn--mhb8f.xn--oob2585kfdsfsbo7h; يٴ.󠏬݁𞪭𐹪; [B1, V6]; xn--mhb8f.xn--oob2585kfdsfsbo7h; ; ;  # يٴ.݁𐹪
+𐫆ꌄ｡‍ᣬ; 𐫆ꌄ.‍ᣬ; [B1, B2, B3, C2]; xn--y77ao18q.xn--wdf367a; ; xn--y77ao18q.xn--wdf; [B2, B3] # 𐫆ꌄ.ᣬ
+𐫆ꌄ。‍ᣬ; 𐫆ꌄ.‍ᣬ; [B1, B2, B3, C2]; xn--y77ao18q.xn--wdf367a; ; xn--y77ao18q.xn--wdf; [B2, B3] # 𐫆ꌄ.ᣬ
+xn--y77ao18q.xn--wdf; 𐫆ꌄ.ᣬ; [B2, B3]; xn--y77ao18q.xn--wdf; ; ;  # 𐫆ꌄ.ᣬ
+xn--y77ao18q.xn--wdf367a; 𐫆ꌄ.‍ᣬ; [B1, B2, B3, C2]; xn--y77ao18q.xn--wdf367a; ; ;  # 𐫆ꌄ.ᣬ
+₀٢。󅪞≯-; 0٢.󅪞≯-; [B1, B6, P1, V3, V6]; xn--0-dqc.xn----ogov3342l; ; ;  # 0٢.≯-
+₀٢。󅪞≯-; 0٢.󅪞≯-; [B1, B6, P1, V3, V6]; xn--0-dqc.xn----ogov3342l; ; ;  # 0٢.≯-
+0٢。󅪞≯-; 0٢.󅪞≯-; [B1, B6, P1, V3, V6]; xn--0-dqc.xn----ogov3342l; ; ;  # 0٢.≯-
+0٢。󅪞≯-; 0٢.󅪞≯-; [B1, B6, P1, V3, V6]; xn--0-dqc.xn----ogov3342l; ; ;  # 0٢.≯-
+xn--0-dqc.xn----ogov3342l; 0٢.󅪞≯-; [B1, B6, V3, V6]; xn--0-dqc.xn----ogov3342l; ; ;  # 0٢.≯-
+̜𐹫-𞯃.𐋤ࡅ; ; [B1, P1, V5, V6]; xn----gdb7046r692g.xn--3vb1349j; ; ;  # ̜𐹫-.𐋤ࡅ
+xn----gdb7046r692g.xn--3vb1349j; ̜𐹫-𞯃.𐋤ࡅ; [B1, V5, V6]; xn----gdb7046r692g.xn--3vb1349j; ; ;  # ̜𐹫-.𐋤ࡅ
+≠｡𝩑𐹩Ⴡ֔; ≠.𝩑𐹩Ⴡ֔; [B1, P1, V5, V6]; xn--1ch.xn--fcb538c649rypog; ; ;  # ≠.𝩑𐹩Ⴡ֔
+≠｡𝩑𐹩Ⴡ֔; ≠.𝩑𐹩Ⴡ֔; [B1, P1, V5, V6]; xn--1ch.xn--fcb538c649rypog; ; ;  # ≠.𝩑𐹩Ⴡ֔
+≠。𝩑𐹩Ⴡ֔; ≠.𝩑𐹩Ⴡ֔; [B1, P1, V5, V6]; xn--1ch.xn--fcb538c649rypog; ; ;  # ≠.𝩑𐹩Ⴡ֔
+≠。𝩑𐹩Ⴡ֔; ≠.𝩑𐹩Ⴡ֔; [B1, P1, V5, V6]; xn--1ch.xn--fcb538c649rypog; ; ;  # ≠.𝩑𐹩Ⴡ֔
+≠。𝩑𐹩ⴡ֔; ≠.𝩑𐹩ⴡ֔; [B1, P1, V5, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+≠。𝩑𐹩ⴡ֔; ≠.𝩑𐹩ⴡ֔; [B1, P1, V5, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+xn--1ch.xn--fcb363rk03mypug; ≠.𝩑𐹩ⴡ֔; [B1, V5, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+xn--1ch.xn--fcb538c649rypog; ≠.𝩑𐹩Ⴡ֔; [B1, V5, V6]; xn--1ch.xn--fcb538c649rypog; ; ;  # ≠.𝩑𐹩Ⴡ֔
+≠｡𝩑𐹩ⴡ֔; ≠.𝩑𐹩ⴡ֔; [B1, P1, V5, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+≠｡𝩑𐹩ⴡ֔; ≠.𝩑𐹩ⴡ֔; [B1, P1, V5, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+𖫳≠.Ⴀ𐮀; ; [B1, B5, B6, P1, V5, V6]; xn--1ch9250k.xn--7md2659j; ; ;  # 𖫳≠.Ⴀ𐮀
+𖫳≠.Ⴀ𐮀; 𖫳≠.Ⴀ𐮀; [B1, B5, B6, P1, V5, V6]; xn--1ch9250k.xn--7md2659j; ; ;  # 𖫳≠.Ⴀ𐮀
+𖫳≠.ⴀ𐮀; 𖫳≠.ⴀ𐮀; [B1, B5, B6, P1, V5, V6]; xn--1ch9250k.xn--rkj6232e; ; ;  # 𖫳≠.ⴀ𐮀
+𖫳≠.ⴀ𐮀; ; [B1, B5, B6, P1, V5, V6]; xn--1ch9250k.xn--rkj6232e; ; ;  # 𖫳≠.ⴀ𐮀
+xn--1ch9250k.xn--rkj6232e; 𖫳≠.ⴀ𐮀; [B1, B5, B6, V5, V6]; xn--1ch9250k.xn--rkj6232e; ; ;  # 𖫳≠.ⴀ𐮀
+xn--1ch9250k.xn--7md2659j; 𖫳≠.Ⴀ𐮀; [B1, B5, B6, V5, V6]; xn--1ch9250k.xn--7md2659j; ; ;  # 𖫳≠.Ⴀ𐮀
+󠅾ܶܦ．ᢚ閪࣢𝩟; ܶܦ.ᢚ閪࣢𝩟; [B1, B5, B6, P1, V5, V6]; xn--wnb5a.xn--l0b161fis8gbp5m; ; ;  # ܶܦ.ᢚ閪𝩟
+󠅾ܶܦ.ᢚ閪࣢𝩟; ܶܦ.ᢚ閪࣢𝩟; [B1, B5, B6, P1, V5, V6]; xn--wnb5a.xn--l0b161fis8gbp5m; ; ;  # ܶܦ.ᢚ閪𝩟
+xn--wnb5a.xn--l0b161fis8gbp5m; ܶܦ.ᢚ閪࣢𝩟; [B1, B5, B6, V5, V6]; xn--wnb5a.xn--l0b161fis8gbp5m; ; ;  # ܶܦ.ᢚ閪𝩟
+‍󠇜ۋ꣩｡⃝ྰ-ᛟ; ‍ۋ꣩.⃝ྰ-ᛟ; [B1, C2, V5]; xn--blb540ke10h.xn----gmg236cj6k; ; xn--blb8114f.xn----gmg236cj6k; [B1, V5] # ۋ꣩.⃝ྰ-ᛟ
+‍󠇜ۋ꣩。⃝ྰ-ᛟ; ‍ۋ꣩.⃝ྰ-ᛟ; [B1, C2, V5]; xn--blb540ke10h.xn----gmg236cj6k; ; xn--blb8114f.xn----gmg236cj6k; [B1, V5] # ۋ꣩.⃝ྰ-ᛟ
+xn--blb8114f.xn----gmg236cj6k; ۋ꣩.⃝ྰ-ᛟ; [B1, V5]; xn--blb8114f.xn----gmg236cj6k; ; ;  # ۋ꣩.⃝ྰ-ᛟ
+xn--blb540ke10h.xn----gmg236cj6k; ‍ۋ꣩.⃝ྰ-ᛟ; [B1, C2, V5]; xn--blb540ke10h.xn----gmg236cj6k; ; ;  # ۋ꣩.⃝ྰ-ᛟ
+헁󘖙ฺ󚍚。ں𝟜; 헁󘖙ฺ󚍚.ں4; [P1, V6]; xn--o4c1723h8g85gt4ya.xn--4-dvc; ; ;  # 헁ฺ.ں4
+헁󘖙ฺ󚍚。ں𝟜; 헁󘖙ฺ󚍚.ں4; [P1, V6]; xn--o4c1723h8g85gt4ya.xn--4-dvc; ; ;  # 헁ฺ.ں4
+헁󘖙ฺ󚍚。ں4; 헁󘖙ฺ󚍚.ں4; [P1, V6]; xn--o4c1723h8g85gt4ya.xn--4-dvc; ; ;  # 헁ฺ.ں4
+헁󘖙ฺ󚍚。ں4; 헁󘖙ฺ󚍚.ں4; [P1, V6]; xn--o4c1723h8g85gt4ya.xn--4-dvc; ; ;  # 헁ฺ.ں4
+xn--o4c1723h8g85gt4ya.xn--4-dvc; 헁󘖙ฺ󚍚.ں4; [V6]; xn--o4c1723h8g85gt4ya.xn--4-dvc; ; ;  # 헁ฺ.ں4
+𐹭｡󃱂‌Ⴞ; 𐹭.󃱂‌Ⴞ; [B1, C1, P1, V6]; xn--lo0d.xn--2nd949eqw95u; ; xn--lo0d.xn--2nd75260n; [B1, P1, V6] # 𐹭.Ⴞ
+𐹭。󃱂‌Ⴞ; 𐹭.󃱂‌Ⴞ; [B1, C1, P1, V6]; xn--lo0d.xn--2nd949eqw95u; ; xn--lo0d.xn--2nd75260n; [B1, P1, V6] # 𐹭.Ⴞ
+𐹭。󃱂‌ⴞ; 𐹭.󃱂‌ⴞ; [B1, C1, P1, V6]; xn--lo0d.xn--0ugx72cwi33v; ; xn--lo0d.xn--mljx1099g; [B1, P1, V6] # 𐹭.ⴞ
+xn--lo0d.xn--mljx1099g; 𐹭.󃱂ⴞ; [B1, V6]; xn--lo0d.xn--mljx1099g; ; ;  # 𐹭.ⴞ
+xn--lo0d.xn--0ugx72cwi33v; 𐹭.󃱂‌ⴞ; [B1, C1, V6]; xn--lo0d.xn--0ugx72cwi33v; ; ;  # 𐹭.ⴞ
+xn--lo0d.xn--2nd75260n; 𐹭.󃱂Ⴞ; [B1, V6]; xn--lo0d.xn--2nd75260n; ; ;  # 𐹭.Ⴞ
+xn--lo0d.xn--2nd949eqw95u; 𐹭.󃱂‌Ⴞ; [B1, C1, V6]; xn--lo0d.xn--2nd949eqw95u; ; ;  # 𐹭.Ⴞ
+𐹭｡󃱂‌ⴞ; 𐹭.󃱂‌ⴞ; [B1, C1, P1, V6]; xn--lo0d.xn--0ugx72cwi33v; ; xn--lo0d.xn--mljx1099g; [B1, P1, V6] # 𐹭.ⴞ
+꥓.̽𑂽馋; ; [P1, V5, V6]; xn--3j9a.xn--bua0708eqzrd; ; ;  # ꥓.̽馋
+xn--3j9a.xn--bua0708eqzrd; ꥓.̽𑂽馋; [V5, V6]; xn--3j9a.xn--bua0708eqzrd; ; ;  # ꥓.̽馋
+󈫝򪛸‍｡䜖; 󈫝򪛸‍.䜖; [C2, P1, V6]; xn--1ug30527h9mxi.xn--k0o; ; xn--g138cxw05a.xn--k0o; [P1, V6] # .䜖
+󈫝򪛸‍。䜖; 󈫝򪛸‍.䜖; [C2, P1, V6]; xn--1ug30527h9mxi.xn--k0o; ; xn--g138cxw05a.xn--k0o; [P1, V6] # .䜖
+xn--g138cxw05a.xn--k0o; 󈫝򪛸.䜖; [V6]; xn--g138cxw05a.xn--k0o; ; ;  # .䜖
+xn--1ug30527h9mxi.xn--k0o; 󈫝򪛸‍.䜖; [C2, V6]; xn--1ug30527h9mxi.xn--k0o; ; ;  # .䜖
+ᡯ⚉姶🄉．۷‍🎪‍; ᡯ⚉姶🄉.۷‍🎪‍; [C2, P1, V6]; xn--c9e433epi4b3j20a.xn--kmb859ja94998b; ; xn--c9e433epi4b3j20a.xn--kmb6733w; [P1, V6] # ᡯ⚉姶🄉.۷🎪
+ᡯ⚉姶8,.۷‍🎪‍; ; [C2, P1, V6]; xn--8,-g9oy26fzu4d.xn--kmb859ja94998b; ; xn--8,-g9oy26fzu4d.xn--kmb6733w; [P1, V6] # ᡯ⚉姶8,.۷🎪
+xn--8,-g9oy26fzu4d.xn--kmb6733w; ᡯ⚉姶8,.۷🎪; [P1, V6]; xn--8,-g9oy26fzu4d.xn--kmb6733w; ; ;  # ᡯ⚉姶8,.۷🎪
+xn--8,-g9oy26fzu4d.xn--kmb859ja94998b; ᡯ⚉姶8,.۷‍🎪‍; [C2, P1, V6]; xn--8,-g9oy26fzu4d.xn--kmb859ja94998b; ; ;  # ᡯ⚉姶8,.۷🎪
+xn--c9e433epi4b3j20a.xn--kmb6733w; ᡯ⚉姶🄉.۷🎪; [V6]; xn--c9e433epi4b3j20a.xn--kmb6733w; ; ;  # ᡯ⚉姶🄉.۷🎪
+xn--c9e433epi4b3j20a.xn--kmb859ja94998b; ᡯ⚉姶🄉.۷‍🎪‍; [C2, V6]; xn--c9e433epi4b3j20a.xn--kmb859ja94998b; ; ;  # ᡯ⚉姶🄉.۷🎪
+𞽀.𐹸🚖ฺ; ; [B1, P1, V6]; xn--0n7h.xn--o4c9032klszf; ; ;  # .𐹸🚖ฺ
+xn--0n7h.xn--o4c9032klszf; 𞽀.𐹸🚖ฺ; [B1, V6]; xn--0n7h.xn--o4c9032klszf; ; ;  # .𐹸🚖ฺ
+Ⴔᠵ｡𐹧݇۹; Ⴔᠵ.𐹧݇۹; [B1, P1, V6]; xn--snd659a.xn--mmb9ml895e; ; ;  # Ⴔᠵ.𐹧݇۹
+Ⴔᠵ。𐹧݇۹; Ⴔᠵ.𐹧݇۹; [B1, P1, V6]; xn--snd659a.xn--mmb9ml895e; ; ;  # Ⴔᠵ.𐹧݇۹
+ⴔᠵ。𐹧݇۹; ⴔᠵ.𐹧݇۹; [B1]; xn--o7e997h.xn--mmb9ml895e; ; ;  # ⴔᠵ.𐹧݇۹
+xn--o7e997h.xn--mmb9ml895e; ⴔᠵ.𐹧݇۹; [B1]; xn--o7e997h.xn--mmb9ml895e; ; ;  # ⴔᠵ.𐹧݇۹
+xn--snd659a.xn--mmb9ml895e; Ⴔᠵ.𐹧݇۹; [B1, V6]; xn--snd659a.xn--mmb9ml895e; ; ;  # Ⴔᠵ.𐹧݇۹
+ⴔᠵ｡𐹧݇۹; ⴔᠵ.𐹧݇۹; [B1]; xn--o7e997h.xn--mmb9ml895e; ; ;  # ⴔᠵ.𐹧݇۹
+፟ᡈ‌．︒-𖾐-; ፟ᡈ‌.︒-𖾐-; [C1, P1, V3, V5, V6]; xn--b7d82wo4h.xn-----c82nz547a; ; xn--b7d82w.xn-----c82nz547a; [P1, V3, V5, V6] # ፟ᡈ.︒-𖾐-
+፟ᡈ‌.。-𖾐-; ፟ᡈ‌..-𖾐-; [C1, V3, V5, X4_2]; xn--b7d82wo4h..xn-----pe4u; [C1, V3, V5, A4_2]; xn--b7d82w..xn-----pe4u; [V3, V5, A4_2] # ፟ᡈ..-𖾐-
+xn--b7d82w..xn-----pe4u; ፟ᡈ..-𖾐-; [V3, V5, X4_2]; xn--b7d82w..xn-----pe4u; [V3, V5, A4_2]; ;  # ፟ᡈ..-𖾐-
+xn--b7d82wo4h..xn-----pe4u; ፟ᡈ‌..-𖾐-; [C1, V3, V5, X4_2]; xn--b7d82wo4h..xn-----pe4u; [C1, V3, V5, A4_2]; ;  # ፟ᡈ..-𖾐-
+xn--b7d82w.xn-----c82nz547a; ፟ᡈ.︒-𖾐-; [V3, V5, V6]; xn--b7d82w.xn-----c82nz547a; ; ;  # ፟ᡈ.︒-𖾐-
+xn--b7d82wo4h.xn-----c82nz547a; ፟ᡈ‌.︒-𖾐-; [C1, V3, V5, V6]; xn--b7d82wo4h.xn-----c82nz547a; ; ;  # ፟ᡈ.︒-𖾐-
+⒈؁⒖‌.ᷰߛ; ; [B1, C1, P1, V5, V6]; xn--jfb844kmfdwb.xn--2sb914i; ; xn--jfb347mib.xn--2sb914i; [B1, P1, V5, V6] # ⒈⒖.ᷰߛ
+1.؁15.‌.ᷰߛ; ; [B1, C1, P1, V5, V6]; 1.xn--15-1pd.xn--0ug.xn--2sb914i; ; 1.xn--15-1pd..xn--2sb914i; [B1, P1, V5, V6, A4_2] # 1.15..ᷰߛ
+1.xn--15-1pd..xn--2sb914i; 1.؁15..ᷰߛ; [B1, V5, V6, X4_2]; 1.xn--15-1pd..xn--2sb914i; [B1, V5, V6, A4_2]; ;  # 1.15..ᷰߛ
+1.xn--15-1pd.xn--0ug.xn--2sb914i; 1.؁15.‌.ᷰߛ; [B1, C1, V5, V6]; 1.xn--15-1pd.xn--0ug.xn--2sb914i; ; ;  # 1.15..ᷰߛ
+xn--jfb347mib.xn--2sb914i; ⒈؁⒖.ᷰߛ; [B1, V5, V6]; xn--jfb347mib.xn--2sb914i; ; ;  # ⒈⒖.ᷰߛ
+xn--jfb844kmfdwb.xn--2sb914i; ⒈؁⒖‌.ᷰߛ; [B1, C1, V5, V6]; xn--jfb844kmfdwb.xn--2sb914i; ; ;  # ⒈⒖.ᷰߛ
+𝩜。-୍Ⴋ; 𝩜.-୍Ⴋ; [P1, V3, V5, V6]; xn--792h.xn----bse632b; ; ;  # 𝩜.-୍Ⴋ
+𝩜。-୍ⴋ; 𝩜.-୍ⴋ; [V3, V5]; xn--792h.xn----bse820x; ; ;  # 𝩜.-୍ⴋ
+xn--792h.xn----bse820x; 𝩜.-୍ⴋ; [V3, V5]; xn--792h.xn----bse820x; ; ;  # 𝩜.-୍ⴋ
+xn--792h.xn----bse632b; 𝩜.-୍Ⴋ; [V3, V5, V6]; xn--792h.xn----bse632b; ; ;  # 𝩜.-୍Ⴋ
+ßჀ.ؠ刯Ⴝ; ; [B2, B3, P1, V6]; xn--zca442f.xn--fgb845cb66c; ; xn--ss-wgk.xn--fgb845cb66c;  # ßჀ.ؠ刯Ⴝ
+ßⴠ.ؠ刯ⴝ; ; [B2, B3]; xn--zca277t.xn--fgb670rovy; ; xn--ss-j81a.xn--fgb670rovy;  # ßⴠ.ؠ刯ⴝ
+SSჀ.ؠ刯Ⴝ; ssჀ.ؠ刯Ⴝ; [B2, B3, P1, V6]; xn--ss-wgk.xn--fgb845cb66c; ; ;  # ssჀ.ؠ刯Ⴝ
+ssⴠ.ؠ刯ⴝ; ; [B2, B3]; xn--ss-j81a.xn--fgb670rovy; ; ;  # ssⴠ.ؠ刯ⴝ
+Ssⴠ.ؠ刯Ⴝ; ssⴠ.ؠ刯Ⴝ; [B2, B3, P1, V6]; xn--ss-j81a.xn--fgb845cb66c; ; ;  # ssⴠ.ؠ刯Ⴝ
+xn--ss-j81a.xn--fgb845cb66c; ssⴠ.ؠ刯Ⴝ; [B2, B3, V6]; xn--ss-j81a.xn--fgb845cb66c; ; ;  # ssⴠ.ؠ刯Ⴝ
+xn--ss-j81a.xn--fgb670rovy; ssⴠ.ؠ刯ⴝ; [B2, B3]; xn--ss-j81a.xn--fgb670rovy; ; ;  # ssⴠ.ؠ刯ⴝ
+xn--ss-wgk.xn--fgb845cb66c; ssჀ.ؠ刯Ⴝ; [B2, B3, V6]; xn--ss-wgk.xn--fgb845cb66c; ; ;  # ssჀ.ؠ刯Ⴝ
+xn--zca277t.xn--fgb670rovy; ßⴠ.ؠ刯ⴝ; [B2, B3]; xn--zca277t.xn--fgb670rovy; ; ;  # ßⴠ.ؠ刯ⴝ
+xn--zca442f.xn--fgb845cb66c; ßჀ.ؠ刯Ⴝ; [B2, B3, V6]; xn--zca442f.xn--fgb845cb66c; ; ;  # ßჀ.ؠ刯Ⴝ
+᮪ႣℲ｡ᠳ툻ٳ; ᮪ႣℲ.ᠳ툻ٳ; [B5, B6, P1, V5, V6]; xn--bnd957cone.xn--sib102gc69k; ; ;  # ᮪ႣℲ.ᠳ툻ٳ
+᮪ႣℲ｡ᠳ툻ٳ; ᮪ႣℲ.ᠳ툻ٳ; [B5, B6, P1, V5, V6]; xn--bnd957cone.xn--sib102gc69k; ; ;  # ᮪ႣℲ.ᠳ툻ٳ
+᮪ႣℲ。ᠳ툻ٳ; ᮪ႣℲ.ᠳ툻ٳ; [B5, B6, P1, V5, V6]; xn--bnd957cone.xn--sib102gc69k; ; ;  # ᮪ႣℲ.ᠳ툻ٳ
+᮪ႣℲ。ᠳ툻ٳ; ᮪ႣℲ.ᠳ툻ٳ; [B5, B6, P1, V5, V6]; xn--bnd957cone.xn--sib102gc69k; ; ;  # ᮪ႣℲ.ᠳ툻ٳ
+᮪ⴃⅎ。ᠳ툻ٳ; ᮪ⴃⅎ.ᠳ툻ٳ; [B5, B6, V5]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+᮪ⴃⅎ。ᠳ툻ٳ; ᮪ⴃⅎ.ᠳ툻ٳ; [B5, B6, V5]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+᮪Ⴃⅎ。ᠳ툻ٳ; ᮪Ⴃⅎ.ᠳ툻ٳ; [B5, B6, P1, V5, V6]; xn--bnd957c2pe.xn--sib102gc69k; ; ;  # ᮪Ⴃⅎ.ᠳ툻ٳ
+᮪Ⴃⅎ。ᠳ툻ٳ; ᮪Ⴃⅎ.ᠳ툻ٳ; [B5, B6, P1, V5, V6]; xn--bnd957c2pe.xn--sib102gc69k; ; ;  # ᮪Ⴃⅎ.ᠳ툻ٳ
+xn--bnd957c2pe.xn--sib102gc69k; ᮪Ⴃⅎ.ᠳ툻ٳ; [B5, B6, V5, V6]; xn--bnd957c2pe.xn--sib102gc69k; ; ;  # ᮪Ⴃⅎ.ᠳ툻ٳ
+xn--yxf24x4ol.xn--sib102gc69k; ᮪ⴃⅎ.ᠳ툻ٳ; [B5, B6, V5]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+xn--bnd957cone.xn--sib102gc69k; ᮪ႣℲ.ᠳ툻ٳ; [B5, B6, V5, V6]; xn--bnd957cone.xn--sib102gc69k; ; ;  # ᮪ႣℲ.ᠳ툻ٳ
+᮪ⴃⅎ｡ᠳ툻ٳ; ᮪ⴃⅎ.ᠳ툻ٳ; [B5, B6, V5]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+᮪ⴃⅎ｡ᠳ툻ٳ; ᮪ⴃⅎ.ᠳ툻ٳ; [B5, B6, V5]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+᮪Ⴃⅎ｡ᠳ툻ٳ; ᮪Ⴃⅎ.ᠳ툻ٳ; [B5, B6, P1, V5, V6]; xn--bnd957c2pe.xn--sib102gc69k; ; ;  # ᮪Ⴃⅎ.ᠳ툻ٳ
+᮪Ⴃⅎ｡ᠳ툻ٳ; ᮪Ⴃⅎ.ᠳ툻ٳ; [B5, B6, P1, V5, V6]; xn--bnd957c2pe.xn--sib102gc69k; ; ;  # ᮪Ⴃⅎ.ᠳ툻ٳ
+۬.ࢢ𐹫ټ; ; [B1, B3, B6, V5]; xn--8lb.xn--1ib31ily45b; ; ;  # ۬.ࢢ𐹫ټ
+xn--8lb.xn--1ib31ily45b; ۬.ࢢ𐹫ټ; [B1, B3, B6, V5]; xn--8lb.xn--1ib31ily45b; ; ;  # ۬.ࢢ𐹫ټ
+ڶ۟。₇꠆; ڶ۟.7꠆; [B1]; xn--pkb6f.xn--7-x93e; ; ;  # ڶ۟.7꠆
+ڶ۟。7꠆; ڶ۟.7꠆; [B1]; xn--pkb6f.xn--7-x93e; ; ;  # ڶ۟.7꠆
+xn--pkb6f.xn--7-x93e; ڶ۟.7꠆; [B1]; xn--pkb6f.xn--7-x93e; ; ;  # ڶ۟.7꠆
+ڶ۟.7꠆; ; [B1]; xn--pkb6f.xn--7-x93e; ; ;  # ڶ۟.7꠆
+Ⴣ𐹻.‌𝪣≮󠩉; ; [B1, B5, B6, C1, P1, V6]; xn--7nd8101k.xn--0ugy6gn120eb103g; ; xn--7nd8101k.xn--gdh4944ob3x3e; [B1, B5, B6, P1, V5, V6] # Ⴣ𐹻.𝪣≮
+Ⴣ𐹻.‌𝪣≮󠩉; Ⴣ𐹻.‌𝪣≮󠩉; [B1, B5, B6, C1, P1, V6]; xn--7nd8101k.xn--0ugy6gn120eb103g; ; xn--7nd8101k.xn--gdh4944ob3x3e; [B1, B5, B6, P1, V5, V6] # Ⴣ𐹻.𝪣≮
+ⴣ𐹻.‌𝪣≮󠩉; ⴣ𐹻.‌𝪣≮󠩉; [B1, B5, B6, C1, P1, V6]; xn--rlj6323e.xn--0ugy6gn120eb103g; ; xn--rlj6323e.xn--gdh4944ob3x3e; [B1, B5, B6, P1, V5, V6] # ⴣ𐹻.𝪣≮
+ⴣ𐹻.‌𝪣≮󠩉; ; [B1, B5, B6, C1, P1, V6]; xn--rlj6323e.xn--0ugy6gn120eb103g; ; xn--rlj6323e.xn--gdh4944ob3x3e; [B1, B5, B6, P1, V5, V6] # ⴣ𐹻.𝪣≮
+xn--rlj6323e.xn--gdh4944ob3x3e; ⴣ𐹻.𝪣≮󠩉; [B1, B5, B6, V5, V6]; xn--rlj6323e.xn--gdh4944ob3x3e; ; ;  # ⴣ𐹻.𝪣≮
+xn--rlj6323e.xn--0ugy6gn120eb103g; ⴣ𐹻.‌𝪣≮󠩉; [B1, B5, B6, C1, V6]; xn--rlj6323e.xn--0ugy6gn120eb103g; ; ;  # ⴣ𐹻.𝪣≮
+xn--7nd8101k.xn--gdh4944ob3x3e; Ⴣ𐹻.𝪣≮󠩉; [B1, B5, B6, V5, V6]; xn--7nd8101k.xn--gdh4944ob3x3e; ; ;  # Ⴣ𐹻.𝪣≮
+xn--7nd8101k.xn--0ugy6gn120eb103g; Ⴣ𐹻.‌𝪣≮󠩉; [B1, B5, B6, C1, V6]; xn--7nd8101k.xn--0ugy6gn120eb103g; ; ;  # Ⴣ𐹻.𝪣≮
+𝟵隁⯮．᠍‌; 9隁⯮.‌; [C1]; xn--9-mfs8024b.xn--0ug; ; xn--9-mfs8024b.; [] # 9隁⯮.
+9隁⯮.᠍‌; 9隁⯮.‌; [C1]; xn--9-mfs8024b.xn--0ug; ; xn--9-mfs8024b.; [] # 9隁⯮.
+xn--9-mfs8024b.; 9隁⯮.; ; xn--9-mfs8024b.; ; ;  # 9隁⯮.
+9隁⯮.; ; ; xn--9-mfs8024b.; ; ;  # 9隁⯮.
+xn--9-mfs8024b.xn--0ug; 9隁⯮.‌; [C1]; xn--9-mfs8024b.xn--0ug; ; ;  # 9隁⯮.
+⒏𐹧｡Ⴣ྄彦; ⒏𐹧.Ⴣ྄彦; [B1, P1, V6]; xn--0sh2466f.xn--3ed15dt93o; ; ;  # ⒏𐹧.Ⴣ྄彦
+8.𐹧。Ⴣ྄彦; 8.𐹧.Ⴣ྄彦; [B1, P1, V6]; 8.xn--fo0d.xn--3ed15dt93o; ; ;  # 8.𐹧.Ⴣ྄彦
+8.𐹧。ⴣ྄彦; 8.𐹧.ⴣ྄彦; [B1]; 8.xn--fo0d.xn--3ed972m6o8a; ; ;  # 8.𐹧.ⴣ྄彦
+8.xn--fo0d.xn--3ed972m6o8a; 8.𐹧.ⴣ྄彦; [B1]; 8.xn--fo0d.xn--3ed972m6o8a; ; ;  # 8.𐹧.ⴣ྄彦
+8.xn--fo0d.xn--3ed15dt93o; 8.𐹧.Ⴣ྄彦; [B1, V6]; 8.xn--fo0d.xn--3ed15dt93o; ; ;  # 8.𐹧.Ⴣ྄彦
+⒏𐹧｡ⴣ྄彦; ⒏𐹧.ⴣ྄彦; [B1, P1, V6]; xn--0sh2466f.xn--3ed972m6o8a; ; ;  # ⒏𐹧.ⴣ྄彦
+xn--0sh2466f.xn--3ed972m6o8a; ⒏𐹧.ⴣ྄彦; [B1, V6]; xn--0sh2466f.xn--3ed972m6o8a; ; ;  # ⒏𐹧.ⴣ྄彦
+xn--0sh2466f.xn--3ed15dt93o; ⒏𐹧.Ⴣ྄彦; [B1, V6]; xn--0sh2466f.xn--3ed15dt93o; ; ;  # ⒏𐹧.Ⴣ྄彦
+-问񬰔⒛。؄-񜗉橬; -问񬰔⒛.؄-񜗉橬; [B1, P1, V3, V6]; xn----hdpu849bhis3e.xn----ykc7228efm46d; ; ;  # -问⒛.-橬
+-问񬰔20.。؄-񜗉橬; -问񬰔20..؄-񜗉橬; [B1, P1, V3, V6, X4_2]; xn---20-658jx1776d..xn----ykc7228efm46d; [B1, P1, V3, V6, A4_2]; ;  # -问20..-橬
+xn---20-658jx1776d..xn----ykc7228efm46d; -问񬰔20..؄-񜗉橬; [B1, V3, V6, X4_2]; xn---20-658jx1776d..xn----ykc7228efm46d; [B1, V3, V6, A4_2]; ;  # -问20..-橬
+xn----hdpu849bhis3e.xn----ykc7228efm46d; -问񬰔⒛.؄-񜗉橬; [B1, V3, V6]; xn----hdpu849bhis3e.xn----ykc7228efm46d; ; ;  # -问⒛.-橬
+ᮬႬ‌̥。𝟸; ᮬႬ‌̥.2; [C1, P1, V5, V6]; xn--mta930emribme.2; ; xn--mta930emri.2; [P1, V5, V6] # ᮬႬ̥.2
+ᮬႬ‌̥。2; ᮬႬ‌̥.2; [C1, P1, V5, V6]; xn--mta930emribme.2; ; xn--mta930emri.2; [P1, V5, V6] # ᮬႬ̥.2
+ᮬⴌ‌̥。2; ᮬⴌ‌̥.2; [C1, V5]; xn--mta176j97cl2q.2; ; xn--mta176jjjm.2; [V5] # ᮬⴌ̥.2
+xn--mta176jjjm.2; ᮬⴌ̥.2; [V5]; xn--mta176jjjm.2; ; ;  # ᮬⴌ̥.2
+xn--mta176j97cl2q.2; ᮬⴌ‌̥.2; [C1, V5]; xn--mta176j97cl2q.2; ; ;  # ᮬⴌ̥.2
+xn--mta930emri.2; ᮬႬ̥.2; [V5, V6]; xn--mta930emri.2; ; ;  # ᮬႬ̥.2
+xn--mta930emribme.2; ᮬႬ‌̥.2; [C1, V5, V6]; xn--mta930emribme.2; ; ;  # ᮬႬ̥.2
+ᮬⴌ‌̥。𝟸; ᮬⴌ‌̥.2; [C1, V5]; xn--mta176j97cl2q.2; ; xn--mta176jjjm.2; [V5] # ᮬⴌ̥.2
+?。꠆٩󠒩; ?.꠆٩󠒩; [B1, P1, V5, V6]; ?.xn--iib9583fusy0i; [B1, P1, V5, V6, A3]; ;  # .꠆٩
+?.xn--iib9583fusy0i; ?.꠆٩󠒩; [B1, P1, V5, V6]; ?.xn--iib9583fusy0i; [B1, P1, V5, V6, A3]; ;  # .꠆٩
+?.XN--IIB9583FUSY0I; ?.꠆٩󠒩; [B1, P1, V5, V6]; ?.xn--iib9583fusy0i; [B1, P1, V5, V6, A3]; ;  # .꠆٩
+?.Xn--Iib9583fusy0i; ?.꠆٩󠒩; [B1, P1, V5, V6]; ?.xn--iib9583fusy0i; [B1, P1, V5, V6, A3]; ;  # .꠆٩
+󠄁͟⾶｡₇︒눇≮; ͟飛.7︒눇≮; [P1, V5, V6]; xn--9ua0567e.xn--7-ngou006d1ttc; ; ;  # ͟飛.7︒눇≮
+󠄁͟⾶｡₇︒눇≮; ͟飛.7︒눇≮; [P1, V5, V6]; xn--9ua0567e.xn--7-ngou006d1ttc; ; ;  # ͟飛.7︒눇≮
+󠄁͟飛。7。눇≮; ͟飛.7.눇≮; [P1, V5, V6]; xn--9ua0567e.7.xn--gdh6767c; ; ;  # ͟飛.7.눇≮
+󠄁͟飛。7。눇≮; ͟飛.7.눇≮; [P1, V5, V6]; xn--9ua0567e.7.xn--gdh6767c; ; ;  # ͟飛.7.눇≮
+xn--9ua0567e.7.xn--gdh6767c; ͟飛.7.눇≮; [V5, V6]; xn--9ua0567e.7.xn--gdh6767c; ; ;  # ͟飛.7.눇≮
+xn--9ua0567e.xn--7-ngou006d1ttc; ͟飛.7︒눇≮; [V5, V6]; xn--9ua0567e.xn--7-ngou006d1ttc; ; ;  # ͟飛.7︒눇≮
+‌︉𐹴‍．‌⿃; ‌𐹴‍.‌鳥; [B1, C1, C2]; xn--0ugc6024p.xn--0ug1920c; ; xn--so0d.xn--6x6a; [B1] # 𐹴.鳥
+‌︉𐹴‍.‌鳥; ‌𐹴‍.‌鳥; [B1, C1, C2]; xn--0ugc6024p.xn--0ug1920c; ; xn--so0d.xn--6x6a; [B1] # 𐹴.鳥
+xn--so0d.xn--6x6a; 𐹴.鳥; [B1]; xn--so0d.xn--6x6a; ; ;  # 𐹴.鳥
+xn--0ugc6024p.xn--0ug1920c; ‌𐹴‍.‌鳥; [B1, C1, C2]; xn--0ugc6024p.xn--0ug1920c; ; ;  # 𐹴.鳥
+🍮．‍󠗒𐦁𝨝; 🍮.‍󠗒𐦁𝨝; [B1, C2, P1, V6]; xn--lj8h.xn--1ug6603gr1pfwq37h; ; xn--lj8h.xn--ln9ci476aqmr2g; [B1, P1, V6] # 🍮.𐦁𝨝
+🍮.‍󠗒𐦁𝨝; ; [B1, C2, P1, V6]; xn--lj8h.xn--1ug6603gr1pfwq37h; ; xn--lj8h.xn--ln9ci476aqmr2g; [B1, P1, V6] # 🍮.𐦁𝨝
+xn--lj8h.xn--ln9ci476aqmr2g; 🍮.󠗒𐦁𝨝; [B1, V6]; xn--lj8h.xn--ln9ci476aqmr2g; ; ;  # 🍮.𐦁𝨝
+xn--lj8h.xn--1ug6603gr1pfwq37h; 🍮.‍󠗒𐦁𝨝; [B1, C2, V6]; xn--lj8h.xn--1ug6603gr1pfwq37h; ; ;  # 🍮.𐦁𝨝
+ٽृ.𞤓‍; ٽृ.𞤵‍; [B3, C2]; xn--2ib43l.xn--1ugy711p; ; xn--2ib43l.xn--te6h; [] # ٽृ.𞤵
+ٽृ.𞤵‍; ; [B3, C2]; xn--2ib43l.xn--1ugy711p; ; xn--2ib43l.xn--te6h; [] # ٽृ.𞤵
+xn--2ib43l.xn--te6h; ٽृ.𞤵; ; xn--2ib43l.xn--te6h; ; ;  # ٽृ.𞤵
+ٽृ.𞤵; ; ; xn--2ib43l.xn--te6h; ; ;  # ٽृ.𞤵
+ٽृ.𞤓; ٽृ.𞤵; ; xn--2ib43l.xn--te6h; ; ;  # ٽृ.𞤵
+xn--2ib43l.xn--1ugy711p; ٽृ.𞤵‍; [B3, C2]; xn--2ib43l.xn--1ugy711p; ; ;  # ٽृ.𞤵
+٤੍-．󥜽္񦦐; ٤੍-.󥜽္񦦐; [B1, P1, V3, V6]; xn----gqc711a.xn--9jd88234f3qm0b; ; ;  # ٤੍-.္
+٤੍-.󥜽္񦦐; ; [B1, P1, V3, V6]; xn----gqc711a.xn--9jd88234f3qm0b; ; ;  # ٤੍-.္
+xn----gqc711a.xn--9jd88234f3qm0b; ٤੍-.󥜽္񦦐; [B1, V3, V6]; xn----gqc711a.xn--9jd88234f3qm0b; ; ;  # ٤੍-.္
+4်-𐹸｡ꨩ‌𐹴≮; 4်-𐹸.ꨩ‌𐹴≮; [B1, C1, P1, V5, V6]; xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; ; xn--4--e4j7831r.xn--gdh8754cz40c; [B1, P1, V5, V6] # 4်-𐹸.ꨩ𐹴≮
+4်-𐹸｡ꨩ‌𐹴≮; 4်-𐹸.ꨩ‌𐹴≮; [B1, C1, P1, V5, V6]; xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; ; xn--4--e4j7831r.xn--gdh8754cz40c; [B1, P1, V5, V6] # 4်-𐹸.ꨩ𐹴≮
+4်-𐹸。ꨩ‌𐹴≮; 4်-𐹸.ꨩ‌𐹴≮; [B1, C1, P1, V5, V6]; xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; ; xn--4--e4j7831r.xn--gdh8754cz40c; [B1, P1, V5, V6] # 4်-𐹸.ꨩ𐹴≮
+4်-𐹸。ꨩ‌𐹴≮; 4်-𐹸.ꨩ‌𐹴≮; [B1, C1, P1, V5, V6]; xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; ; xn--4--e4j7831r.xn--gdh8754cz40c; [B1, P1, V5, V6] # 4်-𐹸.ꨩ𐹴≮
+xn--4--e4j7831r.xn--gdh8754cz40c; 4်-𐹸.ꨩ𐹴≮; [B1, V5, V6]; xn--4--e4j7831r.xn--gdh8754cz40c; ; ;  # 4်-𐹸.ꨩ𐹴≮
+xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; 4်-𐹸.ꨩ‌𐹴≮; [B1, C1, V5, V6]; xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; ; ;  # 4်-𐹸.ꨩ𐹴≮
+‌。ﾠ྄ྖ; ‌.ﾠ྄ྖ; [C1, P1, V6]; xn--0ug.xn--3ed0by082k; ; .xn--3ed0by082k; [P1, V6, A4_2] # .྄ྖ
+‌。ᅠ྄ྖ; ‌.ᅠ྄ྖ; [C1, P1, V6]; xn--0ug.xn--3ed0b20h; ; .xn--3ed0b20h; [P1, V6, A4_2] # .྄ྖ
+.xn--3ed0b20h; .ᅠ྄ྖ; [V6, X4_2]; .xn--3ed0b20h; [V6, A4_2]; ;  # .྄ྖ
+xn--0ug.xn--3ed0b20h; ‌.ᅠ྄ྖ; [C1, V6]; xn--0ug.xn--3ed0b20h; ; ;  # .྄ྖ
+.xn--3ed0by082k; .ﾠ྄ྖ; [V6, X4_2]; .xn--3ed0by082k; [V6, A4_2]; ;  # .྄ྖ
+xn--0ug.xn--3ed0by082k; ‌.ﾠ྄ྖ; [C1, V6]; xn--0ug.xn--3ed0by082k; ; ;  # .྄ྖ
+≯򍘅．‍𐅼򲇛; ≯򍘅.‍𐅼򲇛; [C2, P1, V6]; xn--hdh84488f.xn--1ug8099fbjp4e; ; xn--hdh84488f.xn--xy7cw2886b; [P1, V6] # ≯.𐅼
+≯򍘅．‍𐅼򲇛; ≯򍘅.‍𐅼򲇛; [C2, P1, V6]; xn--hdh84488f.xn--1ug8099fbjp4e; ; xn--hdh84488f.xn--xy7cw2886b; [P1, V6] # ≯.𐅼
+≯򍘅.‍𐅼򲇛; ; [C2, P1, V6]; xn--hdh84488f.xn--1ug8099fbjp4e; ; xn--hdh84488f.xn--xy7cw2886b; [P1, V6] # ≯.𐅼
+≯򍘅.‍𐅼򲇛; ≯򍘅.‍𐅼򲇛; [C2, P1, V6]; xn--hdh84488f.xn--1ug8099fbjp4e; ; xn--hdh84488f.xn--xy7cw2886b; [P1, V6] # ≯.𐅼
+xn--hdh84488f.xn--xy7cw2886b; ≯򍘅.𐅼򲇛; [V6]; xn--hdh84488f.xn--xy7cw2886b; ; ;  # ≯.𐅼
+xn--hdh84488f.xn--1ug8099fbjp4e; ≯򍘅.‍𐅼򲇛; [C2, V6]; xn--hdh84488f.xn--1ug8099fbjp4e; ; ;  # ≯.𐅼
+فß𐰯｡𝟕𐫫; فß𐰯.7𐫫; [B1, B2]; xn--zca96ys96y.xn--7-mm5i; ; xn--ss-jvd2339x.xn--7-mm5i;  # فß𐰯.7𐫫
+فß𐰯。7𐫫; فß𐰯.7𐫫; [B1, B2]; xn--zca96ys96y.xn--7-mm5i; ; xn--ss-jvd2339x.xn--7-mm5i;  # فß𐰯.7𐫫
+فSS𐰯。7𐫫; فss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+فss𐰯。7𐫫; فss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+xn--ss-jvd2339x.xn--7-mm5i; فss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+xn--zca96ys96y.xn--7-mm5i; فß𐰯.7𐫫; [B1, B2]; xn--zca96ys96y.xn--7-mm5i; ; ;  # فß𐰯.7𐫫
+فSS𐰯｡𝟕𐫫; فss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+فss𐰯｡𝟕𐫫; فss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+فSs𐰯。7𐫫; فss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+فSs𐰯｡𝟕𐫫; فss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+ßެާࢱ。𐭁􅮙𐹲; ßެާࢱ.𐭁􅮙𐹲; [B2, B5, B6, P1, V6]; xn--zca685aoa95h.xn--e09co8cr9861c; ; xn--ss-9qet02k.xn--e09co8cr9861c;  # ßެާࢱ.𐭁𐹲
+SSެާࢱ。𐭁􅮙𐹲; ssެާࢱ.𐭁􅮙𐹲; [B2, B5, B6, P1, V6]; xn--ss-9qet02k.xn--e09co8cr9861c; ; ;  # ssެާࢱ.𐭁𐹲
+ssެާࢱ。𐭁􅮙𐹲; ssެާࢱ.𐭁􅮙𐹲; [B2, B5, B6, P1, V6]; xn--ss-9qet02k.xn--e09co8cr9861c; ; ;  # ssެާࢱ.𐭁𐹲
+Ssެާࢱ。𐭁􅮙𐹲; ssެާࢱ.𐭁􅮙𐹲; [B2, B5, B6, P1, V6]; xn--ss-9qet02k.xn--e09co8cr9861c; ; ;  # ssެާࢱ.𐭁𐹲
+xn--ss-9qet02k.xn--e09co8cr9861c; ssެާࢱ.𐭁􅮙𐹲; [B2, B5, B6, V6]; xn--ss-9qet02k.xn--e09co8cr9861c; ; ;  # ssެާࢱ.𐭁𐹲
+xn--zca685aoa95h.xn--e09co8cr9861c; ßެާࢱ.𐭁􅮙𐹲; [B2, B5, B6, V6]; xn--zca685aoa95h.xn--e09co8cr9861c; ; ;  # ßެާࢱ.𐭁𐹲
+-｡󠉗⒌𞯛; -.󠉗⒌𞯛; [B1, P1, V3, V6]; -.xn--xsh6367n1bi3e; ; ;  # -.⒌
+-。󠉗5.𞯛; -.󠉗5.𞯛; [B1, P1, V3, V6]; -.xn--5-zz21m.xn--6x6h; ; ;  # -.5.
+-.xn--5-zz21m.xn--6x6h; -.󠉗5.𞯛; [B1, V3, V6]; -.xn--5-zz21m.xn--6x6h; ; ;  # -.5.
+-.xn--xsh6367n1bi3e; -.󠉗⒌𞯛; [B1, V3, V6]; -.xn--xsh6367n1bi3e; ; ;  # -.⒌
+𼎏ς．-≮ﲫ; 𼎏ς.-≮خج; [B1, P1, V3, V6]; xn--3xa13520c.xn----9mcf1400a; ; xn--4xa92520c.xn----9mcf1400a;  # ς.-≮خج
+𼎏ς．-≮ﲫ; 𼎏ς.-≮خج; [B1, P1, V3, V6]; xn--3xa13520c.xn----9mcf1400a; ; xn--4xa92520c.xn----9mcf1400a;  # ς.-≮خج
+𼎏ς.-≮خج; ; [B1, P1, V3, V6]; xn--3xa13520c.xn----9mcf1400a; ; xn--4xa92520c.xn----9mcf1400a;  # ς.-≮خج
+𼎏ς.-≮خج; 𼎏ς.-≮خج; [B1, P1, V3, V6]; xn--3xa13520c.xn----9mcf1400a; ; xn--4xa92520c.xn----9mcf1400a;  # ς.-≮خج
+𼎏Σ.-≮خج; 𼎏σ.-≮خج; [B1, P1, V3, V6]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏Σ.-≮خج; 𼎏σ.-≮خج; [B1, P1, V3, V6]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏σ.-≮خج; ; [B1, P1, V3, V6]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏σ.-≮خج; 𼎏σ.-≮خج; [B1, P1, V3, V6]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+xn--4xa92520c.xn----9mcf1400a; 𼎏σ.-≮خج; [B1, V3, V6]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+xn--3xa13520c.xn----9mcf1400a; 𼎏ς.-≮خج; [B1, V3, V6]; xn--3xa13520c.xn----9mcf1400a; ; ;  # ς.-≮خج
+𼎏Σ．-≮ﲫ; 𼎏σ.-≮خج; [B1, P1, V3, V6]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏Σ．-≮ﲫ; 𼎏σ.-≮خج; [B1, P1, V3, V6]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏σ．-≮ﲫ; 𼎏σ.-≮خج; [B1, P1, V3, V6]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏σ．-≮ﲫ; 𼎏σ.-≮خج; [B1, P1, V3, V6]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+ꡗࢸܙ．񔤔󠛙్ﰾ; ꡗࢸܙ.񔤔󠛙్كي; [B5, B6, P1, V6]; xn--jnb34fs003a.xn--fhbo927bk128mpi24d; ; ;  # ꡗࢸܙ.్كي
+ꡗࢸܙ.񔤔󠛙్كي; ; [B5, B6, P1, V6]; xn--jnb34fs003a.xn--fhbo927bk128mpi24d; ; ;  # ꡗࢸܙ.్كي
+xn--jnb34fs003a.xn--fhbo927bk128mpi24d; ꡗࢸܙ.񔤔󠛙్كي; [B5, B6, V6]; xn--jnb34fs003a.xn--fhbo927bk128mpi24d; ; ;  # ꡗࢸܙ.్كي
+𐠰ࢷ𞤌𐫭。𐋦៍𝩃; 𐠰ࢷ𞤮𐫭.𐋦៍𝩃; [B1]; xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; ; ;  # 𐠰ࢷ𞤮𐫭.𐋦៍𝩃
+𐠰ࢷ𞤮𐫭。𐋦៍𝩃; 𐠰ࢷ𞤮𐫭.𐋦៍𝩃; [B1]; xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; ; ;  # 𐠰ࢷ𞤮𐫭.𐋦៍𝩃
+xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; 𐠰ࢷ𞤮𐫭.𐋦៍𝩃; [B1]; xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; ; ;  # 𐠰ࢷ𞤮𐫭.𐋦៍𝩃
+𐠰ࢷ𞤮𐫭.𐋦៍𝩃; ; [B1]; xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; ; ;  # 𐠰ࢷ𞤮𐫭.𐋦៍𝩃
+𐠰ࢷ𞤌𐫭.𐋦៍𝩃; 𐠰ࢷ𞤮𐫭.𐋦៍𝩃; [B1]; xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; ; ;  # 𐠰ࢷ𞤮𐫭.𐋦៍𝩃
+₂㘷--。ۓ‌𐫆𑖿; 2㘷--.ۓ‌𐫆𑖿; [B1, C1, V2, V3]; xn--2---u58b.xn--jlb820ku99nbgj; ; xn--2---u58b.xn--jlb8024k14g; [B1, V2, V3] # 2㘷--.ۓ𐫆𑖿
+₂㘷--。ۓ‌𐫆𑖿; 2㘷--.ۓ‌𐫆𑖿; [B1, C1, V2, V3]; xn--2---u58b.xn--jlb820ku99nbgj; ; xn--2---u58b.xn--jlb8024k14g; [B1, V2, V3] # 2㘷--.ۓ𐫆𑖿
+2㘷--。ۓ‌𐫆𑖿; 2㘷--.ۓ‌𐫆𑖿; [B1, C1, V2, V3]; xn--2---u58b.xn--jlb820ku99nbgj; ; xn--2---u58b.xn--jlb8024k14g; [B1, V2, V3] # 2㘷--.ۓ𐫆𑖿
+2㘷--。ۓ‌𐫆𑖿; 2㘷--.ۓ‌𐫆𑖿; [B1, C1, V2, V3]; xn--2---u58b.xn--jlb820ku99nbgj; ; xn--2---u58b.xn--jlb8024k14g; [B1, V2, V3] # 2㘷--.ۓ𐫆𑖿
+xn--2---u58b.xn--jlb8024k14g; 2㘷--.ۓ𐫆𑖿; [B1, V2, V3]; xn--2---u58b.xn--jlb8024k14g; ; ;  # 2㘷--.ۓ𐫆𑖿
+xn--2---u58b.xn--jlb820ku99nbgj; 2㘷--.ۓ‌𐫆𑖿; [B1, C1, V2, V3]; xn--2---u58b.xn--jlb820ku99nbgj; ; ;  # 2㘷--.ۓ𐫆𑖿
+-𘊻．ᡮح-; -𘊻.ᡮح-; [B1, B5, B6, V3]; xn----bp5n.xn----bnc231l; ; ;  # -𘊻.ᡮح-
+-𘊻.ᡮح-; ; [B1, B5, B6, V3]; xn----bp5n.xn----bnc231l; ; ;  # -𘊻.ᡮح-
+xn----bp5n.xn----bnc231l; -𘊻.ᡮح-; [B1, B5, B6, V3]; xn----bp5n.xn----bnc231l; ; ;  # -𘊻.ᡮح-
+‌-ß｡ᢣ𐹭ؿ; ‌-ß.ᢣ𐹭ؿ; [B1, B5, B6, C1]; xn----qfa550v.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ß.ᢣ𐹭ؿ
+‌-ß。ᢣ𐹭ؿ; ‌-ß.ᢣ𐹭ؿ; [B1, B5, B6, C1]; xn----qfa550v.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ß.ᢣ𐹭ؿ
+‌-SS。ᢣ𐹭ؿ; ‌-ss.ᢣ𐹭ؿ; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+‌-ss。ᢣ𐹭ؿ; ‌-ss.ᢣ𐹭ؿ; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+‌-Ss。ᢣ𐹭ؿ; ‌-ss.ᢣ𐹭ؿ; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+-ss.xn--bhb925glx3p; -ss.ᢣ𐹭ؿ; [B1, B5, B6, V3]; -ss.xn--bhb925glx3p; ; ;  # -ss.ᢣ𐹭ؿ
+xn---ss-8m0a.xn--bhb925glx3p; ‌-ss.ᢣ𐹭ؿ; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; ;  # -ss.ᢣ𐹭ؿ
+xn----qfa550v.xn--bhb925glx3p; ‌-ß.ᢣ𐹭ؿ; [B1, B5, B6, C1]; xn----qfa550v.xn--bhb925glx3p; ; ;  # -ß.ᢣ𐹭ؿ
+‌-SS｡ᢣ𐹭ؿ; ‌-ss.ᢣ𐹭ؿ; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+‌-ss｡ᢣ𐹭ؿ; ‌-ss.ᢣ𐹭ؿ; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+‌-Ss｡ᢣ𐹭ؿ; ‌-ss.ᢣ𐹭ؿ; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+꧐Ӏ᮪ࣶ．눵; ꧐Ӏ᮪ࣶ.눵; [P1, V6]; xn--d5a07sn4u297k.xn--2e1b; ; ;  # ꧐Ӏ᮪ࣶ.눵
+꧐Ӏ᮪ࣶ．눵; ꧐Ӏ᮪ࣶ.눵; [P1, V6]; xn--d5a07sn4u297k.xn--2e1b; ; ;  # ꧐Ӏ᮪ࣶ.눵
+꧐Ӏ᮪ࣶ.눵; ; [P1, V6]; xn--d5a07sn4u297k.xn--2e1b; ; ;  # ꧐Ӏ᮪ࣶ.눵
+꧐Ӏ᮪ࣶ.눵; ꧐Ӏ᮪ࣶ.눵; [P1, V6]; xn--d5a07sn4u297k.xn--2e1b; ; ;  # ꧐Ӏ᮪ࣶ.눵
+꧐ӏ᮪ࣶ.눵; ꧐ӏ᮪ࣶ.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+꧐ӏ᮪ࣶ.눵; ; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+xn--s5a04sn4u297k.xn--2e1b; ꧐ӏ᮪ࣶ.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+xn--d5a07sn4u297k.xn--2e1b; ꧐Ӏ᮪ࣶ.눵; [V6]; xn--d5a07sn4u297k.xn--2e1b; ; ;  # ꧐Ӏ᮪ࣶ.눵
+꧐ӏ᮪ࣶ．눵; ꧐ӏ᮪ࣶ.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+꧐ӏ᮪ࣶ．눵; ꧐ӏ᮪ࣶ.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+꣪｡𖄿𑆾󠇗; ꣪.𖄿𑆾; [P1, V5, V6]; xn--3g9a.xn--ud1dz07k; ; ;  # ꣪.𑆾
+꣪。𖄿𑆾󠇗; ꣪.𖄿𑆾; [P1, V5, V6]; xn--3g9a.xn--ud1dz07k; ; ;  # ꣪.𑆾
+xn--3g9a.xn--ud1dz07k; ꣪.𖄿𑆾; [V5, V6]; xn--3g9a.xn--ud1dz07k; ; ;  # ꣪.𑆾
+󇓓𑚳。񐷿≯⾇; 󇓓𑚳.񐷿≯舛; [P1, V6]; xn--3e2d79770c.xn--hdh0088abyy1c; ; ;  # 𑚳.≯舛
+󇓓𑚳。񐷿≯⾇; 󇓓𑚳.񐷿≯舛; [P1, V6]; xn--3e2d79770c.xn--hdh0088abyy1c; ; ;  # 𑚳.≯舛
+󇓓𑚳。񐷿≯舛; 󇓓𑚳.񐷿≯舛; [P1, V6]; xn--3e2d79770c.xn--hdh0088abyy1c; ; ;  # 𑚳.≯舛
+󇓓𑚳。񐷿≯舛; 󇓓𑚳.񐷿≯舛; [P1, V6]; xn--3e2d79770c.xn--hdh0088abyy1c; ; ;  # 𑚳.≯舛
+xn--3e2d79770c.xn--hdh0088abyy1c; 󇓓𑚳.񐷿≯舛; [V6]; xn--3e2d79770c.xn--hdh0088abyy1c; ; ;  # 𑚳.≯舛
+𐫇١‌．‍‌; 𐫇١‌.‍‌; [B1, B3, C1, C2]; xn--9hb652kv99n.xn--0ugb; ; xn--9hb7344k.; [] # 𐫇١.
+𐫇١‌.‍‌; ; [B1, B3, C1, C2]; xn--9hb652kv99n.xn--0ugb; ; xn--9hb7344k.; [] # 𐫇١.
+xn--9hb7344k.; 𐫇١.; ; xn--9hb7344k.; ; ;  # 𐫇١.
+𐫇١.; ; ; xn--9hb7344k.; ; ;  # 𐫇١.
+xn--9hb652kv99n.xn--0ugb; 𐫇١‌.‍‌; [B1, B3, C1, C2]; xn--9hb652kv99n.xn--0ugb; ; ;  # 𐫇١.
+񡅈砪≯ᢑ｡≯𝩚򓴔‌; 񡅈砪≯ᢑ.≯𝩚򓴔‌; [C1, P1, V6]; xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; ; xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; [P1, V6] # 砪≯ᢑ.≯𝩚
+񡅈砪≯ᢑ｡≯𝩚򓴔‌; 񡅈砪≯ᢑ.≯𝩚򓴔‌; [C1, P1, V6]; xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; ; xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; [P1, V6] # 砪≯ᢑ.≯𝩚
+񡅈砪≯ᢑ。≯𝩚򓴔‌; 񡅈砪≯ᢑ.≯𝩚򓴔‌; [C1, P1, V6]; xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; ; xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; [P1, V6] # 砪≯ᢑ.≯𝩚
+񡅈砪≯ᢑ。≯𝩚򓴔‌; 񡅈砪≯ᢑ.≯𝩚򓴔‌; [C1, P1, V6]; xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; ; xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; [P1, V6] # 砪≯ᢑ.≯𝩚
+xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; 񡅈砪≯ᢑ.≯𝩚򓴔; [V6]; xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; ; ;  # 砪≯ᢑ.≯𝩚
+xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; 񡅈砪≯ᢑ.≯𝩚򓴔‌; [C1, V6]; xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; ; ;  # 砪≯ᢑ.≯𝩚
+Ⴥ.𑄳㊸; Ⴥ.𑄳43; [P1, V5, V6]; xn--9nd.xn--43-274o; ; ;  # Ⴥ.𑄳43
+Ⴥ.𑄳43; ; [P1, V5, V6]; xn--9nd.xn--43-274o; ; ;  # Ⴥ.𑄳43
+ⴥ.𑄳43; ; [V5]; xn--tlj.xn--43-274o; ; ;  # ⴥ.𑄳43
+xn--tlj.xn--43-274o; ⴥ.𑄳43; [V5]; xn--tlj.xn--43-274o; ; ;  # ⴥ.𑄳43
+xn--9nd.xn--43-274o; Ⴥ.𑄳43; [V5, V6]; xn--9nd.xn--43-274o; ; ;  # Ⴥ.𑄳43
+ⴥ.𑄳㊸; ⴥ.𑄳43; [V5]; xn--tlj.xn--43-274o; ; ;  # ⴥ.𑄳43
+𝟎٣。Ⴒᡇࣲ𐹠; 0٣.Ⴒᡇࣲ𐹠; [B1, B5, B6, P1, V6]; xn--0-fqc.xn--10b180bnwgfy0z; ; ;  # 0٣.Ⴒᡇࣲ𐹠
+0٣。Ⴒᡇࣲ𐹠; 0٣.Ⴒᡇࣲ𐹠; [B1, B5, B6, P1, V6]; xn--0-fqc.xn--10b180bnwgfy0z; ; ;  # 0٣.Ⴒᡇࣲ𐹠
+0٣。ⴒᡇࣲ𐹠; 0٣.ⴒᡇࣲ𐹠; [B1, B5, B6]; xn--0-fqc.xn--10b369eivp359r; ; ;  # 0٣.ⴒᡇࣲ𐹠
+xn--0-fqc.xn--10b369eivp359r; 0٣.ⴒᡇࣲ𐹠; [B1, B5, B6]; xn--0-fqc.xn--10b369eivp359r; ; ;  # 0٣.ⴒᡇࣲ𐹠
+xn--0-fqc.xn--10b180bnwgfy0z; 0٣.Ⴒᡇࣲ𐹠; [B1, B5, B6, V6]; xn--0-fqc.xn--10b180bnwgfy0z; ; ;  # 0٣.Ⴒᡇࣲ𐹠
+𝟎٣。ⴒᡇࣲ𐹠; 0٣.ⴒᡇࣲ𐹠; [B1, B5, B6]; xn--0-fqc.xn--10b369eivp359r; ; ;  # 0٣.ⴒᡇࣲ𐹠
+񗪨󠄉ﾠྷ.񸞰꥓; 񗪨ﾠྷ.񸞰꥓; [P1, V6]; xn--kgd7493jee34a.xn--3j9au7544a; ; ;  # ྷ.꥓
+񗪨󠄉ᅠྷ.񸞰꥓; 񗪨ᅠྷ.񸞰꥓; [P1, V6]; xn--kgd36f9z57y.xn--3j9au7544a; ; ;  # ྷ.꥓
+xn--kgd36f9z57y.xn--3j9au7544a; 񗪨ᅠྷ.񸞰꥓; [V6]; xn--kgd36f9z57y.xn--3j9au7544a; ; ;  # ྷ.꥓
+xn--kgd7493jee34a.xn--3j9au7544a; 񗪨ﾠྷ.񸞰꥓; [V6]; xn--kgd7493jee34a.xn--3j9au7544a; ; ;  # ྷ.꥓
+ؘ.۳‌꥓; ; [C1, V5]; xn--6fb.xn--gmb469jjf1h; ; xn--6fb.xn--gmb0524f; [V5] # ؘ.۳꥓
+xn--6fb.xn--gmb0524f; ؘ.۳꥓; [V5]; xn--6fb.xn--gmb0524f; ; ;  # ؘ.۳꥓
+xn--6fb.xn--gmb469jjf1h; ؘ.۳‌꥓; [C1, V5]; xn--6fb.xn--gmb469jjf1h; ; ;  # ؘ.۳꥓
+ᡌ．︒ᢑ; ᡌ.︒ᢑ; [P1, V6]; xn--c8e.xn--bbf9168i; ; ;  # ᡌ.︒ᢑ
+ᡌ.。ᢑ; ᡌ..ᢑ; [X4_2]; xn--c8e..xn--bbf; [A4_2]; ;  # ᡌ..ᢑ
+xn--c8e..xn--bbf; ᡌ..ᢑ; [X4_2]; xn--c8e..xn--bbf; [A4_2]; ;  # ᡌ..ᢑ
+xn--c8e.xn--bbf9168i; ᡌ.︒ᢑ; [V6]; xn--c8e.xn--bbf9168i; ; ;  # ᡌ.︒ᢑ
+𑋪ၳ｡𞽧; 𑋪ၳ.𞽧; [B1, B3, B6, P1, V5, V6]; xn--xld7443k.xn--4o7h; ; ;  # 𑋪ၳ.
+𑋪ၳ。𞽧; 𑋪ၳ.𞽧; [B1, B3, B6, P1, V5, V6]; xn--xld7443k.xn--4o7h; ; ;  # 𑋪ၳ.
+xn--xld7443k.xn--4o7h; 𑋪ၳ.𞽧; [B1, B3, B6, V5, V6]; xn--xld7443k.xn--4o7h; ; ;  # 𑋪ၳ.
+𞷏。ᠢ򓘆; 𞷏.ᠢ򓘆; [P1, V6]; xn--hd7h.xn--46e66060j; ; ;  # .ᠢ
+xn--hd7h.xn--46e66060j; 𞷏.ᠢ򓘆; [V6]; xn--hd7h.xn--46e66060j; ; ;  # .ᠢ
+𑄳㴼．‌𐹡⃫񫺦; 𑄳㴼.‌𐹡⃫񫺦; [B1, C1, P1, V5, V6]; xn--iym9428c.xn--0ug46a7218cllv0c; ; xn--iym9428c.xn--e1g3464g08p3b; [B1, P1, V5, V6] # 𑄳㴼.𐹡⃫
+𑄳㴼.‌𐹡⃫񫺦; ; [B1, C1, P1, V5, V6]; xn--iym9428c.xn--0ug46a7218cllv0c; ; xn--iym9428c.xn--e1g3464g08p3b; [B1, P1, V5, V6] # 𑄳㴼.𐹡⃫
+xn--iym9428c.xn--e1g3464g08p3b; 𑄳㴼.𐹡⃫񫺦; [B1, V5, V6]; xn--iym9428c.xn--e1g3464g08p3b; ; ;  # 𑄳㴼.𐹡⃫
+xn--iym9428c.xn--0ug46a7218cllv0c; 𑄳㴼.‌𐹡⃫񫺦; [B1, C1, V5, V6]; xn--iym9428c.xn--0ug46a7218cllv0c; ; ;  # 𑄳㴼.𐹡⃫
+񠻟𐹳𑈯｡̝; 񠻟𐹳𑈯.̝; [B1, B3, B5, B6, P1, V5, V6]; xn--ro0dw7dey96m.xn--eta; ; ;  # 𐹳𑈯.̝
+񠻟𐹳𑈯。̝; 񠻟𐹳𑈯.̝; [B1, B3, B5, B6, P1, V5, V6]; xn--ro0dw7dey96m.xn--eta; ; ;  # 𐹳𑈯.̝
+xn--ro0dw7dey96m.xn--eta; 񠻟𐹳𑈯.̝; [B1, B3, B5, B6, V5, V6]; xn--ro0dw7dey96m.xn--eta; ; ;  # 𐹳𑈯.̝
+ᢊ뾜󠱴𑚶。࢝𐹥; ᢊ뾜󠱴𑚶.࢝𐹥; [P1, V6]; xn--39e4566fjv8bwmt6n.xn--myb6415k; ; ;  # ᢊ뾜𑚶.𐹥
+ᢊ뾜󠱴𑚶。࢝𐹥; ᢊ뾜󠱴𑚶.࢝𐹥; [P1, V6]; xn--39e4566fjv8bwmt6n.xn--myb6415k; ; ;  # ᢊ뾜𑚶.𐹥
+xn--39e4566fjv8bwmt6n.xn--myb6415k; ᢊ뾜󠱴𑚶.࢝𐹥; [V6]; xn--39e4566fjv8bwmt6n.xn--myb6415k; ; ;  # ᢊ뾜𑚶.𐹥
+𐹥≠｡𐋲󠧠‌; 𐹥≠.𐋲󠧠‌; [B1, C1, P1, V6]; xn--1ch6704g.xn--0ug3840g51u4g; ; xn--1ch6704g.xn--m97cw2999c; [B1, P1, V6] # 𐹥≠.𐋲
+𐹥≠｡𐋲󠧠‌; 𐹥≠.𐋲󠧠‌; [B1, C1, P1, V6]; xn--1ch6704g.xn--0ug3840g51u4g; ; xn--1ch6704g.xn--m97cw2999c; [B1, P1, V6] # 𐹥≠.𐋲
+𐹥≠。𐋲󠧠‌; 𐹥≠.𐋲󠧠‌; [B1, C1, P1, V6]; xn--1ch6704g.xn--0ug3840g51u4g; ; xn--1ch6704g.xn--m97cw2999c; [B1, P1, V6] # 𐹥≠.𐋲
+𐹥≠。𐋲󠧠‌; 𐹥≠.𐋲󠧠‌; [B1, C1, P1, V6]; xn--1ch6704g.xn--0ug3840g51u4g; ; xn--1ch6704g.xn--m97cw2999c; [B1, P1, V6] # 𐹥≠.𐋲
+xn--1ch6704g.xn--m97cw2999c; 𐹥≠.𐋲󠧠; [B1, V6]; xn--1ch6704g.xn--m97cw2999c; ; ;  # 𐹥≠.𐋲
+xn--1ch6704g.xn--0ug3840g51u4g; 𐹥≠.𐋲󠧠‌; [B1, C1, V6]; xn--1ch6704g.xn--0ug3840g51u4g; ; ;  # 𐹥≠.𐋲
+ᅟ񙯠्．‍꥓𐪤; ᅟ񙯠्.‍꥓𐪤; [B1, C2, P1, V6]; xn--n3b542bb085j.xn--1ug6815co9wc; ; xn--n3b542bb085j.xn--3j9al95p; [B5, B6, P1, V5, V6] # ्.꥓
+ᅟ񙯠्.‍꥓𐪤; ; [B1, C2, P1, V6]; xn--n3b542bb085j.xn--1ug6815co9wc; ; xn--n3b542bb085j.xn--3j9al95p; [B5, B6, P1, V5, V6] # ्.꥓
+xn--n3b542bb085j.xn--3j9al95p; ᅟ񙯠्.꥓𐪤; [B5, B6, V5, V6]; xn--n3b542bb085j.xn--3j9al95p; ; ;  # ्.꥓
+xn--n3b542bb085j.xn--1ug6815co9wc; ᅟ񙯠्.‍꥓𐪤; [B1, C2, V6]; xn--n3b542bb085j.xn--1ug6815co9wc; ; ;  # ्.꥓
+򌋔󠆎󠆗𑲕。≮; 򌋔𑲕.≮; [P1, V6]; xn--4m3dv4354a.xn--gdh; ; ;  # 𑲕.≮
+򌋔󠆎󠆗𑲕。≮; 򌋔𑲕.≮; [P1, V6]; xn--4m3dv4354a.xn--gdh; ; ;  # 𑲕.≮
+xn--4m3dv4354a.xn--gdh; 򌋔𑲕.≮; [V6]; xn--4m3dv4354a.xn--gdh; ; ;  # 𑲕.≮
+󠆦.ࣣ暀≠; .ࣣ暀≠; [P1, V5, V6, X4_2]; .xn--m0b461k3g2c; [P1, V5, V6, A4_2]; ;  # .ࣣ暀≠
+󠆦.ࣣ暀≠; .ࣣ暀≠; [P1, V5, V6, X4_2]; .xn--m0b461k3g2c; [P1, V5, V6, A4_2]; ;  # .ࣣ暀≠
+.xn--m0b461k3g2c; .ࣣ暀≠; [V5, V6, X4_2]; .xn--m0b461k3g2c; [V5, V6, A4_2]; ;  # .ࣣ暀≠
+𐡤꯭｡ﴰ򜖅ᷰ; 𐡤꯭.شم򜖅ᷰ; [B2, B3, P1, V6]; xn--429ak76o.xn--zgb8a701kox37t; ; ;  # 𐡤꯭.شمᷰ
+𐡤꯭。شم򜖅ᷰ; 𐡤꯭.شم򜖅ᷰ; [B2, B3, P1, V6]; xn--429ak76o.xn--zgb8a701kox37t; ; ;  # 𐡤꯭.شمᷰ
+xn--429ak76o.xn--zgb8a701kox37t; 𐡤꯭.شم򜖅ᷰ; [B2, B3, V6]; xn--429ak76o.xn--zgb8a701kox37t; ; ;  # 𐡤꯭.شمᷰ
+𝉃‍⒈｡Ⴌ𞱓; 𝉃‍⒈.Ⴌ𞱓; [B1, B5, B6, C2, P1, V5, V6]; xn--1ug68oq348b.xn--knd8464v; ; xn--tshz828m.xn--knd8464v; [B1, B5, B6, P1, V5, V6] # 𝉃⒈.Ⴌ
+𝉃‍1.。Ⴌ𞱓; 𝉃‍1..Ⴌ𞱓; [B1, B5, B6, C2, P1, V5, V6, X4_2]; xn--1-tgn9827q..xn--knd8464v; [B1, B5, B6, C2, P1, V5, V6, A4_2]; xn--1-px8q..xn--knd8464v; [B1, B5, B6, P1, V5, V6, A4_2] # 𝉃1..Ⴌ
+𝉃‍1.。ⴌ𞱓; 𝉃‍1..ⴌ𞱓; [B1, B5, B6, C2, P1, V5, V6, X4_2]; xn--1-tgn9827q..xn--3kj4524l; [B1, B5, B6, C2, P1, V5, V6, A4_2]; xn--1-px8q..xn--3kj4524l; [B1, B5, B6, P1, V5, V6, A4_2] # 𝉃1..ⴌ
+xn--1-px8q..xn--3kj4524l; 𝉃1..ⴌ𞱓; [B1, B5, B6, V5, V6, X4_2]; xn--1-px8q..xn--3kj4524l; [B1, B5, B6, V5, V6, A4_2]; ;  # 𝉃1..ⴌ
+xn--1-tgn9827q..xn--3kj4524l; 𝉃‍1..ⴌ𞱓; [B1, B5, B6, C2, V5, V6, X4_2]; xn--1-tgn9827q..xn--3kj4524l; [B1, B5, B6, C2, V5, V6, A4_2]; ;  # 𝉃1..ⴌ
+xn--1-px8q..xn--knd8464v; 𝉃1..Ⴌ𞱓; [B1, B5, B6, V5, V6, X4_2]; xn--1-px8q..xn--knd8464v; [B1, B5, B6, V5, V6, A4_2]; ;  # 𝉃1..Ⴌ
+xn--1-tgn9827q..xn--knd8464v; 𝉃‍1..Ⴌ𞱓; [B1, B5, B6, C2, V5, V6, X4_2]; xn--1-tgn9827q..xn--knd8464v; [B1, B5, B6, C2, V5, V6, A4_2]; ;  # 𝉃1..Ⴌ
+𝉃‍⒈｡ⴌ𞱓; 𝉃‍⒈.ⴌ𞱓; [B1, B5, B6, C2, P1, V5, V6]; xn--1ug68oq348b.xn--3kj4524l; ; xn--tshz828m.xn--3kj4524l; [B1, B5, B6, P1, V5, V6] # 𝉃⒈.ⴌ
+xn--tshz828m.xn--3kj4524l; 𝉃⒈.ⴌ𞱓; [B1, B5, B6, V5, V6]; xn--tshz828m.xn--3kj4524l; ; ;  # 𝉃⒈.ⴌ
+xn--1ug68oq348b.xn--3kj4524l; 𝉃‍⒈.ⴌ𞱓; [B1, B5, B6, C2, V5, V6]; xn--1ug68oq348b.xn--3kj4524l; ; ;  # 𝉃⒈.ⴌ
+xn--tshz828m.xn--knd8464v; 𝉃⒈.Ⴌ𞱓; [B1, B5, B6, V5, V6]; xn--tshz828m.xn--knd8464v; ; ;  # 𝉃⒈.Ⴌ
+xn--1ug68oq348b.xn--knd8464v; 𝉃‍⒈.Ⴌ𞱓; [B1, B5, B6, C2, V5, V6]; xn--1ug68oq348b.xn--knd8464v; ; ;  # 𝉃⒈.Ⴌ
+󠣙੍𱫘𞤸.ς񵯞􈰔; ; [B1, P1, V6]; xn--ybc0236vjvxgt5q0g.xn--3xa03737giye6b; ; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b;  # ੍𞤸.ς
+󠣙੍𱫘𞤖.Σ񵯞􈰔; 󠣙੍𱫘𞤸.σ񵯞􈰔; [B1, P1, V6]; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; ; ;  # ੍𞤸.σ
+󠣙੍𱫘𞤸.σ񵯞􈰔; ; [B1, P1, V6]; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; ; ;  # ੍𞤸.σ
+󠣙੍𱫘𞤖.σ񵯞􈰔; 󠣙੍𱫘𞤸.σ񵯞􈰔; [B1, P1, V6]; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; ; ;  # ੍𞤸.σ
+xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; 󠣙੍𱫘𞤸.σ񵯞􈰔; [B1, V6]; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; ; ;  # ੍𞤸.σ
+󠣙੍𱫘𞤖.ς񵯞􈰔; 󠣙੍𱫘𞤸.ς񵯞􈰔; [B1, P1, V6]; xn--ybc0236vjvxgt5q0g.xn--3xa03737giye6b; ; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b;  # ੍𞤸.ς
+xn--ybc0236vjvxgt5q0g.xn--3xa03737giye6b; 󠣙੍𱫘𞤸.ς񵯞􈰔; [B1, V6]; xn--ybc0236vjvxgt5q0g.xn--3xa03737giye6b; ; ;  # ੍𞤸.ς
+󠣙੍𱫘𞤸.Σ񵯞􈰔; 󠣙੍𱫘𞤸.σ񵯞􈰔; [B1, P1, V6]; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; ; ;  # ੍𞤸.σ
+ߓ。‌𐫀򞭱; ߓ.‌𐫀򞭱; [B1, C1, P1, V6]; xn--usb.xn--0ug9553gm3v5d; ; xn--usb.xn--pw9ci1099a; [B2, B3, P1, V6] # ߓ.𐫀
+xn--usb.xn--pw9ci1099a; ߓ.𐫀򞭱; [B2, B3, V6]; xn--usb.xn--pw9ci1099a; ; ;  # ߓ.𐫀
+xn--usb.xn--0ug9553gm3v5d; ߓ.‌𐫀򞭱; [B1, C1, V6]; xn--usb.xn--0ug9553gm3v5d; ; ;  # ߓ.𐫀
+ᰮ𞀝.֦ꡟ𞤕󠆖; ᰮ𞀝.֦ꡟ𞤷; [B1, B3, B6, V5]; xn--q1f4493q.xn--xcb8244fifvj; ; ;  # ᰮ𞀝.֦ꡟ𞤷
+ᰮ𞀝.֦ꡟ𞤷󠆖; ᰮ𞀝.֦ꡟ𞤷; [B1, B3, B6, V5]; xn--q1f4493q.xn--xcb8244fifvj; ; ;  # ᰮ𞀝.֦ꡟ𞤷
+xn--q1f4493q.xn--xcb8244fifvj; ᰮ𞀝.֦ꡟ𞤷; [B1, B3, B6, V5]; xn--q1f4493q.xn--xcb8244fifvj; ; ;  # ᰮ𞀝.֦ꡟ𞤷
+䂹󾖅𐋦．‍; 䂹󾖅𐋦.‍; [C2, P1, V6]; xn--0on3543c5981i.xn--1ug; ; xn--0on3543c5981i.; [P1, V6] # 䂹𐋦.
+䂹󾖅𐋦.‍; ; [C2, P1, V6]; xn--0on3543c5981i.xn--1ug; ; xn--0on3543c5981i.; [P1, V6] # 䂹𐋦.
+xn--0on3543c5981i.; 䂹󾖅𐋦.; [V6]; xn--0on3543c5981i.; ; ;  # 䂹𐋦.
+xn--0on3543c5981i.xn--1ug; 䂹󾖅𐋦.‍; [C2, V6]; xn--0on3543c5981i.xn--1ug; ; ;  # 䂹𐋦.
+꧀‌𐹲‌｡ݧ🄉; ꧀‌𐹲‌.ݧ🄉; [B5, B6, C1, P1, V5, V6]; xn--0uga8686hdgvd.xn--rpb6081w; ; xn--7m9an32q.xn--rpb6081w; [B5, B6, P1, V5, V6] # ꧀𐹲.ݧ🄉
+꧀‌𐹲‌。ݧ8,; ꧀‌𐹲‌.ݧ8,; [B3, B5, B6, C1, P1, V5, V6]; xn--0uga8686hdgvd.xn--8,-qle; ; xn--7m9an32q.xn--8,-qle; [B3, B5, B6, P1, V5, V6] # ꧀𐹲.ݧ8,
+xn--7m9an32q.xn--8,-qle; ꧀𐹲.ݧ8,; [B3, B5, B6, P1, V5, V6]; xn--7m9an32q.xn--8,-qle; ; ;  # ꧀𐹲.ݧ8,
+xn--0uga8686hdgvd.xn--8,-qle; ꧀‌𐹲‌.ݧ8,; [B3, B5, B6, C1, P1, V5, V6]; xn--0uga8686hdgvd.xn--8,-qle; ; ;  # ꧀𐹲.ݧ8,
+xn--7m9an32q.xn--rpb6081w; ꧀𐹲.ݧ🄉; [B5, B6, V5, V6]; xn--7m9an32q.xn--rpb6081w; ; ;  # ꧀𐹲.ݧ🄉
+xn--0uga8686hdgvd.xn--rpb6081w; ꧀‌𐹲‌.ݧ🄉; [B5, B6, C1, V5, V6]; xn--0uga8686hdgvd.xn--rpb6081w; ; ;  # ꧀𐹲.ݧ🄉
+︒｡Ⴃ≯; ︒.Ⴃ≯; [P1, V6]; xn--y86c.xn--bnd622g; ; ;  # ︒.Ⴃ≯
+︒｡Ⴃ≯; ︒.Ⴃ≯; [P1, V6]; xn--y86c.xn--bnd622g; ; ;  # ︒.Ⴃ≯
+。。Ⴃ≯; ..Ⴃ≯; [P1, V6, X4_2]; ..xn--bnd622g; [P1, V6, A4_2]; ;  # ..Ⴃ≯
+。。Ⴃ≯; ..Ⴃ≯; [P1, V6, X4_2]; ..xn--bnd622g; [P1, V6, A4_2]; ;  # ..Ⴃ≯
+。。ⴃ≯; ..ⴃ≯; [P1, V6, X4_2]; ..xn--hdh782b; [P1, V6, A4_2]; ;  # ..ⴃ≯
+。。ⴃ≯; ..ⴃ≯; [P1, V6, X4_2]; ..xn--hdh782b; [P1, V6, A4_2]; ;  # ..ⴃ≯
+..xn--hdh782b; ..ⴃ≯; [V6, X4_2]; ..xn--hdh782b; [V6, A4_2]; ;  # ..ⴃ≯
+..xn--bnd622g; ..Ⴃ≯; [V6, X4_2]; ..xn--bnd622g; [V6, A4_2]; ;  # ..Ⴃ≯
+︒｡ⴃ≯; ︒.ⴃ≯; [P1, V6]; xn--y86c.xn--hdh782b; ; ;  # ︒.ⴃ≯
+︒｡ⴃ≯; ︒.ⴃ≯; [P1, V6]; xn--y86c.xn--hdh782b; ; ;  # ︒.ⴃ≯
+xn--y86c.xn--hdh782b; ︒.ⴃ≯; [V6]; xn--y86c.xn--hdh782b; ; ;  # ︒.ⴃ≯
+xn--y86c.xn--bnd622g; ︒.Ⴃ≯; [V6]; xn--y86c.xn--bnd622g; ; ;  # ︒.Ⴃ≯
+𐹮｡󠢼‍; 𐹮.󠢼‍; [B1, C2, P1, V6]; xn--mo0d.xn--1ug18431l; ; xn--mo0d.xn--wy46e; [B1, P1, V6] # 𐹮.
+𐹮。󠢼‍; 𐹮.󠢼‍; [B1, C2, P1, V6]; xn--mo0d.xn--1ug18431l; ; xn--mo0d.xn--wy46e; [B1, P1, V6] # 𐹮.
+xn--mo0d.xn--wy46e; 𐹮.󠢼; [B1, V6]; xn--mo0d.xn--wy46e; ; ;  # 𐹮.
+xn--mo0d.xn--1ug18431l; 𐹮.󠢼‍; [B1, C2, V6]; xn--mo0d.xn--1ug18431l; ; ;  # 𐹮.
+Ⴞ𐹨｡︒ݽ‍Ⴏ; Ⴞ𐹨.︒ݽ‍Ⴏ; [B1, B5, B6, C2, P1, V6]; xn--2nd0990k.xn--eqb228bgzmvp0t; ; xn--2nd0990k.xn--eqb228b583r; [B1, B5, B6, P1, V6] # Ⴞ𐹨.︒ݽႯ
+Ⴞ𐹨。。ݽ‍Ⴏ; Ⴞ𐹨..ݽ‍Ⴏ; [B2, B3, B5, B6, C2, P1, V6, X4_2]; xn--2nd0990k..xn--eqb228bgzm; [B2, B3, B5, B6, C2, P1, V6, A4_2]; xn--2nd0990k..xn--eqb228b; [B2, B3, B5, B6, P1, V6, A4_2] # Ⴞ𐹨..ݽႯ
+ⴞ𐹨。。ݽ‍ⴏ; ⴞ𐹨..ݽ‍ⴏ; [B2, B3, B5, B6, C2, X4_2]; xn--mlju223e..xn--eqb096jpgj; [B2, B3, B5, B6, C2, A4_2]; xn--mlju223e..xn--eqb053q; [B2, B3, B5, B6, A4_2] # ⴞ𐹨..ݽⴏ
+Ⴞ𐹨。。ݽ‍ⴏ; Ⴞ𐹨..ݽ‍ⴏ; [B2, B3, B5, B6, C2, P1, V6, X4_2]; xn--2nd0990k..xn--eqb096jpgj; [B2, B3, B5, B6, C2, P1, V6, A4_2]; xn--2nd0990k..xn--eqb053q; [B2, B3, B5, B6, P1, V6, A4_2] # Ⴞ𐹨..ݽⴏ
+xn--2nd0990k..xn--eqb053q; Ⴞ𐹨..ݽⴏ; [B2, B3, B5, B6, V6, X4_2]; xn--2nd0990k..xn--eqb053q; [B2, B3, B5, B6, V6, A4_2]; ;  # Ⴞ𐹨..ݽⴏ
+xn--2nd0990k..xn--eqb096jpgj; Ⴞ𐹨..ݽ‍ⴏ; [B2, B3, B5, B6, C2, V6, X4_2]; xn--2nd0990k..xn--eqb096jpgj; [B2, B3, B5, B6, C2, V6, A4_2]; ;  # Ⴞ𐹨..ݽⴏ
+xn--mlju223e..xn--eqb053q; ⴞ𐹨..ݽⴏ; [B2, B3, B5, B6, X4_2]; xn--mlju223e..xn--eqb053q; [B2, B3, B5, B6, A4_2]; ;  # ⴞ𐹨..ݽⴏ
+xn--mlju223e..xn--eqb096jpgj; ⴞ𐹨..ݽ‍ⴏ; [B2, B3, B5, B6, C2, X4_2]; xn--mlju223e..xn--eqb096jpgj; [B2, B3, B5, B6, C2, A4_2]; ;  # ⴞ𐹨..ݽⴏ
+xn--2nd0990k..xn--eqb228b; Ⴞ𐹨..ݽႯ; [B2, B3, B5, B6, V6, X4_2]; xn--2nd0990k..xn--eqb228b; [B2, B3, B5, B6, V6, A4_2]; ;  # Ⴞ𐹨..ݽႯ
+xn--2nd0990k..xn--eqb228bgzm; Ⴞ𐹨..ݽ‍Ⴏ; [B2, B3, B5, B6, C2, V6, X4_2]; xn--2nd0990k..xn--eqb228bgzm; [B2, B3, B5, B6, C2, V6, A4_2]; ;  # Ⴞ𐹨..ݽႯ
+ⴞ𐹨｡︒ݽ‍ⴏ; ⴞ𐹨.︒ݽ‍ⴏ; [B1, B5, B6, C2, P1, V6]; xn--mlju223e.xn--eqb096jpgj9y7r; ; xn--mlju223e.xn--eqb053qjk7l; [B1, B5, B6, P1, V6] # ⴞ𐹨.︒ݽⴏ
+Ⴞ𐹨｡︒ݽ‍ⴏ; Ⴞ𐹨.︒ݽ‍ⴏ; [B1, B5, B6, C2, P1, V6]; xn--2nd0990k.xn--eqb096jpgj9y7r; ; xn--2nd0990k.xn--eqb053qjk7l; [B1, B5, B6, P1, V6] # Ⴞ𐹨.︒ݽⴏ
+xn--2nd0990k.xn--eqb053qjk7l; Ⴞ𐹨.︒ݽⴏ; [B1, B5, B6, V6]; xn--2nd0990k.xn--eqb053qjk7l; ; ;  # Ⴞ𐹨.︒ݽⴏ
+xn--2nd0990k.xn--eqb096jpgj9y7r; Ⴞ𐹨.︒ݽ‍ⴏ; [B1, B5, B6, C2, V6]; xn--2nd0990k.xn--eqb096jpgj9y7r; ; ;  # Ⴞ𐹨.︒ݽⴏ
+xn--mlju223e.xn--eqb053qjk7l; ⴞ𐹨.︒ݽⴏ; [B1, B5, B6, V6]; xn--mlju223e.xn--eqb053qjk7l; ; ;  # ⴞ𐹨.︒ݽⴏ
+xn--mlju223e.xn--eqb096jpgj9y7r; ⴞ𐹨.︒ݽ‍ⴏ; [B1, B5, B6, C2, V6]; xn--mlju223e.xn--eqb096jpgj9y7r; ; ;  # ⴞ𐹨.︒ݽⴏ
+xn--2nd0990k.xn--eqb228b583r; Ⴞ𐹨.︒ݽႯ; [B1, B5, B6, V6]; xn--2nd0990k.xn--eqb228b583r; ; ;  # Ⴞ𐹨.︒ݽႯ
+xn--2nd0990k.xn--eqb228bgzmvp0t; Ⴞ𐹨.︒ݽ‍Ⴏ; [B1, B5, B6, C2, V6]; xn--2nd0990k.xn--eqb228bgzmvp0t; ; ;  # Ⴞ𐹨.︒ݽႯ
+‌Ⴆ𝟹。-⃒-ߑ; ‌Ⴆ3.-⃒-ߑ; [B1, C1, P1, V3, V6]; xn--3-i0g939i.xn-----vue617w; ; xn--3-i0g.xn-----vue617w; [B1, P1, V3, V6] # Ⴆ3.-⃒-ߑ
+‌Ⴆ3。-⃒-ߑ; ‌Ⴆ3.-⃒-ߑ; [B1, C1, P1, V3, V6]; xn--3-i0g939i.xn-----vue617w; ; xn--3-i0g.xn-----vue617w; [B1, P1, V3, V6] # Ⴆ3.-⃒-ߑ
+‌ⴆ3。-⃒-ߑ; ‌ⴆ3.-⃒-ߑ; [B1, C1, V3]; xn--3-rgnv99c.xn-----vue617w; ; xn--3-lvs.xn-----vue617w; [B1, V3] # ⴆ3.-⃒-ߑ
+xn--3-lvs.xn-----vue617w; ⴆ3.-⃒-ߑ; [B1, V3]; xn--3-lvs.xn-----vue617w; ; ;  # ⴆ3.-⃒-ߑ
+xn--3-rgnv99c.xn-----vue617w; ‌ⴆ3.-⃒-ߑ; [B1, C1, V3]; xn--3-rgnv99c.xn-----vue617w; ; ;  # ⴆ3.-⃒-ߑ
+xn--3-i0g.xn-----vue617w; Ⴆ3.-⃒-ߑ; [B1, V3, V6]; xn--3-i0g.xn-----vue617w; ; ;  # Ⴆ3.-⃒-ߑ
+xn--3-i0g939i.xn-----vue617w; ‌Ⴆ3.-⃒-ߑ; [B1, C1, V3, V6]; xn--3-i0g939i.xn-----vue617w; ; ;  # Ⴆ3.-⃒-ߑ
+‌ⴆ𝟹。-⃒-ߑ; ‌ⴆ3.-⃒-ߑ; [B1, C1, V3]; xn--3-rgnv99c.xn-----vue617w; ; xn--3-lvs.xn-----vue617w; [B1, V3] # ⴆ3.-⃒-ߑ
+箃Ⴡ-󠁝｡≠-🤖; 箃Ⴡ-󠁝.≠-🤖; [P1, V6]; xn----11g3013fy8x5m.xn----tfot873s; ; ;  # 箃Ⴡ-.≠-🤖
+箃Ⴡ-󠁝｡≠-🤖; 箃Ⴡ-󠁝.≠-🤖; [P1, V6]; xn----11g3013fy8x5m.xn----tfot873s; ; ;  # 箃Ⴡ-.≠-🤖
+箃Ⴡ-󠁝。≠-🤖; 箃Ⴡ-󠁝.≠-🤖; [P1, V6]; xn----11g3013fy8x5m.xn----tfot873s; ; ;  # 箃Ⴡ-.≠-🤖
+箃Ⴡ-󠁝。≠-🤖; 箃Ⴡ-󠁝.≠-🤖; [P1, V6]; xn----11g3013fy8x5m.xn----tfot873s; ; ;  # 箃Ⴡ-.≠-🤖
+箃ⴡ-󠁝。≠-🤖; 箃ⴡ-󠁝.≠-🤖; [P1, V6]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+箃ⴡ-󠁝。≠-🤖; 箃ⴡ-󠁝.≠-🤖; [P1, V6]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+xn----4wsr321ay823p.xn----tfot873s; 箃ⴡ-󠁝.≠-🤖; [V6]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+xn----11g3013fy8x5m.xn----tfot873s; 箃Ⴡ-󠁝.≠-🤖; [V6]; xn----11g3013fy8x5m.xn----tfot873s; ; ;  # 箃Ⴡ-.≠-🤖
+箃ⴡ-󠁝｡≠-🤖; 箃ⴡ-󠁝.≠-🤖; [P1, V6]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+箃ⴡ-󠁝｡≠-🤖; 箃ⴡ-󠁝.≠-🤖; [P1, V6]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+ߥ.ڵ; ; ; xn--dtb.xn--okb; ; ;  # ߥ.ڵ
+xn--dtb.xn--okb; ߥ.ڵ; ; xn--dtb.xn--okb; ; ;  # ߥ.ڵ
+‌‍.𞤿; ; [B1, C1, C2]; xn--0ugc.xn--3e6h; ; .xn--3e6h; [A4_2] # .𞤿
+‌‍.𞤝; ‌‍.𞤿; [B1, C1, C2]; xn--0ugc.xn--3e6h; ; .xn--3e6h; [A4_2] # .𞤿
+.xn--3e6h; .𞤿; [X4_2]; .xn--3e6h; [A4_2]; ;  # .𞤿
+xn--0ugc.xn--3e6h; ‌‍.𞤿; [B1, C1, C2]; xn--0ugc.xn--3e6h; ; ;  # .𞤿
+xn--3e6h; 𞤿; ; xn--3e6h; ; ;  # 𞤿
+𞤿; ; ; xn--3e6h; ; ;  # 𞤿
+𞤝; 𞤿; ; xn--3e6h; ; ;  # 𞤿
+🜑𐹧ع.ς𑍍蜹; ; [B1]; xn--4gb3736kk4zf.xn--3xa4248dy27d; ; xn--4gb3736kk4zf.xn--4xa2248dy27d;  # 🜑𐹧ع.ς𑍍蜹
+🜑𐹧ع.Σ𑍍蜹; 🜑𐹧ع.σ𑍍蜹; [B1]; xn--4gb3736kk4zf.xn--4xa2248dy27d; ; ;  # 🜑𐹧ع.σ𑍍蜹
+🜑𐹧ع.σ𑍍蜹; ; [B1]; xn--4gb3736kk4zf.xn--4xa2248dy27d; ; ;  # 🜑𐹧ع.σ𑍍蜹
+xn--4gb3736kk4zf.xn--4xa2248dy27d; 🜑𐹧ع.σ𑍍蜹; [B1]; xn--4gb3736kk4zf.xn--4xa2248dy27d; ; ;  # 🜑𐹧ع.σ𑍍蜹
+xn--4gb3736kk4zf.xn--3xa4248dy27d; 🜑𐹧ع.ς𑍍蜹; [B1]; xn--4gb3736kk4zf.xn--3xa4248dy27d; ; ;  # 🜑𐹧ع.ς𑍍蜹
+򫠐ス􆟤٩．󚃟; 򫠐ス􆟤٩.󚃟; [B5, B6, P1, V6]; xn--iib777sp230oo708a.xn--7824e; ; ;  # ス٩.
+򫠐ス􆟤٩.󚃟; ; [B5, B6, P1, V6]; xn--iib777sp230oo708a.xn--7824e; ; ;  # ス٩.
+xn--iib777sp230oo708a.xn--7824e; 򫠐ス􆟤٩.󚃟; [B5, B6, V6]; xn--iib777sp230oo708a.xn--7824e; ; ;  # ス٩.
+𝪣򕡝．֚?ۂ; 𝪣򕡝.֚?ۂ; [B1, P1, V5, V6]; xn--8c3hu7971a.֚?ۂ; [B1, P1, V5, V6, A3]; ;  # 𝪣.֚ۂ
+𝪣򕡝．֚?ۂ; 𝪣򕡝.֚?ۂ; [B1, P1, V5, V6]; xn--8c3hu7971a.֚?ۂ; [B1, P1, V5, V6, A3]; ;  # 𝪣.֚ۂ
+𝪣򕡝.֚?ۂ; ; [B1, P1, V5, V6]; xn--8c3hu7971a.֚?ۂ; [B1, P1, V5, V6, A3]; ;  # 𝪣.֚ۂ
+𝪣򕡝.֚?ۂ; 𝪣򕡝.֚?ۂ; [B1, P1, V5, V6]; xn--8c3hu7971a.֚?ۂ; [B1, P1, V5, V6, A3]; ;  # 𝪣.֚ۂ
+xn--8c3hu7971a.֚?ۂ; 𝪣򕡝.֚?ۂ; [B1, P1, V5, V6]; xn--8c3hu7971a.֚?ۂ; [B1, P1, V5, V6, A3]; ;  # 𝪣.֚ۂ
+xn--8c3hu7971a.֚?ۂ; 𝪣򕡝.֚?ۂ; [B1, P1, V5, V6]; xn--8c3hu7971a.֚?ۂ; [B1, P1, V5, V6, A3]; ;  # 𝪣.֚ۂ
+XN--8C3HU7971A.֚?ۂ; 𝪣򕡝.֚?ۂ; [B1, P1, V5, V6]; xn--8c3hu7971a.֚?ۂ; [B1, P1, V5, V6, A3]; ;  # 𝪣.֚ۂ
+XN--8C3HU7971A.֚?ۂ; 𝪣򕡝.֚?ۂ; [B1, P1, V5, V6]; xn--8c3hu7971a.֚?ۂ; [B1, P1, V5, V6, A3]; ;  # 𝪣.֚ۂ
+Xn--8c3hu7971a.֚?ۂ; 𝪣򕡝.֚?ۂ; [B1, P1, V5, V6]; xn--8c3hu7971a.֚?ۂ; [B1, P1, V5, V6, A3]; ;  # 𝪣.֚ۂ
+Xn--8c3hu7971a.֚?ۂ; 𝪣򕡝.֚?ۂ; [B1, P1, V5, V6]; xn--8c3hu7971a.֚?ۂ; [B1, P1, V5, V6, A3]; ;  # 𝪣.֚ۂ
+٠򪓵‌。ݗ; ٠򪓵‌.ݗ; [B1, C1, P1, V6]; xn--8hb852ke991q.xn--bpb; ; xn--8hb82030l.xn--bpb; [B1, P1, V6] # ٠.ݗ
+xn--8hb82030l.xn--bpb; ٠򪓵.ݗ; [B1, V6]; xn--8hb82030l.xn--bpb; ; ;  # ٠.ݗ
+xn--8hb852ke991q.xn--bpb; ٠򪓵‌.ݗ; [B1, C1, V6]; xn--8hb852ke991q.xn--bpb; ; ;  # ٠.ݗ
+်‍‌。-‌; ်‍‌.-‌; [C1, V3, V5]; xn--bkd412fca.xn----sgn; ; xn--bkd.-; [V3, V5] # ်.-
+xn--bkd.-; ်.-; [V3, V5]; xn--bkd.-; ; ;  # ်.-
+xn--bkd412fca.xn----sgn; ်‍‌.-‌; [C1, V3, V5]; xn--bkd412fca.xn----sgn; ; ;  # ်.-
+︒｡᭄ᡉ; ︒.᭄ᡉ; [P1, V5, V6]; xn--y86c.xn--87e93m; ; ;  # ︒.᭄ᡉ
+。。᭄ᡉ; ..᭄ᡉ; [V5, X4_2]; ..xn--87e93m; [V5, A4_2]; ;  # ..᭄ᡉ
+..xn--87e93m; ..᭄ᡉ; [V5, X4_2]; ..xn--87e93m; [V5, A4_2]; ;  # ..᭄ᡉ
+xn--y86c.xn--87e93m; ︒.᭄ᡉ; [V5, V6]; xn--y86c.xn--87e93m; ; ;  # ︒.᭄ᡉ
+ݘß。ጫᢊݨ𝟐; ݘß.ጫᢊݨ2; [B2, B3, B5]; xn--zca724a.xn--2-b5c641gfmf; ; xn--ss-gke.xn--2-b5c641gfmf;  # ݘß.ጫᢊݨ2
+ݘß。ጫᢊݨ2; ݘß.ጫᢊݨ2; [B2, B3, B5]; xn--zca724a.xn--2-b5c641gfmf; ; xn--ss-gke.xn--2-b5c641gfmf;  # ݘß.ጫᢊݨ2
+ݘSS。ጫᢊݨ2; ݘss.ጫᢊݨ2; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+ݘss。ጫᢊݨ2; ݘss.ጫᢊݨ2; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+xn--ss-gke.xn--2-b5c641gfmf; ݘss.ጫᢊݨ2; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+xn--zca724a.xn--2-b5c641gfmf; ݘß.ጫᢊݨ2; [B2, B3, B5]; xn--zca724a.xn--2-b5c641gfmf; ; ;  # ݘß.ጫᢊݨ2
+ݘSS。ጫᢊݨ𝟐; ݘss.ጫᢊݨ2; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+ݘss。ጫᢊݨ𝟐; ݘss.ጫᢊݨ2; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+ݘSs。ጫᢊݨ2; ݘss.ጫᢊݨ2; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+ݘSs。ጫᢊݨ𝟐; ݘss.ጫᢊݨ2; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+߃𞶇ᚲ.ं͓𝟚্; ߃𞶇ᚲ.ं͓2্; [B1, B2, B3, P1, V5, V6]; xn--esb067enh07a.xn--2-lgb874bjxa; ; ;  # ߃ᚲ.ं͓2্
+߃𞶇ᚲ.ं͓2্; ; [B1, B2, B3, P1, V5, V6]; xn--esb067enh07a.xn--2-lgb874bjxa; ; ;  # ߃ᚲ.ं͓2্
+xn--esb067enh07a.xn--2-lgb874bjxa; ߃𞶇ᚲ.ं͓2্; [B1, B2, B3, V5, V6]; xn--esb067enh07a.xn--2-lgb874bjxa; ; ;  # ߃ᚲ.ं͓2্
+-᮫︒‍.񒶈񥹓; ; [C2, P1, V3, V6]; xn----qmlv7tw180a.xn--x50zy803a; ; xn----qml1407i.xn--x50zy803a; [P1, V3, V6] # -᮫︒.
+-᮫。‍.񒶈񥹓; -᮫.‍.񒶈񥹓; [C2, P1, V3, V6]; xn----qml.xn--1ug.xn--x50zy803a; ; xn----qml..xn--x50zy803a; [P1, V3, V6, A4_2] # -᮫..
+xn----qml..xn--x50zy803a; -᮫..񒶈񥹓; [V3, V6, X4_2]; xn----qml..xn--x50zy803a; [V3, V6, A4_2]; ;  # -᮫..
+xn----qml.xn--1ug.xn--x50zy803a; -᮫.‍.񒶈񥹓; [C2, V3, V6]; xn----qml.xn--1ug.xn--x50zy803a; ; ;  # -᮫..
+xn----qml1407i.xn--x50zy803a; -᮫︒.񒶈񥹓; [V3, V6]; xn----qml1407i.xn--x50zy803a; ; ;  # -᮫︒.
+xn----qmlv7tw180a.xn--x50zy803a; -᮫︒‍.񒶈񥹓; [C2, V3, V6]; xn----qmlv7tw180a.xn--x50zy803a; ; ;  # -᮫︒.
+󠦮.≯𞀆; ; [P1, V6]; xn--t546e.xn--hdh5166o; ; ;  # .≯𞀆
+󠦮.≯𞀆; 󠦮.≯𞀆; [P1, V6]; xn--t546e.xn--hdh5166o; ; ;  # .≯𞀆
+xn--t546e.xn--hdh5166o; 󠦮.≯𞀆; [V6]; xn--t546e.xn--hdh5166o; ; ;  # .≯𞀆
+-𑄳󠊗𐹩。𞮱; -𑄳󠊗𐹩.𞮱; [B1, P1, V3, V6]; xn----p26i72em2894c.xn--zw6h; ; ;  # -𑄳𐹩.
+xn----p26i72em2894c.xn--zw6h; -𑄳󠊗𐹩.𞮱; [B1, V3, V6]; xn----p26i72em2894c.xn--zw6h; ; ;  # -𑄳𐹩.
+ڹ．ᡳᅟ; ڹ.ᡳᅟ; [P1, V6]; xn--skb.xn--osd737a; ; ;  # ڹ.ᡳ
+ڹ.ᡳᅟ; ; [P1, V6]; xn--skb.xn--osd737a; ; ;  # ڹ.ᡳ
+xn--skb.xn--osd737a; ڹ.ᡳᅟ; [V6]; xn--skb.xn--osd737a; ; ;  # ڹ.ᡳ
+㨛𘱎.︒𝟕ഁ; 㨛𘱎.︒7ഁ; [P1, V6]; xn--mbm8237g.xn--7-7hf1526p; ; ;  # 㨛.︒7ഁ
+㨛𘱎.。7ഁ; 㨛𘱎..7ഁ; [P1, V6, X4_2]; xn--mbm8237g..xn--7-7hf; [P1, V6, A4_2]; ;  # 㨛..7ഁ
+xn--mbm8237g..xn--7-7hf; 㨛𘱎..7ഁ; [V6, X4_2]; xn--mbm8237g..xn--7-7hf; [V6, A4_2]; ;  # 㨛..7ഁ
+xn--mbm8237g.xn--7-7hf1526p; 㨛𘱎.︒7ഁ; [V6]; xn--mbm8237g.xn--7-7hf1526p; ; ;  # 㨛.︒7ഁ
+۝𻱧-｡𞷁⁤𞤣≮; ۝𻱧-.𞷁𞤣≮; [B1, B3, P1, V3, V6]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+۝𻱧-｡𞷁⁤𞤣≮; ۝𻱧-.𞷁𞤣≮; [B1, B3, P1, V3, V6]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+۝𻱧-。𞷁⁤𞤣≮; ۝𻱧-.𞷁𞤣≮; [B1, B3, P1, V3, V6]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+۝𻱧-。𞷁⁤𞤣≮; ۝𻱧-.𞷁𞤣≮; [B1, B3, P1, V3, V6]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+۝𻱧-。𞷁⁤𞤁≮; ۝𻱧-.𞷁𞤣≮; [B1, B3, P1, V3, V6]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+۝𻱧-。𞷁⁤𞤁≮; ۝𻱧-.𞷁𞤣≮; [B1, B3, P1, V3, V6]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+xn----dxc06304e.xn--gdh5020pk5c; ۝𻱧-.𞷁𞤣≮; [B1, B3, V3, V6]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+۝𻱧-｡𞷁⁤𞤁≮; ۝𻱧-.𞷁𞤣≮; [B1, B3, P1, V3, V6]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+۝𻱧-｡𞷁⁤𞤁≮; ۝𻱧-.𞷁𞤣≮; [B1, B3, P1, V3, V6]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+ß‌꫶ᢥ．⊶ჁႶ; ß‌꫶ᢥ.⊶ჁႶ; [C1, P1, V6]; xn--zca682johfi89m.xn--undv409k; ; xn--ss-4epx629f.xn--undv409k; [P1, V6] # ß꫶ᢥ.⊶ჁႶ
+ß‌꫶ᢥ.⊶ჁႶ; ; [C1, P1, V6]; xn--zca682johfi89m.xn--undv409k; ; xn--ss-4epx629f.xn--undv409k; [P1, V6] # ß꫶ᢥ.⊶ჁႶ
+ß‌꫶ᢥ.⊶ⴡⴖ; ; [C1]; xn--zca682johfi89m.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ß꫶ᢥ.⊶ⴡⴖ
+SS‌꫶ᢥ.⊶ჁႶ; ss‌꫶ᢥ.⊶ჁႶ; [C1, P1, V6]; xn--ss-4ep585bkm5p.xn--undv409k; ; xn--ss-4epx629f.xn--undv409k; [P1, V6] # ss꫶ᢥ.⊶ჁႶ
+ss‌꫶ᢥ.⊶ⴡⴖ; ; [C1]; xn--ss-4ep585bkm5p.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ss꫶ᢥ.⊶ⴡⴖ
+Ss‌꫶ᢥ.⊶Ⴡⴖ; ss‌꫶ᢥ.⊶Ⴡⴖ; [C1, P1, V6]; xn--ss-4ep585bkm5p.xn--5nd703gyrh; ; xn--ss-4epx629f.xn--5nd703gyrh; [P1, V6] # ss꫶ᢥ.⊶Ⴡⴖ
+xn--ss-4epx629f.xn--5nd703gyrh; ss꫶ᢥ.⊶Ⴡⴖ; [V6]; xn--ss-4epx629f.xn--5nd703gyrh; ; ;  # ss꫶ᢥ.⊶Ⴡⴖ
+xn--ss-4ep585bkm5p.xn--5nd703gyrh; ss‌꫶ᢥ.⊶Ⴡⴖ; [C1, V6]; xn--ss-4ep585bkm5p.xn--5nd703gyrh; ; ;  # ss꫶ᢥ.⊶Ⴡⴖ
+xn--ss-4epx629f.xn--ifh802b6a; ss꫶ᢥ.⊶ⴡⴖ; ; xn--ss-4epx629f.xn--ifh802b6a; ; ;  # ss꫶ᢥ.⊶ⴡⴖ
+ss꫶ᢥ.⊶ⴡⴖ; ; ; xn--ss-4epx629f.xn--ifh802b6a; ; ;  # ss꫶ᢥ.⊶ⴡⴖ
+SS꫶ᢥ.⊶ჁႶ; ss꫶ᢥ.⊶ჁႶ; [P1, V6]; xn--ss-4epx629f.xn--undv409k; ; ;  # ss꫶ᢥ.⊶ჁႶ
+Ss꫶ᢥ.⊶Ⴡⴖ; ss꫶ᢥ.⊶Ⴡⴖ; [P1, V6]; xn--ss-4epx629f.xn--5nd703gyrh; ; ;  # ss꫶ᢥ.⊶Ⴡⴖ
+xn--ss-4epx629f.xn--undv409k; ss꫶ᢥ.⊶ჁႶ; [V6]; xn--ss-4epx629f.xn--undv409k; ; ;  # ss꫶ᢥ.⊶ჁႶ
+xn--ss-4ep585bkm5p.xn--ifh802b6a; ss‌꫶ᢥ.⊶ⴡⴖ; [C1]; xn--ss-4ep585bkm5p.xn--ifh802b6a; ; ;  # ss꫶ᢥ.⊶ⴡⴖ
+xn--ss-4ep585bkm5p.xn--undv409k; ss‌꫶ᢥ.⊶ჁႶ; [C1, V6]; xn--ss-4ep585bkm5p.xn--undv409k; ; ;  # ss꫶ᢥ.⊶ჁႶ
+xn--zca682johfi89m.xn--ifh802b6a; ß‌꫶ᢥ.⊶ⴡⴖ; [C1]; xn--zca682johfi89m.xn--ifh802b6a; ; ;  # ß꫶ᢥ.⊶ⴡⴖ
+xn--zca682johfi89m.xn--undv409k; ß‌꫶ᢥ.⊶ჁႶ; [C1, V6]; xn--zca682johfi89m.xn--undv409k; ; ;  # ß꫶ᢥ.⊶ჁႶ
+ß‌꫶ᢥ．⊶ⴡⴖ; ß‌꫶ᢥ.⊶ⴡⴖ; [C1]; xn--zca682johfi89m.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ß꫶ᢥ.⊶ⴡⴖ
+SS‌꫶ᢥ．⊶ჁႶ; ss‌꫶ᢥ.⊶ჁႶ; [C1, P1, V6]; xn--ss-4ep585bkm5p.xn--undv409k; ; xn--ss-4epx629f.xn--undv409k; [P1, V6] # ss꫶ᢥ.⊶ჁႶ
+ss‌꫶ᢥ．⊶ⴡⴖ; ss‌꫶ᢥ.⊶ⴡⴖ; [C1]; xn--ss-4ep585bkm5p.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ss꫶ᢥ.⊶ⴡⴖ
+Ss‌꫶ᢥ．⊶Ⴡⴖ; ss‌꫶ᢥ.⊶Ⴡⴖ; [C1, P1, V6]; xn--ss-4ep585bkm5p.xn--5nd703gyrh; ; xn--ss-4epx629f.xn--5nd703gyrh; [P1, V6] # ss꫶ᢥ.⊶Ⴡⴖ
+‍。ς󠁉; ‍.ς󠁉; [C2, P1, V6]; xn--1ug.xn--3xa44344p; ; .xn--4xa24344p; [P1, V6, A4_2] # .ς
+‍。Σ󠁉; ‍.σ󠁉; [C2, P1, V6]; xn--1ug.xn--4xa24344p; ; .xn--4xa24344p; [P1, V6, A4_2] # .σ
+‍。σ󠁉; ‍.σ󠁉; [C2, P1, V6]; xn--1ug.xn--4xa24344p; ; .xn--4xa24344p; [P1, V6, A4_2] # .σ
+.xn--4xa24344p; .σ󠁉; [V6, X4_2]; .xn--4xa24344p; [V6, A4_2]; ;  # .σ
+xn--1ug.xn--4xa24344p; ‍.σ󠁉; [C2, V6]; xn--1ug.xn--4xa24344p; ; ;  # .σ
+xn--1ug.xn--3xa44344p; ‍.ς󠁉; [C2, V6]; xn--1ug.xn--3xa44344p; ; ;  # .ς
+𞵑ß.ݑ‍𞤛-; 𞵑ß.ݑ‍𞤽-; [B2, B3, C2, P1, V3, V6]; xn--zca5423w.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, P1, V3, V6] # ß.ݑ𞤽-
+𞵑ß.ݑ‍𞤽-; ; [B2, B3, C2, P1, V3, V6]; xn--zca5423w.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, P1, V3, V6] # ß.ݑ𞤽-
+𞵑SS.ݑ‍𞤛-; 𞵑ss.ݑ‍𞤽-; [B2, B3, C2, P1, V3, V6]; xn--ss-2722a.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, P1, V3, V6] # ss.ݑ𞤽-
+𞵑ss.ݑ‍𞤽-; ; [B2, B3, C2, P1, V3, V6]; xn--ss-2722a.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, P1, V3, V6] # ss.ݑ𞤽-
+𞵑Ss.ݑ‍𞤽-; 𞵑ss.ݑ‍𞤽-; [B2, B3, C2, P1, V3, V6]; xn--ss-2722a.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, P1, V3, V6] # ss.ݑ𞤽-
+xn--ss-2722a.xn----z3c03218a; 𞵑ss.ݑ𞤽-; [B2, B3, V3, V6]; xn--ss-2722a.xn----z3c03218a; ; ;  # ss.ݑ𞤽-
+xn--ss-2722a.xn----z3c011q9513b; 𞵑ss.ݑ‍𞤽-; [B2, B3, C2, V3, V6]; xn--ss-2722a.xn----z3c011q9513b; ; ;  # ss.ݑ𞤽-
+xn--zca5423w.xn----z3c011q9513b; 𞵑ß.ݑ‍𞤽-; [B2, B3, C2, V3, V6]; xn--zca5423w.xn----z3c011q9513b; ; ;  # ß.ݑ𞤽-
+𞵑ss.ݑ‍𞤛-; 𞵑ss.ݑ‍𞤽-; [B2, B3, C2, P1, V3, V6]; xn--ss-2722a.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, P1, V3, V6] # ss.ݑ𞤽-
+𞵑Ss.ݑ‍𞤛-; 𞵑ss.ݑ‍𞤽-; [B2, B3, C2, P1, V3, V6]; xn--ss-2722a.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, P1, V3, V6] # ss.ݑ𞤽-
+𑘽‍𞤧．𐹧󡦪-; 𑘽‍𞤧.𐹧󡦪-; [B1, C2, P1, V3, V5, V6]; xn--1ugz808gdimf.xn----k26iq1483f; ; xn--qb2ds317a.xn----k26iq1483f; [B1, P1, V3, V5, V6] # 𑘽𞤧.𐹧-
+𑘽‍𞤧.𐹧󡦪-; ; [B1, C2, P1, V3, V5, V6]; xn--1ugz808gdimf.xn----k26iq1483f; ; xn--qb2ds317a.xn----k26iq1483f; [B1, P1, V3, V5, V6] # 𑘽𞤧.𐹧-
+𑘽‍𞤅.𐹧󡦪-; 𑘽‍𞤧.𐹧󡦪-; [B1, C2, P1, V3, V5, V6]; xn--1ugz808gdimf.xn----k26iq1483f; ; xn--qb2ds317a.xn----k26iq1483f; [B1, P1, V3, V5, V6] # 𑘽𞤧.𐹧-
+xn--qb2ds317a.xn----k26iq1483f; 𑘽𞤧.𐹧󡦪-; [B1, V3, V5, V6]; xn--qb2ds317a.xn----k26iq1483f; ; ;  # 𑘽𞤧.𐹧-
+xn--1ugz808gdimf.xn----k26iq1483f; 𑘽‍𞤧.𐹧󡦪-; [B1, C2, V3, V5, V6]; xn--1ugz808gdimf.xn----k26iq1483f; ; ;  # 𑘽𞤧.𐹧-
+𑘽‍𞤅．𐹧󡦪-; 𑘽‍𞤧.𐹧󡦪-; [B1, C2, P1, V3, V5, V6]; xn--1ugz808gdimf.xn----k26iq1483f; ; xn--qb2ds317a.xn----k26iq1483f; [B1, P1, V3, V5, V6] # 𑘽𞤧.𐹧-
+⒒򨘙򳳠𑓀.-󞡊; ; [P1, V3, V6]; xn--3shy698frsu9dt1me.xn----x310m; ; ;  # ⒒𑓀.-
+11.򨘙򳳠𑓀.-󞡊; ; [P1, V3, V6]; 11.xn--uz1d59632bxujd.xn----x310m; ; ;  # 11.𑓀.-
+11.xn--uz1d59632bxujd.xn----x310m; 11.򨘙򳳠𑓀.-󞡊; [V3, V6]; 11.xn--uz1d59632bxujd.xn----x310m; ; ;  # 11.𑓀.-
+xn--3shy698frsu9dt1me.xn----x310m; ⒒򨘙򳳠𑓀.-󞡊; [V3, V6]; xn--3shy698frsu9dt1me.xn----x310m; ; ;  # ⒒𑓀.-
+-｡‍; -.‍; [C2, V3]; -.xn--1ug; ; -.; [V3] # -.
+-。‍; -.‍; [C2, V3]; -.xn--1ug; ; -.; [V3] # -.
+-.; ; [V3]; ; ; ;  # -.
+-.xn--1ug; -.‍; [C2, V3]; -.xn--1ug; ; ;  # -.
+≮ᡬ．ς¹-?; ≮ᡬ.ς1-?; [P1, V6]; xn--88e732c.ς1-?; [P1, V6, A3]; xn--88e732c.σ1-?;  # ≮ᡬ.ς1-
+≮ᡬ．ς¹-?; ≮ᡬ.ς1-?; [P1, V6]; xn--88e732c.ς1-?; [P1, V6, A3]; xn--88e732c.σ1-?;  # ≮ᡬ.ς1-
+≮ᡬ.ς1-?; ; [P1, V6]; xn--88e732c.ς1-?; [P1, V6, A3]; xn--88e732c.σ1-?;  # ≮ᡬ.ς1-
+≮ᡬ.ς1-?; ≮ᡬ.ς1-?; [P1, V6]; xn--88e732c.ς1-?; [P1, V6, A3]; xn--88e732c.σ1-?;  # ≮ᡬ.ς1-
+≮ᡬ.Σ1-?; ≮ᡬ.σ1-?; [P1, V6]; xn--88e732c.σ1-?; [P1, V6, A3]; ;  # ≮ᡬ.σ1-
+≮ᡬ.Σ1-?; ≮ᡬ.σ1-?; [P1, V6]; xn--88e732c.σ1-?; [P1, V6, A3]; ;  # ≮ᡬ.σ1-
+≮ᡬ.σ1-?; ; [P1, V6]; xn--88e732c.σ1-?; [P1, V6, A3]; ;  # ≮ᡬ.σ1-
+≮ᡬ.σ1-?; ≮ᡬ.σ1-?; [P1, V6]; xn--88e732c.σ1-?; [P1, V6, A3]; ;  # ≮ᡬ.σ1-
+xn--88e732c.σ1-?; ≮ᡬ.σ1-?; [P1, V6]; xn--88e732c.σ1-?; [P1, V6, A3]; ;  # ≮ᡬ.σ1-
+XN--88E732C.Σ1-?; ≮ᡬ.σ1-?; [P1, V6]; xn--88e732c.σ1-?; [P1, V6, A3]; ;  # ≮ᡬ.σ1-
+xn--88e732c.ς1-?; ≮ᡬ.ς1-?; [P1, V6]; xn--88e732c.ς1-?; [P1, V6, A3]; xn--88e732c.σ1-?;  # ≮ᡬ.ς1-
+Xn--88e732c.ς1-?; ≮ᡬ.ς1-?; [P1, V6]; xn--88e732c.ς1-?; [P1, V6, A3]; xn--88e732c.σ1-?;  # ≮ᡬ.ς1-
+Xn--88e732c.σ1-?; ≮ᡬ.σ1-?; [P1, V6]; xn--88e732c.σ1-?; [P1, V6, A3]; ;  # ≮ᡬ.σ1-
+≮ᡬ．Σ¹-?; ≮ᡬ.σ1-?; [P1, V6]; xn--88e732c.σ1-?; [P1, V6, A3]; ;  # ≮ᡬ.σ1-
+≮ᡬ．Σ¹-?; ≮ᡬ.σ1-?; [P1, V6]; xn--88e732c.σ1-?; [P1, V6, A3]; ;  # ≮ᡬ.σ1-
+≮ᡬ．σ¹-?; ≮ᡬ.σ1-?; [P1, V6]; xn--88e732c.σ1-?; [P1, V6, A3]; ;  # ≮ᡬ.σ1-
+≮ᡬ．σ¹-?; ≮ᡬ.σ1-?; [P1, V6]; xn--88e732c.σ1-?; [P1, V6, A3]; ;  # ≮ᡬ.σ1-
+ቬ򔠼񁗶｡𐨬𝟠; ቬ򔠼񁗶.𐨬8; [P1, V6]; xn--d0d41273c887z.xn--8-ob5i; ; ;  # ቬ.𐨬8
+ቬ򔠼񁗶。𐨬8; ቬ򔠼񁗶.𐨬8; [P1, V6]; xn--d0d41273c887z.xn--8-ob5i; ; ;  # ቬ.𐨬8
+xn--d0d41273c887z.xn--8-ob5i; ቬ򔠼񁗶.𐨬8; [V6]; xn--d0d41273c887z.xn--8-ob5i; ; ;  # ቬ.𐨬8
+𐱲。蔫ݦ; 𐱲.蔫ݦ; [B5, B6, P1, V6]; xn--389c.xn--qpb7055d; ; ;  # .蔫ݦ
+xn--389c.xn--qpb7055d; 𐱲.蔫ݦ; [B5, B6, V6]; xn--389c.xn--qpb7055d; ; ;  # .蔫ݦ
+򒲧₃｡ꡚ𛇑󠄳ه; 򒲧3.ꡚ𛇑ه; [B5, B6, P1, V6]; xn--3-ep59g.xn--jhb5904fcp0h; ; ;  # 3.ꡚ𛇑ه
+򒲧3。ꡚ𛇑󠄳ه; 򒲧3.ꡚ𛇑ه; [B5, B6, P1, V6]; xn--3-ep59g.xn--jhb5904fcp0h; ; ;  # 3.ꡚ𛇑ه
+xn--3-ep59g.xn--jhb5904fcp0h; 򒲧3.ꡚ𛇑ه; [B5, B6, V6]; xn--3-ep59g.xn--jhb5904fcp0h; ; ;  # 3.ꡚ𛇑ه
+蓸ق≠.ß; ; [B5, B6, P1, V6]; xn--ehb015lnt1e.xn--zca; ; xn--ehb015lnt1e.ss;  # 蓸ق≠.ß
+蓸ق≠.ß; 蓸ق≠.ß; [B5, B6, P1, V6]; xn--ehb015lnt1e.xn--zca; ; xn--ehb015lnt1e.ss;  # 蓸ق≠.ß
+蓸ق≠.SS; 蓸ق≠.ss; [B5, B6, P1, V6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+蓸ق≠.SS; 蓸ق≠.ss; [B5, B6, P1, V6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+蓸ق≠.ss; ; [B5, B6, P1, V6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+蓸ق≠.ss; 蓸ق≠.ss; [B5, B6, P1, V6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+蓸ق≠.Ss; 蓸ق≠.ss; [B5, B6, P1, V6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+蓸ق≠.Ss; 蓸ق≠.ss; [B5, B6, P1, V6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+xn--ehb015lnt1e.ss; 蓸ق≠.ss; [B5, B6, V6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+xn--ehb015lnt1e.xn--zca; 蓸ق≠.ß; [B5, B6, V6]; xn--ehb015lnt1e.xn--zca; ; ;  # 蓸ق≠.ß
+ࡎٺී⒊.𐹹𞱩󠃪‌; ; [B1, C1, P1, V6]; xn--zib94gfziuq1a.xn--0ug3205g7eyf3c96h; ; xn--zib94gfziuq1a.xn--xo0dw109an237f; [B1, P1, V6] # ࡎٺී⒊.𐹹
+ࡎٺී3..𐹹𞱩󠃪‌; ; [B1, C1, P1, V6, X4_2]; xn--3-prc71ls9j..xn--0ug3205g7eyf3c96h; [B1, C1, P1, V6, A4_2]; xn--3-prc71ls9j..xn--xo0dw109an237f; [B1, P1, V6, A4_2] # ࡎٺී3..𐹹
+xn--3-prc71ls9j..xn--xo0dw109an237f; ࡎٺී3..𐹹𞱩󠃪; [B1, V6, X4_2]; xn--3-prc71ls9j..xn--xo0dw109an237f; [B1, V6, A4_2]; ;  # ࡎٺී3..𐹹
+xn--3-prc71ls9j..xn--0ug3205g7eyf3c96h; ࡎٺී3..𐹹𞱩󠃪‌; [B1, C1, V6, X4_2]; xn--3-prc71ls9j..xn--0ug3205g7eyf3c96h; [B1, C1, V6, A4_2]; ;  # ࡎٺී3..𐹹
+xn--zib94gfziuq1a.xn--xo0dw109an237f; ࡎٺී⒊.𐹹𞱩󠃪; [B1, V6]; xn--zib94gfziuq1a.xn--xo0dw109an237f; ; ;  # ࡎٺී⒊.𐹹
+xn--zib94gfziuq1a.xn--0ug3205g7eyf3c96h; ࡎٺී⒊.𐹹𞱩󠃪‌; [B1, C1, V6]; xn--zib94gfziuq1a.xn--0ug3205g7eyf3c96h; ; ;  # ࡎٺී⒊.𐹹
+ς‍-.Ⴣ𦟙; ; [C2, P1, V3, V6]; xn----xmb348s.xn--7nd64871a; ; xn----zmb.xn--7nd64871a; [P1, V3, V6] # ς-.Ⴣ𦟙
+ς‍-.ⴣ𦟙; ; [C2, V3]; xn----xmb348s.xn--rlj2573p; ; xn----zmb.xn--rlj2573p; [V3] # ς-.ⴣ𦟙
+Σ‍-.Ⴣ𦟙; σ‍-.Ⴣ𦟙; [C2, P1, V3, V6]; xn----zmb048s.xn--7nd64871a; ; xn----zmb.xn--7nd64871a; [P1, V3, V6] # σ-.Ⴣ𦟙
+σ‍-.ⴣ𦟙; ; [C2, V3]; xn----zmb048s.xn--rlj2573p; ; xn----zmb.xn--rlj2573p; [V3] # σ-.ⴣ𦟙
+xn----zmb.xn--rlj2573p; σ-.ⴣ𦟙; [V3]; xn----zmb.xn--rlj2573p; ; ;  # σ-.ⴣ𦟙
+xn----zmb048s.xn--rlj2573p; σ‍-.ⴣ𦟙; [C2, V3]; xn----zmb048s.xn--rlj2573p; ; ;  # σ-.ⴣ𦟙
+xn----zmb.xn--7nd64871a; σ-.Ⴣ𦟙; [V3, V6]; xn----zmb.xn--7nd64871a; ; ;  # σ-.Ⴣ𦟙
+xn----zmb048s.xn--7nd64871a; σ‍-.Ⴣ𦟙; [C2, V3, V6]; xn----zmb048s.xn--7nd64871a; ; ;  # σ-.Ⴣ𦟙
+xn----xmb348s.xn--rlj2573p; ς‍-.ⴣ𦟙; [C2, V3]; xn----xmb348s.xn--rlj2573p; ; ;  # ς-.ⴣ𦟙
+xn----xmb348s.xn--7nd64871a; ς‍-.Ⴣ𦟙; [C2, V3, V6]; xn----xmb348s.xn--7nd64871a; ; ;  # ς-.Ⴣ𦟙
+≠。🞳𝟲; ≠.🞳6; [P1, V6]; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+≠。🞳𝟲; ≠.🞳6; [P1, V6]; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+≠。🞳6; ≠.🞳6; [P1, V6]; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+≠。🞳6; ≠.🞳6; [P1, V6]; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+xn--1ch.xn--6-dl4s; ≠.🞳6; [V6]; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+󅬽.蠔; ; [P1, V6]; xn--g747d.xn--xl2a; ; ;  # .蠔
+xn--g747d.xn--xl2a; 󅬽.蠔; [V6]; xn--g747d.xn--xl2a; ; ;  # .蠔
+ࣦ‍．뼽; ࣦ‍.뼽; [C2, V5]; xn--p0b869i.xn--e43b; ; xn--p0b.xn--e43b; [V5] # ࣦ.뼽
+ࣦ‍．뼽; ࣦ‍.뼽; [C2, V5]; xn--p0b869i.xn--e43b; ; xn--p0b.xn--e43b; [V5] # ࣦ.뼽
+ࣦ‍.뼽; ; [C2, V5]; xn--p0b869i.xn--e43b; ; xn--p0b.xn--e43b; [V5] # ࣦ.뼽
+ࣦ‍.뼽; ࣦ‍.뼽; [C2, V5]; xn--p0b869i.xn--e43b; ; xn--p0b.xn--e43b; [V5] # ࣦ.뼽
+xn--p0b.xn--e43b; ࣦ.뼽; [V5]; xn--p0b.xn--e43b; ; ;  # ࣦ.뼽
+xn--p0b869i.xn--e43b; ࣦ‍.뼽; [C2, V5]; xn--p0b869i.xn--e43b; ; ;  # ࣦ.뼽
+₇்􃂷ے。👖ٵ-𞪑; 7்􃂷ے.👖اٴ-𞪑; [B1, P1, V6]; xn--7-rwc839aj3073c.xn----ymc5uv818oghka; ; ;  # 7்ے.👖اٴ-
+7்􃂷ے。👖اٴ-𞪑; 7்􃂷ے.👖اٴ-𞪑; [B1, P1, V6]; xn--7-rwc839aj3073c.xn----ymc5uv818oghka; ; ;  # 7்ے.👖اٴ-
+xn--7-rwc839aj3073c.xn----ymc5uv818oghka; 7்􃂷ے.👖اٴ-𞪑; [B1, V6]; xn--7-rwc839aj3073c.xn----ymc5uv818oghka; ; ;  # 7்ے.👖اٴ-
+-｡ݻ; -.ݻ; [B1, V3]; -.xn--cqb; ; ;  # -.ݻ
+-。ݻ; -.ݻ; [B1, V3]; -.xn--cqb; ; ;  # -.ݻ
+-.xn--cqb; -.ݻ; [B1, V3]; -.xn--cqb; ; ;  # -.ݻ
+𑇌𵛓｡-⒈ꡏܫ; 𑇌𵛓.-⒈ꡏܫ; [B1, P1, V3, V5, V6]; xn--8d1dg030h.xn----u1c466tp10j; ; ;  # 𑇌.-⒈ꡏܫ
+𑇌𵛓。-1.ꡏܫ; 𑇌𵛓.-1.ꡏܫ; [B1, B5, B6, P1, V3, V5, V6]; xn--8d1dg030h.-1.xn--1nb7163f; ; ;  # 𑇌.-1.ꡏܫ
+xn--8d1dg030h.-1.xn--1nb7163f; 𑇌𵛓.-1.ꡏܫ; [B1, B5, B6, V3, V5, V6]; xn--8d1dg030h.-1.xn--1nb7163f; ; ;  # 𑇌.-1.ꡏܫ
+xn--8d1dg030h.xn----u1c466tp10j; 𑇌𵛓.-⒈ꡏܫ; [B1, V3, V5, V6]; xn--8d1dg030h.xn----u1c466tp10j; ; ;  # 𑇌.-⒈ꡏܫ
+璛᜴گ.-; ; [B1, B5, B6, V3]; xn--ikb175frt4e.-; ; ;  # 璛᜴گ.-
+xn--ikb175frt4e.-; 璛᜴گ.-; [B1, B5, B6, V3]; xn--ikb175frt4e.-; ; ;  # 璛᜴گ.-
+󠆰ࢡ੍샕．𐹲휁; ࢡ੍샕.𐹲휁; [B1, B2, B3]; xn--qyb07fj857a.xn--728bv72h; ; ;  # ࢡ੍샕.𐹲휁
+󠆰ࢡ੍샕．𐹲휁; ࢡ੍샕.𐹲휁; [B1, B2, B3]; xn--qyb07fj857a.xn--728bv72h; ; ;  # ࢡ੍샕.𐹲휁
+󠆰ࢡ੍샕.𐹲휁; ࢡ੍샕.𐹲휁; [B1, B2, B3]; xn--qyb07fj857a.xn--728bv72h; ; ;  # ࢡ੍샕.𐹲휁
+󠆰ࢡ੍샕.𐹲휁; ࢡ੍샕.𐹲휁; [B1, B2, B3]; xn--qyb07fj857a.xn--728bv72h; ; ;  # ࢡ੍샕.𐹲휁
+xn--qyb07fj857a.xn--728bv72h; ࢡ੍샕.𐹲휁; [B1, B2, B3]; xn--qyb07fj857a.xn--728bv72h; ; ;  # ࢡ੍샕.𐹲휁
+񍨽．񋸕; 񍨽.񋸕; [P1, V6]; xn--pr3x.xn--rv7w; ; ;  # .
+񍨽.񋸕; ; [P1, V6]; xn--pr3x.xn--rv7w; ; ;  # .
+xn--pr3x.xn--rv7w; 񍨽.񋸕; [V6]; xn--pr3x.xn--rv7w; ; ;  # .
+ٽ𞥕｡𑑂𞤶Ⴍ-; ٽ𞥕.𑑂𞤶Ⴍ-; [B1, P1, V3, V5, V6]; xn--2ib0338v.xn----w0g2740ro9vg; ; ;  # ٽ𞥕.𑑂𞤶Ⴍ-
+ٽ𞥕。𑑂𞤶Ⴍ-; ٽ𞥕.𑑂𞤶Ⴍ-; [B1, P1, V3, V5, V6]; xn--2ib0338v.xn----w0g2740ro9vg; ; ;  # ٽ𞥕.𑑂𞤶Ⴍ-
+ٽ𞥕。𑑂𞤶ⴍ-; ٽ𞥕.𑑂𞤶ⴍ-; [B1, V3, V5]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+ٽ𞥕。𑑂𞤔Ⴍ-; ٽ𞥕.𑑂𞤶Ⴍ-; [B1, P1, V3, V5, V6]; xn--2ib0338v.xn----w0g2740ro9vg; ; ;  # ٽ𞥕.𑑂𞤶Ⴍ-
+ٽ𞥕。𑑂𞤔ⴍ-; ٽ𞥕.𑑂𞤶ⴍ-; [B1, V3, V5]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+xn--2ib0338v.xn----zvs0199fo91g; ٽ𞥕.𑑂𞤶ⴍ-; [B1, V3, V5]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+xn--2ib0338v.xn----w0g2740ro9vg; ٽ𞥕.𑑂𞤶Ⴍ-; [B1, V3, V5, V6]; xn--2ib0338v.xn----w0g2740ro9vg; ; ;  # ٽ𞥕.𑑂𞤶Ⴍ-
+ٽ𞥕｡𑑂𞤶ⴍ-; ٽ𞥕.𑑂𞤶ⴍ-; [B1, V3, V5]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+ٽ𞥕｡𑑂𞤔Ⴍ-; ٽ𞥕.𑑂𞤶Ⴍ-; [B1, P1, V3, V5, V6]; xn--2ib0338v.xn----w0g2740ro9vg; ; ;  # ٽ𞥕.𑑂𞤶Ⴍ-
+ٽ𞥕｡𑑂𞤔ⴍ-; ٽ𞥕.𑑂𞤶ⴍ-; [B1, V3, V5]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+𐯀𐸉𞧏。񢚧₄Ⴋ񂹫; 𐯀𐸉𞧏.񢚧4Ⴋ񂹫; [P1, V6]; xn--039c42bq865a.xn--4-t0g49302fnrzm; ; ;  # .4Ⴋ
+𐯀𐸉𞧏。񢚧4Ⴋ񂹫; 𐯀𐸉𞧏.񢚧4Ⴋ񂹫; [P1, V6]; xn--039c42bq865a.xn--4-t0g49302fnrzm; ; ;  # .4Ⴋ
+𐯀𐸉𞧏。񢚧4ⴋ񂹫; 𐯀𐸉𞧏.񢚧4ⴋ񂹫; [P1, V6]; xn--039c42bq865a.xn--4-wvs27840bnrzm; ; ;  # .4ⴋ
+xn--039c42bq865a.xn--4-wvs27840bnrzm; 𐯀𐸉𞧏.񢚧4ⴋ񂹫; [V6]; xn--039c42bq865a.xn--4-wvs27840bnrzm; ; ;  # .4ⴋ
+xn--039c42bq865a.xn--4-t0g49302fnrzm; 𐯀𐸉𞧏.񢚧4Ⴋ񂹫; [V6]; xn--039c42bq865a.xn--4-t0g49302fnrzm; ; ;  # .4Ⴋ
+𐯀𐸉𞧏。񢚧₄ⴋ񂹫; 𐯀𐸉𞧏.񢚧4ⴋ񂹫; [P1, V6]; xn--039c42bq865a.xn--4-wvs27840bnrzm; ; ;  # .4ⴋ
+4ڽ︒󠑥.≠; ; [B1, P1, V6]; xn--4-kvc5601q2h50i.xn--1ch; ; ;  # 4ڽ︒.≠
+4ڽ︒󠑥.≠; 4ڽ︒󠑥.≠; [B1, P1, V6]; xn--4-kvc5601q2h50i.xn--1ch; ; ;  # 4ڽ︒.≠
+4ڽ。󠑥.≠; 4ڽ.󠑥.≠; [B1, P1, V6]; xn--4-kvc.xn--5136e.xn--1ch; ; ;  # 4ڽ..≠
+4ڽ。󠑥.≠; 4ڽ.󠑥.≠; [B1, P1, V6]; xn--4-kvc.xn--5136e.xn--1ch; ; ;  # 4ڽ..≠
+xn--4-kvc.xn--5136e.xn--1ch; 4ڽ.󠑥.≠; [B1, V6]; xn--4-kvc.xn--5136e.xn--1ch; ; ;  # 4ڽ..≠
+xn--4-kvc5601q2h50i.xn--1ch; 4ڽ︒󠑥.≠; [B1, V6]; xn--4-kvc5601q2h50i.xn--1ch; ; ;  # 4ڽ︒.≠
+𝟓。ۗ; 5.ۗ; [V5]; 5.xn--nlb; ; ;  # 5.ۗ
+5。ۗ; 5.ۗ; [V5]; 5.xn--nlb; ; ;  # 5.ۗ
+5.xn--nlb; 5.ۗ; [V5]; 5.xn--nlb; ; ;  # 5.ۗ
+‌򺸩.⾕; ‌򺸩.谷; [C1, P1, V6]; xn--0ug26167i.xn--6g3a; ; xn--i183d.xn--6g3a; [P1, V6] # .谷
+‌򺸩.谷; ; [C1, P1, V6]; xn--0ug26167i.xn--6g3a; ; xn--i183d.xn--6g3a; [P1, V6] # .谷
+xn--i183d.xn--6g3a; 򺸩.谷; [V6]; xn--i183d.xn--6g3a; ; ;  # .谷
+xn--0ug26167i.xn--6g3a; ‌򺸩.谷; [C1, V6]; xn--0ug26167i.xn--6g3a; ; ;  # .谷
+︒󎰇‍.-ܼ‌; ; [C1, C2, P1, V3, V6]; xn--1ug1658ftw26f.xn----t2c071q; ; xn--y86c71305c.xn----t2c; [P1, V3, V6] # ︒.-ܼ
+。󎰇‍.-ܼ‌; .󎰇‍.-ܼ‌; [C1, C2, P1, V3, V6, X4_2]; .xn--1ug05310k.xn----t2c071q; [C1, C2, P1, V3, V6, A4_2]; .xn--hh50e.xn----t2c; [P1, V3, V6, A4_2] # ..-ܼ
+.xn--hh50e.xn----t2c; .󎰇.-ܼ; [V3, V6, X4_2]; .xn--hh50e.xn----t2c; [V3, V6, A4_2]; ;  # ..-ܼ
+.xn--1ug05310k.xn----t2c071q; .󎰇‍.-ܼ‌; [C1, C2, V3, V6, X4_2]; .xn--1ug05310k.xn----t2c071q; [C1, C2, V3, V6, A4_2]; ;  # ..-ܼ
+xn--y86c71305c.xn----t2c; ︒󎰇.-ܼ; [V3, V6]; xn--y86c71305c.xn----t2c; ; ;  # ︒.-ܼ
+xn--1ug1658ftw26f.xn----t2c071q; ︒󎰇‍.-ܼ‌; [C1, C2, V3, V6]; xn--1ug1658ftw26f.xn----t2c071q; ; ;  # ︒.-ܼ
+≯𞤟。ᡨ; ≯𞥁.ᡨ; [B1, P1, V6]; xn--hdhz520p.xn--48e; ; ;  # ≯𞥁.ᡨ
+≯𞤟。ᡨ; ≯𞥁.ᡨ; [B1, P1, V6]; xn--hdhz520p.xn--48e; ; ;  # ≯𞥁.ᡨ
+≯𞥁。ᡨ; ≯𞥁.ᡨ; [B1, P1, V6]; xn--hdhz520p.xn--48e; ; ;  # ≯𞥁.ᡨ
+≯𞥁。ᡨ; ≯𞥁.ᡨ; [B1, P1, V6]; xn--hdhz520p.xn--48e; ; ;  # ≯𞥁.ᡨ
+xn--hdhz520p.xn--48e; ≯𞥁.ᡨ; [B1, V6]; xn--hdhz520p.xn--48e; ; ;  # ≯𞥁.ᡨ
+ུ𫫰𝨄。ܓ𐹦; ུ𫫰𝨄.ܓ𐹦; [B1, V5]; xn--ned8985uo92e.xn--dnb6395k; ; ;  # ུ𫫰𝨄.ܓ𐹦
+xn--ned8985uo92e.xn--dnb6395k; ུ𫫰𝨄.ܓ𐹦; [B1, V5]; xn--ned8985uo92e.xn--dnb6395k; ; ;  # ུ𫫰𝨄.ܓ𐹦
+̼ߛ⁷𝟹｡𝟬; ̼ߛ73.0; [B1, V5]; xn--73-9yb648b.0; ; ;  # ̼ߛ73.0
+̼ߛ73。0; ̼ߛ73.0; [B1, V5]; xn--73-9yb648b.0; ; ;  # ̼ߛ73.0
+xn--73-9yb648b.0; ̼ߛ73.0; [B1, V5]; xn--73-9yb648b.0; ; ;  # ̼ߛ73.0
+‍．𝟗; ‍.9; [C2]; xn--1ug.9; ; .9; [A4_2] # .9
+‍.9; ; [C2]; xn--1ug.9; ; .9; [A4_2] # .9
+.9; ; [X4_2]; ; [A4_2]; ;  # .9
+xn--1ug.9; ‍.9; [C2]; xn--1ug.9; ; ;  # .9
+9; ; ; ; ; ;  # 9
+ݹᡭ𪕈。ڶࣙ; ݹᡭ𪕈.ڶࣙ; [B2, B3]; xn--9pb497fs270c.xn--pkb80i; ; ;  # ݹᡭ𪕈.ڶࣙ
+xn--9pb497fs270c.xn--pkb80i; ݹᡭ𪕈.ڶࣙ; [B2, B3]; xn--9pb497fs270c.xn--pkb80i; ; ;  # ݹᡭ𪕈.ڶࣙ
+ܦ５ߢ겙。᳴𐷚; ܦ5ߢ겙.᳴𐷚; [B1, B2, B3, P1, V5, V6]; xn--5-j1c97c2483c.xn--e7f2093h; ; ;  # ܦ5ߢ겙.᳴
+ܦ５ߢ겙。᳴𐷚; ܦ5ߢ겙.᳴𐷚; [B1, B2, B3, P1, V5, V6]; xn--5-j1c97c2483c.xn--e7f2093h; ; ;  # ܦ5ߢ겙.᳴
+ܦ5ߢ겙。᳴𐷚; ܦ5ߢ겙.᳴𐷚; [B1, B2, B3, P1, V5, V6]; xn--5-j1c97c2483c.xn--e7f2093h; ; ;  # ܦ5ߢ겙.᳴
+ܦ5ߢ겙。᳴𐷚; ܦ5ߢ겙.᳴𐷚; [B1, B2, B3, P1, V5, V6]; xn--5-j1c97c2483c.xn--e7f2093h; ; ;  # ܦ5ߢ겙.᳴
+xn--5-j1c97c2483c.xn--e7f2093h; ܦ5ߢ겙.᳴𐷚; [B1, B2, B3, V5, V6]; xn--5-j1c97c2483c.xn--e7f2093h; ; ;  # ܦ5ߢ겙.᳴
+Ⴍ𿣍ꡨ֮。Ⴞ‌‌; Ⴍ𿣍ꡨ֮.Ⴞ‌‌; [C1, P1, V6]; xn--5cb347co96jug15a.xn--2nd059ea; ; xn--5cb347co96jug15a.xn--2nd; [P1, V6] # Ⴍꡨ֮.Ⴞ
+ⴍ𿣍ꡨ֮。ⴞ‌‌; ⴍ𿣍ꡨ֮.ⴞ‌‌; [C1, P1, V6]; xn--5cb172r175fug38a.xn--0uga051h; ; xn--5cb172r175fug38a.xn--mlj; [P1, V6] # ⴍꡨ֮.ⴞ
+xn--5cb172r175fug38a.xn--mlj; ⴍ𿣍ꡨ֮.ⴞ; [V6]; xn--5cb172r175fug38a.xn--mlj; ; ;  # ⴍꡨ֮.ⴞ
+xn--5cb172r175fug38a.xn--0uga051h; ⴍ𿣍ꡨ֮.ⴞ‌‌; [C1, V6]; xn--5cb172r175fug38a.xn--0uga051h; ; ;  # ⴍꡨ֮.ⴞ
+xn--5cb347co96jug15a.xn--2nd; Ⴍ𿣍ꡨ֮.Ⴞ; [V6]; xn--5cb347co96jug15a.xn--2nd; ; ;  # Ⴍꡨ֮.Ⴞ
+xn--5cb347co96jug15a.xn--2nd059ea; Ⴍ𿣍ꡨ֮.Ⴞ‌‌; [C1, V6]; xn--5cb347co96jug15a.xn--2nd059ea; ; ;  # Ⴍꡨ֮.Ⴞ
+𐋰。󑓱; 𐋰.󑓱; [P1, V6]; xn--k97c.xn--q031e; ; ;  # 𐋰.
+xn--k97c.xn--q031e; 𐋰.󑓱; [V6]; xn--k97c.xn--q031e; ; ;  # 𐋰.
+󡎦឴୍.𐹾; ; [B1, P1, V6]; xn--9ic364dho91z.xn--2o0d; ; ;  # ୍.𐹾
+xn--9ic364dho91z.xn--2o0d; 󡎦឴୍.𐹾; [B1, V6]; xn--9ic364dho91z.xn--2o0d; ; ;  # ୍.𐹾
+ࣟႫ𶿸귤．򠅼𝟢휪ૣ; ࣟႫ𶿸귤.򠅼0휪ૣ; [P1, V5, V6]; xn--i0b601b6r7l2hs0a.xn--0-8le8997mulr5f; ; ;  # ࣟႫ귤.0휪ૣ
+ࣟႫ𶿸귤．򠅼𝟢휪ૣ; ࣟႫ𶿸귤.򠅼0휪ૣ; [P1, V5, V6]; xn--i0b601b6r7l2hs0a.xn--0-8le8997mulr5f; ; ;  # ࣟႫ귤.0휪ૣ
+ࣟႫ𶿸귤.򠅼0휪ૣ; ; [P1, V5, V6]; xn--i0b601b6r7l2hs0a.xn--0-8le8997mulr5f; ; ;  # ࣟႫ귤.0휪ૣ
+ࣟႫ𶿸귤.򠅼0휪ૣ; ࣟႫ𶿸귤.򠅼0휪ૣ; [P1, V5, V6]; xn--i0b601b6r7l2hs0a.xn--0-8le8997mulr5f; ; ;  # ࣟႫ귤.0휪ૣ
+ࣟⴋ𶿸귤.򠅼0휪ૣ; ࣟⴋ𶿸귤.򠅼0휪ૣ; [P1, V5, V6]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+ࣟⴋ𶿸귤.򠅼0휪ૣ; ; [P1, V5, V6]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ࣟⴋ𶿸귤.򠅼0휪ૣ; [V5, V6]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+xn--i0b601b6r7l2hs0a.xn--0-8le8997mulr5f; ࣟႫ𶿸귤.򠅼0휪ૣ; [V5, V6]; xn--i0b601b6r7l2hs0a.xn--0-8le8997mulr5f; ; ;  # ࣟႫ귤.0휪ૣ
+ࣟⴋ𶿸귤．򠅼𝟢휪ૣ; ࣟⴋ𶿸귤.򠅼0휪ૣ; [P1, V5, V6]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+ࣟⴋ𶿸귤．򠅼𝟢휪ૣ; ࣟⴋ𶿸귤.򠅼0휪ૣ; [P1, V5, V6]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+ބ．𞡝؁; ބ.𞡝؁; [P1, V6]; xn--lqb.xn--jfb1808v; ; ;  # ބ.𞡝
+ބ.𞡝؁; ; [P1, V6]; xn--lqb.xn--jfb1808v; ; ;  # ބ.𞡝
+xn--lqb.xn--jfb1808v; ބ.𞡝؁; [V6]; xn--lqb.xn--jfb1808v; ; ;  # ބ.𞡝
+્₃.8꣄‍🃤; ્3.8꣄‍🃤; [V5]; xn--3-yke.xn--8-ugnv982dbkwm; ; xn--3-yke.xn--8-sl4et308f;  # ્3.8꣄🃤
+્3.8꣄‍🃤; ; [V5]; xn--3-yke.xn--8-ugnv982dbkwm; ; xn--3-yke.xn--8-sl4et308f;  # ્3.8꣄🃤
+xn--3-yke.xn--8-sl4et308f; ્3.8꣄🃤; [V5]; xn--3-yke.xn--8-sl4et308f; ; ;  # ્3.8꣄🃤
+xn--3-yke.xn--8-ugnv982dbkwm; ્3.8꣄‍🃤; [V5]; xn--3-yke.xn--8-ugnv982dbkwm; ; ;  # ્3.8꣄🃤
+℻⩷𝆆。𞤠󠆁᠌; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+FAX⩷𝆆。𞤠󠆁᠌; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+fax⩷𝆆。𞥂󠆁᠌; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+Fax⩷𝆆。𞤠󠆁᠌; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+xn--fax-4c9a1676t.xn--6e6h; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+℻⩷𝆆。𞥂󠆁᠌; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+FAX⩷𝆆。𞥂󠆁᠌; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+fax⩷𝆆。𞤠󠆁᠌; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+fax⩷𝆆.𞥂; ; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+FAX⩷𝆆.𞤠; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+Fax⩷𝆆.𞤠; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+FAX⩷𝆆.𞥂; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+Fax⩷𝆆.𞥂; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+ꡕ≠ၞ󮿱｡𐵧󠄫ﾠ; ꡕ≠ၞ󮿱.𐵧ﾠ; [B2, B3, P1, V6]; xn--cld333gn31h0158l.xn--cl7c96v; ; ;  # ꡕ≠ၞ.
+ꡕ≠ၞ󮿱｡𐵧󠄫ﾠ; ꡕ≠ၞ󮿱.𐵧ﾠ; [B2, B3, P1, V6]; xn--cld333gn31h0158l.xn--cl7c96v; ; ;  # ꡕ≠ၞ.
+ꡕ≠ၞ󮿱。𐵧󠄫ᅠ; ꡕ≠ၞ󮿱.𐵧ᅠ; [B2, B3, P1, V6]; xn--cld333gn31h0158l.xn--psd1510k; ; ;  # ꡕ≠ၞ.
+ꡕ≠ၞ󮿱。𐵧󠄫ᅠ; ꡕ≠ၞ󮿱.𐵧ᅠ; [B2, B3, P1, V6]; xn--cld333gn31h0158l.xn--psd1510k; ; ;  # ꡕ≠ၞ.
+xn--cld333gn31h0158l.xn--psd1510k; ꡕ≠ၞ󮿱.𐵧ᅠ; [B2, B3, V6]; xn--cld333gn31h0158l.xn--psd1510k; ; ;  # ꡕ≠ၞ.
+xn--cld333gn31h0158l.xn--cl7c96v; ꡕ≠ၞ󮿱.𐵧ﾠ; [B2, B3, V6]; xn--cld333gn31h0158l.xn--cl7c96v; ; ;  # ꡕ≠ၞ.
+鱊。‌; 鱊.‌; [C1]; xn--rt6a.xn--0ug; ; xn--rt6a.; [] # 鱊.
+xn--rt6a.; 鱊.; ; xn--rt6a.; ; ;  # 鱊.
+鱊.; ; ; xn--rt6a.; ; ;  # 鱊.
+xn--rt6a.xn--0ug; 鱊.‌; [C1]; xn--rt6a.xn--0ug; ; ;  # 鱊.
+8𐹣．𑍨; 8𐹣.𑍨; [B1, B3, B6, V5]; xn--8-d26i.xn--0p1d; ; ;  # 8𐹣.𑍨
+8𐹣.𑍨; ; [B1, B3, B6, V5]; xn--8-d26i.xn--0p1d; ; ;  # 8𐹣.𑍨
+xn--8-d26i.xn--0p1d; 8𐹣.𑍨; [B1, B3, B6, V5]; xn--8-d26i.xn--0p1d; ; ;  # 8𐹣.𑍨
+⏹𐧀．𐫯; ⏹𐧀.𐫯; [B1]; xn--qoh9161g.xn--1x9c; ; ;  # ⏹𐧀.𐫯
+⏹𐧀.𐫯; ; [B1]; xn--qoh9161g.xn--1x9c; ; ;  # ⏹𐧀.𐫯
+xn--qoh9161g.xn--1x9c; ⏹𐧀.𐫯; [B1]; xn--qoh9161g.xn--1x9c; ; ;  # ⏹𐧀.𐫯
+𞤺ߌ4．‍; 𞤺ߌ4.‍; [B1, C2]; xn--4-0bd15808a.xn--1ug; ; xn--4-0bd15808a.; [] # 𞤺ߌ4.
+𞤺ߌ4.‍; ; [B1, C2]; xn--4-0bd15808a.xn--1ug; ; xn--4-0bd15808a.; [] # 𞤺ߌ4.
+𞤘ߌ4.‍; 𞤺ߌ4.‍; [B1, C2]; xn--4-0bd15808a.xn--1ug; ; xn--4-0bd15808a.; [] # 𞤺ߌ4.
+xn--4-0bd15808a.; 𞤺ߌ4.; ; xn--4-0bd15808a.; ; ;  # 𞤺ߌ4.
+𞤺ߌ4.; ; ; xn--4-0bd15808a.; ; ;  # 𞤺ߌ4.
+𞤘ߌ4.; 𞤺ߌ4.; ; xn--4-0bd15808a.; ; ;  # 𞤺ߌ4.
+xn--4-0bd15808a.xn--1ug; 𞤺ߌ4.‍; [B1, C2]; xn--4-0bd15808a.xn--1ug; ; ;  # 𞤺ߌ4.
+𞤘ߌ4．‍; 𞤺ߌ4.‍; [B1, C2]; xn--4-0bd15808a.xn--1ug; ; xn--4-0bd15808a.; [] # 𞤺ߌ4.
+⒗ঁ⃯-.࣢•; ; [B1, P1, V3, V6]; xn----z0d801p6kd.xn--l0b810j; ; ;  # ⒗ঁ⃯-.•
+16.ঁ⃯-.࣢•; ; [B1, P1, V3, V5, V6]; 16.xn----z0d801p.xn--l0b810j; ; ;  # 16.ঁ⃯-.•
+16.xn----z0d801p.xn--l0b810j; 16.ঁ⃯-.࣢•; [B1, V3, V5, V6]; 16.xn----z0d801p.xn--l0b810j; ; ;  # 16.ঁ⃯-.•
+xn----z0d801p6kd.xn--l0b810j; ⒗ঁ⃯-.࣢•; [B1, V3, V6]; xn----z0d801p6kd.xn--l0b810j; ; ;  # ⒗ঁ⃯-.•
+-｡䏛; -.䏛; [V3]; -.xn--xco; ; ;  # -.䏛
+-。䏛; -.䏛; [V3]; -.xn--xco; ; ;  # -.䏛
+-.xn--xco; -.䏛; [V3]; -.xn--xco; ; ;  # -.䏛
+‌񒃠．‍; ‌񒃠.‍; [C1, C2, P1, V6]; xn--0ugz7551c.xn--1ug; ; xn--dj8y.; [P1, V6] # .
+‌񒃠.‍; ; [C1, C2, P1, V6]; xn--0ugz7551c.xn--1ug; ; xn--dj8y.; [P1, V6] # .
+xn--dj8y.; 񒃠.; [V6]; xn--dj8y.; ; ;  # .
+xn--0ugz7551c.xn--1ug; ‌񒃠.‍; [C1, C2, V6]; xn--0ugz7551c.xn--1ug; ; ;  # .
+⒈⓰󥣇｡𐹠‍򗷦Ⴕ; ⒈⓰󥣇.𐹠‍򗷦Ⴕ; [B1, C2, P1, V6]; xn--tsh0nz9380h.xn--tnd969erj4psgl3e; ; xn--tsh0nz9380h.xn--tnd1990ke579c; [B1, P1, V6] # ⒈⓰.𐹠Ⴕ
+1.⓰󥣇。𐹠‍򗷦Ⴕ; 1.⓰󥣇.𐹠‍򗷦Ⴕ; [B1, C2, P1, V6]; 1.xn--svh00804k.xn--tnd969erj4psgl3e; ; 1.xn--svh00804k.xn--tnd1990ke579c; [B1, P1, V6] # 1.⓰.𐹠Ⴕ
+1.⓰󥣇。𐹠‍򗷦ⴕ; 1.⓰󥣇.𐹠‍򗷦ⴕ; [B1, C2, P1, V6]; 1.xn--svh00804k.xn--1ug352csp0psg45e; ; 1.xn--svh00804k.xn--dljv223ee5t2d; [B1, P1, V6] # 1.⓰.𐹠ⴕ
+1.xn--svh00804k.xn--dljv223ee5t2d; 1.⓰󥣇.𐹠򗷦ⴕ; [B1, V6]; 1.xn--svh00804k.xn--dljv223ee5t2d; ; ;  # 1.⓰.𐹠ⴕ
+1.xn--svh00804k.xn--1ug352csp0psg45e; 1.⓰󥣇.𐹠‍򗷦ⴕ; [B1, C2, V6]; 1.xn--svh00804k.xn--1ug352csp0psg45e; ; ;  # 1.⓰.𐹠ⴕ
+1.xn--svh00804k.xn--tnd1990ke579c; 1.⓰󥣇.𐹠򗷦Ⴕ; [B1, V6]; 1.xn--svh00804k.xn--tnd1990ke579c; ; ;  # 1.⓰.𐹠Ⴕ
+1.xn--svh00804k.xn--tnd969erj4psgl3e; 1.⓰󥣇.𐹠‍򗷦Ⴕ; [B1, C2, V6]; 1.xn--svh00804k.xn--tnd969erj4psgl3e; ; ;  # 1.⓰.𐹠Ⴕ
+⒈⓰󥣇｡𐹠‍򗷦ⴕ; ⒈⓰󥣇.𐹠‍򗷦ⴕ; [B1, C2, P1, V6]; xn--tsh0nz9380h.xn--1ug352csp0psg45e; ; xn--tsh0nz9380h.xn--dljv223ee5t2d; [B1, P1, V6] # ⒈⓰.𐹠ⴕ
+xn--tsh0nz9380h.xn--dljv223ee5t2d; ⒈⓰󥣇.𐹠򗷦ⴕ; [B1, V6]; xn--tsh0nz9380h.xn--dljv223ee5t2d; ; ;  # ⒈⓰.𐹠ⴕ
+xn--tsh0nz9380h.xn--1ug352csp0psg45e; ⒈⓰󥣇.𐹠‍򗷦ⴕ; [B1, C2, V6]; xn--tsh0nz9380h.xn--1ug352csp0psg45e; ; ;  # ⒈⓰.𐹠ⴕ
+xn--tsh0nz9380h.xn--tnd1990ke579c; ⒈⓰󥣇.𐹠򗷦Ⴕ; [B1, V6]; xn--tsh0nz9380h.xn--tnd1990ke579c; ; ;  # ⒈⓰.𐹠Ⴕ
+xn--tsh0nz9380h.xn--tnd969erj4psgl3e; ⒈⓰󥣇.𐹠‍򗷦Ⴕ; [B1, C2, V6]; xn--tsh0nz9380h.xn--tnd969erj4psgl3e; ; ;  # ⒈⓰.𐹠Ⴕ
+𞠊ᠮ-ß｡᳐効؁𷣭; 𞠊ᠮ-ß.᳐効؁𷣭; [B1, B2, B3, P1, V5, V6]; xn----qfa310pg973b.xn--jfb197i791bi6x4c; ; xn---ss-21t18904a.xn--jfb197i791bi6x4c;  # 𞠊ᠮ-ß.᳐効
+𞠊ᠮ-ß。᳐効؁𷣭; 𞠊ᠮ-ß.᳐効؁𷣭; [B1, B2, B3, P1, V5, V6]; xn----qfa310pg973b.xn--jfb197i791bi6x4c; ; xn---ss-21t18904a.xn--jfb197i791bi6x4c;  # 𞠊ᠮ-ß.᳐効
+𞠊ᠮ-SS。᳐効؁𷣭; 𞠊ᠮ-ss.᳐効؁𷣭; [B1, B2, B3, P1, V5, V6]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+𞠊ᠮ-ss。᳐効؁𷣭; 𞠊ᠮ-ss.᳐効؁𷣭; [B1, B2, B3, P1, V5, V6]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+𞠊ᠮ-Ss。᳐効؁𷣭; 𞠊ᠮ-ss.᳐効؁𷣭; [B1, B2, B3, P1, V5, V6]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+xn---ss-21t18904a.xn--jfb197i791bi6x4c; 𞠊ᠮ-ss.᳐効؁𷣭; [B1, B2, B3, V5, V6]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+xn----qfa310pg973b.xn--jfb197i791bi6x4c; 𞠊ᠮ-ß.᳐効؁𷣭; [B1, B2, B3, V5, V6]; xn----qfa310pg973b.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ß.᳐効
+𞠊ᠮ-SS｡᳐効؁𷣭; 𞠊ᠮ-ss.᳐効؁𷣭; [B1, B2, B3, P1, V5, V6]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+𞠊ᠮ-ss｡᳐効؁𷣭; 𞠊ᠮ-ss.᳐効؁𷣭; [B1, B2, B3, P1, V5, V6]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+𞠊ᠮ-Ss｡᳐効؁𷣭; 𞠊ᠮ-ss.᳐効؁𷣭; [B1, B2, B3, P1, V5, V6]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+𑇀.󠨱; ; [P1, V5, V6]; xn--wd1d.xn--k946e; ; ;  # 𑇀.
+xn--wd1d.xn--k946e; 𑇀.󠨱; [V5, V6]; xn--wd1d.xn--k946e; ; ;  # 𑇀.
+␒3ﮈ｡𝟘𐨿𐹆; ␒3ڈ.0𐨿𐹆; [B1, P1, V6]; xn--3-jsc897t.xn--0-sc5iy3h; ; ;  # ␒3ڈ.0𐨿
+␒3ڈ。0𐨿𐹆; ␒3ڈ.0𐨿𐹆; [B1, P1, V6]; xn--3-jsc897t.xn--0-sc5iy3h; ; ;  # ␒3ڈ.0𐨿
+xn--3-jsc897t.xn--0-sc5iy3h; ␒3ڈ.0𐨿𐹆; [B1, V6]; xn--3-jsc897t.xn--0-sc5iy3h; ; ;  # ␒3ڈ.0𐨿
+ݫ６ઁࢦ。ᷣ; ݫ6ઁࢦ.ᷣ; [B1, B3, B6, V5]; xn--6-h5c06gj6c.xn--7eg; ; ;  # ݫ6ઁࢦ.ᷣ
+ݫ6ઁࢦ。ᷣ; ݫ6ઁࢦ.ᷣ; [B1, B3, B6, V5]; xn--6-h5c06gj6c.xn--7eg; ; ;  # ݫ6ઁࢦ.ᷣ
+xn--6-h5c06gj6c.xn--7eg; ݫ6ઁࢦ.ᷣ; [B1, B3, B6, V5]; xn--6-h5c06gj6c.xn--7eg; ; ;  # ݫ6ઁࢦ.ᷣ
+؅-𽤞Ⴂ。򅤶‍; ؅-𽤞Ⴂ.򅤶‍; [B1, B6, C2, P1, V6]; xn----0kc662fc152h.xn--1ugy3204f; ; xn----0kc662fc152h.xn--ss06b; [B1, P1, V6] # -Ⴂ.
+؅-𽤞ⴂ。򅤶‍; ؅-𽤞ⴂ.򅤶‍; [B1, B6, C2, P1, V6]; xn----0kc8501a5399e.xn--1ugy3204f; ; xn----0kc8501a5399e.xn--ss06b; [B1, P1, V6] # -ⴂ.
+xn----0kc8501a5399e.xn--ss06b; ؅-𽤞ⴂ.򅤶; [B1, V6]; xn----0kc8501a5399e.xn--ss06b; ; ;  # -ⴂ.
+xn----0kc8501a5399e.xn--1ugy3204f; ؅-𽤞ⴂ.򅤶‍; [B1, B6, C2, V6]; xn----0kc8501a5399e.xn--1ugy3204f; ; ;  # -ⴂ.
+xn----0kc662fc152h.xn--ss06b; ؅-𽤞Ⴂ.򅤶; [B1, V6]; xn----0kc662fc152h.xn--ss06b; ; ;  # -Ⴂ.
+xn----0kc662fc152h.xn--1ugy3204f; ؅-𽤞Ⴂ.򅤶‍; [B1, B6, C2, V6]; xn----0kc662fc152h.xn--1ugy3204f; ; ;  # -Ⴂ.
+⾆．ꡈ５≯ß; 舌.ꡈ5≯ß; [P1, V6]; xn--tc1a.xn--5-qfa988w745i; ; xn--tc1a.xn--5ss-3m2a5009e;  # 舌.ꡈ5≯ß
+⾆．ꡈ５≯ß; 舌.ꡈ5≯ß; [P1, V6]; xn--tc1a.xn--5-qfa988w745i; ; xn--tc1a.xn--5ss-3m2a5009e;  # 舌.ꡈ5≯ß
+舌.ꡈ5≯ß; ; [P1, V6]; xn--tc1a.xn--5-qfa988w745i; ; xn--tc1a.xn--5ss-3m2a5009e;  # 舌.ꡈ5≯ß
+舌.ꡈ5≯ß; 舌.ꡈ5≯ß; [P1, V6]; xn--tc1a.xn--5-qfa988w745i; ; xn--tc1a.xn--5ss-3m2a5009e;  # 舌.ꡈ5≯ß
+舌.ꡈ5≯SS; 舌.ꡈ5≯ss; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+舌.ꡈ5≯SS; 舌.ꡈ5≯ss; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+舌.ꡈ5≯ss; ; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+舌.ꡈ5≯ss; 舌.ꡈ5≯ss; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+舌.ꡈ5≯Ss; 舌.ꡈ5≯ss; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+舌.ꡈ5≯Ss; 舌.ꡈ5≯ss; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+xn--tc1a.xn--5ss-3m2a5009e; 舌.ꡈ5≯ss; [V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+xn--tc1a.xn--5-qfa988w745i; 舌.ꡈ5≯ß; [V6]; xn--tc1a.xn--5-qfa988w745i; ; ;  # 舌.ꡈ5≯ß
+⾆．ꡈ５≯SS; 舌.ꡈ5≯ss; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+⾆．ꡈ５≯SS; 舌.ꡈ5≯ss; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+⾆．ꡈ５≯ss; 舌.ꡈ5≯ss; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+⾆．ꡈ５≯ss; 舌.ꡈ5≯ss; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+⾆．ꡈ５≯Ss; 舌.ꡈ5≯ss; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+⾆．ꡈ５≯Ss; 舌.ꡈ5≯ss; [P1, V6]; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+્8‍．򾂈ݜ; ્8‍.򾂈ݜ; [B1, B5, B6, C2, P1, V5, V6]; xn--8-yke534n.xn--gpb79046m; ; xn--8-yke.xn--gpb79046m; [B1, B5, B6, P1, V5, V6] # ્8.ݜ
+્8‍.򾂈ݜ; ; [B1, B5, B6, C2, P1, V5, V6]; xn--8-yke534n.xn--gpb79046m; ; xn--8-yke.xn--gpb79046m; [B1, B5, B6, P1, V5, V6] # ્8.ݜ
+xn--8-yke.xn--gpb79046m; ્8.򾂈ݜ; [B1, B5, B6, V5, V6]; xn--8-yke.xn--gpb79046m; ; ;  # ્8.ݜ
+xn--8-yke534n.xn--gpb79046m; ્8‍.򾂈ݜ; [B1, B5, B6, C2, V5, V6]; xn--8-yke534n.xn--gpb79046m; ; ;  # ્8.ݜ
+򸷆ੰ≮򹓙．񞎧⁷󠯙ڶ; 򸷆ੰ≮򹓙.񞎧7󠯙ڶ; [B5, B6, P1, V6]; xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; ; ;  # ੰ≮.7ڶ
+򸷆ੰ≮򹓙．񞎧⁷󠯙ڶ; 򸷆ੰ≮򹓙.񞎧7󠯙ڶ; [B5, B6, P1, V6]; xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; ; ;  # ੰ≮.7ڶ
+򸷆ੰ≮򹓙.񞎧7󠯙ڶ; ; [B5, B6, P1, V6]; xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; ; ;  # ੰ≮.7ڶ
+򸷆ੰ≮򹓙.񞎧7󠯙ڶ; 򸷆ੰ≮򹓙.񞎧7󠯙ڶ; [B5, B6, P1, V6]; xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; ; ;  # ੰ≮.7ڶ
+xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; 򸷆ੰ≮򹓙.񞎧7󠯙ڶ; [B5, B6, V6]; xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; ; ;  # ੰ≮.7ڶ
+𞤪.ς; ; ; xn--ie6h.xn--3xa; ; xn--ie6h.xn--4xa;  # 𞤪.ς
+𞤈.Σ; 𞤪.σ; ; xn--ie6h.xn--4xa; ; ;  # 𞤪.σ
+𞤪.σ; ; ; xn--ie6h.xn--4xa; ; ;  # 𞤪.σ
+𞤈.σ; 𞤪.σ; ; xn--ie6h.xn--4xa; ; ;  # 𞤪.σ
+xn--ie6h.xn--4xa; 𞤪.σ; ; xn--ie6h.xn--4xa; ; ;  # 𞤪.σ
+𞤈.ς; 𞤪.ς; ; xn--ie6h.xn--3xa; ; xn--ie6h.xn--4xa;  # 𞤪.ς
+xn--ie6h.xn--3xa; 𞤪.ς; ; xn--ie6h.xn--3xa; ; ;  # 𞤪.ς
+𞤪.Σ; 𞤪.σ; ; xn--ie6h.xn--4xa; ; ;  # 𞤪.σ
+‌Ⴚ｡ς; ‌Ⴚ.ς; [C1, P1, V6]; xn--ynd759e.xn--3xa; ; xn--ynd.xn--4xa; [P1, V6] # Ⴚ.ς
+‌Ⴚ。ς; ‌Ⴚ.ς; [C1, P1, V6]; xn--ynd759e.xn--3xa; ; xn--ynd.xn--4xa; [P1, V6] # Ⴚ.ς
+‌ⴚ。ς; ‌ⴚ.ς; [C1]; xn--0ug262c.xn--3xa; ; xn--ilj.xn--4xa; [] # ⴚ.ς
+‌Ⴚ。Σ; ‌Ⴚ.σ; [C1, P1, V6]; xn--ynd759e.xn--4xa; ; xn--ynd.xn--4xa; [P1, V6] # Ⴚ.σ
+‌ⴚ。σ; ‌ⴚ.σ; [C1]; xn--0ug262c.xn--4xa; ; xn--ilj.xn--4xa; [] # ⴚ.σ
+xn--ilj.xn--4xa; ⴚ.σ; ; xn--ilj.xn--4xa; ; ;  # ⴚ.σ
+ⴚ.σ; ; ; xn--ilj.xn--4xa; ; ;  # ⴚ.σ
+Ⴚ.Σ; Ⴚ.σ; [P1, V6]; xn--ynd.xn--4xa; ; ;  # Ⴚ.σ
+ⴚ.ς; ; ; xn--ilj.xn--3xa; ; xn--ilj.xn--4xa;  # ⴚ.ς
+Ⴚ.ς; ; [P1, V6]; xn--ynd.xn--3xa; ; xn--ynd.xn--4xa;  # Ⴚ.ς
+xn--ynd.xn--4xa; Ⴚ.σ; [V6]; xn--ynd.xn--4xa; ; ;  # Ⴚ.σ
+xn--ynd.xn--3xa; Ⴚ.ς; [V6]; xn--ynd.xn--3xa; ; ;  # Ⴚ.ς
+xn--ilj.xn--3xa; ⴚ.ς; ; xn--ilj.xn--3xa; ; ;  # ⴚ.ς
+Ⴚ.σ; ; [P1, V6]; xn--ynd.xn--4xa; ; ;  # Ⴚ.σ
+xn--0ug262c.xn--4xa; ‌ⴚ.σ; [C1]; xn--0ug262c.xn--4xa; ; ;  # ⴚ.σ
+xn--ynd759e.xn--4xa; ‌Ⴚ.σ; [C1, V6]; xn--ynd759e.xn--4xa; ; ;  # Ⴚ.σ
+xn--0ug262c.xn--3xa; ‌ⴚ.ς; [C1]; xn--0ug262c.xn--3xa; ; ;  # ⴚ.ς
+xn--ynd759e.xn--3xa; ‌Ⴚ.ς; [C1, V6]; xn--ynd759e.xn--3xa; ; ;  # Ⴚ.ς
+‌ⴚ｡ς; ‌ⴚ.ς; [C1]; xn--0ug262c.xn--3xa; ; xn--ilj.xn--4xa; [] # ⴚ.ς
+‌Ⴚ｡Σ; ‌Ⴚ.σ; [C1, P1, V6]; xn--ynd759e.xn--4xa; ; xn--ynd.xn--4xa; [P1, V6] # Ⴚ.σ
+‌ⴚ｡σ; ‌ⴚ.σ; [C1]; xn--0ug262c.xn--4xa; ; xn--ilj.xn--4xa; [] # ⴚ.σ
+𞤃．𐹦; 𞤥.𐹦; [B1]; xn--de6h.xn--eo0d; ; ;  # 𞤥.𐹦
+𞤃.𐹦; 𞤥.𐹦; [B1]; xn--de6h.xn--eo0d; ; ;  # 𞤥.𐹦
+𞤥.𐹦; ; [B1]; xn--de6h.xn--eo0d; ; ;  # 𞤥.𐹦
+xn--de6h.xn--eo0d; 𞤥.𐹦; [B1]; xn--de6h.xn--eo0d; ; ;  # 𞤥.𐹦
+𞤥．𐹦; 𞤥.𐹦; [B1]; xn--de6h.xn--eo0d; ; ;  # 𞤥.𐹦
+‍⾕。‌꥓̐ꡎ; ‍谷.‌꥓̐ꡎ; [C1, C2]; xn--1ug0273b.xn--0sa359l6n7g13a; ; xn--6g3a.xn--0sa8175flwa; [V5] # 谷.꥓̐ꡎ
+‍⾕。‌꥓̐ꡎ; ‍谷.‌꥓̐ꡎ; [C1, C2]; xn--1ug0273b.xn--0sa359l6n7g13a; ; xn--6g3a.xn--0sa8175flwa; [V5] # 谷.꥓̐ꡎ
+‍谷。‌꥓̐ꡎ; ‍谷.‌꥓̐ꡎ; [C1, C2]; xn--1ug0273b.xn--0sa359l6n7g13a; ; xn--6g3a.xn--0sa8175flwa; [V5] # 谷.꥓̐ꡎ
+xn--6g3a.xn--0sa8175flwa; 谷.꥓̐ꡎ; [V5]; xn--6g3a.xn--0sa8175flwa; ; ;  # 谷.꥓̐ꡎ
+xn--1ug0273b.xn--0sa359l6n7g13a; ‍谷.‌꥓̐ꡎ; [C1, C2]; xn--1ug0273b.xn--0sa359l6n7g13a; ; ;  # 谷.꥓̐ꡎ
+ڪ-뉔．𞤐‌; ڪ-뉔.𞤲‌; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+ڪ-뉔．𞤐‌; ڪ-뉔.𞤲‌; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+ڪ-뉔.𞤐‌; ڪ-뉔.𞤲‌; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+ڪ-뉔.𞤐‌; ڪ-뉔.𞤲‌; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+ڪ-뉔.𞤲‌; ڪ-뉔.𞤲‌; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+ڪ-뉔.𞤲‌; ; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+xn----guc3592k.xn--qe6h; ڪ-뉔.𞤲; [B2, B3]; xn----guc3592k.xn--qe6h; ; ;  # ڪ-뉔.𞤲
+xn----guc3592k.xn--0ug7611p; ڪ-뉔.𞤲‌; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; ;  # ڪ-뉔.𞤲
+ڪ-뉔．𞤲‌; ڪ-뉔.𞤲‌; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+ڪ-뉔．𞤲‌; ڪ-뉔.𞤲‌; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+񔲵５ᦛς.꣄ݻܸ᳒; 񔲵5ᦛς.꣄ݻܸ᳒; [B1, P1, V5, V6]; xn--5-ymb298ng603j.xn--fob7kk44dl41k; ; xn--5-0mb988ng603j.xn--fob7kk44dl41k;  # 5ᦛς.꣄ݻܸ᳒
+񔲵５ᦛς.꣄ݻܸ᳒; 񔲵5ᦛς.꣄ݻܸ᳒; [B1, P1, V5, V6]; xn--5-ymb298ng603j.xn--fob7kk44dl41k; ; xn--5-0mb988ng603j.xn--fob7kk44dl41k;  # 5ᦛς.꣄ݻܸ᳒
+񔲵5ᦛς.꣄ݻܸ᳒; ; [B1, P1, V5, V6]; xn--5-ymb298ng603j.xn--fob7kk44dl41k; ; xn--5-0mb988ng603j.xn--fob7kk44dl41k;  # 5ᦛς.꣄ݻܸ᳒
+񔲵5ᦛΣ.꣄ݻܸ᳒; 񔲵5ᦛσ.꣄ݻܸ᳒; [B1, P1, V5, V6]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+񔲵5ᦛσ.꣄ݻܸ᳒; ; [B1, P1, V5, V6]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+xn--5-0mb988ng603j.xn--fob7kk44dl41k; 񔲵5ᦛσ.꣄ݻܸ᳒; [B1, V5, V6]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+xn--5-ymb298ng603j.xn--fob7kk44dl41k; 񔲵5ᦛς.꣄ݻܸ᳒; [B1, V5, V6]; xn--5-ymb298ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛς.꣄ݻܸ᳒
+񔲵５ᦛΣ.꣄ݻܸ᳒; 񔲵5ᦛσ.꣄ݻܸ᳒; [B1, P1, V5, V6]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+񔲵５ᦛσ.꣄ݻܸ᳒; 񔲵5ᦛσ.꣄ݻܸ᳒; [B1, P1, V5, V6]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+񔲵５ᦛΣ.꣄ݻܸ᳒; 񔲵5ᦛσ.꣄ݻܸ᳒; [B1, P1, V5, V6]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+񔲵５ᦛσ.꣄ݻܸ᳒; 񔲵5ᦛσ.꣄ݻܸ᳒; [B1, P1, V5, V6]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+淽。ᠾ; 淽.ᠾ; ; xn--34w.xn--x7e; ; ;  # 淽.ᠾ
+xn--34w.xn--x7e; 淽.ᠾ; ; xn--34w.xn--x7e; ; ;  # 淽.ᠾ
+淽.ᠾ; ; ; xn--34w.xn--x7e; ; ;  # 淽.ᠾ
+𐹴𑘷。-; 𐹴𑘷.-; [B1, V3]; xn--so0do6k.-; ; ;  # 𐹴𑘷.-
+xn--so0do6k.-; 𐹴𑘷.-; [B1, V3]; xn--so0do6k.-; ; ;  # 𐹴𑘷.-
+򬨩Ⴓ❓｡𑄨; 򬨩Ⴓ❓.𑄨; [P1, V5, V6]; xn--rnd896i0j14q.xn--k80d; ; ;  # Ⴓ❓.𑄨
+򬨩Ⴓ❓。𑄨; 򬨩Ⴓ❓.𑄨; [P1, V5, V6]; xn--rnd896i0j14q.xn--k80d; ; ;  # Ⴓ❓.𑄨
+򬨩ⴓ❓。𑄨; 򬨩ⴓ❓.𑄨; [P1, V5, V6]; xn--8di78qvw32y.xn--k80d; ; ;  # ⴓ❓.𑄨
+xn--8di78qvw32y.xn--k80d; 򬨩ⴓ❓.𑄨; [V5, V6]; xn--8di78qvw32y.xn--k80d; ; ;  # ⴓ❓.𑄨
+xn--rnd896i0j14q.xn--k80d; 򬨩Ⴓ❓.𑄨; [V5, V6]; xn--rnd896i0j14q.xn--k80d; ; ;  # Ⴓ❓.𑄨
+򬨩ⴓ❓｡𑄨; 򬨩ⴓ❓.𑄨; [P1, V5, V6]; xn--8di78qvw32y.xn--k80d; ; ;  # ⴓ❓.𑄨
+‌𐹡𞤌Ⴇ｡ßႣ; ‌𐹡𞤮Ⴇ.ßႣ; [B1, C1, P1, V6]; xn--fnd599eyj4pr50g.xn--zca681f; ; xn--fnd1201kegrf.xn--ss-fek; [B1, P1, V6] # 𐹡𞤮Ⴇ.ßႣ
+‌𐹡𞤌Ⴇ。ßႣ; ‌𐹡𞤮Ⴇ.ßႣ; [B1, C1, P1, V6]; xn--fnd599eyj4pr50g.xn--zca681f; ; xn--fnd1201kegrf.xn--ss-fek; [B1, P1, V6] # 𐹡𞤮Ⴇ.ßႣ
+‌𐹡𞤮ⴇ。ßⴃ; ‌𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ßⴃ
+‌𐹡𞤌Ⴇ。SSႣ; ‌𐹡𞤮Ⴇ.ssႣ; [B1, C1, P1, V6]; xn--fnd599eyj4pr50g.xn--ss-fek; ; xn--fnd1201kegrf.xn--ss-fek; [B1, P1, V6] # 𐹡𞤮Ⴇ.ssႣ
+‌𐹡𞤮ⴇ。ssⴃ; ‌𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+‌𐹡𞤌ⴇ。Ssⴃ; ‌𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+xn--ykj9323eegwf.xn--ss-151a; 𐹡𞤮ⴇ.ssⴃ; [B1]; xn--ykj9323eegwf.xn--ss-151a; ; ;  # 𐹡𞤮ⴇ.ssⴃ
+xn--0ug332c3q0pr56g.xn--ss-151a; ‌𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; ;  # 𐹡𞤮ⴇ.ssⴃ
+xn--fnd1201kegrf.xn--ss-fek; 𐹡𞤮Ⴇ.ssႣ; [B1, V6]; xn--fnd1201kegrf.xn--ss-fek; ; ;  # 𐹡𞤮Ⴇ.ssႣ
+xn--fnd599eyj4pr50g.xn--ss-fek; ‌𐹡𞤮Ⴇ.ssႣ; [B1, C1, V6]; xn--fnd599eyj4pr50g.xn--ss-fek; ; ;  # 𐹡𞤮Ⴇ.ssႣ
+xn--0ug332c3q0pr56g.xn--zca417t; ‌𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; ;  # 𐹡𞤮ⴇ.ßⴃ
+xn--fnd599eyj4pr50g.xn--zca681f; ‌𐹡𞤮Ⴇ.ßႣ; [B1, C1, V6]; xn--fnd599eyj4pr50g.xn--zca681f; ; ;  # 𐹡𞤮Ⴇ.ßႣ
+‌𐹡𞤮ⴇ｡ßⴃ; ‌𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ßⴃ
+‌𐹡𞤌Ⴇ｡SSႣ; ‌𐹡𞤮Ⴇ.ssႣ; [B1, C1, P1, V6]; xn--fnd599eyj4pr50g.xn--ss-fek; ; xn--fnd1201kegrf.xn--ss-fek; [B1, P1, V6] # 𐹡𞤮Ⴇ.ssႣ
+‌𐹡𞤮ⴇ｡ssⴃ; ‌𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+‌𐹡𞤌ⴇ｡Ssⴃ; ‌𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+‌𐹡𞤌ⴇ。ßⴃ; ‌𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ßⴃ
+‌𐹡𞤌ⴇ。ssⴃ; ‌𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+‌𐹡𞤌Ⴇ。Ssⴃ; ‌𐹡𞤮Ⴇ.ssⴃ; [B1, C1, P1, V6]; xn--fnd599eyj4pr50g.xn--ss-151a; ; xn--fnd1201kegrf.xn--ss-151a; [B1, P1, V6] # 𐹡𞤮Ⴇ.ssⴃ
+xn--fnd1201kegrf.xn--ss-151a; 𐹡𞤮Ⴇ.ssⴃ; [B1, V6]; xn--fnd1201kegrf.xn--ss-151a; ; ;  # 𐹡𞤮Ⴇ.ssⴃ
+xn--fnd599eyj4pr50g.xn--ss-151a; ‌𐹡𞤮Ⴇ.ssⴃ; [B1, C1, V6]; xn--fnd599eyj4pr50g.xn--ss-151a; ; ;  # 𐹡𞤮Ⴇ.ssⴃ
+‌𐹡𞤌ⴇ｡ßⴃ; ‌𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ßⴃ
+‌𐹡𞤌ⴇ｡ssⴃ; ‌𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+‌𐹡𞤌Ⴇ｡Ssⴃ; ‌𐹡𞤮Ⴇ.ssⴃ; [B1, C1, P1, V6]; xn--fnd599eyj4pr50g.xn--ss-151a; ; xn--fnd1201kegrf.xn--ss-151a; [B1, P1, V6] # 𐹡𞤮Ⴇ.ssⴃ
+៿｡𞬳; ៿.𞬳; [P1, V6]; xn--45e.xn--et6h; ; ;  # .
+៿。𞬳; ៿.𞬳; [P1, V6]; xn--45e.xn--et6h; ; ;  # .
+xn--45e.xn--et6h; ៿.𞬳; [V6]; xn--45e.xn--et6h; ; ;  # .
+ْ‍｡್𑚳; ْ‍.್𑚳; [C2, V5]; xn--uhb882k.xn--8tc4527k; ; xn--uhb.xn--8tc4527k; [V5] # ْ.್𑚳
+ْ‍。್𑚳; ْ‍.್𑚳; [C2, V5]; xn--uhb882k.xn--8tc4527k; ; xn--uhb.xn--8tc4527k; [V5] # ْ.್𑚳
+xn--uhb.xn--8tc4527k; ْ.್𑚳; [V5]; xn--uhb.xn--8tc4527k; ; ;  # ْ.್𑚳
+xn--uhb882k.xn--8tc4527k; ْ‍.್𑚳; [C2, V5]; xn--uhb882k.xn--8tc4527k; ; ;  # ْ.್𑚳
+-≠ᠻ．ݭ𞥃≮󟷺; -≠ᠻ.ݭ𞥃≮󟷺; [B1, B2, B3, P1, V3, V6]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-≠ᠻ．ݭ𞥃≮󟷺; -≠ᠻ.ݭ𞥃≮󟷺; [B1, B2, B3, P1, V3, V6]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-≠ᠻ.ݭ𞥃≮󟷺; ; [B1, B2, B3, P1, V3, V6]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-≠ᠻ.ݭ𞥃≮󟷺; -≠ᠻ.ݭ𞥃≮󟷺; [B1, B2, B3, P1, V3, V6]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-≠ᠻ.ݭ𞤡≮󟷺; -≠ᠻ.ݭ𞥃≮󟷺; [B1, B2, B3, P1, V3, V6]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-≠ᠻ.ݭ𞤡≮󟷺; -≠ᠻ.ݭ𞥃≮󟷺; [B1, B2, B3, P1, V3, V6]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+xn----g6j886c.xn--xpb049kk353abj99f; -≠ᠻ.ݭ𞥃≮󟷺; [B1, B2, B3, V3, V6]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-≠ᠻ．ݭ𞤡≮󟷺; -≠ᠻ.ݭ𞥃≮󟷺; [B1, B2, B3, P1, V3, V6]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-≠ᠻ．ݭ𞤡≮󟷺; -≠ᠻ.ݭ𞥃≮󟷺; [B1, B2, B3, P1, V3, V6]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+󠰆≯޵𐻪．򊥕≮𑁆ࡌ; 󠰆≯޵𐻪.򊥕≮𑁆ࡌ; [B1, B5, B6, P1, V6]; xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; ; ;  # ≯.≮𑁆ࡌ
+󠰆≯޵𐻪．򊥕≮𑁆ࡌ; 󠰆≯޵𐻪.򊥕≮𑁆ࡌ; [B1, B5, B6, P1, V6]; xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; ; ;  # ≯.≮𑁆ࡌ
+󠰆≯޵𐻪.򊥕≮𑁆ࡌ; ; [B1, B5, B6, P1, V6]; xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; ; ;  # ≯.≮𑁆ࡌ
+󠰆≯޵𐻪.򊥕≮𑁆ࡌ; 󠰆≯޵𐻪.򊥕≮𑁆ࡌ; [B1, B5, B6, P1, V6]; xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; ; ;  # ≯.≮𑁆ࡌ
+xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; 󠰆≯޵𐻪.򊥕≮𑁆ࡌ; [B1, B5, B6, V6]; xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; ; ;  # ≯.≮𑁆ࡌ
+≠󦋂.؀்-ڹ; ; [B1, P1, V6]; xn--1ch22084l.xn----qkc07co6n; ; ;  # ≠.்-ڹ
+≠󦋂.؀்-ڹ; ≠󦋂.؀்-ڹ; [B1, P1, V6]; xn--1ch22084l.xn----qkc07co6n; ; ;  # ≠.்-ڹ
+xn--1ch22084l.xn----qkc07co6n; ≠󦋂.؀்-ڹ; [B1, V6]; xn--1ch22084l.xn----qkc07co6n; ; ;  # ≠.்-ڹ
+៝󠁣≠｡𐹼𐋤; ៝󠁣≠.𐹼𐋤; [B1, P1, V5, V6]; xn--54e694cn389z.xn--787ct8r; ; ;  # ៝≠.𐹼𐋤
+៝󠁣≠｡𐹼𐋤; ៝󠁣≠.𐹼𐋤; [B1, P1, V5, V6]; xn--54e694cn389z.xn--787ct8r; ; ;  # ៝≠.𐹼𐋤
+៝󠁣≠。𐹼𐋤; ៝󠁣≠.𐹼𐋤; [B1, P1, V5, V6]; xn--54e694cn389z.xn--787ct8r; ; ;  # ៝≠.𐹼𐋤
+៝󠁣≠。𐹼𐋤; ៝󠁣≠.𐹼𐋤; [B1, P1, V5, V6]; xn--54e694cn389z.xn--787ct8r; ; ;  # ៝≠.𐹼𐋤
+xn--54e694cn389z.xn--787ct8r; ៝󠁣≠.𐹼𐋤; [B1, V5, V6]; xn--54e694cn389z.xn--787ct8r; ; ;  # ៝≠.𐹼𐋤
+ß𰀻񆬗｡𝩨🕮ß; ß𰀻񆬗.𝩨🕮ß; [P1, V5, V6]; xn--zca20040bgrkh.xn--zca3653v86qa; ; xn--ss-jl59biy67d.xn--ss-4d11aw87d;  # ß.𝩨🕮ß
+ß𰀻񆬗。𝩨🕮ß; ß𰀻񆬗.𝩨🕮ß; [P1, V5, V6]; xn--zca20040bgrkh.xn--zca3653v86qa; ; xn--ss-jl59biy67d.xn--ss-4d11aw87d;  # ß.𝩨🕮ß
+SS𰀻񆬗。𝩨🕮SS; ss𰀻񆬗.𝩨🕮ss; [P1, V5, V6]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss.𝩨🕮ss
+ss𰀻񆬗。𝩨🕮ss; ss𰀻񆬗.𝩨🕮ss; [P1, V5, V6]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss.𝩨🕮ss
+Ss𰀻񆬗。𝩨🕮Ss; ss𰀻񆬗.𝩨🕮ss; [P1, V5, V6]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss.𝩨🕮ss
+xn--ss-jl59biy67d.xn--ss-4d11aw87d; ss𰀻񆬗.𝩨🕮ss; [V5, V6]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss.𝩨🕮ss
+xn--zca20040bgrkh.xn--zca3653v86qa; ß𰀻񆬗.𝩨🕮ß; [V5, V6]; xn--zca20040bgrkh.xn--zca3653v86qa; ; ;  # ß.𝩨🕮ß
+SS𰀻񆬗｡𝩨🕮SS; ss𰀻񆬗.𝩨🕮ss; [P1, V5, V6]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss.𝩨🕮ss
+ss𰀻񆬗｡𝩨🕮ss; ss𰀻񆬗.𝩨🕮ss; [P1, V5, V6]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss.𝩨🕮ss
+Ss𰀻񆬗｡𝩨🕮Ss; ss𰀻񆬗.𝩨🕮ss; [P1, V5, V6]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss.𝩨🕮ss
+‍。‌; ‍.‌; [C1, C2]; xn--1ug.xn--0ug; ; .; [A4_2] # .
+xn--1ug.xn--0ug; ‍.‌; [C1, C2]; xn--1ug.xn--0ug; ; ;  # .
+҃𐭞‍.ឹ𞯌򟩚; ; [B1, C2, P1, V5, V6]; xn--m3a412lrr0o.xn--43e8670vmd79b; ; xn--m3a6965k.xn--43e8670vmd79b; [B1, P1, V5, V6] # ҃𐭞.ឹ
+xn--m3a6965k.xn--43e8670vmd79b; ҃𐭞.ឹ𞯌򟩚; [B1, V5, V6]; xn--m3a6965k.xn--43e8670vmd79b; ; ;  # ҃𐭞.ឹ
+xn--m3a412lrr0o.xn--43e8670vmd79b; ҃𐭞‍.ឹ𞯌򟩚; [B1, C2, V5, V6]; xn--m3a412lrr0o.xn--43e8670vmd79b; ; ;  # ҃𐭞.ឹ
+‌𐠨‌临。ꡢ򄷞ⶏ𐹣; ‌𐠨‌临.ꡢ򄷞ⶏ𐹣; [B1, B5, B6, C1, P1, V6]; xn--0uga2656aop9k.xn--uojv340bk71c99u9f; ; xn--miq9646b.xn--uojv340bk71c99u9f; [B2, B3, B5, B6, P1, V6] # 𐠨临.ꡢⶏ𐹣
+xn--miq9646b.xn--uojv340bk71c99u9f; 𐠨临.ꡢ򄷞ⶏ𐹣; [B2, B3, B5, B6, V6]; xn--miq9646b.xn--uojv340bk71c99u9f; ; ;  # 𐠨临.ꡢⶏ𐹣
+xn--0uga2656aop9k.xn--uojv340bk71c99u9f; ‌𐠨‌临.ꡢ򄷞ⶏ𐹣; [B1, B5, B6, C1, V6]; xn--0uga2656aop9k.xn--uojv340bk71c99u9f; ; ;  # 𐠨临.ꡢⶏ𐹣
+󠑘．󠄮; 󠑘.; [P1, V6]; xn--s136e.; ; ;  # .
+󠑘.󠄮; 󠑘.; [P1, V6]; xn--s136e.; ; ;  # .
+xn--s136e.; 󠑘.; [V6]; xn--s136e.; ; ;  # .
+𐫄്．꫶; 𐫄്.꫶; [B1, B3, B6, V5]; xn--wxc7880k.xn--2v9a; ; ;  # 𐫄്.꫶
+𐫄്.꫶; ; [B1, B3, B6, V5]; xn--wxc7880k.xn--2v9a; ; ;  # 𐫄്.꫶
+xn--wxc7880k.xn--2v9a; 𐫄്.꫶; [B1, B3, B6, V5]; xn--wxc7880k.xn--2v9a; ; ;  # 𐫄്.꫶
+ꦷ󝵙멹。⒛󠨇; ꦷ󝵙멹.⒛󠨇; [P1, V5, V6]; xn--ym9av13acp85w.xn--dth22121k; ; ;  # ꦷ멹.⒛
+ꦷ󝵙멹。⒛󠨇; ꦷ󝵙멹.⒛󠨇; [P1, V5, V6]; xn--ym9av13acp85w.xn--dth22121k; ; ;  # ꦷ멹.⒛
+ꦷ󝵙멹。20.󠨇; ꦷ󝵙멹.20.󠨇; [P1, V5, V6]; xn--ym9av13acp85w.20.xn--d846e; ; ;  # ꦷ멹.20.
+ꦷ󝵙멹。20.󠨇; ꦷ󝵙멹.20.󠨇; [P1, V5, V6]; xn--ym9av13acp85w.20.xn--d846e; ; ;  # ꦷ멹.20.
+xn--ym9av13acp85w.20.xn--d846e; ꦷ󝵙멹.20.󠨇; [V5, V6]; xn--ym9av13acp85w.20.xn--d846e; ; ;  # ꦷ멹.20.
+xn--ym9av13acp85w.xn--dth22121k; ꦷ󝵙멹.⒛󠨇; [V5, V6]; xn--ym9av13acp85w.xn--dth22121k; ; ;  # ꦷ멹.⒛
+Ⴅ󲬹릖󠶚.ݷ𐹳⒊; ; [B4, B6, P1, V6]; xn--dnd2167fnet0io02g.xn--7pb000mwm4n; ; ;  # Ⴅ릖.ݷ𐹳⒊
+Ⴅ󲬹릖󠶚.ݷ𐹳⒊; Ⴅ󲬹릖󠶚.ݷ𐹳⒊; [B4, B6, P1, V6]; xn--dnd2167fnet0io02g.xn--7pb000mwm4n; ; ;  # Ⴅ릖.ݷ𐹳⒊
+Ⴅ󲬹릖󠶚.ݷ𐹳3.; ; [B4, B6, P1, V6]; xn--dnd2167fnet0io02g.xn--3-55c6803r.; ; ;  # Ⴅ릖.ݷ𐹳3.
+Ⴅ󲬹릖󠶚.ݷ𐹳3.; Ⴅ󲬹릖󠶚.ݷ𐹳3.; [B4, B6, P1, V6]; xn--dnd2167fnet0io02g.xn--3-55c6803r.; ; ;  # Ⴅ릖.ݷ𐹳3.
+ⴅ󲬹릖󠶚.ݷ𐹳3.; ⴅ󲬹릖󠶚.ݷ𐹳3.; [B4, B6, P1, V6]; xn--wkj8016bne45io02g.xn--3-55c6803r.; ; ;  # ⴅ릖.ݷ𐹳3.
+ⴅ󲬹릖󠶚.ݷ𐹳3.; ; [B4, B6, P1, V6]; xn--wkj8016bne45io02g.xn--3-55c6803r.; ; ;  # ⴅ릖.ݷ𐹳3.
+xn--wkj8016bne45io02g.xn--3-55c6803r.; ⴅ󲬹릖󠶚.ݷ𐹳3.; [B4, B6, V6]; xn--wkj8016bne45io02g.xn--3-55c6803r.; ; ;  # ⴅ릖.ݷ𐹳3.
+xn--dnd2167fnet0io02g.xn--3-55c6803r.; Ⴅ󲬹릖󠶚.ݷ𐹳3.; [B4, B6, V6]; xn--dnd2167fnet0io02g.xn--3-55c6803r.; ; ;  # Ⴅ릖.ݷ𐹳3.
+ⴅ󲬹릖󠶚.ݷ𐹳⒊; ⴅ󲬹릖󠶚.ݷ𐹳⒊; [B4, B6, P1, V6]; xn--wkj8016bne45io02g.xn--7pb000mwm4n; ; ;  # ⴅ릖.ݷ𐹳⒊
+ⴅ󲬹릖󠶚.ݷ𐹳⒊; ; [B4, B6, P1, V6]; xn--wkj8016bne45io02g.xn--7pb000mwm4n; ; ;  # ⴅ릖.ݷ𐹳⒊
+xn--wkj8016bne45io02g.xn--7pb000mwm4n; ⴅ󲬹릖󠶚.ݷ𐹳⒊; [B4, B6, V6]; xn--wkj8016bne45io02g.xn--7pb000mwm4n; ; ;  # ⴅ릖.ݷ𐹳⒊
+xn--dnd2167fnet0io02g.xn--7pb000mwm4n; Ⴅ󲬹릖󠶚.ݷ𐹳⒊; [B4, B6, V6]; xn--dnd2167fnet0io02g.xn--7pb000mwm4n; ; ;  # Ⴅ릖.ݷ𐹳⒊
+‌｡︒; ‌.︒; [C1, P1, V6]; xn--0ug.xn--y86c; ; .xn--y86c; [P1, V6, A4_2] # .︒
+‌。。; ‌..; [C1, X4_2]; xn--0ug..; [C1, A4_2]; ..; [A4_2] # ..
+..; ; [X4_2]; ; [A4_2]; ;  # ..
+xn--0ug..; ‌..; [C1, X4_2]; xn--0ug..; [C1, A4_2]; ;  # ..
+.xn--y86c; .︒; [V6, X4_2]; .xn--y86c; [V6, A4_2]; ;  # .︒
+xn--0ug.xn--y86c; ‌.︒; [C1, V6]; xn--0ug.xn--y86c; ; ;  # .︒
+≯ݭ．₄; ≯ݭ.4; [B1, P1, V6]; xn--xpb149k.4; ; ;  # ≯ݭ.4
+≯ݭ．₄; ≯ݭ.4; [B1, P1, V6]; xn--xpb149k.4; ; ;  # ≯ݭ.4
+≯ݭ.4; ; [B1, P1, V6]; xn--xpb149k.4; ; ;  # ≯ݭ.4
+≯ݭ.4; ≯ݭ.4; [B1, P1, V6]; xn--xpb149k.4; ; ;  # ≯ݭ.4
+xn--xpb149k.4; ≯ݭ.4; [B1, V6]; xn--xpb149k.4; ; ;  # ≯ݭ.4
+ᡲ-𝟹.ß-‌-; ᡲ-3.ß-‌-; [C1, V3]; xn---3-p9o.xn-----fia9303a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ß--
+ᡲ-3.ß-‌-; ; [C1, V3]; xn---3-p9o.xn-----fia9303a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ß--
+ᡲ-3.SS-‌-; ᡲ-3.ss-‌-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+ᡲ-3.ss-‌-; ; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+ᡲ-3.Ss-‌-; ᡲ-3.ss-‌-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+xn---3-p9o.ss--; ᡲ-3.ss--; [V2, V3]; xn---3-p9o.ss--; ; ;  # ᡲ-3.ss--
+xn---3-p9o.xn--ss---276a; ᡲ-3.ss-‌-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; ;  # ᡲ-3.ss--
+xn---3-p9o.xn-----fia9303a; ᡲ-3.ß-‌-; [C1, V3]; xn---3-p9o.xn-----fia9303a; ; ;  # ᡲ-3.ß--
+ᡲ-𝟹.SS-‌-; ᡲ-3.ss-‌-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+ᡲ-𝟹.ss-‌-; ᡲ-3.ss-‌-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+ᡲ-𝟹.Ss-‌-; ᡲ-3.ss-‌-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+ﴈ𝟦ه󎊯｡Ӏ; ضي4ه󎊯.Ӏ; [B2, B3, P1, V6]; xn--4-tnc6ck183523b.xn--d5a; ; ;  # ضي4ه.Ӏ
+ضي4ه󎊯。Ӏ; ضي4ه󎊯.Ӏ; [B2, B3, P1, V6]; xn--4-tnc6ck183523b.xn--d5a; ; ;  # ضي4ه.Ӏ
+ضي4ه󎊯。ӏ; ضي4ه󎊯.ӏ; [B2, B3, P1, V6]; xn--4-tnc6ck183523b.xn--s5a; ; ;  # ضي4ه.ӏ
+xn--4-tnc6ck183523b.xn--s5a; ضي4ه󎊯.ӏ; [B2, B3, V6]; xn--4-tnc6ck183523b.xn--s5a; ; ;  # ضي4ه.ӏ
+xn--4-tnc6ck183523b.xn--d5a; ضي4ه󎊯.Ӏ; [B2, B3, V6]; xn--4-tnc6ck183523b.xn--d5a; ; ;  # ضي4ه.Ӏ
+ﴈ𝟦ه󎊯｡ӏ; ضي4ه󎊯.ӏ; [B2, B3, P1, V6]; xn--4-tnc6ck183523b.xn--s5a; ; ;  # ضي4ه.ӏ
+-.؂آ𑆾🐹; ; [B1, P1, V3, V6]; -.xn--kfb8dy983hgl7g; ; ;  # -.آ𑆾🐹
+-.؂آ𑆾🐹; -.؂آ𑆾🐹; [B1, P1, V3, V6]; -.xn--kfb8dy983hgl7g; ; ;  # -.آ𑆾🐹
+-.xn--kfb8dy983hgl7g; -.؂آ𑆾🐹; [B1, V3, V6]; -.xn--kfb8dy983hgl7g; ; ;  # -.آ𑆾🐹
+󙶜ᢘ。᩿⺢; 󙶜ᢘ.᩿⺢; [P1, V5, V6]; xn--ibf35138o.xn--fpfz94g; ; ;  # ᢘ.᩿⺢
+xn--ibf35138o.xn--fpfz94g; 󙶜ᢘ.᩿⺢; [V5, V6]; xn--ibf35138o.xn--fpfz94g; ; ;  # ᢘ.᩿⺢
+≠ႷᠤႫ｡?͌س觴; ≠ႷᠤႫ.?͌س觴; [B1, B5, P1, V6]; xn--jndx718cnnl.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ႷᠤႫ.͌س觴
+≠ႷᠤႫ｡?͌س觴; ≠ႷᠤႫ.?͌س觴; [B1, B5, P1, V6]; xn--jndx718cnnl.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ႷᠤႫ.͌س觴
+≠ႷᠤႫ。?͌س觴; ≠ႷᠤႫ.?͌س觴; [B1, B5, P1, V6]; xn--jndx718cnnl.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ႷᠤႫ.͌س觴
+≠ႷᠤႫ。?͌س觴; ≠ႷᠤႫ.?͌س觴; [B1, B5, P1, V6]; xn--jndx718cnnl.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ႷᠤႫ.͌س觴
+≠ⴗᠤⴋ。?͌س觴; ≠ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--66e353ce0ilb.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ⴗᠤⴋ.͌س觴
+≠ⴗᠤⴋ。?͌س觴; ≠ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--66e353ce0ilb.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ⴗᠤⴋ.͌س觴
+≠Ⴗᠤⴋ。?͌س觴; ≠Ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--vnd619as6ig6k.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠Ⴗᠤⴋ.͌س觴
+≠Ⴗᠤⴋ。?͌س觴; ≠Ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--vnd619as6ig6k.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠Ⴗᠤⴋ.͌س觴
+xn--vnd619as6ig6k.?͌س觴; ≠Ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--vnd619as6ig6k.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠Ⴗᠤⴋ.͌س觴
+XN--VND619AS6IG6K.?͌س觴; ≠Ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--vnd619as6ig6k.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠Ⴗᠤⴋ.͌س觴
+Xn--Vnd619as6ig6k.?͌س觴; ≠Ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--vnd619as6ig6k.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠Ⴗᠤⴋ.͌س觴
+xn--66e353ce0ilb.?͌س觴; ≠ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--66e353ce0ilb.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ⴗᠤⴋ.͌س觴
+XN--66E353CE0ILB.?͌س觴; ≠ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--66e353ce0ilb.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ⴗᠤⴋ.͌س觴
+Xn--66e353ce0ilb.?͌س觴; ≠ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--66e353ce0ilb.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ⴗᠤⴋ.͌س觴
+xn--jndx718cnnl.?͌س觴; ≠ႷᠤႫ.?͌س觴; [B1, B5, P1, V6]; xn--jndx718cnnl.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ႷᠤႫ.͌س觴
+XN--JNDX718CNNL.?͌س觴; ≠ႷᠤႫ.?͌س觴; [B1, B5, P1, V6]; xn--jndx718cnnl.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ႷᠤႫ.͌س觴
+Xn--Jndx718cnnl.?͌س觴; ≠ႷᠤႫ.?͌س觴; [B1, B5, P1, V6]; xn--jndx718cnnl.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ႷᠤႫ.͌س觴
+≠ⴗᠤⴋ｡?͌س觴; ≠ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--66e353ce0ilb.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ⴗᠤⴋ.͌س觴
+≠ⴗᠤⴋ｡?͌س觴; ≠ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--66e353ce0ilb.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠ⴗᠤⴋ.͌س觴
+≠Ⴗᠤⴋ｡?͌س觴; ≠Ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--vnd619as6ig6k.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠Ⴗᠤⴋ.͌س觴
+≠Ⴗᠤⴋ｡?͌س觴; ≠Ⴗᠤⴋ.?͌س觴; [B1, B5, P1, V6]; xn--vnd619as6ig6k.?͌س觴; [B1, B5, P1, V6, A3]; ;  # ≠Ⴗᠤⴋ.͌س觴
+٧.𐥨; ; [B1, P1, V6]; xn--gib.xn--vm9c; ; ;  # ٧.
+xn--gib.xn--vm9c; ٧.𐥨; [B1, V6]; xn--gib.xn--vm9c; ; ;  # ٧.
+꧀𝟯｡‍񼑥𐹪᯳; ꧀3.‍񼑥𐹪᯳; [B1, C2, P1, V5, V6]; xn--3-5z4e.xn--1zf96ony8ygd68c; ; xn--3-5z4e.xn--1zfz754hncv8b; [B5, P1, V5, V6] # ꧀3.𐹪᯳
+꧀3。‍񼑥𐹪᯳; ꧀3.‍񼑥𐹪᯳; [B1, C2, P1, V5, V6]; xn--3-5z4e.xn--1zf96ony8ygd68c; ; xn--3-5z4e.xn--1zfz754hncv8b; [B5, P1, V5, V6] # ꧀3.𐹪᯳
+xn--3-5z4e.xn--1zfz754hncv8b; ꧀3.񼑥𐹪᯳; [B5, V5, V6]; xn--3-5z4e.xn--1zfz754hncv8b; ; ;  # ꧀3.𐹪᯳
+xn--3-5z4e.xn--1zf96ony8ygd68c; ꧀3.‍񼑥𐹪᯳; [B1, C2, V5, V6]; xn--3-5z4e.xn--1zf96ony8ygd68c; ; ;  # ꧀3.𐹪᯳
+򣕄4񠖽.≯٤𑀾󠸌; ; [B1, P1, V6]; xn--4-fg85dl688i.xn--dib174li86ntdy0i; ; ;  # 4.≯٤𑀾
+򣕄4񠖽.≯٤𑀾󠸌; 򣕄4񠖽.≯٤𑀾󠸌; [B1, P1, V6]; xn--4-fg85dl688i.xn--dib174li86ntdy0i; ; ;  # 4.≯٤𑀾
+xn--4-fg85dl688i.xn--dib174li86ntdy0i; 򣕄4񠖽.≯٤𑀾󠸌; [B1, V6]; xn--4-fg85dl688i.xn--dib174li86ntdy0i; ; ;  # 4.≯٤𑀾
+򗆧𝟯。⒈᩶𝟚򠘌; 򗆧3.⒈᩶2򠘌; [P1, V6]; xn--3-rj42h.xn--2-13k746cq465x; ; ;  # 3.⒈᩶2
+򗆧3。1.᩶2򠘌; 򗆧3.1.᩶2򠘌; [P1, V5, V6]; xn--3-rj42h.1.xn--2-13k96240l; ; ;  # 3.1.᩶2
+xn--3-rj42h.1.xn--2-13k96240l; 򗆧3.1.᩶2򠘌; [V5, V6]; xn--3-rj42h.1.xn--2-13k96240l; ; ;  # 3.1.᩶2
+xn--3-rj42h.xn--2-13k746cq465x; 򗆧3.⒈᩶2򠘌; [V6]; xn--3-rj42h.xn--2-13k746cq465x; ; ;  # 3.⒈᩶2
+‍₅⒈。≯𝟴‍; ‍5⒈.≯8‍; [C2, P1, V6]; xn--5-tgnz5r.xn--8-ugn00i; ; xn--5-ecp.xn--8-ogo; [P1, V6] # 5⒈.≯8
+‍₅⒈。≯𝟴‍; ‍5⒈.≯8‍; [C2, P1, V6]; xn--5-tgnz5r.xn--8-ugn00i; ; xn--5-ecp.xn--8-ogo; [P1, V6] # 5⒈.≯8
+‍51.。≯8‍; ‍51..≯8‍; [C2, P1, V6, X4_2]; xn--51-l1t..xn--8-ugn00i; [C2, P1, V6, A4_2]; 51..xn--8-ogo; [P1, V6, A4_2] # 51..≯8
+‍51.。≯8‍; ‍51..≯8‍; [C2, P1, V6, X4_2]; xn--51-l1t..xn--8-ugn00i; [C2, P1, V6, A4_2]; 51..xn--8-ogo; [P1, V6, A4_2] # 51..≯8
+51..xn--8-ogo; 51..≯8; [V6, X4_2]; 51..xn--8-ogo; [V6, A4_2]; ;  # 51..≯8
+xn--51-l1t..xn--8-ugn00i; ‍51..≯8‍; [C2, V6, X4_2]; xn--51-l1t..xn--8-ugn00i; [C2, V6, A4_2]; ;  # 51..≯8
+xn--5-ecp.xn--8-ogo; 5⒈.≯8; [V6]; xn--5-ecp.xn--8-ogo; ; ;  # 5⒈.≯8
+xn--5-tgnz5r.xn--8-ugn00i; ‍5⒈.≯8‍; [C2, V6]; xn--5-tgnz5r.xn--8-ugn00i; ; ;  # 5⒈.≯8
+ꡰڗႆ．򪘙ܯ≠‌; ꡰڗႆ.򪘙ܯ≠‌; [B5, B6, C1, P1, V6]; xn--tjb002cn51k.xn--5nb448jcubcz547b; ; xn--tjb002cn51k.xn--5nb630lbj91q; [B5, B6, P1, V6] # ꡰڗႆ.ܯ≠
+ꡰڗႆ．򪘙ܯ≠‌; ꡰڗႆ.򪘙ܯ≠‌; [B5, B6, C1, P1, V6]; xn--tjb002cn51k.xn--5nb448jcubcz547b; ; xn--tjb002cn51k.xn--5nb630lbj91q; [B5, B6, P1, V6] # ꡰڗႆ.ܯ≠
+ꡰڗႆ.򪘙ܯ≠‌; ; [B5, B6, C1, P1, V6]; xn--tjb002cn51k.xn--5nb448jcubcz547b; ; xn--tjb002cn51k.xn--5nb630lbj91q; [B5, B6, P1, V6] # ꡰڗႆ.ܯ≠
+ꡰڗႆ.򪘙ܯ≠‌; ꡰڗႆ.򪘙ܯ≠‌; [B5, B6, C1, P1, V6]; xn--tjb002cn51k.xn--5nb448jcubcz547b; ; xn--tjb002cn51k.xn--5nb630lbj91q; [B5, B6, P1, V6] # ꡰڗႆ.ܯ≠
+xn--tjb002cn51k.xn--5nb630lbj91q; ꡰڗႆ.򪘙ܯ≠; [B5, B6, V6]; xn--tjb002cn51k.xn--5nb630lbj91q; ; ;  # ꡰڗႆ.ܯ≠
+xn--tjb002cn51k.xn--5nb448jcubcz547b; ꡰڗႆ.򪘙ܯ≠‌; [B5, B6, C1, V6]; xn--tjb002cn51k.xn--5nb448jcubcz547b; ; ;  # ꡰڗႆ.ܯ≠
+𑄱｡򪌿𐹵; 𑄱.򪌿𐹵; [B1, B3, B5, B6, P1, V5, V6]; xn--t80d.xn--to0d14792b; ; ;  # 𑄱.𐹵
+𑄱。򪌿𐹵; 𑄱.򪌿𐹵; [B1, B3, B5, B6, P1, V5, V6]; xn--t80d.xn--to0d14792b; ; ;  # 𑄱.𐹵
+xn--t80d.xn--to0d14792b; 𑄱.򪌿𐹵; [B1, B3, B5, B6, V5, V6]; xn--t80d.xn--to0d14792b; ; ;  # 𑄱.𐹵
+𝟥؀。ܽ; 3؀.ܽ; [B1, B3, B6, P1, V5, V6]; xn--3-rkc.xn--kob; ; ;  # 3.ܽ
+3؀。ܽ; 3؀.ܽ; [B1, B3, B6, P1, V5, V6]; xn--3-rkc.xn--kob; ; ;  # 3.ܽ
+xn--3-rkc.xn--kob; 3؀.ܽ; [B1, B3, B6, V5, V6]; xn--3-rkc.xn--kob; ; ;  # 3.ܽ
+ط𐹣٦.ݭ긷; ; [B2, B3]; xn--2gb8gu829f.xn--xpb0156f; ; ;  # ط𐹣٦.ݭ긷
+ط𐹣٦.ݭ긷; ط𐹣٦.ݭ긷; [B2, B3]; xn--2gb8gu829f.xn--xpb0156f; ; ;  # ط𐹣٦.ݭ긷
+xn--2gb8gu829f.xn--xpb0156f; ط𐹣٦.ݭ긷; [B2, B3]; xn--2gb8gu829f.xn--xpb0156f; ; ;  # ط𐹣٦.ݭ긷
+︒Ↄⷧ򾀃．Ⴗ𐣞; ︒Ↄⷧ򾀃.Ⴗ𐣞; [B1, B5, B6, P1, V6]; xn--q5g000c056n0226g.xn--vnd8618j; ; ;  # ︒Ↄⷧ.Ⴗ
+。Ↄⷧ򾀃.Ⴗ𐣞; .Ↄⷧ򾀃.Ⴗ𐣞; [B5, B6, P1, V6, X4_2]; .xn--q5g000cll06u.xn--vnd8618j; [B5, B6, P1, V6, A4_2]; ;  # .Ↄⷧ.Ⴗ
+。ↄⷧ򾀃.ⴗ𐣞; .ↄⷧ򾀃.ⴗ𐣞; [B5, B6, P1, V6, X4_2]; .xn--r5gy00cll06u.xn--flj4541e; [B5, B6, P1, V6, A4_2]; ;  # .ↄⷧ.ⴗ
+.xn--r5gy00cll06u.xn--flj4541e; .ↄⷧ򾀃.ⴗ𐣞; [B5, B6, V6, X4_2]; .xn--r5gy00cll06u.xn--flj4541e; [B5, B6, V6, A4_2]; ;  # .ↄⷧ.ⴗ
+.xn--q5g000cll06u.xn--vnd8618j; .Ↄⷧ򾀃.Ⴗ𐣞; [B5, B6, V6, X4_2]; .xn--q5g000cll06u.xn--vnd8618j; [B5, B6, V6, A4_2]; ;  # .Ↄⷧ.Ⴗ
+︒ↄⷧ򾀃．ⴗ𐣞; ︒ↄⷧ򾀃.ⴗ𐣞; [B1, B5, B6, P1, V6]; xn--r5gy00c056n0226g.xn--flj4541e; ; ;  # ︒ↄⷧ.ⴗ
+xn--r5gy00c056n0226g.xn--flj4541e; ︒ↄⷧ򾀃.ⴗ𐣞; [B1, B5, B6, V6]; xn--r5gy00c056n0226g.xn--flj4541e; ; ;  # ︒ↄⷧ.ⴗ
+xn--q5g000c056n0226g.xn--vnd8618j; ︒Ↄⷧ򾀃.Ⴗ𐣞; [B1, B5, B6, V6]; xn--q5g000c056n0226g.xn--vnd8618j; ; ;  # ︒Ↄⷧ.Ⴗ
+؀.ֱ; ; [B1, B3, B6, P1, V5, V6]; xn--ifb.xn--8cb; ; ;  # .ֱ
+xn--ifb.xn--8cb; ؀.ֱ; [B1, B3, B6, V5, V6]; xn--ifb.xn--8cb; ; ;  # .ֱ
+ς≯｡𐹽; ς≯.𐹽; [B1, B6, P1, V6]; xn--3xa028m.xn--1o0d; ; xn--4xa818m.xn--1o0d;  # ς≯.𐹽
+ς≯｡𐹽; ς≯.𐹽; [B1, B6, P1, V6]; xn--3xa028m.xn--1o0d; ; xn--4xa818m.xn--1o0d;  # ς≯.𐹽
+ς≯。𐹽; ς≯.𐹽; [B1, B6, P1, V6]; xn--3xa028m.xn--1o0d; ; xn--4xa818m.xn--1o0d;  # ς≯.𐹽
+ς≯。𐹽; ς≯.𐹽; [B1, B6, P1, V6]; xn--3xa028m.xn--1o0d; ; xn--4xa818m.xn--1o0d;  # ς≯.𐹽
+Σ≯。𐹽; σ≯.𐹽; [B1, B6, P1, V6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+Σ≯。𐹽; σ≯.𐹽; [B1, B6, P1, V6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+σ≯。𐹽; σ≯.𐹽; [B1, B6, P1, V6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+σ≯。𐹽; σ≯.𐹽; [B1, B6, P1, V6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+xn--4xa818m.xn--1o0d; σ≯.𐹽; [B1, B6, V6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+xn--3xa028m.xn--1o0d; ς≯.𐹽; [B1, B6, V6]; xn--3xa028m.xn--1o0d; ; ;  # ς≯.𐹽
+Σ≯｡𐹽; σ≯.𐹽; [B1, B6, P1, V6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+Σ≯｡𐹽; σ≯.𐹽; [B1, B6, P1, V6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+σ≯｡𐹽; σ≯.𐹽; [B1, B6, P1, V6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+σ≯｡𐹽; σ≯.𐹽; [B1, B6, P1, V6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+្‍ݟ。𐹶; ្‍ݟ.𐹶; [B1, V5]; xn--jpb535fv9f.xn--uo0d; ; xn--jpb535f.xn--uo0d;  # ្ݟ.𐹶
+xn--jpb535f.xn--uo0d; ្ݟ.𐹶; [B1, V5]; xn--jpb535f.xn--uo0d; ; ;  # ្ݟ.𐹶
+xn--jpb535fv9f.xn--uo0d; ្‍ݟ.𐹶; [B1, V5]; xn--jpb535fv9f.xn--uo0d; ; ;  # ្ݟ.𐹶
+𾷂ੂႪ񂂟.≮; ; [P1, V6]; xn--nbc493aro75ggskb.xn--gdh; ; ;  # ੂႪ.≮
+𾷂ੂႪ񂂟.≮; 𾷂ੂႪ񂂟.≮; [P1, V6]; xn--nbc493aro75ggskb.xn--gdh; ; ;  # ੂႪ.≮
+𾷂ੂⴊ񂂟.≮; 𾷂ੂⴊ񂂟.≮; [P1, V6]; xn--nbc229o4y27dgskb.xn--gdh; ; ;  # ੂⴊ.≮
+𾷂ੂⴊ񂂟.≮; ; [P1, V6]; xn--nbc229o4y27dgskb.xn--gdh; ; ;  # ੂⴊ.≮
+xn--nbc229o4y27dgskb.xn--gdh; 𾷂ੂⴊ񂂟.≮; [V6]; xn--nbc229o4y27dgskb.xn--gdh; ; ;  # ੂⴊ.≮
+xn--nbc493aro75ggskb.xn--gdh; 𾷂ੂႪ񂂟.≮; [V6]; xn--nbc493aro75ggskb.xn--gdh; ; ;  # ੂႪ.≮
+ꡠ．۲; ꡠ.۲; ; xn--5c9a.xn--fmb; ; ;  # ꡠ.۲
+ꡠ.۲; ; ; xn--5c9a.xn--fmb; ; ;  # ꡠ.۲
+xn--5c9a.xn--fmb; ꡠ.۲; ; xn--5c9a.xn--fmb; ; ;  # ꡠ.۲
+𐹣񄷄｡ꡬ🄄; 𐹣񄷄.ꡬ🄄; [B1, P1, V6]; xn--bo0d0203l.xn--id9a4443d; ; ;  # 𐹣.ꡬ🄄
+𐹣񄷄。ꡬ3,; 𐹣񄷄.ꡬ3,; [B1, B6, P1, V6]; xn--bo0d0203l.xn--3,-yj9h; ; ;  # 𐹣.ꡬ3,
+xn--bo0d0203l.xn--3,-yj9h; 𐹣񄷄.ꡬ3,; [B1, B6, P1, V6]; xn--bo0d0203l.xn--3,-yj9h; ; ;  # 𐹣.ꡬ3,
+xn--bo0d0203l.xn--id9a4443d; 𐹣񄷄.ꡬ🄄; [B1, V6]; xn--bo0d0203l.xn--id9a4443d; ; ;  # 𐹣.ꡬ🄄
+-్𞾀𑲓｡‍്; -్𞾀𑲓.‍്; [B1, C2, P1, V3, V6]; xn----x6e0220sclug.xn--wxc317g; ; xn----x6e0220sclug.xn--wxc; [B1, B3, B6, P1, V3, V5, V6] # -్𑲓.്
+-్𞾀𑲓。‍്; -్𞾀𑲓.‍്; [B1, C2, P1, V3, V6]; xn----x6e0220sclug.xn--wxc317g; ; xn----x6e0220sclug.xn--wxc; [B1, B3, B6, P1, V3, V5, V6] # -్𑲓.്
+xn----x6e0220sclug.xn--wxc; -్𞾀𑲓.്; [B1, B3, B6, V3, V5, V6]; xn----x6e0220sclug.xn--wxc; ; ;  # -్𑲓.്
+xn----x6e0220sclug.xn--wxc317g; -్𞾀𑲓.‍്; [B1, C2, V3, V6]; xn----x6e0220sclug.xn--wxc317g; ; ;  # -్𑲓.്
+꙽‌霣🄆｡‌𑁂ᬁ; ꙽‌霣🄆.‌𑁂ᬁ; [C1, P1, V5, V6]; xn--0ug4208b2vjuk63a.xn--4sf36u6u4w; ; xn--2q5a751a653w.xn--4sf0725i; [P1, V5, V6] # ꙽霣🄆.𑁂ᬁ
+꙽‌霣🄆｡‌𑁂ᬁ; ꙽‌霣🄆.‌𑁂ᬁ; [C1, P1, V5, V6]; xn--0ug4208b2vjuk63a.xn--4sf36u6u4w; ; xn--2q5a751a653w.xn--4sf0725i; [P1, V5, V6] # ꙽霣🄆.𑁂ᬁ
+꙽‌霣5,。‌𑁂ᬁ; ꙽‌霣5,.‌𑁂ᬁ; [C1, P1, V5, V6]; xn--5,-i1tz135dnbqa.xn--4sf36u6u4w; ; xn--5,-op8g373c.xn--4sf0725i; [P1, V5, V6] # ꙽霣5,.𑁂ᬁ
+xn--5,-op8g373c.xn--4sf0725i; ꙽霣5,.𑁂ᬁ; [P1, V5, V6]; xn--5,-op8g373c.xn--4sf0725i; ; ;  # ꙽霣5,.𑁂ᬁ
+xn--5,-i1tz135dnbqa.xn--4sf36u6u4w; ꙽‌霣5,.‌𑁂ᬁ; [C1, P1, V5, V6]; xn--5,-i1tz135dnbqa.xn--4sf36u6u4w; ; ;  # ꙽霣5,.𑁂ᬁ
+xn--2q5a751a653w.xn--4sf0725i; ꙽霣🄆.𑁂ᬁ; [V5, V6]; xn--2q5a751a653w.xn--4sf0725i; ; ;  # ꙽霣🄆.𑁂ᬁ
+xn--0ug4208b2vjuk63a.xn--4sf36u6u4w; ꙽‌霣🄆.‌𑁂ᬁ; [C1, V5, V6]; xn--0ug4208b2vjuk63a.xn--4sf36u6u4w; ; ;  # ꙽霣🄆.𑁂ᬁ
+兎｡ᠼ󠴜𑚶𑰿; 兎.ᠼ󠴜𑚶𑰿; [P1, V6]; xn--b5q.xn--v7e6041kqqd4m251b; ; ;  # 兎.ᠼ𑚶𑰿
+兎。ᠼ󠴜𑚶𑰿; 兎.ᠼ󠴜𑚶𑰿; [P1, V6]; xn--b5q.xn--v7e6041kqqd4m251b; ; ;  # 兎.ᠼ𑚶𑰿
+xn--b5q.xn--v7e6041kqqd4m251b; 兎.ᠼ󠴜𑚶𑰿; [V6]; xn--b5q.xn--v7e6041kqqd4m251b; ; ;  # 兎.ᠼ𑚶𑰿
+𝟙｡‍𝟸‍⁷; 1.‍2‍7; [C2]; 1.xn--27-l1tb; ; 1.27; [] # 1.27
+1。‍2‍7; 1.‍2‍7; [C2]; 1.xn--27-l1tb; ; 1.27; [] # 1.27
+1.27; ; ; ; ; ;  # 1.27
+1.xn--27-l1tb; 1.‍2‍7; [C2]; 1.xn--27-l1tb; ; ;  # 1.27
+ᡨ-｡󠻋𝟷; ᡨ-.󠻋1; [P1, V3, V6]; xn----z8j.xn--1-5671m; ; ;  # ᡨ-.1
+ᡨ-。󠻋1; ᡨ-.󠻋1; [P1, V3, V6]; xn----z8j.xn--1-5671m; ; ;  # ᡨ-.1
+xn----z8j.xn--1-5671m; ᡨ-.󠻋1; [V3, V6]; xn----z8j.xn--1-5671m; ; ;  # ᡨ-.1
+𑰻񵀐𐫚．٨⁹; 𑰻񵀐𐫚.٨9; [B1, P1, V5, V6]; xn--gx9cr01aul57i.xn--9-oqc; ; ;  # 𑰻𐫚.٨9
+𑰻񵀐𐫚.٨9; ; [B1, P1, V5, V6]; xn--gx9cr01aul57i.xn--9-oqc; ; ;  # 𑰻𐫚.٨9
+xn--gx9cr01aul57i.xn--9-oqc; 𑰻񵀐𐫚.٨9; [B1, V5, V6]; xn--gx9cr01aul57i.xn--9-oqc; ; ;  # 𑰻𐫚.٨9
+Ⴜ򈷭ྀ⾇。Ⴏ♀‌‌; Ⴜ򈷭ྀ舛.Ⴏ♀‌‌; [C1, P1, V6]; xn--zed54dz10wo343g.xn--nnd089ea464d; ; xn--zed54dz10wo343g.xn--nnd651i; [P1, V6] # Ⴜྀ舛.Ⴏ♀
+Ⴜ򈷭ྀ舛。Ⴏ♀‌‌; Ⴜ򈷭ྀ舛.Ⴏ♀‌‌; [C1, P1, V6]; xn--zed54dz10wo343g.xn--nnd089ea464d; ; xn--zed54dz10wo343g.xn--nnd651i; [P1, V6] # Ⴜྀ舛.Ⴏ♀
+ⴜ򈷭ྀ舛。ⴏ♀‌‌; ⴜ򈷭ྀ舛.ⴏ♀‌‌; [C1, P1, V6]; xn--zed372mdj2do3v4h.xn--0uga678bgyh; ; xn--zed372mdj2do3v4h.xn--e5h11w; [P1, V6] # ⴜྀ舛.ⴏ♀
+xn--zed372mdj2do3v4h.xn--e5h11w; ⴜ򈷭ྀ舛.ⴏ♀; [V6]; xn--zed372mdj2do3v4h.xn--e5h11w; ; ;  # ⴜྀ舛.ⴏ♀
+xn--zed372mdj2do3v4h.xn--0uga678bgyh; ⴜ򈷭ྀ舛.ⴏ♀‌‌; [C1, V6]; xn--zed372mdj2do3v4h.xn--0uga678bgyh; ; ;  # ⴜྀ舛.ⴏ♀
+xn--zed54dz10wo343g.xn--nnd651i; Ⴜ򈷭ྀ舛.Ⴏ♀; [V6]; xn--zed54dz10wo343g.xn--nnd651i; ; ;  # Ⴜྀ舛.Ⴏ♀
+xn--zed54dz10wo343g.xn--nnd089ea464d; Ⴜ򈷭ྀ舛.Ⴏ♀‌‌; [C1, V6]; xn--zed54dz10wo343g.xn--nnd089ea464d; ; ;  # Ⴜྀ舛.Ⴏ♀
+ⴜ򈷭ྀ⾇。ⴏ♀‌‌; ⴜ򈷭ྀ舛.ⴏ♀‌‌; [C1, P1, V6]; xn--zed372mdj2do3v4h.xn--0uga678bgyh; ; xn--zed372mdj2do3v4h.xn--e5h11w; [P1, V6] # ⴜྀ舛.ⴏ♀
+𑁆𝟰.‍; 𑁆4.‍; [C2, V5]; xn--4-xu7i.xn--1ug; ; xn--4-xu7i.; [V5] # 𑁆4.
+𑁆4.‍; ; [C2, V5]; xn--4-xu7i.xn--1ug; ; xn--4-xu7i.; [V5] # 𑁆4.
+xn--4-xu7i.; 𑁆4.; [V5]; xn--4-xu7i.; ; ;  # 𑁆4.
+xn--4-xu7i.xn--1ug; 𑁆4.‍; [C2, V5]; xn--4-xu7i.xn--1ug; ; ;  # 𑁆4.
+񮴘Ⴞ癀｡𑘿‍‌붼; 񮴘Ⴞ癀.𑘿‍‌붼; [C1, P1, V5, V6]; xn--2nd6803c7q37d.xn--0ugb6122js83c; ; xn--2nd6803c7q37d.xn--et3bn23n; [P1, V5, V6] # Ⴞ癀.𑘿붼
+񮴘Ⴞ癀｡𑘿‍‌붼; 񮴘Ⴞ癀.𑘿‍‌붼; [C1, P1, V5, V6]; xn--2nd6803c7q37d.xn--0ugb6122js83c; ; xn--2nd6803c7q37d.xn--et3bn23n; [P1, V5, V6] # Ⴞ癀.𑘿붼
+񮴘Ⴞ癀。𑘿‍‌붼; 񮴘Ⴞ癀.𑘿‍‌붼; [C1, P1, V5, V6]; xn--2nd6803c7q37d.xn--0ugb6122js83c; ; xn--2nd6803c7q37d.xn--et3bn23n; [P1, V5, V6] # Ⴞ癀.𑘿붼
+񮴘Ⴞ癀。𑘿‍‌붼; 񮴘Ⴞ癀.𑘿‍‌붼; [C1, P1, V5, V6]; xn--2nd6803c7q37d.xn--0ugb6122js83c; ; xn--2nd6803c7q37d.xn--et3bn23n; [P1, V5, V6] # Ⴞ癀.𑘿붼
+񮴘ⴞ癀。𑘿‍‌붼; 񮴘ⴞ癀.𑘿‍‌붼; [C1, P1, V5, V6]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [P1, V5, V6] # ⴞ癀.𑘿붼
+񮴘ⴞ癀。𑘿‍‌붼; 񮴘ⴞ癀.𑘿‍‌붼; [C1, P1, V5, V6]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [P1, V5, V6] # ⴞ癀.𑘿붼
+xn--mlju35u7qx2f.xn--et3bn23n; 񮴘ⴞ癀.𑘿붼; [V5, V6]; xn--mlju35u7qx2f.xn--et3bn23n; ; ;  # ⴞ癀.𑘿붼
+xn--mlju35u7qx2f.xn--0ugb6122js83c; 񮴘ⴞ癀.𑘿‍‌붼; [C1, V5, V6]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; ;  # ⴞ癀.𑘿붼
+xn--2nd6803c7q37d.xn--et3bn23n; 񮴘Ⴞ癀.𑘿붼; [V5, V6]; xn--2nd6803c7q37d.xn--et3bn23n; ; ;  # Ⴞ癀.𑘿붼
+xn--2nd6803c7q37d.xn--0ugb6122js83c; 񮴘Ⴞ癀.𑘿‍‌붼; [C1, V5, V6]; xn--2nd6803c7q37d.xn--0ugb6122js83c; ; ;  # Ⴞ癀.𑘿붼
+񮴘ⴞ癀｡𑘿‍‌붼; 񮴘ⴞ癀.𑘿‍‌붼; [C1, P1, V5, V6]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [P1, V5, V6] # ⴞ癀.𑘿붼
+񮴘ⴞ癀｡𑘿‍‌붼; 񮴘ⴞ癀.𑘿‍‌붼; [C1, P1, V5, V6]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [P1, V5, V6] # ⴞ癀.𑘿붼
+󚀅-்。ڹ; 󚀅-்.ڹ; [B6, P1, V6]; xn----mze84808x.xn--skb; ; ;  # -்.ڹ
+xn----mze84808x.xn--skb; 󚀅-்.ڹ; [B6, V6]; xn----mze84808x.xn--skb; ; ;  # -்.ڹ
+ᡃ𝟧≯ᠣ．氁񨏱ꁫ; ᡃ5≯ᠣ.氁񨏱ꁫ; [P1, V6]; xn--5-24jyf768b.xn--lqw213ime95g; ; ;  # ᡃ5≯ᠣ.氁ꁫ
+ᡃ𝟧≯ᠣ．氁񨏱ꁫ; ᡃ5≯ᠣ.氁񨏱ꁫ; [P1, V6]; xn--5-24jyf768b.xn--lqw213ime95g; ; ;  # ᡃ5≯ᠣ.氁ꁫ
+ᡃ5≯ᠣ.氁񨏱ꁫ; ; [P1, V6]; xn--5-24jyf768b.xn--lqw213ime95g; ; ;  # ᡃ5≯ᠣ.氁ꁫ
+ᡃ5≯ᠣ.氁񨏱ꁫ; ᡃ5≯ᠣ.氁񨏱ꁫ; [P1, V6]; xn--5-24jyf768b.xn--lqw213ime95g; ; ;  # ᡃ5≯ᠣ.氁ꁫ
+xn--5-24jyf768b.xn--lqw213ime95g; ᡃ5≯ᠣ.氁񨏱ꁫ; [V6]; xn--5-24jyf768b.xn--lqw213ime95g; ; ;  # ᡃ5≯ᠣ.氁ꁫ
+𐹬𝩇．ྲྀ; 𐹬𝩇.ྲྀ; [B1, B3, B6, V5]; xn--ko0d8295a.xn--zed3h; ; ;  # 𐹬𝩇.ྲྀ
+𐹬𝩇．ྲྀ; 𐹬𝩇.ྲྀ; [B1, B3, B6, V5]; xn--ko0d8295a.xn--zed3h; ; ;  # 𐹬𝩇.ྲྀ
+𐹬𝩇.ྲྀ; ; [B1, B3, B6, V5]; xn--ko0d8295a.xn--zed3h; ; ;  # 𐹬𝩇.ྲྀ
+xn--ko0d8295a.xn--zed3h; 𐹬𝩇.ྲྀ; [B1, B3, B6, V5]; xn--ko0d8295a.xn--zed3h; ; ;  # 𐹬𝩇.ྲྀ
+-𑈶⒏．⒎𰛢󠎭; -𑈶⒏.⒎𰛢󠎭; [P1, V3, V6]; xn----scp6252h.xn--zshy411yzpx2d; ; ;  # -𑈶⒏.⒎
+-𑈶8..7.𰛢󠎭; ; [P1, V3, V6, X4_2]; xn---8-bv5o..7.xn--c35nf1622b; [P1, V3, V6, A4_2]; ;  # -𑈶8..7.
+xn---8-bv5o..7.xn--c35nf1622b; -𑈶8..7.𰛢󠎭; [V3, V6, X4_2]; xn---8-bv5o..7.xn--c35nf1622b; [V3, V6, A4_2]; ;  # -𑈶8..7.
+xn----scp6252h.xn--zshy411yzpx2d; -𑈶⒏.⒎𰛢󠎭; [V3, V6]; xn----scp6252h.xn--zshy411yzpx2d; ; ;  # -𑈶⒏.⒎
+‌Ⴁ畝‍．≮; ‌Ⴁ畝‍.≮; [C1, C2, P1, V6]; xn--8md700fea3748f.xn--gdh; ; xn--8md0962c.xn--gdh; [P1, V6] # Ⴁ畝.≮
+‌Ⴁ畝‍．≮; ‌Ⴁ畝‍.≮; [C1, C2, P1, V6]; xn--8md700fea3748f.xn--gdh; ; xn--8md0962c.xn--gdh; [P1, V6] # Ⴁ畝.≮
+‌Ⴁ畝‍.≮; ; [C1, C2, P1, V6]; xn--8md700fea3748f.xn--gdh; ; xn--8md0962c.xn--gdh; [P1, V6] # Ⴁ畝.≮
+‌Ⴁ畝‍.≮; ‌Ⴁ畝‍.≮; [C1, C2, P1, V6]; xn--8md700fea3748f.xn--gdh; ; xn--8md0962c.xn--gdh; [P1, V6] # Ⴁ畝.≮
+‌ⴁ畝‍.≮; ‌ⴁ畝‍.≮; [C1, C2, P1, V6]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [P1, V6] # ⴁ畝.≮
+‌ⴁ畝‍.≮; ; [C1, C2, P1, V6]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [P1, V6] # ⴁ畝.≮
+xn--skjy82u.xn--gdh; ⴁ畝.≮; [V6]; xn--skjy82u.xn--gdh; ; ;  # ⴁ畝.≮
+xn--0ugc160hb36e.xn--gdh; ‌ⴁ畝‍.≮; [C1, C2, V6]; xn--0ugc160hb36e.xn--gdh; ; ;  # ⴁ畝.≮
+xn--8md0962c.xn--gdh; Ⴁ畝.≮; [V6]; xn--8md0962c.xn--gdh; ; ;  # Ⴁ畝.≮
+xn--8md700fea3748f.xn--gdh; ‌Ⴁ畝‍.≮; [C1, C2, V6]; xn--8md700fea3748f.xn--gdh; ; ;  # Ⴁ畝.≮
+‌ⴁ畝‍．≮; ‌ⴁ畝‍.≮; [C1, C2, P1, V6]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [P1, V6] # ⴁ畝.≮
+‌ⴁ畝‍．≮; ‌ⴁ畝‍.≮; [C1, C2, P1, V6]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [P1, V6] # ⴁ畝.≮
+歷｡𐹻≯󳛽‍; 歷.𐹻≯󳛽‍; [B1, C2, P1, V6]; xn--nmw.xn--1ugx6gs128a1134j; ; xn--nmw.xn--hdh7804gdms2h; [B1, P1, V6] # 歷.𐹻≯
+歷｡𐹻≯󳛽‍; 歷.𐹻≯󳛽‍; [B1, C2, P1, V6]; xn--nmw.xn--1ugx6gs128a1134j; ; xn--nmw.xn--hdh7804gdms2h; [B1, P1, V6] # 歷.𐹻≯
+歷。𐹻≯󳛽‍; 歷.𐹻≯󳛽‍; [B1, C2, P1, V6]; xn--nmw.xn--1ugx6gs128a1134j; ; xn--nmw.xn--hdh7804gdms2h; [B1, P1, V6] # 歷.𐹻≯
+歷。𐹻≯󳛽‍; 歷.𐹻≯󳛽‍; [B1, C2, P1, V6]; xn--nmw.xn--1ugx6gs128a1134j; ; xn--nmw.xn--hdh7804gdms2h; [B1, P1, V6] # 歷.𐹻≯
+xn--nmw.xn--hdh7804gdms2h; 歷.𐹻≯󳛽; [B1, V6]; xn--nmw.xn--hdh7804gdms2h; ; ;  # 歷.𐹻≯
+xn--nmw.xn--1ugx6gs128a1134j; 歷.𐹻≯󳛽‍; [B1, C2, V6]; xn--nmw.xn--1ugx6gs128a1134j; ; ;  # 歷.𐹻≯
+໋‍．鎁󠰑; ໋‍.鎁󠰑; [C2, P1, V5, V6]; xn--t8c059f.xn--iz4a43209d; ; xn--t8c.xn--iz4a43209d; [P1, V5, V6] # ໋.鎁
+໋‍.鎁󠰑; ; [C2, P1, V5, V6]; xn--t8c059f.xn--iz4a43209d; ; xn--t8c.xn--iz4a43209d; [P1, V5, V6] # ໋.鎁
+xn--t8c.xn--iz4a43209d; ໋.鎁󠰑; [V5, V6]; xn--t8c.xn--iz4a43209d; ; ;  # ໋.鎁
+xn--t8c059f.xn--iz4a43209d; ໋‍.鎁󠰑; [C2, V5, V6]; xn--t8c059f.xn--iz4a43209d; ; ;  # ໋.鎁
+‍‌𞤀｡𱘅𐶃; ‍‌𞤢.𱘅𐶃; [B1, B5, B6, C1, C2, P1, V6]; xn--0ugb45126a.xn--wh0dj799f; ; xn--9d6h.xn--wh0dj799f; [B5, B6, P1, V6] # 𞤢.
+‍‌𞤀。𱘅𐶃; ‍‌𞤢.𱘅𐶃; [B1, B5, B6, C1, C2, P1, V6]; xn--0ugb45126a.xn--wh0dj799f; ; xn--9d6h.xn--wh0dj799f; [B5, B6, P1, V6] # 𞤢.
+‍‌𞤢。𱘅𐶃; ‍‌𞤢.𱘅𐶃; [B1, B5, B6, C1, C2, P1, V6]; xn--0ugb45126a.xn--wh0dj799f; ; xn--9d6h.xn--wh0dj799f; [B5, B6, P1, V6] # 𞤢.
+xn--9d6h.xn--wh0dj799f; 𞤢.𱘅𐶃; [B5, B6, V6]; xn--9d6h.xn--wh0dj799f; ; ;  # 𞤢.
+xn--0ugb45126a.xn--wh0dj799f; ‍‌𞤢.𱘅𐶃; [B1, B5, B6, C1, C2, V6]; xn--0ugb45126a.xn--wh0dj799f; ; ;  # 𞤢.
+‍‌𞤢｡𱘅𐶃; ‍‌𞤢.𱘅𐶃; [B1, B5, B6, C1, C2, P1, V6]; xn--0ugb45126a.xn--wh0dj799f; ; xn--9d6h.xn--wh0dj799f; [B5, B6, P1, V6] # 𞤢.
+ب≠𝟫-.ς⒍𐹦≠; ب≠9-.ς⒍𐹦≠; [B3, B5, B6, P1, V3, V6]; xn--9--etd0100a.xn--3xa097mzpbzz04b; ; xn--9--etd0100a.xn--4xa887mzpbzz04b;  # ب≠9-.ς⒍𐹦≠
+ب≠𝟫-.ς⒍𐹦≠; ب≠9-.ς⒍𐹦≠; [B3, B5, B6, P1, V3, V6]; xn--9--etd0100a.xn--3xa097mzpbzz04b; ; xn--9--etd0100a.xn--4xa887mzpbzz04b;  # ب≠9-.ς⒍𐹦≠
+ب≠9-.ς6.𐹦≠; ; [B1, B3, P1, V3, V6]; xn--9--etd0100a.xn--6-xmb.xn--1ch8704g; ; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g;  # ب≠9-.ς6.𐹦≠
+ب≠9-.ς6.𐹦≠; ب≠9-.ς6.𐹦≠; [B1, B3, P1, V3, V6]; xn--9--etd0100a.xn--6-xmb.xn--1ch8704g; ; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g;  # ب≠9-.ς6.𐹦≠
+ب≠9-.Σ6.𐹦≠; ب≠9-.σ6.𐹦≠; [B1, B3, P1, V3, V6]; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; ; ;  # ب≠9-.σ6.𐹦≠
+ب≠9-.Σ6.𐹦≠; ب≠9-.σ6.𐹦≠; [B1, B3, P1, V3, V6]; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; ; ;  # ب≠9-.σ6.𐹦≠
+ب≠9-.σ6.𐹦≠; ; [B1, B3, P1, V3, V6]; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; ; ;  # ب≠9-.σ6.𐹦≠
+ب≠9-.σ6.𐹦≠; ب≠9-.σ6.𐹦≠; [B1, B3, P1, V3, V6]; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; ; ;  # ب≠9-.σ6.𐹦≠
+xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; ب≠9-.σ6.𐹦≠; [B1, B3, V3, V6]; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; ; ;  # ب≠9-.σ6.𐹦≠
+xn--9--etd0100a.xn--6-xmb.xn--1ch8704g; ب≠9-.ς6.𐹦≠; [B1, B3, V3, V6]; xn--9--etd0100a.xn--6-xmb.xn--1ch8704g; ; ;  # ب≠9-.ς6.𐹦≠
+ب≠𝟫-.Σ⒍𐹦≠; ب≠9-.σ⒍𐹦≠; [B3, B5, B6, P1, V3, V6]; xn--9--etd0100a.xn--4xa887mzpbzz04b; ; ;  # ب≠9-.σ⒍𐹦≠
+ب≠𝟫-.Σ⒍𐹦≠; ب≠9-.σ⒍𐹦≠; [B3, B5, B6, P1, V3, V6]; xn--9--etd0100a.xn--4xa887mzpbzz04b; ; ;  # ب≠9-.σ⒍𐹦≠
+ب≠𝟫-.σ⒍𐹦≠; ب≠9-.σ⒍𐹦≠; [B3, B5, B6, P1, V3, V6]; xn--9--etd0100a.xn--4xa887mzpbzz04b; ; ;  # ب≠9-.σ⒍𐹦≠
+ب≠𝟫-.σ⒍𐹦≠; ب≠9-.σ⒍𐹦≠; [B3, B5, B6, P1, V3, V6]; xn--9--etd0100a.xn--4xa887mzpbzz04b; ; ;  # ب≠9-.σ⒍𐹦≠
+xn--9--etd0100a.xn--4xa887mzpbzz04b; ب≠9-.σ⒍𐹦≠; [B3, B5, B6, V3, V6]; xn--9--etd0100a.xn--4xa887mzpbzz04b; ; ;  # ب≠9-.σ⒍𐹦≠
+xn--9--etd0100a.xn--3xa097mzpbzz04b; ب≠9-.ς⒍𐹦≠; [B3, B5, B6, V3, V6]; xn--9--etd0100a.xn--3xa097mzpbzz04b; ; ;  # ب≠9-.ς⒍𐹦≠
+򉛴.-ᡢ֒𝨠; ; [P1, V3, V6]; xn--ep37b.xn----hec165lho83b; ; ;  # .-ᡢ֒𝨠
+xn--ep37b.xn----hec165lho83b; 򉛴.-ᡢ֒𝨠; [V3, V6]; xn--ep37b.xn----hec165lho83b; ; ;  # .-ᡢ֒𝨠
+ۋ⒈ß󠄽。񷋍-; ۋ⒈ß.񷋍-; [B2, B3, B6, P1, V3, V6]; xn--zca541ato3a.xn----q001f; ; xn--ss-d7d6651a.xn----q001f;  # ۋ⒈ß.-
+ۋ1.ß󠄽。񷋍-; ۋ1.ß.񷋍-; [B6, P1, V3, V6]; xn--1-cwc.xn--zca.xn----q001f; ; xn--1-cwc.ss.xn----q001f;  # ۋ1.ß.-
+ۋ1.SS󠄽。񷋍-; ۋ1.ss.񷋍-; [B6, P1, V3, V6]; xn--1-cwc.ss.xn----q001f; ; ;  # ۋ1.ss.-
+ۋ1.ss󠄽。񷋍-; ۋ1.ss.񷋍-; [B6, P1, V3, V6]; xn--1-cwc.ss.xn----q001f; ; ;  # ۋ1.ss.-
+ۋ1.Ss󠄽。񷋍-; ۋ1.ss.񷋍-; [B6, P1, V3, V6]; xn--1-cwc.ss.xn----q001f; ; ;  # ۋ1.ss.-
+xn--1-cwc.ss.xn----q001f; ۋ1.ss.񷋍-; [B6, V3, V6]; xn--1-cwc.ss.xn----q001f; ; ;  # ۋ1.ss.-
+xn--1-cwc.xn--zca.xn----q001f; ۋ1.ß.񷋍-; [B6, V3, V6]; xn--1-cwc.xn--zca.xn----q001f; ; ;  # ۋ1.ß.-
+ۋ⒈SS󠄽。񷋍-; ۋ⒈ss.񷋍-; [B2, B3, B6, P1, V3, V6]; xn--ss-d7d6651a.xn----q001f; ; ;  # ۋ⒈ss.-
+ۋ⒈ss󠄽。񷋍-; ۋ⒈ss.񷋍-; [B2, B3, B6, P1, V3, V6]; xn--ss-d7d6651a.xn----q001f; ; ;  # ۋ⒈ss.-
+ۋ⒈Ss󠄽。񷋍-; ۋ⒈ss.񷋍-; [B2, B3, B6, P1, V3, V6]; xn--ss-d7d6651a.xn----q001f; ; ;  # ۋ⒈ss.-
+xn--ss-d7d6651a.xn----q001f; ۋ⒈ss.񷋍-; [B2, B3, B6, V3, V6]; xn--ss-d7d6651a.xn----q001f; ; ;  # ۋ⒈ss.-
+xn--zca541ato3a.xn----q001f; ۋ⒈ß.񷋍-; [B2, B3, B6, V3, V6]; xn--zca541ato3a.xn----q001f; ; ;  # ۋ⒈ß.-
+𿀫．᮪ςႦ‍; 𿀫.᮪ςႦ‍; [C2, P1, V5, V6]; xn--nu4s.xn--3xa417dxriome; ; xn--nu4s.xn--4xa217dxri; [P1, V5, V6] # .᮪ςႦ
+𿀫.᮪ςႦ‍; ; [C2, P1, V5, V6]; xn--nu4s.xn--3xa417dxriome; ; xn--nu4s.xn--4xa217dxri; [P1, V5, V6] # .᮪ςႦ
+𿀫.᮪ςⴆ‍; ; [C2, P1, V5, V6]; xn--nu4s.xn--3xa353jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [P1, V5, V6] # .᮪ςⴆ
+𿀫.᮪ΣႦ‍; 𿀫.᮪σႦ‍; [C2, P1, V5, V6]; xn--nu4s.xn--4xa217dxriome; ; xn--nu4s.xn--4xa217dxri; [P1, V5, V6] # .᮪σႦ
+𿀫.᮪σⴆ‍; ; [C2, P1, V5, V6]; xn--nu4s.xn--4xa153jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [P1, V5, V6] # .᮪σⴆ
+𿀫.᮪Σⴆ‍; 𿀫.᮪σⴆ‍; [C2, P1, V5, V6]; xn--nu4s.xn--4xa153jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [P1, V5, V6] # .᮪σⴆ
+xn--nu4s.xn--4xa153j7im; 𿀫.᮪σⴆ; [V5, V6]; xn--nu4s.xn--4xa153j7im; ; ;  # .᮪σⴆ
+xn--nu4s.xn--4xa153jk8cs1q; 𿀫.᮪σⴆ‍; [C2, V5, V6]; xn--nu4s.xn--4xa153jk8cs1q; ; ;  # .᮪σⴆ
+xn--nu4s.xn--4xa217dxri; 𿀫.᮪σႦ; [V5, V6]; xn--nu4s.xn--4xa217dxri; ; ;  # .᮪σႦ
+xn--nu4s.xn--4xa217dxriome; 𿀫.᮪σႦ‍; [C2, V5, V6]; xn--nu4s.xn--4xa217dxriome; ; ;  # .᮪σႦ
+xn--nu4s.xn--3xa353jk8cs1q; 𿀫.᮪ςⴆ‍; [C2, V5, V6]; xn--nu4s.xn--3xa353jk8cs1q; ; ;  # .᮪ςⴆ
+xn--nu4s.xn--3xa417dxriome; 𿀫.᮪ςႦ‍; [C2, V5, V6]; xn--nu4s.xn--3xa417dxriome; ; ;  # .᮪ςႦ
+𿀫．᮪ςⴆ‍; 𿀫.᮪ςⴆ‍; [C2, P1, V5, V6]; xn--nu4s.xn--3xa353jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [P1, V5, V6] # .᮪ςⴆ
+𿀫．᮪ΣႦ‍; 𿀫.᮪σႦ‍; [C2, P1, V5, V6]; xn--nu4s.xn--4xa217dxriome; ; xn--nu4s.xn--4xa217dxri; [P1, V5, V6] # .᮪σႦ
+𿀫．᮪σⴆ‍; 𿀫.᮪σⴆ‍; [C2, P1, V5, V6]; xn--nu4s.xn--4xa153jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [P1, V5, V6] # .᮪σⴆ
+𿀫．᮪Σⴆ‍; 𿀫.᮪σⴆ‍; [C2, P1, V5, V6]; xn--nu4s.xn--4xa153jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [P1, V5, V6] # .᮪σⴆ
+⾆࣢.𝈴; 舌࣢.𝈴; [B1, B5, B6, P1, V6]; xn--l0b9413d.xn--kl1h; ; ;  # 舌.𝈴
+舌࣢.𝈴; ; [B1, B5, B6, P1, V6]; xn--l0b9413d.xn--kl1h; ; ;  # 舌.𝈴
+xn--l0b9413d.xn--kl1h; 舌࣢.𝈴; [B1, B5, B6, V6]; xn--l0b9413d.xn--kl1h; ; ;  # 舌.𝈴
+⫞𐹶𖫴。⭠⒈; ⫞𐹶𖫴.⭠⒈; [B1, P1, V6]; xn--53ix188et88b.xn--tsh52w; ; ;  # ⫞𐹶𖫴.⭠⒈
+⫞𐹶𖫴。⭠1.; ⫞𐹶𖫴.⭠1.; [B1]; xn--53ix188et88b.xn--1-h6r.; ; ;  # ⫞𐹶𖫴.⭠1.
+xn--53ix188et88b.xn--1-h6r.; ⫞𐹶𖫴.⭠1.; [B1]; xn--53ix188et88b.xn--1-h6r.; ; ;  # ⫞𐹶𖫴.⭠1.
+xn--53ix188et88b.xn--tsh52w; ⫞𐹶𖫴.⭠⒈; [B1, V6]; xn--53ix188et88b.xn--tsh52w; ; ;  # ⫞𐹶𖫴.⭠⒈
+⒈‌ꫬ︒．્; ⒈‌ꫬ︒.્; [C1, P1, V5, V6]; xn--0ug78o720myr1c.xn--mfc; ; xn--tsh0720cse8b.xn--mfc; [P1, V5, V6] # ⒈ꫬ︒.્
+1.‌ꫬ。.્; 1.‌ꫬ..્; [C1, V5, X4_2]; 1.xn--0ug7185c..xn--mfc; [C1, V5, A4_2]; 1.xn--sv9a..xn--mfc; [V5, A4_2] # 1.ꫬ..્
+1.xn--sv9a..xn--mfc; 1.ꫬ..્; [V5, X4_2]; 1.xn--sv9a..xn--mfc; [V5, A4_2]; ;  # 1.ꫬ..્
+1.xn--0ug7185c..xn--mfc; 1.‌ꫬ..્; [C1, V5, X4_2]; 1.xn--0ug7185c..xn--mfc; [C1, V5, A4_2]; ;  # 1.ꫬ..્
+xn--tsh0720cse8b.xn--mfc; ⒈ꫬ︒.્; [V5, V6]; xn--tsh0720cse8b.xn--mfc; ; ;  # ⒈ꫬ︒.્
+xn--0ug78o720myr1c.xn--mfc; ⒈‌ꫬ︒.્; [C1, V5, V6]; xn--0ug78o720myr1c.xn--mfc; ; ;  # ⒈ꫬ︒.્
+ె。䰀٨𞭅󠅼; ె.䰀٨𞭅; [B1, B3, B5, B6, P1, V5, V6]; xn--eqc.xn--hib5476aim6t; ; ;  # ె.䰀٨
+xn--eqc.xn--hib5476aim6t; ె.䰀٨𞭅; [B1, B3, B5, B6, V5, V6]; xn--eqc.xn--hib5476aim6t; ; ;  # ె.䰀٨
+ß‍.᯲񄾼; ; [C2, P1, V5, V6]; xn--zca870n.xn--0zf22107b; ; ss.xn--0zf22107b; [P1, V5, V6] # ß.᯲
+SS‍.᯲񄾼; ss‍.᯲񄾼; [C2, P1, V5, V6]; xn--ss-n1t.xn--0zf22107b; ; ss.xn--0zf22107b; [P1, V5, V6] # ss.᯲
+ss‍.᯲񄾼; ; [C2, P1, V5, V6]; xn--ss-n1t.xn--0zf22107b; ; ss.xn--0zf22107b; [P1, V5, V6] # ss.᯲
+Ss‍.᯲񄾼; ss‍.᯲񄾼; [C2, P1, V5, V6]; xn--ss-n1t.xn--0zf22107b; ; ss.xn--0zf22107b; [P1, V5, V6] # ss.᯲
+ss.xn--0zf22107b; ss.᯲񄾼; [V5, V6]; ss.xn--0zf22107b; ; ;  # ss.᯲
+xn--ss-n1t.xn--0zf22107b; ss‍.᯲񄾼; [C2, V5, V6]; xn--ss-n1t.xn--0zf22107b; ; ;  # ss.᯲
+xn--zca870n.xn--0zf22107b; ß‍.᯲񄾼; [C2, V5, V6]; xn--zca870n.xn--0zf22107b; ; ;  # ß.᯲
+𑓂‌≮.≮; ; [P1, V5, V6]; xn--0ugy6glz29a.xn--gdh; ; xn--gdhz656g.xn--gdh;  # 𑓂≮.≮
+𑓂‌≮.≮; 𑓂‌≮.≮; [P1, V5, V6]; xn--0ugy6glz29a.xn--gdh; ; xn--gdhz656g.xn--gdh;  # 𑓂≮.≮
+xn--gdhz656g.xn--gdh; 𑓂≮.≮; [V5, V6]; xn--gdhz656g.xn--gdh; ; ;  # 𑓂≮.≮
+xn--0ugy6glz29a.xn--gdh; 𑓂‌≮.≮; [V5, V6]; xn--0ugy6glz29a.xn--gdh; ; ;  # 𑓂≮.≮
+🕼．ﾠ; 🕼.ﾠ; [P1, V6]; xn--my8h.xn--cl7c; ; ;  # 🕼.
+🕼.ᅠ; ; [P1, V6]; xn--my8h.xn--psd; ; ;  # 🕼.
+xn--my8h.xn--psd; 🕼.ᅠ; [V6]; xn--my8h.xn--psd; ; ;  # 🕼.
+xn--my8h.xn--cl7c; 🕼.ﾠ; [V6]; xn--my8h.xn--cl7c; ; ;  # 🕼.
+ᡔﶂ。񷘎; ᡔلحى.񷘎; [B5, B6, P1, V6]; xn--sgb9bq785p.xn--bc31b; ; ;  # ᡔلحى.
+ᡔلحى。񷘎; ᡔلحى.񷘎; [B5, B6, P1, V6]; xn--sgb9bq785p.xn--bc31b; ; ;  # ᡔلحى.
+xn--sgb9bq785p.xn--bc31b; ᡔلحى.񷘎; [B5, B6, V6]; xn--sgb9bq785p.xn--bc31b; ; ;  # ᡔلحى.
+爕򳙑．𝟰気; 爕򳙑.4気; [P1, V6]; xn--1zxq3199c.xn--4-678b; ; ;  # 爕.4気
+爕򳙑.4気; ; [P1, V6]; xn--1zxq3199c.xn--4-678b; ; ;  # 爕.4気
+xn--1zxq3199c.xn--4-678b; 爕򳙑.4気; [V6]; xn--1zxq3199c.xn--4-678b; ; ;  # 爕.4気
+⒋𑍍Ⴝ-．𞬪්ֵ; ⒋𑍍Ⴝ-.𞬪්ֵ; [B1, P1, V3, V6]; xn----t1g323mnk9t.xn--ddb152b7y23b; ; ;  # ⒋𑍍Ⴝ-.්ֵ
+4.𑍍Ⴝ-.𞬪්ֵ; ; [B1, B6, P1, V3, V5, V6]; 4.xn----t1g9869q.xn--ddb152b7y23b; ; ;  # 4.𑍍Ⴝ-.්ֵ
+4.𑍍ⴝ-.𞬪්ֵ; ; [B1, B6, P1, V3, V5, V6]; 4.xn----wwsx259f.xn--ddb152b7y23b; ; ;  # 4.𑍍ⴝ-.්ֵ
+4.xn----wwsx259f.xn--ddb152b7y23b; 4.𑍍ⴝ-.𞬪්ֵ; [B1, B6, V3, V5, V6]; 4.xn----wwsx259f.xn--ddb152b7y23b; ; ;  # 4.𑍍ⴝ-.්ֵ
+4.xn----t1g9869q.xn--ddb152b7y23b; 4.𑍍Ⴝ-.𞬪්ֵ; [B1, B6, V3, V5, V6]; 4.xn----t1g9869q.xn--ddb152b7y23b; ; ;  # 4.𑍍Ⴝ-.්ֵ
+⒋𑍍ⴝ-．𞬪්ֵ; ⒋𑍍ⴝ-.𞬪්ֵ; [B1, P1, V3, V6]; xn----jcp487avl3w.xn--ddb152b7y23b; ; ;  # ⒋𑍍ⴝ-.්ֵ
+xn----jcp487avl3w.xn--ddb152b7y23b; ⒋𑍍ⴝ-.𞬪්ֵ; [B1, V3, V6]; xn----jcp487avl3w.xn--ddb152b7y23b; ; ;  # ⒋𑍍ⴝ-.්ֵ
+xn----t1g323mnk9t.xn--ddb152b7y23b; ⒋𑍍Ⴝ-.𞬪්ֵ; [B1, V3, V6]; xn----t1g323mnk9t.xn--ddb152b7y23b; ; ;  # ⒋𑍍Ⴝ-.්ֵ
+󞝃。򑆃񉢗--; 󞝃.򑆃񉢗--; [P1, V2, V3, V6]; xn--2y75e.xn-----1l15eer88n; ; ;  # .--
+xn--2y75e.xn-----1l15eer88n; 󞝃.򑆃񉢗--; [V2, V3, V6]; xn--2y75e.xn-----1l15eer88n; ; ;  # .--
+‍ߟ｡‌꯭; ‍ߟ.‌꯭; [B1, C1, C2]; xn--6sb394j.xn--0ug1126c; ; xn--6sb.xn--429a; [B1, B3, B6, V5] # ߟ.꯭
+‍ߟ。‌꯭; ‍ߟ.‌꯭; [B1, C1, C2]; xn--6sb394j.xn--0ug1126c; ; xn--6sb.xn--429a; [B1, B3, B6, V5] # ߟ.꯭
+xn--6sb.xn--429a; ߟ.꯭; [B1, B3, B6, V5]; xn--6sb.xn--429a; ; ;  # ߟ.꯭
+xn--6sb394j.xn--0ug1126c; ‍ߟ.‌꯭; [B1, C1, C2]; xn--6sb394j.xn--0ug1126c; ; ;  # ߟ.꯭
+𞮽߿ࡎ｡ᢍ򝹁𐫘; 𞮽߿ࡎ.ᢍ򝹁𐫘; [B5, B6, P1, V6]; xn--3tb2nz468k.xn--69e8615j5rn5d; ; ;  # ߿ࡎ.ᢍ𐫘
+𞮽߿ࡎ。ᢍ򝹁𐫘; 𞮽߿ࡎ.ᢍ򝹁𐫘; [B5, B6, P1, V6]; xn--3tb2nz468k.xn--69e8615j5rn5d; ; ;  # ߿ࡎ.ᢍ𐫘
+xn--3tb2nz468k.xn--69e8615j5rn5d; 𞮽߿ࡎ.ᢍ򝹁𐫘; [B5, B6, V6]; xn--3tb2nz468k.xn--69e8615j5rn5d; ; ;  # ߿ࡎ.ᢍ𐫘
+ۭ𞺌𑄚᜔.ꡞࢷ; ۭم𑄚᜔.ꡞࢷ; [B1, B5, B6, V5]; xn--hhb94ag41b739u.xn--dzb5582f; ; ;  # ۭم𑄚᜔.ꡞࢷ
+ۭم𑄚᜔.ꡞࢷ; ; [B1, B5, B6, V5]; xn--hhb94ag41b739u.xn--dzb5582f; ; ;  # ۭم𑄚᜔.ꡞࢷ
+xn--hhb94ag41b739u.xn--dzb5582f; ۭم𑄚᜔.ꡞࢷ; [B1, B5, B6, V5]; xn--hhb94ag41b739u.xn--dzb5582f; ; ;  # ۭم𑄚᜔.ꡞࢷ
+񻂵킃𑘶ߜ｡ςؼς; 񻂵킃𑘶ߜ.ςؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xaa51q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.ςؼς
+񻂵킃𑘶ߜ｡ςؼς; 񻂵킃𑘶ߜ.ςؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xaa51q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.ςؼς
+񻂵킃𑘶ߜ。ςؼς; 񻂵킃𑘶ߜ.ςؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xaa51q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.ςؼς
+񻂵킃𑘶ߜ。ςؼς; 񻂵킃𑘶ߜ.ςؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xaa51q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.ςؼς
+񻂵킃𑘶ߜ。ΣؼΣ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ。ΣؼΣ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ。σؼσ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ。σؼσ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ。Σؼσ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ。Σؼσ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+xn--3sb7483hoyvbbe76g.xn--4xaa21q; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ。Σؼς; 񻂵킃𑘶ߜ.σؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶ߜ。Σؼς; 񻂵킃𑘶ߜ.σؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶ߜ。σؼς; 񻂵킃𑘶ߜ.σؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶ߜ。σؼς; 񻂵킃𑘶ߜ.σؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+xn--3sb7483hoyvbbe76g.xn--3xab31q; 񻂵킃𑘶ߜ.σؼς; [B5, B6, V6]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; ;  # 킃𑘶ߜ.σؼς
+xn--3sb7483hoyvbbe76g.xn--3xaa51q; 񻂵킃𑘶ߜ.ςؼς; [B5, B6, V6]; xn--3sb7483hoyvbbe76g.xn--3xaa51q; ; ;  # 킃𑘶ߜ.ςؼς
+񻂵킃𑘶ߜ｡ΣؼΣ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ｡ΣؼΣ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ｡σؼσ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ｡σؼσ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ｡Σؼσ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ｡Σؼσ; 񻂵킃𑘶ߜ.σؼσ; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶ߜ｡Σؼς; 񻂵킃𑘶ߜ.σؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶ߜ｡Σؼς; 񻂵킃𑘶ߜ.σؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶ߜ｡σؼς; 񻂵킃𑘶ߜ.σؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶ߜ｡σؼς; 񻂵킃𑘶ߜ.σؼς; [B5, B6, P1, V6]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+蔰。󠁹ࣝ-𑈵; 蔰.󠁹ࣝ-𑈵; [P1, V6]; xn--sz1a.xn----mrd9984r3dl0i; ; ;  # 蔰.ࣝ-𑈵
+xn--sz1a.xn----mrd9984r3dl0i; 蔰.󠁹ࣝ-𑈵; [V6]; xn--sz1a.xn----mrd9984r3dl0i; ; ;  # 蔰.ࣝ-𑈵
+ςჅ。ݚ; ςჅ.ݚ; [P1, V6]; xn--3xa677d.xn--epb; ; xn--4xa477d.xn--epb;  # ςჅ.ݚ
+ςⴥ。ݚ; ςⴥ.ݚ; ; xn--3xa403s.xn--epb; ; xn--4xa203s.xn--epb;  # ςⴥ.ݚ
+ΣჅ。ݚ; σჅ.ݚ; [P1, V6]; xn--4xa477d.xn--epb; ; ;  # σჅ.ݚ
+σⴥ。ݚ; σⴥ.ݚ; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+Σⴥ。ݚ; σⴥ.ݚ; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+xn--4xa203s.xn--epb; σⴥ.ݚ; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+σⴥ.ݚ; ; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+ΣჅ.ݚ; σჅ.ݚ; [P1, V6]; xn--4xa477d.xn--epb; ; ;  # σჅ.ݚ
+Σⴥ.ݚ; σⴥ.ݚ; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+xn--4xa477d.xn--epb; σჅ.ݚ; [V6]; xn--4xa477d.xn--epb; ; ;  # σჅ.ݚ
+xn--3xa403s.xn--epb; ςⴥ.ݚ; ; xn--3xa403s.xn--epb; ; ;  # ςⴥ.ݚ
+ςⴥ.ݚ; ; ; xn--3xa403s.xn--epb; ; xn--4xa203s.xn--epb;  # ςⴥ.ݚ
+xn--3xa677d.xn--epb; ςჅ.ݚ; [V6]; xn--3xa677d.xn--epb; ; ;  # ςჅ.ݚ
+్Ⴉ𞰓．᭲; ్Ⴉ𞰓.᭲; [B1, B3, B6, P1, V5, V6]; xn--lqc64t7t26c.xn--dwf; ; ;  # ్Ⴉ.᭲
+్Ⴉ𞰓.᭲; ; [B1, B3, B6, P1, V5, V6]; xn--lqc64t7t26c.xn--dwf; ; ;  # ్Ⴉ.᭲
+్ⴉ𞰓.᭲; ; [B1, B3, B6, P1, V5, V6]; xn--lqc478nlr02a.xn--dwf; ; ;  # ్ⴉ.᭲
+xn--lqc478nlr02a.xn--dwf; ్ⴉ𞰓.᭲; [B1, B3, B6, V5, V6]; xn--lqc478nlr02a.xn--dwf; ; ;  # ్ⴉ.᭲
+xn--lqc64t7t26c.xn--dwf; ్Ⴉ𞰓.᭲; [B1, B3, B6, V5, V6]; xn--lqc64t7t26c.xn--dwf; ; ;  # ్Ⴉ.᭲
+్ⴉ𞰓．᭲; ్ⴉ𞰓.᭲; [B1, B3, B6, P1, V5, V6]; xn--lqc478nlr02a.xn--dwf; ; ;  # ్ⴉ.᭲
+⮷≮񎈴󠄟。𐠄; ⮷≮񎈴.𐠄; [B1, P1, V6]; xn--gdh877a3513h.xn--pc9c; ; ;  # ⮷≮.𐠄
+⮷≮񎈴󠄟。𐠄; ⮷≮񎈴.𐠄; [B1, P1, V6]; xn--gdh877a3513h.xn--pc9c; ; ;  # ⮷≮.𐠄
+xn--gdh877a3513h.xn--pc9c; ⮷≮񎈴.𐠄; [B1, V6]; xn--gdh877a3513h.xn--pc9c; ; ;  # ⮷≮.𐠄
+ڼ｡‍ẏ‌ᡤ; ڼ.‍ẏ‌ᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+ڼ｡‍ẏ‌ᡤ; ڼ.‍ẏ‌ᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+ڼ。‍ẏ‌ᡤ; ڼ.‍ẏ‌ᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+ڼ。‍ẏ‌ᡤ; ڼ.‍ẏ‌ᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+ڼ。‍Ẏ‌ᡤ; ڼ.‍ẏ‌ᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+ڼ。‍Ẏ‌ᡤ; ڼ.‍ẏ‌ᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+xn--vkb.xn--08e172a; ڼ.ẏᡤ; ; xn--vkb.xn--08e172a; ; ;  # ڼ.ẏᡤ
+ڼ.ẏᡤ; ; ; xn--vkb.xn--08e172a; ; ;  # ڼ.ẏᡤ
+ڼ.ẏᡤ; ڼ.ẏᡤ; ; xn--vkb.xn--08e172a; ; ;  # ڼ.ẏᡤ
+ڼ.Ẏᡤ; ڼ.ẏᡤ; ; xn--vkb.xn--08e172a; ; ;  # ڼ.ẏᡤ
+ڼ.Ẏᡤ; ڼ.ẏᡤ; ; xn--vkb.xn--08e172a; ; ;  # ڼ.ẏᡤ
+xn--vkb.xn--08e172ax6aca; ڼ.‍ẏ‌ᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; ;  # ڼ.ẏᡤ
+ڼ｡‍Ẏ‌ᡤ; ڼ.‍ẏ‌ᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+ڼ｡‍Ẏ‌ᡤ; ڼ.‍ẏ‌ᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+𐹹𑲛。񑂐්; 𐹹𑲛.񑂐්; [B1, P1, V6]; xn--xo0dg5v.xn--h1c39876d; ; ;  # 𐹹𑲛.්
+xn--xo0dg5v.xn--h1c39876d; 𐹹𑲛.񑂐්; [B1, V6]; xn--xo0dg5v.xn--h1c39876d; ; ;  # 𐹹𑲛.්
+-≠𑈵｡嵕ﻱ۴꥓; -≠𑈵.嵕ي۴꥓; [B1, B5, P1, V3, V6]; xn----ufo4749h.xn--mhb45a235sns3c; ; ;  # -≠𑈵.嵕ي۴꥓
+-≠𑈵｡嵕ﻱ۴꥓; -≠𑈵.嵕ي۴꥓; [B1, B5, P1, V3, V6]; xn----ufo4749h.xn--mhb45a235sns3c; ; ;  # -≠𑈵.嵕ي۴꥓
+-≠𑈵。嵕ي۴꥓; -≠𑈵.嵕ي۴꥓; [B1, B5, P1, V3, V6]; xn----ufo4749h.xn--mhb45a235sns3c; ; ;  # -≠𑈵.嵕ي۴꥓
+-≠𑈵。嵕ي۴꥓; -≠𑈵.嵕ي۴꥓; [B1, B5, P1, V3, V6]; xn----ufo4749h.xn--mhb45a235sns3c; ; ;  # -≠𑈵.嵕ي۴꥓
+xn----ufo4749h.xn--mhb45a235sns3c; -≠𑈵.嵕ي۴꥓; [B1, B5, V3, V6]; xn----ufo4749h.xn--mhb45a235sns3c; ; ;  # -≠𑈵.嵕ي۴꥓
+‌񍸰𐹶ݮ．ہ‍≯‍; ‌񍸰𐹶ݮ.ہ‍≯‍; [B1, B3, C1, C2, P1, V6]; xn--ypb717jrx2o7v94a.xn--0kb660ka35v; ; xn--ypb5875khz9y.xn--0kb682l; [B3, B5, B6, P1, V6] # 𐹶ݮ.ہ≯
+‌񍸰𐹶ݮ．ہ‍≯‍; ‌񍸰𐹶ݮ.ہ‍≯‍; [B1, B3, C1, C2, P1, V6]; xn--ypb717jrx2o7v94a.xn--0kb660ka35v; ; xn--ypb5875khz9y.xn--0kb682l; [B3, B5, B6, P1, V6] # 𐹶ݮ.ہ≯
+‌񍸰𐹶ݮ.ہ‍≯‍; ; [B1, B3, C1, C2, P1, V6]; xn--ypb717jrx2o7v94a.xn--0kb660ka35v; ; xn--ypb5875khz9y.xn--0kb682l; [B3, B5, B6, P1, V6] # 𐹶ݮ.ہ≯
+‌񍸰𐹶ݮ.ہ‍≯‍; ‌񍸰𐹶ݮ.ہ‍≯‍; [B1, B3, C1, C2, P1, V6]; xn--ypb717jrx2o7v94a.xn--0kb660ka35v; ; xn--ypb5875khz9y.xn--0kb682l; [B3, B5, B6, P1, V6] # 𐹶ݮ.ہ≯
+xn--ypb5875khz9y.xn--0kb682l; 񍸰𐹶ݮ.ہ≯; [B3, B5, B6, V6]; xn--ypb5875khz9y.xn--0kb682l; ; ;  # 𐹶ݮ.ہ≯
+xn--ypb717jrx2o7v94a.xn--0kb660ka35v; ‌񍸰𐹶ݮ.ہ‍≯‍; [B1, B3, C1, C2, V6]; xn--ypb717jrx2o7v94a.xn--0kb660ka35v; ; ;  # 𐹶ݮ.ہ≯
+≮．឵ࡕ𐫔; ≮.឵ࡕ𐫔; [B1, P1, V5, V6]; xn--gdh.xn--kwb589e217p; ; ;  # ≮.ࡕ𐫔
+≮．឵ࡕ𐫔; ≮.឵ࡕ𐫔; [B1, P1, V5, V6]; xn--gdh.xn--kwb589e217p; ; ;  # ≮.ࡕ𐫔
+≮.឵ࡕ𐫔; ; [B1, P1, V5, V6]; xn--gdh.xn--kwb589e217p; ; ;  # ≮.ࡕ𐫔
+≮.឵ࡕ𐫔; ≮.឵ࡕ𐫔; [B1, P1, V5, V6]; xn--gdh.xn--kwb589e217p; ; ;  # ≮.ࡕ𐫔
+xn--gdh.xn--kwb589e217p; ≮.឵ࡕ𐫔; [B1, V5, V6]; xn--gdh.xn--kwb589e217p; ; ;  # ≮.ࡕ𐫔
+𐩗‍｡ႩႵ; 𐩗‍.ႩႵ; [B3, C2, P1, V6]; xn--1ug4933g.xn--hndy; ; xn--pt9c.xn--hndy; [P1, V6] # 𐩗.ႩႵ
+𐩗‍。ႩႵ; 𐩗‍.ႩႵ; [B3, C2, P1, V6]; xn--1ug4933g.xn--hndy; ; xn--pt9c.xn--hndy; [P1, V6] # 𐩗.ႩႵ
+𐩗‍。ⴉⴕ; 𐩗‍.ⴉⴕ; [B3, C2]; xn--1ug4933g.xn--0kjya; ; xn--pt9c.xn--0kjya; [] # 𐩗.ⴉⴕ
+𐩗‍。Ⴉⴕ; 𐩗‍.Ⴉⴕ; [B3, C2, P1, V6]; xn--1ug4933g.xn--hnd666l; ; xn--pt9c.xn--hnd666l; [P1, V6] # 𐩗.Ⴉⴕ
+xn--pt9c.xn--hnd666l; 𐩗.Ⴉⴕ; [V6]; xn--pt9c.xn--hnd666l; ; ;  # 𐩗.Ⴉⴕ
+xn--1ug4933g.xn--hnd666l; 𐩗‍.Ⴉⴕ; [B3, C2, V6]; xn--1ug4933g.xn--hnd666l; ; ;  # 𐩗.Ⴉⴕ
+xn--pt9c.xn--0kjya; 𐩗.ⴉⴕ; ; xn--pt9c.xn--0kjya; ; ;  # 𐩗.ⴉⴕ
+𐩗.ⴉⴕ; ; ; xn--pt9c.xn--0kjya; ; ;  # 𐩗.ⴉⴕ
+𐩗.ႩႵ; ; [P1, V6]; xn--pt9c.xn--hndy; ; ;  # 𐩗.ႩႵ
+𐩗.Ⴉⴕ; ; [P1, V6]; xn--pt9c.xn--hnd666l; ; ;  # 𐩗.Ⴉⴕ
+xn--pt9c.xn--hndy; 𐩗.ႩႵ; [V6]; xn--pt9c.xn--hndy; ; ;  # 𐩗.ႩႵ
+xn--1ug4933g.xn--0kjya; 𐩗‍.ⴉⴕ; [B3, C2]; xn--1ug4933g.xn--0kjya; ; ;  # 𐩗.ⴉⴕ
+xn--1ug4933g.xn--hndy; 𐩗‍.ႩႵ; [B3, C2, V6]; xn--1ug4933g.xn--hndy; ; ;  # 𐩗.ႩႵ
+𐩗‍｡ⴉⴕ; 𐩗‍.ⴉⴕ; [B3, C2]; xn--1ug4933g.xn--0kjya; ; xn--pt9c.xn--0kjya; [] # 𐩗.ⴉⴕ
+𐩗‍｡Ⴉⴕ; 𐩗‍.Ⴉⴕ; [B3, C2, P1, V6]; xn--1ug4933g.xn--hnd666l; ; xn--pt9c.xn--hnd666l; [P1, V6] # 𐩗.Ⴉⴕ
+‌‌ㄤ．̮󕨑ূ; ‌‌ㄤ.̮󕨑ূ; [C1, P1, V5, V6]; xn--0uga242k.xn--vta284a9o563a; ; xn--1fk.xn--vta284a9o563a; [P1, V5, V6] # ㄤ.̮ূ
+‌‌ㄤ.̮󕨑ূ; ; [C1, P1, V5, V6]; xn--0uga242k.xn--vta284a9o563a; ; xn--1fk.xn--vta284a9o563a; [P1, V5, V6] # ㄤ.̮ূ
+xn--1fk.xn--vta284a9o563a; ㄤ.̮󕨑ূ; [V5, V6]; xn--1fk.xn--vta284a9o563a; ; ;  # ㄤ.̮ূ
+xn--0uga242k.xn--vta284a9o563a; ‌‌ㄤ.̮󕨑ূ; [C1, V5, V6]; xn--0uga242k.xn--vta284a9o563a; ; ;  # ㄤ.̮ূ
+𐋻｡-‌𐫄Ⴗ; 𐋻.-‌𐫄Ⴗ; [B1, C1, P1, V3, V6]; xn--v97c.xn----i1g888ih12u; ; xn--v97c.xn----i1g2513q; [B1, P1, V3, V6] # 𐋻.-𐫄Ⴗ
+𐋻。-‌𐫄Ⴗ; 𐋻.-‌𐫄Ⴗ; [B1, C1, P1, V3, V6]; xn--v97c.xn----i1g888ih12u; ; xn--v97c.xn----i1g2513q; [B1, P1, V3, V6] # 𐋻.-𐫄Ⴗ
+𐋻。-‌𐫄ⴗ; 𐋻.-‌𐫄ⴗ; [B1, C1, V3]; xn--v97c.xn----sgnv20du99s; ; xn--v97c.xn----lws0526f; [B1, V3] # 𐋻.-𐫄ⴗ
+xn--v97c.xn----lws0526f; 𐋻.-𐫄ⴗ; [B1, V3]; xn--v97c.xn----lws0526f; ; ;  # 𐋻.-𐫄ⴗ
+xn--v97c.xn----sgnv20du99s; 𐋻.-‌𐫄ⴗ; [B1, C1, V3]; xn--v97c.xn----sgnv20du99s; ; ;  # 𐋻.-𐫄ⴗ
+xn--v97c.xn----i1g2513q; 𐋻.-𐫄Ⴗ; [B1, V3, V6]; xn--v97c.xn----i1g2513q; ; ;  # 𐋻.-𐫄Ⴗ
+xn--v97c.xn----i1g888ih12u; 𐋻.-‌𐫄Ⴗ; [B1, C1, V3, V6]; xn--v97c.xn----i1g888ih12u; ; ;  # 𐋻.-𐫄Ⴗ
+𐋻｡-‌𐫄ⴗ; 𐋻.-‌𐫄ⴗ; [B1, C1, V3]; xn--v97c.xn----sgnv20du99s; ; xn--v97c.xn----lws0526f; [B1, V3] # 𐋻.-𐫄ⴗ
+🙑𐷺．≠‌; 🙑𐷺.≠‌; [B1, C1, P1, V6]; xn--bl0dh970b.xn--0ug83g; ; xn--bl0dh970b.xn--1ch; [B1, P1, V6] # 🙑.≠
+🙑𐷺．≠‌; 🙑𐷺.≠‌; [B1, C1, P1, V6]; xn--bl0dh970b.xn--0ug83g; ; xn--bl0dh970b.xn--1ch; [B1, P1, V6] # 🙑.≠
+🙑𐷺.≠‌; ; [B1, C1, P1, V6]; xn--bl0dh970b.xn--0ug83g; ; xn--bl0dh970b.xn--1ch; [B1, P1, V6] # 🙑.≠
+🙑𐷺.≠‌; 🙑𐷺.≠‌; [B1, C1, P1, V6]; xn--bl0dh970b.xn--0ug83g; ; xn--bl0dh970b.xn--1ch; [B1, P1, V6] # 🙑.≠
+xn--bl0dh970b.xn--1ch; 🙑𐷺.≠; [B1, V6]; xn--bl0dh970b.xn--1ch; ; ;  # 🙑.≠
+xn--bl0dh970b.xn--0ug83g; 🙑𐷺.≠‌; [B1, C1, V6]; xn--bl0dh970b.xn--0ug83g; ; ;  # 🙑.≠
+ٌ᳒｡𞮞⵿⧎; ٌ᳒.𞮞⵿⧎; [B1, B3, B6, P1, V5, V6]; xn--ohb646i.xn--ewi38jf765c; ; ;  # ٌ᳒.⵿⧎
+ٌ᳒。𞮞⵿⧎; ٌ᳒.𞮞⵿⧎; [B1, B3, B6, P1, V5, V6]; xn--ohb646i.xn--ewi38jf765c; ; ;  # ٌ᳒.⵿⧎
+xn--ohb646i.xn--ewi38jf765c; ٌ᳒.𞮞⵿⧎; [B1, B3, B6, V5, V6]; xn--ohb646i.xn--ewi38jf765c; ; ;  # ٌ᳒.⵿⧎
+Ⴔ𝨨₃󠁦．𝟳𑂹ஂ; Ⴔ𝨨3󠁦.7𑂹ஂ; [P1, V6]; xn--3-b1g83426a35t0g.xn--7-cve6271r; ; ;  # Ⴔ𝨨3.7𑂹ஂ
+Ⴔ𝨨3󠁦.7𑂹ஂ; ; [P1, V6]; xn--3-b1g83426a35t0g.xn--7-cve6271r; ; ;  # Ⴔ𝨨3.7𑂹ஂ
+ⴔ𝨨3󠁦.7𑂹ஂ; ; [P1, V6]; xn--3-ews6985n35s3g.xn--7-cve6271r; ; ;  # ⴔ𝨨3.7𑂹ஂ
+xn--3-ews6985n35s3g.xn--7-cve6271r; ⴔ𝨨3󠁦.7𑂹ஂ; [V6]; xn--3-ews6985n35s3g.xn--7-cve6271r; ; ;  # ⴔ𝨨3.7𑂹ஂ
+xn--3-b1g83426a35t0g.xn--7-cve6271r; Ⴔ𝨨3󠁦.7𑂹ஂ; [V6]; xn--3-b1g83426a35t0g.xn--7-cve6271r; ; ;  # Ⴔ𝨨3.7𑂹ஂ
+ⴔ𝨨₃󠁦．𝟳𑂹ஂ; ⴔ𝨨3󠁦.7𑂹ஂ; [P1, V6]; xn--3-ews6985n35s3g.xn--7-cve6271r; ; ;  # ⴔ𝨨3.7𑂹ஂ
+䏈‌。‌⒈񱢕; 䏈‌.‌⒈񱢕; [C1, P1, V6]; xn--0ug491l.xn--0ug88oot66q; ; xn--eco.xn--tsh21126d; [P1, V6] # 䏈.⒈
+䏈‌。‌1.񱢕; 䏈‌.‌1.񱢕; [C1, P1, V6]; xn--0ug491l.xn--1-rgn.xn--ms39a; ; xn--eco.1.xn--ms39a; [P1, V6] # 䏈.1.
+xn--eco.1.xn--ms39a; 䏈.1.񱢕; [V6]; xn--eco.1.xn--ms39a; ; ;  # 䏈.1.
+xn--0ug491l.xn--1-rgn.xn--ms39a; 䏈‌.‌1.񱢕; [C1, V6]; xn--0ug491l.xn--1-rgn.xn--ms39a; ; ;  # 䏈.1.
+xn--eco.xn--tsh21126d; 䏈.⒈񱢕; [V6]; xn--eco.xn--tsh21126d; ; ;  # 䏈.⒈
+xn--0ug491l.xn--0ug88oot66q; 䏈‌.‌⒈񱢕; [C1, V6]; xn--0ug491l.xn--0ug88oot66q; ; ;  # 䏈.⒈
+１꫶ß𑲥｡ᷘ; 1꫶ß𑲥.ᷘ; [V5]; xn--1-qfa2471kdb0d.xn--weg; ; xn--1ss-ir6ln166b.xn--weg;  # 1꫶ß𑲥.ᷘ
+1꫶ß𑲥。ᷘ; 1꫶ß𑲥.ᷘ; [V5]; xn--1-qfa2471kdb0d.xn--weg; ; xn--1ss-ir6ln166b.xn--weg;  # 1꫶ß𑲥.ᷘ
+1꫶SS𑲥。ᷘ; 1꫶ss𑲥.ᷘ; [V5]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+1꫶ss𑲥。ᷘ; 1꫶ss𑲥.ᷘ; [V5]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+xn--1ss-ir6ln166b.xn--weg; 1꫶ss𑲥.ᷘ; [V5]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+xn--1-qfa2471kdb0d.xn--weg; 1꫶ß𑲥.ᷘ; [V5]; xn--1-qfa2471kdb0d.xn--weg; ; ;  # 1꫶ß𑲥.ᷘ
+１꫶SS𑲥｡ᷘ; 1꫶ss𑲥.ᷘ; [V5]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+１꫶ss𑲥｡ᷘ; 1꫶ss𑲥.ᷘ; [V5]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+１꫶Ss𑲥｡ᷘ; 1꫶ss𑲥.ᷘ; [V5]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+1꫶Ss𑲥。ᷘ; 1꫶ss𑲥.ᷘ; [V5]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+‍񫶩𞪯್｡ݼ⒈; ‍񫶩𞪯್.ݼ⒈; [B1, C2, P1, V6]; xn--8tc969gzn94a4lm8a.xn--dqb689l; ; xn--8tc9875v5is1a.xn--dqb689l; [B5, B6, P1, V6] # ್.ݼ⒈
+‍񫶩𞪯್。ݼ1.; ‍񫶩𞪯್.ݼ1.; [B1, C2, P1, V6]; xn--8tc969gzn94a4lm8a.xn--1-g6c.; ; xn--8tc9875v5is1a.xn--1-g6c.; [B5, B6, P1, V6] # ್.ݼ1.
+xn--8tc9875v5is1a.xn--1-g6c.; 񫶩𞪯್.ݼ1.; [B5, B6, V6]; xn--8tc9875v5is1a.xn--1-g6c.; ; ;  # ್.ݼ1.
+xn--8tc969gzn94a4lm8a.xn--1-g6c.; ‍񫶩𞪯್.ݼ1.; [B1, C2, V6]; xn--8tc969gzn94a4lm8a.xn--1-g6c.; ; ;  # ್.ݼ1.
+xn--8tc9875v5is1a.xn--dqb689l; 񫶩𞪯್.ݼ⒈; [B5, B6, V6]; xn--8tc9875v5is1a.xn--dqb689l; ; ;  # ್.ݼ⒈
+xn--8tc969gzn94a4lm8a.xn--dqb689l; ‍񫶩𞪯್.ݼ⒈; [B1, C2, V6]; xn--8tc969gzn94a4lm8a.xn--dqb689l; ; ;  # ್.ݼ⒈
+᪶．𞤳򓢖򻉒ߗ; ᪶.𞤳򓢖򻉒ߗ; [B1, B2, B3, B6, P1, V5, V6]; xn--zqf.xn--ysb9657vuiz5bj0ep; ; ;  # ᪶.𞤳ߗ
+᪶.𞤳򓢖򻉒ߗ; ; [B1, B2, B3, B6, P1, V5, V6]; xn--zqf.xn--ysb9657vuiz5bj0ep; ; ;  # ᪶.𞤳ߗ
+᪶.𞤑򓢖򻉒ߗ; ᪶.𞤳򓢖򻉒ߗ; [B1, B2, B3, B6, P1, V5, V6]; xn--zqf.xn--ysb9657vuiz5bj0ep; ; ;  # ᪶.𞤳ߗ
+xn--zqf.xn--ysb9657vuiz5bj0ep; ᪶.𞤳򓢖򻉒ߗ; [B1, B2, B3, B6, V5, V6]; xn--zqf.xn--ysb9657vuiz5bj0ep; ; ;  # ᪶.𞤳ߗ
+᪶．𞤑򓢖򻉒ߗ; ᪶.𞤳򓢖򻉒ߗ; [B1, B2, B3, B6, P1, V5, V6]; xn--zqf.xn--ysb9657vuiz5bj0ep; ; ;  # ᪶.𞤳ߗ
+ࡂ𞩚⒈．󠬌８򏳏ݰ; ࡂ𞩚⒈.󠬌8򏳏ݰ; [B1, P1, V6]; xn--0vb095ldg52a.xn--8-s5c22427ox454a; ; ;  # ࡂ⒈.8ݰ
+ࡂ𞩚1..󠬌8򏳏ݰ; ; [B1, P1, V6, X4_2]; xn--1-rid26318a..xn--8-s5c22427ox454a; [B1, P1, V6, A4_2]; ;  # ࡂ1..8ݰ
+xn--1-rid26318a..xn--8-s5c22427ox454a; ࡂ𞩚1..󠬌8򏳏ݰ; [B1, V6, X4_2]; xn--1-rid26318a..xn--8-s5c22427ox454a; [B1, V6, A4_2]; ;  # ࡂ1..8ݰ
+xn--0vb095ldg52a.xn--8-s5c22427ox454a; ࡂ𞩚⒈.󠬌8򏳏ݰ; [B1, V6]; xn--0vb095ldg52a.xn--8-s5c22427ox454a; ; ;  # ࡂ⒈.8ݰ
+͡𐫫ͩᡷ。-󠰛鞰; ͡𐫫ͩᡷ.-󠰛鞰; [B1, P1, V3, V5, V6]; xn--cvaq482npv5t.xn----yg7dt1332g; ; ;  # ͡𐫫ͩᡷ.-鞰
+xn--cvaq482npv5t.xn----yg7dt1332g; ͡𐫫ͩᡷ.-󠰛鞰; [B1, V3, V5, V6]; xn--cvaq482npv5t.xn----yg7dt1332g; ; ;  # ͡𐫫ͩᡷ.-鞰
+-.્剘ß𐫃; ; [B1, V3, V5]; -.xn--zca791c493duf8i; ; -.xn--ss-bqg4734erywk;  # -.્剘ß𐫃
+-.્剘SS𐫃; -.્剘ss𐫃; [B1, V3, V5]; -.xn--ss-bqg4734erywk; ; ;  # -.્剘ss𐫃
+-.્剘ss𐫃; ; [B1, V3, V5]; -.xn--ss-bqg4734erywk; ; ;  # -.્剘ss𐫃
+-.્剘Ss𐫃; -.્剘ss𐫃; [B1, V3, V5]; -.xn--ss-bqg4734erywk; ; ;  # -.્剘ss𐫃
+-.xn--ss-bqg4734erywk; -.્剘ss𐫃; [B1, V3, V5]; -.xn--ss-bqg4734erywk; ; ;  # -.્剘ss𐫃
+-.xn--zca791c493duf8i; -.્剘ß𐫃; [B1, V3, V5]; -.xn--zca791c493duf8i; ; ;  # -.્剘ß𐫃
+ࣻ𞵸｡-; ࣻ𞵸.-; [B1, P1, V3, V5, V6]; xn--b1b2719v.-; ; ;  # ࣻ.-
+ࣻ𞵸。-; ࣻ𞵸.-; [B1, P1, V3, V5, V6]; xn--b1b2719v.-; ; ;  # ࣻ.-
+xn--b1b2719v.-; ࣻ𞵸.-; [B1, V3, V5, V6]; xn--b1b2719v.-; ; ;  # ࣻ.-
+⒈󠈻𐹲｡≠؃𐹽; ⒈󠈻𐹲.≠؃𐹽; [B1, P1, V6]; xn--tshw766f1153g.xn--lfb536lb35n; ; ;  # ⒈𐹲.≠𐹽
+⒈󠈻𐹲｡≠؃𐹽; ⒈󠈻𐹲.≠؃𐹽; [B1, P1, V6]; xn--tshw766f1153g.xn--lfb536lb35n; ; ;  # ⒈𐹲.≠𐹽
+1.󠈻𐹲。≠؃𐹽; 1.󠈻𐹲.≠؃𐹽; [B1, P1, V6]; 1.xn--qo0dl3077c.xn--lfb536lb35n; ; ;  # 1.𐹲.≠𐹽
+1.󠈻𐹲。≠؃𐹽; 1.󠈻𐹲.≠؃𐹽; [B1, P1, V6]; 1.xn--qo0dl3077c.xn--lfb536lb35n; ; ;  # 1.𐹲.≠𐹽
+1.xn--qo0dl3077c.xn--lfb536lb35n; 1.󠈻𐹲.≠؃𐹽; [B1, V6]; 1.xn--qo0dl3077c.xn--lfb536lb35n; ; ;  # 1.𐹲.≠𐹽
+xn--tshw766f1153g.xn--lfb536lb35n; ⒈󠈻𐹲.≠؃𐹽; [B1, V6]; xn--tshw766f1153g.xn--lfb536lb35n; ; ;  # ⒈𐹲.≠𐹽
+𐹢󠈚Ⴎ‌.㖾𐹡; ; [B1, B5, B6, C1, P1, V6]; xn--mnd289ezj4pqxp0i.xn--pelu572d; ; xn--mnd9001km0o0g.xn--pelu572d; [B1, B5, B6, P1, V6] # 𐹢Ⴎ.㖾𐹡
+𐹢󠈚ⴎ‌.㖾𐹡; ; [B1, B5, B6, C1, P1, V6]; xn--0ug342clq0pqxv4i.xn--pelu572d; ; xn--5kjx323em053g.xn--pelu572d; [B1, B5, B6, P1, V6] # 𐹢ⴎ.㖾𐹡
+xn--5kjx323em053g.xn--pelu572d; 𐹢󠈚ⴎ.㖾𐹡; [B1, B5, B6, V6]; xn--5kjx323em053g.xn--pelu572d; ; ;  # 𐹢ⴎ.㖾𐹡
+xn--0ug342clq0pqxv4i.xn--pelu572d; 𐹢󠈚ⴎ‌.㖾𐹡; [B1, B5, B6, C1, V6]; xn--0ug342clq0pqxv4i.xn--pelu572d; ; ;  # 𐹢ⴎ.㖾𐹡
+xn--mnd9001km0o0g.xn--pelu572d; 𐹢󠈚Ⴎ.㖾𐹡; [B1, B5, B6, V6]; xn--mnd9001km0o0g.xn--pelu572d; ; ;  # 𐹢Ⴎ.㖾𐹡
+xn--mnd289ezj4pqxp0i.xn--pelu572d; 𐹢󠈚Ⴎ‌.㖾𐹡; [B1, B5, B6, C1, V6]; xn--mnd289ezj4pqxp0i.xn--pelu572d; ; ;  # 𐹢Ⴎ.㖾𐹡
+򩼗．߇ᡖႳႧ; 򩼗.߇ᡖႳႧ; [B2, B3, P1, V6]; xn--te28c.xn--isb856b9a631d; ; ;  # .߇ᡖႳႧ
+򩼗.߇ᡖႳႧ; ; [B2, B3, P1, V6]; xn--te28c.xn--isb856b9a631d; ; ;  # .߇ᡖႳႧ
+򩼗.߇ᡖⴓⴇ; ; [B2, B3, P1, V6]; xn--te28c.xn--isb295fbtpmb; ; ;  # .߇ᡖⴓⴇ
+xn--te28c.xn--isb295fbtpmb; 򩼗.߇ᡖⴓⴇ; [B2, B3, V6]; xn--te28c.xn--isb295fbtpmb; ; ;  # .߇ᡖⴓⴇ
+xn--te28c.xn--isb856b9a631d; 򩼗.߇ᡖႳႧ; [B2, B3, V6]; xn--te28c.xn--isb856b9a631d; ; ;  # .߇ᡖႳႧ
+򩼗．߇ᡖⴓⴇ; 򩼗.߇ᡖⴓⴇ; [B2, B3, P1, V6]; xn--te28c.xn--isb295fbtpmb; ; ;  # .߇ᡖⴓⴇ
+򩼗.߇ᡖႳⴇ; ; [B2, B3, P1, V6]; xn--te28c.xn--isb286btrgo7w; ; ;  # .߇ᡖႳⴇ
+xn--te28c.xn--isb286btrgo7w; 򩼗.߇ᡖႳⴇ; [B2, B3, V6]; xn--te28c.xn--isb286btrgo7w; ; ;  # .߇ᡖႳⴇ
+򩼗．߇ᡖႳⴇ; 򩼗.߇ᡖႳⴇ; [B2, B3, P1, V6]; xn--te28c.xn--isb286btrgo7w; ; ;  # .߇ᡖႳⴇ
+‍􅍉.ڳݵ; ; [B1, C2, P1, V6]; xn--1ug39444n.xn--mkb20b; ; xn--3j78f.xn--mkb20b; [P1, V6] # .ڳݵ
+xn--3j78f.xn--mkb20b; 􅍉.ڳݵ; [V6]; xn--3j78f.xn--mkb20b; ; ;  # .ڳݵ
+xn--1ug39444n.xn--mkb20b; ‍􅍉.ڳݵ; [B1, C2, V6]; xn--1ug39444n.xn--mkb20b; ; ;  # .ڳݵ
+𲤱⒛⾳．ꡦ⒈; 𲤱⒛音.ꡦ⒈; [P1, V6]; xn--dth6033bzbvx.xn--tsh9439b; ; ;  # ⒛音.ꡦ⒈
+𲤱20.音.ꡦ1.; ; [P1, V6]; xn--20-9802c.xn--0w5a.xn--1-eg4e.; ; ;  # 20.音.ꡦ1.
+xn--20-9802c.xn--0w5a.xn--1-eg4e.; 𲤱20.音.ꡦ1.; [V6]; xn--20-9802c.xn--0w5a.xn--1-eg4e.; ; ;  # 20.音.ꡦ1.
+xn--dth6033bzbvx.xn--tsh9439b; 𲤱⒛音.ꡦ⒈; [V6]; xn--dth6033bzbvx.xn--tsh9439b; ; ;  # ⒛音.ꡦ⒈
+ߜ８񳦓-｡򞲙𑁿𐩥্; ߜ8񳦓-.򞲙𑁿𐩥্; [B2, B3, B5, B6, P1, V3, V6]; xn--8--rve13079p.xn--b7b9842k42df776x; ; ;  # ߜ8-.𑁿𐩥্
+ߜ8񳦓-。򞲙𑁿𐩥্; ߜ8񳦓-.򞲙𑁿𐩥্; [B2, B3, B5, B6, P1, V3, V6]; xn--8--rve13079p.xn--b7b9842k42df776x; ; ;  # ߜ8-.𑁿𐩥্
+xn--8--rve13079p.xn--b7b9842k42df776x; ߜ8񳦓-.򞲙𑁿𐩥্; [B2, B3, B5, B6, V3, V6]; xn--8--rve13079p.xn--b7b9842k42df776x; ; ;  # ߜ8-.𑁿𐩥্
+Ⴕ。۰≮ß݅; Ⴕ.۰≮ß݅; [P1, V6]; xn--tnd.xn--zca912alh227g; ; xn--tnd.xn--ss-jbe65aw27i;  # Ⴕ.۰≮ß݅
+Ⴕ。۰≮ß݅; Ⴕ.۰≮ß݅; [P1, V6]; xn--tnd.xn--zca912alh227g; ; xn--tnd.xn--ss-jbe65aw27i;  # Ⴕ.۰≮ß݅
+ⴕ。۰≮ß݅; ⴕ.۰≮ß݅; [P1, V6]; xn--dlj.xn--zca912alh227g; ; xn--dlj.xn--ss-jbe65aw27i;  # ⴕ.۰≮ß݅
+ⴕ。۰≮ß݅; ⴕ.۰≮ß݅; [P1, V6]; xn--dlj.xn--zca912alh227g; ; xn--dlj.xn--ss-jbe65aw27i;  # ⴕ.۰≮ß݅
+Ⴕ。۰≮SS݅; Ⴕ.۰≮ss݅; [P1, V6]; xn--tnd.xn--ss-jbe65aw27i; ; ;  # Ⴕ.۰≮ss݅
+Ⴕ。۰≮SS݅; Ⴕ.۰≮ss݅; [P1, V6]; xn--tnd.xn--ss-jbe65aw27i; ; ;  # Ⴕ.۰≮ss݅
+ⴕ。۰≮ss݅; ⴕ.۰≮ss݅; [P1, V6]; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+ⴕ。۰≮ss݅; ⴕ.۰≮ss݅; [P1, V6]; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+Ⴕ。۰≮Ss݅; Ⴕ.۰≮ss݅; [P1, V6]; xn--tnd.xn--ss-jbe65aw27i; ; ;  # Ⴕ.۰≮ss݅
+Ⴕ。۰≮Ss݅; Ⴕ.۰≮ss݅; [P1, V6]; xn--tnd.xn--ss-jbe65aw27i; ; ;  # Ⴕ.۰≮ss݅
+xn--tnd.xn--ss-jbe65aw27i; Ⴕ.۰≮ss݅; [V6]; xn--tnd.xn--ss-jbe65aw27i; ; ;  # Ⴕ.۰≮ss݅
+xn--dlj.xn--ss-jbe65aw27i; ⴕ.۰≮ss݅; [V6]; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+xn--dlj.xn--zca912alh227g; ⴕ.۰≮ß݅; [V6]; xn--dlj.xn--zca912alh227g; ; ;  # ⴕ.۰≮ß݅
+xn--tnd.xn--zca912alh227g; Ⴕ.۰≮ß݅; [V6]; xn--tnd.xn--zca912alh227g; ; ;  # Ⴕ.۰≮ß݅
+ߩ-.𝨗꒱᭲; ; [B1, B3, V3, V5]; xn----odd.xn--dwf8994dc8wj; ; ;  # ߩ-.𝨗꒱᭲
+xn----odd.xn--dwf8994dc8wj; ߩ-.𝨗꒱᭲; [B1, B3, V3, V5]; xn----odd.xn--dwf8994dc8wj; ; ;  # ߩ-.𝨗꒱᭲
+𞼸‌.≯䕵⫧; ; [B1, B3, C1, P1, V6]; xn--0ugx453p.xn--hdh754ax6w; ; xn--sn7h.xn--hdh754ax6w; [B1, P1, V6] # .≯䕵⫧
+𞼸‌.≯䕵⫧; 𞼸‌.≯䕵⫧; [B1, B3, C1, P1, V6]; xn--0ugx453p.xn--hdh754ax6w; ; xn--sn7h.xn--hdh754ax6w; [B1, P1, V6] # .≯䕵⫧
+xn--sn7h.xn--hdh754ax6w; 𞼸.≯䕵⫧; [B1, V6]; xn--sn7h.xn--hdh754ax6w; ; ;  # .≯䕵⫧
+xn--0ugx453p.xn--hdh754ax6w; 𞼸‌.≯䕵⫧; [B1, B3, C1, V6]; xn--0ugx453p.xn--hdh754ax6w; ; ;  # .≯䕵⫧
+𐨅ßﱗ.ڬ۳︒; 𐨅ßيخ.ڬ۳︒; [B1, B3, P1, V5, V6]; xn--zca23yncs877j.xn--fkb6lp314e; ; xn--ss-ytd5i7765l.xn--fkb6lp314e;  # 𐨅ßيخ.ڬ۳︒
+𐨅ßيخ.ڬ۳。; 𐨅ßيخ.ڬ۳.; [B1, V5]; xn--zca23yncs877j.xn--fkb6l.; ; xn--ss-ytd5i7765l.xn--fkb6l.;  # 𐨅ßيخ.ڬ۳.
+𐨅SSيخ.ڬ۳。; 𐨅ssيخ.ڬ۳.; [B1, V5]; xn--ss-ytd5i7765l.xn--fkb6l.; ; ;  # 𐨅ssيخ.ڬ۳.
+𐨅ssيخ.ڬ۳。; 𐨅ssيخ.ڬ۳.; [B1, V5]; xn--ss-ytd5i7765l.xn--fkb6l.; ; ;  # 𐨅ssيخ.ڬ۳.
+𐨅Ssيخ.ڬ۳。; 𐨅ssيخ.ڬ۳.; [B1, V5]; xn--ss-ytd5i7765l.xn--fkb6l.; ; ;  # 𐨅ssيخ.ڬ۳.
+xn--ss-ytd5i7765l.xn--fkb6l.; 𐨅ssيخ.ڬ۳.; [B1, V5]; xn--ss-ytd5i7765l.xn--fkb6l.; ; ;  # 𐨅ssيخ.ڬ۳.
+xn--zca23yncs877j.xn--fkb6l.; 𐨅ßيخ.ڬ۳.; [B1, V5]; xn--zca23yncs877j.xn--fkb6l.; ; ;  # 𐨅ßيخ.ڬ۳.
+𐨅SSﱗ.ڬ۳︒; 𐨅ssيخ.ڬ۳︒; [B1, B3, P1, V5, V6]; xn--ss-ytd5i7765l.xn--fkb6lp314e; ; ;  # 𐨅ssيخ.ڬ۳︒
+𐨅ssﱗ.ڬ۳︒; 𐨅ssيخ.ڬ۳︒; [B1, B3, P1, V5, V6]; xn--ss-ytd5i7765l.xn--fkb6lp314e; ; ;  # 𐨅ssيخ.ڬ۳︒
+𐨅Ssﱗ.ڬ۳︒; 𐨅ssيخ.ڬ۳︒; [B1, B3, P1, V5, V6]; xn--ss-ytd5i7765l.xn--fkb6lp314e; ; ;  # 𐨅ssيخ.ڬ۳︒
+xn--ss-ytd5i7765l.xn--fkb6lp314e; 𐨅ssيخ.ڬ۳︒; [B1, B3, V5, V6]; xn--ss-ytd5i7765l.xn--fkb6lp314e; ; ;  # 𐨅ssيخ.ڬ۳︒
+xn--zca23yncs877j.xn--fkb6lp314e; 𐨅ßيخ.ڬ۳︒; [B1, B3, V5, V6]; xn--zca23yncs877j.xn--fkb6lp314e; ; ;  # 𐨅ßيخ.ڬ۳︒
+-≮🡒᳭.񏿾Ⴁܔ; ; [B1, P1, V3, V6]; xn----44l04zxt68c.xn--enb300c1597h; ; ;  # -≮🡒᳭.Ⴁܔ
+-≮🡒᳭.񏿾Ⴁܔ; -≮🡒᳭.񏿾Ⴁܔ; [B1, P1, V3, V6]; xn----44l04zxt68c.xn--enb300c1597h; ; ;  # -≮🡒᳭.Ⴁܔ
+-≮🡒᳭.񏿾ⴁܔ; -≮🡒᳭.񏿾ⴁܔ; [B1, P1, V3, V6]; xn----44l04zxt68c.xn--enb135qf106f; ; ;  # -≮🡒᳭.ⴁܔ
+-≮🡒᳭.񏿾ⴁܔ; ; [B1, P1, V3, V6]; xn----44l04zxt68c.xn--enb135qf106f; ; ;  # -≮🡒᳭.ⴁܔ
+xn----44l04zxt68c.xn--enb135qf106f; -≮🡒᳭.񏿾ⴁܔ; [B1, V3, V6]; xn----44l04zxt68c.xn--enb135qf106f; ; ;  # -≮🡒᳭.ⴁܔ
+xn----44l04zxt68c.xn--enb300c1597h; -≮🡒᳭.񏿾Ⴁܔ; [B1, V3, V6]; xn----44l04zxt68c.xn--enb300c1597h; ; ;  # -≮🡒᳭.Ⴁܔ
+𞤨｡ꡏ‍‌; 𞤨.ꡏ‍‌; [B6, C1, C2]; xn--ge6h.xn--0ugb9575h; ; xn--ge6h.xn--oc9a; [] # 𞤨.ꡏ
+𞤨。ꡏ‍‌; 𞤨.ꡏ‍‌; [B6, C1, C2]; xn--ge6h.xn--0ugb9575h; ; xn--ge6h.xn--oc9a; [] # 𞤨.ꡏ
+𞤆。ꡏ‍‌; 𞤨.ꡏ‍‌; [B6, C1, C2]; xn--ge6h.xn--0ugb9575h; ; xn--ge6h.xn--oc9a; [] # 𞤨.ꡏ
+xn--ge6h.xn--oc9a; 𞤨.ꡏ; ; xn--ge6h.xn--oc9a; ; ;  # 𞤨.ꡏ
+𞤨.ꡏ; ; ; xn--ge6h.xn--oc9a; ; ;  # 𞤨.ꡏ
+𞤆.ꡏ; 𞤨.ꡏ; ; xn--ge6h.xn--oc9a; ; ;  # 𞤨.ꡏ
+xn--ge6h.xn--0ugb9575h; 𞤨.ꡏ‍‌; [B6, C1, C2]; xn--ge6h.xn--0ugb9575h; ; ;  # 𞤨.ꡏ
+𞤆｡ꡏ‍‌; 𞤨.ꡏ‍‌; [B6, C1, C2]; xn--ge6h.xn--0ugb9575h; ; xn--ge6h.xn--oc9a; [] # 𞤨.ꡏ
+󠅹𑂶．ᢌ𑂹٩; 𑂶.ᢌ𑂹٩; [B1, B3, B5, B6, V5]; xn--b50d.xn--iib993gyp5p; ; ;  # 𑂶.ᢌ𑂹٩
+󠅹𑂶.ᢌ𑂹٩; 𑂶.ᢌ𑂹٩; [B1, B3, B5, B6, V5]; xn--b50d.xn--iib993gyp5p; ; ;  # 𑂶.ᢌ𑂹٩
+xn--b50d.xn--iib993gyp5p; 𑂶.ᢌ𑂹٩; [B1, B3, B5, B6, V5]; xn--b50d.xn--iib993gyp5p; ; ;  # 𑂶.ᢌ𑂹٩
+Ⅎ󠅺񝵒。≯⾑; Ⅎ񝵒.≯襾; [P1, V6]; xn--f3g73398c.xn--hdhz171b; ; ;  # Ⅎ.≯襾
+Ⅎ󠅺񝵒。≯⾑; Ⅎ񝵒.≯襾; [P1, V6]; xn--f3g73398c.xn--hdhz171b; ; ;  # Ⅎ.≯襾
+Ⅎ󠅺񝵒。≯襾; Ⅎ񝵒.≯襾; [P1, V6]; xn--f3g73398c.xn--hdhz171b; ; ;  # Ⅎ.≯襾
+Ⅎ󠅺񝵒。≯襾; Ⅎ񝵒.≯襾; [P1, V6]; xn--f3g73398c.xn--hdhz171b; ; ;  # Ⅎ.≯襾
+ⅎ󠅺񝵒。≯襾; ⅎ񝵒.≯襾; [P1, V6]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+ⅎ󠅺񝵒。≯襾; ⅎ񝵒.≯襾; [P1, V6]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+xn--73g39298c.xn--hdhz171b; ⅎ񝵒.≯襾; [V6]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+xn--f3g73398c.xn--hdhz171b; Ⅎ񝵒.≯襾; [V6]; xn--f3g73398c.xn--hdhz171b; ; ;  # Ⅎ.≯襾
+ⅎ󠅺񝵒。≯⾑; ⅎ񝵒.≯襾; [P1, V6]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+ⅎ󠅺񝵒。≯⾑; ⅎ񝵒.≯襾; [P1, V6]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+ς‍ු٠｡-; ς‍ු٠.-; [B1, B5, B6, C2, V3]; xn--3xa45ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # ςු٠.-
+ς‍ු٠。-; ς‍ු٠.-; [B1, B5, B6, C2, V3]; xn--3xa45ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # ςු٠.-
+Σ‍ු٠。-; σ‍ු٠.-; [B1, B5, B6, C2, V3]; xn--4xa25ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # σු٠.-
+σ‍ු٠。-; σ‍ු٠.-; [B1, B5, B6, C2, V3]; xn--4xa25ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # σු٠.-
+xn--4xa25ks2j.-; σු٠.-; [B1, B5, B6, V3]; xn--4xa25ks2j.-; ; ;  # σු٠.-
+xn--4xa25ks2jenu.-; σ‍ු٠.-; [B1, B5, B6, C2, V3]; xn--4xa25ks2jenu.-; ; ;  # σු٠.-
+xn--3xa45ks2jenu.-; ς‍ු٠.-; [B1, B5, B6, C2, V3]; xn--3xa45ks2jenu.-; ; ;  # ςු٠.-
+Σ‍ු٠｡-; σ‍ු٠.-; [B1, B5, B6, C2, V3]; xn--4xa25ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # σු٠.-
+σ‍ු٠｡-; σ‍ු٠.-; [B1, B5, B6, C2, V3]; xn--4xa25ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # σු٠.-
+‌.ßႩ-; ; [C1, P1, V3, V6]; xn--0ug.xn----pfa042j; ; .xn--ss--4rn; [P1, V3, V6, A4_2] # .ßႩ-
+‌.ßⴉ-; ; [C1, V3]; xn--0ug.xn----pfa2305a; ; .xn--ss--bi1b; [V3, A4_2] # .ßⴉ-
+‌.SSႩ-; ‌.ssႩ-; [C1, P1, V3, V6]; xn--0ug.xn--ss--4rn; ; .xn--ss--4rn; [P1, V3, V6, A4_2] # .ssႩ-
+‌.ssⴉ-; ; [C1, V3]; xn--0ug.xn--ss--bi1b; ; .xn--ss--bi1b; [V3, A4_2] # .ssⴉ-
+‌.Ssⴉ-; ‌.ssⴉ-; [C1, V3]; xn--0ug.xn--ss--bi1b; ; .xn--ss--bi1b; [V3, A4_2] # .ssⴉ-
+.xn--ss--bi1b; .ssⴉ-; [V3, X4_2]; .xn--ss--bi1b; [V3, A4_2]; ;  # .ssⴉ-
+xn--0ug.xn--ss--bi1b; ‌.ssⴉ-; [C1, V3]; xn--0ug.xn--ss--bi1b; ; ;  # .ssⴉ-
+.xn--ss--4rn; .ssႩ-; [V3, V6, X4_2]; .xn--ss--4rn; [V3, V6, A4_2]; ;  # .ssႩ-
+xn--0ug.xn--ss--4rn; ‌.ssႩ-; [C1, V3, V6]; xn--0ug.xn--ss--4rn; ; ;  # .ssႩ-
+xn--0ug.xn----pfa2305a; ‌.ßⴉ-; [C1, V3]; xn--0ug.xn----pfa2305a; ; ;  # .ßⴉ-
+xn--0ug.xn----pfa042j; ‌.ßႩ-; [C1, V3, V6]; xn--0ug.xn----pfa042j; ; ;  # .ßႩ-
+󍭲𐫍㓱。⾑; 󍭲𐫍㓱.襾; [B5, P1, V6]; xn--u7kt691dlj09f.xn--9v2a; ; ;  # 𐫍㓱.襾
+󍭲𐫍㓱。襾; 󍭲𐫍㓱.襾; [B5, P1, V6]; xn--u7kt691dlj09f.xn--9v2a; ; ;  # 𐫍㓱.襾
+xn--u7kt691dlj09f.xn--9v2a; 󍭲𐫍㓱.襾; [B5, V6]; xn--u7kt691dlj09f.xn--9v2a; ; ;  # 𐫍㓱.襾
+ڠ𐮋𐹰≮。≯󠦗‍; ڠ𐮋𐹰≮.≯󠦗‍; [B1, B3, C2, P1, V6]; xn--2jb053lf13nyoc.xn--1ugx6gc8096c; ; xn--2jb053lf13nyoc.xn--hdh08821l; [B1, B3, P1, V6] # ڠ𐮋𐹰≮.≯
+ڠ𐮋𐹰≮。≯󠦗‍; ڠ𐮋𐹰≮.≯󠦗‍; [B1, B3, C2, P1, V6]; xn--2jb053lf13nyoc.xn--1ugx6gc8096c; ; xn--2jb053lf13nyoc.xn--hdh08821l; [B1, B3, P1, V6] # ڠ𐮋𐹰≮.≯
+xn--2jb053lf13nyoc.xn--hdh08821l; ڠ𐮋𐹰≮.≯󠦗; [B1, B3, V6]; xn--2jb053lf13nyoc.xn--hdh08821l; ; ;  # ڠ𐮋𐹰≮.≯
+xn--2jb053lf13nyoc.xn--1ugx6gc8096c; ڠ𐮋𐹰≮.≯󠦗‍; [B1, B3, C2, V6]; xn--2jb053lf13nyoc.xn--1ugx6gc8096c; ; ;  # ڠ𐮋𐹰≮.≯
+𝟞｡񃰶ݷࢰ⩋; 6.񃰶ݷࢰ⩋; [B1, B5, B6, P1, V6]; 6.xn--7pb04do15eq748f; ; ;  # 6.ݷࢰ⩋
+6。񃰶ݷࢰ⩋; 6.񃰶ݷࢰ⩋; [B1, B5, B6, P1, V6]; 6.xn--7pb04do15eq748f; ; ;  # 6.ݷࢰ⩋
+6.xn--7pb04do15eq748f; 6.񃰶ݷࢰ⩋; [B1, B5, B6, V6]; 6.xn--7pb04do15eq748f; ; ;  # 6.ݷࢰ⩋
+-ﳽ。𑇀𑍴; -شى.𑇀𑍴; [B1, V3, V5]; xn----qnc7d.xn--wd1d62a; ; ;  # -شى.𑇀𑍴
+-ﳽ。𑇀𑍴; -شى.𑇀𑍴; [B1, V3, V5]; xn----qnc7d.xn--wd1d62a; ; ;  # -شى.𑇀𑍴
+-شى。𑇀𑍴; -شى.𑇀𑍴; [B1, V3, V5]; xn----qnc7d.xn--wd1d62a; ; ;  # -شى.𑇀𑍴
+xn----qnc7d.xn--wd1d62a; -شى.𑇀𑍴; [B1, V3, V5]; xn----qnc7d.xn--wd1d62a; ; ;  # -شى.𑇀𑍴
+‌󠊶𝟏.ൃ򪥐𐹬󊓶; ‌󠊶1.ൃ򪥐𐹬󊓶; [B1, C1, P1, V5, V6]; xn--1-rgnu0071n.xn--mxc0872kcu37dnmem; ; xn--1-f521m.xn--mxc0872kcu37dnmem; [B1, P1, V5, V6] # 1.ൃ𐹬
+‌󠊶1.ൃ򪥐𐹬󊓶; ; [B1, C1, P1, V5, V6]; xn--1-rgnu0071n.xn--mxc0872kcu37dnmem; ; xn--1-f521m.xn--mxc0872kcu37dnmem; [B1, P1, V5, V6] # 1.ൃ𐹬
+xn--1-f521m.xn--mxc0872kcu37dnmem; 󠊶1.ൃ򪥐𐹬󊓶; [B1, V5, V6]; xn--1-f521m.xn--mxc0872kcu37dnmem; ; ;  # 1.ൃ𐹬
+xn--1-rgnu0071n.xn--mxc0872kcu37dnmem; ‌󠊶1.ൃ򪥐𐹬󊓶; [B1, C1, V5, V6]; xn--1-rgnu0071n.xn--mxc0872kcu37dnmem; ; ;  # 1.ൃ𐹬
+齙--𝟰.ß; 齙--4.ß; ; xn----4-p16k.xn--zca; ; xn----4-p16k.ss;  # 齙--4.ß
+齙--4.ß; ; ; xn----4-p16k.xn--zca; ; xn----4-p16k.ss;  # 齙--4.ß
+齙--4.SS; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+齙--4.ss; ; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+齙--4.Ss; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+xn----4-p16k.ss; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+xn----4-p16k.xn--zca; 齙--4.ß; ; xn----4-p16k.xn--zca; ; ;  # 齙--4.ß
+齙--𝟰.SS; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+齙--𝟰.ss; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+齙--𝟰.Ss; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+᯲.𐹢𞀖‌; ; [B1, C1, V5]; xn--0zf.xn--0ug9894grqqf; ; xn--0zf.xn--9n0d2296a; [B1, V5] # ᯲.𐹢𞀖
+xn--0zf.xn--9n0d2296a; ᯲.𐹢𞀖; [B1, V5]; xn--0zf.xn--9n0d2296a; ; ;  # ᯲.𐹢𞀖
+xn--0zf.xn--0ug9894grqqf; ᯲.𐹢𞀖‌; [B1, C1, V5]; xn--0zf.xn--0ug9894grqqf; ; ;  # ᯲.𐹢𞀖
+󃲙󠋘｡?-‍; 󃲙󠋘.?-‍; [C2, P1, V6]; xn--ct86d8w51a.?-‍; [C2, P1, V6, A3]; xn--ct86d8w51a.?-; [P1, V3, V6, A3] # .-
+󃲙󠋘。?-‍; 󃲙󠋘.?-‍; [C2, P1, V6]; xn--ct86d8w51a.?-‍; [C2, P1, V6, A3]; xn--ct86d8w51a.?-; [P1, V3, V6, A3] # .-
+xn--ct86d8w51a.?-; 󃲙󠋘.?-; [P1, V3, V6]; xn--ct86d8w51a.?-; [P1, V3, V6, A3]; ;  # .-
+XN--CT86D8W51A.?-; 󃲙󠋘.?-; [P1, V3, V6]; xn--ct86d8w51a.?-; [P1, V3, V6, A3]; ;  # .-
+Xn--Ct86d8w51a.?-; 󃲙󠋘.?-; [P1, V3, V6]; xn--ct86d8w51a.?-; [P1, V3, V6, A3]; ;  # .-
+xn--ct86d8w51a.?-‍; 󃲙󠋘.?-‍; [C2, P1, V6]; xn--ct86d8w51a.?-‍; [C2, P1, V6, A3]; xn--ct86d8w51a.?-; [P1, V3, V6, A3] # .-
+XN--CT86D8W51A.?-‍; 󃲙󠋘.?-‍; [C2, P1, V6]; xn--ct86d8w51a.?-‍; [C2, P1, V6, A3]; xn--ct86d8w51a.?-; [P1, V3, V6, A3] # .-
+Xn--Ct86d8w51a.?-‍; 󃲙󠋘.?-‍; [C2, P1, V6]; xn--ct86d8w51a.?-‍; [C2, P1, V6, A3]; xn--ct86d8w51a.?-; [P1, V3, V6, A3] # .-
+᩠．𞵷-𝪩悎; ᩠.𞵷-𝪩悎; [B1, B2, B3, B6, P1, V5, V6]; xn--jof.xn----gf4bq282iezpa; ; ;  # ᩠.-𝪩悎
+᩠.𞵷-𝪩悎; ; [B1, B2, B3, B6, P1, V5, V6]; xn--jof.xn----gf4bq282iezpa; ; ;  # ᩠.-𝪩悎
+xn--jof.xn----gf4bq282iezpa; ᩠.𞵷-𝪩悎; [B1, B2, B3, B6, V5, V6]; xn--jof.xn----gf4bq282iezpa; ; ;  # ᩠.-𝪩悎
+𛜯󠊛．𞤳񏥾; 𛜯󠊛.𞤳񏥾; [B2, B3, B6, P1, V6]; xn--xx5gy2741c.xn--re6hw266j; ; ;  # .𞤳
+𛜯󠊛.𞤳񏥾; ; [B2, B3, B6, P1, V6]; xn--xx5gy2741c.xn--re6hw266j; ; ;  # .𞤳
+𛜯󠊛.𞤑񏥾; 𛜯󠊛.𞤳񏥾; [B2, B3, B6, P1, V6]; xn--xx5gy2741c.xn--re6hw266j; ; ;  # .𞤳
+xn--xx5gy2741c.xn--re6hw266j; 𛜯󠊛.𞤳񏥾; [B2, B3, B6, V6]; xn--xx5gy2741c.xn--re6hw266j; ; ;  # .𞤳
+𛜯󠊛．𞤑񏥾; 𛜯󠊛.𞤳񏥾; [B2, B3, B6, P1, V6]; xn--xx5gy2741c.xn--re6hw266j; ; ;  # .𞤳
+ܜ𐫒خ.𐋲; ; [B1]; xn--tgb98b8643d.xn--m97c; ; ;  # ܜ𐫒خ.𐋲
+xn--tgb98b8643d.xn--m97c; ܜ𐫒خ.𐋲; [B1]; xn--tgb98b8643d.xn--m97c; ; ;  # ܜ𐫒خ.𐋲
+𐼑𞤓ط࣢.?; 𐼑𞤵ط࣢.?; [P1, V6]; xn--2gb08k9w69agm0g.?; [P1, V6, A3]; ;  # 𐼑𞤵ط.
+𐼑𞤵ط࣢.?; ; [P1, V6]; xn--2gb08k9w69agm0g.?; [P1, V6, A3]; ;  # 𐼑𞤵ط.
+xn--2gb08k9w69agm0g.?; 𐼑𞤵ط࣢.?; [P1, V6]; xn--2gb08k9w69agm0g.?; [P1, V6, A3]; ;  # 𐼑𞤵ط.
+XN--2GB08K9W69AGM0G.?; 𐼑𞤵ط࣢.?; [P1, V6]; xn--2gb08k9w69agm0g.?; [P1, V6, A3]; ;  # 𐼑𞤵ط.
+Xn--2gb08k9w69agm0g.?; 𐼑𞤵ط࣢.?; [P1, V6]; xn--2gb08k9w69agm0g.?; [P1, V6, A3]; ;  # 𐼑𞤵ط.
+Ↄ。᳔੍𞷣; Ↄ.᳔੍𞷣; [B1, P1, V5, V6]; xn--q5g.xn--ybc995g0835a; ; ;  # Ↄ.᳔੍
+Ↄ。᳔੍𞷣; Ↄ.᳔੍𞷣; [B1, P1, V5, V6]; xn--q5g.xn--ybc995g0835a; ; ;  # Ↄ.᳔੍
+ↄ。᳔੍𞷣; ↄ.᳔੍𞷣; [B1, P1, V5, V6]; xn--r5g.xn--ybc995g0835a; ; ;  # ↄ.᳔੍
+xn--r5g.xn--ybc995g0835a; ↄ.᳔੍𞷣; [B1, V5, V6]; xn--r5g.xn--ybc995g0835a; ; ;  # ↄ.᳔੍
+xn--q5g.xn--ybc995g0835a; Ↄ.᳔੍𞷣; [B1, V5, V6]; xn--q5g.xn--ybc995g0835a; ; ;  # Ↄ.᳔੍
+ↄ。᳔੍𞷣; ↄ.᳔੍𞷣; [B1, P1, V5, V6]; xn--r5g.xn--ybc995g0835a; ; ;  # ↄ.᳔੍
+󠪢-。򛂏≮𑜫; 󠪢-.򛂏≮𑜫; [P1, V3, V6]; xn----bh61m.xn--gdhz157g0em1d; ; ;  # -.≮𑜫
+󠪢-。򛂏≮𑜫; 󠪢-.򛂏≮𑜫; [P1, V3, V6]; xn----bh61m.xn--gdhz157g0em1d; ; ;  # -.≮𑜫
+xn----bh61m.xn--gdhz157g0em1d; 󠪢-.򛂏≮𑜫; [V3, V6]; xn----bh61m.xn--gdhz157g0em1d; ; ;  # -.≮𑜫
+‌󠉹‍。򌿧≮Ⴉ; ‌󠉹‍.򌿧≮Ⴉ; [C1, C2, P1, V6]; xn--0ugc90904y.xn--hnd112gpz83n; ; xn--3n36e.xn--hnd112gpz83n; [P1, V6] # .≮Ⴉ
+‌󠉹‍。򌿧≮Ⴉ; ‌󠉹‍.򌿧≮Ⴉ; [C1, C2, P1, V6]; xn--0ugc90904y.xn--hnd112gpz83n; ; xn--3n36e.xn--hnd112gpz83n; [P1, V6] # .≮Ⴉ
+‌󠉹‍。򌿧≮ⴉ; ‌󠉹‍.򌿧≮ⴉ; [C1, C2, P1, V6]; xn--0ugc90904y.xn--gdh992byu01p; ; xn--3n36e.xn--gdh992byu01p; [P1, V6] # .≮ⴉ
+‌󠉹‍。򌿧≮ⴉ; ‌󠉹‍.򌿧≮ⴉ; [C1, C2, P1, V6]; xn--0ugc90904y.xn--gdh992byu01p; ; xn--3n36e.xn--gdh992byu01p; [P1, V6] # .≮ⴉ
+xn--3n36e.xn--gdh992byu01p; 󠉹.򌿧≮ⴉ; [V6]; xn--3n36e.xn--gdh992byu01p; ; ;  # .≮ⴉ
+xn--0ugc90904y.xn--gdh992byu01p; ‌󠉹‍.򌿧≮ⴉ; [C1, C2, V6]; xn--0ugc90904y.xn--gdh992byu01p; ; ;  # .≮ⴉ
+xn--3n36e.xn--hnd112gpz83n; 󠉹.򌿧≮Ⴉ; [V6]; xn--3n36e.xn--hnd112gpz83n; ; ;  # .≮Ⴉ
+xn--0ugc90904y.xn--hnd112gpz83n; ‌󠉹‍.򌿧≮Ⴉ; [C1, C2, V6]; xn--0ugc90904y.xn--hnd112gpz83n; ; ;  # .≮Ⴉ
+𐹯-𑄴ࢼ。︒䖐⾆; 𐹯-𑄴ࢼ.︒䖐舌; [B1, P1, V6]; xn----rpd7902rclc.xn--fpo216mn07e; ; ;  # 𐹯-𑄴ࢼ.︒䖐舌
+𐹯-𑄴ࢼ。。䖐舌; 𐹯-𑄴ࢼ..䖐舌; [B1, X4_2]; xn----rpd7902rclc..xn--fpo216m; [B1, A4_2]; ;  # 𐹯-𑄴ࢼ..䖐舌
+xn----rpd7902rclc..xn--fpo216m; 𐹯-𑄴ࢼ..䖐舌; [B1, X4_2]; xn----rpd7902rclc..xn--fpo216m; [B1, A4_2]; ;  # 𐹯-𑄴ࢼ..䖐舌
+xn----rpd7902rclc.xn--fpo216mn07e; 𐹯-𑄴ࢼ.︒䖐舌; [B1, V6]; xn----rpd7902rclc.xn--fpo216mn07e; ; ;  # 𐹯-𑄴ࢼ.︒䖐舌
+𝪞Ⴐ｡쪡; 𝪞Ⴐ.쪡; [P1, V5, V6]; xn--ond3755u.xn--pi6b; ; ;  # 𝪞Ⴐ.쪡
+𝪞Ⴐ｡쪡; 𝪞Ⴐ.쪡; [P1, V5, V6]; xn--ond3755u.xn--pi6b; ; ;  # 𝪞Ⴐ.쪡
+𝪞Ⴐ。쪡; 𝪞Ⴐ.쪡; [P1, V5, V6]; xn--ond3755u.xn--pi6b; ; ;  # 𝪞Ⴐ.쪡
+𝪞Ⴐ。쪡; 𝪞Ⴐ.쪡; [P1, V5, V6]; xn--ond3755u.xn--pi6b; ; ;  # 𝪞Ⴐ.쪡
+𝪞ⴐ。쪡; 𝪞ⴐ.쪡; [V5]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+𝪞ⴐ。쪡; 𝪞ⴐ.쪡; [V5]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+xn--7kj1858k.xn--pi6b; 𝪞ⴐ.쪡; [V5]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+xn--ond3755u.xn--pi6b; 𝪞Ⴐ.쪡; [V5, V6]; xn--ond3755u.xn--pi6b; ; ;  # 𝪞Ⴐ.쪡
+𝪞ⴐ｡쪡; 𝪞ⴐ.쪡; [V5]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+𝪞ⴐ｡쪡; 𝪞ⴐ.쪡; [V5]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+ฺ쩁𐹬.􋉳; ; [B1, P1, V5, V6]; xn--o4c4837g2zvb.xn--5f70g; ; ;  # ฺ쩁𐹬.
+ฺ쩁𐹬.􋉳; ฺ쩁𐹬.􋉳; [B1, P1, V5, V6]; xn--o4c4837g2zvb.xn--5f70g; ; ;  # ฺ쩁𐹬.
+xn--o4c4837g2zvb.xn--5f70g; ฺ쩁𐹬.􋉳; [B1, V5, V6]; xn--o4c4837g2zvb.xn--5f70g; ; ;  # ฺ쩁𐹬.
+ᡅ０‌｡⎢󤨄; ᡅ0‌.⎢󤨄; [C1, P1, V6]; xn--0-z6jy93b.xn--8lh28773l; ; xn--0-z6j.xn--8lh28773l; [P1, V6] # ᡅ0.⎢
+ᡅ0‌。⎢󤨄; ᡅ0‌.⎢󤨄; [C1, P1, V6]; xn--0-z6jy93b.xn--8lh28773l; ; xn--0-z6j.xn--8lh28773l; [P1, V6] # ᡅ0.⎢
+xn--0-z6j.xn--8lh28773l; ᡅ0.⎢󤨄; [V6]; xn--0-z6j.xn--8lh28773l; ; ;  # ᡅ0.⎢
+xn--0-z6jy93b.xn--8lh28773l; ᡅ0‌.⎢󤨄; [C1, V6]; xn--0-z6jy93b.xn--8lh28773l; ; ;  # ᡅ0.⎢
+𲮚９ꍩ៓．‍ß; 𲮚9ꍩ៓.‍ß; [C2, P1, V6]; xn--9-i0j5967eg3qz.xn--zca770n; ; xn--9-i0j5967eg3qz.ss; [P1, V6] # 9ꍩ៓.ß
+𲮚9ꍩ៓.‍ß; ; [C2, P1, V6]; xn--9-i0j5967eg3qz.xn--zca770n; ; xn--9-i0j5967eg3qz.ss; [P1, V6] # 9ꍩ៓.ß
+𲮚9ꍩ៓.‍SS; 𲮚9ꍩ៓.‍ss; [C2, P1, V6]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [P1, V6] # 9ꍩ៓.ss
+𲮚9ꍩ៓.‍ss; ; [C2, P1, V6]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [P1, V6] # 9ꍩ៓.ss
+xn--9-i0j5967eg3qz.ss; 𲮚9ꍩ៓.ss; [V6]; xn--9-i0j5967eg3qz.ss; ; ;  # 9ꍩ៓.ss
+xn--9-i0j5967eg3qz.xn--ss-l1t; 𲮚9ꍩ៓.‍ss; [C2, V6]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; ;  # 9ꍩ៓.ss
+xn--9-i0j5967eg3qz.xn--zca770n; 𲮚9ꍩ៓.‍ß; [C2, V6]; xn--9-i0j5967eg3qz.xn--zca770n; ; ;  # 9ꍩ៓.ß
+𲮚９ꍩ៓．‍SS; 𲮚9ꍩ៓.‍ss; [C2, P1, V6]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [P1, V6] # 9ꍩ៓.ss
+𲮚９ꍩ៓．‍ss; 𲮚9ꍩ៓.‍ss; [C2, P1, V6]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [P1, V6] # 9ꍩ៓.ss
+𲮚9ꍩ៓.‍Ss; 𲮚9ꍩ៓.‍ss; [C2, P1, V6]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [P1, V6] # 9ꍩ៓.ss
+𲮚９ꍩ៓．‍Ss; 𲮚9ꍩ៓.‍ss; [C2, P1, V6]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [P1, V6] # 9ꍩ៓.ss
+ꗷ𑆀.ݝ𐩒; ; ; xn--ju8a625r.xn--hpb0073k; ; ;  # ꗷ𑆀.ݝ𐩒
+xn--ju8a625r.xn--hpb0073k; ꗷ𑆀.ݝ𐩒; ; xn--ju8a625r.xn--hpb0073k; ; ;  # ꗷ𑆀.ݝ𐩒
+⒐≯-。︒򩑣-񞛠; ⒐≯-.︒򩑣-񞛠; [P1, V3, V6]; xn----ogot9g.xn----n89hl0522az9u2a; ; ;  # ⒐≯-.︒-
+⒐≯-。︒򩑣-񞛠; ⒐≯-.︒򩑣-񞛠; [P1, V3, V6]; xn----ogot9g.xn----n89hl0522az9u2a; ; ;  # ⒐≯-.︒-
+9.≯-。。򩑣-񞛠; 9.≯-..򩑣-񞛠; [P1, V3, V6, X4_2]; 9.xn----ogo..xn----xj54d1s69k; [P1, V3, V6, A4_2]; ;  # 9.≯-..-
+9.≯-。。򩑣-񞛠; 9.≯-..򩑣-񞛠; [P1, V3, V6, X4_2]; 9.xn----ogo..xn----xj54d1s69k; [P1, V3, V6, A4_2]; ;  # 9.≯-..-
+9.xn----ogo..xn----xj54d1s69k; 9.≯-..򩑣-񞛠; [V3, V6, X4_2]; 9.xn----ogo..xn----xj54d1s69k; [V3, V6, A4_2]; ;  # 9.≯-..-
+xn----ogot9g.xn----n89hl0522az9u2a; ⒐≯-.︒򩑣-񞛠; [V3, V6]; xn----ogot9g.xn----n89hl0522az9u2a; ; ;  # ⒐≯-.︒-
+򈪚ೣჁ󠢏．؝; 򈪚ೣჁ󠢏.؝; [B6, P1, V6]; xn--vuc49qvu85xmju7a.xn--cgb; ; ;  # ೣჁ.
+򈪚ೣჁ󠢏.؝; ; [B6, P1, V6]; xn--vuc49qvu85xmju7a.xn--cgb; ; ;  # ೣჁ.
+򈪚ೣⴡ󠢏.؝; ; [B6, P1, V6]; xn--vuc226n8n28lmju7a.xn--cgb; ; ;  # ೣⴡ.
+xn--vuc226n8n28lmju7a.xn--cgb; 򈪚ೣⴡ󠢏.؝; [B6, V6]; xn--vuc226n8n28lmju7a.xn--cgb; ; ;  # ೣⴡ.
+xn--vuc49qvu85xmju7a.xn--cgb; 򈪚ೣჁ󠢏.؝; [B6, V6]; xn--vuc49qvu85xmju7a.xn--cgb; ; ;  # ೣჁ.
+򈪚ೣⴡ󠢏．؝; 򈪚ೣⴡ󠢏.؝; [B6, P1, V6]; xn--vuc226n8n28lmju7a.xn--cgb; ; ;  # ೣⴡ.
+ᷫ。𐋩ظ-𐫮; ᷫ.𐋩ظ-𐫮; [B1, B3, B6, V5]; xn--gfg.xn----xnc0815qyyg; ; ;  # ᷫ.𐋩ظ-𐫮
+xn--gfg.xn----xnc0815qyyg; ᷫ.𐋩ظ-𐫮; [B1, B3, B6, V5]; xn--gfg.xn----xnc0815qyyg; ; ;  # ᷫ.𐋩ظ-𐫮
+싇。⾇𐳋Ⴝ; 싇.舛𐳋Ⴝ; [B5, P1, V6]; xn--9u4b.xn--1nd7519ch79d; ; ;  # 싇.舛𐳋Ⴝ
+싇。⾇𐳋Ⴝ; 싇.舛𐳋Ⴝ; [B5, P1, V6]; xn--9u4b.xn--1nd7519ch79d; ; ;  # 싇.舛𐳋Ⴝ
+싇。舛𐳋Ⴝ; 싇.舛𐳋Ⴝ; [B5, P1, V6]; xn--9u4b.xn--1nd7519ch79d; ; ;  # 싇.舛𐳋Ⴝ
+싇。舛𐳋Ⴝ; 싇.舛𐳋Ⴝ; [B5, P1, V6]; xn--9u4b.xn--1nd7519ch79d; ; ;  # 싇.舛𐳋Ⴝ
+싇。舛𐳋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。舛𐳋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。舛𐲋Ⴝ; 싇.舛𐳋Ⴝ; [B5, P1, V6]; xn--9u4b.xn--1nd7519ch79d; ; ;  # 싇.舛𐳋Ⴝ
+싇。舛𐲋Ⴝ; 싇.舛𐳋Ⴝ; [B5, P1, V6]; xn--9u4b.xn--1nd7519ch79d; ; ;  # 싇.舛𐳋Ⴝ
+싇。舛𐲋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。舛𐲋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+xn--9u4b.xn--llj123yh74e; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+xn--9u4b.xn--1nd7519ch79d; 싇.舛𐳋Ⴝ; [B5, V6]; xn--9u4b.xn--1nd7519ch79d; ; ;  # 싇.舛𐳋Ⴝ
+싇。⾇𐳋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。⾇𐳋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。⾇𐲋Ⴝ; 싇.舛𐳋Ⴝ; [B5, P1, V6]; xn--9u4b.xn--1nd7519ch79d; ; ;  # 싇.舛𐳋Ⴝ
+싇。⾇𐲋Ⴝ; 싇.舛𐳋Ⴝ; [B5, P1, V6]; xn--9u4b.xn--1nd7519ch79d; ; ;  # 싇.舛𐳋Ⴝ
+싇。⾇𐲋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。⾇𐲋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+𐹠ς。‌ڿჀ; 𐹠ς.‌ڿჀ; [B1, C1, P1, V6]; xn--3xa1267k.xn--ykb632cvxm; ; xn--4xa9167k.xn--ykb632c; [B1, B2, B3, P1, V6] # 𐹠ς.ڿჀ
+𐹠ς。‌ڿⴠ; 𐹠ς.‌ڿⴠ; [B1, C1]; xn--3xa1267k.xn--ykb760k9hj; ; xn--4xa9167k.xn--ykb467q; [B1, B2, B3] # 𐹠ς.ڿⴠ
+𐹠Σ。‌ڿჀ; 𐹠σ.‌ڿჀ; [B1, C1, P1, V6]; xn--4xa9167k.xn--ykb632cvxm; ; xn--4xa9167k.xn--ykb632c; [B1, B2, B3, P1, V6] # 𐹠σ.ڿჀ
+𐹠σ。‌ڿⴠ; 𐹠σ.‌ڿⴠ; [B1, C1]; xn--4xa9167k.xn--ykb760k9hj; ; xn--4xa9167k.xn--ykb467q; [B1, B2, B3] # 𐹠σ.ڿⴠ
+𐹠Σ。‌ڿⴠ; 𐹠σ.‌ڿⴠ; [B1, C1]; xn--4xa9167k.xn--ykb760k9hj; ; xn--4xa9167k.xn--ykb467q; [B1, B2, B3] # 𐹠σ.ڿⴠ
+xn--4xa9167k.xn--ykb467q; 𐹠σ.ڿⴠ; [B1, B2, B3]; xn--4xa9167k.xn--ykb467q; ; ;  # 𐹠σ.ڿⴠ
+xn--4xa9167k.xn--ykb760k9hj; 𐹠σ.‌ڿⴠ; [B1, C1]; xn--4xa9167k.xn--ykb760k9hj; ; ;  # 𐹠σ.ڿⴠ
+xn--4xa9167k.xn--ykb632c; 𐹠σ.ڿჀ; [B1, B2, B3, V6]; xn--4xa9167k.xn--ykb632c; ; ;  # 𐹠σ.ڿჀ
+xn--4xa9167k.xn--ykb632cvxm; 𐹠σ.‌ڿჀ; [B1, C1, V6]; xn--4xa9167k.xn--ykb632cvxm; ; ;  # 𐹠σ.ڿჀ
+xn--3xa1267k.xn--ykb760k9hj; 𐹠ς.‌ڿⴠ; [B1, C1]; xn--3xa1267k.xn--ykb760k9hj; ; ;  # 𐹠ς.ڿⴠ
+xn--3xa1267k.xn--ykb632cvxm; 𐹠ς.‌ڿჀ; [B1, C1, V6]; xn--3xa1267k.xn--ykb632cvxm; ; ;  # 𐹠ς.ڿჀ
+򇒐‌؄.ښ-ß; ; [B2, B3, B5, B6, C1, P1, V6]; xn--mfb144kqo32m.xn----qfa315b; ; xn--mfb98261i.xn---ss-sdf; [B2, B3, B5, B6, P1, V6] # .ښ-ß
+򇒐‌؄.ښ-SS; 򇒐‌؄.ښ-ss; [B2, B3, B5, B6, C1, P1, V6]; xn--mfb144kqo32m.xn---ss-sdf; ; xn--mfb98261i.xn---ss-sdf; [B2, B3, B5, B6, P1, V6] # .ښ-ss
+򇒐‌؄.ښ-ss; ; [B2, B3, B5, B6, C1, P1, V6]; xn--mfb144kqo32m.xn---ss-sdf; ; xn--mfb98261i.xn---ss-sdf; [B2, B3, B5, B6, P1, V6] # .ښ-ss
+򇒐‌؄.ښ-Ss; 򇒐‌؄.ښ-ss; [B2, B3, B5, B6, C1, P1, V6]; xn--mfb144kqo32m.xn---ss-sdf; ; xn--mfb98261i.xn---ss-sdf; [B2, B3, B5, B6, P1, V6] # .ښ-ss
+xn--mfb98261i.xn---ss-sdf; 򇒐؄.ښ-ss; [B2, B3, B5, B6, V6]; xn--mfb98261i.xn---ss-sdf; ; ;  # .ښ-ss
+xn--mfb144kqo32m.xn---ss-sdf; 򇒐‌؄.ښ-ss; [B2, B3, B5, B6, C1, V6]; xn--mfb144kqo32m.xn---ss-sdf; ; ;  # .ښ-ss
+xn--mfb144kqo32m.xn----qfa315b; 򇒐‌؄.ښ-ß; [B2, B3, B5, B6, C1, V6]; xn--mfb144kqo32m.xn----qfa315b; ; ;  # .ښ-ß
+‌‍឵ٺ.-ﮰ󅄞𐸚; ‌‍឵ٺ.-ۓ󅄞𐸚; [B1, C1, C2, P1, V3, V6]; xn--zib539f8igea.xn----twc1133r17r6g; ; xn--zib539f.xn----twc1133r17r6g; [B1, P1, V3, V5, V6] # ٺ.-ۓ
+‌‍឵ٺ.-ۓ󅄞𐸚; ; [B1, C1, C2, P1, V3, V6]; xn--zib539f8igea.xn----twc1133r17r6g; ; xn--zib539f.xn----twc1133r17r6g; [B1, P1, V3, V5, V6] # ٺ.-ۓ
+‌‍឵ٺ.-ۓ󅄞𐸚; ‌‍឵ٺ.-ۓ󅄞𐸚; [B1, C1, C2, P1, V3, V6]; xn--zib539f8igea.xn----twc1133r17r6g; ; xn--zib539f.xn----twc1133r17r6g; [B1, P1, V3, V5, V6] # ٺ.-ۓ
+xn--zib539f.xn----twc1133r17r6g; ឵ٺ.-ۓ󅄞𐸚; [B1, V3, V5, V6]; xn--zib539f.xn----twc1133r17r6g; ; ;  # ٺ.-ۓ
+xn--zib539f8igea.xn----twc1133r17r6g; ‌‍឵ٺ.-ۓ󅄞𐸚; [B1, C1, C2, V3, V6]; xn--zib539f8igea.xn----twc1133r17r6g; ; ;  # ٺ.-ۓ
+򡶱｡𐮬≠; 򡶱.𐮬≠; [B3, P1, V6]; xn--dd55c.xn--1ch3003g; ; ;  # .𐮬≠
+򡶱｡𐮬≠; 򡶱.𐮬≠; [B3, P1, V6]; xn--dd55c.xn--1ch3003g; ; ;  # .𐮬≠
+򡶱。𐮬≠; 򡶱.𐮬≠; [B3, P1, V6]; xn--dd55c.xn--1ch3003g; ; ;  # .𐮬≠
+򡶱。𐮬≠; 򡶱.𐮬≠; [B3, P1, V6]; xn--dd55c.xn--1ch3003g; ; ;  # .𐮬≠
+xn--dd55c.xn--1ch3003g; 򡶱.𐮬≠; [B3, V6]; xn--dd55c.xn--1ch3003g; ; ;  # .𐮬≠
+ྲ𞶅｡𐹮𐹷덝۵; ྲ𞶅.𐹮𐹷덝۵; [B1, P1, V5, V6]; xn--fgd0675v.xn--imb5839fidpcbba; ; ;  # ྲ.𐹮𐹷덝۵
+ྲ𞶅｡𐹮𐹷덝۵; ྲ𞶅.𐹮𐹷덝۵; [B1, P1, V5, V6]; xn--fgd0675v.xn--imb5839fidpcbba; ; ;  # ྲ.𐹮𐹷덝۵
+ྲ𞶅。𐹮𐹷덝۵; ྲ𞶅.𐹮𐹷덝۵; [B1, P1, V5, V6]; xn--fgd0675v.xn--imb5839fidpcbba; ; ;  # ྲ.𐹮𐹷덝۵
+ྲ𞶅。𐹮𐹷덝۵; ྲ𞶅.𐹮𐹷덝۵; [B1, P1, V5, V6]; xn--fgd0675v.xn--imb5839fidpcbba; ; ;  # ྲ.𐹮𐹷덝۵
+xn--fgd0675v.xn--imb5839fidpcbba; ྲ𞶅.𐹮𐹷덝۵; [B1, V5, V6]; xn--fgd0675v.xn--imb5839fidpcbba; ; ;  # ྲ.𐹮𐹷덝۵
+Ⴏ󠅋-．‍Ⴉ; Ⴏ-.‍Ⴉ; [C2, P1, V3, V6]; xn----00g.xn--hnd399e; ; xn----00g.xn--hnd; [P1, V3, V6] # Ⴏ-.Ⴉ
+Ⴏ󠅋-.‍Ⴉ; Ⴏ-.‍Ⴉ; [C2, P1, V3, V6]; xn----00g.xn--hnd399e; ; xn----00g.xn--hnd; [P1, V3, V6] # Ⴏ-.Ⴉ
+ⴏ󠅋-.‍ⴉ; ⴏ-.‍ⴉ; [C2, V3]; xn----3vs.xn--1ug532c; ; xn----3vs.xn--0kj; [V3] # ⴏ-.ⴉ
+xn----3vs.xn--0kj; ⴏ-.ⴉ; [V3]; xn----3vs.xn--0kj; ; ;  # ⴏ-.ⴉ
+xn----3vs.xn--1ug532c; ⴏ-.‍ⴉ; [C2, V3]; xn----3vs.xn--1ug532c; ; ;  # ⴏ-.ⴉ
+xn----00g.xn--hnd; Ⴏ-.Ⴉ; [V3, V6]; xn----00g.xn--hnd; ; ;  # Ⴏ-.Ⴉ
+xn----00g.xn--hnd399e; Ⴏ-.‍Ⴉ; [C2, V3, V6]; xn----00g.xn--hnd399e; ; ;  # Ⴏ-.Ⴉ
+ⴏ󠅋-．‍ⴉ; ⴏ-.‍ⴉ; [C2, V3]; xn----3vs.xn--1ug532c; ; xn----3vs.xn--0kj; [V3] # ⴏ-.ⴉ
+⇧𐨏󠾈󯶅。؀󠈵󠆉; ⇧𐨏󠾈󯶅.؀󠈵; [B1, P1, V6]; xn--l8g5552g64t4g46xf.xn--ifb08144p; ; ;  # ⇧𐨏.
+xn--l8g5552g64t4g46xf.xn--ifb08144p; ⇧𐨏󠾈󯶅.؀󠈵; [B1, V6]; xn--l8g5552g64t4g46xf.xn--ifb08144p; ; ;  # ⇧𐨏.
+≠𐮂.↑🄇⒈; ; [B1, P1, V6]; xn--1chy492g.xn--45gx9iuy44d; ; ;  # ≠𐮂.↑🄇⒈
+≠𐮂.↑🄇⒈; ≠𐮂.↑🄇⒈; [B1, P1, V6]; xn--1chy492g.xn--45gx9iuy44d; ; ;  # ≠𐮂.↑🄇⒈
+≠𐮂.↑6,1.; ; [B1, P1, V6]; xn--1chy492g.xn--6,1-pw1a.; ; ;  # ≠𐮂.↑6,1.
+≠𐮂.↑6,1.; ≠𐮂.↑6,1.; [B1, P1, V6]; xn--1chy492g.xn--6,1-pw1a.; ; ;  # ≠𐮂.↑6,1.
+xn--1chy492g.xn--6,1-pw1a.; ≠𐮂.↑6,1.; [B1, P1, V6]; xn--1chy492g.xn--6,1-pw1a.; ; ;  # ≠𐮂.↑6,1.
+xn--1chy492g.xn--45gx9iuy44d; ≠𐮂.↑🄇⒈; [B1, V6]; xn--1chy492g.xn--45gx9iuy44d; ; ;  # ≠𐮂.↑🄇⒈
+𝩏󠲉ß.ᢤ򄦌‌𐹫; ; [B1, B5, B6, C1, P1, V5, V6]; xn--zca3153vupz3e.xn--ubf609atw1tynn3d; ; xn--ss-zb11ap1427e.xn--ubf2596jbt61c; [B1, B5, B6, P1, V5, V6] # 𝩏ß.ᢤ𐹫
+𝩏󠲉SS.ᢤ򄦌‌𐹫; 𝩏󠲉ss.ᢤ򄦌‌𐹫; [B1, B5, B6, C1, P1, V5, V6]; xn--ss-zb11ap1427e.xn--ubf609atw1tynn3d; ; xn--ss-zb11ap1427e.xn--ubf2596jbt61c; [B1, B5, B6, P1, V5, V6] # 𝩏ss.ᢤ𐹫
+𝩏󠲉ss.ᢤ򄦌‌𐹫; ; [B1, B5, B6, C1, P1, V5, V6]; xn--ss-zb11ap1427e.xn--ubf609atw1tynn3d; ; xn--ss-zb11ap1427e.xn--ubf2596jbt61c; [B1, B5, B6, P1, V5, V6] # 𝩏ss.ᢤ𐹫
+𝩏󠲉Ss.ᢤ򄦌‌𐹫; 𝩏󠲉ss.ᢤ򄦌‌𐹫; [B1, B5, B6, C1, P1, V5, V6]; xn--ss-zb11ap1427e.xn--ubf609atw1tynn3d; ; xn--ss-zb11ap1427e.xn--ubf2596jbt61c; [B1, B5, B6, P1, V5, V6] # 𝩏ss.ᢤ𐹫
+xn--ss-zb11ap1427e.xn--ubf2596jbt61c; 𝩏󠲉ss.ᢤ򄦌𐹫; [B1, B5, B6, V5, V6]; xn--ss-zb11ap1427e.xn--ubf2596jbt61c; ; ;  # 𝩏ss.ᢤ𐹫
+xn--ss-zb11ap1427e.xn--ubf609atw1tynn3d; 𝩏󠲉ss.ᢤ򄦌‌𐹫; [B1, B5, B6, C1, V5, V6]; xn--ss-zb11ap1427e.xn--ubf609atw1tynn3d; ; ;  # 𝩏ss.ᢤ𐹫
+xn--zca3153vupz3e.xn--ubf609atw1tynn3d; 𝩏󠲉ß.ᢤ򄦌‌𐹫; [B1, B5, B6, C1, V5, V6]; xn--zca3153vupz3e.xn--ubf609atw1tynn3d; ; ;  # 𝩏ß.ᢤ𐹫
+ß𐵳񗘁Ⴇ｡ꙺ; ß𐵳񗘁Ⴇ.ꙺ; [B1, B3, B5, B6, P1, V5, V6]; xn--zca491fci5qkn79a.xn--9x8a; ; xn--ss-rek7420r4hs7b.xn--9x8a;  # ßႧ.ꙺ
+ß𐵳񗘁Ⴇ。ꙺ; ß𐵳񗘁Ⴇ.ꙺ; [B1, B3, B5, B6, P1, V5, V6]; xn--zca491fci5qkn79a.xn--9x8a; ; xn--ss-rek7420r4hs7b.xn--9x8a;  # ßႧ.ꙺ
+ß𐵳񗘁ⴇ。ꙺ; ß𐵳񗘁ⴇ.ꙺ; [B1, B3, B5, B6, P1, V5, V6]; xn--zca227tpy4lkns1b.xn--9x8a; ; xn--ss-e61ar955h4hs7b.xn--9x8a;  # ßⴇ.ꙺ
+SS𐵳񗘁Ⴇ。ꙺ; ss𐵳񗘁Ⴇ.ꙺ; [B1, B3, B5, B6, P1, V5, V6]; xn--ss-rek7420r4hs7b.xn--9x8a; ; ;  # ssႧ.ꙺ
+ss𐵳񗘁ⴇ。ꙺ; ss𐵳񗘁ⴇ.ꙺ; [B1, B3, B5, B6, P1, V5, V6]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ssⴇ.ꙺ
+Ss𐵳񗘁Ⴇ。ꙺ; ss𐵳񗘁Ⴇ.ꙺ; [B1, B3, B5, B6, P1, V5, V6]; xn--ss-rek7420r4hs7b.xn--9x8a; ; ;  # ssႧ.ꙺ
+xn--ss-rek7420r4hs7b.xn--9x8a; ss𐵳񗘁Ⴇ.ꙺ; [B1, B3, B5, B6, V5, V6]; xn--ss-rek7420r4hs7b.xn--9x8a; ; ;  # ssႧ.ꙺ
+xn--ss-e61ar955h4hs7b.xn--9x8a; ss𐵳񗘁ⴇ.ꙺ; [B1, B3, B5, B6, V5, V6]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ssⴇ.ꙺ
+xn--zca227tpy4lkns1b.xn--9x8a; ß𐵳񗘁ⴇ.ꙺ; [B1, B3, B5, B6, V5, V6]; xn--zca227tpy4lkns1b.xn--9x8a; ; ;  # ßⴇ.ꙺ
+xn--zca491fci5qkn79a.xn--9x8a; ß𐵳񗘁Ⴇ.ꙺ; [B1, B3, B5, B6, V5, V6]; xn--zca491fci5qkn79a.xn--9x8a; ; ;  # ßႧ.ꙺ
+ß𐵳񗘁ⴇ｡ꙺ; ß𐵳񗘁ⴇ.ꙺ; [B1, B3, B5, B6, P1, V5, V6]; xn--zca227tpy4lkns1b.xn--9x8a; ; xn--ss-e61ar955h4hs7b.xn--9x8a;  # ßⴇ.ꙺ
+SS𐵳񗘁Ⴇ｡ꙺ; ss𐵳񗘁Ⴇ.ꙺ; [B1, B3, B5, B6, P1, V5, V6]; xn--ss-rek7420r4hs7b.xn--9x8a; ; ;  # ssႧ.ꙺ
+ss𐵳񗘁ⴇ｡ꙺ; ss𐵳񗘁ⴇ.ꙺ; [B1, B3, B5, B6, P1, V5, V6]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ssⴇ.ꙺ
+Ss𐵳񗘁Ⴇ｡ꙺ; ss𐵳񗘁Ⴇ.ꙺ; [B1, B3, B5, B6, P1, V5, V6]; xn--ss-rek7420r4hs7b.xn--9x8a; ; ;  # ssႧ.ꙺ
+᜔。󠆣-𑋪; ᜔.-𑋪; [V3, V5]; xn--fze.xn----ly8i; ; ;  # ᜔.-𑋪
+xn--fze.xn----ly8i; ᜔.-𑋪; [V3, V5]; xn--fze.xn----ly8i; ; ;  # ᜔.-𑋪
+ꯨ-．򨏜ֽß; ꯨ-.򨏜ֽß; [P1, V3, V5, V6]; xn----pw5e.xn--zca50wfv060a; ; xn----pw5e.xn--ss-7jd10716y;  # ꯨ-.ֽß
+ꯨ-.򨏜ֽß; ; [P1, V3, V5, V6]; xn----pw5e.xn--zca50wfv060a; ; xn----pw5e.xn--ss-7jd10716y;  # ꯨ-.ֽß
+ꯨ-.򨏜ֽSS; ꯨ-.򨏜ֽss; [P1, V3, V5, V6]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+ꯨ-.򨏜ֽss; ; [P1, V3, V5, V6]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+ꯨ-.򨏜ֽSs; ꯨ-.򨏜ֽss; [P1, V3, V5, V6]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+xn----pw5e.xn--ss-7jd10716y; ꯨ-.򨏜ֽss; [V3, V5, V6]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+xn----pw5e.xn--zca50wfv060a; ꯨ-.򨏜ֽß; [V3, V5, V6]; xn----pw5e.xn--zca50wfv060a; ; ;  # ꯨ-.ֽß
+ꯨ-．򨏜ֽSS; ꯨ-.򨏜ֽss; [P1, V3, V5, V6]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+ꯨ-．򨏜ֽss; ꯨ-.򨏜ֽss; [P1, V3, V5, V6]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+ꯨ-．򨏜ֽSs; ꯨ-.򨏜ֽss; [P1, V3, V5, V6]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+ᡓ-≮。٫󠅱ᡄ; ᡓ-≮.٫ᡄ; [B1, B6, P1, V6]; xn----s7j866c.xn--kib252g; ; ;  # ᡓ-≮.٫ᡄ
+ᡓ-≮。٫󠅱ᡄ; ᡓ-≮.٫ᡄ; [B1, B6, P1, V6]; xn----s7j866c.xn--kib252g; ; ;  # ᡓ-≮.٫ᡄ
+xn----s7j866c.xn--kib252g; ᡓ-≮.٫ᡄ; [B1, B6, V6]; xn----s7j866c.xn--kib252g; ; ;  # ᡓ-≮.٫ᡄ
+𝟥♮𑜫࣭．្𑜫8󠆏; 3♮𑜫࣭.្𑜫8; [V5]; xn--3-ksd277tlo7s.xn--8-f0jx021l; ; ;  # 3♮𑜫࣭.្𑜫8
+3♮𑜫࣭.្𑜫8󠆏; 3♮𑜫࣭.្𑜫8; [V5]; xn--3-ksd277tlo7s.xn--8-f0jx021l; ; ;  # 3♮𑜫࣭.្𑜫8
+xn--3-ksd277tlo7s.xn--8-f0jx021l; 3♮𑜫࣭.្𑜫8; [V5]; xn--3-ksd277tlo7s.xn--8-f0jx021l; ; ;  # 3♮𑜫࣭.្𑜫8
+-｡򕌀‍❡; -.򕌀‍❡; [C2, P1, V3, V6]; -.xn--1ug800aq795s; ; -.xn--nei54421f; [P1, V3, V6] # -.❡
+-。򕌀‍❡; -.򕌀‍❡; [C2, P1, V3, V6]; -.xn--1ug800aq795s; ; -.xn--nei54421f; [P1, V3, V6] # -.❡
+-.xn--nei54421f; -.򕌀❡; [V3, V6]; -.xn--nei54421f; ; ;  # -.❡
+-.xn--1ug800aq795s; -.򕌀‍❡; [C2, V3, V6]; -.xn--1ug800aq795s; ; ;  # -.❡
+𝟓☱𝟐򥰵｡𝪮񐡳; 5☱2򥰵.𝪮񐡳; [P1, V5, V6]; xn--52-dwx47758j.xn--kd3hk431k; ; ;  # 5☱2.𝪮
+5☱2򥰵。𝪮񐡳; 5☱2򥰵.𝪮񐡳; [P1, V5, V6]; xn--52-dwx47758j.xn--kd3hk431k; ; ;  # 5☱2.𝪮
+xn--52-dwx47758j.xn--kd3hk431k; 5☱2򥰵.𝪮񐡳; [V5, V6]; xn--52-dwx47758j.xn--kd3hk431k; ; ;  # 5☱2.𝪮
+-.-├򖦣; ; [P1, V3, V6]; -.xn----ukp70432h; ; ;  # -.-├
+-.xn----ukp70432h; -.-├򖦣; [V3, V6]; -.xn----ukp70432h; ; ;  # -.-├
+֥ݭ｡‍󠀘; ֥ݭ.‍󠀘; [B1, C2, P1, V5, V6]; xn--wcb62g.xn--1ugy8001l; ; xn--wcb62g.xn--p526e; [B1, P1, V5, V6] # ֥ݭ.
+֥ݭ。‍󠀘; ֥ݭ.‍󠀘; [B1, C2, P1, V5, V6]; xn--wcb62g.xn--1ugy8001l; ; xn--wcb62g.xn--p526e; [B1, P1, V5, V6] # ֥ݭ.
+xn--wcb62g.xn--p526e; ֥ݭ.󠀘; [B1, V5, V6]; xn--wcb62g.xn--p526e; ; ;  # ֥ݭ.
+xn--wcb62g.xn--1ugy8001l; ֥ݭ.‍󠀘; [B1, C2, V5, V6]; xn--wcb62g.xn--1ugy8001l; ; ;  # ֥ݭ.
+쥥󔏉Ⴎ．‌⒈⒈𐫒; 쥥󔏉Ⴎ.‌⒈⒈𐫒; [B1, C1, P1, V6]; xn--mnd7865gcy28g.xn--0ug88oa0396u; ; xn--mnd7865gcy28g.xn--tsha6797o; [B1, P1, V6] # 쥥Ⴎ.⒈⒈𐫒
+쥥󔏉Ⴎ．‌⒈⒈𐫒; 쥥󔏉Ⴎ.‌⒈⒈𐫒; [B1, C1, P1, V6]; xn--mnd7865gcy28g.xn--0ug88oa0396u; ; xn--mnd7865gcy28g.xn--tsha6797o; [B1, P1, V6] # 쥥Ⴎ.⒈⒈𐫒
+쥥󔏉Ⴎ.‌1.1.𐫒; ; [B1, C1, P1, V6]; xn--mnd7865gcy28g.xn--1-rgn.1.xn--7w9c; ; xn--mnd7865gcy28g.1.1.xn--7w9c; [B1, P1, V6] # 쥥Ⴎ.1.1.𐫒
+쥥󔏉Ⴎ.‌1.1.𐫒; 쥥󔏉Ⴎ.‌1.1.𐫒; [B1, C1, P1, V6]; xn--mnd7865gcy28g.xn--1-rgn.1.xn--7w9c; ; xn--mnd7865gcy28g.1.1.xn--7w9c; [B1, P1, V6] # 쥥Ⴎ.1.1.𐫒
+쥥󔏉ⴎ.‌1.1.𐫒; 쥥󔏉ⴎ.‌1.1.𐫒; [B1, C1, P1, V6]; xn--5kj3511ccyw3h.xn--1-rgn.1.xn--7w9c; ; xn--5kj3511ccyw3h.1.1.xn--7w9c; [B1, P1, V6] # 쥥ⴎ.1.1.𐫒
+쥥󔏉ⴎ.‌1.1.𐫒; ; [B1, C1, P1, V6]; xn--5kj3511ccyw3h.xn--1-rgn.1.xn--7w9c; ; xn--5kj3511ccyw3h.1.1.xn--7w9c; [B1, P1, V6] # 쥥ⴎ.1.1.𐫒
+xn--5kj3511ccyw3h.1.1.xn--7w9c; 쥥󔏉ⴎ.1.1.𐫒; [B1, V6]; xn--5kj3511ccyw3h.1.1.xn--7w9c; ; ;  # 쥥ⴎ.1.1.𐫒
+xn--5kj3511ccyw3h.xn--1-rgn.1.xn--7w9c; 쥥󔏉ⴎ.‌1.1.𐫒; [B1, C1, V6]; xn--5kj3511ccyw3h.xn--1-rgn.1.xn--7w9c; ; ;  # 쥥ⴎ.1.1.𐫒
+xn--mnd7865gcy28g.1.1.xn--7w9c; 쥥󔏉Ⴎ.1.1.𐫒; [B1, V6]; xn--mnd7865gcy28g.1.1.xn--7w9c; ; ;  # 쥥Ⴎ.1.1.𐫒
+xn--mnd7865gcy28g.xn--1-rgn.1.xn--7w9c; 쥥󔏉Ⴎ.‌1.1.𐫒; [B1, C1, V6]; xn--mnd7865gcy28g.xn--1-rgn.1.xn--7w9c; ; ;  # 쥥Ⴎ.1.1.𐫒
+쥥󔏉ⴎ．‌⒈⒈𐫒; 쥥󔏉ⴎ.‌⒈⒈𐫒; [B1, C1, P1, V6]; xn--5kj3511ccyw3h.xn--0ug88oa0396u; ; xn--5kj3511ccyw3h.xn--tsha6797o; [B1, P1, V6] # 쥥ⴎ.⒈⒈𐫒
+쥥󔏉ⴎ．‌⒈⒈𐫒; 쥥󔏉ⴎ.‌⒈⒈𐫒; [B1, C1, P1, V6]; xn--5kj3511ccyw3h.xn--0ug88oa0396u; ; xn--5kj3511ccyw3h.xn--tsha6797o; [B1, P1, V6] # 쥥ⴎ.⒈⒈𐫒
+xn--5kj3511ccyw3h.xn--tsha6797o; 쥥󔏉ⴎ.⒈⒈𐫒; [B1, V6]; xn--5kj3511ccyw3h.xn--tsha6797o; ; ;  # 쥥ⴎ.⒈⒈𐫒
+xn--5kj3511ccyw3h.xn--0ug88oa0396u; 쥥󔏉ⴎ.‌⒈⒈𐫒; [B1, C1, V6]; xn--5kj3511ccyw3h.xn--0ug88oa0396u; ; ;  # 쥥ⴎ.⒈⒈𐫒
+xn--mnd7865gcy28g.xn--tsha6797o; 쥥󔏉Ⴎ.⒈⒈𐫒; [B1, V6]; xn--mnd7865gcy28g.xn--tsha6797o; ; ;  # 쥥Ⴎ.⒈⒈𐫒
+xn--mnd7865gcy28g.xn--0ug88oa0396u; 쥥󔏉Ⴎ.‌⒈⒈𐫒; [B1, C1, V6]; xn--mnd7865gcy28g.xn--0ug88oa0396u; ; ;  # 쥥Ⴎ.⒈⒈𐫒
+ࠧ𝟶ڠ-。𑄳; ࠧ0ڠ-.𑄳; [B1, B3, B6, V3, V5]; xn--0--p3d67m.xn--v80d; ; ;  # ࠧ0ڠ-.𑄳
+ࠧ0ڠ-。𑄳; ࠧ0ڠ-.𑄳; [B1, B3, B6, V3, V5]; xn--0--p3d67m.xn--v80d; ; ;  # ࠧ0ڠ-.𑄳
+xn--0--p3d67m.xn--v80d; ࠧ0ڠ-.𑄳; [B1, B3, B6, V3, V5]; xn--0--p3d67m.xn--v80d; ; ;  # ࠧ0ڠ-.𑄳
+ς．ﷁ🞛⒈; ς.فمي🞛⒈; [P1, V6]; xn--3xa.xn--dhbip2802atb20c; ; xn--4xa.xn--dhbip2802atb20c;  # ς.فمي🞛⒈
+ς.فمي🞛1.; ; ; xn--3xa.xn--1-gocmu97674d.; ; xn--4xa.xn--1-gocmu97674d.;  # ς.فمي🞛1.
+Σ.فمي🞛1.; σ.فمي🞛1.; ; xn--4xa.xn--1-gocmu97674d.; ; ;  # σ.فمي🞛1.
+σ.فمي🞛1.; ; ; xn--4xa.xn--1-gocmu97674d.; ; ;  # σ.فمي🞛1.
+xn--4xa.xn--1-gocmu97674d.; σ.فمي🞛1.; ; xn--4xa.xn--1-gocmu97674d.; ; ;  # σ.فمي🞛1.
+xn--3xa.xn--1-gocmu97674d.; ς.فمي🞛1.; ; xn--3xa.xn--1-gocmu97674d.; ; ;  # ς.فمي🞛1.
+Σ．ﷁ🞛⒈; σ.فمي🞛⒈; [P1, V6]; xn--4xa.xn--dhbip2802atb20c; ; ;  # σ.فمي🞛⒈
+σ．ﷁ🞛⒈; σ.فمي🞛⒈; [P1, V6]; xn--4xa.xn--dhbip2802atb20c; ; ;  # σ.فمي🞛⒈
+xn--4xa.xn--dhbip2802atb20c; σ.فمي🞛⒈; [V6]; xn--4xa.xn--dhbip2802atb20c; ; ;  # σ.فمي🞛⒈
+xn--3xa.xn--dhbip2802atb20c; ς.فمي🞛⒈; [V6]; xn--3xa.xn--dhbip2802atb20c; ; ;  # ς.فمي🞛⒈
+🗩-｡𐹻󐞆񥉮; 🗩-.𐹻󐞆񥉮; [B1, P1, V3, V6]; xn----6t3s.xn--zo0d4811u6ru6a; ; ;  # 🗩-.𐹻
+🗩-。𐹻󐞆񥉮; 🗩-.𐹻󐞆񥉮; [B1, P1, V3, V6]; xn----6t3s.xn--zo0d4811u6ru6a; ; ;  # 🗩-.𐹻
+xn----6t3s.xn--zo0d4811u6ru6a; 🗩-.𐹻󐞆񥉮; [B1, V3, V6]; xn----6t3s.xn--zo0d4811u6ru6a; ; ;  # 🗩-.𐹻
+𐡜-🔪｡𝟻‌𐿀; 𐡜-🔪.5‌𐿀; [B1, B3, C1, P1, V6]; xn----5j4iv089c.xn--5-sgn7149h; ; xn----5j4iv089c.xn--5-bn7i; [B1, B3, P1, V6] # 𐡜-🔪.5
+𐡜-🔪。5‌𐿀; 𐡜-🔪.5‌𐿀; [B1, B3, C1, P1, V6]; xn----5j4iv089c.xn--5-sgn7149h; ; xn----5j4iv089c.xn--5-bn7i; [B1, B3, P1, V6] # 𐡜-🔪.5
+xn----5j4iv089c.xn--5-bn7i; 𐡜-🔪.5𐿀; [B1, B3, V6]; xn----5j4iv089c.xn--5-bn7i; ; ;  # 𐡜-🔪.5
+xn----5j4iv089c.xn--5-sgn7149h; 𐡜-🔪.5‌𐿀; [B1, B3, C1, V6]; xn----5j4iv089c.xn--5-sgn7149h; ; ;  # 𐡜-🔪.5
+𐹣늿‍ß．ߏ0ּ; 𐹣늿‍ß.ߏ0ּ; [B1, C2]; xn--zca770n5s4hev6c.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ß.ߏ0ּ
+𐹣늿‍ß．ߏ0ּ; 𐹣늿‍ß.ߏ0ּ; [B1, C2]; xn--zca770n5s4hev6c.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ß.ߏ0ּ
+𐹣늿‍ß.ߏ0ּ; ; [B1, C2]; xn--zca770n5s4hev6c.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ß.ߏ0ּ
+𐹣늿‍ß.ߏ0ּ; 𐹣늿‍ß.ߏ0ּ; [B1, C2]; xn--zca770n5s4hev6c.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ß.ߏ0ּ
+𐹣늿‍SS.ߏ0ּ; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿‍SS.ߏ0ּ; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿‍ss.ߏ0ּ; ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿‍ss.ߏ0ּ; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+xn--ss-i05i7041a.xn--0-vgc50n; 𐹣늿ss.ߏ0ּ; [B1]; xn--ss-i05i7041a.xn--0-vgc50n; ; ;  # 𐹣늿ss.ߏ0ּ
+xn--ss-l1tu910fo0xd.xn--0-vgc50n; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; ;  # 𐹣늿ss.ߏ0ּ
+𐹣늿‍Ss.ߏ0ּ; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿‍Ss.ߏ0ּ; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+xn--zca770n5s4hev6c.xn--0-vgc50n; 𐹣늿‍ß.ߏ0ּ; [B1, C2]; xn--zca770n5s4hev6c.xn--0-vgc50n; ; ;  # 𐹣늿ß.ߏ0ּ
+𐹣늿‍SS．ߏ0ּ; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿‍SS．ߏ0ּ; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿‍ss．ߏ0ּ; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿‍ss．ߏ0ּ; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿‍Ss．ߏ0ּ; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿‍Ss．ߏ0ּ; 𐹣늿‍ss.ߏ0ּ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+9󠇥．󪴴ᢓ; 9.󪴴ᢓ; [P1, V6]; 9.xn--dbf91222q; ; ;  # 9.ᢓ
+9󠇥.󪴴ᢓ; 9.󪴴ᢓ; [P1, V6]; 9.xn--dbf91222q; ; ;  # 9.ᢓ
+9.xn--dbf91222q; 9.󪴴ᢓ; [V6]; 9.xn--dbf91222q; ; ;  # 9.ᢓ
+‌ﾠ.𐫭🠗ß⽟; ‌ﾠ.𐫭🠗ß玉; [B1, B2, B3, C1, P1, V6]; xn--0ug7719f.xn--zca2289c550e0iwi; ; xn--cl7c.xn--ss-je6eq954cp25j; [B2, B3, P1, V6] # .𐫭🠗ß玉
+‌ᅠ.𐫭🠗ß玉; ; [B1, B2, B3, C1, P1, V6]; xn--psd526e.xn--zca2289c550e0iwi; ; xn--psd.xn--ss-je6eq954cp25j; [B2, B3, P1, V6] # .𐫭🠗ß玉
+‌ᅠ.𐫭🠗SS玉; ‌ᅠ.𐫭🠗ss玉; [B1, B2, B3, C1, P1, V6]; xn--psd526e.xn--ss-je6eq954cp25j; ; xn--psd.xn--ss-je6eq954cp25j; [B2, B3, P1, V6] # .𐫭🠗ss玉
+‌ᅠ.𐫭🠗ss玉; ; [B1, B2, B3, C1, P1, V6]; xn--psd526e.xn--ss-je6eq954cp25j; ; xn--psd.xn--ss-je6eq954cp25j; [B2, B3, P1, V6] # .𐫭🠗ss玉
+‌ᅠ.𐫭🠗Ss玉; ‌ᅠ.𐫭🠗ss玉; [B1, B2, B3, C1, P1, V6]; xn--psd526e.xn--ss-je6eq954cp25j; ; xn--psd.xn--ss-je6eq954cp25j; [B2, B3, P1, V6] # .𐫭🠗ss玉
+xn--psd.xn--ss-je6eq954cp25j; ᅠ.𐫭🠗ss玉; [B2, B3, V6]; xn--psd.xn--ss-je6eq954cp25j; ; ;  # .𐫭🠗ss玉
+xn--psd526e.xn--ss-je6eq954cp25j; ‌ᅠ.𐫭🠗ss玉; [B1, B2, B3, C1, V6]; xn--psd526e.xn--ss-je6eq954cp25j; ; ;  # .𐫭🠗ss玉
+xn--psd526e.xn--zca2289c550e0iwi; ‌ᅠ.𐫭🠗ß玉; [B1, B2, B3, C1, V6]; xn--psd526e.xn--zca2289c550e0iwi; ; ;  # .𐫭🠗ß玉
+‌ﾠ.𐫭🠗SS⽟; ‌ﾠ.𐫭🠗ss玉; [B1, B2, B3, C1, P1, V6]; xn--0ug7719f.xn--ss-je6eq954cp25j; ; xn--cl7c.xn--ss-je6eq954cp25j; [B2, B3, P1, V6] # .𐫭🠗ss玉
+‌ﾠ.𐫭🠗ss⽟; ‌ﾠ.𐫭🠗ss玉; [B1, B2, B3, C1, P1, V6]; xn--0ug7719f.xn--ss-je6eq954cp25j; ; xn--cl7c.xn--ss-je6eq954cp25j; [B2, B3, P1, V6] # .𐫭🠗ss玉
+‌ﾠ.𐫭🠗Ss⽟; ‌ﾠ.𐫭🠗ss玉; [B1, B2, B3, C1, P1, V6]; xn--0ug7719f.xn--ss-je6eq954cp25j; ; xn--cl7c.xn--ss-je6eq954cp25j; [B2, B3, P1, V6] # .𐫭🠗ss玉
+xn--cl7c.xn--ss-je6eq954cp25j; ﾠ.𐫭🠗ss玉; [B2, B3, V6]; xn--cl7c.xn--ss-je6eq954cp25j; ; ;  # .𐫭🠗ss玉
+xn--0ug7719f.xn--ss-je6eq954cp25j; ‌ﾠ.𐫭🠗ss玉; [B1, B2, B3, C1, V6]; xn--0ug7719f.xn--ss-je6eq954cp25j; ; ;  # .𐫭🠗ss玉
+xn--0ug7719f.xn--zca2289c550e0iwi; ‌ﾠ.𐫭🠗ß玉; [B1, B2, B3, C1, V6]; xn--0ug7719f.xn--zca2289c550e0iwi; ; ;  # .𐫭🠗ß玉
+︒Ⴖͦ．‌; ︒Ⴖͦ.‌; [C1, P1, V6]; xn--hva929dl29p.xn--0ug; ; xn--hva929dl29p.; [P1, V6] # ︒Ⴖͦ.
+。Ⴖͦ.‌; .Ⴖͦ.‌; [C1, P1, V6, X4_2]; .xn--hva929d.xn--0ug; [C1, P1, V6, A4_2]; .xn--hva929d.; [P1, V6, A4_2] # .Ⴖͦ.
+。ⴖͦ.‌; .ⴖͦ.‌; [C1, X4_2]; .xn--hva754s.xn--0ug; [C1, A4_2]; .xn--hva754s.; [A4_2] # .ⴖͦ.
+.xn--hva754s.; .ⴖͦ.; [X4_2]; .xn--hva754s.; [A4_2]; ;  # .ⴖͦ.
+.xn--hva754s.xn--0ug; .ⴖͦ.‌; [C1, X4_2]; .xn--hva754s.xn--0ug; [C1, A4_2]; ;  # .ⴖͦ.
+.xn--hva929d.; .Ⴖͦ.; [V6, X4_2]; .xn--hva929d.; [V6, A4_2]; ;  # .Ⴖͦ.
+.xn--hva929d.xn--0ug; .Ⴖͦ.‌; [C1, V6, X4_2]; .xn--hva929d.xn--0ug; [C1, V6, A4_2]; ;  # .Ⴖͦ.
+︒ⴖͦ．‌; ︒ⴖͦ.‌; [C1, P1, V6]; xn--hva754sy94k.xn--0ug; ; xn--hva754sy94k.; [P1, V6] # ︒ⴖͦ.
+xn--hva754sy94k.; ︒ⴖͦ.; [V6]; xn--hva754sy94k.; ; ;  # ︒ⴖͦ.
+xn--hva754sy94k.xn--0ug; ︒ⴖͦ.‌; [C1, V6]; xn--hva754sy94k.xn--0ug; ; ;  # ︒ⴖͦ.
+xn--hva929dl29p.; ︒Ⴖͦ.; [V6]; xn--hva929dl29p.; ; ;  # ︒Ⴖͦ.
+xn--hva929dl29p.xn--0ug; ︒Ⴖͦ.‌; [C1, V6]; xn--hva929dl29p.xn--0ug; ; ;  # ︒Ⴖͦ.
+xn--hva754s.; ⴖͦ.; ; xn--hva754s.; ; ;  # ⴖͦ.
+ⴖͦ.; ; ; xn--hva754s.; ; ;  # ⴖͦ.
+Ⴖͦ.; ; [P1, V6]; xn--hva929d.; ; ;  # Ⴖͦ.
+xn--hva929d.; Ⴖͦ.; [V6]; xn--hva929d.; ; ;  # Ⴖͦ.
+ࢻ．‌Ⴃ𞀒; ࢻ.‌Ⴃ𞀒; [B1, C1, P1, V6]; xn--hzb.xn--bnd300f7225a; ; xn--hzb.xn--bnd2938u; [P1, V6] # ࢻ.Ⴃ𞀒
+ࢻ.‌Ⴃ𞀒; ; [B1, C1, P1, V6]; xn--hzb.xn--bnd300f7225a; ; xn--hzb.xn--bnd2938u; [P1, V6] # ࢻ.Ⴃ𞀒
+ࢻ.‌ⴃ𞀒; ; [B1, C1]; xn--hzb.xn--0ug822cp045a; ; xn--hzb.xn--ukj4430l; [] # ࢻ.ⴃ𞀒
+xn--hzb.xn--ukj4430l; ࢻ.ⴃ𞀒; ; xn--hzb.xn--ukj4430l; ; ;  # ࢻ.ⴃ𞀒
+ࢻ.ⴃ𞀒; ; ; xn--hzb.xn--ukj4430l; ; ;  # ࢻ.ⴃ𞀒
+ࢻ.Ⴃ𞀒; ; [P1, V6]; xn--hzb.xn--bnd2938u; ; ;  # ࢻ.Ⴃ𞀒
+xn--hzb.xn--bnd2938u; ࢻ.Ⴃ𞀒; [V6]; xn--hzb.xn--bnd2938u; ; ;  # ࢻ.Ⴃ𞀒
+xn--hzb.xn--0ug822cp045a; ࢻ.‌ⴃ𞀒; [B1, C1]; xn--hzb.xn--0ug822cp045a; ; ;  # ࢻ.ⴃ𞀒
+xn--hzb.xn--bnd300f7225a; ࢻ.‌Ⴃ𞀒; [B1, C1, V6]; xn--hzb.xn--bnd300f7225a; ; ;  # ࢻ.Ⴃ𞀒
+ࢻ．‌ⴃ𞀒; ࢻ.‌ⴃ𞀒; [B1, C1]; xn--hzb.xn--0ug822cp045a; ; xn--hzb.xn--ukj4430l; [] # ࢻ.ⴃ𞀒
+‍‌。２䫷󠧷; ‍‌.2䫷󠧷; [C1, C2, P1, V6]; xn--0ugb.xn--2-me5ay1273i; ; .xn--2-me5ay1273i; [P1, V6, A4_2] # .2䫷
+‍‌。2䫷󠧷; ‍‌.2䫷󠧷; [C1, C2, P1, V6]; xn--0ugb.xn--2-me5ay1273i; ; .xn--2-me5ay1273i; [P1, V6, A4_2] # .2䫷
+.xn--2-me5ay1273i; .2䫷󠧷; [V6, X4_2]; .xn--2-me5ay1273i; [V6, A4_2]; ;  # .2䫷
+xn--0ugb.xn--2-me5ay1273i; ‍‌.2䫷󠧷; [C1, C2, V6]; xn--0ugb.xn--2-me5ay1273i; ; ;  # .2䫷
+-𞀤󜠐。򈬖; -𞀤󜠐.򈬖; [P1, V3, V6]; xn----rq4re4997d.xn--l707b; ; ;  # -𞀤.
+xn----rq4re4997d.xn--l707b; -𞀤󜠐.򈬖; [V3, V6]; xn----rq4re4997d.xn--l707b; ; ;  # -𞀤.
+󳛂︒‌㟀．ؤ⒈; 󳛂︒‌㟀.ؤ⒈; [C1, P1, V6]; xn--0ug754gxl4ldlt0k.xn--jgb476m; ; xn--etlt457ccrq7h.xn--jgb476m; [P1, V6] # ︒㟀.ؤ⒈
+󳛂︒‌㟀．ؤ⒈; 󳛂︒‌㟀.ؤ⒈; [C1, P1, V6]; xn--0ug754gxl4ldlt0k.xn--jgb476m; ; xn--etlt457ccrq7h.xn--jgb476m; [P1, V6] # ︒㟀.ؤ⒈
+󳛂。‌㟀.ؤ1.; 󳛂.‌㟀.ؤ1.; [B1, C1, P1, V6]; xn--z272f.xn--0ug754g.xn--1-smc.; ; xn--z272f.xn--etl.xn--1-smc.; [P1, V6] # .㟀.ؤ1.
+󳛂。‌㟀.ؤ1.; 󳛂.‌㟀.ؤ1.; [B1, C1, P1, V6]; xn--z272f.xn--0ug754g.xn--1-smc.; ; xn--z272f.xn--etl.xn--1-smc.; [P1, V6] # .㟀.ؤ1.
+xn--z272f.xn--etl.xn--1-smc.; 󳛂.㟀.ؤ1.; [V6]; xn--z272f.xn--etl.xn--1-smc.; ; ;  # .㟀.ؤ1.
+xn--z272f.xn--0ug754g.xn--1-smc.; 󳛂.‌㟀.ؤ1.; [B1, C1, V6]; xn--z272f.xn--0ug754g.xn--1-smc.; ; ;  # .㟀.ؤ1.
+xn--etlt457ccrq7h.xn--jgb476m; 󳛂︒㟀.ؤ⒈; [V6]; xn--etlt457ccrq7h.xn--jgb476m; ; ;  # ︒㟀.ؤ⒈
+xn--0ug754gxl4ldlt0k.xn--jgb476m; 󳛂︒‌㟀.ؤ⒈; [C1, V6]; xn--0ug754gxl4ldlt0k.xn--jgb476m; ; ;  # ︒㟀.ؤ⒈
+𑲜ߊ𝅼。-‍; 𑲜ߊ𝅼.-‍; [B1, C2, V3, V5]; xn--lsb5482l7nre.xn----ugn; ; xn--lsb5482l7nre.-; [B1, V3, V5] # 𑲜ߊ𝅼.-
+xn--lsb5482l7nre.-; 𑲜ߊ𝅼.-; [B1, V3, V5]; xn--lsb5482l7nre.-; ; ;  # 𑲜ߊ𝅼.-
+xn--lsb5482l7nre.xn----ugn; 𑲜ߊ𝅼.-‍; [B1, C2, V3, V5]; xn--lsb5482l7nre.xn----ugn; ; ;  # 𑲜ߊ𝅼.-
+‌．Ⴉ≠𐫶; ‌.Ⴉ≠𐫶; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--hnd481gv73o; ; .xn--hnd481gv73o; [B5, B6, P1, V6, A4_2] # .Ⴉ≠𐫶
+‌．Ⴉ≠𐫶; ‌.Ⴉ≠𐫶; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--hnd481gv73o; ; .xn--hnd481gv73o; [B5, B6, P1, V6, A4_2] # .Ⴉ≠𐫶
+‌.Ⴉ≠𐫶; ; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--hnd481gv73o; ; .xn--hnd481gv73o; [B5, B6, P1, V6, A4_2] # .Ⴉ≠𐫶
+‌.Ⴉ≠𐫶; ‌.Ⴉ≠𐫶; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--hnd481gv73o; ; .xn--hnd481gv73o; [B5, B6, P1, V6, A4_2] # .Ⴉ≠𐫶
+‌.ⴉ≠𐫶; ‌.ⴉ≠𐫶; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, P1, V6, A4_2] # .ⴉ≠𐫶
+‌.ⴉ≠𐫶; ; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, P1, V6, A4_2] # .ⴉ≠𐫶
+.xn--1chx23bzj4p; .ⴉ≠𐫶; [B5, B6, V6, X4_2]; .xn--1chx23bzj4p; [B5, B6, V6, A4_2]; ;  # .ⴉ≠𐫶
+xn--0ug.xn--1chx23bzj4p; ‌.ⴉ≠𐫶; [B1, B5, B6, C1, V6]; xn--0ug.xn--1chx23bzj4p; ; ;  # .ⴉ≠𐫶
+.xn--hnd481gv73o; .Ⴉ≠𐫶; [B5, B6, V6, X4_2]; .xn--hnd481gv73o; [B5, B6, V6, A4_2]; ;  # .Ⴉ≠𐫶
+xn--0ug.xn--hnd481gv73o; ‌.Ⴉ≠𐫶; [B1, B5, B6, C1, V6]; xn--0ug.xn--hnd481gv73o; ; ;  # .Ⴉ≠𐫶
+‌．ⴉ≠𐫶; ‌.ⴉ≠𐫶; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, P1, V6, A4_2] # .ⴉ≠𐫶
+‌．ⴉ≠𐫶; ‌.ⴉ≠𐫶; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, P1, V6, A4_2] # .ⴉ≠𐫶
+ݐ。≯ς; ݐ.≯ς; [B1, P1, V6]; xn--3ob.xn--3xa918m; ; xn--3ob.xn--4xa718m;  # ݐ.≯ς
+ݐ。≯ς; ݐ.≯ς; [B1, P1, V6]; xn--3ob.xn--3xa918m; ; xn--3ob.xn--4xa718m;  # ݐ.≯ς
+ݐ。≯Σ; ݐ.≯σ; [B1, P1, V6]; xn--3ob.xn--4xa718m; ; ;  # ݐ.≯σ
+ݐ。≯Σ; ݐ.≯σ; [B1, P1, V6]; xn--3ob.xn--4xa718m; ; ;  # ݐ.≯σ
+ݐ。≯σ; ݐ.≯σ; [B1, P1, V6]; xn--3ob.xn--4xa718m; ; ;  # ݐ.≯σ
+ݐ。≯σ; ݐ.≯σ; [B1, P1, V6]; xn--3ob.xn--4xa718m; ; ;  # ݐ.≯σ
+xn--3ob.xn--4xa718m; ݐ.≯σ; [B1, V6]; xn--3ob.xn--4xa718m; ; ;  # ݐ.≯σ
+xn--3ob.xn--3xa918m; ݐ.≯ς; [B1, V6]; xn--3ob.xn--3xa918m; ; ;  # ݐ.≯ς
+߼𐸆.𓖏︒񊨩Ⴐ; ; [P1, V6]; xn--0tb8725k.xn--ond3562jt18a7py9c; ; ;  # .︒Ⴐ
+߼𐸆.𓖏。񊨩Ⴐ; ߼𐸆.𓖏.񊨩Ⴐ; [P1, V6]; xn--0tb8725k.xn--tu8d.xn--ond97931d; ; ;  # ..Ⴐ
+߼𐸆.𓖏。񊨩ⴐ; ߼𐸆.𓖏.񊨩ⴐ; [P1, V6]; xn--0tb8725k.xn--tu8d.xn--7kj73887a; ; ;  # ..ⴐ
+xn--0tb8725k.xn--tu8d.xn--7kj73887a; ߼𐸆.𓖏.񊨩ⴐ; [V6]; xn--0tb8725k.xn--tu8d.xn--7kj73887a; ; ;  # ..ⴐ
+xn--0tb8725k.xn--tu8d.xn--ond97931d; ߼𐸆.𓖏.񊨩Ⴐ; [V6]; xn--0tb8725k.xn--tu8d.xn--ond97931d; ; ;  # ..Ⴐ
+߼𐸆.𓖏︒񊨩ⴐ; ; [P1, V6]; xn--0tb8725k.xn--7kj9008dt18a7py9c; ; ;  # .︒ⴐ
+xn--0tb8725k.xn--7kj9008dt18a7py9c; ߼𐸆.𓖏︒񊨩ⴐ; [V6]; xn--0tb8725k.xn--7kj9008dt18a7py9c; ; ;  # .︒ⴐ
+xn--0tb8725k.xn--ond3562jt18a7py9c; ߼𐸆.𓖏︒񊨩Ⴐ; [V6]; xn--0tb8725k.xn--ond3562jt18a7py9c; ; ;  # .︒Ⴐ
+Ⴥ⚭󠖫⋃｡𑌼; Ⴥ⚭󠖫⋃.𑌼; [P1, V5, V6]; xn--9nd623g4zc5z060c.xn--ro1d; ; ;  # Ⴥ⚭⋃.𑌼
+Ⴥ⚭󠖫⋃。𑌼; Ⴥ⚭󠖫⋃.𑌼; [P1, V5, V6]; xn--9nd623g4zc5z060c.xn--ro1d; ; ;  # Ⴥ⚭⋃.𑌼
+ⴥ⚭󠖫⋃。𑌼; ⴥ⚭󠖫⋃.𑌼; [P1, V5, V6]; xn--vfh16m67gx1162b.xn--ro1d; ; ;  # ⴥ⚭⋃.𑌼
+xn--vfh16m67gx1162b.xn--ro1d; ⴥ⚭󠖫⋃.𑌼; [V5, V6]; xn--vfh16m67gx1162b.xn--ro1d; ; ;  # ⴥ⚭⋃.𑌼
+xn--9nd623g4zc5z060c.xn--ro1d; Ⴥ⚭󠖫⋃.𑌼; [V5, V6]; xn--9nd623g4zc5z060c.xn--ro1d; ; ;  # Ⴥ⚭⋃.𑌼
+ⴥ⚭󠖫⋃｡𑌼; ⴥ⚭󠖫⋃.𑌼; [P1, V5, V6]; xn--vfh16m67gx1162b.xn--ro1d; ; ;  # ⴥ⚭⋃.𑌼
+🄈。󠷳ࡄ; 🄈.󠷳ࡄ; [B1, P1, V6]; xn--107h.xn--2vb13094p; ; ;  # 🄈.ࡄ
+7,。󠷳ࡄ; 7,.󠷳ࡄ; [B1, P1, V6]; 7,.xn--2vb13094p; ; ;  # 7,.ࡄ
+7,.xn--2vb13094p; 7,.󠷳ࡄ; [B1, P1, V6]; 7,.xn--2vb13094p; ; ;  # 7,.ࡄ
+xn--107h.xn--2vb13094p; 🄈.󠷳ࡄ; [B1, V6]; xn--107h.xn--2vb13094p; ; ;  # 🄈.ࡄ
+≮ࡆ。섖쮖ß; ≮ࡆ.섖쮖ß; [B1, P1, V6]; xn--4vb505k.xn--zca7259goug; ; xn--4vb505k.xn--ss-5z4j006a;  # ≮ࡆ.섖쮖ß
+≮ࡆ。섖쮖ß; ≮ࡆ.섖쮖ß; [B1, P1, V6]; xn--4vb505k.xn--zca7259goug; ; xn--4vb505k.xn--ss-5z4j006a;  # ≮ࡆ.섖쮖ß
+≮ࡆ。섖쮖SS; ≮ࡆ.섖쮖ss; [B1, P1, V6]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+≮ࡆ。섖쮖SS; ≮ࡆ.섖쮖ss; [B1, P1, V6]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+≮ࡆ。섖쮖ss; ≮ࡆ.섖쮖ss; [B1, P1, V6]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+≮ࡆ。섖쮖ss; ≮ࡆ.섖쮖ss; [B1, P1, V6]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+xn--4vb505k.xn--ss-5z4j006a; ≮ࡆ.섖쮖ss; [B1, V6]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+≮ࡆ。섖쮖Ss; ≮ࡆ.섖쮖ss; [B1, P1, V6]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+≮ࡆ。섖쮖Ss; ≮ࡆ.섖쮖ss; [B1, P1, V6]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+xn--4vb505k.xn--zca7259goug; ≮ࡆ.섖쮖ß; [B1, V6]; xn--4vb505k.xn--zca7259goug; ; ;  # ≮ࡆ.섖쮖ß
+󠆓⛏-。ꡒ; ⛏-.ꡒ; [V3]; xn----o9p.xn--rc9a; ; ;  # ⛏-.ꡒ
+xn----o9p.xn--rc9a; ⛏-.ꡒ; [V3]; xn----o9p.xn--rc9a; ; ;  # ⛏-.ꡒ
+޻𐹳ئ𑁆。ࢧڰ‌ᢒ; ޻𐹳ئ𑁆.ࢧڰ‌ᢒ; [B2, B3, P1, V6]; xn--lgb32f2753cosb.xn--jkb91hlz1azih; ; xn--lgb32f2753cosb.xn--jkb91hlz1a;  # 𐹳ئ𑁆.ࢧڰᢒ
+޻𐹳ئ𑁆。ࢧڰ‌ᢒ; ޻𐹳ئ𑁆.ࢧڰ‌ᢒ; [B2, B3, P1, V6]; xn--lgb32f2753cosb.xn--jkb91hlz1azih; ; xn--lgb32f2753cosb.xn--jkb91hlz1a;  # 𐹳ئ𑁆.ࢧڰᢒ
+xn--lgb32f2753cosb.xn--jkb91hlz1a; ޻𐹳ئ𑁆.ࢧڰᢒ; [B2, B3, V6]; xn--lgb32f2753cosb.xn--jkb91hlz1a; ; ;  # 𐹳ئ𑁆.ࢧڰᢒ
+xn--lgb32f2753cosb.xn--jkb91hlz1azih; ޻𐹳ئ𑁆.ࢧڰ‌ᢒ; [B2, B3, V6]; xn--lgb32f2753cosb.xn--jkb91hlz1azih; ; ;  # 𐹳ئ𑁆.ࢧڰᢒ
+ࠖ.𐨕𚚕; ; [B1, B2, B3, B6, P1, V5, V6]; xn--rub.xn--tr9c248x; ; ;  # ࠖ.𐨕
+xn--rub.xn--tr9c248x; ࠖ.𐨕𚚕; [B1, B2, B3, B6, V5, V6]; xn--rub.xn--tr9c248x; ; ;  # ࠖ.𐨕
+--。𽊆ݧ𐽋𞠬; --.𽊆ݧ𐽋𞠬; [B1, B5, B6, P1, V3, V6]; --.xn--rpb6226k77pfh58p; ; ;  # --.ݧ𐽋𞠬
+--.xn--rpb6226k77pfh58p; --.𽊆ݧ𐽋𞠬; [B1, B5, B6, V3, V6]; --.xn--rpb6226k77pfh58p; ; ;  # --.ݧ𐽋𞠬
+򛭦𐋥𹸐.≯ࢰࢦ󔛣; ; [B1, P1, V6]; xn--887c2298i5mv6a.xn--vybt688qm8981a; ; ;  # 𐋥.≯ࢰࢦ
+򛭦𐋥𹸐.≯ࢰࢦ󔛣; 򛭦𐋥𹸐.≯ࢰࢦ󔛣; [B1, P1, V6]; xn--887c2298i5mv6a.xn--vybt688qm8981a; ; ;  # 𐋥.≯ࢰࢦ
+xn--887c2298i5mv6a.xn--vybt688qm8981a; 򛭦𐋥𹸐.≯ࢰࢦ󔛣; [B1, V6]; xn--887c2298i5mv6a.xn--vybt688qm8981a; ; ;  # 𐋥.≯ࢰࢦ
+䔛󠇒򤸞𐹧．-䤷; 䔛򤸞𐹧.-䤷; [B1, B5, B6, P1, V3, V6]; xn--2loy662coo60e.xn----0n4a; ; ;  # 䔛𐹧.-䤷
+䔛󠇒򤸞𐹧.-䤷; 䔛򤸞𐹧.-䤷; [B1, B5, B6, P1, V3, V6]; xn--2loy662coo60e.xn----0n4a; ; ;  # 䔛𐹧.-䤷
+xn--2loy662coo60e.xn----0n4a; 䔛򤸞𐹧.-䤷; [B1, B5, B6, V3, V6]; xn--2loy662coo60e.xn----0n4a; ; ;  # 䔛𐹧.-䤷
+𐹩．‍-; 𐹩.‍-; [B1, C2, V3]; xn--ho0d.xn----tgn; ; xn--ho0d.-; [B1, V3] # 𐹩.-
+𐹩.‍-; ; [B1, C2, V3]; xn--ho0d.xn----tgn; ; xn--ho0d.-; [B1, V3] # 𐹩.-
+xn--ho0d.-; 𐹩.-; [B1, V3]; xn--ho0d.-; ; ;  # 𐹩.-
+xn--ho0d.xn----tgn; 𐹩.‍-; [B1, C2, V3]; xn--ho0d.xn----tgn; ; ;  # 𐹩.-
+񂈦帷｡≯萺᷈-; 񂈦帷.≯萺᷈-; [P1, V3, V6]; xn--qutw175s.xn----mimu6tf67j; ; ;  # 帷.≯萺᷈-
+񂈦帷｡≯萺᷈-; 񂈦帷.≯萺᷈-; [P1, V3, V6]; xn--qutw175s.xn----mimu6tf67j; ; ;  # 帷.≯萺᷈-
+񂈦帷。≯萺᷈-; 񂈦帷.≯萺᷈-; [P1, V3, V6]; xn--qutw175s.xn----mimu6tf67j; ; ;  # 帷.≯萺᷈-
+񂈦帷。≯萺᷈-; 񂈦帷.≯萺᷈-; [P1, V3, V6]; xn--qutw175s.xn----mimu6tf67j; ; ;  # 帷.≯萺᷈-
+xn--qutw175s.xn----mimu6tf67j; 񂈦帷.≯萺᷈-; [V3, V6]; xn--qutw175s.xn----mimu6tf67j; ; ;  # 帷.≯萺᷈-
+‍攌꯭。ᢖ-Ⴘ; ‍攌꯭.ᢖ-Ⴘ; [C2, P1, V6]; xn--1ug592ykp6b.xn----k1g451d; ; xn--p9ut19m.xn----k1g451d; [P1, V6] # 攌꯭.ᢖ-Ⴘ
+‍攌꯭。ᢖ-ⴘ; ‍攌꯭.ᢖ-ⴘ; [C2]; xn--1ug592ykp6b.xn----mck373i; ; xn--p9ut19m.xn----mck373i; [] # 攌꯭.ᢖ-ⴘ
+xn--p9ut19m.xn----mck373i; 攌꯭.ᢖ-ⴘ; ; xn--p9ut19m.xn----mck373i; ; ;  # 攌꯭.ᢖ-ⴘ
+攌꯭.ᢖ-ⴘ; ; ; xn--p9ut19m.xn----mck373i; ; ;  # 攌꯭.ᢖ-ⴘ
+攌꯭.ᢖ-Ⴘ; ; [P1, V6]; xn--p9ut19m.xn----k1g451d; ; ;  # 攌꯭.ᢖ-Ⴘ
+xn--p9ut19m.xn----k1g451d; 攌꯭.ᢖ-Ⴘ; [V6]; xn--p9ut19m.xn----k1g451d; ; ;  # 攌꯭.ᢖ-Ⴘ
+xn--1ug592ykp6b.xn----mck373i; ‍攌꯭.ᢖ-ⴘ; [C2]; xn--1ug592ykp6b.xn----mck373i; ; ;  # 攌꯭.ᢖ-ⴘ
+xn--1ug592ykp6b.xn----k1g451d; ‍攌꯭.ᢖ-Ⴘ; [C2, V6]; xn--1ug592ykp6b.xn----k1g451d; ; ;  # 攌꯭.ᢖ-Ⴘ
+‌ꖨ．⒗３툒۳; ‌ꖨ.⒗3툒۳; [C1, P1, V6]; xn--0ug2473c.xn--3-nyc678tu07m; ; xn--9r8a.xn--3-nyc678tu07m; [P1, V6] # ꖨ.⒗3툒۳
+‌ꖨ．⒗３툒۳; ‌ꖨ.⒗3툒۳; [C1, P1, V6]; xn--0ug2473c.xn--3-nyc678tu07m; ; xn--9r8a.xn--3-nyc678tu07m; [P1, V6] # ꖨ.⒗3툒۳
+‌ꖨ.16.3툒۳; ; [C1]; xn--0ug2473c.16.xn--3-nyc0117m; ; xn--9r8a.16.xn--3-nyc0117m; [] # ꖨ.16.3툒۳
+‌ꖨ.16.3툒۳; ‌ꖨ.16.3툒۳; [C1]; xn--0ug2473c.16.xn--3-nyc0117m; ; xn--9r8a.16.xn--3-nyc0117m; [] # ꖨ.16.3툒۳
+xn--9r8a.16.xn--3-nyc0117m; ꖨ.16.3툒۳; ; xn--9r8a.16.xn--3-nyc0117m; ; ;  # ꖨ.16.3툒۳
+ꖨ.16.3툒۳; ; ; xn--9r8a.16.xn--3-nyc0117m; ; ;  # ꖨ.16.3툒۳
+ꖨ.16.3툒۳; ꖨ.16.3툒۳; ; xn--9r8a.16.xn--3-nyc0117m; ; ;  # ꖨ.16.3툒۳
+xn--0ug2473c.16.xn--3-nyc0117m; ‌ꖨ.16.3툒۳; [C1]; xn--0ug2473c.16.xn--3-nyc0117m; ; ;  # ꖨ.16.3툒۳
+xn--9r8a.xn--3-nyc678tu07m; ꖨ.⒗3툒۳; [V6]; xn--9r8a.xn--3-nyc678tu07m; ; ;  # ꖨ.⒗3툒۳
+xn--0ug2473c.xn--3-nyc678tu07m; ‌ꖨ.⒗3툒۳; [C1, V6]; xn--0ug2473c.xn--3-nyc678tu07m; ; ;  # ꖨ.⒗3툒۳
+⒈걾6.𐱁ې; ; [B1, P1, V6]; xn--6-dcps419c.xn--glb1794k; ; ;  # ⒈걾6.𐱁ې
+⒈걾6.𐱁ې; ⒈걾6.𐱁ې; [B1, P1, V6]; xn--6-dcps419c.xn--glb1794k; ; ;  # ⒈걾6.𐱁ې
+1.걾6.𐱁ې; ; [B1]; 1.xn--6-945e.xn--glb1794k; ; ;  # 1.걾6.𐱁ې
+1.걾6.𐱁ې; 1.걾6.𐱁ې; [B1]; 1.xn--6-945e.xn--glb1794k; ; ;  # 1.걾6.𐱁ې
+1.xn--6-945e.xn--glb1794k; 1.걾6.𐱁ې; [B1]; 1.xn--6-945e.xn--glb1794k; ; ;  # 1.걾6.𐱁ې
+xn--6-dcps419c.xn--glb1794k; ⒈걾6.𐱁ې; [B1, V6]; xn--6-dcps419c.xn--glb1794k; ; ;  # ⒈걾6.𐱁ې
+𐲞𝟶≮≮.󠀧ع; 𐳞0≮≮.󠀧ع; [B1, B3, P1, V6]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐲞𝟶≮≮.󠀧ع; 𐳞0≮≮.󠀧ع; [B1, B3, P1, V6]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐲞0≮≮.󠀧ع; 𐳞0≮≮.󠀧ع; [B1, B3, P1, V6]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐲞0≮≮.󠀧ع; 𐳞0≮≮.󠀧ع; [B1, B3, P1, V6]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐳞0≮≮.󠀧ع; 𐳞0≮≮.󠀧ع; [B1, B3, P1, V6]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐳞0≮≮.󠀧ع; ; [B1, B3, P1, V6]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+xn--0-ngoa5711v.xn--4gb31034p; 𐳞0≮≮.󠀧ع; [B1, B3, V6]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐳞𝟶≮≮.󠀧ع; 𐳞0≮≮.󠀧ع; [B1, B3, P1, V6]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐳞𝟶≮≮.󠀧ع; 𐳞0≮≮.󠀧ع; [B1, B3, P1, V6]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+ૣ.𐹺ᅟ; ; [B1, B3, B6, P1, V5, V6]; xn--8fc.xn--osd3070k; ; ;  # ૣ.𐹺
+xn--8fc.xn--osd3070k; ૣ.𐹺ᅟ; [B1, B3, B6, V5, V6]; xn--8fc.xn--osd3070k; ; ;  # ૣ.𐹺
+𝟏𝨙⸖.‍; 1𝨙⸖.‍; [C2]; xn--1-5bt6845n.xn--1ug; ; xn--1-5bt6845n.; [] # 1𝨙⸖.
+1𝨙⸖.‍; ; [C2]; xn--1-5bt6845n.xn--1ug; ; xn--1-5bt6845n.; [] # 1𝨙⸖.
+xn--1-5bt6845n.; 1𝨙⸖.; ; xn--1-5bt6845n.; ; ;  # 1𝨙⸖.
+1𝨙⸖.; ; ; xn--1-5bt6845n.; ; ;  # 1𝨙⸖.
+xn--1-5bt6845n.xn--1ug; 1𝨙⸖.‍; [C2]; xn--1-5bt6845n.xn--1ug; ; ;  # 1𝨙⸖.
+𞤐≠ܦ᩠｡-‌ߕ; 𞤲≠ܦ᩠.-‌ߕ; [B1, C1, P1, V3, V6]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, P1, V3, V6] # 𞤲≠ܦ᩠.-ߕ
+𞤐≠ܦ᩠｡-‌ߕ; 𞤲≠ܦ᩠.-‌ߕ; [B1, C1, P1, V3, V6]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, P1, V3, V6] # 𞤲≠ܦ᩠.-ߕ
+𞤐≠ܦ᩠。-‌ߕ; 𞤲≠ܦ᩠.-‌ߕ; [B1, C1, P1, V3, V6]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, P1, V3, V6] # 𞤲≠ܦ᩠.-ߕ
+𞤐≠ܦ᩠。-‌ߕ; 𞤲≠ܦ᩠.-‌ߕ; [B1, C1, P1, V3, V6]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, P1, V3, V6] # 𞤲≠ܦ᩠.-ߕ
+𞤲≠ܦ᩠。-‌ߕ; 𞤲≠ܦ᩠.-‌ߕ; [B1, C1, P1, V3, V6]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, P1, V3, V6] # 𞤲≠ܦ᩠.-ߕ
+𞤲≠ܦ᩠。-‌ߕ; 𞤲≠ܦ᩠.-‌ߕ; [B1, C1, P1, V3, V6]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, P1, V3, V6] # 𞤲≠ܦ᩠.-ߕ
+xn--wnb859grzfzw60c.xn----kcd; 𞤲≠ܦ᩠.-ߕ; [B1, V3, V6]; xn--wnb859grzfzw60c.xn----kcd; ; ;  # 𞤲≠ܦ᩠.-ߕ
+xn--wnb859grzfzw60c.xn----kcd017p; 𞤲≠ܦ᩠.-‌ߕ; [B1, C1, V3, V6]; xn--wnb859grzfzw60c.xn----kcd017p; ; ;  # 𞤲≠ܦ᩠.-ߕ
+𞤲≠ܦ᩠｡-‌ߕ; 𞤲≠ܦ᩠.-‌ߕ; [B1, C1, P1, V3, V6]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, P1, V3, V6] # 𞤲≠ܦ᩠.-ߕ
+𞤲≠ܦ᩠｡-‌ߕ; 𞤲≠ܦ᩠.-‌ߕ; [B1, C1, P1, V3, V6]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, P1, V3, V6] # 𞤲≠ܦ᩠.-ߕ
+𐹰ͨ-ꡧ｡ٵ; 𐹰ͨ-ꡧ.اٴ; [B1]; xn----shb2387jgkqd.xn--mgb8m; ; ;  # 𐹰ͨ-ꡧ.اٴ
+𐹰ͨ-ꡧ。اٴ; 𐹰ͨ-ꡧ.اٴ; [B1]; xn----shb2387jgkqd.xn--mgb8m; ; ;  # 𐹰ͨ-ꡧ.اٴ
+xn----shb2387jgkqd.xn--mgb8m; 𐹰ͨ-ꡧ.اٴ; [B1]; xn----shb2387jgkqd.xn--mgb8m; ; ;  # 𐹰ͨ-ꡧ.اٴ
+F󠅟｡򏗅♚; f.򏗅♚; [P1, V6]; f.xn--45hz6953f; ; ;  # f.♚
+F󠅟。򏗅♚; f.򏗅♚; [P1, V6]; f.xn--45hz6953f; ; ;  # f.♚
+f󠅟。򏗅♚; f.򏗅♚; [P1, V6]; f.xn--45hz6953f; ; ;  # f.♚
+f.xn--45hz6953f; f.򏗅♚; [V6]; f.xn--45hz6953f; ; ;  # f.♚
+f󠅟｡򏗅♚; f.򏗅♚; [P1, V6]; f.xn--45hz6953f; ; ;  # f.♚
+୍𑄴ᷩ。𝟮Ⴘ𞀨񃥇; ୍𑄴ᷩ.2Ⴘ𞀨񃥇; [P1, V5, V6]; xn--9ic246gs21p.xn--2-k1g43076adrwq; ; ;  # ୍𑄴ᷩ.2Ⴘ𞀨
+୍𑄴ᷩ。2Ⴘ𞀨񃥇; ୍𑄴ᷩ.2Ⴘ𞀨񃥇; [P1, V5, V6]; xn--9ic246gs21p.xn--2-k1g43076adrwq; ; ;  # ୍𑄴ᷩ.2Ⴘ𞀨
+୍𑄴ᷩ。2ⴘ𞀨񃥇; ୍𑄴ᷩ.2ⴘ𞀨񃥇; [P1, V5, V6]; xn--9ic246gs21p.xn--2-nws2918ndrjr; ; ;  # ୍𑄴ᷩ.2ⴘ𞀨
+xn--9ic246gs21p.xn--2-nws2918ndrjr; ୍𑄴ᷩ.2ⴘ𞀨񃥇; [V5, V6]; xn--9ic246gs21p.xn--2-nws2918ndrjr; ; ;  # ୍𑄴ᷩ.2ⴘ𞀨
+xn--9ic246gs21p.xn--2-k1g43076adrwq; ୍𑄴ᷩ.2Ⴘ𞀨񃥇; [V5, V6]; xn--9ic246gs21p.xn--2-k1g43076adrwq; ; ;  # ୍𑄴ᷩ.2Ⴘ𞀨
+୍𑄴ᷩ。𝟮ⴘ𞀨񃥇; ୍𑄴ᷩ.2ⴘ𞀨񃥇; [P1, V5, V6]; xn--9ic246gs21p.xn--2-nws2918ndrjr; ; ;  # ୍𑄴ᷩ.2ⴘ𞀨
+򓠭‌‌⒈。勉𑁅; 򓠭‌‌⒈.勉𑁅; [C1, P1, V6]; xn--0uga855aez302a.xn--4grs325b; ; xn--tsh11906f.xn--4grs325b; [P1, V6] # ⒈.勉𑁅
+򓠭‌‌1.。勉𑁅; 򓠭‌‌1..勉𑁅; [C1, P1, V6, X4_2]; xn--1-rgna61159u..xn--4grs325b; [C1, P1, V6, A4_2]; xn--1-yi00h..xn--4grs325b; [P1, V6, A4_2] # 1..勉𑁅
+xn--1-yi00h..xn--4grs325b; 򓠭1..勉𑁅; [V6, X4_2]; xn--1-yi00h..xn--4grs325b; [V6, A4_2]; ;  # 1..勉𑁅
+xn--1-rgna61159u..xn--4grs325b; 򓠭‌‌1..勉𑁅; [C1, V6, X4_2]; xn--1-rgna61159u..xn--4grs325b; [C1, V6, A4_2]; ;  # 1..勉𑁅
+xn--tsh11906f.xn--4grs325b; 򓠭⒈.勉𑁅; [V6]; xn--tsh11906f.xn--4grs325b; ; ;  # ⒈.勉𑁅
+xn--0uga855aez302a.xn--4grs325b; 򓠭‌‌⒈.勉𑁅; [C1, V6]; xn--0uga855aez302a.xn--4grs325b; ; ;  # ⒈.勉𑁅
+ᡃ.玿񫈜󕞐; ; [P1, V6]; xn--27e.xn--7cy81125a0yq4a; ; ;  # ᡃ.玿
+xn--27e.xn--7cy81125a0yq4a; ᡃ.玿񫈜󕞐; [V6]; xn--27e.xn--7cy81125a0yq4a; ; ;  # ᡃ.玿
+‌‌｡⒈≯𝟵; ‌‌.⒈≯9; [C1, P1, V6]; xn--0uga.xn--9-ogo37g; ; .xn--9-ogo37g; [P1, V6, A4_2] # .⒈≯9
+‌‌｡⒈≯𝟵; ‌‌.⒈≯9; [C1, P1, V6]; xn--0uga.xn--9-ogo37g; ; .xn--9-ogo37g; [P1, V6, A4_2] # .⒈≯9
+‌‌。1.≯9; ‌‌.1.≯9; [C1, P1, V6]; xn--0uga.1.xn--9-ogo; ; .1.xn--9-ogo; [P1, V6, A4_2] # .1.≯9
+‌‌。1.≯9; ‌‌.1.≯9; [C1, P1, V6]; xn--0uga.1.xn--9-ogo; ; .1.xn--9-ogo; [P1, V6, A4_2] # .1.≯9
+.1.xn--9-ogo; .1.≯9; [V6, X4_2]; .1.xn--9-ogo; [V6, A4_2]; ;  # .1.≯9
+xn--0uga.1.xn--9-ogo; ‌‌.1.≯9; [C1, V6]; xn--0uga.1.xn--9-ogo; ; ;  # .1.≯9
+.xn--9-ogo37g; .⒈≯9; [V6, X4_2]; .xn--9-ogo37g; [V6, A4_2]; ;  # .⒈≯9
+xn--0uga.xn--9-ogo37g; ‌‌.⒈≯9; [C1, V6]; xn--0uga.xn--9-ogo37g; ; ;  # .⒈≯9
+ᅟᷠ򐀁.𺻆≯𐮁; ; [B5, B6, P1, V6]; xn--osd615d5659o.xn--hdh5192gkm6r; ; ;  # ᷠ.≯𐮁
+ᅟᷠ򐀁.𺻆≯𐮁; ᅟᷠ򐀁.𺻆≯𐮁; [B5, B6, P1, V6]; xn--osd615d5659o.xn--hdh5192gkm6r; ; ;  # ᷠ.≯𐮁
+xn--osd615d5659o.xn--hdh5192gkm6r; ᅟᷠ򐀁.𺻆≯𐮁; [B5, B6, V6]; xn--osd615d5659o.xn--hdh5192gkm6r; ; ;  # ᷠ.≯𐮁
+󠄫𝩤‍ؾ.𝩩-ࠞ󑼩; 𝩤‍ؾ.𝩩-ࠞ󑼩; [B1, C2, P1, V5, V6]; xn--9gb723kg862a.xn----qgd52296avol4f; ; xn--9gb5080v.xn----qgd52296avol4f; [B1, P1, V5, V6] # 𝩤ؾ.𝩩-ࠞ
+xn--9gb5080v.xn----qgd52296avol4f; 𝩤ؾ.𝩩-ࠞ󑼩; [B1, V5, V6]; xn--9gb5080v.xn----qgd52296avol4f; ; ;  # 𝩤ؾ.𝩩-ࠞ
+xn--9gb723kg862a.xn----qgd52296avol4f; 𝩤‍ؾ.𝩩-ࠞ󑼩; [B1, C2, V5, V6]; xn--9gb723kg862a.xn----qgd52296avol4f; ; ;  # 𝩤ؾ.𝩩-ࠞ
+⃚．𑘿-; ⃚.𑘿-; [V3, V5]; xn--w0g.xn----bd0j; ; ;  # ⃚.𑘿-
+⃚.𑘿-; ; [V3, V5]; xn--w0g.xn----bd0j; ; ;  # ⃚.𑘿-
+xn--w0g.xn----bd0j; ⃚.𑘿-; [V3, V5]; xn--w0g.xn----bd0j; ; ;  # ⃚.𑘿-
+䮸ß.󠵟󠭎紙ࢨ; ; [B1, P1, V6]; xn--zca5349a.xn--xyb1370div70kpzba; ; xn--ss-sf1c.xn--xyb1370div70kpzba;  # 䮸ß.紙ࢨ
+䮸SS.󠵟󠭎紙ࢨ; 䮸ss.󠵟󠭎紙ࢨ; [B1, P1, V6]; xn--ss-sf1c.xn--xyb1370div70kpzba; ; ;  # 䮸ss.紙ࢨ
+䮸ss.󠵟󠭎紙ࢨ; ; [B1, P1, V6]; xn--ss-sf1c.xn--xyb1370div70kpzba; ; ;  # 䮸ss.紙ࢨ
+䮸Ss.󠵟󠭎紙ࢨ; 䮸ss.󠵟󠭎紙ࢨ; [B1, P1, V6]; xn--ss-sf1c.xn--xyb1370div70kpzba; ; ;  # 䮸ss.紙ࢨ
+xn--ss-sf1c.xn--xyb1370div70kpzba; 䮸ss.󠵟󠭎紙ࢨ; [B1, V6]; xn--ss-sf1c.xn--xyb1370div70kpzba; ; ;  # 䮸ss.紙ࢨ
+xn--zca5349a.xn--xyb1370div70kpzba; 䮸ß.󠵟󠭎紙ࢨ; [B1, V6]; xn--zca5349a.xn--xyb1370div70kpzba; ; ;  # 䮸ß.紙ࢨ
+-Ⴞ.-𝩨⅔𐦕; -Ⴞ.-𝩨2⁄3𐦕; [B1, P1, V3, V6]; xn----w1g.xn---23-pt0a0433lk3jj; ; ;  # -Ⴞ.-𝩨2⁄3𐦕
+-Ⴞ.-𝩨2⁄3𐦕; ; [B1, P1, V3, V6]; xn----w1g.xn---23-pt0a0433lk3jj; ; ;  # -Ⴞ.-𝩨2⁄3𐦕
+-ⴞ.-𝩨2⁄3𐦕; ; [B1, V3]; xn----zws.xn---23-pt0a0433lk3jj; ; ;  # -ⴞ.-𝩨2⁄3𐦕
+xn----zws.xn---23-pt0a0433lk3jj; -ⴞ.-𝩨2⁄3𐦕; [B1, V3]; xn----zws.xn---23-pt0a0433lk3jj; ; ;  # -ⴞ.-𝩨2⁄3𐦕
+xn----w1g.xn---23-pt0a0433lk3jj; -Ⴞ.-𝩨2⁄3𐦕; [B1, V3, V6]; xn----w1g.xn---23-pt0a0433lk3jj; ; ;  # -Ⴞ.-𝩨2⁄3𐦕
+-ⴞ.-𝩨⅔𐦕; -ⴞ.-𝩨2⁄3𐦕; [B1, V3]; xn----zws.xn---23-pt0a0433lk3jj; ; ;  # -ⴞ.-𝩨2⁄3𐦕
+󧈯𐹯ૂ｡򖢨𐮁񇼖ᡂ; 󧈯𐹯ૂ.򖢨𐮁񇼖ᡂ; [B5, B6, P1, V6]; xn--bfc7604kv8m3g.xn--17e5565jl7zw4h16a; ; ;  # 𐹯ૂ.𐮁ᡂ
+󧈯𐹯ૂ。򖢨𐮁񇼖ᡂ; 󧈯𐹯ૂ.򖢨𐮁񇼖ᡂ; [B5, B6, P1, V6]; xn--bfc7604kv8m3g.xn--17e5565jl7zw4h16a; ; ;  # 𐹯ૂ.𐮁ᡂ
+xn--bfc7604kv8m3g.xn--17e5565jl7zw4h16a; 󧈯𐹯ૂ.򖢨𐮁񇼖ᡂ; [B5, B6, V6]; xn--bfc7604kv8m3g.xn--17e5565jl7zw4h16a; ; ;  # 𐹯ૂ.𐮁ᡂ
+ႂ-‍꣪．ꡊ‍񼸳; ႂ-‍꣪.ꡊ‍񼸳; [C2, P1, V5, V6]; xn----gyg250jio7k.xn--1ug8774cri56d; ; xn----gyg3618i.xn--jc9ao4185a; [P1, V5, V6] # ႂ-꣪.ꡊ
+ႂ-‍꣪.ꡊ‍񼸳; ; [C2, P1, V5, V6]; xn----gyg250jio7k.xn--1ug8774cri56d; ; xn----gyg3618i.xn--jc9ao4185a; [P1, V5, V6] # ႂ-꣪.ꡊ
+xn----gyg3618i.xn--jc9ao4185a; ႂ-꣪.ꡊ񼸳; [V5, V6]; xn----gyg3618i.xn--jc9ao4185a; ; ;  # ႂ-꣪.ꡊ
+xn----gyg250jio7k.xn--1ug8774cri56d; ႂ-‍꣪.ꡊ‍񼸳; [C2, V5, V6]; xn----gyg250jio7k.xn--1ug8774cri56d; ; ;  # ႂ-꣪.ꡊ
+۱。≠٨; ۱.≠٨; [B1, P1, V6]; xn--emb.xn--hib334l; ; ;  # ۱.≠٨
+۱。≠٨; ۱.≠٨; [B1, P1, V6]; xn--emb.xn--hib334l; ; ;  # ۱.≠٨
+xn--emb.xn--hib334l; ۱.≠٨; [B1, V6]; xn--emb.xn--hib334l; ; ;  # ۱.≠٨
+𑈵廊.𐠍; ; [V5]; xn--xytw701b.xn--yc9c; ; ;  # 𑈵廊.𐠍
+xn--xytw701b.xn--yc9c; 𑈵廊.𐠍; [V5]; xn--xytw701b.xn--yc9c; ; ;  # 𑈵廊.𐠍
+‍͖-．-Ⴐ١; ‍͖-.-Ⴐ١; [B1, C2, P1, V3, V6]; xn----rgb661t.xn----bqc030f; ; xn----rgb.xn----bqc030f; [B1, P1, V3, V5, V6] # ͖-.-Ⴐ١
+‍͖-.-Ⴐ١; ; [B1, C2, P1, V3, V6]; xn----rgb661t.xn----bqc030f; ; xn----rgb.xn----bqc030f; [B1, P1, V3, V5, V6] # ͖-.-Ⴐ١
+‍͖-.-ⴐ١; ; [B1, C2, V3]; xn----rgb661t.xn----bqc2280a; ; xn----rgb.xn----bqc2280a; [B1, V3, V5] # ͖-.-ⴐ١
+xn----rgb.xn----bqc2280a; ͖-.-ⴐ١; [B1, V3, V5]; xn----rgb.xn----bqc2280a; ; ;  # ͖-.-ⴐ١
+xn----rgb661t.xn----bqc2280a; ‍͖-.-ⴐ١; [B1, C2, V3]; xn----rgb661t.xn----bqc2280a; ; ;  # ͖-.-ⴐ١
+xn----rgb.xn----bqc030f; ͖-.-Ⴐ١; [B1, V3, V5, V6]; xn----rgb.xn----bqc030f; ; ;  # ͖-.-Ⴐ١
+xn----rgb661t.xn----bqc030f; ‍͖-.-Ⴐ١; [B1, C2, V3, V6]; xn----rgb661t.xn----bqc030f; ; ;  # ͖-.-Ⴐ١
+‍͖-．-ⴐ١; ‍͖-.-ⴐ١; [B1, C2, V3]; xn----rgb661t.xn----bqc2280a; ; xn----rgb.xn----bqc2280a; [B1, V3, V5] # ͖-.-ⴐ١
+غ١挏󾯐.-; ; [B1, B2, B3, P1, V3, V6]; xn--5gb2f4205aqi47p.-; ; ;  # غ١挏.-
+xn--5gb2f4205aqi47p.-; غ١挏󾯐.-; [B1, B2, B3, V3, V6]; xn--5gb2f4205aqi47p.-; ; ;  # غ١挏.-
+ۯ｡𐹧𞤽; ۯ.𐹧𞤽; [B1]; xn--cmb.xn--fo0dy848a; ; ;  # ۯ.𐹧𞤽
+ۯ。𐹧𞤽; ۯ.𐹧𞤽; [B1]; xn--cmb.xn--fo0dy848a; ; ;  # ۯ.𐹧𞤽
+ۯ。𐹧𞤛; ۯ.𐹧𞤽; [B1]; xn--cmb.xn--fo0dy848a; ; ;  # ۯ.𐹧𞤽
+xn--cmb.xn--fo0dy848a; ۯ.𐹧𞤽; [B1]; xn--cmb.xn--fo0dy848a; ; ;  # ۯ.𐹧𞤽
+ۯ｡𐹧𞤛; ۯ.𐹧𞤽; [B1]; xn--cmb.xn--fo0dy848a; ; ;  # ۯ.𐹧𞤽
+Ⴞ𶛀𛗻．ᢗ릫; Ⴞ𶛀𛗻.ᢗ릫; [P1, V6]; xn--2nd8876sgl2j.xn--hbf6853f; ; ;  # Ⴞ.ᢗ릫
+Ⴞ𶛀𛗻．ᢗ릫; Ⴞ𶛀𛗻.ᢗ릫; [P1, V6]; xn--2nd8876sgl2j.xn--hbf6853f; ; ;  # Ⴞ.ᢗ릫
+Ⴞ𶛀𛗻.ᢗ릫; ; [P1, V6]; xn--2nd8876sgl2j.xn--hbf6853f; ; ;  # Ⴞ.ᢗ릫
+Ⴞ𶛀𛗻.ᢗ릫; Ⴞ𶛀𛗻.ᢗ릫; [P1, V6]; xn--2nd8876sgl2j.xn--hbf6853f; ; ;  # Ⴞ.ᢗ릫
+ⴞ𶛀𛗻.ᢗ릫; ⴞ𶛀𛗻.ᢗ릫; [P1, V6]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+ⴞ𶛀𛗻.ᢗ릫; ; [P1, V6]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+xn--mlj0486jgl2j.xn--hbf6853f; ⴞ𶛀𛗻.ᢗ릫; [V6]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+xn--2nd8876sgl2j.xn--hbf6853f; Ⴞ𶛀𛗻.ᢗ릫; [V6]; xn--2nd8876sgl2j.xn--hbf6853f; ; ;  # Ⴞ.ᢗ릫
+ⴞ𶛀𛗻．ᢗ릫; ⴞ𶛀𛗻.ᢗ릫; [P1, V6]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+ⴞ𶛀𛗻．ᢗ릫; ⴞ𶛀𛗻.ᢗ릫; [P1, V6]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+󠎃󗭞ڷ𐹷｡≯‌᷾; 󠎃󗭞ڷ𐹷.≯‌᷾; [B1, C1, P1, V6]; xn--qkb4516kbi06fg2id.xn--zfg59fm0c; ; xn--qkb4516kbi06fg2id.xn--zfg31q; [B1, P1, V6] # ڷ𐹷.≯᷾
+󠎃󗭞ڷ𐹷｡≯‌᷾; 󠎃󗭞ڷ𐹷.≯‌᷾; [B1, C1, P1, V6]; xn--qkb4516kbi06fg2id.xn--zfg59fm0c; ; xn--qkb4516kbi06fg2id.xn--zfg31q; [B1, P1, V6] # ڷ𐹷.≯᷾
+󠎃󗭞ڷ𐹷。≯‌᷾; 󠎃󗭞ڷ𐹷.≯‌᷾; [B1, C1, P1, V6]; xn--qkb4516kbi06fg2id.xn--zfg59fm0c; ; xn--qkb4516kbi06fg2id.xn--zfg31q; [B1, P1, V6] # ڷ𐹷.≯᷾
+󠎃󗭞ڷ𐹷。≯‌᷾; 󠎃󗭞ڷ𐹷.≯‌᷾; [B1, C1, P1, V6]; xn--qkb4516kbi06fg2id.xn--zfg59fm0c; ; xn--qkb4516kbi06fg2id.xn--zfg31q; [B1, P1, V6] # ڷ𐹷.≯᷾
+xn--qkb4516kbi06fg2id.xn--zfg31q; 󠎃󗭞ڷ𐹷.≯᷾; [B1, V6]; xn--qkb4516kbi06fg2id.xn--zfg31q; ; ;  # ڷ𐹷.≯᷾
+xn--qkb4516kbi06fg2id.xn--zfg59fm0c; 󠎃󗭞ڷ𐹷.≯‌᷾; [B1, C1, V6]; xn--qkb4516kbi06fg2id.xn--zfg59fm0c; ; ;  # ڷ𐹷.≯᷾
+ᛎ󠅍󠐕‍｡𐹾𐹪𐻝-; ᛎ󠐕‍.𐹾𐹪𐻝-; [B1, B6, C2, P1, V3, V6]; xn--fxe848bq3411a.xn----q26i2bvu; ; xn--fxe63563p.xn----q26i2bvu; [B1, B6, P1, V3, V6] # ᛎ.𐹾𐹪-
+ᛎ󠅍󠐕‍。𐹾𐹪𐻝-; ᛎ󠐕‍.𐹾𐹪𐻝-; [B1, B6, C2, P1, V3, V6]; xn--fxe848bq3411a.xn----q26i2bvu; ; xn--fxe63563p.xn----q26i2bvu; [B1, B6, P1, V3, V6] # ᛎ.𐹾𐹪-
+xn--fxe63563p.xn----q26i2bvu; ᛎ󠐕.𐹾𐹪𐻝-; [B1, B6, V3, V6]; xn--fxe63563p.xn----q26i2bvu; ; ;  # ᛎ.𐹾𐹪-
+xn--fxe848bq3411a.xn----q26i2bvu; ᛎ󠐕‍.𐹾𐹪𐻝-; [B1, B6, C2, V3, V6]; xn--fxe848bq3411a.xn----q26i2bvu; ; ;  # ᛎ.𐹾𐹪-
+𐹶.𐫂; ; [B1]; xn--uo0d.xn--rw9c; ; ;  # 𐹶.𐫂
+xn--uo0d.xn--rw9c; 𐹶.𐫂; [B1]; xn--uo0d.xn--rw9c; ; ;  # 𐹶.𐫂
+ß‍်｡⒈; ß‍်.⒈; [C2, P1, V6]; xn--zca679eh2l.xn--tsh; ; xn--ss-f4j.xn--tsh; [P1, V6] # ß်.⒈
+ß‍်。1.; ß‍်.1.; [C2]; xn--zca679eh2l.1.; ; xn--ss-f4j.1.; [] # ß်.1.
+SS‍်。1.; ss‍်.1.; [C2]; xn--ss-f4j585j.1.; ; xn--ss-f4j.1.; [] # ss်.1.
+ss‍်。1.; ss‍်.1.; [C2]; xn--ss-f4j585j.1.; ; xn--ss-f4j.1.; [] # ss်.1.
+Ss‍်。1.; ss‍်.1.; [C2]; xn--ss-f4j585j.1.; ; xn--ss-f4j.1.; [] # ss်.1.
+xn--ss-f4j.1.; ss်.1.; ; xn--ss-f4j.1.; ; ;  # ss်.1.
+ss်.1.; ; ; xn--ss-f4j.1.; ; ;  # ss်.1.
+SS်.1.; ss်.1.; ; xn--ss-f4j.1.; ; ;  # ss်.1.
+Ss်.1.; ss်.1.; ; xn--ss-f4j.1.; ; ;  # ss်.1.
+xn--ss-f4j585j.1.; ss‍်.1.; [C2]; xn--ss-f4j585j.1.; ; ;  # ss်.1.
+xn--zca679eh2l.1.; ß‍်.1.; [C2]; xn--zca679eh2l.1.; ; ;  # ß်.1.
+SS‍်｡⒈; ss‍်.⒈; [C2, P1, V6]; xn--ss-f4j585j.xn--tsh; ; xn--ss-f4j.xn--tsh; [P1, V6] # ss်.⒈
+ss‍်｡⒈; ss‍်.⒈; [C2, P1, V6]; xn--ss-f4j585j.xn--tsh; ; xn--ss-f4j.xn--tsh; [P1, V6] # ss်.⒈
+Ss‍်｡⒈; ss‍်.⒈; [C2, P1, V6]; xn--ss-f4j585j.xn--tsh; ; xn--ss-f4j.xn--tsh; [P1, V6] # ss်.⒈
+xn--ss-f4j.xn--tsh; ss်.⒈; [V6]; xn--ss-f4j.xn--tsh; ; ;  # ss်.⒈
+xn--ss-f4j585j.xn--tsh; ss‍်.⒈; [C2, V6]; xn--ss-f4j585j.xn--tsh; ; ;  # ss်.⒈
+xn--zca679eh2l.xn--tsh; ß‍်.⒈; [C2, V6]; xn--zca679eh2l.xn--tsh; ; ;  # ß်.⒈
+୍‌𙶵𞻘。‍; ୍‌𙶵𞻘.‍; [B1, C2, P1, V5, V6]; xn--9ic637hz82z32jc.xn--1ug; ; xn--9ic6417rn4xb.; [B1, P1, V5, V6] # ୍.
+xn--9ic6417rn4xb.; ୍𙶵𞻘.; [B1, V5, V6]; xn--9ic6417rn4xb.; ; ;  # ୍.
+xn--9ic637hz82z32jc.xn--1ug; ୍‌𙶵𞻘.‍; [B1, C2, V5, V6]; xn--9ic637hz82z32jc.xn--1ug; ; ;  # ୍.
+𐮅｡ڼ🁕; 𐮅.ڼ🁕; [B3]; xn--c29c.xn--vkb8871w; ; ;  # 𐮅.ڼ🁕
+𐮅。ڼ🁕; 𐮅.ڼ🁕; [B3]; xn--c29c.xn--vkb8871w; ; ;  # 𐮅.ڼ🁕
+xn--c29c.xn--vkb8871w; 𐮅.ڼ🁕; [B3]; xn--c29c.xn--vkb8871w; ; ;  # 𐮅.ڼ🁕
+ؠ្。𐫔󠀧‌𑈵; ؠ្.𐫔󠀧‌𑈵; [B2, B3, C1, P1, V6]; xn--fgb471g.xn--0ug9853g7verp838a; ; xn--fgb471g.xn--9w9c29jw3931a; [B2, B3, P1, V6] # ؠ្.𐫔𑈵
+xn--fgb471g.xn--9w9c29jw3931a; ؠ្.𐫔󠀧𑈵; [B2, B3, V6]; xn--fgb471g.xn--9w9c29jw3931a; ; ;  # ؠ្.𐫔𑈵
+xn--fgb471g.xn--0ug9853g7verp838a; ؠ្.𐫔󠀧‌𑈵; [B2, B3, C1, V6]; xn--fgb471g.xn--0ug9853g7verp838a; ; ;  # ؠ្.𐫔𑈵
+񋉕.𞣕𞤊; 񋉕.𞣕𞤬; [B1, P1, V5, V6]; xn--tf5w.xn--2b6hof; ; ;  # .𞣕𞤬
+񋉕.𞣕𞤬; ; [B1, P1, V5, V6]; xn--tf5w.xn--2b6hof; ; ;  # .𞣕𞤬
+xn--tf5w.xn--2b6hof; 񋉕.𞣕𞤬; [B1, V5, V6]; xn--tf5w.xn--2b6hof; ; ;  # .𞣕𞤬
+ی𐨿．ß྄𑍬; ی𐨿.ß྄𑍬; ; xn--clb2593k.xn--zca216edt0r; ; xn--clb2593k.xn--ss-toj6092t;  # ی𐨿.ß྄𑍬
+ی𐨿.ß྄𑍬; ; ; xn--clb2593k.xn--zca216edt0r; ; xn--clb2593k.xn--ss-toj6092t;  # ی𐨿.ß྄𑍬
+ی𐨿.SS྄𑍬; ی𐨿.ss྄𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+ی𐨿.ss྄𑍬; ; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+xn--clb2593k.xn--ss-toj6092t; ی𐨿.ss྄𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+xn--clb2593k.xn--zca216edt0r; ی𐨿.ß྄𑍬; ; xn--clb2593k.xn--zca216edt0r; ; ;  # ی𐨿.ß྄𑍬
+ی𐨿．SS྄𑍬; ی𐨿.ss྄𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+ی𐨿．ss྄𑍬; ی𐨿.ss྄𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+ی𐨿.Ss྄𑍬; ی𐨿.ss྄𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+ی𐨿．Ss྄𑍬; ی𐨿.ss྄𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+𝟠≮‌｡󠅱឴; 8≮‌.឴; [C1, P1, V5, V6]; xn--8-sgn10i.xn--z3e; ; xn--8-ngo.xn--z3e; [P1, V5, V6] # 8≮.
+𝟠≮‌｡󠅱឴; 8≮‌.឴; [C1, P1, V5, V6]; xn--8-sgn10i.xn--z3e; ; xn--8-ngo.xn--z3e; [P1, V5, V6] # 8≮.
+8≮‌。󠅱឴; 8≮‌.឴; [C1, P1, V5, V6]; xn--8-sgn10i.xn--z3e; ; xn--8-ngo.xn--z3e; [P1, V5, V6] # 8≮.
+8≮‌。󠅱឴; 8≮‌.឴; [C1, P1, V5, V6]; xn--8-sgn10i.xn--z3e; ; xn--8-ngo.xn--z3e; [P1, V5, V6] # 8≮.
+xn--8-ngo.xn--z3e; 8≮.឴; [V5, V6]; xn--8-ngo.xn--z3e; ; ;  # 8≮.
+xn--8-sgn10i.xn--z3e; 8≮‌.឴; [C1, V5, V6]; xn--8-sgn10i.xn--z3e; ; ;  # 8≮.
+ᢕ≯︒񄂯．Ⴀ; ᢕ≯︒񄂯.Ⴀ; [P1, V6]; xn--fbf851cq98poxw1a.xn--7md; ; ;  # ᢕ≯︒.Ⴀ
+ᢕ≯︒񄂯．Ⴀ; ᢕ≯︒񄂯.Ⴀ; [P1, V6]; xn--fbf851cq98poxw1a.xn--7md; ; ;  # ᢕ≯︒.Ⴀ
+ᢕ≯。񄂯.Ⴀ; ᢕ≯.񄂯.Ⴀ; [P1, V6]; xn--fbf851c.xn--ko1u.xn--7md; ; ;  # ᢕ≯..Ⴀ
+ᢕ≯。񄂯.Ⴀ; ᢕ≯.񄂯.Ⴀ; [P1, V6]; xn--fbf851c.xn--ko1u.xn--7md; ; ;  # ᢕ≯..Ⴀ
+ᢕ≯。񄂯.ⴀ; ᢕ≯.񄂯.ⴀ; [P1, V6]; xn--fbf851c.xn--ko1u.xn--rkj; ; ;  # ᢕ≯..ⴀ
+ᢕ≯。񄂯.ⴀ; ᢕ≯.񄂯.ⴀ; [P1, V6]; xn--fbf851c.xn--ko1u.xn--rkj; ; ;  # ᢕ≯..ⴀ
+xn--fbf851c.xn--ko1u.xn--rkj; ᢕ≯.񄂯.ⴀ; [V6]; xn--fbf851c.xn--ko1u.xn--rkj; ; ;  # ᢕ≯..ⴀ
+xn--fbf851c.xn--ko1u.xn--7md; ᢕ≯.񄂯.Ⴀ; [V6]; xn--fbf851c.xn--ko1u.xn--7md; ; ;  # ᢕ≯..Ⴀ
+ᢕ≯︒񄂯．ⴀ; ᢕ≯︒񄂯.ⴀ; [P1, V6]; xn--fbf851cq98poxw1a.xn--rkj; ; ;  # ᢕ≯︒.ⴀ
+ᢕ≯︒񄂯．ⴀ; ᢕ≯︒񄂯.ⴀ; [P1, V6]; xn--fbf851cq98poxw1a.xn--rkj; ; ;  # ᢕ≯︒.ⴀ
+xn--fbf851cq98poxw1a.xn--rkj; ᢕ≯︒񄂯.ⴀ; [V6]; xn--fbf851cq98poxw1a.xn--rkj; ; ;  # ᢕ≯︒.ⴀ
+xn--fbf851cq98poxw1a.xn--7md; ᢕ≯︒񄂯.Ⴀ; [V6]; xn--fbf851cq98poxw1a.xn--7md; ; ;  # ᢕ≯︒.Ⴀ
+ྟ．-ࠪ; ྟ.-ࠪ; [V3, V5]; xn--vfd.xn----fhd; ; ;  # ྟ.-ࠪ
+ྟ.-ࠪ; ; [V3, V5]; xn--vfd.xn----fhd; ; ;  # ྟ.-ࠪ
+xn--vfd.xn----fhd; ྟ.-ࠪ; [V3, V5]; xn--vfd.xn----fhd; ; ;  # ྟ.-ࠪ
+ᵬ󠆠．핒⒒⒈􈄦; ᵬ.핒⒒⒈􈄦; [P1, V6]; xn--tbg.xn--tsht7586kyts9l; ; ;  # ᵬ.핒⒒⒈
+ᵬ󠆠．핒⒒⒈􈄦; ᵬ.핒⒒⒈􈄦; [P1, V6]; xn--tbg.xn--tsht7586kyts9l; ; ;  # ᵬ.핒⒒⒈
+ᵬ󠆠.핒11.1.􈄦; ᵬ.핒11.1.􈄦; [P1, V6]; xn--tbg.xn--11-5o7k.1.xn--k469f; ; ;  # ᵬ.핒11.1.
+ᵬ󠆠.핒11.1.􈄦; ᵬ.핒11.1.􈄦; [P1, V6]; xn--tbg.xn--11-5o7k.1.xn--k469f; ; ;  # ᵬ.핒11.1.
+xn--tbg.xn--11-5o7k.1.xn--k469f; ᵬ.핒11.1.􈄦; [V6]; xn--tbg.xn--11-5o7k.1.xn--k469f; ; ;  # ᵬ.핒11.1.
+xn--tbg.xn--tsht7586kyts9l; ᵬ.핒⒒⒈􈄦; [V6]; xn--tbg.xn--tsht7586kyts9l; ; ;  # ᵬ.핒⒒⒈
+ς𑓂𐋢．٨; ς𑓂𐋢.٨; [B1]; xn--3xa8371khhl.xn--hib; ; xn--4xa6371khhl.xn--hib;  # ς𑓂𐋢.٨
+ς𑓂𐋢.٨; ; [B1]; xn--3xa8371khhl.xn--hib; ; xn--4xa6371khhl.xn--hib;  # ς𑓂𐋢.٨
+Σ𑓂𐋢.٨; σ𑓂𐋢.٨; [B1]; xn--4xa6371khhl.xn--hib; ; ;  # σ𑓂𐋢.٨
+σ𑓂𐋢.٨; ; [B1]; xn--4xa6371khhl.xn--hib; ; ;  # σ𑓂𐋢.٨
+xn--4xa6371khhl.xn--hib; σ𑓂𐋢.٨; [B1]; xn--4xa6371khhl.xn--hib; ; ;  # σ𑓂𐋢.٨
+xn--3xa8371khhl.xn--hib; ς𑓂𐋢.٨; [B1]; xn--3xa8371khhl.xn--hib; ; ;  # ς𑓂𐋢.٨
+Σ𑓂𐋢．٨; σ𑓂𐋢.٨; [B1]; xn--4xa6371khhl.xn--hib; ; ;  # σ𑓂𐋢.٨
+σ𑓂𐋢．٨; σ𑓂𐋢.٨; [B1]; xn--4xa6371khhl.xn--hib; ; ;  # σ𑓂𐋢.٨
+꥓‌𐋻‍.ⷸ𞿄𐹲; ; [B1, B6, C2, P1, V5, V6]; xn--0ugc8356he76c.xn--urju692efj0f; ; xn--3j9a531o.xn--urju692efj0f; [B1, P1, V5, V6] # ꥓𐋻.ⷸ𐹲
+xn--3j9a531o.xn--urju692efj0f; ꥓𐋻.ⷸ𞿄𐹲; [B1, V5, V6]; xn--3j9a531o.xn--urju692efj0f; ; ;  # ꥓𐋻.ⷸ𐹲
+xn--0ugc8356he76c.xn--urju692efj0f; ꥓‌𐋻‍.ⷸ𞿄𐹲; [B1, B6, C2, V5, V6]; xn--0ugc8356he76c.xn--urju692efj0f; ; ;  # ꥓𐋻.ⷸ𐹲
+⊼。񪧖ڕ; ⊼.񪧖ڕ; [B1, B5, B6, P1, V6]; xn--ofh.xn--rjb13118f; ; ;  # ⊼.ڕ
+xn--ofh.xn--rjb13118f; ⊼.񪧖ڕ; [B1, B5, B6, V6]; xn--ofh.xn--rjb13118f; ; ;  # ⊼.ڕ
+𐯬񖋔。󜳥; 𐯬񖋔.󜳥; [B2, B3, P1, V6]; xn--949co370q.xn--7g25e; ; ;  # .
+xn--949co370q.xn--7g25e; 𐯬񖋔.󜳥; [B2, B3, V6]; xn--949co370q.xn--7g25e; ; ;  # .
+؁𑍧ߝ。ς򬍘🀞឵; ؁𑍧ߝ.ς򬍘🀞឵; [B1, B6, P1, V6]; xn--jfb66gt010c.xn--3xa823h9p95ars26d; ; xn--jfb66gt010c.xn--4xa623h9p95ars26d;  # 𑍧ߝ.ς🀞
+؁𑍧ߝ。Σ򬍘🀞឵; ؁𑍧ߝ.σ򬍘🀞឵; [B1, B6, P1, V6]; xn--jfb66gt010c.xn--4xa623h9p95ars26d; ; ;  # 𑍧ߝ.σ🀞
+؁𑍧ߝ。σ򬍘🀞឵; ؁𑍧ߝ.σ򬍘🀞឵; [B1, B6, P1, V6]; xn--jfb66gt010c.xn--4xa623h9p95ars26d; ; ;  # 𑍧ߝ.σ🀞
+xn--jfb66gt010c.xn--4xa623h9p95ars26d; ؁𑍧ߝ.σ򬍘🀞឵; [B1, B6, V6]; xn--jfb66gt010c.xn--4xa623h9p95ars26d; ; ;  # 𑍧ߝ.σ🀞
+xn--jfb66gt010c.xn--3xa823h9p95ars26d; ؁𑍧ߝ.ς򬍘🀞឵; [B1, B6, V6]; xn--jfb66gt010c.xn--3xa823h9p95ars26d; ; ;  # 𑍧ߝ.ς🀞
+-𐳲ن󠺐。꯭𝟥; -𐳲ن󠺐.꯭3; [B1, P1, V3, V5, V6]; xn----roc5482rek10i.xn--3-zw5e; ; ;  # -𐳲ن.꯭3
+-𐳲ن󠺐。꯭3; -𐳲ن󠺐.꯭3; [B1, P1, V3, V5, V6]; xn----roc5482rek10i.xn--3-zw5e; ; ;  # -𐳲ن.꯭3
+-𐲲ن󠺐。꯭3; -𐳲ن󠺐.꯭3; [B1, P1, V3, V5, V6]; xn----roc5482rek10i.xn--3-zw5e; ; ;  # -𐳲ن.꯭3
+xn----roc5482rek10i.xn--3-zw5e; -𐳲ن󠺐.꯭3; [B1, V3, V5, V6]; xn----roc5482rek10i.xn--3-zw5e; ; ;  # -𐳲ن.꯭3
+-𐲲ن󠺐。꯭𝟥; -𐳲ن󠺐.꯭3; [B1, P1, V3, V5, V6]; xn----roc5482rek10i.xn--3-zw5e; ; ;  # -𐳲ن.꯭3
+‌󠴦｡񲨕≮𐦜; ‌󠴦.񲨕≮𐦜; [B1, B5, B6, C1, P1, V6]; xn--0ug22251l.xn--gdhz712gzlr6b; ; xn--6v56e.xn--gdhz712gzlr6b; [B1, B5, B6, P1, V6] # .≮𐦜
+‌󠴦｡񲨕≮𐦜; ‌󠴦.񲨕≮𐦜; [B1, B5, B6, C1, P1, V6]; xn--0ug22251l.xn--gdhz712gzlr6b; ; xn--6v56e.xn--gdhz712gzlr6b; [B1, B5, B6, P1, V6] # .≮𐦜
+‌󠴦。񲨕≮𐦜; ‌󠴦.񲨕≮𐦜; [B1, B5, B6, C1, P1, V6]; xn--0ug22251l.xn--gdhz712gzlr6b; ; xn--6v56e.xn--gdhz712gzlr6b; [B1, B5, B6, P1, V6] # .≮𐦜
+‌󠴦。񲨕≮𐦜; ‌󠴦.񲨕≮𐦜; [B1, B5, B6, C1, P1, V6]; xn--0ug22251l.xn--gdhz712gzlr6b; ; xn--6v56e.xn--gdhz712gzlr6b; [B1, B5, B6, P1, V6] # .≮𐦜
+xn--6v56e.xn--gdhz712gzlr6b; 󠴦.񲨕≮𐦜; [B1, B5, B6, V6]; xn--6v56e.xn--gdhz712gzlr6b; ; ;  # .≮𐦜
+xn--0ug22251l.xn--gdhz712gzlr6b; ‌󠴦.񲨕≮𐦜; [B1, B5, B6, C1, V6]; xn--0ug22251l.xn--gdhz712gzlr6b; ; ;  # .≮𐦜
+⒈✌򟬟．𝟡񠱣; ⒈✌򟬟.9񠱣; [P1, V6]; xn--tsh24g49550b.xn--9-o706d; ; ;  # ⒈✌.9
+1.✌򟬟.9񠱣; ; [P1, V6]; 1.xn--7bi44996f.xn--9-o706d; ; ;  # 1.✌.9
+1.xn--7bi44996f.xn--9-o706d; 1.✌򟬟.9񠱣; [V6]; 1.xn--7bi44996f.xn--9-o706d; ; ;  # 1.✌.9
+xn--tsh24g49550b.xn--9-o706d; ⒈✌򟬟.9񠱣; [V6]; xn--tsh24g49550b.xn--9-o706d; ; ;  # ⒈✌.9
+𑆾𞤬𐮆.٦ᷔ; ; [B1, V5]; xn--d29c79hf98r.xn--fib011j; ; ;  # 𑆾𞤬𐮆.٦ᷔ
+𑆾𞤊𐮆.٦ᷔ; 𑆾𞤬𐮆.٦ᷔ; [B1, V5]; xn--d29c79hf98r.xn--fib011j; ; ;  # 𑆾𞤬𐮆.٦ᷔ
+xn--d29c79hf98r.xn--fib011j; 𑆾𞤬𐮆.٦ᷔ; [B1, V5]; xn--d29c79hf98r.xn--fib011j; ; ;  # 𑆾𞤬𐮆.٦ᷔ
+ς．꧀꣄; ς.꧀꣄; [V5]; xn--3xa.xn--0f9ars; ; xn--4xa.xn--0f9ars;  # ς.꧀꣄
+ς.꧀꣄; ; [V5]; xn--3xa.xn--0f9ars; ; xn--4xa.xn--0f9ars;  # ς.꧀꣄
+Σ.꧀꣄; σ.꧀꣄; [V5]; xn--4xa.xn--0f9ars; ; ;  # σ.꧀꣄
+σ.꧀꣄; ; [V5]; xn--4xa.xn--0f9ars; ; ;  # σ.꧀꣄
+xn--4xa.xn--0f9ars; σ.꧀꣄; [V5]; xn--4xa.xn--0f9ars; ; ;  # σ.꧀꣄
+xn--3xa.xn--0f9ars; ς.꧀꣄; [V5]; xn--3xa.xn--0f9ars; ; ;  # ς.꧀꣄
+Σ．꧀꣄; σ.꧀꣄; [V5]; xn--4xa.xn--0f9ars; ; ;  # σ.꧀꣄
+σ．꧀꣄; σ.꧀꣄; [V5]; xn--4xa.xn--0f9ars; ; ;  # σ.꧀꣄
+𑰶‌≯𐳐．࡛; 𑰶‌≯𐳐.࡛; [B1, B3, B6, C1, P1, V5, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, B3, B6, P1, V5, V6] # 𑰶≯𐳐.࡛
+𑰶‌≯𐳐．࡛; 𑰶‌≯𐳐.࡛; [B1, B3, B6, C1, P1, V5, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, B3, B6, P1, V5, V6] # 𑰶≯𐳐.࡛
+𑰶‌≯𐳐.࡛; ; [B1, B3, B6, C1, P1, V5, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, B3, B6, P1, V5, V6] # 𑰶≯𐳐.࡛
+𑰶‌≯𐳐.࡛; 𑰶‌≯𐳐.࡛; [B1, B3, B6, C1, P1, V5, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, B3, B6, P1, V5, V6] # 𑰶≯𐳐.࡛
+𑰶‌≯𐲐.࡛; 𑰶‌≯𐳐.࡛; [B1, B3, B6, C1, P1, V5, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, B3, B6, P1, V5, V6] # 𑰶≯𐳐.࡛
+𑰶‌≯𐲐.࡛; 𑰶‌≯𐳐.࡛; [B1, B3, B6, C1, P1, V5, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, B3, B6, P1, V5, V6] # 𑰶≯𐳐.࡛
+xn--hdhz343g3wj.xn--qwb; 𑰶≯𐳐.࡛; [B1, B3, B6, V5, V6]; xn--hdhz343g3wj.xn--qwb; ; ;  # 𑰶≯𐳐.࡛
+xn--0ug06g7697ap4ma.xn--qwb; 𑰶‌≯𐳐.࡛; [B1, B3, B6, C1, V5, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; ;  # 𑰶≯𐳐.࡛
+𑰶‌≯𐲐．࡛; 𑰶‌≯𐳐.࡛; [B1, B3, B6, C1, P1, V5, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, B3, B6, P1, V5, V6] # 𑰶≯𐳐.࡛
+𑰶‌≯𐲐．࡛; 𑰶‌≯𐳐.࡛; [B1, B3, B6, C1, P1, V5, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, B3, B6, P1, V5, V6] # 𑰶≯𐳐.࡛
+羚｡≯; 羚.≯; [P1, V6]; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+羚｡≯; 羚.≯; [P1, V6]; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+羚。≯; 羚.≯; [P1, V6]; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+羚。≯; 羚.≯; [P1, V6]; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+xn--xt0a.xn--hdh; 羚.≯; [V6]; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+𑓂᝙．ࢨ; 𑓂᝙.ࢨ; [B1, P1, V5, V6]; xn--e1e9580k.xn--xyb; ; ;  # 𑓂.ࢨ
+𑓂᝙.ࢨ; ; [B1, P1, V5, V6]; xn--e1e9580k.xn--xyb; ; ;  # 𑓂.ࢨ
+xn--e1e9580k.xn--xyb; 𑓂᝙.ࢨ; [B1, V5, V6]; xn--e1e9580k.xn--xyb; ; ;  # 𑓂.ࢨ
+󨣿󠇀‍｡٣ҠჀ𝟑; 󨣿‍.٣ҡჀ3; [B1, B6, C2, P1, V6]; xn--1ug89936l.xn--3-ozb36kixu; ; xn--1r19e.xn--3-ozb36kixu; [B1, P1, V6] # .٣ҡჀ3
+󨣿󠇀‍。٣ҠჀ3; 󨣿‍.٣ҡჀ3; [B1, B6, C2, P1, V6]; xn--1ug89936l.xn--3-ozb36kixu; ; xn--1r19e.xn--3-ozb36kixu; [B1, P1, V6] # .٣ҡჀ3
+󨣿󠇀‍。٣ҡⴠ3; 󨣿‍.٣ҡⴠ3; [B1, B6, C2, P1, V6]; xn--1ug89936l.xn--3-ozb36ko13f; ; xn--1r19e.xn--3-ozb36ko13f; [B1, P1, V6] # .٣ҡⴠ3
+xn--1r19e.xn--3-ozb36ko13f; 󨣿.٣ҡⴠ3; [B1, V6]; xn--1r19e.xn--3-ozb36ko13f; ; ;  # .٣ҡⴠ3
+xn--1ug89936l.xn--3-ozb36ko13f; 󨣿‍.٣ҡⴠ3; [B1, B6, C2, V6]; xn--1ug89936l.xn--3-ozb36ko13f; ; ;  # .٣ҡⴠ3
+xn--1r19e.xn--3-ozb36kixu; 󨣿.٣ҡჀ3; [B1, V6]; xn--1r19e.xn--3-ozb36kixu; ; ;  # .٣ҡჀ3
+xn--1ug89936l.xn--3-ozb36kixu; 󨣿‍.٣ҡჀ3; [B1, B6, C2, V6]; xn--1ug89936l.xn--3-ozb36kixu; ; ;  # .٣ҡჀ3
+󨣿󠇀‍｡٣ҡⴠ𝟑; 󨣿‍.٣ҡⴠ3; [B1, B6, C2, P1, V6]; xn--1ug89936l.xn--3-ozb36ko13f; ; xn--1r19e.xn--3-ozb36ko13f; [B1, P1, V6] # .٣ҡⴠ3
+󨣿󠇀‍。٣Ҡⴠ3; 󨣿‍.٣ҡⴠ3; [B1, B6, C2, P1, V6]; xn--1ug89936l.xn--3-ozb36ko13f; ; xn--1r19e.xn--3-ozb36ko13f; [B1, P1, V6] # .٣ҡⴠ3
+󨣿󠇀‍｡٣Ҡⴠ𝟑; 󨣿‍.٣ҡⴠ3; [B1, B6, C2, P1, V6]; xn--1ug89936l.xn--3-ozb36ko13f; ; xn--1r19e.xn--3-ozb36ko13f; [B1, P1, V6] # .٣ҡⴠ3
+ᡷ。𐹢࣠; ᡷ.𐹢࣠; [B1]; xn--k9e.xn--j0b5005k; ; ;  # ᡷ.𐹢࣠
+xn--k9e.xn--j0b5005k; ᡷ.𐹢࣠; [B1]; xn--k9e.xn--j0b5005k; ; ;  # ᡷ.𐹢࣠
+򕮇᯳｡٦񗜼្ß; 򕮇᯳.٦񗜼្ß; [B1, P1, V6]; xn--1zf58212h.xn--zca34zk4qx711k; ; xn--1zf58212h.xn--ss-pyd459o3258m;  # ᯳.٦្ß
+򕮇᯳。٦񗜼្ß; 򕮇᯳.٦񗜼្ß; [B1, P1, V6]; xn--1zf58212h.xn--zca34zk4qx711k; ; xn--1zf58212h.xn--ss-pyd459o3258m;  # ᯳.٦្ß
+򕮇᯳。٦񗜼្SS; 򕮇᯳.٦񗜼្ss; [B1, P1, V6]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+򕮇᯳。٦񗜼្ss; 򕮇᯳.٦񗜼្ss; [B1, P1, V6]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+򕮇᯳。٦񗜼្Ss; 򕮇᯳.٦񗜼្ss; [B1, P1, V6]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+xn--1zf58212h.xn--ss-pyd459o3258m; 򕮇᯳.٦񗜼្ss; [B1, V6]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+xn--1zf58212h.xn--zca34zk4qx711k; 򕮇᯳.٦񗜼្ß; [B1, V6]; xn--1zf58212h.xn--zca34zk4qx711k; ; ;  # ᯳.٦្ß
+򕮇᯳｡٦񗜼្SS; 򕮇᯳.٦񗜼្ss; [B1, P1, V6]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+򕮇᯳｡٦񗜼្ss; 򕮇᯳.٦񗜼្ss; [B1, P1, V6]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+򕮇᯳｡٦񗜼្Ss; 򕮇᯳.٦񗜼្ss; [B1, P1, V6]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+٤򤽎𑲛.󠔢︒≠; ; [B1, P1, V6]; xn--dib0653l2i02d.xn--1ch7467f14u4g; ; ;  # ٤𑲛.︒≠
+٤򤽎𑲛.󠔢︒≠; ٤򤽎𑲛.󠔢︒≠; [B1, P1, V6]; xn--dib0653l2i02d.xn--1ch7467f14u4g; ; ;  # ٤𑲛.︒≠
+٤򤽎𑲛.󠔢。≠; ٤򤽎𑲛.󠔢.≠; [B1, P1, V6]; xn--dib0653l2i02d.xn--k736e.xn--1ch; ; ;  # ٤𑲛..≠
+٤򤽎𑲛.󠔢。≠; ٤򤽎𑲛.󠔢.≠; [B1, P1, V6]; xn--dib0653l2i02d.xn--k736e.xn--1ch; ; ;  # ٤𑲛..≠
+xn--dib0653l2i02d.xn--k736e.xn--1ch; ٤򤽎𑲛.󠔢.≠; [B1, V6]; xn--dib0653l2i02d.xn--k736e.xn--1ch; ; ;  # ٤𑲛..≠
+xn--dib0653l2i02d.xn--1ch7467f14u4g; ٤򤽎𑲛.󠔢︒≠; [B1, V6]; xn--dib0653l2i02d.xn--1ch7467f14u4g; ; ;  # ٤𑲛.︒≠
+➆񷧕ỗ⒈．򑬒񡘮࡛𝟫; ➆񷧕ỗ⒈.򑬒񡘮࡛9; [P1, V6]; xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ; ;  # ➆ỗ⒈.࡛9
+➆񷧕ỗ⒈．򑬒񡘮࡛𝟫; ➆񷧕ỗ⒈.򑬒񡘮࡛9; [P1, V6]; xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ; ;  # ➆ỗ⒈.࡛9
+➆񷧕ỗ1..򑬒񡘮࡛9; ; [P1, V6, X4_2]; xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; [P1, V6, A4_2]; ;  # ➆ỗ1..࡛9
+➆񷧕ỗ1..򑬒񡘮࡛9; ➆񷧕ỗ1..򑬒񡘮࡛9; [P1, V6, X4_2]; xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; [P1, V6, A4_2]; ;  # ➆ỗ1..࡛9
+➆񷧕Ỗ1..򑬒񡘮࡛9; ➆񷧕ỗ1..򑬒񡘮࡛9; [P1, V6, X4_2]; xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; [P1, V6, A4_2]; ;  # ➆ỗ1..࡛9
+➆񷧕Ỗ1..򑬒񡘮࡛9; ➆񷧕ỗ1..򑬒񡘮࡛9; [P1, V6, X4_2]; xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; [P1, V6, A4_2]; ;  # ➆ỗ1..࡛9
+xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; ➆񷧕ỗ1..򑬒񡘮࡛9; [V6, X4_2]; xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; [V6, A4_2]; ;  # ➆ỗ1..࡛9
+➆񷧕Ỗ⒈．򑬒񡘮࡛𝟫; ➆񷧕ỗ⒈.򑬒񡘮࡛9; [P1, V6]; xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ; ;  # ➆ỗ⒈.࡛9
+➆񷧕Ỗ⒈．򑬒񡘮࡛𝟫; ➆񷧕ỗ⒈.򑬒񡘮࡛9; [P1, V6]; xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ; ;  # ➆ỗ⒈.࡛9
+xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ➆񷧕ỗ⒈.򑬒񡘮࡛9; [V6]; xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ; ;  # ➆ỗ⒈.࡛9
+‍｡𞤘; ‍.𞤺; [B1, C2]; xn--1ug.xn--ye6h; ; .xn--ye6h; [A4_2] # .𞤺
+‍。𞤘; ‍.𞤺; [B1, C2]; xn--1ug.xn--ye6h; ; .xn--ye6h; [A4_2] # .𞤺
+‍。𞤺; ‍.𞤺; [B1, C2]; xn--1ug.xn--ye6h; ; .xn--ye6h; [A4_2] # .𞤺
+.xn--ye6h; .𞤺; [X4_2]; .xn--ye6h; [A4_2]; ;  # .𞤺
+xn--1ug.xn--ye6h; ‍.𞤺; [B1, C2]; xn--1ug.xn--ye6h; ; ;  # .𞤺
+‍｡𞤺; ‍.𞤺; [B1, C2]; xn--1ug.xn--ye6h; ; .xn--ye6h; [A4_2] # .𞤺
+xn--ye6h; 𞤺; ; xn--ye6h; ; ;  # 𞤺
+𞤺; ; ; xn--ye6h; ; ;  # 𞤺
+𞤘; 𞤺; ; xn--ye6h; ; ;  # 𞤺
+ࠩܤ.ᢣ; ; [B1, V5]; xn--unb53c.xn--tbf; ; ;  # ࠩܤ.ᢣ
+xn--unb53c.xn--tbf; ࠩܤ.ᢣ; [B1, V5]; xn--unb53c.xn--tbf; ; ;  # ࠩܤ.ᢣ
+ܼ‌-。𓐾ß; ܼ‌-.𓐾ß; [C1, P1, V3, V5, V6]; xn----s2c071q.xn--zca7848m; ; xn----s2c.xn--ss-066q; [P1, V3, V5, V6] # ܼ-.ß
+ܼ‌-。𓐾SS; ܼ‌-.𓐾ss; [C1, P1, V3, V5, V6]; xn----s2c071q.xn--ss-066q; ; xn----s2c.xn--ss-066q; [P1, V3, V5, V6] # ܼ-.ss
+ܼ‌-。𓐾ss; ܼ‌-.𓐾ss; [C1, P1, V3, V5, V6]; xn----s2c071q.xn--ss-066q; ; xn----s2c.xn--ss-066q; [P1, V3, V5, V6] # ܼ-.ss
+ܼ‌-。𓐾Ss; ܼ‌-.𓐾ss; [C1, P1, V3, V5, V6]; xn----s2c071q.xn--ss-066q; ; xn----s2c.xn--ss-066q; [P1, V3, V5, V6] # ܼ-.ss
+xn----s2c.xn--ss-066q; ܼ-.𓐾ss; [V3, V5, V6]; xn----s2c.xn--ss-066q; ; ;  # ܼ-.ss
+xn----s2c071q.xn--ss-066q; ܼ‌-.𓐾ss; [C1, V3, V5, V6]; xn----s2c071q.xn--ss-066q; ; ;  # ܼ-.ss
+xn----s2c071q.xn--zca7848m; ܼ‌-.𓐾ß; [C1, V3, V5, V6]; xn----s2c071q.xn--zca7848m; ; ;  # ܼ-.ß
+‌ς🃡⒗.ೆ仧ݖ; ; [B1, B5, B6, C1, P1, V5, V6]; xn--3xa795lz9czy52d.xn--9ob79ycx2e; ; xn--4xa229nbu92a.xn--9ob79ycx2e; [B5, B6, P1, V5, V6] # ς🃡⒗.ೆ仧ݖ
+‌ς🃡16..ೆ仧ݖ; ; [B1, B5, B6, C1, V5, X4_2]; xn--16-rbc1800avy99b..xn--9ob79ycx2e; [B1, B5, B6, C1, V5, A4_2]; xn--16-ubc66061c..xn--9ob79ycx2e; [B5, B6, V5, A4_2] # ς🃡16..ೆ仧ݖ
+‌Σ🃡16..ೆ仧ݖ; ‌σ🃡16..ೆ仧ݖ; [B1, B5, B6, C1, V5, X4_2]; xn--16-ubc7700avy99b..xn--9ob79ycx2e; [B1, B5, B6, C1, V5, A4_2]; xn--16-ubc66061c..xn--9ob79ycx2e; [B5, B6, V5, A4_2] # σ🃡16..ೆ仧ݖ
+‌σ🃡16..ೆ仧ݖ; ; [B1, B5, B6, C1, V5, X4_2]; xn--16-ubc7700avy99b..xn--9ob79ycx2e; [B1, B5, B6, C1, V5, A4_2]; xn--16-ubc66061c..xn--9ob79ycx2e; [B5, B6, V5, A4_2] # σ🃡16..ೆ仧ݖ
+xn--16-ubc66061c..xn--9ob79ycx2e; σ🃡16..ೆ仧ݖ; [B5, B6, V5, X4_2]; xn--16-ubc66061c..xn--9ob79ycx2e; [B5, B6, V5, A4_2]; ;  # σ🃡16..ೆ仧ݖ
+xn--16-ubc7700avy99b..xn--9ob79ycx2e; ‌σ🃡16..ೆ仧ݖ; [B1, B5, B6, C1, V5, X4_2]; xn--16-ubc7700avy99b..xn--9ob79ycx2e; [B1, B5, B6, C1, V5, A4_2]; ;  # σ🃡16..ೆ仧ݖ
+xn--16-rbc1800avy99b..xn--9ob79ycx2e; ‌ς🃡16..ೆ仧ݖ; [B1, B5, B6, C1, V5, X4_2]; xn--16-rbc1800avy99b..xn--9ob79ycx2e; [B1, B5, B6, C1, V5, A4_2]; ;  # ς🃡16..ೆ仧ݖ
+‌Σ🃡⒗.ೆ仧ݖ; ‌σ🃡⒗.ೆ仧ݖ; [B1, B5, B6, C1, P1, V5, V6]; xn--4xa595lz9czy52d.xn--9ob79ycx2e; ; xn--4xa229nbu92a.xn--9ob79ycx2e; [B5, B6, P1, V5, V6] # σ🃡⒗.ೆ仧ݖ
+‌σ🃡⒗.ೆ仧ݖ; ; [B1, B5, B6, C1, P1, V5, V6]; xn--4xa595lz9czy52d.xn--9ob79ycx2e; ; xn--4xa229nbu92a.xn--9ob79ycx2e; [B5, B6, P1, V5, V6] # σ🃡⒗.ೆ仧ݖ
+xn--4xa229nbu92a.xn--9ob79ycx2e; σ🃡⒗.ೆ仧ݖ; [B5, B6, V5, V6]; xn--4xa229nbu92a.xn--9ob79ycx2e; ; ;  # σ🃡⒗.ೆ仧ݖ
+xn--4xa595lz9czy52d.xn--9ob79ycx2e; ‌σ🃡⒗.ೆ仧ݖ; [B1, B5, B6, C1, V5, V6]; xn--4xa595lz9czy52d.xn--9ob79ycx2e; ; ;  # σ🃡⒗.ೆ仧ݖ
+xn--3xa795lz9czy52d.xn--9ob79ycx2e; ‌ς🃡⒗.ೆ仧ݖ; [B1, B5, B6, C1, V5, V6]; xn--3xa795lz9czy52d.xn--9ob79ycx2e; ; ;  # ς🃡⒗.ೆ仧ݖ
+-.𞸚; -.ظ; [B1, V3]; -.xn--3gb; ; ;  # -.ظ
+-.ظ; ; [B1, V3]; -.xn--3gb; ; ;  # -.ظ
+-.xn--3gb; -.ظ; [B1, V3]; -.xn--3gb; ; ;  # -.ظ
+򏛓ڃ.ཾش; ; [B1, B5, B6, P1, V5, V6]; xn--8ib92728i.xn--zgb968b; ; ;  # ڃ.ཾش
+xn--8ib92728i.xn--zgb968b; 򏛓ڃ.ཾش; [B1, B5, B6, V5, V6]; xn--8ib92728i.xn--zgb968b; ; ;  # ڃ.ཾش
+࿦ࡃ񽶬.𐮏; ; [B5, P1, V6]; xn--1vb320b5m04p.xn--m29c; ; ;  # ࡃ.𐮏
+xn--1vb320b5m04p.xn--m29c; ࿦ࡃ񽶬.𐮏; [B5, V6]; xn--1vb320b5m04p.xn--m29c; ; ;  # ࡃ.𐮏
+2񎨠ߋß。ᠽ; 2񎨠ߋß.ᠽ; [B1, P1, V6]; xn--2-qfa924cez02l.xn--w7e; ; xn--2ss-odg83511n.xn--w7e;  # 2ߋß.ᠽ
+2񎨠ߋSS。ᠽ; 2񎨠ߋss.ᠽ; [B1, P1, V6]; xn--2ss-odg83511n.xn--w7e; ; ;  # 2ߋss.ᠽ
+2񎨠ߋss。ᠽ; 2񎨠ߋss.ᠽ; [B1, P1, V6]; xn--2ss-odg83511n.xn--w7e; ; ;  # 2ߋss.ᠽ
+xn--2ss-odg83511n.xn--w7e; 2񎨠ߋss.ᠽ; [B1, V6]; xn--2ss-odg83511n.xn--w7e; ; ;  # 2ߋss.ᠽ
+xn--2-qfa924cez02l.xn--w7e; 2񎨠ߋß.ᠽ; [B1, V6]; xn--2-qfa924cez02l.xn--w7e; ; ;  # 2ߋß.ᠽ
+2񎨠ߋSs。ᠽ; 2񎨠ߋss.ᠽ; [B1, P1, V6]; xn--2ss-odg83511n.xn--w7e; ; ;  # 2ߋss.ᠽ
+㸳ߊ≮．ێß-‍; 㸳ߊ≮.ێß-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn----pfa076bys4a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێß-
+㸳ߊ≮．ێß-‍; 㸳ߊ≮.ێß-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn----pfa076bys4a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێß-
+㸳ߊ≮.ێß-‍; ; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn----pfa076bys4a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێß-
+㸳ߊ≮.ێß-‍; 㸳ߊ≮.ێß-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn----pfa076bys4a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێß-
+㸳ߊ≮.ێSS-‍; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+㸳ߊ≮.ێSS-‍; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+㸳ߊ≮.ێss-‍; ; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+㸳ߊ≮.ێss-‍; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+xn--lsb457kkut.xn--ss--qjf; 㸳ߊ≮.ێss-; [B2, B3, B5, B6, V3, V6]; xn--lsb457kkut.xn--ss--qjf; ; ;  # 㸳ߊ≮.ێss-
+xn--lsb457kkut.xn--ss--qjf2343a; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; ;  # 㸳ߊ≮.ێss-
+xn--lsb457kkut.xn----pfa076bys4a; 㸳ߊ≮.ێß-‍; [B2, B3, B5, B6, C2, V6]; xn--lsb457kkut.xn----pfa076bys4a; ; ;  # 㸳ߊ≮.ێß-
+㸳ߊ≮．ێSS-‍; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+㸳ߊ≮．ێSS-‍; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+㸳ߊ≮．ێss-‍; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+㸳ߊ≮．ێss-‍; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+㸳ߊ≮.ێSs-‍; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+㸳ߊ≮.ێSs-‍; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+㸳ߊ≮．ێSs-‍; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+㸳ߊ≮．ێSs-‍; 㸳ߊ≮.ێss-‍; [B2, B3, B5, B6, C2, P1, V6]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, P1, V3, V6] # 㸳ߊ≮.ێss-
+-򷝬፞𑜧.ᷫ-︒; ; [P1, V3, V5, V6]; xn----b5h1837n2ok9f.xn----mkmw278h; ; ;  # -፞𑜧.ᷫ-︒
+-򷝬፞𑜧.ᷫ-。; -򷝬፞𑜧.ᷫ-.; [P1, V3, V5, V6]; xn----b5h1837n2ok9f.xn----mkm.; ; ;  # -፞𑜧.ᷫ-.
+xn----b5h1837n2ok9f.xn----mkm.; -򷝬፞𑜧.ᷫ-.; [V3, V5, V6]; xn----b5h1837n2ok9f.xn----mkm.; ; ;  # -፞𑜧.ᷫ-.
+xn----b5h1837n2ok9f.xn----mkmw278h; -򷝬፞𑜧.ᷫ-︒; [V3, V5, V6]; xn----b5h1837n2ok9f.xn----mkmw278h; ; ;  # -፞𑜧.ᷫ-︒
+︒.򚠡ᩙ; ; [P1, V6]; xn--y86c.xn--cof61594i; ; ;  # ︒.ᩙ
+。.򚠡ᩙ; ..򚠡ᩙ; [P1, V6, X4_2]; ..xn--cof61594i; [P1, V6, A4_2]; ;  # ..ᩙ
+..xn--cof61594i; ..򚠡ᩙ; [V6, X4_2]; ..xn--cof61594i; [V6, A4_2]; ;  # ..ᩙ
+xn--y86c.xn--cof61594i; ︒.򚠡ᩙ; [V6]; xn--y86c.xn--cof61594i; ; ;  # ︒.ᩙ
+̣ⷡ。‌⓾‌ڹ; ̣ⷡ.‌⓾‌ڹ; [B1, B3, B6, C1, V5]; xn--kta899s.xn--skb970ka771c; ; xn--kta899s.xn--skb116m; [B1, B3, B6, V5] # ̣ⷡ.⓾ڹ
+xn--kta899s.xn--skb116m; ̣ⷡ.⓾ڹ; [B1, B3, B6, V5]; xn--kta899s.xn--skb116m; ; ;  # ̣ⷡ.⓾ڹ
+xn--kta899s.xn--skb970ka771c; ̣ⷡ.‌⓾‌ڹ; [B1, B3, B6, C1, V5]; xn--kta899s.xn--skb970ka771c; ; ;  # ̣ⷡ.⓾ڹ
+𞠶ᠴ۝｡ၴ𞤵󠅦; 𞠶ᠴ۝.ၴ𞤵; [B1, B2, P1, V5, V6]; xn--tlb199fwl35a.xn--yld4613v; ; ;  # 𞠶ᠴ.ၴ𞤵
+𞠶ᠴ۝。ၴ𞤵󠅦; 𞠶ᠴ۝.ၴ𞤵; [B1, B2, P1, V5, V6]; xn--tlb199fwl35a.xn--yld4613v; ; ;  # 𞠶ᠴ.ၴ𞤵
+𞠶ᠴ۝。ၴ𞤓󠅦; 𞠶ᠴ۝.ၴ𞤵; [B1, B2, P1, V5, V6]; xn--tlb199fwl35a.xn--yld4613v; ; ;  # 𞠶ᠴ.ၴ𞤵
+xn--tlb199fwl35a.xn--yld4613v; 𞠶ᠴ۝.ၴ𞤵; [B1, B2, V5, V6]; xn--tlb199fwl35a.xn--yld4613v; ; ;  # 𞠶ᠴ.ၴ𞤵
+𞠶ᠴ۝｡ၴ𞤓󠅦; 𞠶ᠴ۝.ၴ𞤵; [B1, B2, P1, V5, V6]; xn--tlb199fwl35a.xn--yld4613v; ; ;  # 𞠶ᠴ.ၴ𞤵
+𑰺.-򑟏; ; [P1, V3, V5, V6]; xn--jk3d.xn----iz68g; ; ;  # 𑰺.-
+xn--jk3d.xn----iz68g; 𑰺.-򑟏; [V3, V5, V6]; xn--jk3d.xn----iz68g; ; ;  # 𑰺.-
+󠻩．赏; 󠻩.赏; [P1, V6]; xn--2856e.xn--6o3a; ; ;  # .赏
+󠻩.赏; ; [P1, V6]; xn--2856e.xn--6o3a; ; ;  # .赏
+xn--2856e.xn--6o3a; 󠻩.赏; [V6]; xn--2856e.xn--6o3a; ; ;  # .赏
+ڰᠡ｡Ⴁ; ڰᠡ.Ⴁ; [B2, B3, P1, V6]; xn--jkb440g.xn--8md; ; ;  # ڰᠡ.Ⴁ
+ڰᠡ。Ⴁ; ڰᠡ.Ⴁ; [B2, B3, P1, V6]; xn--jkb440g.xn--8md; ; ;  # ڰᠡ.Ⴁ
+ڰᠡ。ⴁ; ڰᠡ.ⴁ; [B2, B3]; xn--jkb440g.xn--skj; ; ;  # ڰᠡ.ⴁ
+xn--jkb440g.xn--skj; ڰᠡ.ⴁ; [B2, B3]; xn--jkb440g.xn--skj; ; ;  # ڰᠡ.ⴁ
+xn--jkb440g.xn--8md; ڰᠡ.Ⴁ; [B2, B3, V6]; xn--jkb440g.xn--8md; ; ;  # ڰᠡ.Ⴁ
+ڰᠡ｡ⴁ; ڰᠡ.ⴁ; [B2, B3]; xn--jkb440g.xn--skj; ; ;  # ڰᠡ.ⴁ
+⃞Ⴊڻς｡-; ⃞Ⴊڻς.-; [B1, P1, V3, V5, V6]; xn--3xa53m7zmb0q.-; ; xn--4xa33m7zmb0q.-;  # ⃞Ⴊڻς.-
+⃞Ⴊڻς。-; ⃞Ⴊڻς.-; [B1, P1, V3, V5, V6]; xn--3xa53m7zmb0q.-; ; xn--4xa33m7zmb0q.-;  # ⃞Ⴊڻς.-
+⃞ⴊڻς。-; ⃞ⴊڻς.-; [B1, V3, V5]; xn--3xa53mr38aeel.-; ; xn--4xa33mr38aeel.-;  # ⃞ⴊڻς.-
+⃞ႪڻΣ。-; ⃞Ⴊڻσ.-; [B1, P1, V3, V5, V6]; xn--4xa33m7zmb0q.-; ; ;  # ⃞Ⴊڻσ.-
+⃞ⴊڻσ。-; ⃞ⴊڻσ.-; [B1, V3, V5]; xn--4xa33mr38aeel.-; ; ;  # ⃞ⴊڻσ.-
+⃞Ⴊڻσ。-; ⃞Ⴊڻσ.-; [B1, P1, V3, V5, V6]; xn--4xa33m7zmb0q.-; ; ;  # ⃞Ⴊڻσ.-
+xn--4xa33m7zmb0q.-; ⃞Ⴊڻσ.-; [B1, V3, V5, V6]; xn--4xa33m7zmb0q.-; ; ;  # ⃞Ⴊڻσ.-
+xn--4xa33mr38aeel.-; ⃞ⴊڻσ.-; [B1, V3, V5]; xn--4xa33mr38aeel.-; ; ;  # ⃞ⴊڻσ.-
+xn--3xa53mr38aeel.-; ⃞ⴊڻς.-; [B1, V3, V5]; xn--3xa53mr38aeel.-; ; ;  # ⃞ⴊڻς.-
+xn--3xa53m7zmb0q.-; ⃞Ⴊڻς.-; [B1, V3, V5, V6]; xn--3xa53m7zmb0q.-; ; ;  # ⃞Ⴊڻς.-
+⃞ⴊڻς｡-; ⃞ⴊڻς.-; [B1, V3, V5]; xn--3xa53mr38aeel.-; ; xn--4xa33mr38aeel.-;  # ⃞ⴊڻς.-
+⃞ႪڻΣ｡-; ⃞Ⴊڻσ.-; [B1, P1, V3, V5, V6]; xn--4xa33m7zmb0q.-; ; ;  # ⃞Ⴊڻσ.-
+⃞ⴊڻσ｡-; ⃞ⴊڻσ.-; [B1, V3, V5]; xn--4xa33mr38aeel.-; ; ;  # ⃞ⴊڻσ.-
+⃞Ⴊڻσ｡-; ⃞Ⴊڻσ.-; [B1, P1, V3, V5, V6]; xn--4xa33m7zmb0q.-; ; ;  # ⃞Ⴊڻσ.-
+Ⴍ．񍇦‌; Ⴍ.񍇦‌; [C1, P1, V6]; xn--lnd.xn--0ug56448b; ; xn--lnd.xn--p01x; [P1, V6] # Ⴍ.
+Ⴍ.񍇦‌; ; [C1, P1, V6]; xn--lnd.xn--0ug56448b; ; xn--lnd.xn--p01x; [P1, V6] # Ⴍ.
+ⴍ.񍇦‌; ; [C1, P1, V6]; xn--4kj.xn--0ug56448b; ; xn--4kj.xn--p01x; [P1, V6] # ⴍ.
+xn--4kj.xn--p01x; ⴍ.񍇦; [V6]; xn--4kj.xn--p01x; ; ;  # ⴍ.
+xn--4kj.xn--0ug56448b; ⴍ.񍇦‌; [C1, V6]; xn--4kj.xn--0ug56448b; ; ;  # ⴍ.
+xn--lnd.xn--p01x; Ⴍ.񍇦; [V6]; xn--lnd.xn--p01x; ; ;  # Ⴍ.
+xn--lnd.xn--0ug56448b; Ⴍ.񍇦‌; [C1, V6]; xn--lnd.xn--0ug56448b; ; ;  # Ⴍ.
+ⴍ．񍇦‌; ⴍ.񍇦‌; [C1, P1, V6]; xn--4kj.xn--0ug56448b; ; xn--4kj.xn--p01x; [P1, V6] # ⴍ.
+򉟂󠵣.𐫫᩠󴺖᭄; ; [B2, B3, B6, P1, V6]; xn--9u37blu98h.xn--jof13bt568cork1j; ; ;  # .𐫫᩠᭄
+xn--9u37blu98h.xn--jof13bt568cork1j; 򉟂󠵣.𐫫᩠󴺖᭄; [B2, B3, B6, V6]; xn--9u37blu98h.xn--jof13bt568cork1j; ; ;  # .𐫫᩠᭄
+≯❊ᠯ｡𐹱⺨; ≯❊ᠯ.𐹱⺨; [B1, P1, V6]; xn--i7e163ct2d.xn--vwj7372e; ; ;  # ≯❊ᠯ.𐹱⺨
+≯❊ᠯ｡𐹱⺨; ≯❊ᠯ.𐹱⺨; [B1, P1, V6]; xn--i7e163ct2d.xn--vwj7372e; ; ;  # ≯❊ᠯ.𐹱⺨
+≯❊ᠯ。𐹱⺨; ≯❊ᠯ.𐹱⺨; [B1, P1, V6]; xn--i7e163ct2d.xn--vwj7372e; ; ;  # ≯❊ᠯ.𐹱⺨
+≯❊ᠯ。𐹱⺨; ≯❊ᠯ.𐹱⺨; [B1, P1, V6]; xn--i7e163ct2d.xn--vwj7372e; ; ;  # ≯❊ᠯ.𐹱⺨
+xn--i7e163ct2d.xn--vwj7372e; ≯❊ᠯ.𐹱⺨; [B1, V6]; xn--i7e163ct2d.xn--vwj7372e; ; ;  # ≯❊ᠯ.𐹱⺨
+􁕜𐹧𞭁𐹩。Ⴈ𐫮Ⴏ; 􁕜𐹧𞭁𐹩.Ⴈ𐫮Ⴏ; [B5, B6, P1, V6]; xn--fo0de1270ope54j.xn--gndo2033q; ; ;  # 𐹧𐹩.Ⴈ𐫮Ⴏ
+􁕜𐹧𞭁𐹩。ⴈ𐫮ⴏ; 􁕜𐹧𞭁𐹩.ⴈ𐫮ⴏ; [B5, B6, P1, V6]; xn--fo0de1270ope54j.xn--zkjo0151o; ; ;  # 𐹧𐹩.ⴈ𐫮ⴏ
+xn--fo0de1270ope54j.xn--zkjo0151o; 􁕜𐹧𞭁𐹩.ⴈ𐫮ⴏ; [B5, B6, V6]; xn--fo0de1270ope54j.xn--zkjo0151o; ; ;  # 𐹧𐹩.ⴈ𐫮ⴏ
+xn--fo0de1270ope54j.xn--gndo2033q; 􁕜𐹧𞭁𐹩.Ⴈ𐫮Ⴏ; [B5, B6, V6]; xn--fo0de1270ope54j.xn--gndo2033q; ; ;  # 𐹧𐹩.Ⴈ𐫮Ⴏ
+𞠂。ꤦ; 𞠂.ꤦ; [B1, B3, B6, V5]; xn--145h.xn--ti9a; ; ;  # 𞠂.ꤦ
+xn--145h.xn--ti9a; 𞠂.ꤦ; [B1, B3, B6, V5]; xn--145h.xn--ti9a; ; ;  # 𞠂.ꤦ
+𝟔𐹫．့ܳ９ꡇ; 6𐹫.့ܳ9ꡇ; [B1, V5]; xn--6-t26i.xn--9-91c730e8u8n; ; ;  # 6𐹫.့ܳ9ꡇ
+𝟔𐹫．့ܳ９ꡇ; 6𐹫.့ܳ9ꡇ; [B1, V5]; xn--6-t26i.xn--9-91c730e8u8n; ; ;  # 6𐹫.့ܳ9ꡇ
+6𐹫.့ܳ9ꡇ; ; [B1, V5]; xn--6-t26i.xn--9-91c730e8u8n; ; ;  # 6𐹫.့ܳ9ꡇ
+xn--6-t26i.xn--9-91c730e8u8n; 6𐹫.့ܳ9ꡇ; [B1, V5]; xn--6-t26i.xn--9-91c730e8u8n; ; ;  # 6𐹫.့ܳ9ꡇ
+ܤ؃𞲶．ۘ; ܤ؃𞲶.ۘ; [B1, B3, B6, P1, V5, V6]; xn--lfb19ct414i.xn--olb; ; ;  # ܤ.ۘ
+ܤ؃𞲶.ۘ; ; [B1, B3, B6, P1, V5, V6]; xn--lfb19ct414i.xn--olb; ; ;  # ܤ.ۘ
+xn--lfb19ct414i.xn--olb; ܤ؃𞲶.ۘ; [B1, B3, B6, V5, V6]; xn--lfb19ct414i.xn--olb; ; ;  # ܤ.ۘ
+✆񱔩ꡋ．ز‍𞣴; ✆񱔩ꡋ.ز‍𞣴; [B1, C2, P1, V6]; xn--1biv525bcix0d.xn--xgb253k0m73a; ; xn--1biv525bcix0d.xn--xgb6828v; [B1, P1, V6] # ✆ꡋ.ز
+✆񱔩ꡋ.ز‍𞣴; ; [B1, C2, P1, V6]; xn--1biv525bcix0d.xn--xgb253k0m73a; ; xn--1biv525bcix0d.xn--xgb6828v; [B1, P1, V6] # ✆ꡋ.ز
+xn--1biv525bcix0d.xn--xgb6828v; ✆񱔩ꡋ.ز𞣴; [B1, V6]; xn--1biv525bcix0d.xn--xgb6828v; ; ;  # ✆ꡋ.ز
+xn--1biv525bcix0d.xn--xgb253k0m73a; ✆񱔩ꡋ.ز‍𞣴; [B1, C2, V6]; xn--1biv525bcix0d.xn--xgb253k0m73a; ; ;  # ✆ꡋ.ز
+ࡅ񃾰𞸍-．≠򃁟𑋪; ࡅ񃾰ن-.≠򃁟𑋪; [B1, B2, B3, P1, V3, V6]; xn----qoc64my971s.xn--1ch7585g76o3c; ; ;  # ࡅن-.≠𑋪
+ࡅ񃾰𞸍-．≠򃁟𑋪; ࡅ񃾰ن-.≠򃁟𑋪; [B1, B2, B3, P1, V3, V6]; xn----qoc64my971s.xn--1ch7585g76o3c; ; ;  # ࡅن-.≠𑋪
+ࡅ񃾰ن-.≠򃁟𑋪; ; [B1, B2, B3, P1, V3, V6]; xn----qoc64my971s.xn--1ch7585g76o3c; ; ;  # ࡅن-.≠𑋪
+ࡅ񃾰ن-.≠򃁟𑋪; ࡅ񃾰ن-.≠򃁟𑋪; [B1, B2, B3, P1, V3, V6]; xn----qoc64my971s.xn--1ch7585g76o3c; ; ;  # ࡅن-.≠𑋪
+xn----qoc64my971s.xn--1ch7585g76o3c; ࡅ񃾰ن-.≠򃁟𑋪; [B1, B2, B3, V3, V6]; xn----qoc64my971s.xn--1ch7585g76o3c; ; ;  # ࡅن-.≠𑋪
+𝟛．笠; 3.笠; ; 3.xn--6vz; ; ;  # 3.笠
+𝟛．笠; 3.笠; ; 3.xn--6vz; ; ;  # 3.笠
+3.笠; ; ; 3.xn--6vz; ; ;  # 3.笠
+3.xn--6vz; 3.笠; ; 3.xn--6vz; ; ;  # 3.笠
+-‍.Ⴞ𐋷; ; [C2, P1, V3, V6]; xn----ugn.xn--2nd2315j; ; -.xn--2nd2315j; [P1, V3, V6] # -.Ⴞ𐋷
+-‍.ⴞ𐋷; ; [C2, V3]; xn----ugn.xn--mlj8559d; ; -.xn--mlj8559d; [V3] # -.ⴞ𐋷
+-.xn--mlj8559d; -.ⴞ𐋷; [V3]; -.xn--mlj8559d; ; ;  # -.ⴞ𐋷
+xn----ugn.xn--mlj8559d; -‍.ⴞ𐋷; [C2, V3]; xn----ugn.xn--mlj8559d; ; ;  # -.ⴞ𐋷
+-.xn--2nd2315j; -.Ⴞ𐋷; [V3, V6]; -.xn--2nd2315j; ; ;  # -.Ⴞ𐋷
+xn----ugn.xn--2nd2315j; -‍.Ⴞ𐋷; [C2, V3, V6]; xn----ugn.xn--2nd2315j; ; ;  # -.Ⴞ𐋷
+‍ςßܱ．்; ‍ςßܱ.்; [C2, V5]; xn--zca19ln1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # ςßܱ.்
+‍ςßܱ.்; ; [C2, V5]; xn--zca19ln1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # ςßܱ.்
+‍ΣSSܱ.்; ‍σssܱ.்; [C2, V5]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # σssܱ.்
+‍σssܱ.்; ; [C2, V5]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # σssܱ.்
+‍Σssܱ.்; ‍σssܱ.்; [C2, V5]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # σssܱ.்
+xn--ss-ubc826a.xn--xmc; σssܱ.்; [V5]; xn--ss-ubc826a.xn--xmc; ; ;  # σssܱ.்
+xn--ss-ubc826ab34b.xn--xmc; ‍σssܱ.்; [C2, V5]; xn--ss-ubc826ab34b.xn--xmc; ; ;  # σssܱ.்
+‍Σßܱ.்; ‍σßܱ.்; [C2, V5]; xn--zca39lk1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # σßܱ.்
+‍σßܱ.்; ; [C2, V5]; xn--zca39lk1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # σßܱ.்
+xn--zca39lk1di19a.xn--xmc; ‍σßܱ.்; [C2, V5]; xn--zca39lk1di19a.xn--xmc; ; ;  # σßܱ.்
+xn--zca19ln1di19a.xn--xmc; ‍ςßܱ.்; [C2, V5]; xn--zca19ln1di19a.xn--xmc; ; ;  # ςßܱ.்
+‍ΣSSܱ．்; ‍σssܱ.்; [C2, V5]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # σssܱ.்
+‍σssܱ．்; ‍σssܱ.்; [C2, V5]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # σssܱ.்
+‍Σssܱ．்; ‍σssܱ.்; [C2, V5]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # σssܱ.்
+‍Σßܱ．்; ‍σßܱ.்; [C2, V5]; xn--zca39lk1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # σßܱ.்
+‍σßܱ．்; ‍σßܱ.்; [C2, V5]; xn--zca39lk1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V5] # σßܱ.்
+≠．‍; ≠.‍; [C2, P1, V6]; xn--1ch.xn--1ug; ; xn--1ch.; [P1, V6] # ≠.
+≠．‍; ≠.‍; [C2, P1, V6]; xn--1ch.xn--1ug; ; xn--1ch.; [P1, V6] # ≠.
+≠.‍; ; [C2, P1, V6]; xn--1ch.xn--1ug; ; xn--1ch.; [P1, V6] # ≠.
+≠.‍; ≠.‍; [C2, P1, V6]; xn--1ch.xn--1ug; ; xn--1ch.; [P1, V6] # ≠.
+xn--1ch.; ≠.; [V6]; xn--1ch.; ; ;  # ≠.
+xn--1ch.xn--1ug; ≠.‍; [C2, V6]; xn--1ch.xn--1ug; ; ;  # ≠.
+ﰁ｡ಁᠼ▗򒁋; ئح.ಁᠼ▗򒁋; [B1, P1, V5, V6]; xn--lgbo.xn--2rc021dcxkrx55t; ; ;  # ئح.ಁᠼ▗
+ئح。ಁᠼ▗򒁋; ئح.ಁᠼ▗򒁋; [B1, P1, V5, V6]; xn--lgbo.xn--2rc021dcxkrx55t; ; ;  # ئح.ಁᠼ▗
+ئح。ಁᠼ▗򒁋; ئح.ಁᠼ▗򒁋; [B1, P1, V5, V6]; xn--lgbo.xn--2rc021dcxkrx55t; ; ;  # ئح.ಁᠼ▗
+xn--lgbo.xn--2rc021dcxkrx55t; ئح.ಁᠼ▗򒁋; [B1, V5, V6]; xn--lgbo.xn--2rc021dcxkrx55t; ; ;  # ئح.ಁᠼ▗
+󧋵্ς．ς𐨿; 󧋵্ς.ς𐨿; [P1, V6]; xn--3xa702av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্ς.ς𐨿
+󧋵্ς.ς𐨿; ; [P1, V6]; xn--3xa702av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্ς.ς𐨿
+󧋵্Σ.Σ𐨿; 󧋵্σ.σ𐨿; [P1, V6]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵্σ.ς𐨿; ; [P1, V6]; xn--4xa502av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্σ.ς𐨿
+󧋵্σ.σ𐨿; ; [P1, V6]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵্Σ.σ𐨿; 󧋵্σ.σ𐨿; [P1, V6]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+xn--4xa502av8297a.xn--4xa6055k; 󧋵্σ.σ𐨿; [V6]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵্Σ.ς𐨿; 󧋵্σ.ς𐨿; [P1, V6]; xn--4xa502av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্σ.ς𐨿
+xn--4xa502av8297a.xn--3xa8055k; 󧋵্σ.ς𐨿; [V6]; xn--4xa502av8297a.xn--3xa8055k; ; ;  # ্σ.ς𐨿
+xn--3xa702av8297a.xn--3xa8055k; 󧋵্ς.ς𐨿; [V6]; xn--3xa702av8297a.xn--3xa8055k; ; ;  # ্ς.ς𐨿
+󧋵্Σ．Σ𐨿; 󧋵্σ.σ𐨿; [P1, V6]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵্σ．ς𐨿; 󧋵্σ.ς𐨿; [P1, V6]; xn--4xa502av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্σ.ς𐨿
+󧋵্σ．σ𐨿; 󧋵্σ.σ𐨿; [P1, V6]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵্Σ．σ𐨿; 󧋵্σ.σ𐨿; [P1, V6]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵্Σ．ς𐨿; 󧋵্σ.ς𐨿; [P1, V6]; xn--4xa502av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্σ.ς𐨿
+𐫓ߘ牅ࣸ｡𞦤ᨗ򱍰Ⴙ; 𐫓ߘ牅ࣸ.𞦤ᨗ򱍰Ⴙ; [B2, B3, P1, V6]; xn--zsb09cu46vjs6f.xn--xnd909bv540bm5k9d; ; ;  # 𐫓ߘ牅ࣸ.ᨗႹ
+𐫓ߘ牅ࣸ。𞦤ᨗ򱍰Ⴙ; 𐫓ߘ牅ࣸ.𞦤ᨗ򱍰Ⴙ; [B2, B3, P1, V6]; xn--zsb09cu46vjs6f.xn--xnd909bv540bm5k9d; ; ;  # 𐫓ߘ牅ࣸ.ᨗႹ
+𐫓ߘ牅ࣸ。𞦤ᨗ򱍰ⴙ; 𐫓ߘ牅ࣸ.𞦤ᨗ򱍰ⴙ; [B2, B3, P1, V6]; xn--zsb09cu46vjs6f.xn--gmf469fr883am5r1e; ; ;  # 𐫓ߘ牅ࣸ.ᨗⴙ
+xn--zsb09cu46vjs6f.xn--gmf469fr883am5r1e; 𐫓ߘ牅ࣸ.𞦤ᨗ򱍰ⴙ; [B2, B3, V6]; xn--zsb09cu46vjs6f.xn--gmf469fr883am5r1e; ; ;  # 𐫓ߘ牅ࣸ.ᨗⴙ
+xn--zsb09cu46vjs6f.xn--xnd909bv540bm5k9d; 𐫓ߘ牅ࣸ.𞦤ᨗ򱍰Ⴙ; [B2, B3, V6]; xn--zsb09cu46vjs6f.xn--xnd909bv540bm5k9d; ; ;  # 𐫓ߘ牅ࣸ.ᨗႹ
+𐫓ߘ牅ࣸ｡𞦤ᨗ򱍰ⴙ; 𐫓ߘ牅ࣸ.𞦤ᨗ򱍰ⴙ; [B2, B3, P1, V6]; xn--zsb09cu46vjs6f.xn--gmf469fr883am5r1e; ; ;  # 𐫓ߘ牅ࣸ.ᨗⴙ
+񣤒｡륧; 񣤒.륧; [P1, V6]; xn--s264a.xn--pw2b; ; ;  # .륧
+񣤒｡륧; 񣤒.륧; [P1, V6]; xn--s264a.xn--pw2b; ; ;  # .륧
+񣤒。륧; 񣤒.륧; [P1, V6]; xn--s264a.xn--pw2b; ; ;  # .륧
+񣤒。륧; 񣤒.륧; [P1, V6]; xn--s264a.xn--pw2b; ; ;  # .륧
+xn--s264a.xn--pw2b; 񣤒.륧; [V6]; xn--s264a.xn--pw2b; ; ;  # .륧
+𐹷‍。󉵢; 𐹷‍.󉵢; [B1, C2, P1, V6]; xn--1ugx205g.xn--8088d; ; xn--vo0d.xn--8088d; [B1, P1, V6] # 𐹷.
+xn--vo0d.xn--8088d; 𐹷.󉵢; [B1, V6]; xn--vo0d.xn--8088d; ; ;  # 𐹷.
+xn--1ugx205g.xn--8088d; 𐹷‍.󉵢; [B1, C2, V6]; xn--1ugx205g.xn--8088d; ; ;  # 𐹷.
+Ⴘۂ𑲭｡-; Ⴘۂ𑲭.-; [B1, B5, B6, P1, V3, V6]; xn--1kb312c139t.-; ; ;  # Ⴘۂ𑲭.-
+Ⴘۂ𑲭｡-; Ⴘۂ𑲭.-; [B1, B5, B6, P1, V3, V6]; xn--1kb312c139t.-; ; ;  # Ⴘۂ𑲭.-
+Ⴘۂ𑲭。-; Ⴘۂ𑲭.-; [B1, B5, B6, P1, V3, V6]; xn--1kb312c139t.-; ; ;  # Ⴘۂ𑲭.-
+Ⴘۂ𑲭。-; Ⴘۂ𑲭.-; [B1, B5, B6, P1, V3, V6]; xn--1kb312c139t.-; ; ;  # Ⴘۂ𑲭.-
+ⴘۂ𑲭。-; ⴘۂ𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+ⴘۂ𑲭。-; ⴘۂ𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+xn--1kb147qfk3n.-; ⴘۂ𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+xn--1kb312c139t.-; Ⴘۂ𑲭.-; [B1, B5, B6, V3, V6]; xn--1kb312c139t.-; ; ;  # Ⴘۂ𑲭.-
+ⴘۂ𑲭｡-; ⴘۂ𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+ⴘۂ𑲭｡-; ⴘۂ𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+꠆ٻ₆ᡐ。🛇ﳝ; ꠆ٻ6ᡐ.🛇يم; [B1, V5]; xn--6-rrc018krt9k.xn--hhbj61429a; ; ;  # ꠆ٻ6ᡐ.🛇يم
+꠆ٻ6ᡐ。🛇يم; ꠆ٻ6ᡐ.🛇يم; [B1, V5]; xn--6-rrc018krt9k.xn--hhbj61429a; ; ;  # ꠆ٻ6ᡐ.🛇يم
+xn--6-rrc018krt9k.xn--hhbj61429a; ꠆ٻ6ᡐ.🛇يم; [B1, V5]; xn--6-rrc018krt9k.xn--hhbj61429a; ; ;  # ꠆ٻ6ᡐ.🛇يم
+򸍂.㇄ᡟ𐫂آ; ; [B1, P1, V6]; xn--p292d.xn--hgb154ghrsvm2r; ; ;  # .㇄ᡟ𐫂آ
+򸍂.㇄ᡟ𐫂آ; 򸍂.㇄ᡟ𐫂آ; [B1, P1, V6]; xn--p292d.xn--hgb154ghrsvm2r; ; ;  # .㇄ᡟ𐫂آ
+xn--p292d.xn--hgb154ghrsvm2r; 򸍂.㇄ᡟ𐫂آ; [B1, V6]; xn--p292d.xn--hgb154ghrsvm2r; ; ;  # .㇄ᡟ𐫂آ
+ߟ򵚌。-ߩ; ߟ򵚌.-ߩ; [B1, B2, B3, P1, V3, V6]; xn--6sb88139l.xn----pdd; ; ;  # ߟ.-ߩ
+xn--6sb88139l.xn----pdd; ߟ򵚌.-ߩ; [B1, B2, B3, V3, V6]; xn--6sb88139l.xn----pdd; ; ;  # ߟ.-ߩ
+ςك⾑．‌ᢟ‌⒈; ςك襾.‌ᢟ‌⒈; [B1, B5, C1, P1, V6]; xn--3xa69jux8r.xn--pbf519aba607b; ; xn--4xa49jux8r.xn--pbf212d; [B5, P1, V6] # ςك襾.ᢟ⒈
+ςك襾.‌ᢟ‌1.; ; [B1, B5, C1]; xn--3xa69jux8r.xn--1-4ck691bba.; ; xn--4xa49jux8r.xn--1-4ck.; [B5] # ςك襾.ᢟ1.
+Σك襾.‌ᢟ‌1.; σك襾.‌ᢟ‌1.; [B1, B5, C1]; xn--4xa49jux8r.xn--1-4ck691bba.; ; xn--4xa49jux8r.xn--1-4ck.; [B5] # σك襾.ᢟ1.
+σك襾.‌ᢟ‌1.; ; [B1, B5, C1]; xn--4xa49jux8r.xn--1-4ck691bba.; ; xn--4xa49jux8r.xn--1-4ck.; [B5] # σك襾.ᢟ1.
+xn--4xa49jux8r.xn--1-4ck.; σك襾.ᢟ1.; [B5]; xn--4xa49jux8r.xn--1-4ck.; ; ;  # σك襾.ᢟ1.
+xn--4xa49jux8r.xn--1-4ck691bba.; σك襾.‌ᢟ‌1.; [B1, B5, C1]; xn--4xa49jux8r.xn--1-4ck691bba.; ; ;  # σك襾.ᢟ1.
+xn--3xa69jux8r.xn--1-4ck691bba.; ςك襾.‌ᢟ‌1.; [B1, B5, C1]; xn--3xa69jux8r.xn--1-4ck691bba.; ; ;  # ςك襾.ᢟ1.
+Σك⾑．‌ᢟ‌⒈; σك襾.‌ᢟ‌⒈; [B1, B5, C1, P1, V6]; xn--4xa49jux8r.xn--pbf519aba607b; ; xn--4xa49jux8r.xn--pbf212d; [B5, P1, V6] # σك襾.ᢟ⒈
+σك⾑．‌ᢟ‌⒈; σك襾.‌ᢟ‌⒈; [B1, B5, C1, P1, V6]; xn--4xa49jux8r.xn--pbf519aba607b; ; xn--4xa49jux8r.xn--pbf212d; [B5, P1, V6] # σك襾.ᢟ⒈
+xn--4xa49jux8r.xn--pbf212d; σك襾.ᢟ⒈; [B5, V6]; xn--4xa49jux8r.xn--pbf212d; ; ;  # σك襾.ᢟ⒈
+xn--4xa49jux8r.xn--pbf519aba607b; σك襾.‌ᢟ‌⒈; [B1, B5, C1, V6]; xn--4xa49jux8r.xn--pbf519aba607b; ; ;  # σك襾.ᢟ⒈
+xn--3xa69jux8r.xn--pbf519aba607b; ςك襾.‌ᢟ‌⒈; [B1, B5, C1, V6]; xn--3xa69jux8r.xn--pbf519aba607b; ; ;  # ςك襾.ᢟ⒈
+ᡆ𑓝．𞵆; ᡆ𑓝.𞵆; [P1, V6]; xn--57e0440k.xn--k86h; ; ;  # ᡆ.
+ᡆ𑓝.𞵆; ; [P1, V6]; xn--57e0440k.xn--k86h; ; ;  # ᡆ.
+xn--57e0440k.xn--k86h; ᡆ𑓝.𞵆; [V6]; xn--57e0440k.xn--k86h; ; ;  # ᡆ.
+੍𦍓ᷮ｡‌ࢽ񝹲; ੍𦍓ᷮ.‌ࢽ񝹲; [B1, C1, P1, V5, V6]; xn--ybc461hph93b.xn--jzb740j1y45h; ; xn--ybc461hph93b.xn--jzb29857e; [B1, B2, B3, P1, V5, V6] # ੍𦍓ᷮ.ࢽ
+੍𦍓ᷮ。‌ࢽ񝹲; ੍𦍓ᷮ.‌ࢽ񝹲; [B1, C1, P1, V5, V6]; xn--ybc461hph93b.xn--jzb740j1y45h; ; xn--ybc461hph93b.xn--jzb29857e; [B1, B2, B3, P1, V5, V6] # ੍𦍓ᷮ.ࢽ
+xn--ybc461hph93b.xn--jzb29857e; ੍𦍓ᷮ.ࢽ񝹲; [B1, B2, B3, V5, V6]; xn--ybc461hph93b.xn--jzb29857e; ; ;  # ੍𦍓ᷮ.ࢽ
+xn--ybc461hph93b.xn--jzb740j1y45h; ੍𦍓ᷮ.‌ࢽ񝹲; [B1, C1, V5, V6]; xn--ybc461hph93b.xn--jzb740j1y45h; ; ;  # ੍𦍓ᷮ.ࢽ
+خ݈񅪪-．‌먿; خ݈񅪪-.‌먿; [B1, B2, B3, C1, P1, V3, V6]; xn----dnc06f42153a.xn--0ug1581d; ; xn----dnc06f42153a.xn--v22b; [B2, B3, P1, V3, V6] # خ݈-.먿
+خ݈񅪪-．‌먿; خ݈񅪪-.‌먿; [B1, B2, B3, C1, P1, V3, V6]; xn----dnc06f42153a.xn--0ug1581d; ; xn----dnc06f42153a.xn--v22b; [B2, B3, P1, V3, V6] # خ݈-.먿
+خ݈񅪪-.‌먿; ; [B1, B2, B3, C1, P1, V3, V6]; xn----dnc06f42153a.xn--0ug1581d; ; xn----dnc06f42153a.xn--v22b; [B2, B3, P1, V3, V6] # خ݈-.먿
+خ݈񅪪-.‌먿; خ݈񅪪-.‌먿; [B1, B2, B3, C1, P1, V3, V6]; xn----dnc06f42153a.xn--0ug1581d; ; xn----dnc06f42153a.xn--v22b; [B2, B3, P1, V3, V6] # خ݈-.먿
+xn----dnc06f42153a.xn--v22b; خ݈񅪪-.먿; [B2, B3, V3, V6]; xn----dnc06f42153a.xn--v22b; ; ;  # خ݈-.먿
+xn----dnc06f42153a.xn--0ug1581d; خ݈񅪪-.‌먿; [B1, B2, B3, C1, V3, V6]; xn----dnc06f42153a.xn--0ug1581d; ; ;  # خ݈-.먿
+􋿦｡ᠽ; 􋿦.ᠽ; [P1, V6]; xn--j890g.xn--w7e; ; ;  # .ᠽ
+􋿦。ᠽ; 􋿦.ᠽ; [P1, V6]; xn--j890g.xn--w7e; ; ;  # .ᠽ
+xn--j890g.xn--w7e; 􋿦.ᠽ; [V6]; xn--j890g.xn--w7e; ; ;  # .ᠽ
+嬃𝍌．‍ୄ; 嬃𝍌.‍ୄ; [C2]; xn--b6s0078f.xn--0ic557h; ; xn--b6s0078f.xn--0ic; [V5] # 嬃𝍌.ୄ
+嬃𝍌.‍ୄ; ; [C2]; xn--b6s0078f.xn--0ic557h; ; xn--b6s0078f.xn--0ic; [V5] # 嬃𝍌.ୄ
+xn--b6s0078f.xn--0ic; 嬃𝍌.ୄ; [V5]; xn--b6s0078f.xn--0ic; ; ;  # 嬃𝍌.ୄ
+xn--b6s0078f.xn--0ic557h; 嬃𝍌.‍ୄ; [C2]; xn--b6s0078f.xn--0ic557h; ; ;  # 嬃𝍌.ୄ
+؂𝌪≯．𚋲򵁨; ؂𝌪≯.𚋲򵁨; [B1, P1, V6]; xn--kfb866llx01a.xn--wp1gm3570b; ; ;  # 𝌪≯.
+؂𝌪≯．𚋲򵁨; ؂𝌪≯.𚋲򵁨; [B1, P1, V6]; xn--kfb866llx01a.xn--wp1gm3570b; ; ;  # 𝌪≯.
+؂𝌪≯.𚋲򵁨; ; [B1, P1, V6]; xn--kfb866llx01a.xn--wp1gm3570b; ; ;  # 𝌪≯.
+؂𝌪≯.𚋲򵁨; ؂𝌪≯.𚋲򵁨; [B1, P1, V6]; xn--kfb866llx01a.xn--wp1gm3570b; ; ;  # 𝌪≯.
+xn--kfb866llx01a.xn--wp1gm3570b; ؂𝌪≯.𚋲򵁨; [B1, V6]; xn--kfb866llx01a.xn--wp1gm3570b; ; ;  # 𝌪≯.
+򫾥ࢷ៌꧀.𞼠; ; [B5, P1, V6]; xn--dzb638ewm4i1iy1h.xn--3m7h; ; ;  # ࢷ៌꧀.
+xn--dzb638ewm4i1iy1h.xn--3m7h; 򫾥ࢷ៌꧀.𞼠; [B5, V6]; xn--dzb638ewm4i1iy1h.xn--3m7h; ; ;  # ࢷ៌꧀.
+‌.񟛤; ; [C1, P1, V6]; xn--0ug.xn--q823a; ; .xn--q823a; [P1, V6, A4_2] # .
+.xn--q823a; .񟛤; [V6, X4_2]; .xn--q823a; [V6, A4_2]; ;  # .
+xn--0ug.xn--q823a; ‌.񟛤; [C1, V6]; xn--0ug.xn--q823a; ; ;  # .
+򺛕Ⴃ䠅．𐸑; 򺛕Ⴃ䠅.𐸑; [P1, V6]; xn--bnd074zr557n.xn--yl0d; ; ;  # Ⴃ䠅.
+򺛕Ⴃ䠅.𐸑; ; [P1, V6]; xn--bnd074zr557n.xn--yl0d; ; ;  # Ⴃ䠅.
+򺛕ⴃ䠅.𐸑; ; [P1, V6]; xn--ukju77frl47r.xn--yl0d; ; ;  # ⴃ䠅.
+xn--ukju77frl47r.xn--yl0d; 򺛕ⴃ䠅.𐸑; [V6]; xn--ukju77frl47r.xn--yl0d; ; ;  # ⴃ䠅.
+xn--bnd074zr557n.xn--yl0d; 򺛕Ⴃ䠅.𐸑; [V6]; xn--bnd074zr557n.xn--yl0d; ; ;  # Ⴃ䠅.
+򺛕ⴃ䠅．𐸑; 򺛕ⴃ䠅.𐸑; [P1, V6]; xn--ukju77frl47r.xn--yl0d; ; ;  # ⴃ䠅.
+ᯱ𐹳𐹵𞤚｡𝟨Ⴅ; ᯱ𐹳𐹵𞤼.6Ⴅ; [B1, P1, V5, V6]; xn--zzfy954hga2415t.xn--6-h0g; ; ;  # ᯱ𐹳𐹵𞤼.6Ⴅ
+ᯱ𐹳𐹵𞤚。6Ⴅ; ᯱ𐹳𐹵𞤼.6Ⴅ; [B1, P1, V5, V6]; xn--zzfy954hga2415t.xn--6-h0g; ; ;  # ᯱ𐹳𐹵𞤼.6Ⴅ
+ᯱ𐹳𐹵𞤼。6ⴅ; ᯱ𐹳𐹵𞤼.6ⴅ; [B1, V5]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+ᯱ𐹳𐹵𞤚。6ⴅ; ᯱ𐹳𐹵𞤼.6ⴅ; [B1, V5]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+xn--zzfy954hga2415t.xn--6-kvs; ᯱ𐹳𐹵𞤼.6ⴅ; [B1, V5]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+xn--zzfy954hga2415t.xn--6-h0g; ᯱ𐹳𐹵𞤼.6Ⴅ; [B1, V5, V6]; xn--zzfy954hga2415t.xn--6-h0g; ; ;  # ᯱ𐹳𐹵𞤼.6Ⴅ
+ᯱ𐹳𐹵𞤼｡𝟨ⴅ; ᯱ𐹳𐹵𞤼.6ⴅ; [B1, V5]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+ᯱ𐹳𐹵𞤚｡𝟨ⴅ; ᯱ𐹳𐹵𞤼.6ⴅ; [B1, V5]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+-｡︒; -.︒; [P1, V3, V6]; -.xn--y86c; ; ;  # -.︒
+-。。; -..; [V3, X4_2]; ; [V3, A4_2]; ;  # -..
+-..; ; [V3, X4_2]; ; [V3, A4_2]; ;  # -..
+-.xn--y86c; -.︒; [V3, V6]; -.xn--y86c; ; ;  # -.︒
+ߛჀ｡-⁵--; ߛჀ.-5--; [B1, B2, B3, P1, V2, V3, V6]; xn--2sb866b.-5--; ; ;  # ߛჀ.-5--
+ߛჀ。-5--; ߛჀ.-5--; [B1, B2, B3, P1, V2, V3, V6]; xn--2sb866b.-5--; ; ;  # ߛჀ.-5--
+ߛⴠ。-5--; ߛⴠ.-5--; [B1, B2, B3, V2, V3]; xn--2sb691q.-5--; ; ;  # ߛⴠ.-5--
+xn--2sb691q.-5--; ߛⴠ.-5--; [B1, B2, B3, V2, V3]; xn--2sb691q.-5--; ; ;  # ߛⴠ.-5--
+xn--2sb866b.-5--; ߛჀ.-5--; [B1, B2, B3, V2, V3, V6]; xn--2sb866b.-5--; ; ;  # ߛჀ.-5--
+ߛⴠ｡-⁵--; ߛⴠ.-5--; [B1, B2, B3, V2, V3]; xn--2sb691q.-5--; ; ;  # ߛⴠ.-5--
+≯?󠑕｡𐹷𐹻≯𐷒; ≯?󠑕.𐹷𐹻≯𐷒; [B1, P1, V6]; ≯?󠑕.xn--hdh8283gdoaqa; [B1, P1, V6, A3]; ;  # ≯.𐹷𐹻≯
+≯?󠑕｡𐹷𐹻≯𐷒; ≯?󠑕.𐹷𐹻≯𐷒; [B1, P1, V6]; ≯?󠑕.xn--hdh8283gdoaqa; [B1, P1, V6, A3]; ;  # ≯.𐹷𐹻≯
+≯?󠑕。𐹷𐹻≯𐷒; ≯?󠑕.𐹷𐹻≯𐷒; [B1, P1, V6]; ≯?󠑕.xn--hdh8283gdoaqa; [B1, P1, V6, A3]; ;  # ≯.𐹷𐹻≯
+≯?󠑕。𐹷𐹻≯𐷒; ≯?󠑕.𐹷𐹻≯𐷒; [B1, P1, V6]; ≯?󠑕.xn--hdh8283gdoaqa; [B1, P1, V6, A3]; ;  # ≯.𐹷𐹻≯
+≯?󠑕.xn--hdh8283gdoaqa; ≯?󠑕.𐹷𐹻≯𐷒; [B1, P1, V6]; ≯?󠑕.xn--hdh8283gdoaqa; [B1, P1, V6, A3]; ;  # ≯.𐹷𐹻≯
+≯?󠑕.xn--hdh8283gdoaqa; ≯?󠑕.𐹷𐹻≯𐷒; [B1, P1, V6]; ≯?󠑕.xn--hdh8283gdoaqa; [B1, P1, V6, A3]; ;  # ≯.𐹷𐹻≯
+≯?󠑕.XN--HDH8283GDOAQA; ≯?󠑕.𐹷𐹻≯𐷒; [B1, P1, V6]; ≯?󠑕.xn--hdh8283gdoaqa; [B1, P1, V6, A3]; ;  # ≯.𐹷𐹻≯
+≯?󠑕.XN--HDH8283GDOAQA; ≯?󠑕.𐹷𐹻≯𐷒; [B1, P1, V6]; ≯?󠑕.xn--hdh8283gdoaqa; [B1, P1, V6, A3]; ;  # ≯.𐹷𐹻≯
+≯?󠑕.Xn--Hdh8283gdoaqa; ≯?󠑕.𐹷𐹻≯𐷒; [B1, P1, V6]; ≯?󠑕.xn--hdh8283gdoaqa; [B1, P1, V6, A3]; ;  # ≯.𐹷𐹻≯
+≯?󠑕.Xn--Hdh8283gdoaqa; ≯?󠑕.𐹷𐹻≯𐷒; [B1, P1, V6]; ≯?󠑕.xn--hdh8283gdoaqa; [B1, P1, V6, A3]; ;  # ≯.𐹷𐹻≯
+㍔ࣦݼ‍。͆򁳊𝅶؄; ルーブルࣦݼ‍.͆򁳊𝅶؄; [B1, B5, B6, C2, P1, V5, V6]; xn--dqb73ec22c9kp8cb1j.xn--kua81ls548d3608b; ; xn--dqb73el09fncab4h.xn--kua81ls548d3608b; [B1, B5, B6, P1, V5, V6] # ルーブルࣦݼ.͆
+ルーブルࣦݼ‍。͆򁳊𝅶؄; ルーブルࣦݼ‍.͆򁳊𝅶؄; [B1, B5, B6, C2, P1, V5, V6]; xn--dqb73ec22c9kp8cb1j.xn--kua81ls548d3608b; ; xn--dqb73el09fncab4h.xn--kua81ls548d3608b; [B1, B5, B6, P1, V5, V6] # ルーブルࣦݼ.͆
+ルーブルࣦݼ‍。͆򁳊𝅶؄; ルーブルࣦݼ‍.͆򁳊𝅶؄; [B1, B5, B6, C2, P1, V5, V6]; xn--dqb73ec22c9kp8cb1j.xn--kua81ls548d3608b; ; xn--dqb73el09fncab4h.xn--kua81ls548d3608b; [B1, B5, B6, P1, V5, V6] # ルーブルࣦݼ.͆
+xn--dqb73el09fncab4h.xn--kua81ls548d3608b; ルーブルࣦݼ.͆򁳊𝅶؄; [B1, B5, B6, V5, V6]; xn--dqb73el09fncab4h.xn--kua81ls548d3608b; ; ;  # ルーブルࣦݼ.͆
+xn--dqb73ec22c9kp8cb1j.xn--kua81ls548d3608b; ルーブルࣦݼ‍.͆򁳊𝅶؄; [B1, B5, B6, C2, V5, V6]; xn--dqb73ec22c9kp8cb1j.xn--kua81ls548d3608b; ; ;  # ルーブルࣦݼ.͆
+‍.F; ‍.f; [C2]; xn--1ug.f; ; .f; [A4_2] # .f
+‍.f; ; [C2]; xn--1ug.f; ; .f; [A4_2] # .f
+.f; ; [X4_2]; ; [A4_2]; ;  # .f
+xn--1ug.f; ‍.f; [C2]; xn--1ug.f; ; ;  # .f
+f; ; ; ; ; ;  # f
+‍㨲｡ß; ‍㨲.ß; [C2]; xn--1ug914h.xn--zca; ; xn--9bm.ss; [] # 㨲.ß
+‍㨲。ß; ‍㨲.ß; [C2]; xn--1ug914h.xn--zca; ; xn--9bm.ss; [] # 㨲.ß
+‍㨲。SS; ‍㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+‍㨲。ss; ‍㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+‍㨲。Ss; ‍㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+xn--9bm.ss; 㨲.ss; ; xn--9bm.ss; ; ;  # 㨲.ss
+㨲.ss; ; ; xn--9bm.ss; ; ;  # 㨲.ss
+㨲.SS; 㨲.ss; ; xn--9bm.ss; ; ;  # 㨲.ss
+㨲.Ss; 㨲.ss; ; xn--9bm.ss; ; ;  # 㨲.ss
+xn--1ug914h.ss; ‍㨲.ss; [C2]; xn--1ug914h.ss; ; ;  # 㨲.ss
+xn--1ug914h.xn--zca; ‍㨲.ß; [C2]; xn--1ug914h.xn--zca; ; ;  # 㨲.ß
+‍㨲｡SS; ‍㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+‍㨲｡ss; ‍㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+‍㨲｡Ss; ‍㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+؅پ｡ࢨ; ؅پ.ࢨ; [B1, P1, V6]; xn--nfb6v.xn--xyb; ; ;  # پ.ࢨ
+؅پ。ࢨ; ؅پ.ࢨ; [B1, P1, V6]; xn--nfb6v.xn--xyb; ; ;  # پ.ࢨ
+xn--nfb6v.xn--xyb; ؅پ.ࢨ; [B1, V6]; xn--nfb6v.xn--xyb; ; ;  # پ.ࢨ
+⾑ݓ𞤁。𐹵ڂ; 襾ݓ𞤣.𐹵ڂ; [B1, B5, B6]; xn--6ob9577deqwl.xn--7ib5526k; ; ;  # 襾ݓ𞤣.𐹵ڂ
+襾ݓ𞤁。𐹵ڂ; 襾ݓ𞤣.𐹵ڂ; [B1, B5, B6]; xn--6ob9577deqwl.xn--7ib5526k; ; ;  # 襾ݓ𞤣.𐹵ڂ
+襾ݓ𞤣。𐹵ڂ; 襾ݓ𞤣.𐹵ڂ; [B1, B5, B6]; xn--6ob9577deqwl.xn--7ib5526k; ; ;  # 襾ݓ𞤣.𐹵ڂ
+xn--6ob9577deqwl.xn--7ib5526k; 襾ݓ𞤣.𐹵ڂ; [B1, B5, B6]; xn--6ob9577deqwl.xn--7ib5526k; ; ;  # 襾ݓ𞤣.𐹵ڂ
+⾑ݓ𞤣。𐹵ڂ; 襾ݓ𞤣.𐹵ڂ; [B1, B5, B6]; xn--6ob9577deqwl.xn--7ib5526k; ; ;  # 襾ݓ𞤣.𐹵ڂ
+񦴻ς-⃫｡ݔ-ꡛ; 񦴻ς-⃫.ݔ-ꡛ; [B2, B3, B6, P1, V6]; xn----xmb015tuo34l.xn----53c4874j; ; xn----zmb705tuo34l.xn----53c4874j;  # ς-⃫.ݔ-ꡛ
+񦴻ς-⃫。ݔ-ꡛ; 񦴻ς-⃫.ݔ-ꡛ; [B2, B3, B6, P1, V6]; xn----xmb015tuo34l.xn----53c4874j; ; xn----zmb705tuo34l.xn----53c4874j;  # ς-⃫.ݔ-ꡛ
+񦴻Σ-⃫。ݔ-ꡛ; 񦴻σ-⃫.ݔ-ꡛ; [B2, B3, B6, P1, V6]; xn----zmb705tuo34l.xn----53c4874j; ; ;  # σ-⃫.ݔ-ꡛ
+񦴻σ-⃫。ݔ-ꡛ; 񦴻σ-⃫.ݔ-ꡛ; [B2, B3, B6, P1, V6]; xn----zmb705tuo34l.xn----53c4874j; ; ;  # σ-⃫.ݔ-ꡛ
+xn----zmb705tuo34l.xn----53c4874j; 񦴻σ-⃫.ݔ-ꡛ; [B2, B3, B6, V6]; xn----zmb705tuo34l.xn----53c4874j; ; ;  # σ-⃫.ݔ-ꡛ
+xn----xmb015tuo34l.xn----53c4874j; 񦴻ς-⃫.ݔ-ꡛ; [B2, B3, B6, V6]; xn----xmb015tuo34l.xn----53c4874j; ; ;  # ς-⃫.ݔ-ꡛ
+񦴻Σ-⃫｡ݔ-ꡛ; 񦴻σ-⃫.ݔ-ꡛ; [B2, B3, B6, P1, V6]; xn----zmb705tuo34l.xn----53c4874j; ; ;  # σ-⃫.ݔ-ꡛ
+񦴻σ-⃫｡ݔ-ꡛ; 񦴻σ-⃫.ݔ-ꡛ; [B2, B3, B6, P1, V6]; xn----zmb705tuo34l.xn----53c4874j; ; ;  # σ-⃫.ݔ-ꡛ
+‍．􀸨; ‍.􀸨; [C2, P1, V6]; xn--1ug.xn--h327f; ; .xn--h327f; [P1, V6, A4_2] # .
+‍.􀸨; ; [C2, P1, V6]; xn--1ug.xn--h327f; ; .xn--h327f; [P1, V6, A4_2] # .
+.xn--h327f; .􀸨; [V6, X4_2]; .xn--h327f; [V6, A4_2]; ;  # .
+xn--1ug.xn--h327f; ‍.􀸨; [C2, V6]; xn--1ug.xn--h327f; ; ;  # .
+񣭻񌥁｡≠𝟲; 񣭻񌥁.≠6; [P1, V6]; xn--h79w4z99a.xn--6-tfo; ; ;  # .≠6
+񣭻񌥁｡≠𝟲; 񣭻񌥁.≠6; [P1, V6]; xn--h79w4z99a.xn--6-tfo; ; ;  # .≠6
+񣭻񌥁。≠6; 񣭻񌥁.≠6; [P1, V6]; xn--h79w4z99a.xn--6-tfo; ; ;  # .≠6
+񣭻񌥁。≠6; 񣭻񌥁.≠6; [P1, V6]; xn--h79w4z99a.xn--6-tfo; ; ;  # .≠6
+xn--h79w4z99a.xn--6-tfo; 񣭻񌥁.≠6; [V6]; xn--h79w4z99a.xn--6-tfo; ; ;  # .≠6
+󠅊ᡭ‍.𐥡; ᡭ‍.𐥡; [B6, C2, P1, V6]; xn--98e810b.xn--om9c; ; xn--98e.xn--om9c; [P1, V6] # ᡭ.
+xn--98e.xn--om9c; ᡭ.𐥡; [V6]; xn--98e.xn--om9c; ; ;  # ᡭ.
+xn--98e810b.xn--om9c; ᡭ‍.𐥡; [B6, C2, V6]; xn--98e810b.xn--om9c; ; ;  # ᡭ.
+ీࡕ𐥛𑄴．󭰵; ీࡕ𐥛𑄴.󭰵; [B1, P1, V5, V6]; xn--kwb91r5112avtg.xn--o580f; ; ;  # ీࡕ𑄴.
+ీࡕ𐥛𑄴.󭰵; ; [B1, P1, V5, V6]; xn--kwb91r5112avtg.xn--o580f; ; ;  # ీࡕ𑄴.
+xn--kwb91r5112avtg.xn--o580f; ీࡕ𐥛𑄴.󭰵; [B1, V5, V6]; xn--kwb91r5112avtg.xn--o580f; ; ;  # ీࡕ𑄴.
+𞤮。𑇊‌≯᳦; 𞤮.𑇊‌≯᳦; [B1, C1, P1, V5, V6]; xn--me6h.xn--z6f16kn9b2642b; ; xn--me6h.xn--z6fz8ueq2v; [B1, P1, V5, V6] # 𞤮.𑇊≯᳦
+𞤮。𑇊‌≯᳦; 𞤮.𑇊‌≯᳦; [B1, C1, P1, V5, V6]; xn--me6h.xn--z6f16kn9b2642b; ; xn--me6h.xn--z6fz8ueq2v; [B1, P1, V5, V6] # 𞤮.𑇊≯᳦
+𞤌。𑇊‌≯᳦; 𞤮.𑇊‌≯᳦; [B1, C1, P1, V5, V6]; xn--me6h.xn--z6f16kn9b2642b; ; xn--me6h.xn--z6fz8ueq2v; [B1, P1, V5, V6] # 𞤮.𑇊≯᳦
+𞤌。𑇊‌≯᳦; 𞤮.𑇊‌≯᳦; [B1, C1, P1, V5, V6]; xn--me6h.xn--z6f16kn9b2642b; ; xn--me6h.xn--z6fz8ueq2v; [B1, P1, V5, V6] # 𞤮.𑇊≯᳦
+xn--me6h.xn--z6fz8ueq2v; 𞤮.𑇊≯᳦; [B1, V5, V6]; xn--me6h.xn--z6fz8ueq2v; ; ;  # 𞤮.𑇊≯᳦
+xn--me6h.xn--z6f16kn9b2642b; 𞤮.𑇊‌≯᳦; [B1, C1, V5, V6]; xn--me6h.xn--z6f16kn9b2642b; ; ;  # 𞤮.𑇊≯᳦
+󠄀𝟕.𞤌񛗓Ⴉ; 7.𞤮񛗓Ⴉ; [B1, B2, B3, P1, V6]; 7.xn--hnd3403vv1vv; ; ;  # 7.𞤮Ⴉ
+󠄀7.𞤌񛗓Ⴉ; 7.𞤮񛗓Ⴉ; [B1, B2, B3, P1, V6]; 7.xn--hnd3403vv1vv; ; ;  # 7.𞤮Ⴉ
+󠄀7.𞤮񛗓ⴉ; 7.𞤮񛗓ⴉ; [B1, B2, B3, P1, V6]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+7.xn--0kjz523lv1vv; 7.𞤮񛗓ⴉ; [B1, B2, B3, V6]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+7.xn--hnd3403vv1vv; 7.𞤮񛗓Ⴉ; [B1, B2, B3, V6]; 7.xn--hnd3403vv1vv; ; ;  # 7.𞤮Ⴉ
+󠄀𝟕.𞤮񛗓ⴉ; 7.𞤮񛗓ⴉ; [B1, B2, B3, P1, V6]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+󠄀7.𞤌񛗓ⴉ; 7.𞤮񛗓ⴉ; [B1, B2, B3, P1, V6]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+󠄀𝟕.𞤌񛗓ⴉ; 7.𞤮񛗓ⴉ; [B1, B2, B3, P1, V6]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+閃9𝩍。Ↄ٩ࢱ୍; 閃9𝩍.Ↄ٩ࢱ୍; [B5, B6, P1, V6]; xn--9-3j6dk517f.xn--iib28ij3c0t9a; ; ;  # 閃9𝩍.Ↄ٩ࢱ୍
+閃9𝩍。ↄ٩ࢱ୍; 閃9𝩍.ↄ٩ࢱ୍; [B5, B6]; xn--9-3j6dk517f.xn--iib28ij3c4t9a; ; ;  # 閃9𝩍.ↄ٩ࢱ୍
+xn--9-3j6dk517f.xn--iib28ij3c4t9a; 閃9𝩍.ↄ٩ࢱ୍; [B5, B6]; xn--9-3j6dk517f.xn--iib28ij3c4t9a; ; ;  # 閃9𝩍.ↄ٩ࢱ୍
+xn--9-3j6dk517f.xn--iib28ij3c0t9a; 閃9𝩍.Ↄ٩ࢱ୍; [B5, B6, V6]; xn--9-3j6dk517f.xn--iib28ij3c0t9a; ; ;  # 閃9𝩍.Ↄ٩ࢱ୍
+꫶ᢏฺ２.𐋢݅ྟ︒; ꫶ᢏฺ2.𐋢݅ྟ︒; [P1, V5, V6]; xn--2-2zf840fk16m.xn--sob093bj62sz9d; ; ;  # ꫶ᢏฺ2.𐋢݅ྟ︒
+꫶ᢏฺ2.𐋢݅ྟ。; ꫶ᢏฺ2.𐋢݅ྟ.; [V5]; xn--2-2zf840fk16m.xn--sob093b2m7s.; ; ;  # ꫶ᢏฺ2.𐋢݅ྟ.
+xn--2-2zf840fk16m.xn--sob093b2m7s.; ꫶ᢏฺ2.𐋢݅ྟ.; [V5]; xn--2-2zf840fk16m.xn--sob093b2m7s.; ; ;  # ꫶ᢏฺ2.𐋢݅ྟ.
+xn--2-2zf840fk16m.xn--sob093bj62sz9d; ꫶ᢏฺ2.𐋢݅ྟ︒; [V5, V6]; xn--2-2zf840fk16m.xn--sob093bj62sz9d; ; ;  # ꫶ᢏฺ2.𐋢݅ྟ︒
+󅴧｡≠-󠙄⾛; 󅴧.≠-󠙄走; [P1, V6]; xn--gm57d.xn----tfo4949b3664m; ; ;  # .≠-走
+󅴧｡≠-󠙄⾛; 󅴧.≠-󠙄走; [P1, V6]; xn--gm57d.xn----tfo4949b3664m; ; ;  # .≠-走
+󅴧。≠-󠙄走; 󅴧.≠-󠙄走; [P1, V6]; xn--gm57d.xn----tfo4949b3664m; ; ;  # .≠-走
+󅴧。≠-󠙄走; 󅴧.≠-󠙄走; [P1, V6]; xn--gm57d.xn----tfo4949b3664m; ; ;  # .≠-走
+xn--gm57d.xn----tfo4949b3664m; 󅴧.≠-󠙄走; [V6]; xn--gm57d.xn----tfo4949b3664m; ; ;  # .≠-走
+ݮ؄Ⴊ。-≠ᅠ; ݮ؄Ⴊ.-≠ᅠ; [B1, B2, B3, P1, V3, V6]; xn--mfb73ex6r.xn----5bh589i; ; ;  # ݮႪ.-≠
+ݮ؄Ⴊ。-≠ᅠ; ݮ؄Ⴊ.-≠ᅠ; [B1, B2, B3, P1, V3, V6]; xn--mfb73ex6r.xn----5bh589i; ; ;  # ݮႪ.-≠
+ݮ؄ⴊ。-≠ᅠ; ݮ؄ⴊ.-≠ᅠ; [B1, B2, B3, P1, V3, V6]; xn--mfb73ek93f.xn----5bh589i; ; ;  # ݮⴊ.-≠
+ݮ؄ⴊ。-≠ᅠ; ݮ؄ⴊ.-≠ᅠ; [B1, B2, B3, P1, V3, V6]; xn--mfb73ek93f.xn----5bh589i; ; ;  # ݮⴊ.-≠
+xn--mfb73ek93f.xn----5bh589i; ݮ؄ⴊ.-≠ᅠ; [B1, B2, B3, V3, V6]; xn--mfb73ek93f.xn----5bh589i; ; ;  # ݮⴊ.-≠
+xn--mfb73ex6r.xn----5bh589i; ݮ؄Ⴊ.-≠ᅠ; [B1, B2, B3, V3, V6]; xn--mfb73ex6r.xn----5bh589i; ; ;  # ݮႪ.-≠
+ﭏ𐹧𝟒≯｡‌; אל𐹧4≯.‌; [B1, B3, B4, C1, P1, V6]; xn--4-zhc0by36txt0w.xn--0ug; ; xn--4-zhc0by36txt0w.; [B3, B4, P1, V6] # אל𐹧4≯.
+ﭏ𐹧𝟒≯｡‌; אל𐹧4≯.‌; [B1, B3, B4, C1, P1, V6]; xn--4-zhc0by36txt0w.xn--0ug; ; xn--4-zhc0by36txt0w.; [B3, B4, P1, V6] # אל𐹧4≯.
+אל𐹧4≯。‌; אל𐹧4≯.‌; [B1, B3, B4, C1, P1, V6]; xn--4-zhc0by36txt0w.xn--0ug; ; xn--4-zhc0by36txt0w.; [B3, B4, P1, V6] # אל𐹧4≯.
+אל𐹧4≯。‌; אל𐹧4≯.‌; [B1, B3, B4, C1, P1, V6]; xn--4-zhc0by36txt0w.xn--0ug; ; xn--4-zhc0by36txt0w.; [B3, B4, P1, V6] # אל𐹧4≯.
+xn--4-zhc0by36txt0w.; אל𐹧4≯.; [B3, B4, V6]; xn--4-zhc0by36txt0w.; ; ;  # אל𐹧4≯.
+xn--4-zhc0by36txt0w.xn--0ug; אל𐹧4≯.‌; [B1, B3, B4, C1, V6]; xn--4-zhc0by36txt0w.xn--0ug; ; ;  # אל𐹧4≯.
+𝟎。甯; 0.甯; ; 0.xn--qny; ; ;  # 0.甯
+0。甯; 0.甯; ; 0.xn--qny; ; ;  # 0.甯
+0.xn--qny; 0.甯; ; 0.xn--qny; ; ;  # 0.甯
+0.甯; ; ; 0.xn--qny; ; ;  # 0.甯
+-⾆．꫶; -舌.꫶; [V3, V5]; xn----ef8c.xn--2v9a; ; ;  # -舌.꫶
+-舌.꫶; ; [V3, V5]; xn----ef8c.xn--2v9a; ; ;  # -舌.꫶
+xn----ef8c.xn--2v9a; -舌.꫶; [V3, V5]; xn----ef8c.xn--2v9a; ; ;  # -舌.꫶
+-｡ᢘ; -.ᢘ; [V3]; -.xn--ibf; ; ;  # -.ᢘ
+-。ᢘ; -.ᢘ; [V3]; -.xn--ibf; ; ;  # -.ᢘ
+-.xn--ibf; -.ᢘ; [V3]; -.xn--ibf; ; ;  # -.ᢘ
+🂴Ⴋ.≮; ; [P1, V6]; xn--jnd1986v.xn--gdh; ; ;  # 🂴Ⴋ.≮
+🂴Ⴋ.≮; 🂴Ⴋ.≮; [P1, V6]; xn--jnd1986v.xn--gdh; ; ;  # 🂴Ⴋ.≮
+🂴ⴋ.≮; 🂴ⴋ.≮; [P1, V6]; xn--2kj7565l.xn--gdh; ; ;  # 🂴ⴋ.≮
+🂴ⴋ.≮; ; [P1, V6]; xn--2kj7565l.xn--gdh; ; ;  # 🂴ⴋ.≮
+xn--2kj7565l.xn--gdh; 🂴ⴋ.≮; [V6]; xn--2kj7565l.xn--gdh; ; ;  # 🂴ⴋ.≮
+xn--jnd1986v.xn--gdh; 🂴Ⴋ.≮; [V6]; xn--jnd1986v.xn--gdh; ; ;  # 🂴Ⴋ.≮
+璼𝨭｡‌󠇟; 璼𝨭.‌; [C1]; xn--gky8837e.xn--0ug; ; xn--gky8837e.; [] # 璼𝨭.
+璼𝨭。‌󠇟; 璼𝨭.‌; [C1]; xn--gky8837e.xn--0ug; ; xn--gky8837e.; [] # 璼𝨭.
+xn--gky8837e.; 璼𝨭.; ; xn--gky8837e.; ; ;  # 璼𝨭.
+璼𝨭.; ; ; xn--gky8837e.; ; ;  # 璼𝨭.
+xn--gky8837e.xn--0ug; 璼𝨭.‌; [C1]; xn--gky8837e.xn--0ug; ; ;  # 璼𝨭.
+٩8񂍽｡-5🞥; ٩8񂍽.-5🞥; [B1, P1, V3, V6]; xn--8-qqc97891f.xn---5-rp92a; ; ;  # ٩8.-5🞥
+٩8񂍽。-5🞥; ٩8񂍽.-5🞥; [B1, P1, V3, V6]; xn--8-qqc97891f.xn---5-rp92a; ; ;  # ٩8.-5🞥
+xn--8-qqc97891f.xn---5-rp92a; ٩8񂍽.-5🞥; [B1, V3, V6]; xn--8-qqc97891f.xn---5-rp92a; ; ;  # ٩8.-5🞥
+‌.‌; ; [C1]; xn--0ug.xn--0ug; ; .; [A4_2] # .
+xn--0ug.xn--0ug; ‌.‌; [C1]; xn--0ug.xn--0ug; ; ;  # .
+‍튛.ܖ; ; [B1, C2]; xn--1ug4441e.xn--gnb; ; xn--157b.xn--gnb; [] # 튛.ܖ
+‍튛.ܖ; ‍튛.ܖ; [B1, C2]; xn--1ug4441e.xn--gnb; ; xn--157b.xn--gnb; [] # 튛.ܖ
+xn--157b.xn--gnb; 튛.ܖ; ; xn--157b.xn--gnb; ; ;  # 튛.ܖ
+튛.ܖ; ; ; xn--157b.xn--gnb; ; ;  # 튛.ܖ
+튛.ܖ; 튛.ܖ; ; xn--157b.xn--gnb; ; ;  # 튛.ܖ
+xn--1ug4441e.xn--gnb; ‍튛.ܖ; [B1, C2]; xn--1ug4441e.xn--gnb; ; ;  # 튛.ܖ
+ᡋ𐹰𞽳.ݹⴞ; ; [B2, B3, B5, B6, P1, V6]; xn--b8e0417jocvf.xn--9pb883q; ; ;  # ᡋ𐹰.ݹⴞ
+ᡋ𐹰𞽳.ݹႾ; ; [B2, B3, B5, B6, P1, V6]; xn--b8e0417jocvf.xn--9pb068b; ; ;  # ᡋ𐹰.ݹႾ
+xn--b8e0417jocvf.xn--9pb068b; ᡋ𐹰𞽳.ݹႾ; [B2, B3, B5, B6, V6]; xn--b8e0417jocvf.xn--9pb068b; ; ;  # ᡋ𐹰.ݹႾ
+xn--b8e0417jocvf.xn--9pb883q; ᡋ𐹰𞽳.ݹⴞ; [B2, B3, B5, B6, V6]; xn--b8e0417jocvf.xn--9pb883q; ; ;  # ᡋ𐹰.ݹⴞ
+𐷃٢𝅻𝟧．𐹮𐹬Ⴇ; 𐷃٢𝅻5.𐹮𐹬Ⴇ; [B1, B4, P1, V6]; xn--5-cqc8833rhv7f.xn--fnd3401kfa; ; ;  # ٢𝅻5.𐹮𐹬Ⴇ
+𐷃٢𝅻5.𐹮𐹬Ⴇ; ; [B1, B4, P1, V6]; xn--5-cqc8833rhv7f.xn--fnd3401kfa; ; ;  # ٢𝅻5.𐹮𐹬Ⴇ
+𐷃٢𝅻5.𐹮𐹬ⴇ; ; [B1, B4, P1, V6]; xn--5-cqc8833rhv7f.xn--ykjz523efa; ; ;  # ٢𝅻5.𐹮𐹬ⴇ
+xn--5-cqc8833rhv7f.xn--ykjz523efa; 𐷃٢𝅻5.𐹮𐹬ⴇ; [B1, B4, V6]; xn--5-cqc8833rhv7f.xn--ykjz523efa; ; ;  # ٢𝅻5.𐹮𐹬ⴇ
+xn--5-cqc8833rhv7f.xn--fnd3401kfa; 𐷃٢𝅻5.𐹮𐹬Ⴇ; [B1, B4, V6]; xn--5-cqc8833rhv7f.xn--fnd3401kfa; ; ;  # ٢𝅻5.𐹮𐹬Ⴇ
+𐷃٢𝅻𝟧．𐹮𐹬ⴇ; 𐷃٢𝅻5.𐹮𐹬ⴇ; [B1, B4, P1, V6]; xn--5-cqc8833rhv7f.xn--ykjz523efa; ; ;  # ٢𝅻5.𐹮𐹬ⴇ
+Ⴗ．𑄴ׂꦷ񘃨; Ⴗ.𑄴ׂꦷ񘃨; [P1, V5, V6]; xn--vnd.xn--qdb0605f14ycrms3c; ; ;  # Ⴗ.𑄴ׂꦷ
+Ⴗ．𑄴ׂꦷ񘃨; Ⴗ.𑄴ׂꦷ񘃨; [P1, V5, V6]; xn--vnd.xn--qdb0605f14ycrms3c; ; ;  # Ⴗ.𑄴ׂꦷ
+Ⴗ.𑄴ׂꦷ񘃨; ; [P1, V5, V6]; xn--vnd.xn--qdb0605f14ycrms3c; ; ;  # Ⴗ.𑄴ׂꦷ
+ⴗ.𑄴ׂꦷ񘃨; ; [P1, V5, V6]; xn--flj.xn--qdb0605f14ycrms3c; ; ;  # ⴗ.𑄴ׂꦷ
+xn--flj.xn--qdb0605f14ycrms3c; ⴗ.𑄴ׂꦷ񘃨; [V5, V6]; xn--flj.xn--qdb0605f14ycrms3c; ; ;  # ⴗ.𑄴ׂꦷ
+xn--vnd.xn--qdb0605f14ycrms3c; Ⴗ.𑄴ׂꦷ񘃨; [V5, V6]; xn--vnd.xn--qdb0605f14ycrms3c; ; ;  # Ⴗ.𑄴ׂꦷ
+ⴗ．𑄴ׂꦷ񘃨; ⴗ.𑄴ׂꦷ񘃨; [P1, V5, V6]; xn--flj.xn--qdb0605f14ycrms3c; ; ;  # ⴗ.𑄴ׂꦷ
+ⴗ．𑄴ׂꦷ񘃨; ⴗ.𑄴ׂꦷ񘃨; [P1, V5, V6]; xn--flj.xn--qdb0605f14ycrms3c; ; ;  # ⴗ.𑄴ׂꦷ
+𝟾𾤘．򇕛٬; 8𾤘.򇕛٬; [B1, B5, B6, P1, V6]; xn--8-kh23b.xn--lib78461i; ; ;  # 8.٬
+8𾤘.򇕛٬; ; [B1, B5, B6, P1, V6]; xn--8-kh23b.xn--lib78461i; ; ;  # 8.٬
+xn--8-kh23b.xn--lib78461i; 8𾤘.򇕛٬; [B1, B5, B6, V6]; xn--8-kh23b.xn--lib78461i; ; ;  # 8.٬
+⒈酫︒。ࣖ; ⒈酫︒.ࣖ; [P1, V5, V6]; xn--tsh4490bfe8c.xn--8zb; ; ;  # ⒈酫︒.ࣖ
+1.酫。。ࣖ; 1.酫..ࣖ; [V5, X4_2]; 1.xn--8j4a..xn--8zb; [V5, A4_2]; ;  # 1.酫..ࣖ
+1.xn--8j4a..xn--8zb; 1.酫..ࣖ; [V5, X4_2]; 1.xn--8j4a..xn--8zb; [V5, A4_2]; ;  # 1.酫..ࣖ
+xn--tsh4490bfe8c.xn--8zb; ⒈酫︒.ࣖ; [V5, V6]; xn--tsh4490bfe8c.xn--8zb; ; ;  # ⒈酫︒.ࣖ
+ⷣ‌≮ᩫ.‌ฺ; ; [C1, P1, V5, V6]; xn--uof63xk4bf3s.xn--o4c732g; ; xn--uof548an0j.xn--o4c; [P1, V5, V6] # ⷣ≮ᩫ.ฺ
+ⷣ‌≮ᩫ.‌ฺ; ⷣ‌≮ᩫ.‌ฺ; [C1, P1, V5, V6]; xn--uof63xk4bf3s.xn--o4c732g; ; xn--uof548an0j.xn--o4c; [P1, V5, V6] # ⷣ≮ᩫ.ฺ
+xn--uof548an0j.xn--o4c; ⷣ≮ᩫ.ฺ; [V5, V6]; xn--uof548an0j.xn--o4c; ; ;  # ⷣ≮ᩫ.ฺ
+xn--uof63xk4bf3s.xn--o4c732g; ⷣ‌≮ᩫ.‌ฺ; [C1, V5, V6]; xn--uof63xk4bf3s.xn--o4c732g; ; ;  # ⷣ≮ᩫ.ฺ
+𞪂。ႷႽ¹‍; 𞪂.ႷႽ1‍; [B6, C2, P1, V6]; xn--co6h.xn--1-h1gs597m; ; xn--co6h.xn--1-h1gs; [P1, V6] # .ႷႽ1
+𞪂。ႷႽ1‍; 𞪂.ႷႽ1‍; [B6, C2, P1, V6]; xn--co6h.xn--1-h1gs597m; ; xn--co6h.xn--1-h1gs; [P1, V6] # .ႷႽ1
+𞪂。ⴗⴝ1‍; 𞪂.ⴗⴝ1‍; [B6, C2, P1, V6]; xn--co6h.xn--1-ugn710dya; ; xn--co6h.xn--1-kwssa; [P1, V6] # .ⴗⴝ1
+𞪂。Ⴗⴝ1‍; 𞪂.Ⴗⴝ1‍; [B6, C2, P1, V6]; xn--co6h.xn--1-h1g398iewm; ; xn--co6h.xn--1-h1g429s; [P1, V6] # .Ⴗⴝ1
+xn--co6h.xn--1-h1g429s; 𞪂.Ⴗⴝ1; [V6]; xn--co6h.xn--1-h1g429s; ; ;  # .Ⴗⴝ1
+xn--co6h.xn--1-h1g398iewm; 𞪂.Ⴗⴝ1‍; [B6, C2, V6]; xn--co6h.xn--1-h1g398iewm; ; ;  # .Ⴗⴝ1
+xn--co6h.xn--1-kwssa; 𞪂.ⴗⴝ1; [V6]; xn--co6h.xn--1-kwssa; ; ;  # .ⴗⴝ1
+xn--co6h.xn--1-ugn710dya; 𞪂.ⴗⴝ1‍; [B6, C2, V6]; xn--co6h.xn--1-ugn710dya; ; ;  # .ⴗⴝ1
+xn--co6h.xn--1-h1gs; 𞪂.ႷႽ1; [V6]; xn--co6h.xn--1-h1gs; ; ;  # .ႷႽ1
+xn--co6h.xn--1-h1gs597m; 𞪂.ႷႽ1‍; [B6, C2, V6]; xn--co6h.xn--1-h1gs597m; ; ;  # .ႷႽ1
+𞪂。ⴗⴝ¹‍; 𞪂.ⴗⴝ1‍; [B6, C2, P1, V6]; xn--co6h.xn--1-ugn710dya; ; xn--co6h.xn--1-kwssa; [P1, V6] # .ⴗⴝ1
+𞪂。Ⴗⴝ¹‍; 𞪂.Ⴗⴝ1‍; [B6, C2, P1, V6]; xn--co6h.xn--1-h1g398iewm; ; xn--co6h.xn--1-h1g429s; [P1, V6] # .Ⴗⴝ1
+𑄴𑄳2.𞳿󠀳-; ; [B1, B3, P1, V3, V5, V6]; xn--2-h87ic.xn----s39r33498d; ; ;  # 𑄴𑄳2.-
+xn--2-h87ic.xn----s39r33498d; 𑄴𑄳2.𞳿󠀳-; [B1, B3, V3, V5, V6]; xn--2-h87ic.xn----s39r33498d; ; ;  # 𑄴𑄳2.-
+󠕲󟶶٥｡񀁁𑄳𞤃ܐ; 󠕲󟶶٥.񀁁𑄳𞤥ܐ; [B1, B5, B6, P1, V6]; xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; ; ;  # ٥.𑄳𞤥ܐ
+󠕲󟶶٥。񀁁𑄳𞤃ܐ; 󠕲󟶶٥.񀁁𑄳𞤥ܐ; [B1, B5, B6, P1, V6]; xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; ; ;  # ٥.𑄳𞤥ܐ
+󠕲󟶶٥。񀁁𑄳𞤥ܐ; 󠕲󟶶٥.񀁁𑄳𞤥ܐ; [B1, B5, B6, P1, V6]; xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; ; ;  # ٥.𑄳𞤥ܐ
+xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; 󠕲󟶶٥.񀁁𑄳𞤥ܐ; [B1, B5, B6, V6]; xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; ; ;  # ٥.𑄳𞤥ܐ
+󠕲󟶶٥｡񀁁𑄳𞤥ܐ; 󠕲󟶶٥.񀁁𑄳𞤥ܐ; [B1, B5, B6, P1, V6]; xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; ; ;  # ٥.𑄳𞤥ܐ
+ܠ򲠽𐹢ុ｡ςᢈ🝭‌; ܠ򲠽𐹢ុ.ςᢈ🝭‌; [B2, B6, C1, P1, V6]; xn--qnb616fis0qzt36f.xn--3xa057h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, P1, V6] # ܠ𐹢ុ.ςᢈ🝭
+ܠ򲠽𐹢ុ。ςᢈ🝭‌; ܠ򲠽𐹢ុ.ςᢈ🝭‌; [B2, B6, C1, P1, V6]; xn--qnb616fis0qzt36f.xn--3xa057h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, P1, V6] # ܠ𐹢ុ.ςᢈ🝭
+ܠ򲠽𐹢ុ。Σᢈ🝭‌; ܠ򲠽𐹢ុ.σᢈ🝭‌; [B2, B6, C1, P1, V6]; xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, P1, V6] # ܠ𐹢ុ.σᢈ🝭
+ܠ򲠽𐹢ុ。σᢈ🝭‌; ܠ򲠽𐹢ុ.σᢈ🝭‌; [B2, B6, C1, P1, V6]; xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, P1, V6] # ܠ𐹢ុ.σᢈ🝭
+xn--qnb616fis0qzt36f.xn--4xa847hli46a; ܠ򲠽𐹢ុ.σᢈ🝭; [B2, B6, V6]; xn--qnb616fis0qzt36f.xn--4xa847hli46a; ; ;  # ܠ𐹢ុ.σᢈ🝭
+xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; ܠ򲠽𐹢ុ.σᢈ🝭‌; [B2, B6, C1, V6]; xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; ; ;  # ܠ𐹢ុ.σᢈ🝭
+xn--qnb616fis0qzt36f.xn--3xa057h6ofgl44c; ܠ򲠽𐹢ុ.ςᢈ🝭‌; [B2, B6, C1, V6]; xn--qnb616fis0qzt36f.xn--3xa057h6ofgl44c; ; ;  # ܠ𐹢ុ.ςᢈ🝭
+ܠ򲠽𐹢ុ｡Σᢈ🝭‌; ܠ򲠽𐹢ុ.σᢈ🝭‌; [B2, B6, C1, P1, V6]; xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, P1, V6] # ܠ𐹢ុ.σᢈ🝭
+ܠ򲠽𐹢ុ｡σᢈ🝭‌; ܠ򲠽𐹢ុ.σᢈ🝭‌; [B2, B6, C1, P1, V6]; xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, P1, V6] # ܠ𐹢ុ.σᢈ🝭
+‍--≮。𐹧; ‍--≮.𐹧; [B1, C2, P1, V6]; xn-----l1tz1k.xn--fo0d; ; xn-----ujv.xn--fo0d; [B1, P1, V3, V6] # --≮.𐹧
+‍--≮。𐹧; ‍--≮.𐹧; [B1, C2, P1, V6]; xn-----l1tz1k.xn--fo0d; ; xn-----ujv.xn--fo0d; [B1, P1, V3, V6] # --≮.𐹧
+xn-----ujv.xn--fo0d; --≮.𐹧; [B1, V3, V6]; xn-----ujv.xn--fo0d; ; ;  # --≮.𐹧
+xn-----l1tz1k.xn--fo0d; ‍--≮.𐹧; [B1, C2, V6]; xn-----l1tz1k.xn--fo0d; ; ;  # --≮.𐹧
+꠆。𻚏ྰ⒕; ꠆.𻚏ྰ⒕; [P1, V5, V6]; xn--l98a.xn--dgd218hhp28d; ; ;  # ꠆.ྰ⒕
+꠆。𻚏ྰ14.; ꠆.𻚏ྰ14.; [P1, V5, V6]; xn--l98a.xn--14-jsj57880f.; ; ;  # ꠆.ྰ14.
+xn--l98a.xn--14-jsj57880f.; ꠆.𻚏ྰ14.; [V5, V6]; xn--l98a.xn--14-jsj57880f.; ; ;  # ꠆.ྰ14.
+xn--l98a.xn--dgd218hhp28d; ꠆.𻚏ྰ⒕; [V5, V6]; xn--l98a.xn--dgd218hhp28d; ; ;  # ꠆.ྰ⒕
+򮉂ڼ．𑆺٩; 򮉂ڼ.𑆺٩; [B1, B5, B6, P1, V5, V6]; xn--vkb92243l.xn--iib9797k; ; ;  # ڼ.𑆺٩
+򮉂ڼ.𑆺٩; ; [B1, B5, B6, P1, V5, V6]; xn--vkb92243l.xn--iib9797k; ; ;  # ڼ.𑆺٩
+xn--vkb92243l.xn--iib9797k; 򮉂ڼ.𑆺٩; [B1, B5, B6, V5, V6]; xn--vkb92243l.xn--iib9797k; ; ;  # ڼ.𑆺٩
+󠁎ې-。𞤴; 󠁎ې-.𞤴; [B1, P1, V3, V6]; xn----mwc72685y.xn--se6h; ; ;  # ې-.𞤴
+󠁎ې-。𞤒; 󠁎ې-.𞤴; [B1, P1, V3, V6]; xn----mwc72685y.xn--se6h; ; ;  # ې-.𞤴
+xn----mwc72685y.xn--se6h; 󠁎ې-.𞤴; [B1, V3, V6]; xn----mwc72685y.xn--se6h; ; ;  # ې-.𞤴
+𝟠4󠇗𝈻．‍𐋵⛧‍; 84𝈻.‍𐋵⛧‍; [C2]; xn--84-s850a.xn--1uga573cfq1w; ; xn--84-s850a.xn--59h6326e; [] # 84𝈻.𐋵⛧
+84󠇗𝈻.‍𐋵⛧‍; 84𝈻.‍𐋵⛧‍; [C2]; xn--84-s850a.xn--1uga573cfq1w; ; xn--84-s850a.xn--59h6326e; [] # 84𝈻.𐋵⛧
+xn--84-s850a.xn--59h6326e; 84𝈻.𐋵⛧; ; xn--84-s850a.xn--59h6326e; ; ;  # 84𝈻.𐋵⛧
+84𝈻.𐋵⛧; ; ; xn--84-s850a.xn--59h6326e; ; ;  # 84𝈻.𐋵⛧
+xn--84-s850a.xn--1uga573cfq1w; 84𝈻.‍𐋵⛧‍; [C2]; xn--84-s850a.xn--1uga573cfq1w; ; ;  # 84𝈻.𐋵⛧
+-؁｡ᡪ; -؁.ᡪ; [B1, P1, V3, V6]; xn----tkc.xn--68e; ; ;  # -.ᡪ
+-؁。ᡪ; -؁.ᡪ; [B1, P1, V3, V6]; xn----tkc.xn--68e; ; ;  # -.ᡪ
+xn----tkc.xn--68e; -؁.ᡪ; [B1, V3, V6]; xn----tkc.xn--68e; ; ;  # -.ᡪ
+≮𝟕．謖ß≯; ≮7.謖ß≯; [P1, V6]; xn--7-mgo.xn--zca892oly5e; ; xn--7-mgo.xn--ss-xjvv174c;  # ≮7.謖ß≯
+≮𝟕．謖ß≯; ≮7.謖ß≯; [P1, V6]; xn--7-mgo.xn--zca892oly5e; ; xn--7-mgo.xn--ss-xjvv174c;  # ≮7.謖ß≯
+≮7.謖ß≯; ; [P1, V6]; xn--7-mgo.xn--zca892oly5e; ; xn--7-mgo.xn--ss-xjvv174c;  # ≮7.謖ß≯
+≮7.謖ß≯; ≮7.謖ß≯; [P1, V6]; xn--7-mgo.xn--zca892oly5e; ; xn--7-mgo.xn--ss-xjvv174c;  # ≮7.謖ß≯
+≮7.謖SS≯; ≮7.謖ss≯; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮7.謖SS≯; ≮7.謖ss≯; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮7.謖ss≯; ; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮7.謖ss≯; ≮7.謖ss≯; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮7.謖Ss≯; ≮7.謖ss≯; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮7.謖Ss≯; ≮7.謖ss≯; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+xn--7-mgo.xn--ss-xjvv174c; ≮7.謖ss≯; [V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+xn--7-mgo.xn--zca892oly5e; ≮7.謖ß≯; [V6]; xn--7-mgo.xn--zca892oly5e; ; ;  # ≮7.謖ß≯
+≮𝟕．謖SS≯; ≮7.謖ss≯; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮𝟕．謖SS≯; ≮7.謖ss≯; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮𝟕．謖ss≯; ≮7.謖ss≯; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮𝟕．謖ss≯; ≮7.謖ss≯; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮𝟕．謖Ss≯; ≮7.謖ss≯; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮𝟕．謖Ss≯; ≮7.謖ss≯; [P1, V6]; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+朶Ⴉ𞪡.𝨽ࠥ📻-; ; [B1, B5, B6, P1, V3, V5, V6]; xn--hnd7245bd56p.xn----3gd37096apmwa; ; ;  # 朶Ⴉ.𝨽ࠥ📻-
+朶ⴉ𞪡.𝨽ࠥ📻-; ; [B1, B5, B6, P1, V3, V5, V6]; xn--0kjz47pd57t.xn----3gd37096apmwa; ; ;  # 朶ⴉ.𝨽ࠥ📻-
+xn--0kjz47pd57t.xn----3gd37096apmwa; 朶ⴉ𞪡.𝨽ࠥ📻-; [B1, B5, B6, V3, V5, V6]; xn--0kjz47pd57t.xn----3gd37096apmwa; ; ;  # 朶ⴉ.𝨽ࠥ📻-
+xn--hnd7245bd56p.xn----3gd37096apmwa; 朶Ⴉ𞪡.𝨽ࠥ📻-; [B1, B5, B6, V3, V5, V6]; xn--hnd7245bd56p.xn----3gd37096apmwa; ; ;  # 朶Ⴉ.𝨽ࠥ📻-
+𐤎。󑿰‌≮‍; 𐤎.󑿰‌≮‍; [B6, C1, C2, P1, V6]; xn--bk9c.xn--0ugc04p2u638c; ; xn--bk9c.xn--gdhx6802k; [B6, P1, V6] # 𐤎.≮
+𐤎。󑿰‌≮‍; 𐤎.󑿰‌≮‍; [B6, C1, C2, P1, V6]; xn--bk9c.xn--0ugc04p2u638c; ; xn--bk9c.xn--gdhx6802k; [B6, P1, V6] # 𐤎.≮
+xn--bk9c.xn--gdhx6802k; 𐤎.󑿰≮; [B6, V6]; xn--bk9c.xn--gdhx6802k; ; ;  # 𐤎.≮
+xn--bk9c.xn--0ugc04p2u638c; 𐤎.󑿰‌≮‍; [B6, C1, C2, V6]; xn--bk9c.xn--0ugc04p2u638c; ; ;  # 𐤎.≮
+񭜎⒈｡‌𝟤; 񭜎⒈.‌2; [C1, P1, V6]; xn--tsh94183d.xn--2-rgn; ; xn--tsh94183d.2; [P1, V6] # ⒈.2
+񭜎1.。‌2; 񭜎1..‌2; [C1, P1, V6, X4_2]; xn--1-ex54e..xn--2-rgn; [C1, P1, V6, A4_2]; xn--1-ex54e..2; [P1, V6, A4_2] # 1..2
+xn--1-ex54e..2; 񭜎1..2; [V6, X4_2]; xn--1-ex54e..2; [V6, A4_2]; ;  # 1..2
+xn--1-ex54e..xn--2-rgn; 񭜎1..‌2; [C1, V6, X4_2]; xn--1-ex54e..xn--2-rgn; [C1, V6, A4_2]; ;  # 1..2
+xn--tsh94183d.2; 񭜎⒈.2; [V6]; xn--tsh94183d.2; ; ;  # ⒈.2
+xn--tsh94183d.xn--2-rgn; 񭜎⒈.‌2; [C1, V6]; xn--tsh94183d.xn--2-rgn; ; ;  # ⒈.2
+󠟊𐹤‍．𐹳󙄵𐹶; 󠟊𐹤‍.𐹳󙄵𐹶; [B1, C2, P1, V6]; xn--1ugy994g7k93g.xn--ro0dga22807v; ; xn--co0d98977c.xn--ro0dga22807v; [B1, P1, V6] # 𐹤.𐹳𐹶
+󠟊𐹤‍.𐹳󙄵𐹶; ; [B1, C2, P1, V6]; xn--1ugy994g7k93g.xn--ro0dga22807v; ; xn--co0d98977c.xn--ro0dga22807v; [B1, P1, V6] # 𐹤.𐹳𐹶
+xn--co0d98977c.xn--ro0dga22807v; 󠟊𐹤.𐹳󙄵𐹶; [B1, V6]; xn--co0d98977c.xn--ro0dga22807v; ; ;  # 𐹤.𐹳𐹶
+xn--1ugy994g7k93g.xn--ro0dga22807v; 󠟊𐹤‍.𐹳󙄵𐹶; [B1, C2, V6]; xn--1ugy994g7k93g.xn--ro0dga22807v; ; ;  # 𐹤.𐹳𐹶
+𞤴𐹻𑓂𐭝．्︇􉛯; 𞤴𐹻𑓂𐭝.्􉛯; [B1, P1, V5, V6]; xn--609c96c09grp2w.xn--n3b28708s; ; ;  # 𞤴𐹻𑓂𐭝.्
+𞤴𐹻𑓂𐭝.्︇􉛯; 𞤴𐹻𑓂𐭝.्􉛯; [B1, P1, V5, V6]; xn--609c96c09grp2w.xn--n3b28708s; ; ;  # 𞤴𐹻𑓂𐭝.्
+𞤒𐹻𑓂𐭝.्︇􉛯; 𞤴𐹻𑓂𐭝.्􉛯; [B1, P1, V5, V6]; xn--609c96c09grp2w.xn--n3b28708s; ; ;  # 𞤴𐹻𑓂𐭝.्
+xn--609c96c09grp2w.xn--n3b28708s; 𞤴𐹻𑓂𐭝.्􉛯; [B1, V5, V6]; xn--609c96c09grp2w.xn--n3b28708s; ; ;  # 𞤴𐹻𑓂𐭝.्
+𞤒𐹻𑓂𐭝．्︇􉛯; 𞤴𐹻𑓂𐭝.्􉛯; [B1, P1, V5, V6]; xn--609c96c09grp2w.xn--n3b28708s; ; ;  # 𞤴𐹻𑓂𐭝.्
+٨｡𐹠𐹽񗮶; ٨.𐹠𐹽񗮶; [B1, P1, V6]; xn--hib.xn--7n0d2bu9196b; ; ;  # ٨.𐹠𐹽
+٨。𐹠𐹽񗮶; ٨.𐹠𐹽񗮶; [B1, P1, V6]; xn--hib.xn--7n0d2bu9196b; ; ;  # ٨.𐹠𐹽
+xn--hib.xn--7n0d2bu9196b; ٨.𐹠𐹽񗮶; [B1, V6]; xn--hib.xn--7n0d2bu9196b; ; ;  # ٨.𐹠𐹽
+ᅠ񍀜.8򶾵ڜ; ; [B1, P1, V6]; xn--psd85033d.xn--8-otc61545t; ; ;  # .8ڜ
+xn--psd85033d.xn--8-otc61545t; ᅠ񍀜.8򶾵ڜ; [B1, V6]; xn--psd85033d.xn--8-otc61545t; ; ;  # .8ڜ
+‍‌󠆪｡ß𑓃; ‍‌.ß𑓃; [C1, C2]; xn--0ugb.xn--zca0732l; ; .xn--ss-bh7o; [A4_2] # .ß𑓃
+‍‌󠆪。ß𑓃; ‍‌.ß𑓃; [C1, C2]; xn--0ugb.xn--zca0732l; ; .xn--ss-bh7o; [A4_2] # .ß𑓃
+‍‌󠆪。SS𑓃; ‍‌.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+‍‌󠆪。ss𑓃; ‍‌.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+‍‌󠆪。Ss𑓃; ‍‌.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+.xn--ss-bh7o; .ss𑓃; [X4_2]; .xn--ss-bh7o; [A4_2]; ;  # .ss𑓃
+xn--0ugb.xn--ss-bh7o; ‍‌.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; ;  # .ss𑓃
+xn--0ugb.xn--zca0732l; ‍‌.ß𑓃; [C1, C2]; xn--0ugb.xn--zca0732l; ; ;  # .ß𑓃
+‍‌󠆪｡SS𑓃; ‍‌.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+‍‌󠆪｡ss𑓃; ‍‌.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+‍‌󠆪｡Ss𑓃; ‍‌.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+xn--ss-bh7o; ss𑓃; ; xn--ss-bh7o; ; ;  # ss𑓃
+ss𑓃; ; ; xn--ss-bh7o; ; ;  # ss𑓃
+SS𑓃; ss𑓃; ; xn--ss-bh7o; ; ;  # ss𑓃
+Ss𑓃; ss𑓃; ; xn--ss-bh7o; ; ;  # ss𑓃
+︒‌ヶ䒩.ꡪ; ; [C1, P1, V6]; xn--0ug287dj0or48o.xn--gd9a; ; xn--qekw60dns9k.xn--gd9a; [P1, V6] # ︒ヶ䒩.ꡪ
+。‌ヶ䒩.ꡪ; .‌ヶ䒩.ꡪ; [C1, X4_2]; .xn--0ug287dj0o.xn--gd9a; [C1, A4_2]; .xn--qekw60d.xn--gd9a; [A4_2] # .ヶ䒩.ꡪ
+.xn--qekw60d.xn--gd9a; .ヶ䒩.ꡪ; [X4_2]; .xn--qekw60d.xn--gd9a; [A4_2]; ;  # .ヶ䒩.ꡪ
+.xn--0ug287dj0o.xn--gd9a; .‌ヶ䒩.ꡪ; [C1, X4_2]; .xn--0ug287dj0o.xn--gd9a; [C1, A4_2]; ;  # .ヶ䒩.ꡪ
+xn--qekw60dns9k.xn--gd9a; ︒ヶ䒩.ꡪ; [V6]; xn--qekw60dns9k.xn--gd9a; ; ;  # ︒ヶ䒩.ꡪ
+xn--0ug287dj0or48o.xn--gd9a; ︒‌ヶ䒩.ꡪ; [C1, V6]; xn--0ug287dj0or48o.xn--gd9a; ; ;  # ︒ヶ䒩.ꡪ
+xn--qekw60d.xn--gd9a; ヶ䒩.ꡪ; ; xn--qekw60d.xn--gd9a; ; ;  # ヶ䒩.ꡪ
+ヶ䒩.ꡪ; ; ; xn--qekw60d.xn--gd9a; ; ;  # ヶ䒩.ꡪ
+‌⒈𤮍.󢓋᩠; ; [C1, P1, V6]; xn--0ug88o7471d.xn--jof45148n; ; xn--tshw462r.xn--jof45148n; [P1, V6] # ⒈𤮍.᩠
+‌1.𤮍.󢓋᩠; ; [C1, P1, V6]; xn--1-rgn.xn--4x6j.xn--jof45148n; ; 1.xn--4x6j.xn--jof45148n; [P1, V6] # 1.𤮍.᩠
+1.xn--4x6j.xn--jof45148n; 1.𤮍.󢓋᩠; [V6]; 1.xn--4x6j.xn--jof45148n; ; ;  # 1.𤮍.᩠
+xn--1-rgn.xn--4x6j.xn--jof45148n; ‌1.𤮍.󢓋᩠; [C1, V6]; xn--1-rgn.xn--4x6j.xn--jof45148n; ; ;  # 1.𤮍.᩠
+xn--tshw462r.xn--jof45148n; ⒈𤮍.󢓋᩠; [V6]; xn--tshw462r.xn--jof45148n; ; ;  # ⒈𤮍.᩠
+xn--0ug88o7471d.xn--jof45148n; ‌⒈𤮍.󢓋᩠; [C1, V6]; xn--0ug88o7471d.xn--jof45148n; ; ;  # ⒈𤮍.᩠
+⒈‌𐫓󠀺。᩠񤰵‍; ⒈‌𐫓󠀺.᩠񤰵‍; [B1, C1, C2, P1, V5, V6]; xn--0ug78ol75wzcx4i.xn--jof95xex98m; ; xn--tsh4435fk263g.xn--jofz5294e; [B1, P1, V5, V6] # ⒈𐫓.᩠
+1.‌𐫓󠀺。᩠񤰵‍; 1.‌𐫓󠀺.᩠񤰵‍; [B1, C1, C2, P1, V5, V6]; 1.xn--0ug8853gk263g.xn--jof95xex98m; ; 1.xn--8w9c40377c.xn--jofz5294e; [B1, B3, P1, V5, V6] # 1.𐫓.᩠
+1.xn--8w9c40377c.xn--jofz5294e; 1.𐫓󠀺.᩠񤰵; [B1, B3, V5, V6]; 1.xn--8w9c40377c.xn--jofz5294e; ; ;  # 1.𐫓.᩠
+1.xn--0ug8853gk263g.xn--jof95xex98m; 1.‌𐫓󠀺.᩠񤰵‍; [B1, C1, C2, V5, V6]; 1.xn--0ug8853gk263g.xn--jof95xex98m; ; ;  # 1.𐫓.᩠
+xn--tsh4435fk263g.xn--jofz5294e; ⒈𐫓󠀺.᩠񤰵; [B1, V5, V6]; xn--tsh4435fk263g.xn--jofz5294e; ; ;  # ⒈𐫓.᩠
+xn--0ug78ol75wzcx4i.xn--jof95xex98m; ⒈‌𐫓󠀺.᩠񤰵‍; [B1, C1, C2, V5, V6]; xn--0ug78ol75wzcx4i.xn--jof95xex98m; ; ;  # ⒈𐫓.᩠
+𝅵｡𝟫𞀈䬺⒈; 𝅵.9𞀈䬺⒈; [P1, V6]; xn--3f1h.xn--9-ecp936non25a; ; ;  # .9𞀈䬺⒈
+𝅵。9𞀈䬺1.; 𝅵.9𞀈䬺1.; [P1, V6]; xn--3f1h.xn--91-030c1650n.; ; ;  # .9𞀈䬺1.
+xn--3f1h.xn--91-030c1650n.; 𝅵.9𞀈䬺1.; [V6]; xn--3f1h.xn--91-030c1650n.; ; ;  # .9𞀈䬺1.
+xn--3f1h.xn--9-ecp936non25a; 𝅵.9𞀈䬺⒈; [V6]; xn--3f1h.xn--9-ecp936non25a; ; ;  # .9𞀈䬺⒈
+򡼺≯。盚ص; 򡼺≯.盚ص; [B5, B6, P1, V6]; xn--hdh30181h.xn--0gb7878c; ; ;  # ≯.盚ص
+򡼺≯。盚ص; 򡼺≯.盚ص; [B5, B6, P1, V6]; xn--hdh30181h.xn--0gb7878c; ; ;  # ≯.盚ص
+xn--hdh30181h.xn--0gb7878c; 򡼺≯.盚ص; [B5, B6, V6]; xn--hdh30181h.xn--0gb7878c; ; ;  # ≯.盚ص
+-񿰭ִ。-󠁊𐢸≯; -񿰭ִ.-󠁊𐢸≯; [B1, P1, V3, V6]; xn----fgc06667m.xn----pgoy615he5y4i; ; ;  # -ִ.-≯
+-񿰭ִ。-󠁊𐢸≯; -񿰭ִ.-󠁊𐢸≯; [B1, P1, V3, V6]; xn----fgc06667m.xn----pgoy615he5y4i; ; ;  # -ִ.-≯
+xn----fgc06667m.xn----pgoy615he5y4i; -񿰭ִ.-󠁊𐢸≯; [B1, V3, V6]; xn----fgc06667m.xn----pgoy615he5y4i; ; ;  # -ִ.-≯
+󿭓᭄‌੍．𐭛񳋔; 󿭓᭄‌੍.𐭛񳋔; [B2, B3, B6, P1, V6]; xn--ybc997f6rd2n772c.xn--409c6100y; ; xn--ybc997fb5881a.xn--409c6100y; [B2, B3, P1, V6] # ᭄੍.𐭛
+󿭓᭄‌੍.𐭛񳋔; ; [B2, B3, B6, P1, V6]; xn--ybc997f6rd2n772c.xn--409c6100y; ; xn--ybc997fb5881a.xn--409c6100y; [B2, B3, P1, V6] # ᭄੍.𐭛
+xn--ybc997fb5881a.xn--409c6100y; 󿭓᭄੍.𐭛񳋔; [B2, B3, V6]; xn--ybc997fb5881a.xn--409c6100y; ; ;  # ᭄੍.𐭛
+xn--ybc997f6rd2n772c.xn--409c6100y; 󿭓᭄‌੍.𐭛񳋔; [B2, B3, B6, V6]; xn--ybc997f6rd2n772c.xn--409c6100y; ; ;  # ᭄੍.𐭛
+⾇.ٽ𞤴ڻ‍; 舛.ٽ𞤴ڻ‍; [B3, C2]; xn--8c1a.xn--2ib8jv19e6413b; ; xn--8c1a.xn--2ib8jn539l; [] # 舛.ٽ𞤴ڻ
+舛.ٽ𞤴ڻ‍; ; [B3, C2]; xn--8c1a.xn--2ib8jv19e6413b; ; xn--8c1a.xn--2ib8jn539l; [] # 舛.ٽ𞤴ڻ
+舛.ٽ𞤒ڻ‍; 舛.ٽ𞤴ڻ‍; [B3, C2]; xn--8c1a.xn--2ib8jv19e6413b; ; xn--8c1a.xn--2ib8jn539l; [] # 舛.ٽ𞤴ڻ
+xn--8c1a.xn--2ib8jn539l; 舛.ٽ𞤴ڻ; ; xn--8c1a.xn--2ib8jn539l; ; ;  # 舛.ٽ𞤴ڻ
+舛.ٽ𞤴ڻ; ; ; xn--8c1a.xn--2ib8jn539l; ; ;  # 舛.ٽ𞤴ڻ
+舛.ٽ𞤒ڻ; 舛.ٽ𞤴ڻ; ; xn--8c1a.xn--2ib8jn539l; ; ;  # 舛.ٽ𞤴ڻ
+xn--8c1a.xn--2ib8jv19e6413b; 舛.ٽ𞤴ڻ‍; [B3, C2]; xn--8c1a.xn--2ib8jv19e6413b; ; ;  # 舛.ٽ𞤴ڻ
+⾇.ٽ𞤒ڻ‍; 舛.ٽ𞤴ڻ‍; [B3, C2]; xn--8c1a.xn--2ib8jv19e6413b; ; xn--8c1a.xn--2ib8jn539l; [] # 舛.ٽ𞤴ڻ
+4򭆥。ݧ≯; 4򭆥.ݧ≯; [B1, B3, P1, V6]; xn--4-xn17i.xn--rpb459k; ; ;  # 4.ݧ≯
+4򭆥。ݧ≯; 4򭆥.ݧ≯; [B1, B3, P1, V6]; xn--4-xn17i.xn--rpb459k; ; ;  # 4.ݧ≯
+xn--4-xn17i.xn--rpb459k; 4򭆥.ݧ≯; [B1, B3, V6]; xn--4-xn17i.xn--rpb459k; ; ;  # 4.ݧ≯
+𲔏𞫨񺿂硲．ڭ; 𲔏𞫨񺿂硲.ڭ; [B5, P1, V6]; xn--lcz1610fn78gk609a.xn--gkb; ; ;  # 硲.ڭ
+𲔏𞫨񺿂硲.ڭ; ; [B5, P1, V6]; xn--lcz1610fn78gk609a.xn--gkb; ; ;  # 硲.ڭ
+xn--lcz1610fn78gk609a.xn--gkb; 𲔏𞫨񺿂硲.ڭ; [B5, V6]; xn--lcz1610fn78gk609a.xn--gkb; ; ;  # 硲.ڭ
+‌.︈٦Ⴆ℮; ‌.٦Ⴆ℮; [B1, C1, P1, V6]; xn--0ug.xn--fib263c0yn; ; .xn--fib263c0yn; [B1, P1, V6, A4_2] # .٦Ⴆ℮
+‌.︈٦ⴆ℮; ‌.٦ⴆ℮; [B1, C1]; xn--0ug.xn--fib628k4li; ; .xn--fib628k4li; [B1, A4_2] # .٦ⴆ℮
+.xn--fib628k4li; .٦ⴆ℮; [B1, X4_2]; .xn--fib628k4li; [B1, A4_2]; ;  # .٦ⴆ℮
+xn--0ug.xn--fib628k4li; ‌.٦ⴆ℮; [B1, C1]; xn--0ug.xn--fib628k4li; ; ;  # .٦ⴆ℮
+.xn--fib263c0yn; .٦Ⴆ℮; [B1, V6, X4_2]; .xn--fib263c0yn; [B1, V6, A4_2]; ;  # .٦Ⴆ℮
+xn--0ug.xn--fib263c0yn; ‌.٦Ⴆ℮; [B1, C1, V6]; xn--0ug.xn--fib263c0yn; ; ;  # .٦Ⴆ℮
+ڣ．്‍Ϟ; ڣ.്‍ϟ; [B1, V5]; xn--5jb.xn--xya149bpvp; ; xn--5jb.xn--xya149b;  # ڣ.്ϟ
+ڣ.്‍Ϟ; ڣ.്‍ϟ; [B1, V5]; xn--5jb.xn--xya149bpvp; ; xn--5jb.xn--xya149b;  # ڣ.്ϟ
+ڣ.്‍ϟ; ; [B1, V5]; xn--5jb.xn--xya149bpvp; ; xn--5jb.xn--xya149b;  # ڣ.്ϟ
+xn--5jb.xn--xya149b; ڣ.്ϟ; [B1, V5]; xn--5jb.xn--xya149b; ; ;  # ڣ.്ϟ
+xn--5jb.xn--xya149bpvp; ڣ.്‍ϟ; [B1, V5]; xn--5jb.xn--xya149bpvp; ; ;  # ڣ.്ϟ
+ڣ．്‍ϟ; ڣ.്‍ϟ; [B1, V5]; xn--5jb.xn--xya149bpvp; ; xn--5jb.xn--xya149b;  # ڣ.്ϟ
+‌𞸇𑘿。أ𐮂-腍; ‌ح𑘿.أ𐮂-腍; [B1, B2, B3, C1]; xn--sgb953kmi8o.xn----qmc5075grs9e; ; xn--sgb4140l.xn----qmc5075grs9e; [B2, B3] # ح𑘿.أ𐮂-腍
+‌𞸇𑘿。أ𐮂-腍; ‌ح𑘿.أ𐮂-腍; [B1, B2, B3, C1]; xn--sgb953kmi8o.xn----qmc5075grs9e; ; xn--sgb4140l.xn----qmc5075grs9e; [B2, B3] # ح𑘿.أ𐮂-腍
+‌ح𑘿。أ𐮂-腍; ‌ح𑘿.أ𐮂-腍; [B1, B2, B3, C1]; xn--sgb953kmi8o.xn----qmc5075grs9e; ; xn--sgb4140l.xn----qmc5075grs9e; [B2, B3] # ح𑘿.أ𐮂-腍
+‌ح𑘿。أ𐮂-腍; ‌ح𑘿.أ𐮂-腍; [B1, B2, B3, C1]; xn--sgb953kmi8o.xn----qmc5075grs9e; ; xn--sgb4140l.xn----qmc5075grs9e; [B2, B3] # ح𑘿.أ𐮂-腍
+xn--sgb4140l.xn----qmc5075grs9e; ح𑘿.أ𐮂-腍; [B2, B3]; xn--sgb4140l.xn----qmc5075grs9e; ; ;  # ح𑘿.أ𐮂-腍
+xn--sgb953kmi8o.xn----qmc5075grs9e; ‌ح𑘿.أ𐮂-腍; [B1, B2, B3, C1]; xn--sgb953kmi8o.xn----qmc5075grs9e; ; ;  # ح𑘿.أ𐮂-腍
+-򭷙٫纛｡𝟛񭤇🄅; -򭷙٫纛.3񭤇🄅; [B1, P1, V3, V6]; xn----vqc8143g0tt4i.xn--3-os1sn476y; ; ;  # -٫纛.3🄅
+-򭷙٫纛。3񭤇4,; -򭷙٫纛.3񭤇4,; [B1, P1, V3, V6]; xn----vqc8143g0tt4i.xn--34,-8787l; ; ;  # -٫纛.34,
+xn----vqc8143g0tt4i.xn--34,-8787l; -򭷙٫纛.3񭤇4,; [B1, P1, V3, V6]; xn----vqc8143g0tt4i.xn--34,-8787l; ; ;  # -٫纛.34,
+xn----vqc8143g0tt4i.xn--3-os1sn476y; -򭷙٫纛.3񭤇🄅; [B1, V3, V6]; xn----vqc8143g0tt4i.xn--3-os1sn476y; ; ;  # -٫纛.3🄅
+🔔．Ⴂߌ்𐋮; 🔔.Ⴂߌ்𐋮; [B1, B5, P1, V6]; xn--nv8h.xn--nsb46r83e8112a; ; ;  # 🔔.Ⴂߌ்𐋮
+🔔.Ⴂߌ்𐋮; ; [B1, B5, P1, V6]; xn--nv8h.xn--nsb46r83e8112a; ; ;  # 🔔.Ⴂߌ்𐋮
+🔔.ⴂߌ்𐋮; ; [B1, B5]; xn--nv8h.xn--nsb46rvz1b222p; ; ;  # 🔔.ⴂߌ்𐋮
+xn--nv8h.xn--nsb46rvz1b222p; 🔔.ⴂߌ்𐋮; [B1, B5]; xn--nv8h.xn--nsb46rvz1b222p; ; ;  # 🔔.ⴂߌ்𐋮
+xn--nv8h.xn--nsb46r83e8112a; 🔔.Ⴂߌ்𐋮; [B1, B5, V6]; xn--nv8h.xn--nsb46r83e8112a; ; ;  # 🔔.Ⴂߌ்𐋮
+🔔．ⴂߌ்𐋮; 🔔.ⴂߌ்𐋮; [B1, B5]; xn--nv8h.xn--nsb46rvz1b222p; ; ;  # 🔔.ⴂߌ்𐋮
+軥ڳ.-𖬵; ; [B1, B5, B6, V3]; xn--mkb5480e.xn----6u5m; ; ;  # 軥ڳ.-𖬵
+xn--mkb5480e.xn----6u5m; 軥ڳ.-𖬵; [B1, B5, B6, V3]; xn--mkb5480e.xn----6u5m; ; ;  # 軥ڳ.-𖬵
+𐹤ߊڶ.𐨂-; ; [B1, V3, V5]; xn--pkb56cn614d.xn----974i; ; ;  # 𐹤ߊڶ.𐨂-
+xn--pkb56cn614d.xn----974i; 𐹤ߊڶ.𐨂-; [B1, V3, V5]; xn--pkb56cn614d.xn----974i; ; ;  # 𐹤ߊڶ.𐨂-
+-󠅱0｡៏᷽톇십; -0.៏᷽톇십; [V3, V5]; -0.xn--r4e872ah77nghm; ; ;  # -0.៏᷽톇십
+-󠅱0｡៏᷽톇십; -0.៏᷽톇십; [V3, V5]; -0.xn--r4e872ah77nghm; ; ;  # -0.៏᷽톇십
+-󠅱0。៏᷽톇십; -0.៏᷽톇십; [V3, V5]; -0.xn--r4e872ah77nghm; ; ;  # -0.៏᷽톇십
+-󠅱0。៏᷽톇십; -0.៏᷽톇십; [V3, V5]; -0.xn--r4e872ah77nghm; ; ;  # -0.៏᷽톇십
+-0.xn--r4e872ah77nghm; -0.៏᷽톇십; [V3, V5]; -0.xn--r4e872ah77nghm; ; ;  # -0.៏᷽톇십
+ꡰ︒--｡៌靈𐹢񘳮; ꡰ︒--.៌靈𐹢񘳮; [B1, B6, P1, V2, V3, V5, V6]; xn-----bk9hu24z.xn--o4e6836dpxudz0v1c; ; ;  # ꡰ︒--.៌靈𐹢
+ꡰ。--。៌靈𐹢񘳮; ꡰ.--.៌靈𐹢񘳮; [B1, P1, V3, V5, V6]; xn--md9a.--.xn--o4e6836dpxudz0v1c; ; ;  # ꡰ.--.៌靈𐹢
+xn--md9a.--.xn--o4e6836dpxudz0v1c; ꡰ.--.៌靈𐹢񘳮; [B1, V3, V5, V6]; xn--md9a.--.xn--o4e6836dpxudz0v1c; ; ;  # ꡰ.--.៌靈𐹢
+xn-----bk9hu24z.xn--o4e6836dpxudz0v1c; ꡰ︒--.៌靈𐹢񘳮; [B1, B6, V2, V3, V5, V6]; xn-----bk9hu24z.xn--o4e6836dpxudz0v1c; ; ;  # ꡰ︒--.៌靈𐹢
+ᅟႿႵრ｡୍; ᅟႿႵრ.୍; [P1, V5, V6]; xn--tndt4hvw.xn--9ic; ; ;  # ႿႵრ.୍
+ᅟႿႵრ。୍; ᅟႿႵრ.୍; [P1, V5, V6]; xn--tndt4hvw.xn--9ic; ; ;  # ႿႵრ.୍
+ᅟⴟⴕრ。୍; ᅟⴟⴕრ.୍; [P1, V5, V6]; xn--1od7wz74eeb.xn--9ic; ; ;  # ⴟⴕრ.୍
+ᅟႿႵᲠ。୍; ᅟႿႵᲠ.୍; [P1, V5, V6]; xn--tndt39bg47a.xn--9ic; ; ;  # ႿႵᲠ.୍
+xn--tndt39bg47a.xn--9ic; ᅟႿႵᲠ.୍; [V5, V6]; xn--tndt39bg47a.xn--9ic; ; ;  # ႿႵᲠ.୍
+xn--1od7wz74eeb.xn--9ic; ᅟⴟⴕრ.୍; [V5, V6]; xn--1od7wz74eeb.xn--9ic; ; ;  # ⴟⴕრ.୍
+xn--tndt4hvw.xn--9ic; ᅟႿႵრ.୍; [V5, V6]; xn--tndt4hvw.xn--9ic; ; ;  # ႿႵრ.୍
+ᅟⴟⴕრ｡୍; ᅟⴟⴕრ.୍; [P1, V5, V6]; xn--1od7wz74eeb.xn--9ic; ; ;  # ⴟⴕრ.୍
+ᅟႿႵᲠ｡୍; ᅟႿႵᲠ.୍; [P1, V5, V6]; xn--tndt39bg47a.xn--9ic; ; ;  # ႿႵᲠ.୍
+ᅟႿⴕრ。୍; ᅟႿⴕრ.୍; [P1, V5, V6]; xn--3nd0etsm92g.xn--9ic; ; ;  # Ⴟⴕრ.୍
+xn--3nd0etsm92g.xn--9ic; ᅟႿⴕრ.୍; [V5, V6]; xn--3nd0etsm92g.xn--9ic; ; ;  # Ⴟⴕრ.୍
+ᅟႿⴕრ｡୍; ᅟႿⴕრ.୍; [P1, V5, V6]; xn--3nd0etsm92g.xn--9ic; ; ;  # Ⴟⴕრ.୍
+🄃𐹠.٤󠅇; 🄃𐹠.٤; [B1, P1, V6]; xn--7n0d1189a.xn--dib; ; ;  # 🄃𐹠.٤
+2,𐹠.٤󠅇; 2,𐹠.٤; [B1, P1, V6]; xn--2,-5g3o.xn--dib; ; ;  # 2,𐹠.٤
+xn--2,-5g3o.xn--dib; 2,𐹠.٤; [B1, P1, V6]; xn--2,-5g3o.xn--dib; ; ;  # 2,𐹠.٤
+xn--7n0d1189a.xn--dib; 🄃𐹠.٤; [B1, V6]; xn--7n0d1189a.xn--dib; ; ;  # 🄃𐹠.٤
+򻲼‌ﱛ．ߒࡈ᯳; 򻲼‌ذٰ.ߒࡈ᯳; [B2, B3, B5, B6, C1, P1, V6]; xn--vgb2kq00fl213y.xn--tsb0vz43c; ; xn--vgb2kp1223g.xn--tsb0vz43c; [B2, B3, B5, B6, P1, V6] # ذٰ.ߒࡈ᯳
+򻲼‌ذٰ.ߒࡈ᯳; ; [B2, B3, B5, B6, C1, P1, V6]; xn--vgb2kq00fl213y.xn--tsb0vz43c; ; xn--vgb2kp1223g.xn--tsb0vz43c; [B2, B3, B5, B6, P1, V6] # ذٰ.ߒࡈ᯳
+xn--vgb2kp1223g.xn--tsb0vz43c; 򻲼ذٰ.ߒࡈ᯳; [B2, B3, B5, B6, V6]; xn--vgb2kp1223g.xn--tsb0vz43c; ; ;  # ذٰ.ߒࡈ᯳
+xn--vgb2kq00fl213y.xn--tsb0vz43c; 򻲼‌ذٰ.ߒࡈ᯳; [B2, B3, B5, B6, C1, V6]; xn--vgb2kq00fl213y.xn--tsb0vz43c; ; ;  # ذٰ.ߒࡈ᯳
+‍‍𞵪‌。ᡘ𑲭឵; ‍‍𞵪‌.ᡘ𑲭឵; [B1, C1, C2, P1, V6]; xn--0ugba05538b.xn--03e93aq365d; ; xn--l96h.xn--03e93aq365d; [P1, V6] # .ᡘ𑲭
+xn--l96h.xn--03e93aq365d; 𞵪.ᡘ𑲭឵; [V6]; xn--l96h.xn--03e93aq365d; ; ;  # .ᡘ𑲭
+xn--0ugba05538b.xn--03e93aq365d; ‍‍𞵪‌.ᡘ𑲭឵; [B1, C1, C2, V6]; xn--0ugba05538b.xn--03e93aq365d; ; ;  # .ᡘ𑲭
+𞷻。⚄񗑇𑁿; 𞷻.⚄񗑇𑁿; [B1, P1, V6]; xn--qe7h.xn--c7h2966f7so4a; ; ;  # .⚄𑁿
+xn--qe7h.xn--c7h2966f7so4a; 𞷻.⚄񗑇𑁿; [B1, V6]; xn--qe7h.xn--c7h2966f7so4a; ; ;  # .⚄𑁿
+꣄≠．𞠨٧; ꣄≠.𞠨٧; [B1, P1, V5, V6]; xn--1chy504c.xn--gib1777v; ; ;  # ꣄≠.𞠨٧
+꣄≠．𞠨٧; ꣄≠.𞠨٧; [B1, P1, V5, V6]; xn--1chy504c.xn--gib1777v; ; ;  # ꣄≠.𞠨٧
+꣄≠.𞠨٧; ; [B1, P1, V5, V6]; xn--1chy504c.xn--gib1777v; ; ;  # ꣄≠.𞠨٧
+꣄≠.𞠨٧; ꣄≠.𞠨٧; [B1, P1, V5, V6]; xn--1chy504c.xn--gib1777v; ; ;  # ꣄≠.𞠨٧
+xn--1chy504c.xn--gib1777v; ꣄≠.𞠨٧; [B1, V5, V6]; xn--1chy504c.xn--gib1777v; ; ;  # ꣄≠.𞠨٧
+𝟛꣄𝆪｡꣪-; 3꣄𝆪.꣪-; [V3, V5]; xn--3-sl4eu679e.xn----xn4e; ; ;  # 3꣄𝆪.꣪-
+𝟛꣄𝆪｡꣪-; 3꣄𝆪.꣪-; [V3, V5]; xn--3-sl4eu679e.xn----xn4e; ; ;  # 3꣄𝆪.꣪-
+3꣄𝆪。꣪-; 3꣄𝆪.꣪-; [V3, V5]; xn--3-sl4eu679e.xn----xn4e; ; ;  # 3꣄𝆪.꣪-
+xn--3-sl4eu679e.xn----xn4e; 3꣄𝆪.꣪-; [V3, V5]; xn--3-sl4eu679e.xn----xn4e; ; ;  # 3꣄𝆪.꣪-
+ݟᮢ်Ⴇ.4; ; [B1, B2, B3, P1, V6]; xn--jpb846bmjw88a.4; ; ;  # ݟᮢ်Ⴇ.4
+ݟᮢ်ⴇ.4; ; [B1, B2, B3]; xn--jpb846bjzj7pr.4; ; ;  # ݟᮢ်ⴇ.4
+xn--jpb846bjzj7pr.4; ݟᮢ်ⴇ.4; [B1, B2, B3]; xn--jpb846bjzj7pr.4; ; ;  # ݟᮢ်ⴇ.4
+xn--jpb846bmjw88a.4; ݟᮢ်Ⴇ.4; [B1, B2, B3, V6]; xn--jpb846bmjw88a.4; ; ;  # ݟᮢ်Ⴇ.4
+ᄹ｡໊򠯤󠄞; ᄹ.໊򠯤; [P1, V5, V6]; xn--lrd.xn--s8c05302k; ; ;  # ᄹ.໊
+ᄹ。໊򠯤󠄞; ᄹ.໊򠯤; [P1, V5, V6]; xn--lrd.xn--s8c05302k; ; ;  # ᄹ.໊
+xn--lrd.xn--s8c05302k; ᄹ.໊򠯤; [V5, V6]; xn--lrd.xn--s8c05302k; ; ;  # ᄹ.໊
+Ⴆ򻢩．󠆡︉𞤍; Ⴆ򻢩.𞤯; [P1, V6]; xn--end82983m.xn--ne6h; ; ;  # Ⴆ.𞤯
+Ⴆ򻢩.󠆡︉𞤍; Ⴆ򻢩.𞤯; [P1, V6]; xn--end82983m.xn--ne6h; ; ;  # Ⴆ.𞤯
+ⴆ򻢩.󠆡︉𞤯; ⴆ򻢩.𞤯; [P1, V6]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+xn--xkjw3965g.xn--ne6h; ⴆ򻢩.𞤯; [V6]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+xn--end82983m.xn--ne6h; Ⴆ򻢩.𞤯; [V6]; xn--end82983m.xn--ne6h; ; ;  # Ⴆ.𞤯
+ⴆ򻢩．󠆡︉𞤯; ⴆ򻢩.𞤯; [P1, V6]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+ⴆ򻢩.󠆡︉𞤍; ⴆ򻢩.𞤯; [P1, V6]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+ⴆ򻢩．󠆡︉𞤍; ⴆ򻢩.𞤯; [P1, V6]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+ßࠋ︒ٻ．帼F∬‌; ßࠋ︒ٻ.帼f∫∫‌; [B5, B6, C1, P1, V6]; xn--zca68zj8ac956c.xn--f-sgn48ga6997e; ; xn--ss-k0d31nu121d.xn--f-tcoa9162d; [B5, B6, P1, V6] # ßࠋ︒ٻ.帼f∫∫
+ßࠋ。ٻ.帼F∫∫‌; ßࠋ.ٻ.帼f∫∫‌; [B5, B6, C1]; xn--zca687a.xn--0ib.xn--f-sgn48ga6997e; ; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; [B5, B6] # ßࠋ.ٻ.帼f∫∫
+ßࠋ。ٻ.帼f∫∫‌; ßࠋ.ٻ.帼f∫∫‌; [B5, B6, C1]; xn--zca687a.xn--0ib.xn--f-sgn48ga6997e; ; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; [B5, B6] # ßࠋ.ٻ.帼f∫∫
+SSࠋ。ٻ.帼F∫∫‌; ssࠋ.ٻ.帼f∫∫‌; [B5, B6, C1]; xn--ss-uze.xn--0ib.xn--f-sgn48ga6997e; ; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; [B5, B6] # ssࠋ.ٻ.帼f∫∫
+ssࠋ。ٻ.帼f∫∫‌; ssࠋ.ٻ.帼f∫∫‌; [B5, B6, C1]; xn--ss-uze.xn--0ib.xn--f-sgn48ga6997e; ; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; [B5, B6] # ssࠋ.ٻ.帼f∫∫
+Ssࠋ。ٻ.帼F∫∫‌; ssࠋ.ٻ.帼f∫∫‌; [B5, B6, C1]; xn--ss-uze.xn--0ib.xn--f-sgn48ga6997e; ; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; [B5, B6] # ssࠋ.ٻ.帼f∫∫
+xn--ss-uze.xn--0ib.xn--f-tcoa9162d; ssࠋ.ٻ.帼f∫∫; [B5, B6]; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; ; ;  # ssࠋ.ٻ.帼f∫∫
+xn--ss-uze.xn--0ib.xn--f-sgn48ga6997e; ssࠋ.ٻ.帼f∫∫‌; [B5, B6, C1]; xn--ss-uze.xn--0ib.xn--f-sgn48ga6997e; ; ;  # ssࠋ.ٻ.帼f∫∫
+xn--zca687a.xn--0ib.xn--f-sgn48ga6997e; ßࠋ.ٻ.帼f∫∫‌; [B5, B6, C1]; xn--zca687a.xn--0ib.xn--f-sgn48ga6997e; ; ;  # ßࠋ.ٻ.帼f∫∫
+ßࠋ︒ٻ．帼f∬‌; ßࠋ︒ٻ.帼f∫∫‌; [B5, B6, C1, P1, V6]; xn--zca68zj8ac956c.xn--f-sgn48ga6997e; ; xn--ss-k0d31nu121d.xn--f-tcoa9162d; [B5, B6, P1, V6] # ßࠋ︒ٻ.帼f∫∫
+SSࠋ︒ٻ．帼F∬‌; ssࠋ︒ٻ.帼f∫∫‌; [B5, B6, C1, P1, V6]; xn--ss-k0d31nu121d.xn--f-sgn48ga6997e; ; xn--ss-k0d31nu121d.xn--f-tcoa9162d; [B5, B6, P1, V6] # ssࠋ︒ٻ.帼f∫∫
+ssࠋ︒ٻ．帼f∬‌; ssࠋ︒ٻ.帼f∫∫‌; [B5, B6, C1, P1, V6]; xn--ss-k0d31nu121d.xn--f-sgn48ga6997e; ; xn--ss-k0d31nu121d.xn--f-tcoa9162d; [B5, B6, P1, V6] # ssࠋ︒ٻ.帼f∫∫
+Ssࠋ︒ٻ．帼F∬‌; ssࠋ︒ٻ.帼f∫∫‌; [B5, B6, C1, P1, V6]; xn--ss-k0d31nu121d.xn--f-sgn48ga6997e; ; xn--ss-k0d31nu121d.xn--f-tcoa9162d; [B5, B6, P1, V6] # ssࠋ︒ٻ.帼f∫∫
+xn--ss-k0d31nu121d.xn--f-tcoa9162d; ssࠋ︒ٻ.帼f∫∫; [B5, B6, V6]; xn--ss-k0d31nu121d.xn--f-tcoa9162d; ; ;  # ssࠋ︒ٻ.帼f∫∫
+xn--ss-k0d31nu121d.xn--f-sgn48ga6997e; ssࠋ︒ٻ.帼f∫∫‌; [B5, B6, C1, V6]; xn--ss-k0d31nu121d.xn--f-sgn48ga6997e; ; ;  # ssࠋ︒ٻ.帼f∫∫
+xn--zca68zj8ac956c.xn--f-sgn48ga6997e; ßࠋ︒ٻ.帼f∫∫‌; [B5, B6, C1, V6]; xn--zca68zj8ac956c.xn--f-sgn48ga6997e; ; ;  # ßࠋ︒ٻ.帼f∫∫
+󘪗｡𐹴𞨌‍; 󘪗.𐹴𞨌‍; [B1, C2, P1, V6]; xn--8l83e.xn--1ug4105gsxwf; ; xn--8l83e.xn--so0dw168a; [B1, P1, V6] # .𐹴
+󘪗。𐹴𞨌‍; 󘪗.𐹴𞨌‍; [B1, C2, P1, V6]; xn--8l83e.xn--1ug4105gsxwf; ; xn--8l83e.xn--so0dw168a; [B1, P1, V6] # .𐹴
+xn--8l83e.xn--so0dw168a; 󘪗.𐹴𞨌; [B1, V6]; xn--8l83e.xn--so0dw168a; ; ;  # .𐹴
+xn--8l83e.xn--1ug4105gsxwf; 󘪗.𐹴𞨌‍; [B1, C2, V6]; xn--8l83e.xn--1ug4105gsxwf; ; ;  # .𐹴
+񗛨.򅟢𝟨꣄; 񗛨.򅟢6꣄; [P1, V6]; xn--mi60a.xn--6-sl4es8023c; ; ;  # .6꣄
+񗛨.򅟢6꣄; ; [P1, V6]; xn--mi60a.xn--6-sl4es8023c; ; ;  # .6꣄
+xn--mi60a.xn--6-sl4es8023c; 񗛨.򅟢6꣄; [V6]; xn--mi60a.xn--6-sl4es8023c; ; ;  # .6꣄
+᪲ﶎ。-۹ႱႨ; ᪲مخج.-۹ႱႨ; [B1, P1, V3, V5, V6]; xn--rgbd2e831i.xn----zyc155e9a; ; ;  # ᪲مخج.-۹ႱႨ
+᪲مخج。-۹ႱႨ; ᪲مخج.-۹ႱႨ; [B1, P1, V3, V5, V6]; xn--rgbd2e831i.xn----zyc155e9a; ; ;  # ᪲مخج.-۹ႱႨ
+᪲مخج。-۹ⴑⴈ; ᪲مخج.-۹ⴑⴈ; [B1, V3, V5]; xn--rgbd2e831i.xn----zyc3430a9a; ; ;  # ᪲مخج.-۹ⴑⴈ
+xn--rgbd2e831i.xn----zyc3430a9a; ᪲مخج.-۹ⴑⴈ; [B1, V3, V5]; xn--rgbd2e831i.xn----zyc3430a9a; ; ;  # ᪲مخج.-۹ⴑⴈ
+xn--rgbd2e831i.xn----zyc155e9a; ᪲مخج.-۹ႱႨ; [B1, V3, V5, V6]; xn--rgbd2e831i.xn----zyc155e9a; ; ;  # ᪲مخج.-۹ႱႨ
+᪲ﶎ。-۹ⴑⴈ; ᪲مخج.-۹ⴑⴈ; [B1, V3, V5]; xn--rgbd2e831i.xn----zyc3430a9a; ; ;  # ᪲مخج.-۹ⴑⴈ
+᪲مخج。-۹Ⴑⴈ; ᪲مخج.-۹Ⴑⴈ; [B1, P1, V3, V5, V6]; xn--rgbd2e831i.xn----zyc875efr3a; ; ;  # ᪲مخج.-۹Ⴑⴈ
+xn--rgbd2e831i.xn----zyc875efr3a; ᪲مخج.-۹Ⴑⴈ; [B1, V3, V5, V6]; xn--rgbd2e831i.xn----zyc875efr3a; ; ;  # ᪲مخج.-۹Ⴑⴈ
+᪲ﶎ。-۹Ⴑⴈ; ᪲مخج.-۹Ⴑⴈ; [B1, P1, V3, V5, V6]; xn--rgbd2e831i.xn----zyc875efr3a; ; ;  # ᪲مخج.-۹Ⴑⴈ
+𞤤．-ࢣ︒; 𞤤.-ࢣ︒; [B1, P1, V3, V6]; xn--ce6h.xn----cod7069p; ; ;  # 𞤤.-ࢣ︒
+𞤤.-ࢣ。; 𞤤.-ࢣ.; [B1, V3]; xn--ce6h.xn----cod.; ; ;  # 𞤤.-ࢣ.
+𞤂.-ࢣ。; 𞤤.-ࢣ.; [B1, V3]; xn--ce6h.xn----cod.; ; ;  # 𞤤.-ࢣ.
+xn--ce6h.xn----cod.; 𞤤.-ࢣ.; [B1, V3]; xn--ce6h.xn----cod.; ; ;  # 𞤤.-ࢣ.
+𞤂．-ࢣ︒; 𞤤.-ࢣ︒; [B1, P1, V3, V6]; xn--ce6h.xn----cod7069p; ; ;  # 𞤤.-ࢣ︒
+xn--ce6h.xn----cod7069p; 𞤤.-ࢣ︒; [B1, V3, V6]; xn--ce6h.xn----cod7069p; ; ;  # 𞤤.-ࢣ︒
+‌𐺨.࡙--; ; [B1, C1, P1, V3, V5, V6]; xn--0ug7905g.xn-----h6e; ; xn--9p0d.xn-----h6e; [B1, P1, V3, V5, V6] # .࡙--
+xn--9p0d.xn-----h6e; 𐺨.࡙--; [B1, V3, V5, V6]; xn--9p0d.xn-----h6e; ; ;  # .࡙--
+xn--0ug7905g.xn-----h6e; ‌𐺨.࡙--; [B1, C1, V3, V5, V6]; xn--0ug7905g.xn-----h6e; ; ;  # .࡙--
+𐋸󮘋Ⴢ.Ⴁ; ; [P1, V6]; xn--6nd5215jr2u0h.xn--8md; ; ;  # 𐋸Ⴢ.Ⴁ
+𐋸󮘋ⴢ.ⴁ; ; [P1, V6]; xn--qlj1559dr224h.xn--skj; ; ;  # 𐋸ⴢ.ⴁ
+𐋸󮘋Ⴢ.ⴁ; ; [P1, V6]; xn--6nd5215jr2u0h.xn--skj; ; ;  # 𐋸Ⴢ.ⴁ
+xn--6nd5215jr2u0h.xn--skj; 𐋸󮘋Ⴢ.ⴁ; [V6]; xn--6nd5215jr2u0h.xn--skj; ; ;  # 𐋸Ⴢ.ⴁ
+xn--qlj1559dr224h.xn--skj; 𐋸󮘋ⴢ.ⴁ; [V6]; xn--qlj1559dr224h.xn--skj; ; ;  # 𐋸ⴢ.ⴁ
+xn--6nd5215jr2u0h.xn--8md; 𐋸󮘋Ⴢ.Ⴁ; [V6]; xn--6nd5215jr2u0h.xn--8md; ; ;  # 𐋸Ⴢ.Ⴁ
+񗑿꠆₄򩞆｡𲩧󠒹ς; 񗑿꠆4򩞆.𲩧󠒹ς; [P1, V6]; xn--4-w93ej7463a9io5a.xn--3xa51142bk3f0d; ; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d;  # ꠆4.ς
+񗑿꠆4򩞆。𲩧󠒹ς; 񗑿꠆4򩞆.𲩧󠒹ς; [P1, V6]; xn--4-w93ej7463a9io5a.xn--3xa51142bk3f0d; ; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d;  # ꠆4.ς
+񗑿꠆4򩞆。𲩧󠒹Σ; 񗑿꠆4򩞆.𲩧󠒹σ; [P1, V6]; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; ; ;  # ꠆4.σ
+񗑿꠆4򩞆。𲩧󠒹σ; 񗑿꠆4򩞆.𲩧󠒹σ; [P1, V6]; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; ; ;  # ꠆4.σ
+xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; 񗑿꠆4򩞆.𲩧󠒹σ; [V6]; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; ; ;  # ꠆4.σ
+xn--4-w93ej7463a9io5a.xn--3xa51142bk3f0d; 񗑿꠆4򩞆.𲩧󠒹ς; [V6]; xn--4-w93ej7463a9io5a.xn--3xa51142bk3f0d; ; ;  # ꠆4.ς
+񗑿꠆₄򩞆｡𲩧󠒹Σ; 񗑿꠆4򩞆.𲩧󠒹σ; [P1, V6]; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; ; ;  # ꠆4.σ
+񗑿꠆₄򩞆｡𲩧󠒹σ; 񗑿꠆4򩞆.𲩧󠒹σ; [P1, V6]; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; ; ;  # ꠆4.σ
+󠆀ܣ。ᷴݵ; ܣ.ᷴݵ; [B1, V5]; xn--tnb.xn--5pb136i; ; ;  # ܣ.ᷴݵ
+xn--tnb.xn--5pb136i; ܣ.ᷴݵ; [B1, V5]; xn--tnb.xn--5pb136i; ; ;  # ܣ.ᷴݵ
+𐹱ࡂ𝪨｡𬼖Ⴑ‍; 𐹱ࡂ𝪨.𬼖Ⴑ‍; [B1, B6, C2, P1, V6]; xn--0vb1535kdb6e.xn--pnd879eqy33c; ; xn--0vb1535kdb6e.xn--pnd93707a; [B1, P1, V6] # 𐹱ࡂ𝪨.𬼖Ⴑ
+𐹱ࡂ𝪨。𬼖Ⴑ‍; 𐹱ࡂ𝪨.𬼖Ⴑ‍; [B1, B6, C2, P1, V6]; xn--0vb1535kdb6e.xn--pnd879eqy33c; ; xn--0vb1535kdb6e.xn--pnd93707a; [B1, P1, V6] # 𐹱ࡂ𝪨.𬼖Ⴑ
+𐹱ࡂ𝪨。𬼖ⴑ‍; 𐹱ࡂ𝪨.𬼖ⴑ‍; [B1, B6, C2]; xn--0vb1535kdb6e.xn--1ug742c5714c; ; xn--0vb1535kdb6e.xn--8kjz186s; [B1] # 𐹱ࡂ𝪨.𬼖ⴑ
+xn--0vb1535kdb6e.xn--8kjz186s; 𐹱ࡂ𝪨.𬼖ⴑ; [B1]; xn--0vb1535kdb6e.xn--8kjz186s; ; ;  # 𐹱ࡂ𝪨.𬼖ⴑ
+xn--0vb1535kdb6e.xn--1ug742c5714c; 𐹱ࡂ𝪨.𬼖ⴑ‍; [B1, B6, C2]; xn--0vb1535kdb6e.xn--1ug742c5714c; ; ;  # 𐹱ࡂ𝪨.𬼖ⴑ
+xn--0vb1535kdb6e.xn--pnd93707a; 𐹱ࡂ𝪨.𬼖Ⴑ; [B1, V6]; xn--0vb1535kdb6e.xn--pnd93707a; ; ;  # 𐹱ࡂ𝪨.𬼖Ⴑ
+xn--0vb1535kdb6e.xn--pnd879eqy33c; 𐹱ࡂ𝪨.𬼖Ⴑ‍; [B1, B6, C2, V6]; xn--0vb1535kdb6e.xn--pnd879eqy33c; ; ;  # 𐹱ࡂ𝪨.𬼖Ⴑ
+𐹱ࡂ𝪨｡𬼖ⴑ‍; 𐹱ࡂ𝪨.𬼖ⴑ‍; [B1, B6, C2]; xn--0vb1535kdb6e.xn--1ug742c5714c; ; xn--0vb1535kdb6e.xn--8kjz186s; [B1] # 𐹱ࡂ𝪨.𬼖ⴑ
+᜔𐭪󠙘‍｡-𐹴; ᜔𐭪󠙘‍.-𐹴; [B1, C2, P1, V3, V5, V6]; xn--fze807bso0spy14i.xn----c36i; ; xn--fze4126jujt0g.xn----c36i; [B1, P1, V3, V5, V6] # ᜔𐭪.-𐹴
+᜔𐭪󠙘‍。-𐹴; ᜔𐭪󠙘‍.-𐹴; [B1, C2, P1, V3, V5, V6]; xn--fze807bso0spy14i.xn----c36i; ; xn--fze4126jujt0g.xn----c36i; [B1, P1, V3, V5, V6] # ᜔𐭪.-𐹴
+xn--fze4126jujt0g.xn----c36i; ᜔𐭪󠙘.-𐹴; [B1, V3, V5, V6]; xn--fze4126jujt0g.xn----c36i; ; ;  # ᜔𐭪.-𐹴
+xn--fze807bso0spy14i.xn----c36i; ᜔𐭪󠙘‍.-𐹴; [B1, C2, V3, V5, V6]; xn--fze807bso0spy14i.xn----c36i; ; ;  # ᜔𐭪.-𐹴
+𾢬｡ܩ︒쯙𝟧; 𾢬.ܩ︒쯙5; [B2, P1, V6]; xn--t92s.xn--5-p1c0712mm8rb; ; ;  # .ܩ︒쯙5
+𾢬｡ܩ︒쯙𝟧; 𾢬.ܩ︒쯙5; [B2, P1, V6]; xn--t92s.xn--5-p1c0712mm8rb; ; ;  # .ܩ︒쯙5
+𾢬。ܩ。쯙5; 𾢬.ܩ.쯙5; [P1, V6]; xn--t92s.xn--znb.xn--5-y88f; ; ;  # .ܩ.쯙5
+𾢬。ܩ。쯙5; 𾢬.ܩ.쯙5; [P1, V6]; xn--t92s.xn--znb.xn--5-y88f; ; ;  # .ܩ.쯙5
+xn--t92s.xn--znb.xn--5-y88f; 𾢬.ܩ.쯙5; [V6]; xn--t92s.xn--znb.xn--5-y88f; ; ;  # .ܩ.쯙5
+xn--t92s.xn--5-p1c0712mm8rb; 𾢬.ܩ︒쯙5; [B2, V6]; xn--t92s.xn--5-p1c0712mm8rb; ; ;  # .ܩ︒쯙5
+𞤟-。ݢ≮뻐; 𞥁-.ݢ≮뻐; [B2, B3, P1, V3, V6]; xn----1j8r.xn--mpb269krv4i; ; ;  # 𞥁-.ݢ≮뻐
+𞤟-。ݢ≮뻐; 𞥁-.ݢ≮뻐; [B2, B3, P1, V3, V6]; xn----1j8r.xn--mpb269krv4i; ; ;  # 𞥁-.ݢ≮뻐
+𞥁-。ݢ≮뻐; 𞥁-.ݢ≮뻐; [B2, B3, P1, V3, V6]; xn----1j8r.xn--mpb269krv4i; ; ;  # 𞥁-.ݢ≮뻐
+𞥁-。ݢ≮뻐; 𞥁-.ݢ≮뻐; [B2, B3, P1, V3, V6]; xn----1j8r.xn--mpb269krv4i; ; ;  # 𞥁-.ݢ≮뻐
+xn----1j8r.xn--mpb269krv4i; 𞥁-.ݢ≮뻐; [B2, B3, V3, V6]; xn----1j8r.xn--mpb269krv4i; ; ;  # 𞥁-.ݢ≮뻐
+𞥩-򊫠．ࢴ≠; 𞥩-򊫠.ࢴ≠; [B2, B3, P1, V6]; xn----cm8rp3609a.xn--9yb852k; ; ;  # -.ࢴ≠
+𞥩-򊫠．ࢴ≠; 𞥩-򊫠.ࢴ≠; [B2, B3, P1, V6]; xn----cm8rp3609a.xn--9yb852k; ; ;  # -.ࢴ≠
+𞥩-򊫠.ࢴ≠; ; [B2, B3, P1, V6]; xn----cm8rp3609a.xn--9yb852k; ; ;  # -.ࢴ≠
+𞥩-򊫠.ࢴ≠; 𞥩-򊫠.ࢴ≠; [B2, B3, P1, V6]; xn----cm8rp3609a.xn--9yb852k; ; ;  # -.ࢴ≠
+xn----cm8rp3609a.xn--9yb852k; 𞥩-򊫠.ࢴ≠; [B2, B3, V6]; xn----cm8rp3609a.xn--9yb852k; ; ;  # -.ࢴ≠
+-񅂏ςႼ．١; -񅂏ςႼ.١; [B1, P1, V3, V6]; xn----ymb080hun11i.xn--9hb; ; xn----0mb770hun11i.xn--9hb;  # -ςႼ.١
+-񅂏ςႼ.١; ; [B1, P1, V3, V6]; xn----ymb080hun11i.xn--9hb; ; xn----0mb770hun11i.xn--9hb;  # -ςႼ.١
+-񅂏ςⴜ.١; ; [B1, P1, V3, V6]; xn----ymb2782aov12f.xn--9hb; ; xn----0mb9682aov12f.xn--9hb;  # -ςⴜ.١
+-񅂏ΣႼ.١; -񅂏σႼ.١; [B1, P1, V3, V6]; xn----0mb770hun11i.xn--9hb; ; ;  # -σႼ.١
+-񅂏σⴜ.١; ; [B1, P1, V3, V6]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+-񅂏Σⴜ.١; -񅂏σⴜ.١; [B1, P1, V3, V6]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+xn----0mb9682aov12f.xn--9hb; -񅂏σⴜ.١; [B1, V3, V6]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+xn----0mb770hun11i.xn--9hb; -񅂏σႼ.١; [B1, V3, V6]; xn----0mb770hun11i.xn--9hb; ; ;  # -σႼ.١
+xn----ymb2782aov12f.xn--9hb; -񅂏ςⴜ.١; [B1, V3, V6]; xn----ymb2782aov12f.xn--9hb; ; ;  # -ςⴜ.١
+xn----ymb080hun11i.xn--9hb; -񅂏ςႼ.١; [B1, V3, V6]; xn----ymb080hun11i.xn--9hb; ; ;  # -ςႼ.١
+-񅂏ςⴜ．١; -񅂏ςⴜ.١; [B1, P1, V3, V6]; xn----ymb2782aov12f.xn--9hb; ; xn----0mb9682aov12f.xn--9hb;  # -ςⴜ.١
+-񅂏ΣႼ．١; -񅂏σႼ.١; [B1, P1, V3, V6]; xn----0mb770hun11i.xn--9hb; ; ;  # -σႼ.١
+-񅂏σⴜ．١; -񅂏σⴜ.١; [B1, P1, V3, V6]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+-񅂏Σⴜ．١; -񅂏σⴜ.١; [B1, P1, V3, V6]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+៊.‍𝟮𑀿; ៊.‍2𑀿; [C2, V5]; xn--m4e.xn--2-tgnv469h; ; xn--m4e.xn--2-ku7i; [V5] # ៊.2𑀿
+៊.‍2𑀿; ; [C2, V5]; xn--m4e.xn--2-tgnv469h; ; xn--m4e.xn--2-ku7i; [V5] # ៊.2𑀿
+xn--m4e.xn--2-ku7i; ៊.2𑀿; [V5]; xn--m4e.xn--2-ku7i; ; ;  # ៊.2𑀿
+xn--m4e.xn--2-tgnv469h; ៊.‍2𑀿; [C2, V5]; xn--m4e.xn--2-tgnv469h; ; ;  # ៊.2𑀿
+≯𝟖｡᩠𐫓򟇑; ≯8.᩠𐫓򟇑; [B1, P1, V5, V6]; xn--8-ogo.xn--jof5303iv1z5d; ; ;  # ≯8.᩠𐫓
+≯𝟖｡᩠𐫓򟇑; ≯8.᩠𐫓򟇑; [B1, P1, V5, V6]; xn--8-ogo.xn--jof5303iv1z5d; ; ;  # ≯8.᩠𐫓
+≯8。᩠𐫓򟇑; ≯8.᩠𐫓򟇑; [B1, P1, V5, V6]; xn--8-ogo.xn--jof5303iv1z5d; ; ;  # ≯8.᩠𐫓
+≯8。᩠𐫓򟇑; ≯8.᩠𐫓򟇑; [B1, P1, V5, V6]; xn--8-ogo.xn--jof5303iv1z5d; ; ;  # ≯8.᩠𐫓
+xn--8-ogo.xn--jof5303iv1z5d; ≯8.᩠𐫓򟇑; [B1, V5, V6]; xn--8-ogo.xn--jof5303iv1z5d; ; ;  # ≯8.᩠𐫓
+𑲫Ↄ٤｡‌; 𑲫Ↄ٤.‌; [B1, C1, P1, V5, V6]; xn--dib999kcy1p.xn--0ug; ; xn--dib999kcy1p.; [B1, P1, V5, V6] # 𑲫Ↄ٤.
+𑲫Ↄ٤。‌; 𑲫Ↄ٤.‌; [B1, C1, P1, V5, V6]; xn--dib999kcy1p.xn--0ug; ; xn--dib999kcy1p.; [B1, P1, V5, V6] # 𑲫Ↄ٤.
+𑲫ↄ٤。‌; 𑲫ↄ٤.‌; [B1, C1, V5]; xn--dib100l8x1p.xn--0ug; ; xn--dib100l8x1p.; [B1, V5] # 𑲫ↄ٤.
+xn--dib100l8x1p.; 𑲫ↄ٤.; [B1, V5]; xn--dib100l8x1p.; ; ;  # 𑲫ↄ٤.
+xn--dib100l8x1p.xn--0ug; 𑲫ↄ٤.‌; [B1, C1, V5]; xn--dib100l8x1p.xn--0ug; ; ;  # 𑲫ↄ٤.
+xn--dib999kcy1p.; 𑲫Ↄ٤.; [B1, V5, V6]; xn--dib999kcy1p.; ; ;  # 𑲫Ↄ٤.
+xn--dib999kcy1p.xn--0ug; 𑲫Ↄ٤.‌; [B1, C1, V5, V6]; xn--dib999kcy1p.xn--0ug; ; ;  # 𑲫Ↄ٤.
+𑲫ↄ٤｡‌; 𑲫ↄ٤.‌; [B1, C1, V5]; xn--dib100l8x1p.xn--0ug; ; xn--dib100l8x1p.; [B1, V5] # 𑲫ↄ٤.
+ఀ𝟵‍ﲝ.‍ݐ⒈; ఀ9‍بح.‍ݐ⒈; [B1, C2, P1, V5, V6]; xn--9-1mcp570dl51a.xn--3ob977jmfd; ; xn--9-1mcp570d.xn--3ob470m; [B1, P1, V5, V6] # ఀ9بح.ݐ⒈
+ఀ9‍بح.‍ݐ1.; ; [B1, C2, V5]; xn--9-1mcp570dl51a.xn--1-x3c211q.; ; xn--9-1mcp570d.xn--1-x3c.; [B1, V5] # ఀ9بح.ݐ1.
+xn--9-1mcp570d.xn--1-x3c.; ఀ9بح.ݐ1.; [B1, V5]; xn--9-1mcp570d.xn--1-x3c.; ; ;  # ఀ9بح.ݐ1.
+xn--9-1mcp570dl51a.xn--1-x3c211q.; ఀ9‍بح.‍ݐ1.; [B1, C2, V5]; xn--9-1mcp570dl51a.xn--1-x3c211q.; ; ;  # ఀ9بح.ݐ1.
+xn--9-1mcp570d.xn--3ob470m; ఀ9بح.ݐ⒈; [B1, V5, V6]; xn--9-1mcp570d.xn--3ob470m; ; ;  # ఀ9بح.ݐ⒈
+xn--9-1mcp570dl51a.xn--3ob977jmfd; ఀ9‍بح.‍ݐ⒈; [B1, C2, V5, V6]; xn--9-1mcp570dl51a.xn--3ob977jmfd; ; ;  # ఀ9بح.ݐ⒈
+꫶。嬶ß葽; ꫶.嬶ß葽; [V5]; xn--2v9a.xn--zca7637b14za; ; xn--2v9a.xn--ss-q40dp97m;  # ꫶.嬶ß葽
+꫶。嬶SS葽; ꫶.嬶ss葽; [V5]; xn--2v9a.xn--ss-q40dp97m; ; ;  # ꫶.嬶ss葽
+꫶。嬶ss葽; ꫶.嬶ss葽; [V5]; xn--2v9a.xn--ss-q40dp97m; ; ;  # ꫶.嬶ss葽
+꫶。嬶Ss葽; ꫶.嬶ss葽; [V5]; xn--2v9a.xn--ss-q40dp97m; ; ;  # ꫶.嬶ss葽
+xn--2v9a.xn--ss-q40dp97m; ꫶.嬶ss葽; [V5]; xn--2v9a.xn--ss-q40dp97m; ; ;  # ꫶.嬶ss葽
+xn--2v9a.xn--zca7637b14za; ꫶.嬶ß葽; [V5]; xn--2v9a.xn--zca7637b14za; ; ;  # ꫶.嬶ß葽
+𑚶⒈。񞻡𐹺; 𑚶⒈.񞻡𐹺; [B5, B6, P1, V5, V6]; xn--tshz969f.xn--yo0d5914s; ; ;  # 𑚶⒈.𐹺
+𑚶1.。񞻡𐹺; 𑚶1..񞻡𐹺; [B5, B6, P1, V5, V6, X4_2]; xn--1-3j0j..xn--yo0d5914s; [B5, B6, P1, V5, V6, A4_2]; ;  # 𑚶1..𐹺
+xn--1-3j0j..xn--yo0d5914s; 𑚶1..񞻡𐹺; [B5, B6, V5, V6, X4_2]; xn--1-3j0j..xn--yo0d5914s; [B5, B6, V5, V6, A4_2]; ;  # 𑚶1..𐹺
+xn--tshz969f.xn--yo0d5914s; 𑚶⒈.񞻡𐹺; [B5, B6, V5, V6]; xn--tshz969f.xn--yo0d5914s; ; ;  # 𑚶⒈.𐹺
+𑜤︒≮．񚕽ט𞾩; 𑜤︒≮.񚕽ט𞾩; [B1, B5, B6, P1, V5, V6]; xn--gdh5267fdzpa.xn--deb0091w5q9u; ; ;  # 𑜤︒≮.ט
+𑜤︒≮．񚕽ט𞾩; 𑜤︒≮.񚕽ט𞾩; [B1, B5, B6, P1, V5, V6]; xn--gdh5267fdzpa.xn--deb0091w5q9u; ; ;  # 𑜤︒≮.ט
+𑜤。≮.񚕽ט𞾩; 𑜤.≮.񚕽ט𞾩; [B1, B3, B5, B6, P1, V5, V6]; xn--ci2d.xn--gdh.xn--deb0091w5q9u; ; ;  # 𑜤.≮.ט
+𑜤。≮.񚕽ט𞾩; 𑜤.≮.񚕽ט𞾩; [B1, B3, B5, B6, P1, V5, V6]; xn--ci2d.xn--gdh.xn--deb0091w5q9u; ; ;  # 𑜤.≮.ט
+xn--ci2d.xn--gdh.xn--deb0091w5q9u; 𑜤.≮.񚕽ט𞾩; [B1, B3, B5, B6, V5, V6]; xn--ci2d.xn--gdh.xn--deb0091w5q9u; ; ;  # 𑜤.≮.ט
+xn--gdh5267fdzpa.xn--deb0091w5q9u; 𑜤︒≮.񚕽ט𞾩; [B1, B5, B6, V5, V6]; xn--gdh5267fdzpa.xn--deb0091w5q9u; ; ;  # 𑜤︒≮.ט
+󠆋؃񏦤.⇁ς򏋈򺇥; ؃񏦤.⇁ς򏋈򺇥; [B1, P1, V6]; xn--lfb04106d.xn--3xa174mxv16m8moq; ; xn--lfb04106d.xn--4xa964mxv16m8moq;  # .⇁ς
+󠆋؃񏦤.⇁Σ򏋈򺇥; ؃񏦤.⇁σ򏋈򺇥; [B1, P1, V6]; xn--lfb04106d.xn--4xa964mxv16m8moq; ; ;  # .⇁σ
+󠆋؃񏦤.⇁σ򏋈򺇥; ؃񏦤.⇁σ򏋈򺇥; [B1, P1, V6]; xn--lfb04106d.xn--4xa964mxv16m8moq; ; ;  # .⇁σ
+xn--lfb04106d.xn--4xa964mxv16m8moq; ؃񏦤.⇁σ򏋈򺇥; [B1, V6]; xn--lfb04106d.xn--4xa964mxv16m8moq; ; ;  # .⇁σ
+xn--lfb04106d.xn--3xa174mxv16m8moq; ؃񏦤.⇁ς򏋈򺇥; [B1, V6]; xn--lfb04106d.xn--3xa174mxv16m8moq; ; ;  # .⇁ς
+ς𑐽𵢈𑜫｡𞬩‌𐫄; ς𑐽𵢈𑜫.𞬩‌𐫄; [C1, P1, V6]; xn--3xa4260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [P1, V6] # ς𑐽𑜫.𐫄
+ς𑐽𵢈𑜫。𞬩‌𐫄; ς𑐽𵢈𑜫.𞬩‌𐫄; [C1, P1, V6]; xn--3xa4260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [P1, V6] # ς𑐽𑜫.𐫄
+Σ𑐽𵢈𑜫。𞬩‌𐫄; σ𑐽𵢈𑜫.𞬩‌𐫄; [C1, P1, V6]; xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [P1, V6] # σ𑐽𑜫.𐫄
+σ𑐽𵢈𑜫。𞬩‌𐫄; σ𑐽𵢈𑜫.𞬩‌𐫄; [C1, P1, V6]; xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [P1, V6] # σ𑐽𑜫.𐫄
+xn--4xa2260lk3b8z15g.xn--tw9ct349a; σ𑐽𵢈𑜫.𞬩𐫄; [V6]; xn--4xa2260lk3b8z15g.xn--tw9ct349a; ; ;  # σ𑐽𑜫.𐫄
+xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; σ𑐽𵢈𑜫.𞬩‌𐫄; [C1, V6]; xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; ; ;  # σ𑐽𑜫.𐫄
+xn--3xa4260lk3b8z15g.xn--0ug4653g2xzf; ς𑐽𵢈𑜫.𞬩‌𐫄; [C1, V6]; xn--3xa4260lk3b8z15g.xn--0ug4653g2xzf; ; ;  # ς𑐽𑜫.𐫄
+Σ𑐽𵢈𑜫｡𞬩‌𐫄; σ𑐽𵢈𑜫.𞬩‌𐫄; [C1, P1, V6]; xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [P1, V6] # σ𑐽𑜫.𐫄
+σ𑐽𵢈𑜫｡𞬩‌𐫄; σ𑐽𵢈𑜫.𞬩‌𐫄; [C1, P1, V6]; xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [P1, V6] # σ𑐽𑜫.𐫄
+-򵏽｡-ﱌݛ; -򵏽.-نحݛ; [B1, P1, V3, V6]; xn----o452j.xn----cnc8e38c; ; ;  # -.-نحݛ
+-򵏽。-نحݛ; -򵏽.-نحݛ; [B1, P1, V3, V6]; xn----o452j.xn----cnc8e38c; ; ;  # -.-نحݛ
+xn----o452j.xn----cnc8e38c; -򵏽.-نحݛ; [B1, V3, V6]; xn----o452j.xn----cnc8e38c; ; ;  # -.-نحݛ
+⺢򇺅𝟤｡‍🚷; ⺢򇺅2.‍🚷; [C2, P1, V6]; xn--2-4jtr4282f.xn--1ugz946p; ; xn--2-4jtr4282f.xn--m78h; [P1, V6] # ⺢2.🚷
+⺢򇺅2。‍🚷; ⺢򇺅2.‍🚷; [C2, P1, V6]; xn--2-4jtr4282f.xn--1ugz946p; ; xn--2-4jtr4282f.xn--m78h; [P1, V6] # ⺢2.🚷
+xn--2-4jtr4282f.xn--m78h; ⺢򇺅2.🚷; [V6]; xn--2-4jtr4282f.xn--m78h; ; ;  # ⺢2.🚷
+xn--2-4jtr4282f.xn--1ugz946p; ⺢򇺅2.‍🚷; [C2, V6]; xn--2-4jtr4282f.xn--1ugz946p; ; ;  # ⺢2.🚷
+೸‍ⷾ𐹲｡򤐶; ೸‍ⷾ𐹲.򤐶; [B5, B6, C2, P1, V6]; xn--hvc488g69j402t.xn--3e36c; ; xn--hvc220of37m.xn--3e36c; [B5, B6, P1, V6] # ⷾ𐹲.
+೸‍ⷾ𐹲。򤐶; ೸‍ⷾ𐹲.򤐶; [B5, B6, C2, P1, V6]; xn--hvc488g69j402t.xn--3e36c; ; xn--hvc220of37m.xn--3e36c; [B5, B6, P1, V6] # ⷾ𐹲.
+xn--hvc220of37m.xn--3e36c; ೸ⷾ𐹲.򤐶; [B5, B6, V6]; xn--hvc220of37m.xn--3e36c; ; ;  # ⷾ𐹲.
+xn--hvc488g69j402t.xn--3e36c; ೸‍ⷾ𐹲.򤐶; [B5, B6, C2, V6]; xn--hvc488g69j402t.xn--3e36c; ; ;  # ⷾ𐹲.
+𐹢．Ⴍ₉⁸; 𐹢.Ⴍ98; [B1, P1, V6]; xn--9n0d.xn--98-7ek; ; ;  # 𐹢.Ⴍ98
+𐹢.Ⴍ98; ; [B1, P1, V6]; xn--9n0d.xn--98-7ek; ; ;  # 𐹢.Ⴍ98
+𐹢.ⴍ98; ; [B1]; xn--9n0d.xn--98-u61a; ; ;  # 𐹢.ⴍ98
+xn--9n0d.xn--98-u61a; 𐹢.ⴍ98; [B1]; xn--9n0d.xn--98-u61a; ; ;  # 𐹢.ⴍ98
+xn--9n0d.xn--98-7ek; 𐹢.Ⴍ98; [B1, V6]; xn--9n0d.xn--98-7ek; ; ;  # 𐹢.Ⴍ98
+𐹢．ⴍ₉⁸; 𐹢.ⴍ98; [B1]; xn--9n0d.xn--98-u61a; ; ;  # 𐹢.ⴍ98
+‌͏｡ß࣢⒚≯; ‌.ß࣢⒚≯; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--zca612bx9vo5b; ; .xn--ss-9if872xjjc; [B5, B6, P1, V6, A4_2] # .ß⒚≯
+‌͏｡ß࣢⒚≯; ‌.ß࣢⒚≯; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--zca612bx9vo5b; ; .xn--ss-9if872xjjc; [B5, B6, P1, V6, A4_2] # .ß⒚≯
+‌͏。ß࣢19.≯; ‌.ß࣢19.≯; [B1, B5, C1, P1, V6]; xn--0ug.xn--19-fia813f.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, P1, V6, A4_2] # .ß19.≯
+‌͏。ß࣢19.≯; ‌.ß࣢19.≯; [B1, B5, C1, P1, V6]; xn--0ug.xn--19-fia813f.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, P1, V6, A4_2] # .ß19.≯
+‌͏。SS࣢19.≯; ‌.ss࣢19.≯; [B1, B5, C1, P1, V6]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, P1, V6, A4_2] # .ss19.≯
+‌͏。SS࣢19.≯; ‌.ss࣢19.≯; [B1, B5, C1, P1, V6]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, P1, V6, A4_2] # .ss19.≯
+‌͏。ss࣢19.≯; ‌.ss࣢19.≯; [B1, B5, C1, P1, V6]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, P1, V6, A4_2] # .ss19.≯
+‌͏。ss࣢19.≯; ‌.ss࣢19.≯; [B1, B5, C1, P1, V6]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, P1, V6, A4_2] # .ss19.≯
+‌͏。Ss࣢19.≯; ‌.ss࣢19.≯; [B1, B5, C1, P1, V6]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, P1, V6, A4_2] # .ss19.≯
+‌͏。Ss࣢19.≯; ‌.ss࣢19.≯; [B1, B5, C1, P1, V6]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, P1, V6, A4_2] # .ss19.≯
+.xn--ss19-w0i.xn--hdh; .ss࣢19.≯; [B1, B5, V6, X4_2]; .xn--ss19-w0i.xn--hdh; [B1, B5, V6, A4_2]; ;  # .ss19.≯
+xn--0ug.xn--ss19-w0i.xn--hdh; ‌.ss࣢19.≯; [B1, B5, C1, V6]; xn--0ug.xn--ss19-w0i.xn--hdh; ; ;  # .ss19.≯
+xn--0ug.xn--19-fia813f.xn--hdh; ‌.ß࣢19.≯; [B1, B5, C1, V6]; xn--0ug.xn--19-fia813f.xn--hdh; ; ;  # .ß19.≯
+‌͏｡SS࣢⒚≯; ‌.ss࣢⒚≯; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, P1, V6, A4_2] # .ss⒚≯
+‌͏｡SS࣢⒚≯; ‌.ss࣢⒚≯; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, P1, V6, A4_2] # .ss⒚≯
+‌͏｡ss࣢⒚≯; ‌.ss࣢⒚≯; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, P1, V6, A4_2] # .ss⒚≯
+‌͏｡ss࣢⒚≯; ‌.ss࣢⒚≯; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, P1, V6, A4_2] # .ss⒚≯
+‌͏｡Ss࣢⒚≯; ‌.ss࣢⒚≯; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, P1, V6, A4_2] # .ss⒚≯
+‌͏｡Ss࣢⒚≯; ‌.ss࣢⒚≯; [B1, B5, B6, C1, P1, V6]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, P1, V6, A4_2] # .ss⒚≯
+.xn--ss-9if872xjjc; .ss࣢⒚≯; [B5, B6, V6, X4_2]; .xn--ss-9if872xjjc; [B5, B6, V6, A4_2]; ;  # .ss⒚≯
+xn--0ug.xn--ss-9if872xjjc; ‌.ss࣢⒚≯; [B1, B5, B6, C1, V6]; xn--0ug.xn--ss-9if872xjjc; ; ;  # .ss⒚≯
+xn--0ug.xn--zca612bx9vo5b; ‌.ß࣢⒚≯; [B1, B5, B6, C1, V6]; xn--0ug.xn--zca612bx9vo5b; ; ;  # .ß⒚≯
+‌𞥍ᡌ．𣃔; ‌𞥍ᡌ.𣃔; [B1, C1, P1, V6]; xn--c8e180bqz13b.xn--od1j; ; xn--c8e5919u.xn--od1j; [B2, B3, P1, V6] # ᡌ.𣃔
+‌𞥍ᡌ.𣃔; ; [B1, C1, P1, V6]; xn--c8e180bqz13b.xn--od1j; ; xn--c8e5919u.xn--od1j; [B2, B3, P1, V6] # ᡌ.𣃔
+xn--c8e5919u.xn--od1j; 𞥍ᡌ.𣃔; [B2, B3, V6]; xn--c8e5919u.xn--od1j; ; ;  # ᡌ.𣃔
+xn--c8e180bqz13b.xn--od1j; ‌𞥍ᡌ.𣃔; [B1, C1, V6]; xn--c8e180bqz13b.xn--od1j; ; ;  # ᡌ.𣃔
+ߐ򜬝-񡢬。ྠႻ𞷏𝆬; ߐ򜬝-񡢬.ྠႻ𞷏𝆬; [B1, B2, B3, P1, V5, V6]; xn----8bd11730jefvw.xn--wfd08cd265hgsxa; ; ;  # ߐ-.ྠႻ𝆬
+ߐ򜬝-񡢬。ྠⴛ𞷏𝆬; ߐ򜬝-񡢬.ྠⴛ𞷏𝆬; [B1, B2, B3, P1, V5, V6]; xn----8bd11730jefvw.xn--wfd802mpm20agsxa; ; ;  # ߐ-.ྠⴛ𝆬
+xn----8bd11730jefvw.xn--wfd802mpm20agsxa; ߐ򜬝-񡢬.ྠⴛ𞷏𝆬; [B1, B2, B3, V5, V6]; xn----8bd11730jefvw.xn--wfd802mpm20agsxa; ; ;  # ߐ-.ྠⴛ𝆬
+xn----8bd11730jefvw.xn--wfd08cd265hgsxa; ߐ򜬝-񡢬.ྠႻ𞷏𝆬; [B1, B2, B3, V5, V6]; xn----8bd11730jefvw.xn--wfd08cd265hgsxa; ; ;  # ߐ-.ྠႻ𝆬
+𝨥。⫟𑈾; 𝨥.⫟𑈾; [V5]; xn--n82h.xn--63iw010f; ; ;  # 𝨥.⫟𑈾
+xn--n82h.xn--63iw010f; 𝨥.⫟𑈾; [V5]; xn--n82h.xn--63iw010f; ; ;  # 𝨥.⫟𑈾
+⾛ݓ.Ⴕ𞠬؄‍; 走ݓ.Ⴕ𞠬؄‍; [B5, B6, C2, P1, V6]; xn--6ob9779d.xn--mfb785czmm0y85b; ; xn--6ob9779d.xn--mfb785ck569a; [B5, B6, P1, V6] # 走ݓ.Ⴕ𞠬
+走ݓ.Ⴕ𞠬؄‍; ; [B5, B6, C2, P1, V6]; xn--6ob9779d.xn--mfb785czmm0y85b; ; xn--6ob9779d.xn--mfb785ck569a; [B5, B6, P1, V6] # 走ݓ.Ⴕ𞠬
+走ݓ.ⴕ𞠬؄‍; ; [B5, B6, C2, P1, V6]; xn--6ob9779d.xn--mfb444k5gjt754b; ; xn--6ob9779d.xn--mfb511rxu80a; [B5, B6, P1, V6] # 走ݓ.ⴕ𞠬
+xn--6ob9779d.xn--mfb511rxu80a; 走ݓ.ⴕ𞠬؄; [B5, B6, V6]; xn--6ob9779d.xn--mfb511rxu80a; ; ;  # 走ݓ.ⴕ𞠬
+xn--6ob9779d.xn--mfb444k5gjt754b; 走ݓ.ⴕ𞠬؄‍; [B5, B6, C2, V6]; xn--6ob9779d.xn--mfb444k5gjt754b; ; ;  # 走ݓ.ⴕ𞠬
+xn--6ob9779d.xn--mfb785ck569a; 走ݓ.Ⴕ𞠬؄; [B5, B6, V6]; xn--6ob9779d.xn--mfb785ck569a; ; ;  # 走ݓ.Ⴕ𞠬
+xn--6ob9779d.xn--mfb785czmm0y85b; 走ݓ.Ⴕ𞠬؄‍; [B5, B6, C2, V6]; xn--6ob9779d.xn--mfb785czmm0y85b; ; ;  # 走ݓ.Ⴕ𞠬
+⾛ݓ.ⴕ𞠬؄‍; 走ݓ.ⴕ𞠬؄‍; [B5, B6, C2, P1, V6]; xn--6ob9779d.xn--mfb444k5gjt754b; ; xn--6ob9779d.xn--mfb511rxu80a; [B5, B6, P1, V6] # 走ݓ.ⴕ𞠬
+-ᢗ‌🄄.𑜢; ; [C1, P1, V3, V5, V6]; xn----pck312bx563c.xn--9h2d; ; xn----pck1820x.xn--9h2d; [P1, V3, V5, V6] # -ᢗ🄄.𑜢
+-ᢗ‌3,.𑜢; ; [C1, P1, V3, V5, V6]; xn---3,-3eu051c.xn--9h2d; ; xn---3,-3eu.xn--9h2d; [P1, V3, V5, V6] # -ᢗ3,.𑜢
+xn---3,-3eu.xn--9h2d; -ᢗ3,.𑜢; [P1, V3, V5, V6]; xn---3,-3eu.xn--9h2d; ; ;  # -ᢗ3,.𑜢
+xn---3,-3eu051c.xn--9h2d; -ᢗ‌3,.𑜢; [C1, P1, V3, V5, V6]; xn---3,-3eu051c.xn--9h2d; ; ;  # -ᢗ3,.𑜢
+xn----pck1820x.xn--9h2d; -ᢗ🄄.𑜢; [V3, V5, V6]; xn----pck1820x.xn--9h2d; ; ;  # -ᢗ🄄.𑜢
+xn----pck312bx563c.xn--9h2d; -ᢗ‌🄄.𑜢; [C1, V3, V5, V6]; xn----pck312bx563c.xn--9h2d; ; ;  # -ᢗ🄄.𑜢
+≠𐸁𹏁‌.Ⴚ򳄠; ; [B1, C1, P1, V6]; xn--0ug83gn618a21ov.xn--ynd49496l; ; xn--1ch2293gv3nr.xn--ynd49496l; [B1, P1, V6] # ≠.Ⴚ
+≠𐸁𹏁‌.Ⴚ򳄠; ≠𐸁𹏁‌.Ⴚ򳄠; [B1, C1, P1, V6]; xn--0ug83gn618a21ov.xn--ynd49496l; ; xn--1ch2293gv3nr.xn--ynd49496l; [B1, P1, V6] # ≠.Ⴚ
+≠𐸁𹏁‌.ⴚ򳄠; ≠𐸁𹏁‌.ⴚ򳄠; [B1, C1, P1, V6]; xn--0ug83gn618a21ov.xn--ilj23531g; ; xn--1ch2293gv3nr.xn--ilj23531g; [B1, P1, V6] # ≠.ⴚ
+≠𐸁𹏁‌.ⴚ򳄠; ; [B1, C1, P1, V6]; xn--0ug83gn618a21ov.xn--ilj23531g; ; xn--1ch2293gv3nr.xn--ilj23531g; [B1, P1, V6] # ≠.ⴚ
+xn--1ch2293gv3nr.xn--ilj23531g; ≠𐸁𹏁.ⴚ򳄠; [B1, V6]; xn--1ch2293gv3nr.xn--ilj23531g; ; ;  # ≠.ⴚ
+xn--0ug83gn618a21ov.xn--ilj23531g; ≠𐸁𹏁‌.ⴚ򳄠; [B1, C1, V6]; xn--0ug83gn618a21ov.xn--ilj23531g; ; ;  # ≠.ⴚ
+xn--1ch2293gv3nr.xn--ynd49496l; ≠𐸁𹏁.Ⴚ򳄠; [B1, V6]; xn--1ch2293gv3nr.xn--ynd49496l; ; ;  # ≠.Ⴚ
+xn--0ug83gn618a21ov.xn--ynd49496l; ≠𐸁𹏁‌.Ⴚ򳄠; [B1, C1, V6]; xn--0ug83gn618a21ov.xn--ynd49496l; ; ;  # ≠.Ⴚ
+٩｡󠇀𑇊; ٩.𑇊; [B1, B3, B6, V5]; xn--iib.xn--6d1d; ; ;  # ٩.𑇊
+٩。󠇀𑇊; ٩.𑇊; [B1, B3, B6, V5]; xn--iib.xn--6d1d; ; ;  # ٩.𑇊
+xn--iib.xn--6d1d; ٩.𑇊; [B1, B3, B6, V5]; xn--iib.xn--6d1d; ; ;  # ٩.𑇊
+ႆ𞶀≯⒍。-; ႆ𞶀≯⒍.-; [B1, P1, V3, V5, V6]; xn--hmd482gqqb8730g.-; ; ;  # ႆ≯⒍.-
+ႆ𞶀≯⒍。-; ႆ𞶀≯⒍.-; [B1, P1, V3, V5, V6]; xn--hmd482gqqb8730g.-; ; ;  # ႆ≯⒍.-
+ႆ𞶀≯6.。-; ႆ𞶀≯6..-; [B1, P1, V3, V5, V6, X4_2]; xn--6-oyg968k7h74b..-; [B1, P1, V3, V5, V6, A4_2]; ;  # ႆ≯6..-
+ႆ𞶀≯6.。-; ႆ𞶀≯6..-; [B1, P1, V3, V5, V6, X4_2]; xn--6-oyg968k7h74b..-; [B1, P1, V3, V5, V6, A4_2]; ;  # ႆ≯6..-
+xn--6-oyg968k7h74b..-; ႆ𞶀≯6..-; [B1, V3, V5, V6, X4_2]; xn--6-oyg968k7h74b..-; [B1, V3, V5, V6, A4_2]; ;  # ႆ≯6..-
+xn--hmd482gqqb8730g.-; ႆ𞶀≯⒍.-; [B1, V3, V5, V6]; xn--hmd482gqqb8730g.-; ; ;  # ႆ≯⒍.-
+឴.쮇-; ; [P1, V3, V5, V6]; xn--z3e.xn----938f; ; ;  # .쮇-
+឴.쮇-; ឴.쮇-; [P1, V3, V5, V6]; xn--z3e.xn----938f; ; ;  # .쮇-
+xn--z3e.xn----938f; ឴.쮇-; [V3, V5, V6]; xn--z3e.xn----938f; ; ;  # .쮇-
+‌𑓂。⒈-􀪛; ‌𑓂.⒈-􀪛; [C1, P1, V6]; xn--0ugy057g.xn----dcp29674o; ; xn--wz1d.xn----dcp29674o; [P1, V5, V6] # 𑓂.⒈-
+‌𑓂。1.-􀪛; ‌𑓂.1.-􀪛; [C1, P1, V3, V6]; xn--0ugy057g.1.xn----rg03o; ; xn--wz1d.1.xn----rg03o; [P1, V3, V5, V6] # 𑓂.1.-
+xn--wz1d.1.xn----rg03o; 𑓂.1.-􀪛; [V3, V5, V6]; xn--wz1d.1.xn----rg03o; ; ;  # 𑓂.1.-
+xn--0ugy057g.1.xn----rg03o; ‌𑓂.1.-􀪛; [C1, V3, V6]; xn--0ugy057g.1.xn----rg03o; ; ;  # 𑓂.1.-
+xn--wz1d.xn----dcp29674o; 𑓂.⒈-􀪛; [V5, V6]; xn--wz1d.xn----dcp29674o; ; ;  # 𑓂.⒈-
+xn--0ugy057g.xn----dcp29674o; ‌𑓂.⒈-􀪛; [C1, V6]; xn--0ugy057g.xn----dcp29674o; ; ;  # 𑓂.⒈-
+⒈ﺮ‌。⃩🖞‌𖬴; ⒈ر‌.⃩🖞‌𖬴; [B1, C1, P1, V5, V6]; xn--wgb253kmfd.xn--0ugz6a8040fty5d; ; xn--wgb746m.xn--c1g6021kg18c; [B1, P1, V5, V6] # ⒈ر.⃩🖞𖬴
+1.ر‌。⃩🖞‌𖬴; 1.ر‌.⃩🖞‌𖬴; [B1, B3, C1, V5]; 1.xn--wgb253k.xn--0ugz6a8040fty5d; ; 1.xn--wgb.xn--c1g6021kg18c; [B1, V5] # 1.ر.⃩🖞𖬴
+1.xn--wgb.xn--c1g6021kg18c; 1.ر.⃩🖞𖬴; [B1, V5]; 1.xn--wgb.xn--c1g6021kg18c; ; ;  # 1.ر.⃩🖞𖬴
+1.xn--wgb253k.xn--0ugz6a8040fty5d; 1.ر‌.⃩🖞‌𖬴; [B1, B3, C1, V5]; 1.xn--wgb253k.xn--0ugz6a8040fty5d; ; ;  # 1.ر.⃩🖞𖬴
+xn--wgb746m.xn--c1g6021kg18c; ⒈ر.⃩🖞𖬴; [B1, V5, V6]; xn--wgb746m.xn--c1g6021kg18c; ; ;  # ⒈ر.⃩🖞𖬴
+xn--wgb253kmfd.xn--0ugz6a8040fty5d; ⒈ر‌.⃩🖞‌𖬴; [B1, C1, V5, V6]; xn--wgb253kmfd.xn--0ugz6a8040fty5d; ; ;  # ⒈ر.⃩🖞𖬴
+󌭇｡𝟐ᮨߔ; 󌭇.2ᮨߔ; [B1, P1, V6]; xn--xm89d.xn--2-icd143m; ; ;  # .2ᮨߔ
+󌭇。2ᮨߔ; 󌭇.2ᮨߔ; [B1, P1, V6]; xn--xm89d.xn--2-icd143m; ; ;  # .2ᮨߔ
+xn--xm89d.xn--2-icd143m; 󌭇.2ᮨߔ; [B1, V6]; xn--xm89d.xn--2-icd143m; ; ;  # .2ᮨߔ
+ﶏ򫳺.ς‍𐹷; مخم򫳺.ς‍𐹷; [B2, B3, B5, B6, C2, P1, V6]; xn--tgb9bb64691z.xn--3xa006lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, P1, V6] # مخم.ς𐹷
+مخم򫳺.ς‍𐹷; ; [B2, B3, B5, B6, C2, P1, V6]; xn--tgb9bb64691z.xn--3xa006lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, P1, V6] # مخم.ς𐹷
+مخم򫳺.Σ‍𐹷; مخم򫳺.σ‍𐹷; [B2, B3, B5, B6, C2, P1, V6]; xn--tgb9bb64691z.xn--4xa895lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, P1, V6] # مخم.σ𐹷
+مخم򫳺.σ‍𐹷; ; [B2, B3, B5, B6, C2, P1, V6]; xn--tgb9bb64691z.xn--4xa895lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, P1, V6] # مخم.σ𐹷
+xn--tgb9bb64691z.xn--4xa6667k; مخم򫳺.σ𐹷; [B2, B3, B5, B6, V6]; xn--tgb9bb64691z.xn--4xa6667k; ; ;  # مخم.σ𐹷
+xn--tgb9bb64691z.xn--4xa895lrp7n; مخم򫳺.σ‍𐹷; [B2, B3, B5, B6, C2, V6]; xn--tgb9bb64691z.xn--4xa895lrp7n; ; ;  # مخم.σ𐹷
+xn--tgb9bb64691z.xn--3xa006lrp7n; مخم򫳺.ς‍𐹷; [B2, B3, B5, B6, C2, V6]; xn--tgb9bb64691z.xn--3xa006lrp7n; ; ;  # مخم.ς𐹷
+ﶏ򫳺.Σ‍𐹷; مخم򫳺.σ‍𐹷; [B2, B3, B5, B6, C2, P1, V6]; xn--tgb9bb64691z.xn--4xa895lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, P1, V6] # مخم.σ𐹷
+ﶏ򫳺.σ‍𐹷; مخم򫳺.σ‍𐹷; [B2, B3, B5, B6, C2, P1, V6]; xn--tgb9bb64691z.xn--4xa895lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, P1, V6] # مخم.σ𐹷
+⒎ہ؅｡꫶۵𐇽; ⒎ہ؅.꫶۵𐇽; [B1, P1, V5, V6]; xn--nfb98ai25e.xn--imb3805fxt8b; ; ;  # ⒎ہ.꫶۵𐇽
+7.ہ؅。꫶۵𐇽; 7.ہ؅.꫶۵𐇽; [B1, P1, V5, V6]; 7.xn--nfb98a.xn--imb3805fxt8b; ; ;  # 7.ہ.꫶۵𐇽
+7.xn--nfb98a.xn--imb3805fxt8b; 7.ہ؅.꫶۵𐇽; [B1, V5, V6]; 7.xn--nfb98a.xn--imb3805fxt8b; ; ;  # 7.ہ.꫶۵𐇽
+xn--nfb98ai25e.xn--imb3805fxt8b; ⒎ہ؅.꫶۵𐇽; [B1, V5, V6]; xn--nfb98ai25e.xn--imb3805fxt8b; ; ;  # ⒎ہ.꫶۵𐇽
+-ᡥ᠆󍲭。؅ᩝ𐹡; -ᡥ᠆󍲭.؅ᩝ𐹡; [B1, P1, V3, V6]; xn----f3j6s87156i.xn--nfb035hoo2p; ; ;  # -ᡥ᠆.ᩝ𐹡
+xn----f3j6s87156i.xn--nfb035hoo2p; -ᡥ᠆󍲭.؅ᩝ𐹡; [B1, V3, V6]; xn----f3j6s87156i.xn--nfb035hoo2p; ; ;  # -ᡥ᠆.ᩝ𐹡
+‍.ڽ٣֖; ; [B1, C2]; xn--1ug.xn--hcb32bni; ; .xn--hcb32bni; [A4_2] # .ڽ٣֖
+.xn--hcb32bni; .ڽ٣֖; [X4_2]; .xn--hcb32bni; [A4_2]; ;  # .ڽ٣֖
+xn--1ug.xn--hcb32bni; ‍.ڽ٣֖; [B1, C2]; xn--1ug.xn--hcb32bni; ; ;  # .ڽ٣֖
+xn--hcb32bni; ڽ٣֖; ; xn--hcb32bni; ; ;  # ڽ٣֖
+ڽ٣֖; ; ; xn--hcb32bni; ; ;  # ڽ٣֖
+㒧۱.Ⴚٸ‍; 㒧۱.Ⴚيٴ‍; [B5, B6, C2, P1, V6]; xn--emb715u.xn--mhb8f817ao2p; ; xn--emb715u.xn--mhb8f817a; [B5, B6, P1, V6] # 㒧۱.Ⴚيٴ
+㒧۱.Ⴚيٴ‍; ; [B5, B6, C2, P1, V6]; xn--emb715u.xn--mhb8f817ao2p; ; xn--emb715u.xn--mhb8f817a; [B5, B6, P1, V6] # 㒧۱.Ⴚيٴ
+㒧۱.ⴚيٴ‍; ; [B5, B6, C2]; xn--emb715u.xn--mhb8f960g03l; ; xn--emb715u.xn--mhb8fy26k; [B5, B6] # 㒧۱.ⴚيٴ
+xn--emb715u.xn--mhb8fy26k; 㒧۱.ⴚيٴ; [B5, B6]; xn--emb715u.xn--mhb8fy26k; ; ;  # 㒧۱.ⴚيٴ
+xn--emb715u.xn--mhb8f960g03l; 㒧۱.ⴚيٴ‍; [B5, B6, C2]; xn--emb715u.xn--mhb8f960g03l; ; ;  # 㒧۱.ⴚيٴ
+xn--emb715u.xn--mhb8f817a; 㒧۱.Ⴚيٴ; [B5, B6, V6]; xn--emb715u.xn--mhb8f817a; ; ;  # 㒧۱.Ⴚيٴ
+xn--emb715u.xn--mhb8f817ao2p; 㒧۱.Ⴚيٴ‍; [B5, B6, C2, V6]; xn--emb715u.xn--mhb8f817ao2p; ; ;  # 㒧۱.Ⴚيٴ
+㒧۱.ⴚٸ‍; 㒧۱.ⴚيٴ‍; [B5, B6, C2]; xn--emb715u.xn--mhb8f960g03l; ; xn--emb715u.xn--mhb8fy26k; [B5, B6] # 㒧۱.ⴚيٴ
+ྔꡋ-．-𖬴; ྔꡋ-.-𖬴; [V3, V5]; xn----ukg9938i.xn----4u5m; ; ;  # ྔꡋ-.-𖬴
+ྔꡋ-.-𖬴; ; [V3, V5]; xn----ukg9938i.xn----4u5m; ; ;  # ྔꡋ-.-𖬴
+xn----ukg9938i.xn----4u5m; ྔꡋ-.-𖬴; [V3, V5]; xn----ukg9938i.xn----4u5m; ; ;  # ྔꡋ-.-𖬴
+񿒳-⋢‌．标-; 񿒳-⋢‌.标-; [C1, P1, V3, V6]; xn----sgn90kn5663a.xn----qj7b; ; xn----9mo67451g.xn----qj7b; [P1, V3, V6] # -⋢.标-
+񿒳-⋢‌．标-; 񿒳-⋢‌.标-; [C1, P1, V3, V6]; xn----sgn90kn5663a.xn----qj7b; ; xn----9mo67451g.xn----qj7b; [P1, V3, V6] # -⋢.标-
+񿒳-⋢‌.标-; ; [C1, P1, V3, V6]; xn----sgn90kn5663a.xn----qj7b; ; xn----9mo67451g.xn----qj7b; [P1, V3, V6] # -⋢.标-
+񿒳-⋢‌.标-; 񿒳-⋢‌.标-; [C1, P1, V3, V6]; xn----sgn90kn5663a.xn----qj7b; ; xn----9mo67451g.xn----qj7b; [P1, V3, V6] # -⋢.标-
+xn----9mo67451g.xn----qj7b; 񿒳-⋢.标-; [V3, V6]; xn----9mo67451g.xn----qj7b; ; ;  # -⋢.标-
+xn----sgn90kn5663a.xn----qj7b; 񿒳-⋢‌.标-; [C1, V3, V6]; xn----sgn90kn5663a.xn----qj7b; ; ;  # -⋢.标-
+ٱ．ςߜ; ٱ.ςߜ; [B5, B6]; xn--qib.xn--3xa41s; ; xn--qib.xn--4xa21s;  # ٱ.ςߜ
+ٱ.ςߜ; ; [B5, B6]; xn--qib.xn--3xa41s; ; xn--qib.xn--4xa21s;  # ٱ.ςߜ
+ٱ.Σߜ; ٱ.σߜ; [B5, B6]; xn--qib.xn--4xa21s; ; ;  # ٱ.σߜ
+ٱ.σߜ; ; [B5, B6]; xn--qib.xn--4xa21s; ; ;  # ٱ.σߜ
+xn--qib.xn--4xa21s; ٱ.σߜ; [B5, B6]; xn--qib.xn--4xa21s; ; ;  # ٱ.σߜ
+xn--qib.xn--3xa41s; ٱ.ςߜ; [B5, B6]; xn--qib.xn--3xa41s; ; ;  # ٱ.ςߜ
+ٱ．Σߜ; ٱ.σߜ; [B5, B6]; xn--qib.xn--4xa21s; ; ;  # ٱ.σߜ
+ٱ．σߜ; ٱ.σߜ; [B5, B6]; xn--qib.xn--4xa21s; ; ;  # ٱ.σߜ
+񼈶؅．ࣁ‍𑑂𱼱; 񼈶؅.ࣁ‍𑑂𱼱; [B2, B3, B5, B6, C2, P1, V6]; xn--nfb17942h.xn--nzb240jv06otevq; ; xn--nfb17942h.xn--nzb6708kx3pn; [B2, B3, B5, B6, P1, V6] # .𑑂
+񼈶؅.ࣁ‍𑑂𱼱; ; [B2, B3, B5, B6, C2, P1, V6]; xn--nfb17942h.xn--nzb240jv06otevq; ; xn--nfb17942h.xn--nzb6708kx3pn; [B2, B3, B5, B6, P1, V6] # .𑑂
+xn--nfb17942h.xn--nzb6708kx3pn; 񼈶؅.ࣁ𑑂𱼱; [B2, B3, B5, B6, V6]; xn--nfb17942h.xn--nzb6708kx3pn; ; ;  # .𑑂
+xn--nfb17942h.xn--nzb240jv06otevq; 񼈶؅.ࣁ‍𑑂𱼱; [B2, B3, B5, B6, C2, V6]; xn--nfb17942h.xn--nzb240jv06otevq; ; ;  # .𑑂
+𐹾𐋩𞵜｡᯲; 𐹾𐋩𞵜.᯲; [B1, P1, V5, V6]; xn--d97cn8rn44p.xn--0zf; ; ;  # 𐹾𐋩.᯲
+𐹾𐋩𞵜。᯲; 𐹾𐋩𞵜.᯲; [B1, P1, V5, V6]; xn--d97cn8rn44p.xn--0zf; ; ;  # 𐹾𐋩.᯲
+xn--d97cn8rn44p.xn--0zf; 𐹾𐋩𞵜.᯲; [B1, V5, V6]; xn--d97cn8rn44p.xn--0zf; ; ;  # 𐹾𐋩.᯲
+6ᅠᰳ󠸧.򟜊锰ܬς; ; [B1, B5, P1, V6]; xn--6-5bh476ewr517a.xn--3xa16ohw6pk078g; ; xn--6-5bh476ewr517a.xn--4xa95ohw6pk078g;  # 6ᰳ.锰ܬς
+6ᅠᰳ󠸧.򟜊锰ܬΣ; 6ᅠᰳ󠸧.򟜊锰ܬσ; [B1, B5, P1, V6]; xn--6-5bh476ewr517a.xn--4xa95ohw6pk078g; ; ;  # 6ᰳ.锰ܬσ
+6ᅠᰳ󠸧.򟜊锰ܬσ; ; [B1, B5, P1, V6]; xn--6-5bh476ewr517a.xn--4xa95ohw6pk078g; ; ;  # 6ᰳ.锰ܬσ
+xn--6-5bh476ewr517a.xn--4xa95ohw6pk078g; 6ᅠᰳ󠸧.򟜊锰ܬσ; [B1, B5, V6]; xn--6-5bh476ewr517a.xn--4xa95ohw6pk078g; ; ;  # 6ᰳ.锰ܬσ
+xn--6-5bh476ewr517a.xn--3xa16ohw6pk078g; 6ᅠᰳ󠸧.򟜊锰ܬς; [B1, B5, V6]; xn--6-5bh476ewr517a.xn--3xa16ohw6pk078g; ; ;  # 6ᰳ.锰ܬς
+ڳ︄񅎦𝟽｡𐹽; ڳ񅎦7.𐹽; [B1, B2, P1, V6]; xn--7-yuc34665f.xn--1o0d; ; ;  # ڳ7.𐹽
+ڳ︄񅎦7。𐹽; ڳ񅎦7.𐹽; [B1, B2, P1, V6]; xn--7-yuc34665f.xn--1o0d; ; ;  # ڳ7.𐹽
+xn--7-yuc34665f.xn--1o0d; ڳ񅎦7.𐹽; [B1, B2, V6]; xn--7-yuc34665f.xn--1o0d; ; ;  # ڳ7.𐹽
+𞮧．‌⫞; 𞮧.‌⫞; [B1, C1, P1, V6]; xn--pw6h.xn--0ug283b; ; xn--pw6h.xn--53i; [B1, P1, V6] # .⫞
+𞮧.‌⫞; ; [B1, C1, P1, V6]; xn--pw6h.xn--0ug283b; ; xn--pw6h.xn--53i; [B1, P1, V6] # .⫞
+xn--pw6h.xn--53i; 𞮧.⫞; [B1, V6]; xn--pw6h.xn--53i; ; ;  # .⫞
+xn--pw6h.xn--0ug283b; 𞮧.‌⫞; [B1, C1, V6]; xn--pw6h.xn--0ug283b; ; ;  # .⫞
+-񕉴.۠ᢚ-; ; [P1, V3, V5, V6]; xn----qi38c.xn----jxc827k; ; ;  # -.۠ᢚ-
+xn----qi38c.xn----jxc827k; -񕉴.۠ᢚ-; [V3, V5, V6]; xn----qi38c.xn----jxc827k; ; ;  # -.۠ᢚ-
+⌁‍𑄴．‌𝟩٬; ⌁‍𑄴.‌7٬; [B1, C1, C2]; xn--1ug38i2093a.xn--7-xqc297q; ; xn--nhh5394g.xn--7-xqc; [B1] # ⌁𑄴.7٬
+⌁‍𑄴.‌7٬; ; [B1, C1, C2]; xn--1ug38i2093a.xn--7-xqc297q; ; xn--nhh5394g.xn--7-xqc; [B1] # ⌁𑄴.7٬
+xn--nhh5394g.xn--7-xqc; ⌁𑄴.7٬; [B1]; xn--nhh5394g.xn--7-xqc; ; ;  # ⌁𑄴.7٬
+xn--1ug38i2093a.xn--7-xqc297q; ⌁‍𑄴.‌7٬; [B1, C1, C2]; xn--1ug38i2093a.xn--7-xqc297q; ; ;  # ⌁𑄴.7٬
+︒ﴅืﻼ。岓᯲󠾃ᡂ; ︒صىืلا.岓᯲󠾃ᡂ; [B1, P1, V6]; xn--mgb1a7bt462hf267a.xn--17e10qe61f9r71s; ; ;  # ︒صىืلا.岓᯲ᡂ
+。صىืلا。岓᯲󠾃ᡂ; .صىืلا.岓᯲󠾃ᡂ; [P1, V6, X4_2]; .xn--mgb1a7bt462h.xn--17e10qe61f9r71s; [P1, V6, A4_2]; ;  # .صىืلا.岓᯲ᡂ
+.xn--mgb1a7bt462h.xn--17e10qe61f9r71s; .صىืلا.岓᯲󠾃ᡂ; [V6, X4_2]; .xn--mgb1a7bt462h.xn--17e10qe61f9r71s; [V6, A4_2]; ;  # .صىืلا.岓᯲ᡂ
+xn--mgb1a7bt462hf267a.xn--17e10qe61f9r71s; ︒صىืلا.岓᯲󠾃ᡂ; [B1, V6]; xn--mgb1a7bt462hf267a.xn--17e10qe61f9r71s; ; ;  # ︒صىืلا.岓᯲ᡂ
+𐹨。8𑁆; 𐹨.8𑁆; [B1]; xn--go0d.xn--8-yu7i; ; ;  # 𐹨.8𑁆
+xn--go0d.xn--8-yu7i; 𐹨.8𑁆; [B1]; xn--go0d.xn--8-yu7i; ; ;  # 𐹨.8𑁆
+𞀕ൃ．ꡚࣺ𐹰ൄ; 𞀕ൃ.ꡚࣺ𐹰ൄ; [B1, B3, B5, B6, V5]; xn--mxc5210v.xn--90b01t8u2p1ltd; ; ;  # 𞀕ൃ.ꡚࣺ𐹰ൄ
+𞀕ൃ.ꡚࣺ𐹰ൄ; ; [B1, B3, B5, B6, V5]; xn--mxc5210v.xn--90b01t8u2p1ltd; ; ;  # 𞀕ൃ.ꡚࣺ𐹰ൄ
+xn--mxc5210v.xn--90b01t8u2p1ltd; 𞀕ൃ.ꡚࣺ𐹰ൄ; [B1, B3, B5, B6, V5]; xn--mxc5210v.xn--90b01t8u2p1ltd; ; ;  # 𞀕ൃ.ꡚࣺ𐹰ൄ
+󆩏𐦹̃｡󠍅; 󆩏𐦹̃.󠍅; [B1, B5, B6, P1, V6]; xn--nsa1265kp9z9e.xn--xt36e; ; ;  # ̃.
+󆩏𐦹̃。󠍅; 󆩏𐦹̃.󠍅; [B1, B5, B6, P1, V6]; xn--nsa1265kp9z9e.xn--xt36e; ; ;  # ̃.
+xn--nsa1265kp9z9e.xn--xt36e; 󆩏𐦹̃.󠍅; [B1, B5, B6, V6]; xn--nsa1265kp9z9e.xn--xt36e; ; ;  # ̃.
+ᢌ．-࡚; ᢌ.-࡚; [V3]; xn--59e.xn----5jd; ; ;  # ᢌ.-࡚
+ᢌ.-࡚; ; [V3]; xn--59e.xn----5jd; ; ;  # ᢌ.-࡚
+xn--59e.xn----5jd; ᢌ.-࡚; [V3]; xn--59e.xn----5jd; ; ;  # ᢌ.-࡚
+𥛛𑘶｡𐹬𐲸்; 𥛛𑘶.𐹬𐲸்; [B1, P1, V6]; xn--jb2dj685c.xn--xmc5562kmcb; ; ;  # 𥛛𑘶.𐹬்
+𥛛𑘶。𐹬𐲸்; 𥛛𑘶.𐹬𐲸்; [B1, P1, V6]; xn--jb2dj685c.xn--xmc5562kmcb; ; ;  # 𥛛𑘶.𐹬்
+xn--jb2dj685c.xn--xmc5562kmcb; 𥛛𑘶.𐹬𐲸்; [B1, V6]; xn--jb2dj685c.xn--xmc5562kmcb; ; ;  # 𥛛𑘶.𐹬்
+Ⴐݿ．‌; Ⴐݿ.‌; [B1, B5, B6, C1, P1, V6]; xn--gqb918b.xn--0ug; ; xn--gqb918b.; [B5, B6, P1, V6] # Ⴐݿ.
+Ⴐݿ.‌; ; [B1, B5, B6, C1, P1, V6]; xn--gqb918b.xn--0ug; ; xn--gqb918b.; [B5, B6, P1, V6] # Ⴐݿ.
+ⴐݿ.‌; ; [B1, B5, B6, C1]; xn--gqb743q.xn--0ug; ; xn--gqb743q.; [B5, B6] # ⴐݿ.
+xn--gqb743q.; ⴐݿ.; [B5, B6]; xn--gqb743q.; ; ;  # ⴐݿ.
+xn--gqb743q.xn--0ug; ⴐݿ.‌; [B1, B5, B6, C1]; xn--gqb743q.xn--0ug; ; ;  # ⴐݿ.
+xn--gqb918b.; Ⴐݿ.; [B5, B6, V6]; xn--gqb918b.; ; ;  # Ⴐݿ.
+xn--gqb918b.xn--0ug; Ⴐݿ.‌; [B1, B5, B6, C1, V6]; xn--gqb918b.xn--0ug; ; ;  # Ⴐݿ.
+ⴐݿ．‌; ⴐݿ.‌; [B1, B5, B6, C1]; xn--gqb743q.xn--0ug; ; xn--gqb743q.; [B5, B6] # ⴐݿ.
+🄅𑲞-⒈。‍ᠩڥ; 🄅𑲞-⒈.‍ᠩڥ; [B1, C2, P1, V6]; xn----ecp8796hjtvg.xn--7jb180gexf; ; xn----ecp8796hjtvg.xn--7jb180g; [B1, B5, B6, P1, V6] # 🄅𑲞-⒈.ᠩڥ
+4,𑲞-1.。‍ᠩڥ; 4,𑲞-1..‍ᠩڥ; [B1, C2, P1, V6, X4_2]; xn--4,-1-w401a..xn--7jb180gexf; [B1, C2, P1, V6, A4_2]; xn--4,-1-w401a..xn--7jb180g; [B1, B5, B6, P1, V6, A4_2] # 4,𑲞-1..ᠩڥ
+xn--4,-1-w401a..xn--7jb180g; 4,𑲞-1..ᠩڥ; [B1, B5, B6, P1, V6, X4_2]; xn--4,-1-w401a..xn--7jb180g; [B1, B5, B6, P1, V6, A4_2]; ;  # 4,𑲞-1..ᠩڥ
+xn--4,-1-w401a..xn--7jb180gexf; 4,𑲞-1..‍ᠩڥ; [B1, C2, P1, V6, X4_2]; xn--4,-1-w401a..xn--7jb180gexf; [B1, C2, P1, V6, A4_2]; ;  # 4,𑲞-1..ᠩڥ
+xn----ecp8796hjtvg.xn--7jb180g; 🄅𑲞-⒈.ᠩڥ; [B1, B5, B6, V6]; xn----ecp8796hjtvg.xn--7jb180g; ; ;  # 🄅𑲞-⒈.ᠩڥ
+xn----ecp8796hjtvg.xn--7jb180gexf; 🄅𑲞-⒈.‍ᠩڥ; [B1, C2, V6]; xn----ecp8796hjtvg.xn--7jb180gexf; ; ;  # 🄅𑲞-⒈.ᠩڥ
+񗀤。𞤪򮿋; 񗀤.𞤪򮿋; [B2, B3, P1, V6]; xn--4240a.xn--ie6h83808a; ; ;  # .𞤪
+񗀤。𞤈򮿋; 񗀤.𞤪򮿋; [B2, B3, P1, V6]; xn--4240a.xn--ie6h83808a; ; ;  # .𞤪
+xn--4240a.xn--ie6h83808a; 񗀤.𞤪򮿋; [B2, B3, V6]; xn--4240a.xn--ie6h83808a; ; ;  # .𞤪
+ׁ۲｡𐮊٬𝨊鄨; ׁ۲.𐮊٬𝨊鄨; [B1, B2, B3, V5]; xn--pdb42d.xn--lib6412enztdwv6h; ; ;  # ׁ۲.𐮊٬𝨊鄨
+ׁ۲。𐮊٬𝨊鄨; ׁ۲.𐮊٬𝨊鄨; [B1, B2, B3, V5]; xn--pdb42d.xn--lib6412enztdwv6h; ; ;  # ׁ۲.𐮊٬𝨊鄨
+xn--pdb42d.xn--lib6412enztdwv6h; ׁ۲.𐮊٬𝨊鄨; [B1, B2, B3, V5]; xn--pdb42d.xn--lib6412enztdwv6h; ; ;  # ׁ۲.𐮊٬𝨊鄨
+𞭳-ꡁ。ᩩ்-; 𞭳-ꡁ.ᩩ்-; [B1, B2, B3, P1, V3, V5, V6]; xn----be4e4276f.xn----lze333i; ; ;  # -ꡁ.ᩩ்-
+xn----be4e4276f.xn----lze333i; 𞭳-ꡁ.ᩩ்-; [B1, B2, B3, V3, V5, V6]; xn----be4e4276f.xn----lze333i; ; ;  # -ꡁ.ᩩ்-
+္-𚮭🞢．ß; ္-𚮭🞢.ß; [P1, V5, V6]; xn----9tg11172akr8b.xn--zca; ; xn----9tg11172akr8b.ss;  # ္-🞢.ß
+္-𚮭🞢.ß; ; [P1, V5, V6]; xn----9tg11172akr8b.xn--zca; ; xn----9tg11172akr8b.ss;  # ္-🞢.ß
+္-𚮭🞢.SS; ္-𚮭🞢.ss; [P1, V5, V6]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+္-𚮭🞢.ss; ; [P1, V5, V6]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+္-𚮭🞢.Ss; ္-𚮭🞢.ss; [P1, V5, V6]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+xn----9tg11172akr8b.ss; ္-𚮭🞢.ss; [V5, V6]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+xn----9tg11172akr8b.xn--zca; ္-𚮭🞢.ß; [V5, V6]; xn----9tg11172akr8b.xn--zca; ; ;  # ္-🞢.ß
+္-𚮭🞢．SS; ္-𚮭🞢.ss; [P1, V5, V6]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+္-𚮭🞢．ss; ္-𚮭🞢.ss; [P1, V5, V6]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+္-𚮭🞢．Ss; ္-𚮭🞢.ss; [P1, V5, V6]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+ﳲ-‌｡Ⴟ‌␣; ـَّ-‌.Ⴟ‌␣; [B3, B6, C1, P1, V6]; xn----eoc6bm0504a.xn--3nd849e05c; ; xn----eoc6bm.xn--3nd240h; [B3, B6, P1, V3, V6] # ـَّ-.Ⴟ␣
+ـَّ-‌。Ⴟ‌␣; ـَّ-‌.Ⴟ‌␣; [B3, B6, C1, P1, V6]; xn----eoc6bm0504a.xn--3nd849e05c; ; xn----eoc6bm.xn--3nd240h; [B3, B6, P1, V3, V6] # ـَّ-.Ⴟ␣
+ـَّ-‌。ⴟ‌␣; ـَّ-‌.ⴟ‌␣; [B3, B6, C1]; xn----eoc6bm0504a.xn--0ug13nd0j; ; xn----eoc6bm.xn--xph904a; [B3, B6, V3] # ـَّ-.ⴟ␣
+xn----eoc6bm.xn--xph904a; ـَّ-.ⴟ␣; [B3, B6, V3]; xn----eoc6bm.xn--xph904a; ; ;  # ـَّ-.ⴟ␣
+xn----eoc6bm0504a.xn--0ug13nd0j; ـَّ-‌.ⴟ‌␣; [B3, B6, C1]; xn----eoc6bm0504a.xn--0ug13nd0j; ; ;  # ـَّ-.ⴟ␣
+xn----eoc6bm.xn--3nd240h; ـَّ-.Ⴟ␣; [B3, B6, V3, V6]; xn----eoc6bm.xn--3nd240h; ; ;  # ـَّ-.Ⴟ␣
+xn----eoc6bm0504a.xn--3nd849e05c; ـَّ-‌.Ⴟ‌␣; [B3, B6, C1, V6]; xn----eoc6bm0504a.xn--3nd849e05c; ; ;  # ـَّ-.Ⴟ␣
+ﳲ-‌｡ⴟ‌␣; ـَّ-‌.ⴟ‌␣; [B3, B6, C1]; xn----eoc6bm0504a.xn--0ug13nd0j; ; xn----eoc6bm.xn--xph904a; [B3, B6, V3] # ـَّ-.ⴟ␣
+്-‍‌｡񥞧₅≠; ്-‍‌.񥞧5≠; [C1, C2, P1, V5, V6]; xn----jmf215lda.xn--5-ufo50192e; ; xn----jmf.xn--5-ufo50192e; [P1, V3, V5, V6] # ്-.5≠
+്-‍‌｡񥞧₅≠; ്-‍‌.񥞧5≠; [C1, C2, P1, V5, V6]; xn----jmf215lda.xn--5-ufo50192e; ; xn----jmf.xn--5-ufo50192e; [P1, V3, V5, V6] # ്-.5≠
+്-‍‌。񥞧5≠; ്-‍‌.񥞧5≠; [C1, C2, P1, V5, V6]; xn----jmf215lda.xn--5-ufo50192e; ; xn----jmf.xn--5-ufo50192e; [P1, V3, V5, V6] # ്-.5≠
+്-‍‌。񥞧5≠; ്-‍‌.񥞧5≠; [C1, C2, P1, V5, V6]; xn----jmf215lda.xn--5-ufo50192e; ; xn----jmf.xn--5-ufo50192e; [P1, V3, V5, V6] # ്-.5≠
+xn----jmf.xn--5-ufo50192e; ്-.񥞧5≠; [V3, V5, V6]; xn----jmf.xn--5-ufo50192e; ; ;  # ്-.5≠
+xn----jmf215lda.xn--5-ufo50192e; ്-‍‌.񥞧5≠; [C1, C2, V5, V6]; xn----jmf215lda.xn--5-ufo50192e; ; ;  # ്-.5≠
+锣。੍󠘻󠚆; 锣.੍󠘻󠚆; [P1, V5, V6]; xn--gc5a.xn--ybc83044ppga; ; ;  # 锣.੍
+xn--gc5a.xn--ybc83044ppga; 锣.੍󠘻󠚆; [V5, V6]; xn--gc5a.xn--ybc83044ppga; ; ;  # 锣.੍
+ؽ𑈾．ى‍꤫; ؽ𑈾.ى‍꤫; [B3, C2]; xn--8gb2338k.xn--lhb603k060h; ; xn--8gb2338k.xn--lhb0154f; [] # ؽ𑈾.ى꤫
+ؽ𑈾.ى‍꤫; ; [B3, C2]; xn--8gb2338k.xn--lhb603k060h; ; xn--8gb2338k.xn--lhb0154f; [] # ؽ𑈾.ى꤫
+xn--8gb2338k.xn--lhb0154f; ؽ𑈾.ى꤫; ; xn--8gb2338k.xn--lhb0154f; ; ;  # ؽ𑈾.ى꤫
+ؽ𑈾.ى꤫; ; ; xn--8gb2338k.xn--lhb0154f; ; ;  # ؽ𑈾.ى꤫
+xn--8gb2338k.xn--lhb603k060h; ؽ𑈾.ى‍꤫; [B3, C2]; xn--8gb2338k.xn--lhb603k060h; ; ;  # ؽ𑈾.ى꤫
+٦⁴Ⴅ．ࢽ‌; ٦4Ⴅ.ࢽ‌; [B1, B3, C1, P1, V6]; xn--4-kqc489e.xn--jzb840j; ; xn--4-kqc489e.xn--jzb; [B1, P1, V6] # ٦4Ⴅ.ࢽ
+٦4Ⴅ.ࢽ‌; ; [B1, B3, C1, P1, V6]; xn--4-kqc489e.xn--jzb840j; ; xn--4-kqc489e.xn--jzb; [B1, P1, V6] # ٦4Ⴅ.ࢽ
+٦4ⴅ.ࢽ‌; ; [B1, B3, C1]; xn--4-kqc6770a.xn--jzb840j; ; xn--4-kqc6770a.xn--jzb; [B1] # ٦4ⴅ.ࢽ
+xn--4-kqc6770a.xn--jzb; ٦4ⴅ.ࢽ; [B1]; xn--4-kqc6770a.xn--jzb; ; ;  # ٦4ⴅ.ࢽ
+xn--4-kqc6770a.xn--jzb840j; ٦4ⴅ.ࢽ‌; [B1, B3, C1]; xn--4-kqc6770a.xn--jzb840j; ; ;  # ٦4ⴅ.ࢽ
+xn--4-kqc489e.xn--jzb; ٦4Ⴅ.ࢽ; [B1, V6]; xn--4-kqc489e.xn--jzb; ; ;  # ٦4Ⴅ.ࢽ
+xn--4-kqc489e.xn--jzb840j; ٦4Ⴅ.ࢽ‌; [B1, B3, C1, V6]; xn--4-kqc489e.xn--jzb840j; ; ;  # ٦4Ⴅ.ࢽ
+٦⁴ⴅ．ࢽ‌; ٦4ⴅ.ࢽ‌; [B1, B3, C1]; xn--4-kqc6770a.xn--jzb840j; ; xn--4-kqc6770a.xn--jzb; [B1] # ٦4ⴅ.ࢽ
+ჁႱ6̘。ßᬃ; ჁႱ6̘.ßᬃ; [P1, V6]; xn--6-8cb555h2b.xn--zca894k; ; xn--6-8cb555h2b.xn--ss-2vq;  # ჁႱ6̘.ßᬃ
+ⴡⴑ6̘。ßᬃ; ⴡⴑ6̘.ßᬃ; ; xn--6-8cb7433a2ba.xn--zca894k; ; xn--6-8cb7433a2ba.xn--ss-2vq;  # ⴡⴑ6̘.ßᬃ
+ჁႱ6̘。SSᬃ; ჁႱ6̘.ssᬃ; [P1, V6]; xn--6-8cb555h2b.xn--ss-2vq; ; ;  # ჁႱ6̘.ssᬃ
+ⴡⴑ6̘。ssᬃ; ⴡⴑ6̘.ssᬃ; ; xn--6-8cb7433a2ba.xn--ss-2vq; ; ;  # ⴡⴑ6̘.ssᬃ
+Ⴡⴑ6̘。Ssᬃ; Ⴡⴑ6̘.ssᬃ; [P1, V6]; xn--6-8cb306hms1a.xn--ss-2vq; ; ;  # Ⴡⴑ6̘.ssᬃ
+xn--6-8cb306hms1a.xn--ss-2vq; Ⴡⴑ6̘.ssᬃ; [V6]; xn--6-8cb306hms1a.xn--ss-2vq; ; ;  # Ⴡⴑ6̘.ssᬃ
+xn--6-8cb7433a2ba.xn--ss-2vq; ⴡⴑ6̘.ssᬃ; ; xn--6-8cb7433a2ba.xn--ss-2vq; ; ;  # ⴡⴑ6̘.ssᬃ
+ⴡⴑ6̘.ssᬃ; ; ; xn--6-8cb7433a2ba.xn--ss-2vq; ; ;  # ⴡⴑ6̘.ssᬃ
+ჁႱ6̘.SSᬃ; ჁႱ6̘.ssᬃ; [P1, V6]; xn--6-8cb555h2b.xn--ss-2vq; ; ;  # ჁႱ6̘.ssᬃ
+Ⴡⴑ6̘.Ssᬃ; Ⴡⴑ6̘.ssᬃ; [P1, V6]; xn--6-8cb306hms1a.xn--ss-2vq; ; ;  # Ⴡⴑ6̘.ssᬃ
+xn--6-8cb555h2b.xn--ss-2vq; ჁႱ6̘.ssᬃ; [V6]; xn--6-8cb555h2b.xn--ss-2vq; ; ;  # ჁႱ6̘.ssᬃ
+xn--6-8cb7433a2ba.xn--zca894k; ⴡⴑ6̘.ßᬃ; ; xn--6-8cb7433a2ba.xn--zca894k; ; ;  # ⴡⴑ6̘.ßᬃ
+ⴡⴑ6̘.ßᬃ; ; ; xn--6-8cb7433a2ba.xn--zca894k; ; xn--6-8cb7433a2ba.xn--ss-2vq;  # ⴡⴑ6̘.ßᬃ
+xn--6-8cb555h2b.xn--zca894k; ჁႱ6̘.ßᬃ; [V6]; xn--6-8cb555h2b.xn--zca894k; ; ;  # ჁႱ6̘.ßᬃ
+򋡐｡≯𑋪; 򋡐.≯𑋪; [P1, V6]; xn--eo08b.xn--hdh3385g; ; ;  # .≯𑋪
+򋡐｡≯𑋪; 򋡐.≯𑋪; [P1, V6]; xn--eo08b.xn--hdh3385g; ; ;  # .≯𑋪
+򋡐。≯𑋪; 򋡐.≯𑋪; [P1, V6]; xn--eo08b.xn--hdh3385g; ; ;  # .≯𑋪
+򋡐。≯𑋪; 򋡐.≯𑋪; [P1, V6]; xn--eo08b.xn--hdh3385g; ; ;  # .≯𑋪
+xn--eo08b.xn--hdh3385g; 򋡐.≯𑋪; [V6]; xn--eo08b.xn--hdh3385g; ; ;  # .≯𑋪
+ٚ۲。‌-᯳࣢; ٚ۲.‌-᯳࣢; [B1, C1, P1, V5, V6]; xn--2hb81a.xn----xrd657l30d; ; xn--2hb81a.xn----xrd657l; [B1, P1, V3, V5, V6] # ٚ۲.-᯳
+xn--2hb81a.xn----xrd657l; ٚ۲.-᯳࣢; [B1, V3, V5, V6]; xn--2hb81a.xn----xrd657l; ; ;  # ٚ۲.-᯳
+xn--2hb81a.xn----xrd657l30d; ٚ۲.‌-᯳࣢; [B1, C1, V5, V6]; xn--2hb81a.xn----xrd657l30d; ; ;  # ٚ۲.-᯳
+󠄏𖬴󠲽｡ﾠ; 𖬴󠲽.ﾠ; [P1, V5, V6]; xn--619ep9154c.xn--cl7c; ; ;  # 𖬴.
+󠄏𖬴󠲽。ᅠ; 𖬴󠲽.ᅠ; [P1, V5, V6]; xn--619ep9154c.xn--psd; ; ;  # 𖬴.
+xn--619ep9154c.xn--psd; 𖬴󠲽.ᅠ; [V5, V6]; xn--619ep9154c.xn--psd; ; ;  # 𖬴.
+xn--619ep9154c.xn--cl7c; 𖬴󠲽.ﾠ; [V5, V6]; xn--619ep9154c.xn--cl7c; ; ;  # 𖬴.
+ß⒈ݠ힮．􉖲󠅄؅򉔯; ß⒈ݠ힮.􉖲؅򉔯; [B5, P1, V6]; xn--zca444a0s1ao12n.xn--nfb09923ifkyyb; ; xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb;  # ß⒈ݠ.
+ß1.ݠ힮.􉖲󠅄؅򉔯; ß1.ݠ힮.􉖲؅򉔯; [B2, B3, B5, P1, V6]; xn--1-pfa.xn--kpb6677h.xn--nfb09923ifkyyb; ; ss1.xn--kpb6677h.xn--nfb09923ifkyyb;  # ß1.ݠ.
+SS1.ݠ힮.􉖲󠅄؅򉔯; ss1.ݠ힮.􉖲؅򉔯; [B2, B3, B5, P1, V6]; ss1.xn--kpb6677h.xn--nfb09923ifkyyb; ; ;  # ss1.ݠ.
+ss1.ݠ힮.􉖲󠅄؅򉔯; ss1.ݠ힮.􉖲؅򉔯; [B2, B3, B5, P1, V6]; ss1.xn--kpb6677h.xn--nfb09923ifkyyb; ; ;  # ss1.ݠ.
+Ss1.ݠ힮.􉖲󠅄؅򉔯; ss1.ݠ힮.􉖲؅򉔯; [B2, B3, B5, P1, V6]; ss1.xn--kpb6677h.xn--nfb09923ifkyyb; ; ;  # ss1.ݠ.
+ss1.xn--kpb6677h.xn--nfb09923ifkyyb; ss1.ݠ힮.􉖲؅򉔯; [B2, B3, B5, V6]; ss1.xn--kpb6677h.xn--nfb09923ifkyyb; ; ;  # ss1.ݠ.
+xn--1-pfa.xn--kpb6677h.xn--nfb09923ifkyyb; ß1.ݠ힮.􉖲؅򉔯; [B2, B3, B5, V6]; xn--1-pfa.xn--kpb6677h.xn--nfb09923ifkyyb; ; ;  # ß1.ݠ.
+SS⒈ݠ힮．􉖲󠅄؅򉔯; ss⒈ݠ힮.􉖲؅򉔯; [B5, P1, V6]; xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb; ; ;  # ss⒈ݠ.
+ss⒈ݠ힮．􉖲󠅄؅򉔯; ss⒈ݠ힮.􉖲؅򉔯; [B5, P1, V6]; xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb; ; ;  # ss⒈ݠ.
+Ss⒈ݠ힮．􉖲󠅄؅򉔯; ss⒈ݠ힮.􉖲؅򉔯; [B5, P1, V6]; xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb; ; ;  # ss⒈ݠ.
+xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb; ss⒈ݠ힮.􉖲؅򉔯; [B5, V6]; xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb; ; ;  # ss⒈ݠ.
+xn--zca444a0s1ao12n.xn--nfb09923ifkyyb; ß⒈ݠ힮.􉖲؅򉔯; [B5, V6]; xn--zca444a0s1ao12n.xn--nfb09923ifkyyb; ; ;  # ß⒈ݠ.
+󠭔.𐋱₂; 󠭔.𐋱2; [P1, V6]; xn--vi56e.xn--2-w91i; ; ;  # .𐋱2
+󠭔.𐋱2; ; [P1, V6]; xn--vi56e.xn--2-w91i; ; ;  # .𐋱2
+xn--vi56e.xn--2-w91i; 󠭔.𐋱2; [V6]; xn--vi56e.xn--2-w91i; ; ;  # .𐋱2
+ܖे。-ßڥ‌; ܖे.-ßڥ‌; [B1, C1, V3]; xn--gnb63i.xn----qfa845bhx4a; ; xn--gnb63i.xn---ss-4ef; [B1, V3] # ܖे.-ßڥ
+ܖे。-SSڥ‌; ܖे.-ssڥ‌; [B1, C1, V3]; xn--gnb63i.xn---ss-4ef9263a; ; xn--gnb63i.xn---ss-4ef; [B1, V3] # ܖे.-ssڥ
+ܖे。-ssڥ‌; ܖे.-ssڥ‌; [B1, C1, V3]; xn--gnb63i.xn---ss-4ef9263a; ; xn--gnb63i.xn---ss-4ef; [B1, V3] # ܖे.-ssڥ
+ܖे。-Ssڥ‌; ܖे.-ssڥ‌; [B1, C1, V3]; xn--gnb63i.xn---ss-4ef9263a; ; xn--gnb63i.xn---ss-4ef; [B1, V3] # ܖे.-ssڥ
+xn--gnb63i.xn---ss-4ef; ܖे.-ssڥ; [B1, V3]; xn--gnb63i.xn---ss-4ef; ; ;  # ܖे.-ssڥ
+xn--gnb63i.xn---ss-4ef9263a; ܖे.-ssڥ‌; [B1, C1, V3]; xn--gnb63i.xn---ss-4ef9263a; ; ;  # ܖे.-ssڥ
+xn--gnb63i.xn----qfa845bhx4a; ܖे.-ßڥ‌; [B1, C1, V3]; xn--gnb63i.xn----qfa845bhx4a; ; ;  # ܖे.-ßڥ
+ᮩ‍ت񡚈．᳕䷉Ⴡ; ᮩ‍ت񡚈.᳕䷉Ⴡ; [B1, C2, P1, V5, V6]; xn--pgb911imgdrw34r.xn--5nd792dgv3b; ; xn--pgb911izv33i.xn--5nd792dgv3b; [B1, P1, V5, V6] # ᮩت.᳕䷉Ⴡ
+ᮩ‍ت񡚈.᳕䷉Ⴡ; ; [B1, C2, P1, V5, V6]; xn--pgb911imgdrw34r.xn--5nd792dgv3b; ; xn--pgb911izv33i.xn--5nd792dgv3b; [B1, P1, V5, V6] # ᮩت.᳕䷉Ⴡ
+ᮩ‍ت񡚈.᳕䷉ⴡ; ; [B1, C2, P1, V5, V6]; xn--pgb911imgdrw34r.xn--i6f270etuy; ; xn--pgb911izv33i.xn--i6f270etuy; [B1, P1, V5, V6] # ᮩت.᳕䷉ⴡ
+xn--pgb911izv33i.xn--i6f270etuy; ᮩت񡚈.᳕䷉ⴡ; [B1, V5, V6]; xn--pgb911izv33i.xn--i6f270etuy; ; ;  # ᮩت.᳕䷉ⴡ
+xn--pgb911imgdrw34r.xn--i6f270etuy; ᮩ‍ت񡚈.᳕䷉ⴡ; [B1, C2, V5, V6]; xn--pgb911imgdrw34r.xn--i6f270etuy; ; ;  # ᮩت.᳕䷉ⴡ
+xn--pgb911izv33i.xn--5nd792dgv3b; ᮩت񡚈.᳕䷉Ⴡ; [B1, V5, V6]; xn--pgb911izv33i.xn--5nd792dgv3b; ; ;  # ᮩت.᳕䷉Ⴡ
+xn--pgb911imgdrw34r.xn--5nd792dgv3b; ᮩ‍ت񡚈.᳕䷉Ⴡ; [B1, C2, V5, V6]; xn--pgb911imgdrw34r.xn--5nd792dgv3b; ; ;  # ᮩت.᳕䷉Ⴡ
+ᮩ‍ت񡚈．᳕䷉ⴡ; ᮩ‍ت񡚈.᳕䷉ⴡ; [B1, C2, P1, V5, V6]; xn--pgb911imgdrw34r.xn--i6f270etuy; ; xn--pgb911izv33i.xn--i6f270etuy; [B1, P1, V5, V6] # ᮩت.᳕䷉ⴡ
+⶿.ß‍; ; [C2, P1, V6]; xn--7pj.xn--zca870n; ; xn--7pj.ss; [P1, V6] # .ß
+⶿.SS‍; ⶿.ss‍; [C2, P1, V6]; xn--7pj.xn--ss-n1t; ; xn--7pj.ss; [P1, V6] # .ss
+⶿.ss‍; ; [C2, P1, V6]; xn--7pj.xn--ss-n1t; ; xn--7pj.ss; [P1, V6] # .ss
+⶿.Ss‍; ⶿.ss‍; [C2, P1, V6]; xn--7pj.xn--ss-n1t; ; xn--7pj.ss; [P1, V6] # .ss
+xn--7pj.ss; ⶿.ss; [V6]; xn--7pj.ss; ; ;  # .ss
+xn--7pj.xn--ss-n1t; ⶿.ss‍; [C2, V6]; xn--7pj.xn--ss-n1t; ; ;  # .ss
+xn--7pj.xn--zca870n; ⶿.ß‍; [C2, V6]; xn--7pj.xn--zca870n; ; ;  # .ß
+᯳︒.ت≯ꡂ; ; [B2, B3, B6, P1, V5, V6]; xn--1zf8957g.xn--pgb885lry5g; ; ;  # ᯳︒.ت≯ꡂ
+᯳︒.ت≯ꡂ; ᯳︒.ت≯ꡂ; [B2, B3, B6, P1, V5, V6]; xn--1zf8957g.xn--pgb885lry5g; ; ;  # ᯳︒.ت≯ꡂ
+᯳。.ت≯ꡂ; ᯳..ت≯ꡂ; [B2, B3, P1, V5, V6, X4_2]; xn--1zf..xn--pgb885lry5g; [B2, B3, P1, V5, V6, A4_2]; ;  # ᯳..ت≯ꡂ
+᯳。.ت≯ꡂ; ᯳..ت≯ꡂ; [B2, B3, P1, V5, V6, X4_2]; xn--1zf..xn--pgb885lry5g; [B2, B3, P1, V5, V6, A4_2]; ;  # ᯳..ت≯ꡂ
+xn--1zf..xn--pgb885lry5g; ᯳..ت≯ꡂ; [B2, B3, V5, V6, X4_2]; xn--1zf..xn--pgb885lry5g; [B2, B3, V5, V6, A4_2]; ;  # ᯳..ت≯ꡂ
+xn--1zf8957g.xn--pgb885lry5g; ᯳︒.ت≯ꡂ; [B2, B3, B6, V5, V6]; xn--1zf8957g.xn--pgb885lry5g; ; ;  # ᯳︒.ت≯ꡂ
+≮≠񏻃｡-𫠆ڷ𐹪; ≮≠񏻃.-𫠆ڷ𐹪; [B1, P1, V3, V6]; xn--1ch1a29470f.xn----7uc5363rc1rn; ; ;  # ≮≠.-𫠆ڷ𐹪
+≮≠񏻃｡-𫠆ڷ𐹪; ≮≠񏻃.-𫠆ڷ𐹪; [B1, P1, V3, V6]; xn--1ch1a29470f.xn----7uc5363rc1rn; ; ;  # ≮≠.-𫠆ڷ𐹪
+≮≠񏻃。-𫠆ڷ𐹪; ≮≠񏻃.-𫠆ڷ𐹪; [B1, P1, V3, V6]; xn--1ch1a29470f.xn----7uc5363rc1rn; ; ;  # ≮≠.-𫠆ڷ𐹪
+≮≠񏻃。-𫠆ڷ𐹪; ≮≠񏻃.-𫠆ڷ𐹪; [B1, P1, V3, V6]; xn--1ch1a29470f.xn----7uc5363rc1rn; ; ;  # ≮≠.-𫠆ڷ𐹪
+xn--1ch1a29470f.xn----7uc5363rc1rn; ≮≠񏻃.-𫠆ڷ𐹪; [B1, V3, V6]; xn--1ch1a29470f.xn----7uc5363rc1rn; ; ;  # ≮≠.-𫠆ڷ𐹪
+𐹡ݷ。ꡂ; 𐹡ݷ.ꡂ; [B1]; xn--7pb5275k.xn--bc9a; ; ;  # 𐹡ݷ.ꡂ
+xn--7pb5275k.xn--bc9a; 𐹡ݷ.ꡂ; [B1]; xn--7pb5275k.xn--bc9a; ; ;  # 𐹡ݷ.ꡂ
+Ⴉ𝆅񔻅ؙ.ß𐧦𐹳ݵ; ; [B5, B6, P1, V6]; xn--7fb125cjv87a7xvz.xn--zca684a699vf2d; ; xn--7fb125cjv87a7xvz.xn--ss-zme7575xp0e;  # Ⴉؙ𝆅.ß𐧦𐹳ݵ
+ⴉ𝆅񔻅ؙ.ß𐧦𐹳ݵ; ; [B5, B6, P1, V6]; xn--7fb940rwt3z7xvz.xn--zca684a699vf2d; ; xn--7fb940rwt3z7xvz.xn--ss-zme7575xp0e;  # ⴉؙ𝆅.ß𐧦𐹳ݵ
+Ⴉ𝆅񔻅ؙ.SS𐧦𐹳ݵ; Ⴉ𝆅񔻅ؙ.ss𐧦𐹳ݵ; [B5, B6, P1, V6]; xn--7fb125cjv87a7xvz.xn--ss-zme7575xp0e; ; ;  # Ⴉؙ𝆅.ss𐧦𐹳ݵ
+ⴉ𝆅񔻅ؙ.ss𐧦𐹳ݵ; ; [B5, B6, P1, V6]; xn--7fb940rwt3z7xvz.xn--ss-zme7575xp0e; ; ;  # ⴉؙ𝆅.ss𐧦𐹳ݵ
+Ⴉ𝆅񔻅ؙ.Ss𐧦𐹳ݵ; Ⴉ𝆅񔻅ؙ.ss𐧦𐹳ݵ; [B5, B6, P1, V6]; xn--7fb125cjv87a7xvz.xn--ss-zme7575xp0e; ; ;  # Ⴉؙ𝆅.ss𐧦𐹳ݵ
+xn--7fb125cjv87a7xvz.xn--ss-zme7575xp0e; Ⴉ𝆅񔻅ؙ.ss𐧦𐹳ݵ; [B5, B6, V6]; xn--7fb125cjv87a7xvz.xn--ss-zme7575xp0e; ; ;  # Ⴉؙ𝆅.ss𐧦𐹳ݵ
+xn--7fb940rwt3z7xvz.xn--ss-zme7575xp0e; ⴉ𝆅񔻅ؙ.ss𐧦𐹳ݵ; [B5, B6, V6]; xn--7fb940rwt3z7xvz.xn--ss-zme7575xp0e; ; ;  # ⴉؙ𝆅.ss𐧦𐹳ݵ
+xn--7fb940rwt3z7xvz.xn--zca684a699vf2d; ⴉ𝆅񔻅ؙ.ß𐧦𐹳ݵ; [B5, B6, V6]; xn--7fb940rwt3z7xvz.xn--zca684a699vf2d; ; ;  # ⴉؙ𝆅.ß𐧦𐹳ݵ
+xn--7fb125cjv87a7xvz.xn--zca684a699vf2d; Ⴉ𝆅񔻅ؙ.ß𐧦𐹳ݵ; [B5, B6, V6]; xn--7fb125cjv87a7xvz.xn--zca684a699vf2d; ; ;  # Ⴉؙ𝆅.ß𐧦𐹳ݵ
+‍ك𐧾↙.񊽡; ; [B1, C2, P1, V6]; xn--fhb713k87ag053c.xn--7s4w; ; xn--fhb011lnp8n.xn--7s4w; [B3, P1, V6] # ك𐧾↙.
+xn--fhb011lnp8n.xn--7s4w; ك𐧾↙.񊽡; [B3, V6]; xn--fhb011lnp8n.xn--7s4w; ; ;  # ك𐧾↙.
+xn--fhb713k87ag053c.xn--7s4w; ‍ك𐧾↙.񊽡; [B1, C2, V6]; xn--fhb713k87ag053c.xn--7s4w; ; ;  # ك𐧾↙.
+梉。‌; 梉.‌; [C1]; xn--7zv.xn--0ug; ; xn--7zv.; [] # 梉.
+xn--7zv.; 梉.; ; xn--7zv.; ; ;  # 梉.
+梉.; ; ; xn--7zv.; ; ;  # 梉.
+xn--7zv.xn--0ug; 梉.‌; [C1]; xn--7zv.xn--0ug; ; ;  # 梉.
+ꡣ-≠.‍𞤗𐅢Ↄ; ꡣ-≠.‍𞤹𐅢Ↄ; [B1, B6, C2, P1, V6]; xn----ufo9661d.xn--1ug79cm620c71sh; ; xn----ufo9661d.xn--q5g0929fhm4f; [B2, B3, B6, P1, V6] # ꡣ-≠.𞤹𐅢Ↄ
+ꡣ-≠.‍𞤗𐅢Ↄ; ꡣ-≠.‍𞤹𐅢Ↄ; [B1, B6, C2, P1, V6]; xn----ufo9661d.xn--1ug79cm620c71sh; ; xn----ufo9661d.xn--q5g0929fhm4f; [B2, B3, B6, P1, V6] # ꡣ-≠.𞤹𐅢Ↄ
+ꡣ-≠.‍𞤹𐅢ↄ; ꡣ-≠.‍𞤹𐅢ↄ; [B1, B6, C2, P1, V6]; xn----ufo9661d.xn--1ug99cj620c71sh; ; xn----ufo9661d.xn--r5gy929fhm4f; [B2, B3, B6, P1, V6] # ꡣ-≠.𞤹𐅢ↄ
+ꡣ-≠.‍𞤹𐅢ↄ; ; [B1, B6, C2, P1, V6]; xn----ufo9661d.xn--1ug99cj620c71sh; ; xn----ufo9661d.xn--r5gy929fhm4f; [B2, B3, B6, P1, V6] # ꡣ-≠.𞤹𐅢ↄ
+ꡣ-≠.‍𞤗𐅢ↄ; ꡣ-≠.‍𞤹𐅢ↄ; [B1, B6, C2, P1, V6]; xn----ufo9661d.xn--1ug99cj620c71sh; ; xn----ufo9661d.xn--r5gy929fhm4f; [B2, B3, B6, P1, V6] # ꡣ-≠.𞤹𐅢ↄ
+ꡣ-≠.‍𞤗𐅢ↄ; ꡣ-≠.‍𞤹𐅢ↄ; [B1, B6, C2, P1, V6]; xn----ufo9661d.xn--1ug99cj620c71sh; ; xn----ufo9661d.xn--r5gy929fhm4f; [B2, B3, B6, P1, V6] # ꡣ-≠.𞤹𐅢ↄ
+xn----ufo9661d.xn--r5gy929fhm4f; ꡣ-≠.𞤹𐅢ↄ; [B2, B3, B6, V6]; xn----ufo9661d.xn--r5gy929fhm4f; ; ;  # ꡣ-≠.𞤹𐅢ↄ
+xn----ufo9661d.xn--1ug99cj620c71sh; ꡣ-≠.‍𞤹𐅢ↄ; [B1, B6, C2, V6]; xn----ufo9661d.xn--1ug99cj620c71sh; ; ;  # ꡣ-≠.𞤹𐅢ↄ
+xn----ufo9661d.xn--q5g0929fhm4f; ꡣ-≠.𞤹𐅢Ↄ; [B2, B3, B6, V6]; xn----ufo9661d.xn--q5g0929fhm4f; ; ;  # ꡣ-≠.𞤹𐅢Ↄ
+xn----ufo9661d.xn--1ug79cm620c71sh; ꡣ-≠.‍𞤹𐅢Ↄ; [B1, B6, C2, V6]; xn----ufo9661d.xn--1ug79cm620c71sh; ; ;  # ꡣ-≠.𞤹𐅢Ↄ
+ς⒐𝆫⸵｡𐱢🄊𝟳; ς⒐𝆫⸵.𐱢🄊7; [B6, P1, V6]; xn--3xa019nwtghi25b.xn--7-075iy877c; ; xn--4xa809nwtghi25b.xn--7-075iy877c;  # ς⒐𝆫⸵.🄊7
+ς9.𝆫⸵。𐱢9,7; ς9.𝆫⸵.𐱢9,7; [B1, P1, V5, V6]; xn--9-xmb.xn--ltj1535k.xn--9,7-r67t; ; xn--9-zmb.xn--ltj1535k.xn--9,7-r67t;  # ς9.𝆫⸵.9,7
+Σ9.𝆫⸵。𐱢9,7; σ9.𝆫⸵.𐱢9,7; [B1, P1, V5, V6]; xn--9-zmb.xn--ltj1535k.xn--9,7-r67t; ; ;  # σ9.𝆫⸵.9,7
+σ9.𝆫⸵。𐱢9,7; σ9.𝆫⸵.𐱢9,7; [B1, P1, V5, V6]; xn--9-zmb.xn--ltj1535k.xn--9,7-r67t; ; ;  # σ9.𝆫⸵.9,7
+xn--9-zmb.xn--ltj1535k.xn--9,7-r67t; σ9.𝆫⸵.𐱢9,7; [B1, P1, V5, V6]; xn--9-zmb.xn--ltj1535k.xn--9,7-r67t; ; ;  # σ9.𝆫⸵.9,7
+xn--9-xmb.xn--ltj1535k.xn--9,7-r67t; ς9.𝆫⸵.𐱢9,7; [B1, P1, V5, V6]; xn--9-xmb.xn--ltj1535k.xn--9,7-r67t; ; ;  # ς9.𝆫⸵.9,7
+Σ⒐𝆫⸵｡𐱢🄊𝟳; σ⒐𝆫⸵.𐱢🄊7; [B6, P1, V6]; xn--4xa809nwtghi25b.xn--7-075iy877c; ; ;  # σ⒐𝆫⸵.🄊7
+σ⒐𝆫⸵｡𐱢🄊𝟳; σ⒐𝆫⸵.𐱢🄊7; [B6, P1, V6]; xn--4xa809nwtghi25b.xn--7-075iy877c; ; ;  # σ⒐𝆫⸵.🄊7
+xn--4xa809nwtghi25b.xn--7-075iy877c; σ⒐𝆫⸵.𐱢🄊7; [B6, V6]; xn--4xa809nwtghi25b.xn--7-075iy877c; ; ;  # σ⒐𝆫⸵.🄊7
+xn--3xa019nwtghi25b.xn--7-075iy877c; ς⒐𝆫⸵.𐱢🄊7; [B6, V6]; xn--3xa019nwtghi25b.xn--7-075iy877c; ; ;  # ς⒐𝆫⸵.🄊7
+ࡓ．‌ß; ࡓ.‌ß; [B1, C1]; xn--iwb.xn--zca570n; ; xn--iwb.ss; [] # ࡓ.ß
+ࡓ.‌ß; ; [B1, C1]; xn--iwb.xn--zca570n; ; xn--iwb.ss; [] # ࡓ.ß
+ࡓ.‌SS; ࡓ.‌ss; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+ࡓ.‌ss; ; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+xn--iwb.ss; ࡓ.ss; ; xn--iwb.ss; ; ;  # ࡓ.ss
+ࡓ.ss; ; ; xn--iwb.ss; ; ;  # ࡓ.ss
+ࡓ.SS; ࡓ.ss; ; xn--iwb.ss; ; ;  # ࡓ.ss
+xn--iwb.xn--ss-i1t; ࡓ.‌ss; [B1, C1]; xn--iwb.xn--ss-i1t; ; ;  # ࡓ.ss
+xn--iwb.xn--zca570n; ࡓ.‌ß; [B1, C1]; xn--iwb.xn--zca570n; ; ;  # ࡓ.ß
+ࡓ．‌SS; ࡓ.‌ss; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+ࡓ．‌ss; ࡓ.‌ss; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+ࡓ.‌Ss; ࡓ.‌ss; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+ࡓ．‌Ss; ࡓ.‌ss; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+񯶣-.‍ݎꥍ󠻨; ; [B1, B6, C2, P1, V3, V6]; xn----s116e.xn--1ob387jy90hq459k; ; xn----s116e.xn--1ob6504fmf40i; [B3, B6, P1, V3, V6] # -.ݎꥍ
+xn----s116e.xn--1ob6504fmf40i; 񯶣-.ݎꥍ󠻨; [B3, B6, V3, V6]; xn----s116e.xn--1ob6504fmf40i; ; ;  # -.ݎꥍ
+xn----s116e.xn--1ob387jy90hq459k; 񯶣-.‍ݎꥍ󠻨; [B1, B6, C2, V3, V6]; xn----s116e.xn--1ob387jy90hq459k; ; ;  # -.ݎꥍ
+䃚蟥-。-񽒘⒈; 䃚蟥-.-񽒘⒈; [P1, V3, V6]; xn----n50a258u.xn----ecp33805f; ; ;  # 䃚蟥-.-⒈
+䃚蟥-。-񽒘1.; 䃚蟥-.-񽒘1.; [P1, V3, V6]; xn----n50a258u.xn---1-up07j.; ; ;  # 䃚蟥-.-1.
+xn----n50a258u.xn---1-up07j.; 䃚蟥-.-񽒘1.; [V3, V6]; xn----n50a258u.xn---1-up07j.; ; ;  # 䃚蟥-.-1.
+xn----n50a258u.xn----ecp33805f; 䃚蟥-.-񽒘⒈; [V3, V6]; xn----n50a258u.xn----ecp33805f; ; ;  # 䃚蟥-.-⒈
+𐹸䚵-ꡡ。⺇; 𐹸䚵-ꡡ.⺇; [B1]; xn----bm3an932a1l5d.xn--xvj; ; ;  # 𐹸䚵-ꡡ.⺇
+xn----bm3an932a1l5d.xn--xvj; 𐹸䚵-ꡡ.⺇; [B1]; xn----bm3an932a1l5d.xn--xvj; ; ;  # 𐹸䚵-ꡡ.⺇
+𑄳。᫜𐹻; 𑄳.᫜𐹻; [B1, B3, B5, B6, P1, V5, V6]; xn--v80d.xn--2rf1154i; ; ;  # 𑄳.𐹻
+xn--v80d.xn--2rf1154i; 𑄳.᫜𐹻; [B1, B3, B5, B6, V5, V6]; xn--v80d.xn--2rf1154i; ; ;  # 𑄳.𐹻
+≮𐹻.⒎𑂵ں؂; ; [B1, P1, V6]; xn--gdhx904g.xn--kfb18a325efm3s; ; ;  # ≮𐹻.⒎𑂵ں
+≮𐹻.⒎𑂵ں؂; ≮𐹻.⒎𑂵ں؂; [B1, P1, V6]; xn--gdhx904g.xn--kfb18a325efm3s; ; ;  # ≮𐹻.⒎𑂵ں
+≮𐹻.7.𑂵ں؂; ; [B1, P1, V5, V6]; xn--gdhx904g.7.xn--kfb18an307d; ; ;  # ≮𐹻.7.𑂵ں
+≮𐹻.7.𑂵ں؂; ≮𐹻.7.𑂵ں؂; [B1, P1, V5, V6]; xn--gdhx904g.7.xn--kfb18an307d; ; ;  # ≮𐹻.7.𑂵ں
+xn--gdhx904g.7.xn--kfb18an307d; ≮𐹻.7.𑂵ں؂; [B1, V5, V6]; xn--gdhx904g.7.xn--kfb18an307d; ; ;  # ≮𐹻.7.𑂵ں
+xn--gdhx904g.xn--kfb18a325efm3s; ≮𐹻.⒎𑂵ں؂; [B1, V6]; xn--gdhx904g.xn--kfb18a325efm3s; ; ;  # ≮𐹻.⒎𑂵ں
+ᢔ≠􋉂.‍𐋢; ; [C2, P1, V6]; xn--ebf031cf7196a.xn--1ug9540g; ; xn--ebf031cf7196a.xn--587c; [P1, V6] # ᢔ≠.𐋢
+ᢔ≠􋉂.‍𐋢; ᢔ≠􋉂.‍𐋢; [C2, P1, V6]; xn--ebf031cf7196a.xn--1ug9540g; ; xn--ebf031cf7196a.xn--587c; [P1, V6] # ᢔ≠.𐋢
+xn--ebf031cf7196a.xn--587c; ᢔ≠􋉂.𐋢; [V6]; xn--ebf031cf7196a.xn--587c; ; ;  # ᢔ≠.𐋢
+xn--ebf031cf7196a.xn--1ug9540g; ᢔ≠􋉂.‍𐋢; [C2, V6]; xn--ebf031cf7196a.xn--1ug9540g; ; ;  # ᢔ≠.𐋢
+𐩁≮񣊛≯．٬𞵕⳿; 𐩁≮񣊛≯.٬𞵕⳿; [B1, B2, B3, P1, V6]; xn--gdhc0519o0y27b.xn--lib468q0d21a; ; ;  # 𐩁≮≯.٬⳿
+𐩁≮񣊛≯．٬𞵕⳿; 𐩁≮񣊛≯.٬𞵕⳿; [B1, B2, B3, P1, V6]; xn--gdhc0519o0y27b.xn--lib468q0d21a; ; ;  # 𐩁≮≯.٬⳿
+𐩁≮񣊛≯.٬𞵕⳿; ; [B1, B2, B3, P1, V6]; xn--gdhc0519o0y27b.xn--lib468q0d21a; ; ;  # 𐩁≮≯.٬⳿
+𐩁≮񣊛≯.٬𞵕⳿; 𐩁≮񣊛≯.٬𞵕⳿; [B1, B2, B3, P1, V6]; xn--gdhc0519o0y27b.xn--lib468q0d21a; ; ;  # 𐩁≮≯.٬⳿
+xn--gdhc0519o0y27b.xn--lib468q0d21a; 𐩁≮񣊛≯.٬𞵕⳿; [B1, B2, B3, V6]; xn--gdhc0519o0y27b.xn--lib468q0d21a; ; ;  # 𐩁≮≯.٬⳿
+-｡⺐; -.⺐; [V3]; -.xn--6vj; ; ;  # -.⺐
+-。⺐; -.⺐; [V3]; -.xn--6vj; ; ;  # -.⺐
+-.xn--6vj; -.⺐; [V3]; -.xn--6vj; ; ;  # -.⺐
+󠰩𑲬．ٜ; 󠰩𑲬.ٜ; [P1, V5, V6]; xn--sn3d59267c.xn--4hb; ; ;  # 𑲬.ٜ
+󠰩𑲬.ٜ; ; [P1, V5, V6]; xn--sn3d59267c.xn--4hb; ; ;  # 𑲬.ٜ
+xn--sn3d59267c.xn--4hb; 󠰩𑲬.ٜ; [V5, V6]; xn--sn3d59267c.xn--4hb; ; ;  # 𑲬.ٜ
+𐍺.񚇃‌; ; [C1, P1, V5, V6]; xn--ie8c.xn--0ug03366c; ; xn--ie8c.xn--2g51a; [P1, V5, V6] # 𐍺.
+xn--ie8c.xn--2g51a; 𐍺.񚇃; [V5, V6]; xn--ie8c.xn--2g51a; ; ;  # 𐍺.
+xn--ie8c.xn--0ug03366c; 𐍺.񚇃‌; [C1, V5, V6]; xn--ie8c.xn--0ug03366c; ; ;  # 𐍺.
+ؽۣ.𐨎; ; [B1, B3, B6, V5]; xn--8gb64a.xn--mr9c; ; ;  # ؽۣ.𐨎
+xn--8gb64a.xn--mr9c; ؽۣ.𐨎; [B1, B3, B6, V5]; xn--8gb64a.xn--mr9c; ; ;  # ؽۣ.𐨎
+漦Ⴙς.񡻀𐴄; ; [B5, B6, P1, V6]; xn--3xa157d717e.xn--9d0d3162t; ; xn--4xa947d717e.xn--9d0d3162t;  # 漦Ⴙς.𐴄
+漦ⴙς.񡻀𐴄; ; [B5, B6, P1, V6]; xn--3xa972sl47b.xn--9d0d3162t; ; xn--4xa772sl47b.xn--9d0d3162t;  # 漦ⴙς.𐴄
+漦ႹΣ.񡻀𐴄; 漦Ⴙσ.񡻀𐴄; [B5, B6, P1, V6]; xn--4xa947d717e.xn--9d0d3162t; ; ;  # 漦Ⴙσ.𐴄
+漦ⴙσ.񡻀𐴄; ; [B5, B6, P1, V6]; xn--4xa772sl47b.xn--9d0d3162t; ; ;  # 漦ⴙσ.𐴄
+漦Ⴙσ.񡻀𐴄; ; [B5, B6, P1, V6]; xn--4xa947d717e.xn--9d0d3162t; ; ;  # 漦Ⴙσ.𐴄
+xn--4xa947d717e.xn--9d0d3162t; 漦Ⴙσ.񡻀𐴄; [B5, B6, V6]; xn--4xa947d717e.xn--9d0d3162t; ; ;  # 漦Ⴙσ.𐴄
+xn--4xa772sl47b.xn--9d0d3162t; 漦ⴙσ.񡻀𐴄; [B5, B6, V6]; xn--4xa772sl47b.xn--9d0d3162t; ; ;  # 漦ⴙσ.𐴄
+xn--3xa972sl47b.xn--9d0d3162t; 漦ⴙς.񡻀𐴄; [B5, B6, V6]; xn--3xa972sl47b.xn--9d0d3162t; ; ;  # 漦ⴙς.𐴄
+xn--3xa157d717e.xn--9d0d3162t; 漦Ⴙς.񡻀𐴄; [B5, B6, V6]; xn--3xa157d717e.xn--9d0d3162t; ; ;  # 漦Ⴙς.𐴄
+𐹫踧್򫚇.󜀃⒈𝨤; ; [B1, P1, V6]; xn--8tc1437dro0d6q06h.xn--tsh2611ncu71e; ; ;  # 𐹫踧್.⒈𝨤
+𐹫踧್򫚇.󜀃1.𝨤; ; [B1, B3, B6, P1, V5, V6]; xn--8tc1437dro0d6q06h.xn--1-p948l.xn--m82h; ; ;  # 𐹫踧್.1.𝨤
+xn--8tc1437dro0d6q06h.xn--1-p948l.xn--m82h; 𐹫踧್򫚇.󜀃1.𝨤; [B1, B3, B6, V5, V6]; xn--8tc1437dro0d6q06h.xn--1-p948l.xn--m82h; ; ;  # 𐹫踧್.1.𝨤
+xn--8tc1437dro0d6q06h.xn--tsh2611ncu71e; 𐹫踧್򫚇.󜀃⒈𝨤; [B1, V6]; xn--8tc1437dro0d6q06h.xn--tsh2611ncu71e; ; ;  # 𐹫踧್.⒈𝨤
+‍≮．󠟪𹫏-; ‍≮.󠟪𹫏-; [C2, P1, V3, V6]; xn--1ug95g.xn----cr99a1w710b; ; xn--gdh.xn----cr99a1w710b; [P1, V3, V6] # ≮.-
+‍≮．󠟪𹫏-; ‍≮.󠟪𹫏-; [C2, P1, V3, V6]; xn--1ug95g.xn----cr99a1w710b; ; xn--gdh.xn----cr99a1w710b; [P1, V3, V6] # ≮.-
+‍≮.󠟪𹫏-; ; [C2, P1, V3, V6]; xn--1ug95g.xn----cr99a1w710b; ; xn--gdh.xn----cr99a1w710b; [P1, V3, V6] # ≮.-
+‍≮.󠟪𹫏-; ‍≮.󠟪𹫏-; [C2, P1, V3, V6]; xn--1ug95g.xn----cr99a1w710b; ; xn--gdh.xn----cr99a1w710b; [P1, V3, V6] # ≮.-
+xn--gdh.xn----cr99a1w710b; ≮.󠟪𹫏-; [V3, V6]; xn--gdh.xn----cr99a1w710b; ; ;  # ≮.-
+xn--1ug95g.xn----cr99a1w710b; ‍≮.󠟪𹫏-; [C2, V3, V6]; xn--1ug95g.xn----cr99a1w710b; ; ;  # ≮.-
+‍‍襔。Ⴜ5ꡮ񵝏; ‍‍襔.Ⴜ5ꡮ񵝏; [C2, P1, V6]; xn--1uga7691f.xn--5-r1g7167ipfw8d; ; xn--2u2a.xn--5-r1g7167ipfw8d; [P1, V6] # 襔.Ⴜ5ꡮ
+‍‍襔。ⴜ5ꡮ񵝏; ‍‍襔.ⴜ5ꡮ񵝏; [C2, P1, V6]; xn--1uga7691f.xn--5-uws5848bpf44e; ; xn--2u2a.xn--5-uws5848bpf44e; [P1, V6] # 襔.ⴜ5ꡮ
+xn--2u2a.xn--5-uws5848bpf44e; 襔.ⴜ5ꡮ񵝏; [V6]; xn--2u2a.xn--5-uws5848bpf44e; ; ;  # 襔.ⴜ5ꡮ
+xn--1uga7691f.xn--5-uws5848bpf44e; ‍‍襔.ⴜ5ꡮ񵝏; [C2, V6]; xn--1uga7691f.xn--5-uws5848bpf44e; ; ;  # 襔.ⴜ5ꡮ
+xn--2u2a.xn--5-r1g7167ipfw8d; 襔.Ⴜ5ꡮ񵝏; [V6]; xn--2u2a.xn--5-r1g7167ipfw8d; ; ;  # 襔.Ⴜ5ꡮ
+xn--1uga7691f.xn--5-r1g7167ipfw8d; ‍‍襔.Ⴜ5ꡮ񵝏; [C2, V6]; xn--1uga7691f.xn--5-r1g7167ipfw8d; ; ;  # 襔.Ⴜ5ꡮ
+𐫜𑌼‍．婀; 𐫜𑌼‍.婀; [B3, C2]; xn--1ugx063g1if.xn--q0s; ; xn--ix9c26l.xn--q0s; [] # 𐫜𑌼.婀
+𐫜𑌼‍.婀; ; [B3, C2]; xn--1ugx063g1if.xn--q0s; ; xn--ix9c26l.xn--q0s; [] # 𐫜𑌼.婀
+xn--ix9c26l.xn--q0s; 𐫜𑌼.婀; ; xn--ix9c26l.xn--q0s; ; ;  # 𐫜𑌼.婀
+𐫜𑌼.婀; ; ; xn--ix9c26l.xn--q0s; ; ;  # 𐫜𑌼.婀
+xn--1ugx063g1if.xn--q0s; 𐫜𑌼‍.婀; [B3, C2]; xn--1ugx063g1if.xn--q0s; ; ;  # 𐫜𑌼.婀
+󠅽︒︒𐹯｡⬳᩸; ︒︒𐹯.⬳᩸; [B1, P1, V6]; xn--y86ca186j.xn--7of309e; ; ;  # ︒︒𐹯.⬳᩸
+󠅽。。𐹯。⬳᩸; ..𐹯.⬳᩸; [B1, X4_2]; ..xn--no0d.xn--7of309e; [B1, A4_2]; ;  # ..𐹯.⬳᩸
+..xn--no0d.xn--7of309e; ..𐹯.⬳᩸; [B1, X4_2]; ..xn--no0d.xn--7of309e; [B1, A4_2]; ;  # ..𐹯.⬳᩸
+xn--y86ca186j.xn--7of309e; ︒︒𐹯.⬳᩸; [B1, V6]; xn--y86ca186j.xn--7of309e; ; ;  # ︒︒𐹯.⬳᩸
+𝟖ß．󠄐-?Ⴏ; 8ß.-?Ⴏ; [P1, V3, V6]; xn--8-qfa.-?Ⴏ; [P1, V3, V6, A3]; 8ss.-?Ⴏ;  # 8ß.-Ⴏ
+8ß.󠄐-?Ⴏ; 8ß.-?Ⴏ; [P1, V3, V6]; xn--8-qfa.-?Ⴏ; [P1, V3, V6, A3]; 8ss.-?Ⴏ;  # 8ß.-Ⴏ
+8ß.󠄐-?ⴏ; 8ß.-?ⴏ; [P1, V3, V6]; xn--8-qfa.-?ⴏ; [P1, V3, V6, A3]; 8ss.-?ⴏ;  # 8ß.-ⴏ
+8SS.󠄐-?Ⴏ; 8ss.-?Ⴏ; [P1, V3, V6]; ; [P1, V3, V6, A3]; ;  # 8ss.-Ⴏ
+8ss.󠄐-?ⴏ; 8ss.-?ⴏ; [P1, V3, V6]; ; [P1, V3, V6, A3]; ;  # 8ss.-ⴏ
+8ss.󠄐-?Ⴏ; 8ss.-?Ⴏ; [P1, V3, V6]; ; [P1, V3, V6, A3]; ;  # 8ss.-Ⴏ
+8ss.-?Ⴏ; ; [P1, V3, V6]; ; [P1, V3, V6, A3]; ;  # 8ss.-Ⴏ
+8ss.-?ⴏ; ; [P1, V3, V6]; ; [P1, V3, V6, A3]; ;  # 8ss.-ⴏ
+8SS.-?Ⴏ; 8ss.-?Ⴏ; [P1, V3, V6]; ; [P1, V3, V6, A3]; ;  # 8ss.-Ⴏ
+xn--8-qfa.-?ⴏ; 8ß.-?ⴏ; [P1, V3, V6]; xn--8-qfa.-?ⴏ; [P1, V3, V6, A3]; ;  # 8ß.-ⴏ
+XN--8-QFA.-?Ⴏ; 8ß.-?Ⴏ; [P1, V3, V6]; xn--8-qfa.-?Ⴏ; [P1, V3, V6, A3]; ;  # 8ß.-Ⴏ
+Xn--8-Qfa.-?Ⴏ; 8ß.-?Ⴏ; [P1, V3, V6]; xn--8-qfa.-?Ⴏ; [P1, V3, V6, A3]; ;  # 8ß.-Ⴏ
+xn--8-qfa.-?Ⴏ; 8ß.-?Ⴏ; [P1, V3, V6]; xn--8-qfa.-?Ⴏ; [P1, V3, V6, A3]; ;  # 8ß.-Ⴏ
+𝟖ß．󠄐-?ⴏ; 8ß.-?ⴏ; [P1, V3, V6]; xn--8-qfa.-?ⴏ; [P1, V3, V6, A3]; 8ss.-?ⴏ;  # 8ß.-ⴏ
+𝟖SS．󠄐-?Ⴏ; 8ss.-?Ⴏ; [P1, V3, V6]; ; [P1, V3, V6, A3]; ;  # 8ss.-Ⴏ
+𝟖ss．󠄐-?ⴏ; 8ss.-?ⴏ; [P1, V3, V6]; ; [P1, V3, V6, A3]; ;  # 8ss.-ⴏ
+𝟖ss．󠄐-?Ⴏ; 8ss.-?Ⴏ; [P1, V3, V6]; ; [P1, V3, V6, A3]; ;  # 8ss.-Ⴏ
+𝟖Ss．󠄐-?Ⴏ; 8ss.-?Ⴏ; [P1, V3, V6]; ; [P1, V3, V6, A3]; ;  # 8ss.-Ⴏ
+8Ss.󠄐-?Ⴏ; 8ss.-?Ⴏ; [P1, V3, V6]; ; [P1, V3, V6, A3]; ;  # 8ss.-Ⴏ
+-‍󠋟.‌𐹣Ⴅ; ; [B1, C1, C2, P1, V3, V6]; xn----ugnv7071n.xn--dnd999e4j4p; ; xn----s721m.xn--dnd9201k; [B1, P1, V3, V6] # -.𐹣Ⴅ
+-‍󠋟.‌𐹣ⴅ; ; [B1, C1, C2, P1, V3, V6]; xn----ugnv7071n.xn--0ugz32cgr0p; ; xn----s721m.xn--wkj1423e; [B1, P1, V3, V6] # -.𐹣ⴅ
+xn----s721m.xn--wkj1423e; -󠋟.𐹣ⴅ; [B1, V3, V6]; xn----s721m.xn--wkj1423e; ; ;  # -.𐹣ⴅ
+xn----ugnv7071n.xn--0ugz32cgr0p; -‍󠋟.‌𐹣ⴅ; [B1, C1, C2, V3, V6]; xn----ugnv7071n.xn--0ugz32cgr0p; ; ;  # -.𐹣ⴅ
+xn----s721m.xn--dnd9201k; -󠋟.𐹣Ⴅ; [B1, V3, V6]; xn----s721m.xn--dnd9201k; ; ;  # -.𐹣Ⴅ
+xn----ugnv7071n.xn--dnd999e4j4p; -‍󠋟.‌𐹣Ⴅ; [B1, C1, C2, V3, V6]; xn----ugnv7071n.xn--dnd999e4j4p; ; ;  # -.𐹣Ⴅ
+ꦹ‍큷𻶡｡₂; ꦹ‍큷𻶡.2; [C2, P1, V5, V6]; xn--1ug1435cfkyaoi04d.2; ; xn--0m9as84e2e21c.2; [P1, V5, V6] # ꦹ큷.2
+ꦹ‍큷𻶡｡₂; ꦹ‍큷𻶡.2; [C2, P1, V5, V6]; xn--1ug1435cfkyaoi04d.2; ; xn--0m9as84e2e21c.2; [P1, V5, V6] # ꦹ큷.2
+ꦹ‍큷𻶡。2; ꦹ‍큷𻶡.2; [C2, P1, V5, V6]; xn--1ug1435cfkyaoi04d.2; ; xn--0m9as84e2e21c.2; [P1, V5, V6] # ꦹ큷.2
+ꦹ‍큷𻶡。2; ꦹ‍큷𻶡.2; [C2, P1, V5, V6]; xn--1ug1435cfkyaoi04d.2; ; xn--0m9as84e2e21c.2; [P1, V5, V6] # ꦹ큷.2
+xn--0m9as84e2e21c.2; ꦹ큷𻶡.2; [V5, V6]; xn--0m9as84e2e21c.2; ; ;  # ꦹ큷.2
+xn--1ug1435cfkyaoi04d.2; ꦹ‍큷𻶡.2; [C2, V5, V6]; xn--1ug1435cfkyaoi04d.2; ; ;  # ꦹ큷.2
+?.🄄𞯘; ; [B1, P1, V6]; ?.xn--3x6hx6f; [B1, P1, V6, A3]; ;  # .🄄
+?.3,𞯘; ; [B1, P1, V6]; ?.xn--3,-tb22a; [B1, P1, V6, A3]; ;  # .3,
+?.xn--3,-tb22a; ?.3,𞯘; [B1, P1, V6]; ?.xn--3,-tb22a; [B1, P1, V6, A3]; ;  # .3,
+?.XN--3,-TB22A; ?.3,𞯘; [B1, P1, V6]; ?.xn--3,-tb22a; [B1, P1, V6, A3]; ;  # .3,
+?.Xn--3,-Tb22a; ?.3,𞯘; [B1, P1, V6]; ?.xn--3,-tb22a; [B1, P1, V6, A3]; ;  # .3,
+?.xn--3x6hx6f; ?.🄄𞯘; [B1, P1, V6]; ?.xn--3x6hx6f; [B1, P1, V6, A3]; ;  # .🄄
+?.XN--3X6HX6F; ?.🄄𞯘; [B1, P1, V6]; ?.xn--3x6hx6f; [B1, P1, V6, A3]; ;  # .🄄
+?.Xn--3x6hx6f; ?.🄄𞯘; [B1, P1, V6]; ?.xn--3x6hx6f; [B1, P1, V6, A3]; ;  # .🄄
+𝨖𐩙。۝󀡶ꣅ⒈; 𝨖𐩙.۝󀡶ꣅ⒈; [B1, P1, V5, V6]; xn--rt9cl956a.xn--tlb403mxv4g06s9i; ; ;  # 𝨖.ꣅ⒈
+𝨖𐩙。۝󀡶ꣅ1.; 𝨖𐩙.۝󀡶ꣅ1.; [B1, P1, V5, V6]; xn--rt9cl956a.xn--1-dxc8545j0693i.; ; ;  # 𝨖.ꣅ1.
+xn--rt9cl956a.xn--1-dxc8545j0693i.; 𝨖𐩙.۝󀡶ꣅ1.; [B1, V5, V6]; xn--rt9cl956a.xn--1-dxc8545j0693i.; ; ;  # 𝨖.ꣅ1.
+xn--rt9cl956a.xn--tlb403mxv4g06s9i; 𝨖𐩙.۝󀡶ꣅ⒈; [B1, V5, V6]; xn--rt9cl956a.xn--tlb403mxv4g06s9i; ; ;  # 𝨖.ꣅ⒈
+򒈣סڸ。Ⴈ‍; 򒈣סڸ.Ⴈ‍; [B5, B6, C2, P1, V6]; xn--meb44b57607c.xn--gnd699e; ; xn--meb44b57607c.xn--gnd; [B5, B6, P1, V6] # סڸ.Ⴈ
+򒈣סڸ。ⴈ‍; 򒈣סڸ.ⴈ‍; [B5, B6, C2, P1, V6]; xn--meb44b57607c.xn--1ug232c; ; xn--meb44b57607c.xn--zkj; [B5, B6, P1, V6] # סڸ.ⴈ
+xn--meb44b57607c.xn--zkj; 򒈣סڸ.ⴈ; [B5, B6, V6]; xn--meb44b57607c.xn--zkj; ; ;  # סڸ.ⴈ
+xn--meb44b57607c.xn--1ug232c; 򒈣סڸ.ⴈ‍; [B5, B6, C2, V6]; xn--meb44b57607c.xn--1ug232c; ; ;  # סڸ.ⴈ
+xn--meb44b57607c.xn--gnd; 򒈣סڸ.Ⴈ; [B5, B6, V6]; xn--meb44b57607c.xn--gnd; ; ;  # סڸ.Ⴈ
+xn--meb44b57607c.xn--gnd699e; 򒈣סڸ.Ⴈ‍; [B5, B6, C2, V6]; xn--meb44b57607c.xn--gnd699e; ; ;  # סڸ.Ⴈ
+󀚶𝨱ߦ⒈．𑗝髯‌; 󀚶𝨱ߦ⒈.𑗝髯‌; [B1, B5, C1, P1, V5, V6]; xn--etb477lq931a1f58e.xn--0ugx259bocxd; ; xn--etb477lq931a1f58e.xn--uj6at43v; [B1, B5, P1, V5, V6] # 𝨱ߦ⒈.𑗝髯
+󀚶𝨱ߦ1..𑗝髯‌; ; [B1, B5, C1, P1, V5, V6, X4_2]; xn--1-idd62296a1fr6e..xn--0ugx259bocxd; [B1, B5, C1, P1, V5, V6, A4_2]; xn--1-idd62296a1fr6e..xn--uj6at43v; [B1, B5, P1, V5, V6, A4_2] # 𝨱ߦ1..𑗝髯
+xn--1-idd62296a1fr6e..xn--uj6at43v; 󀚶𝨱ߦ1..𑗝髯; [B1, B5, V5, V6, X4_2]; xn--1-idd62296a1fr6e..xn--uj6at43v; [B1, B5, V5, V6, A4_2]; ;  # 𝨱ߦ1..𑗝髯
+xn--1-idd62296a1fr6e..xn--0ugx259bocxd; 󀚶𝨱ߦ1..𑗝髯‌; [B1, B5, C1, V5, V6, X4_2]; xn--1-idd62296a1fr6e..xn--0ugx259bocxd; [B1, B5, C1, V5, V6, A4_2]; ;  # 𝨱ߦ1..𑗝髯
+xn--etb477lq931a1f58e.xn--uj6at43v; 󀚶𝨱ߦ⒈.𑗝髯; [B1, B5, V5, V6]; xn--etb477lq931a1f58e.xn--uj6at43v; ; ;  # 𝨱ߦ⒈.𑗝髯
+xn--etb477lq931a1f58e.xn--0ugx259bocxd; 󀚶𝨱ߦ⒈.𑗝髯‌; [B1, B5, C1, V5, V6]; xn--etb477lq931a1f58e.xn--0ugx259bocxd; ; ;  # 𝨱ߦ⒈.𑗝髯
+𐫀．ډ𑌀; 𐫀.ډ𑌀; ; xn--pw9c.xn--fjb8658k; ; ;  # 𐫀.ډ𑌀
+𐫀.ډ𑌀; ; ; xn--pw9c.xn--fjb8658k; ; ;  # 𐫀.ډ𑌀
+xn--pw9c.xn--fjb8658k; 𐫀.ډ𑌀; ; xn--pw9c.xn--fjb8658k; ; ;  # 𐫀.ډ𑌀
+𑋪．𐳝; 𑋪.𐳝; [B1, B3, B6, V5]; xn--fm1d.xn--5c0d; ; ;  # 𑋪.𐳝
+𑋪.𐳝; ; [B1, B3, B6, V5]; xn--fm1d.xn--5c0d; ; ;  # 𑋪.𐳝
+𑋪.𐲝; 𑋪.𐳝; [B1, B3, B6, V5]; xn--fm1d.xn--5c0d; ; ;  # 𑋪.𐳝
+xn--fm1d.xn--5c0d; 𑋪.𐳝; [B1, B3, B6, V5]; xn--fm1d.xn--5c0d; ; ;  # 𑋪.𐳝
+𑋪．𐲝; 𑋪.𐳝; [B1, B3, B6, V5]; xn--fm1d.xn--5c0d; ; ;  # 𑋪.𐳝
+≠膣。ྃ; ≠膣.ྃ; [P1, V5, V6]; xn--1chy468a.xn--2ed; ; ;  # ≠膣.ྃ
+≠膣。ྃ; ≠膣.ྃ; [P1, V5, V6]; xn--1chy468a.xn--2ed; ; ;  # ≠膣.ྃ
+xn--1chy468a.xn--2ed; ≠膣.ྃ; [V5, V6]; xn--1chy468a.xn--2ed; ; ;  # ≠膣.ྃ
+񰀎-ݽ｡ß; 񰀎-ݽ.ß; [B5, B6, P1, V6]; xn----j6c95618k.xn--zca; ; xn----j6c95618k.ss;  # -ݽ.ß
+񰀎-ݽ。ß; 񰀎-ݽ.ß; [B5, B6, P1, V6]; xn----j6c95618k.xn--zca; ; xn----j6c95618k.ss;  # -ݽ.ß
+񰀎-ݽ。SS; 񰀎-ݽ.ss; [B5, B6, P1, V6]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+񰀎-ݽ。ss; 񰀎-ݽ.ss; [B5, B6, P1, V6]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+񰀎-ݽ。Ss; 񰀎-ݽ.ss; [B5, B6, P1, V6]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+xn----j6c95618k.ss; 񰀎-ݽ.ss; [B5, B6, V6]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+xn----j6c95618k.xn--zca; 񰀎-ݽ.ß; [B5, B6, V6]; xn----j6c95618k.xn--zca; ; ;  # -ݽ.ß
+񰀎-ݽ｡SS; 񰀎-ݽ.ss; [B5, B6, P1, V6]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+񰀎-ݽ｡ss; 񰀎-ݽ.ss; [B5, B6, P1, V6]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+񰀎-ݽ｡Ss; 񰀎-ݽ.ss; [B5, B6, P1, V6]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+ς𐹠ᡚ𑄳．⾭𐹽𽐖𐫜; ς𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, P1, V6]; xn--3xa856hp23pxmc.xn--es5a888tvjc2u15h; ; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h;  # ς𐹠ᡚ𑄳.靑𐹽𐫜
+ς𐹠ᡚ𑄳.靑𐹽𽐖𐫜; ; [B5, B6, P1, V6]; xn--3xa856hp23pxmc.xn--es5a888tvjc2u15h; ; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h;  # ς𐹠ᡚ𑄳.靑𐹽𐫜
+Σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, P1, V6]; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # σ𐹠ᡚ𑄳.靑𐹽𐫜
+σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; ; [B5, B6, P1, V6]; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # σ𐹠ᡚ𑄳.靑𐹽𐫜
+xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, V6]; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # σ𐹠ᡚ𑄳.靑𐹽𐫜
+xn--3xa856hp23pxmc.xn--es5a888tvjc2u15h; ς𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, V6]; xn--3xa856hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # ς𐹠ᡚ𑄳.靑𐹽𐫜
+Σ𐹠ᡚ𑄳．⾭𐹽𽐖𐫜; σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, P1, V6]; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # σ𐹠ᡚ𑄳.靑𐹽𐫜
+σ𐹠ᡚ𑄳．⾭𐹽𽐖𐫜; σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, P1, V6]; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # σ𐹠ᡚ𑄳.靑𐹽𐫜
+𐋷。‍; 𐋷.‍; [C2]; xn--r97c.xn--1ug; ; xn--r97c.; [] # 𐋷.
+xn--r97c.; 𐋷.; ; xn--r97c.; ; ;  # 𐋷.
+𐋷.; ; ; xn--r97c.; ; ;  # 𐋷.
+xn--r97c.xn--1ug; 𐋷.‍; [C2]; xn--r97c.xn--1ug; ; ;  # 𐋷.
+𑰳𑈯。⥪; 𑰳𑈯.⥪; [V5]; xn--2g1d14o.xn--jti; ; ;  # 𑰳𑈯.⥪
+xn--2g1d14o.xn--jti; 𑰳𑈯.⥪; [V5]; xn--2g1d14o.xn--jti; ; ;  # 𑰳𑈯.⥪
+𑆀䁴񤧣．Ⴕ𝟜‌͈; 𑆀䁴񤧣.Ⴕ4‌͈; [C1, P1, V5, V6]; xn--1mnx647cg3x1b.xn--4-zfb324h32o; ; xn--1mnx647cg3x1b.xn--4-zfb324h; [P1, V5, V6] # 𑆀䁴.Ⴕ4͈
+𑆀䁴񤧣.Ⴕ4‌͈; ; [C1, P1, V5, V6]; xn--1mnx647cg3x1b.xn--4-zfb324h32o; ; xn--1mnx647cg3x1b.xn--4-zfb324h; [P1, V5, V6] # 𑆀䁴.Ⴕ4͈
+𑆀䁴񤧣.ⴕ4‌͈; ; [C1, P1, V5, V6]; xn--1mnx647cg3x1b.xn--4-zfb502tlsl; ; xn--1mnx647cg3x1b.xn--4-zfb5123a; [P1, V5, V6] # 𑆀䁴.ⴕ4͈
+xn--1mnx647cg3x1b.xn--4-zfb5123a; 𑆀䁴񤧣.ⴕ4͈; [V5, V6]; xn--1mnx647cg3x1b.xn--4-zfb5123a; ; ;  # 𑆀䁴.ⴕ4͈
+xn--1mnx647cg3x1b.xn--4-zfb502tlsl; 𑆀䁴񤧣.ⴕ4‌͈; [C1, V5, V6]; xn--1mnx647cg3x1b.xn--4-zfb502tlsl; ; ;  # 𑆀䁴.ⴕ4͈
+xn--1mnx647cg3x1b.xn--4-zfb324h; 𑆀䁴񤧣.Ⴕ4͈; [V5, V6]; xn--1mnx647cg3x1b.xn--4-zfb324h; ; ;  # 𑆀䁴.Ⴕ4͈
+xn--1mnx647cg3x1b.xn--4-zfb324h32o; 𑆀䁴񤧣.Ⴕ4‌͈; [C1, V5, V6]; xn--1mnx647cg3x1b.xn--4-zfb324h32o; ; ;  # 𑆀䁴.Ⴕ4͈
+𑆀䁴񤧣．ⴕ𝟜‌͈; 𑆀䁴񤧣.ⴕ4‌͈; [C1, P1, V5, V6]; xn--1mnx647cg3x1b.xn--4-zfb502tlsl; ; xn--1mnx647cg3x1b.xn--4-zfb5123a; [P1, V5, V6] # 𑆀䁴.ⴕ4͈
+憡?‌Ⴔ.𐋮‍≠; ; [C1, C2, P1, V6]; 憡?‌Ⴔ.xn--1ug73gl146a; [C1, C2, P1, V6, A3]; 憡?Ⴔ.xn--1chz659f; [P1, V6, A3] # 憡Ⴔ.𐋮≠
+憡?‌Ⴔ.𐋮‍≠; 憡?‌Ⴔ.𐋮‍≠; [C1, C2, P1, V6]; 憡?‌Ⴔ.xn--1ug73gl146a; [C1, C2, P1, V6, A3]; 憡?Ⴔ.xn--1chz659f; [P1, V6, A3] # 憡Ⴔ.𐋮≠
+憡?‌ⴔ.𐋮‍≠; 憡?‌ⴔ.𐋮‍≠; [C1, C2, P1, V6]; 憡?‌ⴔ.xn--1ug73gl146a; [C1, C2, P1, V6, A3]; 憡?ⴔ.xn--1chz659f; [P1, V6, A3] # 憡ⴔ.𐋮≠
+憡?‌ⴔ.𐋮‍≠; ; [C1, C2, P1, V6]; 憡?‌ⴔ.xn--1ug73gl146a; [C1, C2, P1, V6, A3]; 憡?ⴔ.xn--1chz659f; [P1, V6, A3] # 憡ⴔ.𐋮≠
+憡?ⴔ.xn--1chz659f; 憡?ⴔ.𐋮≠; [P1, V6]; 憡?ⴔ.xn--1chz659f; [P1, V6, A3]; ;  # 憡ⴔ.𐋮≠
+憡?Ⴔ.XN--1CHZ659F; 憡?Ⴔ.𐋮≠; [P1, V6]; 憡?Ⴔ.xn--1chz659f; [P1, V6, A3]; ;  # 憡Ⴔ.𐋮≠
+憡?Ⴔ.xn--1chz659f; 憡?Ⴔ.𐋮≠; [P1, V6]; 憡?Ⴔ.xn--1chz659f; [P1, V6, A3]; ;  # 憡Ⴔ.𐋮≠
+憡?‌ⴔ.xn--1ug73gl146a; 憡?‌ⴔ.𐋮‍≠; [C1, C2, P1, V6]; 憡?‌ⴔ.xn--1ug73gl146a; [C1, C2, P1, V6, A3]; 憡?ⴔ.xn--1ug73gl146a; [C2, P1, V6, A3] # 憡ⴔ.𐋮≠
+憡?‌Ⴔ.XN--1UG73GL146A; 憡?‌Ⴔ.𐋮‍≠; [C1, C2, P1, V6]; 憡?‌Ⴔ.xn--1ug73gl146a; [C1, C2, P1, V6, A3]; 憡?Ⴔ.xn--1ug73gl146a; [C2, P1, V6, A3] # 憡Ⴔ.𐋮≠
+憡?‌Ⴔ.xn--1ug73gl146a; 憡?‌Ⴔ.𐋮‍≠; [C1, C2, P1, V6]; 憡?‌Ⴔ.xn--1ug73gl146a; [C1, C2, P1, V6, A3]; 憡?Ⴔ.xn--1ug73gl146a; [C2, P1, V6, A3] # 憡Ⴔ.𐋮≠
+憡?Ⴔ.xn--1ug73gl146a; 憡?Ⴔ.𐋮‍≠; [C2, P1, V6]; 憡?Ⴔ.xn--1ug73gl146a; [C2, P1, V6, A3]; ;  # 憡Ⴔ.𐋮≠
+憡?ⴔ.xn--1ug73gl146a; 憡?ⴔ.𐋮‍≠; [C2, P1, V6]; 憡?ⴔ.xn--1ug73gl146a; [C2, P1, V6, A3]; ;  # 憡ⴔ.𐋮≠
+憡?Ⴔ.XN--1UG73GL146A; 憡?Ⴔ.𐋮‍≠; [C2, P1, V6]; 憡?Ⴔ.xn--1ug73gl146a; [C2, P1, V6, A3]; ;  # 憡Ⴔ.𐋮≠

--- a/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_11_0/ReadMe.txt
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_11_0/ReadMe.txt
@@ -1,0 +1,10 @@
+# Unicode IDNA Mapping and Test Data
+# Date: 2017-02-23, 20:40:00 GMT [KW]
+# © 2018 Unicode®, Inc.
+# Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+# For terms of use, see http://www.unicode.org/terms_of_use.html
+
+This directory contains final data files for version 11.0.0 of
+UTS #46, Unicode IDNA Compatibility Processing.
+ 
+http://www.unicode.org/reports/tr46/

--- a/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_11_0/Unicode_11_0_IdnaTest.cs
+++ b/src/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_11_0/Unicode_11_0_IdnaTest.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using Xunit;
+
+namespace System.Globalization.Tests
+{
+    /// <summary>
+    /// Class to read data obtained from http://www.unicode.org/Public/idna.  For more information read the information
+    /// contained in Data\Unicode_11_0\IdnaTestV2.txt
+    ///
+    /// The structure of the data set is a semicolon delimited list with the following columns:
+    ///
+    /// Column 1: source -          The source string to be tested
+    /// Column 2: toUnicode -       The result of applying toUnicode to the source,
+    ///                             with Transitional_Processing=false.
+    ///                             A blank value means the same as the source value.
+    /// Column 3: toUnicodeStatus - A set of status codes, each corresponding to a particular test.
+    ///                             A blank value means [] (no errors).
+    /// Column 4: toAsciiN -        The result of applying toASCII to the source,
+    ///                             with Transitional_Processing=false.
+    ///                             A blank value means the same as the toUnicode value.
+    /// Column 5: toAsciiNStatus -  A set of status codes, each corresponding to a particular test.
+    ///                             A blank value means the same as the toUnicodeStatus value.
+    ///                             An explicit [] means no errors.
+    /// Column 6: toAsciiT -        The result of applying toASCII to the source,
+    ///                             with Transitional_Processing=true.
+    ///                             A blank value means the same as the toAsciiN value.
+    /// Column 7: toAsciiTStatus -  A set of status codes, each corresponding to a particular test.
+    ///                             A blank value means the same as the toAsciiNStatus value.
+    ///                             An explicit [] means no errors.
+    ///
+    /// If the value of toUnicode or toAsciiN is the same as source, the column will be blank.
+    /// </summary>
+    public class Unicode_11_0_IdnaTest : IConformanceIdnaTest
+    {
+        public IdnType Type => IdnType.Nontransitional;
+        public string Source { get; set; }
+        public ConformanceIdnaUnicodeTestResult UnicodeResult { get; set; }
+        public ConformanceIdnaTestResult ASCIIResult { get; set; }
+        public int LineNumber { get; set; }
+
+        public Unicode_11_0_IdnaTest(string line, int lineNumber)
+        {
+            var split = line.Split(';');
+
+            Source = EscapedToLiteralString(split[0], lineNumber);
+            UnicodeResult = new ConformanceIdnaUnicodeTestResult(EscapedToLiteralString(split[1], lineNumber), Source);
+            ASCIIResult = new ConformanceIdnaTestResult(EscapedToLiteralString(split[3], lineNumber), UnicodeResult.Value);
+            LineNumber = lineNumber;
+        }
+
+        /// <summary>
+        /// This will convert strings with escaped sequences to literal characters.  The input string is
+        /// expected to have escaped sequences in the form of '\uXXXX'.
+        ///
+        /// Example: "a\u0020b" will be converted to 'a b'.
+        /// </summary>
+        private static string EscapedToLiteralString(string escaped, int lineNumber)
+        {
+            var sb = new StringBuilder();
+
+            for (int i = 0; i < escaped.Length; i++)
+            {
+                if (i + 1 < escaped.Length && escaped[i] == '\\' && escaped[i + 1] == 'u')
+                {
+                    // Verify that the escaped sequence is not malformed
+                    Assert.True(i + 5 < escaped.Length, "There was a problem converting to literal string on Line " + lineNumber);
+
+                    var codepoint = Convert.ToInt32(escaped.Substring(i + 2, 4), 16);
+                    sb.Append((char)codepoint);
+                    i += 5;
+                }
+                else
+                {
+                    sb.Append(escaped[i]);
+                }
+            }
+
+            return sb.ToString().Trim();
+        }
+    }
+}

--- a/src/System.Globalization.Extensions/tests/System.Globalization.Extensions.Tests.csproj
+++ b/src/System.Globalization.Extensions/tests/System.Globalization.Extensions.Tests.csproj
@@ -8,6 +8,7 @@
     <Compile Include="GetStringComparerTests.cs" />
     <Compile Include="IdnMapping\Data\ConformanceIdnaUnicodeTestResult.cs" />
     <Compile Include="IdnMapping\Data\Unicode_9_0\Unicode_9_0_IdnaTest.cs" />
+    <Compile Include="IdnMapping\Data\Unicode_11_0\Unicode_11_0_IdnaTest.cs" />
     <Compile Include="IdnMapping\IdnMappingIdnaConformanceTests.cs" />
     <Compile Include="IdnMapping\Data\Factory.cs" />
     <Compile Include="IdnMapping\Data\ConformanceIdnaTestResult.cs" />
@@ -24,6 +25,7 @@
     <EmbeddedResource Include="IdnMapping\Data\Unicode_6_0\IdnaTest_6.txt" />
     <EmbeddedResource Include="IdnMapping\Data\Unicode_Win7\IdnaTest_Win7.txt" />
     <EmbeddedResource Include="IdnMapping\Data\Unicode_9_0\IdnaTest_9.txt" />
+    <EmbeddedResource Include="IdnMapping\Data\Unicode_11_0\IdnaTest_11.txt" />
     <EmbeddedResource Include="Normalization\Data\win8.txt">
       <LogicalName>NormalizationDataWin8</LogicalName>
     </EmbeddedResource>


### PR DESCRIPTION
Windows 19H1  upgraded the IDN data to Unicode 11. The change here is to to use the new Unicode 11 IDN test data  in our tests.

Fixes #36758