### PR TITLE
Revise and disable CreateInstanceAssemblyResolve

### DIFF
--- a/src/System.Runtime/tests/System/ActivatorTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/ActivatorTests.netcoreapp.cs
@@ -256,13 +256,13 @@ namespace System.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Assembly.LoadFile is not supported in AppX.")]
+        [ActiveIssue("dotnet/coreclr#24154")]
         public static void CreateInstanceAssemblyResolve()
         {
             RemoteExecutor.Invoke(() =>
             {
                 AppDomain.CurrentDomain.AssemblyResolve += (object sender, ResolveEventArgs args) => Assembly.LoadFile(Path.Combine(Directory.GetCurrentDirectory(), "TestLoadAssembly.dll"));
-                ObjectHandle oh = Activator.CreateInstance(",,,,", "PublicClassSample");
-                Assert.NotNull(oh.Unwrap());
+                Assert.Throws<FileNotFoundException>(() => Activator.CreateInstance(",,,,", "PublicClassSample"));
             }).Dispose();
         }
 


### PR DESCRIPTION
dotnet/coreclr#24154 will remove the quirk the CreateInstanceAssemblyResolve
test was testing. It will now throw a FileNotFoundException, without triggering
a resolving event.