### PR TITLE
Use NativeLibrary APIs in .NET Core 3 and above

### DIFF
--- a/src/Common/src/CoreLib/Interop/Windows/User32/Interop.LoadString.cs
+++ b/src/Common/src/CoreLib/Interop/Windows/User32/Interop.LoadString.cs
@@ -11,6 +11,6 @@ internal partial class Interop
     internal partial class User32
     {
         [DllImport(Libraries.User32, SetLastError = true, EntryPoint = "LoadStringW", CharSet = CharSet.Unicode)]
-        internal static unsafe extern int LoadString(SafeLibraryHandle hInstance, uint uID, char* lpBuffer, int cchBufferMax);
+        internal static unsafe extern int LoadString(IntPtr hInstance, uint uID, char* lpBuffer, int cchBufferMax);
     }
 }

--- a/src/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage_SafeLibraryHandle.cs
+++ b/src/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage_SafeLibraryHandle.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using Microsoft.Win32.SafeHandles;
 
 internal partial class Interop
 {
@@ -17,7 +16,7 @@ internal partial class Interop
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = true)]
         public static unsafe extern int FormatMessage(
             int dwFlags,
-            SafeLibraryHandle lpSource,
+            IntPtr lpSource,
             uint dwMessageId,
             int dwLanguageId,
             [Out] char[] lpBuffer,

--- a/src/Microsoft.Win32.SystemEvents/src/Microsoft.Win32.SystemEvents.csproj
+++ b/src/Microsoft.Win32.SystemEvents/src/Microsoft.Win32.SystemEvents.csproj
@@ -103,15 +103,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetModuleHandle.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetModuleHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.SetConsoleCtrlHandler.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.SetConsoleCtrlHandler.cs</Link>
     </Compile>
@@ -123,9 +114,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\WtsApi32\Interop.WTSUnRegisterSessionNotification.cs">
       <Link>Common\Interop\Windows\WtsApi32\Interop.WTSUnRegisterSessionNotification.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
-      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
     <Compile Include="Microsoft\Win32\PowerModeChangedEventArgs.cs" />
     <Compile Include="Microsoft\Win32\PowerModeChangedEventHandler.cs" />
@@ -146,6 +134,20 @@
     <Compile Include="Microsoft\Win32\UserPreferenceChangedEventHandler.cs" />
     <Compile Include="Microsoft\Win32\UserPreferenceChangingEventArgs.cs" />
     <Compile Include="Microsoft\Win32\UserPreferenceChangingEventHandler.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND ('$(TargetGroup)' == 'netcoreapp2.0' OR '$(TargetGroup)' == 'netfx')">
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
+      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
     <Reference Include="mscorlib" />

--- a/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.Windows.cs
+++ b/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.Windows.cs
@@ -400,6 +400,7 @@ namespace System.Data.SqlClient
     }
 }
 
+#if netcoreapp20 || netstandard || netfx
 namespace System.Data
 {
     internal static partial class SafeNativeMethods
@@ -408,6 +409,7 @@ namespace System.Data
         internal static extern IntPtr GetProcAddress(IntPtr HModule, [MarshalAs(UnmanagedType.LPStr), In] string funcName);
     }
 }
