### PR TITLE
Add Dictionary support to JsonSerializer

### DIFF
--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -17,6 +17,7 @@
     <Compile Include="System\Text\Json\JsonHelpers.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Date.cs" />
     <Compile Include="System\Text\Json\JsonTokenType.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonSerializer.Write.HandleDictionary.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.Serialization.cs" />
     <Compile Include="System\Text\Json\Document\JsonDocument.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ClassType.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ClassType.cs
@@ -13,5 +13,6 @@ namespace System.Text.Json.Serialization
         Object = 1,         // POCO or rich data type
         Value = 2,          // Data type with single value
         Enumerable = 3,     // IEnumerable
+        Dictionary = 4,     // IDictionary
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -319,7 +319,7 @@ namespace System.Text.Json.Serialization
 
                     if (propertyType.IsGenericType)
                     {
-                        if (typeof(IDictionary).IsAssignableFrom(propertyType))
+                        if (GetClassType(propertyType) == ClassType.Dictionary)
                         {
                             elementType = args[1];
                         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -62,7 +62,7 @@ namespace System.Text.Json.Serialization
             ClassType = JsonClassInfo.GetClassType(runtimePropertyType);
             if (elementType != null)
             {
-                Debug.Assert(ClassType == ClassType.Enumerable);
+                Debug.Assert(ClassType == ClassType.Enumerable || ClassType == ClassType.Dictionary);
                 ElementClassInfo = options.GetOrAddClass(elementType);
             }
 
@@ -251,13 +251,15 @@ namespace System.Text.Json.Serialization
             
         internal abstract IList CreateConverterList();
 
+        internal abstract Type GetConcreteType(Type interfaceType);
+
         internal abstract void Read(JsonTokenType tokenType, JsonSerializerOptions options, ref ReadStack state, ref Utf8JsonReader reader);
         internal abstract void ReadEnumerable(JsonTokenType tokenType, JsonSerializerOptions options, ref ReadStack state, ref Utf8JsonReader reader);
-        internal abstract void ReadDictionaryValue(JsonTokenType tokenType, JsonSerializerOptions options, ref ReadStack state, ref Utf8JsonReader reader);
         internal abstract void SetValueAsObject(object obj, object value, JsonSerializerOptions options);
 
         internal abstract void Write(JsonSerializerOptions options, ref WriteStackFrame current, Utf8JsonWriter writer);
 
+        internal abstract void WriteDictionary(JsonSerializerOptions options, ref WriteStackFrame current, Utf8JsonWriter writer);
         internal abstract void WriteEnumerable(JsonSerializerOptions options, ref WriteStackFrame current, Utf8JsonWriter writer);
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -253,6 +253,7 @@ namespace System.Text.Json.Serialization
 
         internal abstract void Read(JsonTokenType tokenType, JsonSerializerOptions options, ref ReadStack state, ref Utf8JsonReader reader);
         internal abstract void ReadEnumerable(JsonTokenType tokenType, JsonSerializerOptions options, ref ReadStack state, ref Utf8JsonReader reader);
+        internal abstract void ReadDictionaryValue(JsonTokenType tokenType, JsonSerializerOptions options, ref ReadStack state, ref Utf8JsonReader reader);
         internal abstract void SetValueAsObject(object obj, object value, JsonSerializerOptions options);
 
         internal abstract void Write(JsonSerializerOptions options, ref WriteStackFrame current, Utf8JsonWriter writer);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -53,6 +53,11 @@ namespace System.Text.Json.Serialization
                 _isPropertyPolicy = true;
                 HasGetter = true;
                 HasSetter = true;
+
+                if (ClassType == ClassType.Dictionary)
+                {
+                    ValueConverter = DefaultConverters<TRuntimeProperty>.s_converter;
+                }
             }
 
             GetPolicies(options);
@@ -89,6 +94,18 @@ namespace System.Text.Json.Serialization
         internal override IList CreateConverterList()
         {
             return new List<TDeclaredProperty>();
+        }
+
+        // Map interfaces to a well-known implementation.
+        internal override Type GetConcreteType(Type interfaceType)
+        {
+            if (interfaceType.IsAssignableFrom(typeof(IDictionary<string, TRuntimeProperty>)) ||
+                interfaceType.IsAssignableFrom(typeof(IReadOnlyDictionary<string, TRuntimeProperty>)))
+            {
+                return typeof(Dictionary<string, TRuntimeProperty>);
+            }
+
+            return interfaceType;
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -185,7 +185,7 @@ namespace System.Text.Json.Serialization
             {
                 Debug.Assert(frame.JsonPropertyInfo != null);
                 Debug.Assert(frame.ReturnValue != null);
-                ((IDictionary)frame.JsonPropertyInfo.GetValueAsObject(frame.ReturnValue, options)).Add(frame.KeyName, value);
+                frame.JsonPropertyInfo.SetValueAsObject(frame.ReturnValue, value, options);
             }
             else
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -30,6 +30,12 @@ namespace System.Text.Json.Serialization
                 ThrowHelper.ThrowJsonReaderException_DeserializeCannotBeNull(reader, state);
             }
 
+            if (state.Current.IsDictionary())
+            {
+                ApplyObjectToDictionary(null, options, ref state.Current);
+                return false;
+            }
+
             if (state.Current.IsEnumerable())
             {
                 ApplyObjectToEnumerable(null, options, ref state.Current);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -30,19 +30,13 @@ namespace System.Text.Json.Serialization
                 ThrowHelper.ThrowJsonReaderException_DeserializeCannotBeNull(reader, state);
             }
 
-            if (state.Current.IsDictionary())
-            {
-                ApplyObjectToDictionary(null, options, ref state.Current);
-                return false;
-            }
-
-            if (state.Current.IsEnumerable())
+            if (state.Current.IsEnumerable() || state.Current.IsDictionary())
             {
                 ApplyObjectToEnumerable(null, options, ref state.Current);
                 return false;
             }
 
-            if (state.Current.IsPropertyEnumerable())
+            if (state.Current.IsPropertyEnumerable() || state.Current.IsPropertyADictionary())
             {
                 state.Current.JsonPropertyInfo.ApplyNullValue(options, ref state);
                 return false;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Text.Json.Serialization
 {
@@ -22,7 +24,29 @@ namespace System.Text.Json.Serialization
                 // An array of objects either on the current property or on a list
                 Type objType = state.Current.GetElementType();
                 state.Push();
+
                 state.Current.JsonClassInfo = options.GetOrAddClass(objType);
+            }
+            else if (state.Current.IsDictionary())
+            {
+                JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
+
+                bool skip = jsonPropertyInfo != null && !jsonPropertyInfo.ShouldDeserialize;
+                if (skip || state.Current.Skip())
+                {
+                    // The dictionary is not being applied to the object.
+                    state.Push();
+                    state.Current.Drain = true;
+                    return;
+                }
+
+                Type elementType = state.Current.JsonClassInfo.ElementClassInfo.Type;
+
+                state.Current.TempDictKeys = new List<string>();
+                state.Current.TempDictValues = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType));
+                state.Current.ReturnValue = (IDictionary)Activator.CreateInstance(state.Current.JsonClassInfo.Type);
+
+                return;
             }
             else if (state.Current.JsonPropertyInfo != null)
             {
@@ -47,6 +71,23 @@ namespace System.Text.Json.Serialization
 
             state.Current.JsonClassInfo.UpdateSortedPropertyCache(ref state.Current);
 
+            if (state.Current.IsDictionary())
+            {
+                ReadStackFrame frame = state.Current;
+
+                int keyCount = ((IList)frame.TempDictKeys).Count;
+
+                Debug.Assert(keyCount == (frame.TempDictValues).Count);
+
+                IList keys = frame.TempDictKeys;
+                IList values = frame.TempDictValues;
+
+                for (int i = 0; i < keyCount; i++)
+                {
+                    ((IDictionary)state.Current.ReturnValue).Add(keys[i], values[i]);
+                }
+            }
+
             object value = state.Current.ReturnValue;
 
             if (isLastFrame)
@@ -59,6 +100,20 @@ namespace System.Text.Json.Serialization
             state.Pop();
             ApplyObjectToEnumerable(value, options, ref state.Current);
             return false;
+        }
+
+        internal static void ApplyValueToDictionary<TProperty>(ref TProperty value, JsonSerializerOptions options, ref ReadStackFrame frame)
+        {
+            Debug.Assert(frame.IsDictionary());
+            ((List<TProperty>)frame.TempDictValues).Add(value);
+            Debug.Assert(((IList)frame.TempDictKeys).Count == ((IList)frame.TempDictValues).Count);
+        }
+
+        internal static void ApplyObjectToDictionary(object value, JsonSerializerOptions options, ref ReadStackFrame frame)
+        {
+            Debug.Assert(frame.IsDictionary());
+            (frame.TempDictValues).Add(value);
+            Debug.Assert(((IList)frame.TempDictKeys).Count == ((IList)frame.TempDictValues).Count);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-
 namespace System.Text.Json.Serialization
 {
     public static partial class JsonSerializer
@@ -19,34 +15,16 @@ namespace System.Text.Json.Serialization
                 return;
             }
 
-            if (state.Current.IsEnumerable() || state.Current.IsPropertyEnumerable())
+            if (state.Current.IsDictionary())
+            {
+                // Fall through and treat as a return value.
+            }
+            else if (state.Current.IsEnumerable() || state.Current.IsPropertyEnumerable() || state.Current.IsPropertyADictionary())
             {
                 // An array of objects either on the current property or on a list
                 Type objType = state.Current.GetElementType();
                 state.Push();
-
                 state.Current.JsonClassInfo = options.GetOrAddClass(objType);
-            }
-            else if (state.Current.IsDictionary())
-            {
-                JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
-
-                bool skip = jsonPropertyInfo != null && !jsonPropertyInfo.ShouldDeserialize;
-                if (skip || state.Current.Skip())
-                {
-                    // The dictionary is not being applied to the object.
-                    state.Push();
-                    state.Current.Drain = true;
-                    return;
-                }
-
-                Type elementType = state.Current.JsonClassInfo.ElementClassInfo.Type;
-
-                state.Current.TempDictKeys = new List<string>();
-                state.Current.TempDictValues = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(elementType));
-                state.Current.ReturnValue = (IDictionary)Activator.CreateInstance(state.Current.JsonClassInfo.Type);
-
-                return;
             }
             else if (state.Current.JsonPropertyInfo != null)
             {
@@ -71,23 +49,6 @@ namespace System.Text.Json.Serialization
 
             state.Current.JsonClassInfo.UpdateSortedPropertyCache(ref state.Current);
 
-            if (state.Current.IsDictionary())
-            {
-                ReadStackFrame frame = state.Current;
-
-                int keyCount = ((IList)frame.TempDictKeys).Count;
-
-                Debug.Assert(keyCount == (frame.TempDictValues).Count);
-
-                IList keys = frame.TempDictKeys;
-                IList values = frame.TempDictValues;
-
-                for (int i = 0; i < keyCount; i++)
-                {
-                    ((IDictionary)state.Current.ReturnValue).Add(keys[i], values[i]);
-                }
-            }
-
             object value = state.Current.ReturnValue;
 
             if (isLastFrame)
@@ -100,20 +61,6 @@ namespace System.Text.Json.Serialization
             state.Pop();
             ApplyObjectToEnumerable(value, options, ref state.Current);
             return false;
-        }
-
-        internal static void ApplyValueToDictionary<TProperty>(ref TProperty value, JsonSerializerOptions options, ref ReadStackFrame frame)
-        {
-            Debug.Assert(frame.IsDictionary());
-            ((List<TProperty>)frame.TempDictValues).Add(value);
-            Debug.Assert(((IList)frame.TempDictKeys).Count == ((IList)frame.TempDictValues).Count);
-        }
-
-        internal static void ApplyObjectToDictionary(object value, JsonSerializerOptions options, ref ReadStackFrame frame)
-        {
-            Debug.Assert(frame.IsDictionary());
-            (frame.TempDictValues).Add(value);
-            Debug.Assert(((IList)frame.TempDictKeys).Count == ((IList)frame.TempDictValues).Count);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleValue.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleValue.cs
@@ -19,7 +19,9 @@ namespace System.Text.Json.Serialization
                 jsonPropertyInfo = state.Current.JsonClassInfo.CreatePolymorphicProperty(jsonPropertyInfo, typeof(object), options);
             }
 
