### PR TITLE
Add EnumeratorCancellationAttribute

### DIFF
--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -6645,6 +6645,11 @@ namespace System.Runtime.CompilerServices
     {
         public DiscardableAttribute() { }
     }
+    [System.AttributeUsageAttribute(AttributeTargets.Parameter, Inherited = false)]
+    public sealed class EnumeratorCancellationAttribute : Attribute
+    {
+        public EnumeratorCancellationAttribute() { }
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method)]
     public sealed partial class ExtensionAttribute : System.Attribute
     {

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -18,6 +18,7 @@
     <Compile Include="System\IO\HandleInheritability.cs" />
     <Compile Include="System\LazyOfTTMetadata.cs" />
     <Compile Include="System\Reflection\RuntimeReflectionExtensions.cs" />
+    <Compile Include="System\Runtime\CompilerServices\EnumeratorCancellationAttribute.cs" />
     <Compile Include="System\Runtime\ConstrainedExecution\PrePrepareMethodAttribute.cs" />
     <Compile Include="System\Runtime\NgenServicingAttributes.cs" />
     <Compile Include="System\System.Runtime.Typeforwards.cs" />

--- a/src/System.Runtime/src/System/Runtime/CompilerServices/EnumeratorCancellationAttribute.cs
+++ b/src/System.Runtime/src/System/Runtime/CompilerServices/EnumeratorCancellationAttribute.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.CompilerServices
+{
+    [System.AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    public sealed class EnumeratorCancellationAttribute : Attribute
+    {
+        public EnumeratorCancellationAttribute()
+        {
+        }
+    }
+}

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/AttributesTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/AttributesTests.netcoreapp.cs
@@ -29,5 +29,11 @@ namespace System.Runtime.CompilerServices.Tests
         {
             new IsReadOnlyAttribute();
         }
+
+        [Fact]
+        public static void EnumeratorCancellationAttributeTests()
+        {
+            new EnumeratorCancellationAttribute();
+        }
     }
 }

--- a/src/System.Threading.Channels/ref/System.Threading.Channels.netcoreapp.cs
+++ b/src/System.Threading.Channels/ref/System.Threading.Channels.netcoreapp.cs
@@ -13,6 +13,6 @@ namespace System.Threading.Channels
     }
     public abstract partial class ChannelReader<T>
     {
-        public virtual System.Collections.Generic.IAsyncEnumerable<T> ReadAllAsync() { throw null; }
+        public virtual System.Collections.Generic.IAsyncEnumerable<T> ReadAllAsync([System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
 }

--- a/src/System.Threading.Channels/ref/System.Threading.Channels.netcoreapp.cs
+++ b/src/System.Threading.Channels/ref/System.Threading.Channels.netcoreapp.cs
@@ -13,6 +13,6 @@ namespace System.Threading.Channels
     }
     public abstract partial class ChannelReader<T>
     {
-        public virtual System.Collections.Generic.IAsyncEnumerable<T> ReadAllAsync([System.Runtime.CompilerServices.EnumeratorCancellationAttribute] System.Threading.CancellationToken cancellationToken = default) { throw null; }
+        public virtual System.Collections.Generic.IAsyncEnumerable<T> ReadAllAsync(System.Threading.CancellationToken cancellationToken = default) { throw null; }
     }
 }

--- a/src/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.netcoreapp.cs
+++ b/src/System.Threading.Channels/src/System/Threading/Channels/ChannelReader.netcoreapp.cs
@@ -3,42 +3,26 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace System.Threading.Channels
 {
     public abstract partial class ChannelReader<T>
     {
         /// <summary>Creates an <see cref="IAsyncEnumerable{T}"/> that enables reading all of the data from the channel.</summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to use to cancel the enumeration.</param>
         /// <remarks>
         /// Each <see cref="IAsyncEnumerator{T}.MoveNextAsync"/> call that returns <c>true</c> will read the next item out of the channel.
         /// <see cref="IAsyncEnumerator{T}.MoveNextAsync"/> will return false once no more data is or will ever be available to read.
         /// </remarks>
         /// <returns>The created async enumerable.</returns>
-        public virtual IAsyncEnumerable<T> ReadAllAsync() => new AsyncEnumerable(this);
-
-        /// <summary>Provides the async enumerable implementation for <see cref="ReadAllAsync"/>.</summary>
-        private sealed class AsyncEnumerable : IAsyncEnumerable<T>
+        public virtual async IAsyncEnumerable<T> ReadAllAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            /// <summary>The reader instance whose contents should be read.</summary>
-            private readonly ChannelReader<T> _reader;
-
-            /// <summary>Initializes the enumerable.</summary>
-            /// <param name="reader">The reader to read.</param>
-            internal AsyncEnumerable(ChannelReader<T> reader)
+            while (await WaitToReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                Debug.Assert(reader != null);
-                _reader = reader;
-            }
-
-            async IAsyncEnumerator<T> IAsyncEnumerable<T>.GetAsyncEnumerator(CancellationToken cancellationToken)
-            {
-                while (await _reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+                while (TryRead(out T item))
                 {
-                    while (_reader.TryRead(out T item))
-                    {
-                        yield return item;
-                    }
+                    yield return item;
                 }
             }
         }

--- a/src/System.Threading.Channels/tests/ChannelTestBase.netcoreapp.cs
+++ b/src/System.Threading.Channels/tests/ChannelTestBase.netcoreapp.cs
@@ -160,7 +160,7 @@ namespace System.Threading.Channels.Tests
             await e.DisposeAsync();
 
             e = enumerable.GetAsyncEnumerator();
-            Assert.NotSame(enumerable, e);
+            Assert.Same(enumerable, e);
 
             Assert.False(await e.MoveNextAsync());
             Assert.False(await e.MoveNextAsync());
@@ -252,7 +252,7 @@ namespace System.Threading.Channels.Tests
             var cts = new CancellationTokenSource();
             cts.Cancel();
 
-            IAsyncEnumerator<int> e = c.Reader.ReadAllAsync().GetAsyncEnumerator(cts.Token);
+            IAsyncEnumerator<int> e = c.Reader.ReadAllAsync(cts.Token).GetAsyncEnumerator();
             ValueTask<bool> vt = e.MoveNextAsync();
             Assert.True(vt.IsCompleted);
             Assert.False(vt.IsCompletedSuccessfully);
@@ -266,7 +266,7 @@ namespace System.Threading.Channels.Tests
             Channel<int> c = CreateChannel();
             var cts = new CancellationTokenSource();
 
-            IAsyncEnumerator<int> e = c.Reader.ReadAllAsync().GetAsyncEnumerator(cts.Token);
+            IAsyncEnumerator<int> e = c.Reader.ReadAllAsync(cts.Token).GetAsyncEnumerator();
             ValueTask<bool> vt = e.MoveNextAsync();
             Assert.False(vt.IsCompleted);
 


### PR DESCRIPTION
Adds the new EnumeratorCancellationAttribute to System.Runtime.  Eventually we may want to push the implementation down to corelib if/when it's needed for APIs in corelib, but for now we can just have it in corefx.

Also updates the new ChannelReader.ReadAllAsync method to use the attribute and revised pattern.

I'd like to get this merged asap.

cc: @terrajobst, @jcouv, @tarekgh, @bartonjs 
Fixes https://github.com/dotnet/corefx/issues/37012