+#endif
 
 namespace System.Data
 {

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -317,17 +317,19 @@
     <Compile Include="System\Data\SqlClient\SNI\LocalDB.Windows.cs" />
     <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Windows.cs" />
     <Compile Include="System\Data\SqlClient\TdsParser.Windows.cs" />
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
-    </Compile>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(IsPartialFacadeAssembly)' != 'true'">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Data\SqlClient\LocalDBAPI.Common.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(IsPartialFacadeAssembly)' != 'true' AND ('$(TargetGroup)' == 'netcoreapp2.0' OR '$(TargetGroup)' == 'netstandard' OR '$(TargetGroup)' == 'netfx')">
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
       <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.Windows.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Globalization;
@@ -13,7 +12,13 @@ namespace System.Data
 {
     internal static partial class LocalDBAPI
     {
-        private static IntPtr LoadProcAddress() => SafeNativeMethods.GetProcAddress(UserInstanceDLLHandle, "LocalDBFormatMessage");
+        private static IntPtr LoadProcAddress() =>
+#if netcoreapp20 || netcoreapp21 || netstandard || netfx
+            SafeNativeMethods.GetProcAddress(UserInstanceDLLHandle, "LocalDBFormatMessage");
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+            NativeLibrary.TryGetExport(UserInstanceDLLHandle, "LocalDBFormatMessage", out var functionPtr)
+                ? functionPtr : IntPtr.Zero;
+#endif
 
         private static IntPtr UserInstanceDLLHandle
         {

--- a/src/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
+++ b/src/System.Diagnostics.EventLog/src/System.Diagnostics.EventLog.csproj
@@ -58,9 +58,6 @@
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.CloseHandle.cs">
       <Link>Common\CoreLib\Interop\Windows\Kernel32\Interop.CloseHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
-      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Advapi32\Interop.ClearEventLog.cs">
       <Link>Common\Interop\Windows\Advapi32\Interop.ClearEventLog.cs</Link>
     </Compile>
@@ -100,12 +97,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FormatMessage_SafeLibraryHandle.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.FormatMessage_SafeLibraryHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.WaitForSingleObject.cs</Link>
     </Compile>
@@ -117,6 +108,17 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\Diagnostics\NetFrameworkUtils.cs">
       <Link>Common\System\Diagnostics\NetFrameworkUtils.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' AND ('$(TargetGroup)' == 'netcoreapp2.0' OR '$(TargetGroup)' == 'netfx') ">
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
+      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">

--- a/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
+++ b/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
@@ -11,7 +11,10 @@ using System.Security;
 using System.Text;
 using System.Threading;
 using Microsoft.Win32;
+
+#if netcoreapp20 || netfx
 using Microsoft.Win32.SafeHandles;
+#endif
 
 namespace System.Diagnostics
 {
@@ -785,7 +788,11 @@ namespace System.Diagnostics
                 return Path.GetFullPath(path);
         }
 
+#if netcoreapp20 || netfx
         internal static string TryFormatMessage(SafeLibraryHandle hModule, uint messageNum, string[] insertionStrings)
+#else
+        internal static string TryFormatMessage(IntPtr hModule, uint messageNum, string[] insertionStrings)
+#endif
         {
             if (insertionStrings.Length == 0)
             {
@@ -845,7 +852,11 @@ namespace System.Diagnostics
         }
         // FormatMessageW will AV if you don't pass in enough format strings.  If you call TryFormatMessage we ensure insertionStrings
         // is long enough.  You don't want to call this directly unless you're sure insertionStrings is long enough!
+#if netcoreapp20 || netfx
         internal static string UnsafeTryFormatMessage(SafeLibraryHandle hModule, uint messageNum, string[] insertionStrings)
+#else
+        internal static string UnsafeTryFormatMessage(IntPtr hModule, uint messageNum, string[] insertionStrings)
+#endif
         {
             string msg = null;
 
@@ -874,7 +885,11 @@ namespace System.Diagnostics
                 {
                     msgLen = Interop.Kernel32.FormatMessage(
                         flags,
+#if netcoreapp20 || netfx
+                        hModule.DangerousGetHandle(),
+#else
                         hModule,
+#endif
                         messageNum,
                         0,
                         buf,

--- a/src/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
+++ b/src/System.Diagnostics.PerformanceCounter/src/System.Diagnostics.PerformanceCounter.csproj
@@ -92,9 +92,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.DuplicateHandle_SafeProcessHandle.cs">
       <Link>Common\Interop\Windows\kernel32\Interop.DuplicateHandle.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.GetComputerName.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GetComputerName.cs</Link>
     </Compile>
@@ -109,9 +106,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.HandleOptions.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.HandleOptions.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.LocalAlloc.cs</Link>
@@ -172,6 +166,14 @@
     </Compile>
     <Compile Include="$(CommonPath)\System\Diagnostics\NetFrameworkUtils.cs">
       <Link>Common\System\Diagnostics\NetFrameworkUtils.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' AND '$(TargetGroup)' == 'netcoreapp2.0' ">
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/CounterSampleCalculator.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/CounterSampleCalculator.cs
@@ -237,7 +237,11 @@ namespace System.Diagnostics
             string installPath = NetFrameworkUtils.GetLatestBuildDllDirectory(".");
 
             string perfcounterPath = Path.Combine(installPath, "perfcounter.dll");
+#if netcoreapp20
             if (Interop.Kernel32.LoadLibrary(perfcounterPath) == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+            if (!NativeLibrary.TryLoad(perfcounterPath, out _))
+#endif
             {
                 throw new Win32Exception(Marshal.GetLastWin32Error());
             }

--- a/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DomainController.cs
+++ b/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DomainController.cs
@@ -461,7 +461,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
         public override ReplicationCursorCollection GetReplicationCursors(string partition)
         {
-            IntPtr info = (IntPtr)0;
+            IntPtr info = IntPtr.Zero;
             int context = 0;
             bool advanced = true;
 
@@ -482,7 +482,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
         public override ReplicationOperationInformation GetReplicationOperationInformation()
         {
-            IntPtr info = (IntPtr)0;
+            IntPtr info = IntPtr.Zero;
             bool advanced = true;
 
             if (_disposed)
@@ -496,7 +496,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
         public override ReplicationNeighborCollection GetReplicationNeighbors(string partition)
         {
-            IntPtr info = (IntPtr)0;
+            IntPtr info = IntPtr.Zero;
             bool advanced = true;
 
             if (_disposed)
@@ -516,7 +516,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
         public override ReplicationNeighborCollection GetAllReplicationNeighbors()
         {
-            IntPtr info = (IntPtr)0;
+            IntPtr info = IntPtr.Zero;
             bool advanced = true;
 
             if (_disposed)
@@ -535,7 +535,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
         public override ActiveDirectoryReplicationMetadata GetReplicationMetadata(string objectPath)
         {
-            IntPtr info = (IntPtr)0;
+            IntPtr info = IntPtr.Zero;
             bool advanced = true;
 
             if (_disposed)
@@ -1088,8 +1088,12 @@ namespace System.DirectoryServices.ActiveDirectory
             GetDSHandle();
 
             // call DsGetDomainControllerInfo
+#if netcoreapp20
             IntPtr functionPtr = UnsafeNativeMethods.GetProcAddress(DirectoryContext.ADHandle, "DsGetDomainControllerInfoW");
-            if (functionPtr == (IntPtr)0)
+            if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+            if (!NativeLibrary.TryGetExport(DirectoryContext.ADHandle, "DsGetDomainControllerInfoW", out IntPtr functionPtr))
+#endif
             {
                 throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
             }
@@ -1165,8 +1169,12 @@ namespace System.DirectoryServices.ActiveDirectory
                     if (dcInfoPtr != IntPtr.Zero)
                     {
                         // call DsFreeDomainControllerInfo
+#if netcoreapp20
                         functionPtr = UnsafeNativeMethods.GetProcAddress(DirectoryContext.ADHandle, "DsFreeDomainControllerInfoW");
-                        if (functionPtr == (IntPtr)0)
+                        if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+                        if (!NativeLibrary.TryGetExport(DirectoryContext.ADHandle, "DsFreeDomainControllerInfoW", out functionPtr))
+#endif
                         {
                             throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                         }
@@ -1229,7 +1237,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
         internal ReplicationFailureCollection GetReplicationFailures(DS_REPL_INFO_TYPE type)
         {
-            IntPtr info = (IntPtr)0;
+            IntPtr info = IntPtr.Zero;
             bool advanced = true;
 
             if (_disposed)
@@ -1250,8 +1258,12 @@ namespace System.DirectoryServices.ActiveDirectory
             GetDSHandle();
             // Get the roles
             // call DsListRoles
+#if netcoreapp20
             IntPtr functionPtr = UnsafeNativeMethods.GetProcAddress(DirectoryContext.ADHandle, "DsListRolesW");
-            if (functionPtr == (IntPtr)0)
+            if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+            if (!NativeLibrary.TryGetExport(DirectoryContext.ADHandle, "DsListRolesW", out IntPtr functionPtr))
+#endif
             {
                 throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
             }
@@ -1290,8 +1302,12 @@ namespace System.DirectoryServices.ActiveDirectory
                     if (rolesPtr != IntPtr.Zero)
                     {
                         // call DsFreeNameResult
+#if netcoreapp20
                         functionPtr = UnsafeNativeMethods.GetProcAddress(DirectoryContext.ADHandle, "DsFreeNameResultW");
-                        if (functionPtr == (IntPtr)0)
+                        if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+                        if (!NativeLibrary.TryGetExport(DirectoryContext.ADHandle, "DsFreeNameResultW", out functionPtr))
+#endif
                         {
                             throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                         }

--- a/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/SafeHandle.cs
+++ b/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/SafeHandle.cs
@@ -29,6 +29,7 @@ namespace System.DirectoryServices.ActiveDirectory
         override protected bool ReleaseHandle() => NativeMethods.LsaDeregisterLogonProcess(handle) == 0;
     }
 
+#if netcoreapp20
     internal sealed class LoadLibrarySafeHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         private LoadLibrarySafeHandle() : base(true) { }
@@ -40,4 +41,5 @@ namespace System.DirectoryServices.ActiveDirectory
 
         override protected bool ReleaseHandle() => UnsafeNativeMethods.FreeLibrary(handle) != 0;
     }
+#endif
 }

--- a/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/UnsafeNativeMethods.cs
+++ b/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/UnsafeNativeMethods.cs
@@ -473,11 +473,11 @@ namespace System.DirectoryServices.ActiveDirectory
         public LSA_OBJECT_ATTRIBUTES()
         {
             Length = 0;
-            _rootDirectory = (IntPtr)0;
-            _objectName = (IntPtr)0;
+            _rootDirectory = IntPtr.Zero;
+            _objectName = IntPtr.Zero;
             Attributes = 0;
-            _securityDescriptor = (IntPtr)0;
-            _securityQualityOfService = (IntPtr)0;
+            _securityDescriptor = IntPtr.Zero;
+            _securityQualityOfService = IntPtr.Zero;
         }
     }
 
@@ -734,6 +734,7 @@ namespace System.DirectoryServices.ActiveDirectory
         [DllImport("ntdll.dll", EntryPoint = "RtlInitUnicodeString")]
         public static extern int RtlInitUnicodeString(LSA_UNICODE_STRING result, IntPtr s);
 
+#if netcoreapp20
         [DllImport("Kernel32.dll", EntryPoint = "LoadLibraryW", CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern IntPtr LoadLibrary(string name);
 
@@ -741,7 +742,8 @@ namespace System.DirectoryServices.ActiveDirectory
         public extern static uint FreeLibrary(IntPtr libName);
 
         [DllImport("kernel32.dll", EntryPoint = "GetProcAddress", SetLastError = true, BestFitMapping = false)]
-        public extern static IntPtr GetProcAddress(LoadLibrarySafeHandle hModule, string entryPoint);
+        public extern static IntPtr GetProcAddress(IntPtr hModule, string entryPoint);
+#endif
 
         /*
         DWORD DsRoleGetPrimaryDomainInformation(

--- a/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
+++ b/src/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
@@ -108,8 +108,12 @@ namespace System.DirectoryServices.ActiveDirectory
             Debug.Assert(distinguishedName != null);
 
             // call DsCrackNamesW
+#if netcoreapp20
             IntPtr functionPtr = UnsafeNativeMethods.GetProcAddress(DirectoryContext.ADHandle, "DsCrackNamesW");
-            if (functionPtr == (IntPtr)0)
+            if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+            if (!NativeLibrary.TryGetExport(DirectoryContext.ADHandle, "DsCrackNamesW", out IntPtr functionPtr))
+#endif
             {
                 throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
             }
@@ -154,18 +158,22 @@ namespace System.DirectoryServices.ActiveDirectory
                 }
                 finally
                 {
-                    if (ptr != (IntPtr)0)
+                    if (ptr != IntPtr.Zero)
                         Marshal.FreeHGlobal(ptr);
 
-                    if (name != (IntPtr)0)
+                    if (name != IntPtr.Zero)
                         Marshal.FreeHGlobal(name);
 
                     // free the results
                     if (results != IntPtr.Zero)
                     {
                         // call DsFreeNameResultW
+#if netcoreapp20
                         functionPtr = UnsafeNativeMethods.GetProcAddress(DirectoryContext.ADHandle, "DsFreeNameResultW");
-                        if (functionPtr == (IntPtr)0)
+                        if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+                        if (!NativeLibrary.TryGetExport(DirectoryContext.ADHandle, "DsFreeNameResultW", out functionPtr))
+#endif
                         {
                             throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                         }
@@ -196,8 +204,12 @@ namespace System.DirectoryServices.ActiveDirectory
             Debug.Assert(dnsName != null);
 
             // call DsCrackNamesW
+#if netcoreapp20
             IntPtr functionPtr = UnsafeNativeMethods.GetProcAddress(DirectoryContext.ADHandle, "DsCrackNamesW");
-            if (functionPtr == (IntPtr)0)
+            if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+            if (!NativeLibrary.TryGetExport(DirectoryContext.ADHandle, "DsCrackNamesW", out IntPtr functionPtr))
+#endif
             {
                 throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
             }
@@ -223,17 +235,21 @@ namespace System.DirectoryServices.ActiveDirectory
                 }
                 finally
                 {
-                    if (ptr != (IntPtr)0)
+                    if (ptr != IntPtr.Zero)
                         Marshal.FreeHGlobal(ptr);
 
-                    if (name != (IntPtr)0)
+                    if (name != IntPtr.Zero)
                         Marshal.FreeHGlobal(name);
                     // free the results
                     if (results != IntPtr.Zero)
                     {
                         // call DsFreeNameResultW
+#if netcoreapp20
                         functionPtr = UnsafeNativeMethods.GetProcAddress(DirectoryContext.ADHandle, "DsFreeNameResultW");
-                        if (functionPtr == (IntPtr)0)
+                        if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+                        if (!NativeLibrary.TryGetExport(DirectoryContext.ADHandle, "DsFreeNameResultW", out functionPtr))
+#endif
                         {
                             throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                         }
@@ -607,7 +623,7 @@ namespace System.DirectoryServices.ActiveDirectory
             }
         }
 
-        internal static IntPtr GetAuthIdentity(DirectoryContext context, LoadLibrarySafeHandle libHandle)
+        internal static IntPtr GetAuthIdentity(DirectoryContext context, IntPtr libHandle)
         {
             IntPtr authIdentity;
             int result = 0;
@@ -620,8 +636,12 @@ namespace System.DirectoryServices.ActiveDirectory
 
             // create the credentials 
             // call DsMakePasswordCredentialsW
+#if netcoreapp20
             IntPtr functionPtr = UnsafeNativeMethods.GetProcAddress(libHandle, "DsMakePasswordCredentialsW");
-            if (functionPtr == (IntPtr)0)
+            if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+            if (!NativeLibrary.TryGetExport(libHandle, "DsMakePasswordCredentialsW", out IntPtr functionPtr))
+#endif
             {
                 throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
             }
@@ -639,14 +659,18 @@ namespace System.DirectoryServices.ActiveDirectory
             return authIdentity;
         }
 
-        internal static void FreeAuthIdentity(IntPtr authIdentity, LoadLibrarySafeHandle libHandle)
+        internal static void FreeAuthIdentity(IntPtr authIdentity, IntPtr libHandle)
         {
             // free the credentials object
             if (authIdentity != IntPtr.Zero)
             {
                 // call DsMakePasswordCredentialsW
+#if netcoreapp20
                 IntPtr functionPtr = UnsafeNativeMethods.GetProcAddress(libHandle, "DsFreePasswordCredentials");
-                if (functionPtr == (IntPtr)0)
+                if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+                if (!NativeLibrary.TryGetExport(libHandle, "DsFreePasswordCredentials", out IntPtr functionPtr))
+#endif
                 {
                     throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                 }
@@ -655,15 +679,19 @@ namespace System.DirectoryServices.ActiveDirectory
             }
         }
 
-        internal static IntPtr GetDSHandle(string domainControllerName, string domainName, IntPtr authIdentity, LoadLibrarySafeHandle libHandle)
+        internal static IntPtr GetDSHandle(string domainControllerName, string domainName, IntPtr authIdentity, IntPtr libHandle)
         {
             int result = 0;
             IntPtr handle;
 
             // call DsBindWithCred
             Debug.Assert((domainControllerName != null && domainName == null) || (domainName != null && domainControllerName == null));
+#if netcoreapp20
             IntPtr functionPtr = UnsafeNativeMethods.GetProcAddress(libHandle, "DsBindWithCredW");
-            if (functionPtr == (IntPtr)0)
+            if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+            if (!NativeLibrary.TryGetExport(libHandle, "DsBindWithCredW", out IntPtr functionPtr))
+#endif
             {
                 throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
             }
@@ -677,14 +705,18 @@ namespace System.DirectoryServices.ActiveDirectory
             return handle;
         }
 
-        internal static void FreeDSHandle(IntPtr dsHandle, LoadLibrarySafeHandle libHandle)
+        internal static void FreeDSHandle(IntPtr dsHandle, IntPtr libHandle)
         {
             // DsUnbind
             if (dsHandle != IntPtr.Zero)
             {
                 // call DsUnbind
+#if netcoreapp20
                 IntPtr functionPtr = UnsafeNativeMethods.GetProcAddress(libHandle, "DsUnBindW");
-                if (functionPtr == (IntPtr)0)
+                if (functionPtr == IntPtr.Zero)
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+                if (!NativeLibrary.TryGetExport(libHandle, "DsUnBindW", out IntPtr functionPtr))
+#endif
                 {
                     throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
                 }
@@ -835,7 +867,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
                 // get the string representation of the invocationID
                 byte[] byteGuid = invocationID.ToByteArray();
-                IntPtr ptr = (IntPtr)0;
+                IntPtr ptr = IntPtr.Zero;
                 string stringGuid = null;
 
                 // encode the byte arry into binary string representation
@@ -849,7 +881,7 @@ namespace System.DirectoryServices.ActiveDirectory
                     }
                     finally
                     {
-                        if (ptr != (IntPtr)0)
+                        if (ptr != IntPtr.Zero)
                             UnsafeNativeMethods.FreeADsMem(ptr);
                     }
                 }
@@ -918,7 +950,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
         internal static bool Impersonate(DirectoryContext context)
         {
-            IntPtr hToken = (IntPtr)0;
+            IntPtr hToken = IntPtr.Zero;
 
             // default credential is specified, no need to do impersonation
             if ((context.UserName == null) && (context.Password == null))
@@ -945,7 +977,7 @@ namespace System.DirectoryServices.ActiveDirectory
             }
             finally
             {
-                if (hToken != (IntPtr)0)
+                if (hToken != IntPtr.Zero)
                     UnsafeNativeMethods.CloseHandle(hToken);
             }
 
@@ -954,9 +986,9 @@ namespace System.DirectoryServices.ActiveDirectory
 
         internal static void ImpersonateAnonymous()
         {
-            IntPtr hThread = (IntPtr)0;
+            IntPtr hThread = IntPtr.Zero;
             hThread = UnsafeNativeMethods.OpenThread(s_THREAD_ALL_ACCESS, false, UnsafeNativeMethods.GetCurrentThreadId());
-            if (hThread == (IntPtr)0)
+            if (hThread == IntPtr.Zero)
                 throw ExceptionHelper.GetExceptionFromErrorCode(Marshal.GetLastWin32Error());
 
             try
@@ -967,7 +999,7 @@ namespace System.DirectoryServices.ActiveDirectory
             }
             finally
             {
-                if (hThread != (IntPtr)0)
+                if (hThread != IntPtr.Zero)
                     UnsafeNativeMethods.CloseHandle(hThread);
             }
         }
@@ -1041,10 +1073,10 @@ namespace System.DirectoryServices.ActiveDirectory
 
         internal static IntPtr GetPolicyHandle(string serverName)
         {
-            IntPtr handle = (IntPtr)0;
+            IntPtr handle = IntPtr.Zero;
             LSA_UNICODE_STRING systemName;
             LSA_OBJECT_ATTRIBUTES objectAttribute = new LSA_OBJECT_ATTRIBUTES();
-            IntPtr target = (IntPtr)0;
+            IntPtr target = IntPtr.Zero;
 
             int mask = s_POLICY_VIEW_LOCAL_INFORMATION;
 
@@ -1064,7 +1096,7 @@ namespace System.DirectoryServices.ActiveDirectory
             }
             finally
             {
-                if (target != (IntPtr)0)
+                if (target != IntPtr.Zero)
                     Marshal.FreeHGlobal(target);
             }
         }

--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -251,26 +251,11 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.GetSysColor.cs">
       <Link>Common\Interop\Windows\User32\Interop.GetSysColor.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\User32\Interop.Win32SystemColors.cs">
       <Link>Common\Interop\Windows\User32\Interop.Win32SystemColors.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
-      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\FunctionWrapper.Windows.cs">
-      <Link>Common\System\Runtime\InteropServices\FunctionWrapper.Windows.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.IStream.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.IStream.cs</Link>
@@ -289,6 +274,23 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.HRESULT.cs">
       <Link>Common\Interop\Windows\Interop.HRESULT.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(TargetGroup)' == 'netcoreapp2.0'">
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\InteropServices\FunctionWrapper.Windows.cs">
+      <Link>Common\System\Runtime\InteropServices\FunctionWrapper.Windows.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
+      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="$(TargetGroup.StartsWith('netcoreapp')) AND '$(TargetsUnix)' == 'true'">

--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Windows.cs
@@ -17,13 +17,21 @@ namespace System.Drawing
         {
             private const string LibraryName = "gdiplus.dll";
 
+#if netcoreapp20
             private static SafeLibraryHandle s_gdipHandle;
-
             private static IntPtr LoadNativeLibrary()
             {
                 s_gdipHandle = Interop.Kernel32.LoadLibraryExW(LibraryName, IntPtr.Zero, 0);
                 return s_gdipHandle.DangerousGetHandle();
             }
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+            private static IntPtr s_gdipHandle;
+            private static IntPtr LoadNativeLibrary() =>
+                NativeLibrary.TryLoad(LibraryName, out s_gdipHandle) ?
+                    s_gdipHandle : IntPtr.Zero;
+
+            ~Gdip() => NativeLibrary.Free(s_gdipHandle);
+#endif
 
             private static void PlatformInitialize()
             {

--- a/src/System.Management/src/System.Management.csproj
+++ b/src/System.Management/src/System.Management.csproj
@@ -14,17 +14,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GlobalLock.cs">
       <Link>Common\Interop\Windows\Kernel32\Interop.GlobalLock.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
-      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.CoGetObjectContext.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.CoGetObjectContext.cs</Link>
@@ -40,9 +31,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Ole32\Interop.GetHGlobalFromStream.cs">
       <Link>Common\Interop\Windows\Ole32\Interop.GetHGlobalFromStream.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
-      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
     <Compile Include="System\Management\ManagementBaseObject.cs" />
     <Compile Include="System\Management\ManagementClass.cs" />
@@ -69,6 +57,20 @@
     <Compile Include="System\Management\wmiutil.cs" />
     <Compile Include="System\Management\WMIGenerator.cs" />
     <Compile Include="System\Management\InteropClasses\WMIInterop.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(TargetGroup)' == 'netcoreapp2.0'">
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
+      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />

--- a/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
+++ b/src/System.Net.HttpListener/src/System.Net.HttpListener.csproj
@@ -190,12 +190,6 @@
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.CancelIoEx.cs">
       <Link>Common\Interop\Windows\mincore\Interop.CancelIoEx.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
-      <Link>Common\Interop\Windows\mincore\Interop.FreeLibrary.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
-      <Link>Common\Interop\Windows\mincore\Interop.LoadLibraryEx.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\CoreLib\Interop\Windows\Kernel32\Interop.SECURITY_ATTRIBUTES.cs">
       <Link>Common\CoreLib\Interop\Windows\mincore\Interop.SECURITY_ATTRIBUTES.cs</Link>
     </Compile>
@@ -207,9 +201,6 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LocalAlloc.Constants.cs">
       <Link>Common\Interop\Windows\mincore_obsolete\Interop.LocalAlloc.Constants.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
-      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\SafeLocalAllocHandle.cs</Link>
@@ -332,6 +323,17 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\SspiCli\SSPIWrapper.cs">
       <Link>Common\Interop\Windows\SspiCli\SSPIWrapper.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(ForceManagedImplementation)' != 'true' AND '$(TargetGroup)' == 'netcoreapp2.0' ">
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+      <Link>Common\Interop\Windows\mincore\Interop.LoadLibraryEx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+      <Link>Common\Interop\Windows\mincore\Interop.FreeLibrary.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
+      <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true' OR '$(ForceManagedImplementation)' == 'true' OR ('$(TargetsWindows)' == 'true' AND '$(TargetGroup)' == 'uap')">

--- a/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -117,17 +117,19 @@
     <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs">
       <Link>Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' AND '$(TargetGroup)' == 'netcoreapp2.0' ">
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibrary.cs">
+      <Link>Common\Interop\Windows\Kernel32\Interop.LoadLibrary.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs" Condition="'$(TargetGroup)' != 'uap'">
       <Link>Common\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.GetProcAddress.cs" Condition="'$(TargetGroup)' != 'uap'">
-      <Link>Interop\Windows\Kernel32\Interop.GetProcAddress.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs" Condition="'$(TargetGroup)' != 'uap'">
-      <Link>Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
-      <Link>Interop\Windows\Kernel32\Interop.FreeLibrary.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Win32.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Win32.cs
@@ -2,7 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if netcoreapp20
 using Microsoft.Win32.SafeHandles;
+#else
+using System.Runtime.InteropServices;
+#endif
 
 namespace System.Net
 {
@@ -10,6 +14,7 @@ namespace System.Net
     {
         private static bool GetAddrInfoExSupportsOverlapped()
         {
+#if netcoreapp20
             using (SafeLibraryHandle libHandle = Interop.Kernel32.LoadLibraryExW(Interop.Libraries.Ws2_32, IntPtr.Zero, Interop.Kernel32.LOAD_LIBRARY_SEARCH_SYSTEM32))
             {
                 if (libHandle.IsInvalid)
@@ -19,6 +24,17 @@ namespace System.Net
                 // The existence of 'GetAddrInfoExCancel' indicates that overlapped is supported.
                 return Interop.Kernel32.GetProcAddress(libHandle, Interop.Winsock.GetAddrInfoExCancelFunctionName) != IntPtr.Zero;
             }
+#else // use managed NativeLibrary API from .NET Core 3 onwards
+            if (!NativeLibrary.TryLoad(Interop.Libraries.Ws2_32, out var libHandle))
+                return false;
+
+            // We can't just check that 'GetAddrInfoEx' exists, because it existed before supporting overlapped.
+            // The existence of 'GetAddrInfoExCancel' indicates that overlapped is supported.
+            var supported = NativeLibrary.TryGetExport(libHandle, Interop.Winsock.GetAddrInfoExCancelFunctionName, out _);
+
+            NativeLibrary.Free(libHandle);
+            return supported;
+#endif
         }
     }
 }

--- a/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
+++ b/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
@@ -123,6 +123,8 @@
     <Compile Include="$(CommonPath)\Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs">
       <Link>Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsWindows)' == 'true' AND '$(TargetGroup)' == 'netcoreapp2.0' ">
     <Compile Include="$(CommonPath)\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
       <Link>Common\CoreLi\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -10,17 +10,8 @@
     <Compile Include="..\..\Common\src\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\src\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
-      <Link>Common\Interop\Windows\Interop.FreeLibrary.cs</Link>
-    </Compile>
     <Compile Include="..\..\Common\src\Interop\Windows\Kernel32\Interop.GetModuleHandle.cs">
       <Link>Common\Interop\Windows\Interop.GetModuleHandle.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
-      <Link>Common\Interop\Windows\Interop.LoadLibraryEx.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Common\src\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
-      <Link>Common\src\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\tests\System\IO\TempFile.cs">
       <Link>Common\System\IO\TempFile.cs</Link>
@@ -91,6 +82,17 @@
     <Compile Include="Utilities\ImmutableByteArrayInteropTest.cs" />
     <Compile Include="Utilities\MemoryBlockTests.cs" />
     <Compile Include="Utilities\OrderByTests.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(TargetGroup)' == 'netcoreapp2.0' ">
+    <Compile Include="..\..\Common\src\Interop\Windows\Kernel32\Interop.FreeLibrary.cs">
+      <Link>Common\Interop\Windows\Interop.FreeLibrary.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\Interop\Windows\Kernel32\Interop.LoadLibraryEx.cs">
+      <Link>Common\Interop\Windows\Interop.LoadLibraryEx.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Common\src\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs">
+      <Link>Common\src\CoreLib\Microsoft\Win32\SafeHandles\SafeLibraryHandle.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Namespace\NamespaceForwardedCS.cs" />


### PR DESCRIPTION
Windows part of #34633; replacing `LoadLibrary[Ex]` calls with `NativeLibrary.[Try]Load` managed APIs.