-            bool lastCall = (!state.Current.IsEnumerable() && !state.Current.IsPropertyEnumerable() && state.Current.ReturnValue == null);
+            bool notParsingEnumerable = !state.Current.IsEnumerable() && !state.Current.IsPropertyEnumerable();
+            bool lastCall = (notParsingEnumerable && !state.Current.IsDictionary() && state.Current.ReturnValue == null);
+
             jsonPropertyInfo.Read(tokenType, options, ref state, ref reader);
             return lastCall;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleValue.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleValue.cs
@@ -19,8 +19,7 @@ namespace System.Text.Json.Serialization
                 jsonPropertyInfo = state.Current.JsonClassInfo.CreatePolymorphicProperty(jsonPropertyInfo, typeof(object), options);
             }
 
-            bool notParsingEnumerable = !state.Current.IsEnumerable() && !state.Current.IsPropertyEnumerable();
-            bool lastCall = (notParsingEnumerable && !state.Current.IsDictionary() && state.Current.ReturnValue == null);
+            bool lastCall = (!state.Current.IsProcessingEnumerableOrDictionary() && state.Current.ReturnValue == null);
 
             jsonPropertyInfo.Read(tokenType, options, ref state, ref reader);
             return lastCall;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace System.Text.Json.Serialization
@@ -42,13 +43,28 @@ namespace System.Text.Json.Serialization
                         Debug.Assert(state.Current.JsonClassInfo != default);
 
                         ReadOnlySpan<byte> propertyName = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
