### PR TITLE
Fix DefaultLoadContextTest

### DIFF
--- a/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -248,6 +248,8 @@ namespace System.Runtime.Loader.Tests
             var asmTargetAsm = olc.LoadFromAssemblyPath(_assemblyPath);
             var loadedContext = AssemblyLoadContext.GetLoadContext(asmTargetAsm);
 
+            olc.LoadedFromContext = false;
+
             // LoadContext of the assembly should be the custom context and not DefaultContext
             Assert.NotEqual(lcDefault, olc);
             Assert.Equal(olc, loadedContext);
@@ -260,7 +262,6 @@ namespace System.Runtime.Loader.Tests
             // Load System.Runtime - since this is on TPA, it should get resolved from our custom load context
             // since the Load method has been implemented to override TPA assemblies.
             var assemblyName = "System.Runtime, Version=4.0.0.0";
-            olc.LoadedFromContext = false;
             Assembly asmLoaded = (Assembly)method.Invoke(null, new object[] {assemblyName});
             loadedContext = AssemblyLoadContext.GetLoadContext(asmLoaded);
 


### PR DESCRIPTION
Move clear of `olc.LoadedFromContext` earlier before System.Runtime is loaded.

With fix of the binder AssemblyName cache hash, the test started failing.  My assertion is that `System.Runtime` load is triggered before the test expects by other reflection code. 

Likely 
```C#
asmTargetAsm.GetType("System.Runtime.Loader.Tests.TestClass", true);
```