-                        state.Current.JsonPropertyInfo = state.Current.JsonClassInfo.GetProperty(options, propertyName, ref state.Current);
-                        if (state.Current.JsonPropertyInfo == null)
-                        {
-                            state.Current.JsonPropertyInfo = s_missingProperty;
-                        }
 
-                        state.Current.PropertyIndex++;
+                        if (state.Current.IsDictionary())
+                        {
+                            string keyName = reader.GetString();
+
+                            if (options.DictionaryKeyPolicy != null)
+                            {
+                                keyName = options.DictionaryKeyPolicy.ConvertName(keyName);
+                            }
+
+                            state.Current.TempDictKeys.Add(keyName);
+                        }
+                        else
+                        {
+                            state.Current.JsonPropertyInfo = state.Current.JsonClassInfo.GetProperty(options, propertyName, ref state.Current);
+                            if (state.Current.JsonPropertyInfo == null)
+                            {
+                                state.Current.JsonPropertyInfo = s_missingProperty;
+                            }
+
+                            state.Current.PropertyIndex++;
+                        }
                     }
                 }
                 else if (tokenType == JsonTokenType.StartObject)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -47,13 +47,13 @@ namespace System.Text.Json.Serialization
                         if (state.Current.IsDictionary())
                         {
                             string keyName = reader.GetString();
-
                             if (options.DictionaryKeyPolicy != null)
                             {
                                 keyName = options.DictionaryKeyPolicy.ConvertName(keyName);
                             }
 
-                            state.Current.TempDictKeys.Add(keyName);
+                            state.Current.JsonPropertyInfo = state.Current.JsonClassInfo.GetPolicyProperty();
+                            state.Current.KeyName = keyName;
                         }
                         else
                         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -1,0 +1,141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.Json.Serialization.Policies;
+
+namespace System.Text.Json.Serialization
+{
+    public static partial class JsonSerializer
+    {
+        private static bool HandleDictionary(
+            JsonClassInfo elementClassInfo,
+            JsonSerializerOptions options,
+            Utf8JsonWriter writer,
+            ref WriteStack state)
+        {
+            Debug.Assert(state.Current.JsonPropertyInfo.ClassType == ClassType.Dictionary);
+
+            JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
+            if (!jsonPropertyInfo.ShouldSerialize)
+            {
+                // Ignore writing this property.
+                return true;
+            }
+
+            if (state.Current.Enumerator == null)
+            {
+                IEnumerable enumerable = (IEnumerable)jsonPropertyInfo.GetValueAsObject(state.Current.CurrentValue, options);
+
+                if (enumerable == null)
+                {
+                    // Write a null object or enumerable.
+                    writer.WriteNull(jsonPropertyInfo.Name);
+                    return true;
+                }
+
+                state.Current.Enumerator = enumerable.GetEnumerator();
+
+                if (jsonPropertyInfo.Name == null)
+                {
+                    writer.WriteStartObject();
+                }
+                else
+                {
+                    writer.WriteStartObject(jsonPropertyInfo.Name);
+                }
+            }
+
+            if (state.Current.Enumerator.MoveNext())
+            {
+                // Check for polymorphism.
+                if (elementClassInfo.ClassType == ClassType.Unknown)
+                {
+                    //todo:test
+                    object currentValue = ((IDictionaryEnumerator)(state.Current.Enumerator)).Entry;
+                    GetRuntimeClassInfo(currentValue, ref elementClassInfo, options);
+                }
+
+                if (elementClassInfo.ClassType == ClassType.Value)
+                {
+                    elementClassInfo.GetPolicyProperty().WriteDictionary(options, ref state.Current, writer);
+                }
+                else if (state.Current.Enumerator.Current == null)
+                {
+                    writer.WriteNull(jsonPropertyInfo.Name);
+                }
+                else
+                {
+                    // An object or another enumerator requires a new stack frame.
+                    object nextValue = state.Current.Enumerator.Current;
+                    state.Push(elementClassInfo, nextValue);
+                }
+
+                return false;
+            }
+
+            // We are done enumerating.
+            writer.WriteEndObject();
+
+            state.Current.EndDictionary();
+
+            return true;
+        }
+
+        internal static void WriteDictionary<TProperty>(
+            JsonValueConverter<TProperty> converter,
+            JsonSerializerOptions options,
+            ref WriteStackFrame current,
+            Utf8JsonWriter writer)
+        {
+            if (converter == null)
+            {
+                return;
+            }
+
+            Debug.Assert(current.Enumerator != null);
+
+            string key;
+            TProperty value;
+            if (current.Enumerator is IEnumerator<KeyValuePair<string, TProperty>> enumerator)
+            {
+                // Avoid boxing for strongly-typed enumerators such as returned from IDictionary<string, TRuntimeProperty>
+                value = enumerator.Current.Value;
+                key = enumerator.Current.Key;
+            }
+            else
+            {
+                // Todo: support non-generic Dictionary here (IDictionaryEnumerator)
+                throw new NotSupportedException();
+            }
+
+            if (value == null)
+            {
+                writer.WriteNull(key);
+            }
+            else
+            {
+                byte[] pooledKey = null;
+                byte[] utf8Key = Encoding.UTF8.GetBytes(key);
+                int length = JsonWriterHelper.GetMaxEscapedLength(utf8Key.Length, 0);
+
+                Span<byte> escapedKey = length <= JsonConstants.StackallocThreshold ?
+                    stackalloc byte[length] :
+                    (pooledKey = ArrayPool<byte>.Shared.Rent(length));
+
+                JsonWriterHelper.EscapeString(utf8Key, escapedKey, 0, out int written);
+
+                converter.Write(escapedKey.Slice(0, written), value, writer);
+
+                if (pooledKey != null)
+                {
+                    ArrayPool<byte>.Shared.Return(pooledKey);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
@@ -93,6 +93,18 @@ namespace System.Text.Json.Serialization
                 return endOfEnumerable;
             }
 
+            // A property that returns a dictionary keeps the same stack frame.
+            if (jsonPropertyInfo.ClassType == ClassType.Dictionary)
+            {
+                bool endOfEnumerable = HandleDictionary(jsonPropertyInfo.ElementClassInfo, options, writer, ref state);
+                if (endOfEnumerable)
+                {
+                    state.Current.NextProperty();
+                }
+
+                return endOfEnumerable;
+            }
+
             // A property that returns an object.
             if (!obtainedValue)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
@@ -35,8 +35,10 @@ namespace System.Text.Json.Serialization
                         finishedSerializing = true;
                         break;
                     case ClassType.Object:
-                    case ClassType.Dictionary:
                         finishedSerializing = WriteObject(options, writer, ref state);
+                        break;
+                    case ClassType.Dictionary:
+                        finishedSerializing = HandleDictionary(current.JsonClassInfo.ElementClassInfo, options, writer, ref state);
                         break;
                     default:
                         Debug.Assert(state.Current.JsonClassInfo.ClassType == ClassType.Unknown);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
@@ -35,6 +35,7 @@ namespace System.Text.Json.Serialization
                         finishedSerializing = true;
                         break;
                     case ClassType.Object:
+                    case ClassType.Dictionary:
                         finishedSerializing = WriteObject(options, writer, ref state);
                         break;
                     default:

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -15,9 +15,7 @@ namespace System.Text.Json.Serialization
         internal JsonClassInfo JsonClassInfo;
 
         // Support Dictionary
-        internal List<string> TempDictKeys;
-        internal IList TempDictValues;
-        internal bool IsNestedEnumerableInDict;
+        internal string KeyName;
 
         // Current property values
         internal JsonPropertyInfo JsonPropertyInfo;
@@ -59,6 +57,12 @@ namespace System.Text.Json.Serialization
             PopStackOnEndArray = false;
             EnumerableCreated = false;
             TempEnumerableValues = null;
+            KeyName = null;
+        }
+
+        internal bool IsProcessingEnumerableOrDictionary()
+        {
+            return IsEnumerable() ||IsPropertyEnumerable() || IsDictionary() || IsPropertyADictionary();
         }
 
         internal bool IsEnumerable()

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -51,7 +51,7 @@ namespace System.Text.Json.Serialization
             }
             else
             {
-                Debug.Assert(nextClassInfo.ClassType == ClassType.Object || nextClassInfo.ClassType == ClassType.Unknown);
+                Debug.Assert(nextClassInfo.ClassType == ClassType.Object || nextClassInfo.ClassType == ClassType.Dictionary || nextClassInfo.ClassType == ClassType.Unknown);
                 Current.PopStackOnEndObject = true;
             }
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -29,7 +29,7 @@ namespace System.Text.Json.Serialization
         internal void Initialize(Type type, JsonSerializerOptions options)
         {
             JsonClassInfo = options.GetOrAddClass(type);
-            if (JsonClassInfo.ClassType == ClassType.Value || JsonClassInfo.ClassType == ClassType.Enumerable)
+            if (JsonClassInfo.ClassType == ClassType.Value || JsonClassInfo.ClassType == ClassType.Enumerable || JsonClassInfo.ClassType == ClassType.Dictionary)
             {
                 JsonPropertyInfo = JsonClassInfo.GetPolicyProperty();
             }
@@ -48,6 +48,12 @@ namespace System.Text.Json.Serialization
         {
             PropertyIndex = 0;
             PopStackOnEndObject = false;
+            EndProperty();
+        }
+
+        internal void EndDictionary()
+        {
+            Enumerator = null;
             EndProperty();
         }
 

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -18,6 +18,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal("World2", obj["Hello2"]);
 
                 string json = JsonSerializer.ToString(obj);
+                Assert.Equal(@"{""Hello"":""World"",""Hello2"":""World2""}", json);
 
                 // Round-trip the json
                 obj = JsonSerializer.Parse<Dictionary<string, string>>(json);
@@ -30,6 +31,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal("World", obj["Hello"]);
 
                 string json = JsonSerializer.ToString(obj);
+                Assert.Equal(@"{""Hello"":""World""}", json);
 
                 obj = JsonSerializer.Parse<Dictionary<string, string>>(json);
                 Assert.Equal("World", obj["Hello"]);
@@ -40,10 +42,18 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal("World", obj["Hello"]);
 
                 string json = JsonSerializer.ToString(obj);
+                Assert.Equal(@"{""Hello"":""World""}", json);
 
                 obj = JsonSerializer.Parse<Dictionary<string, string>>(json);
                 Assert.Equal("World", obj["Hello"]);
             }
+        }
+
+        [Fact]
+        public static void ThrowsOnDuplicateKeys()
+        {
+            // todo: this should throw a JsonReaderException
+            Assert.Throws<ArgumentException>(() => JsonSerializer.Parse<Dictionary<string, string>>(@"{""Hello"":""World"", ""Hello"":""World""}"));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static partial class DictionaryTests
+    {
+        [Fact]
+        public static void DirectReturn()
+        {
+            {
+                Dictionary<string, string> obj = JsonSerializer.Parse<Dictionary<string, string>>(@"{""Hello"":""World"", ""Hello2"":""World2""}");
+                Assert.Equal("World", obj["Hello"]);
+                Assert.Equal("World2", obj["Hello2"]);
+
+                string json = JsonSerializer.ToString(obj);
+
+                // Round-trip the json
+                obj = JsonSerializer.Parse<Dictionary<string, string>>(json);
+                Assert.Equal("World", obj["Hello"]);
+                Assert.Equal("World2", obj["Hello2"]);
+            }
+
+            {
+                IDictionary<string, string> obj = JsonSerializer.Parse<IDictionary<string, string>>(@"{""Hello"":""World""}");
+                Assert.Equal("World", obj["Hello"]);
+
+                string json = JsonSerializer.ToString(obj);
+
+                obj = JsonSerializer.Parse<Dictionary<string, string>>(json);
+                Assert.Equal("World", obj["Hello"]);
+            }
+
+            {
+                IReadOnlyDictionary<string, string> obj = JsonSerializer.Parse<IReadOnlyDictionary<string, string>>(@"{""Hello"":""World""}");
+                Assert.Equal("World", obj["Hello"]);
+
+                string json = JsonSerializer.ToString(obj);
+
+                obj = JsonSerializer.Parse<Dictionary<string, string>>(json);
+                Assert.Equal("World", obj["Hello"]);
+            }
+        }
+    }
+}

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -49,5 +49,12 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<SimpleTestClass>("[]"));
             Assert.Throws<JsonReaderException>(() => JsonSerializer.Parse<object>("[]"));
         }
+
+        [Fact]
+        public static void ReadClassWithStringToPrimitiveDictionary()
+        {
+            TestClassWithStringToPrimitiveDictionary obj = JsonSerializer.Parse<TestClassWithStringToPrimitiveDictionary>(TestClassWithStringToPrimitiveDictionary.s_data);
+            obj.Verify();
+        }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
@@ -52,6 +52,7 @@ namespace System.Text.Json.Serialization.Tests
         public ICollection<string> MyStringICollectionT { get; set; }
         public IReadOnlyCollection<string> MyStringIReadOnlyCollectionT { get; set; }
         public IReadOnlyList<string> MyStringIReadOnlyListT { get; set; }
+        public Dictionary<string, string> MyStringToStringDict { get; set; }
 
         public static readonly string s_json = $"{{{s_partialJsonProperties},{s_partialJsonArrays}}}";
         public static readonly string s_json_flipped = $"{{{s_partialJsonArrays},{s_partialJsonProperties}}}";
@@ -74,7 +75,8 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyDecimal"" : 3.3," +
                 @"""MyDateTime"" : ""2019-01-30T12:01:02.0000000Z""," +
                 @"""MyDateTimeOffset"" : ""2019-01-30T12:01:02.0000000+01:00""," +
-                @"""MyEnum"" : 2"; // int by default
+                @"""MyEnum"" : 2," + // int by default
+                @"""MyStringToStringDict"" : {""key"" : ""value""}";
 
         private const string s_partialJsonArrays =
                 @"""MyInt16Array"" : [1]," +
@@ -150,6 +152,8 @@ namespace System.Text.Json.Serialization.Tests
             MyStringICollectionT = new string[] { "Hello" };
             MyStringIReadOnlyCollectionT = new string[] { "Hello" };
             MyStringIReadOnlyListT = new string[] { "Hello" };
+
+            MyStringToStringDict = new Dictionary<string, string> { { "key", "value" } };
         }
 
         public void Verify()
@@ -198,6 +202,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("Hello", MyStringICollectionT.First());
             Assert.Equal("Hello", MyStringIReadOnlyCollectionT.First());
             Assert.Equal("Hello", MyStringIReadOnlyListT[0]);
+
+            Assert.Equal("value", MyStringToStringDict["key"]);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
@@ -53,6 +53,8 @@ namespace System.Text.Json.Serialization.Tests
         public IReadOnlyCollection<string> MyStringIReadOnlyCollectionT { get; set; }
         public IReadOnlyList<string> MyStringIReadOnlyListT { get; set; }
         public Dictionary<string, string> MyStringToStringDict { get; set; }
+        public IDictionary<string, string> MyStringToStringIDict { get; set; }
+        public IReadOnlyDictionary<string, string> MyStringToStringIReadOnlyDict { get; set; }
 
         public static readonly string s_json = $"{{{s_partialJsonProperties},{s_partialJsonArrays}}}";
         public static readonly string s_json_flipped = $"{{{s_partialJsonArrays},{s_partialJsonProperties}}}";
@@ -76,7 +78,9 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyDateTime"" : ""2019-01-30T12:01:02.0000000Z""," +
                 @"""MyDateTimeOffset"" : ""2019-01-30T12:01:02.0000000+01:00""," +
                 @"""MyEnum"" : 2," + // int by default
-                @"""MyStringToStringDict"" : {""key"" : ""value""}";
+                @"""MyStringToStringDict"" : {""key"" : ""value""}," +
+                @"""MyStringToStringIDict"" : {""key"" : ""value""}," +
+                @"""MyStringToStringIReadOnlyDict"" : {""key"" : ""value""}";
 
         private const string s_partialJsonArrays =
                 @"""MyInt16Array"" : [1]," +
@@ -154,6 +158,8 @@ namespace System.Text.Json.Serialization.Tests
             MyStringIReadOnlyListT = new string[] { "Hello" };
 
             MyStringToStringDict = new Dictionary<string, string> { { "key", "value" } };
+            MyStringToStringIDict = new Dictionary<string, string> { { "key", "value" } };
+            MyStringToStringIReadOnlyDict = new Dictionary<string, string> { { "key", "value" } };
         }
 
         public void Verify()
@@ -204,6 +210,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("Hello", MyStringIReadOnlyListT[0]);
 
             Assert.Equal("value", MyStringToStringDict["key"]);
+            Assert.Equal("value", MyStringToStringIDict["key"]);
+            Assert.Equal("value", MyStringToStringIReadOnlyDict["key"]);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClassWithObject.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClassWithObject.cs
@@ -50,6 +50,7 @@ namespace System.Text.Json.Serialization.Tests
         public object MyStringICollectionT { get; set; }
         public object MyStringIReadOnlyCollectionT { get; set; }
         public object MyStringIReadOnlyListT { get; set; }
+        public object MyStringToStringDict { get; set; }
 
         public static readonly string s_json =
                 @"{" +
@@ -92,7 +93,8 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyStringIListT"" : [""Hello""]," +
                 @"""MyStringICollectionT"" : [""Hello""]," +
                 @"""MyStringIReadOnlyCollectionT"" : [""Hello""]," +
-                @"""MyStringIReadOnlyListT"" : [""Hello""]" +
+                @"""MyStringIReadOnlyListT"" : [""Hello""]," +
+                @"""MyStringToStringDict"" : {""key"" : ""value""}" +
                 @"}";
 
         public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
@@ -141,6 +143,8 @@ namespace System.Text.Json.Serialization.Tests
             MyStringICollectionT = new string[] { "Hello" };
             MyStringIReadOnlyCollectionT = new string[] { "Hello" };
             MyStringIReadOnlyListT = new string[] { "Hello" };
+
+            MyStringToStringDict = new Dictionary<string, string> { { "key", "value" } };
         }
 
         public void Verify()
@@ -187,6 +191,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("Hello", ((ICollection<string>)MyStringICollectionT).First());
             Assert.Equal("Hello", ((IReadOnlyCollection<string>)MyStringIReadOnlyCollectionT).First());
             Assert.Equal("Hello", ((IReadOnlyList<string>)MyStringIReadOnlyListT)[0]);
+
+            Assert.Equal("value", ((Dictionary<string, string>)MyStringToStringDict)["key"]);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClassWithObject.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClassWithObject.cs
@@ -51,6 +51,8 @@ namespace System.Text.Json.Serialization.Tests
         public object MyStringIReadOnlyCollectionT { get; set; }
         public object MyStringIReadOnlyListT { get; set; }
         public object MyStringToStringDict { get; set; }
+        public object MyStringToStringIDict { get; set; }
+        public object MyStringToStringIReadOnlyDict { get; set; }
 
         public static readonly string s_json =
                 @"{" +
@@ -94,7 +96,9 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyStringICollectionT"" : [""Hello""]," +
                 @"""MyStringIReadOnlyCollectionT"" : [""Hello""]," +
                 @"""MyStringIReadOnlyListT"" : [""Hello""]," +
-                @"""MyStringToStringDict"" : {""key"" : ""value""}" +
+                @"""MyStringToStringDict"" : {""key"" : ""value""}," +
+                @"""MyStringToStringIDict"" : {""key"" : ""value""}," +
+                @"""MyStringToStringIReadOnlyDict"" : {""key"" : ""value""}" +
                 @"}";
 
         public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
@@ -145,6 +149,8 @@ namespace System.Text.Json.Serialization.Tests
             MyStringIReadOnlyListT = new string[] { "Hello" };
 
             MyStringToStringDict = new Dictionary<string, string> { { "key", "value" } };
+            MyStringToStringIDict = new Dictionary<string, string> { { "key", "value" } };
+            MyStringToStringIReadOnlyDict = new Dictionary<string, string> { { "key", "value" } };
         }
 
         public void Verify()
@@ -193,6 +199,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("Hello", ((IReadOnlyList<string>)MyStringIReadOnlyListT)[0]);
 
             Assert.Equal("value", ((Dictionary<string, string>)MyStringToStringDict)["key"]);
+            Assert.Equal("value", ((IDictionary<string, string>)MyStringToStringIDict)["key"]);
+            Assert.Equal("value", ((IReadOnlyDictionary<string, string>)MyStringToStringIReadOnlyDict)["key"]);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.cs
@@ -587,6 +587,173 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class TestClassWithStringToPrimitiveDictionary : ITestClass
+    {
+        public Dictionary<string, int> MyInt32Dict { get; set; }
+        public Dictionary<string, bool> MyBooleanDict { get; set; }
+        public Dictionary<string, float> MySingleDict { get; set; }
+        public Dictionary<string, double> MyDoubleDict { get; set; }
+        public Dictionary<string, DateTime> MyDateTimeDict { get; set; }
+        public IDictionary<string, int> MyInt32IDict { get; set; }
+        public IDictionary<string, bool> MyBooleanIDict { get; set; }
+        public IDictionary<string, float> MySingleIDict { get; set; }
+        public IDictionary<string, double> MyDoubleIDict { get; set; }
+        public IDictionary<string, DateTime> MyDateTimeIDict { get; set; }
+        public IReadOnlyDictionary<string, int> MyInt32IReadOnlyDict { get; set; }
+        public IReadOnlyDictionary<string, bool> MyBooleanIReadOnlyDict { get; set; }
+        public IReadOnlyDictionary<string, float> MySingleIReadOnlyDict { get; set; }
+        public IReadOnlyDictionary<string, double> MyDoubleIReadOnlyDict { get; set; }
+        public IReadOnlyDictionary<string, DateTime> MyDateTimeIReadOnlyDict { get; set; }
+
+        public static readonly byte[] s_data = Encoding.UTF8.GetBytes(
+            @"{" +
+                @"""MyInt32Dict"":{" +
+                    @"""key1"": 1," +
+                    @"""key2"": 2" +
+                @"}," +
+                @"""MyBooleanDict"":{" +
+                    @"""key1"": true," +
+                    @"""key2"": false" +
+                @"}," +
+                @"""MySingleDict"":{" +
+                    @"""key1"": 1.1," +
+                    @"""key2"": 2.2" +
+                @"}," +
+                @"""MyDoubleDict"":{" +
+                    @"""key1"": 3.3," +
+                    @"""key2"": 4.4" +
+                @"}," +
+                @"""MyDateTimeDict"":{" +
+                    @"""key1"": ""2019-01-30T12:01:02.0000000""," +
+                    @"""key2"": ""2019-01-30T12:01:02.0000000Z""" +
+                @"}," +
+                @"""MyInt32IDict"":{" +
+                    @"""key1"": 1," +
+                    @"""key2"": 2" +
+                @"}," +
+                @"""MyBooleanIDict"":{" +
+                    @"""key1"": true," +
+                    @"""key2"": false" +
+                @"}," +
+                @"""MySingleIDict"":{" +
+                    @"""key1"": 1.1," +
+                    @"""key2"": 2.2" +
+                @"}," +
+                @"""MyDoubleIDict"":{" +
+                    @"""key1"": 3.3," +
+                    @"""key2"": 4.4" +
+                @"}," +
+                @"""MyDateTimeIDict"":{" +
+                    @"""key1"": ""2019-01-30T12:01:02.0000000""," +
+                    @"""key2"": ""2019-01-30T12:01:02.0000000Z""" +
+                @"}," +
+                @"""MyInt32IReadOnlyDict"":{" +
+                    @"""key1"": 1," +
+                    @"""key2"": 2" +
+                @"}," +
+                @"""MyBooleanIReadOnlyDict"":{" +
+                    @"""key1"": true," +
+                    @"""key2"": false" +
+                @"}," +
+                @"""MySingleIReadOnlyDict"":{" +
+                    @"""key1"": 1.1," +
+                    @"""key2"": 2.2" +
+                @"}," +
+                @"""MyDoubleIReadOnlyDict"":{" +
+                    @"""key1"": 3.3," +
+                    @"""key2"": 4.4" +
+                @"}," +
+                @"""MyDateTimeIReadOnlyDict"":{" +
+                    @"""key1"": ""2019-01-30T12:01:02.0000000""," +
+                    @"""key2"": ""2019-01-30T12:01:02.0000000Z""" +
+                @"}" +
+            @"}");
+
+        public void Initialize()
+        {
+            MyInt32Dict = new Dictionary<string, int> { { "key1", 1 }, { "key2", 2 } };
+            MyBooleanDict = new Dictionary<string, bool> { { "key1", true }, { "key2", false } };
+            MySingleDict = new Dictionary<string, float> { { "key1", 1.1f }, { "key2", 2.2f } };
+            MyDoubleDict = new Dictionary<string, double> { { "key1", 3.3d }, { "key2", 4.4d } };
+            MyDateTimeDict = new Dictionary<string, DateTime> { { "key1", new DateTime(2019, 1, 30, 12, 1, 2) }, { "key2", new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc) } };
+
+            MyInt32IDict = new Dictionary<string, int> { { "key1", 1 }, { "key2", 2 } };
+            MyBooleanIDict = new Dictionary<string, bool> { { "key1", true }, { "key2", false } };
+            MySingleIDict = new Dictionary<string, float> { { "key1", 1.1f }, { "key2", 2.2f } };
+            MyDoubleIDict = new Dictionary<string, double> { { "key1", 3.3d }, { "key2", 4.4d } };
+            MyDateTimeIDict = new Dictionary<string, DateTime> { { "key1", new DateTime(2019, 1, 30, 12, 1, 2) }, { "key2", new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc) } };
+
+            MyInt32IReadOnlyDict = new Dictionary<string, int> { { "key1", 1 }, { "key2", 2 } };
+            MyBooleanIReadOnlyDict = new Dictionary<string, bool> { { "key1", true }, { "key2", false } };
+            MySingleIReadOnlyDict = new Dictionary<string, float> { { "key1", 1.1f }, { "key2", 2.2f } };
+            MyDoubleIReadOnlyDict = new Dictionary<string, double> { { "key1", 3.3d }, { "key2", 4.4d } };
+            MyDateTimeIReadOnlyDict = new Dictionary<string, DateTime> { { "key1", new DateTime(2019, 1, 30, 12, 1, 2) }, { "key2", new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc) } };
+        }
+
+        public void Verify()
+        {
+            Assert.Equal(1, MyInt32Dict["key1"]);
+            Assert.Equal(2, MyInt32Dict["key2"]);
+            Assert.Equal(2, MyInt32Dict.Count);
+
+            Assert.Equal(true, MyBooleanDict["key1"]);
+            Assert.Equal(false, MyBooleanDict["key2"]);
+            Assert.Equal(2, MyBooleanDict.Count);
+
+            Assert.Equal(1.1f, MySingleDict["key1"]);
+            Assert.Equal(2.2f, MySingleDict["key2"]);
+            Assert.Equal(2, MySingleDict.Count);
+
+            Assert.Equal(3.3d, MyDoubleDict["key1"]);
+            Assert.Equal(4.4d, MyDoubleDict["key2"]);
+            Assert.Equal(2, MyDoubleDict.Count);
+
+            Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2), MyDateTimeDict["key1"]);
+            Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc), MyDateTimeDict["key2"]);
+            Assert.Equal(2, MyDateTimeDict.Count);
+
+            Assert.Equal(1, MyInt32IDict["key1"]);
+            Assert.Equal(2, MyInt32IDict["key2"]);
+            Assert.Equal(2, MyInt32IDict.Count);
+
+            Assert.Equal(true, MyBooleanIDict["key1"]);
+            Assert.Equal(false, MyBooleanIDict["key2"]);
+            Assert.Equal(2, MyBooleanIDict.Count);
+
+            Assert.Equal(1.1f, MySingleIDict["key1"]);
+            Assert.Equal(2.2f, MySingleIDict["key2"]);
+            Assert.Equal(2, MySingleIDict.Count);
+
+            Assert.Equal(3.3d, MyDoubleIDict["key1"]);
+            Assert.Equal(4.4d, MyDoubleIDict["key2"]);
+            Assert.Equal(2, MyDoubleIDict.Count);
+
+            Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2), MyDateTimeIDict["key1"]);
+            Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc), MyDateTimeIDict["key2"]);
+            Assert.Equal(2, MyDateTimeIDict.Count);
+
+            Assert.Equal(1, MyInt32IReadOnlyDict["key1"]);
+            Assert.Equal(2, MyInt32IReadOnlyDict["key2"]);
+            Assert.Equal(2, MyInt32IReadOnlyDict.Count);
+
+            Assert.Equal(true, MyBooleanIReadOnlyDict["key1"]);
+            Assert.Equal(false, MyBooleanIReadOnlyDict["key2"]);
+            Assert.Equal(2, MyBooleanIReadOnlyDict.Count);
+
+            Assert.Equal(1.1f, MySingleIReadOnlyDict["key1"]);
+            Assert.Equal(2.2f, MySingleIReadOnlyDict["key2"]);
+            Assert.Equal(2, MySingleIReadOnlyDict.Count);
+
+            Assert.Equal(3.3d, MyDoubleIReadOnlyDict["key1"]);
+            Assert.Equal(4.4d, MyDoubleIReadOnlyDict["key2"]);
+            Assert.Equal(2, MyDoubleIReadOnlyDict.Count);
+
+            Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2), MyDateTimeIReadOnlyDict["key1"]);
+            Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc), MyDateTimeIReadOnlyDict["key2"]);
+            Assert.Equal(2, MyDateTimeIReadOnlyDict.Count);
+        }
+    }
+
     public class SimpleDerivedTestClass : SimpleTestClass
     {
     }

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="Serialization\CacheTests.cs" />
     <Compile Include="Serialization\CamelCaseUnitTests.cs" />
     <Compile Include="Serialization\CyclicTests.cs" />
+    <Compile Include="Serialization\DictionaryTests.cs" />
     <Compile Include="Serialization\EnumTests.cs" />
     <Compile Include="Serialization\Null.ReadTests.cs" />
     <Compile Include="Serialization\Null.WriteTests.cs" />


### PR DESCRIPTION
Re-creating the PR from https://github.com/dotnet/corefx/pull/37033

This partially addresses #36024.
For the intial version, only `Dictionary<string, [primitive]>`, `IDictionary<string, [primitive]>`, and `IReadOnlyDictionary<string, [primitive]>` are supported.

Support for enumerables, arrays, nested dictionaries, objects, and classes as dictionary values is being tracked in https://github.com/dotnet/corefx/issues/37077.
