### PR TITLE
Add IEnumerable ZipLink extension method

### DIFF
--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -103,6 +103,7 @@
     <Compile Include="System\Linq\Union.cs" />
     <Compile Include="System\Linq\Utilities.cs" />
     <Compile Include="System\Linq\Where.cs" />
+    <Compile Include="System\Linq\ZipLink.cs" />
     <Compile Include="System\Linq\Zip.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Linq/src/System/Linq/ZipLink.cs
+++ b/src/System.Linq/src/System/Linq/ZipLink.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Linq
+{
+    public static partial class Enumerable
+    {
+        public static IEnumerable<TResult> ZipLink<T, TResult>(this IEnumerable<T> source, Func<T, T, TResult> resultSelector)
+        {
+            if (source is null)
+            {
+                throw Error.ArgumentNull(nameof(source));
+            }
+
+            if (resultSelector is null)
+            {
+                throw Error.ArgumentNull(nameof(resultSelector));
+            }
+
+            return ZipLinkIterator(source, resultSelector);
+        }
+
+        private static IEnumerable<TResult> ZipLinkIterator<T, TResult>(IEnumerable<T> source, Func<T, T, TResult> resultSelector)
+        {
+            using (IEnumerator<T> e = source.GetEnumerator())
+            {
+                if (e.MoveNext())
+                {
+                    T last = e.Current;
+                    while (e.MoveNext())
+                    {
+                        yield return resultSelector(last, last = e.Current);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Linq/tests/System.Linq.Tests.csproj
+++ b/src/System.Linq/tests/System.Linq.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="ToLookupTests.cs" />
     <Compile Include="UnionTests.cs" />
     <Compile Include="WhereTests.cs" />
+    <Compile Include="ZipLinkTests.cs" />
     <Compile Include="ZipTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Linq\SkipTakeData.cs">
       <Link>Common\System\Linq\SkipTakeData.cs</Link>

--- a/src/System.Linq/tests/ZipLinkTests.cs
+++ b/src/System.Linq/tests/ZipLinkTests.cs
@@ -1,0 +1,192 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Linq.Tests
+{
+    public class ZipLinkTests : EnumerableTests
+    {
+        [Fact]
+        public void ImplicitTypeParameters()
+        {
+            IEnumerable<int> source = new int[] { 1, 2, 3, 4 };
+            IEnumerable<int> expected = new int[] { 3, 5, 7 };
+
+            Assert.Equal(expected, source.ZipLink((x, y) => x + y));
+        }
+        
+        [Fact]
+        public void ExplicitTypeParameters()
+        {
+            IEnumerable<int> source = new int[] { 1, 2, 3, 4 };
+            IEnumerable<int> expected = new int[] { 3, 5, 7 };
+
+            Assert.Equal(expected, source.ZipLink<int, int>((x, y) => x + y));
+        }
+
+        [Fact]
+        public void SourceIsNull()
+        {
+            IEnumerable<int> source = null;
+            
+            AssertExtensions.Throws<ArgumentNullException>("source", () => source.ZipLink<int, int>((x, y) => x + y));
+        }
+                
+        [Fact]
+        public void FuncIsNull()
+        {
+            IEnumerable<int> source = new int[] { 1, 2, 3, 4 };
+            Func<int, int, int> func = null;
+            
+            AssertExtensions.Throws<ArgumentNullException>("resultSelector", () => source.ZipLink(func));
+        }
+
+        [Fact]
+        public void ExceptionThrownFromEnumerator()
+        {
+            ThrowsOnMatchEnumerable<int> source = new ThrowsOnMatchEnumerable<int>(new int[] { 1, 3, 3, 4 }, 2);
+            Func<int, int, int> func = (x, y) => x + y;
+            IEnumerable<int> expected = new int[] { 4, 6, 7 };
+            
+            Assert.Equal(expected, source.ZipLink(func));
+
+            source = new ThrowsOnMatchEnumerable<int>(new int[] { 1, 2, 3, 4 }, 2);
+            
+            var zipLink = source.ZipLink(func);
+            
+            Assert.Throws<Exception>(() => zipLink.ToList());
+        }
+
+        [Fact]
+        public void SourceIsEmpty()
+        {
+            IEnumerable<int> source = new int[] { };
+            Func<int, int, int> func = (x, y) => x + y;
+            IEnumerable<int> expected = new int[] { };
+
+            Assert.Equal(expected, source.ZipLink(second, func));
+        }
+
+        [Fact]
+        public void SourceIsSingle()
+        {
+            IEnumerable<int> source = new int[] { 1 };
+            Func<int, int, int> func = (x, y) => x + y;
+            IEnumerable<int> expected = new int[] { };
+
+            Assert.Equal(expected, source.ZipLink(second, func));
+        }
+
+        [Fact]
+        public void SourceHasTwoElements()
+        {
+            IEnumerable<int> source = new int[] { 1, 2 };
+            Func<int, int, int> func = (x, y) => x + y;
+            IEnumerable<int> expected = new int[] { 3 };
+
+            Assert.Equal(expected, source.ZipLink(func));
+        }
+
+        [Fact]
+        public void SourceMany()
+        {
+            IEnumerable<int> source = new int[] { 1, 2, 3, 4 };
+            Func<int, int, int> func = (x, y) => x + y;
+            IEnumerable<int> expected = new int[] { 3, 5, 7 };
+
+            Assert.Equal(expected, source.ZipLink(func));
+        }
+        
+        [Fact]
+        public void DelegateFuncChanged()
+        {
+            IEnumerable<int> source = new int[] { 1, 2, 4, 8 };
+            Func<int, int, int> func = (x, y) => x + y;
+            IEnumerable<int> expected = new int[] { 3, 6, 12 };
+
+            Assert.Equal(expected, source.ZipLink(func));
+
+            func = (x, y) => x - y;
+            expected = new int[] { -1, -2, -4 };
+
+            Assert.Equal(expected, source.ZipLink(func));
+        }
+
+        [Fact]
+        public void LambdaFuncChanged()
+        {
+            IEnumerable<int> source = new int[] { 1, 2, 4, 8 };
+            IEnumerable<int> expected = new int[] { 3, 6, 12 };
+
+            Assert.Equal(expected, source.ZipLink((x, y) => x + y));
+
+            expected = new int[] { -1, -2, -4 };
+
+            Assert.Equal(expected, source.ZipLink((x, y) => x - y));
+        }
+
+        [Fact]
+        public void SourceHasFirstElementNull()
+        {
+            IEnumerable<int?> source = new[] { (int?)null, 2, 3, 4, 5 };
+            Func<int?, int?, int?> func = (x, y) => x + y;
+            IEnumerable<int?> expected = new int?[] { null, 5, 7, 9 };
+
+            Assert.Equal(expected, source.ZipLink(func));
+        }
+
+        [Fact]
+        public void SourceHasMiddleNullValue()
+        {
+            IEnumerable<int?> source = new[] { 1, 2, (int?)null, 4, 5 };
+            Func<int?, int?, int?> func = (x, y) => x + y;
+            IEnumerable<int?> expected = new int?[] { 3, null, null, 9 };
+
+            Assert.Equal(expected, source.ZipLink(func));
+        }
+
+        [Fact]
+        public void SourceHasLastElementNull()
+        {
+            IEnumerable<int?> source = new[] { 1, 2, 3, 4, (int?)null };
+            Func<int?, int?, int?> func = (x, y) => x + y;
+            IEnumerable<int?> expected = new int?[] { 3, 5, 7, null };
+
+            Assert.Equal(expected, source.ZipLink(func));
+        }
+
+        [Fact]
+        public void SourceAllElementsNull()
+        {
+            IEnumerable<int?> source = new int?[] { null, null, null, null };
+            Func<int?, int?, int?> func = (x, y) => x + y;
+            IEnumerable<int?> expected = new int?[] { null, null, null };
+
+            Assert.Equal(expected, source.ZipLink(func));
+        }
+
+        [Fact]
+        public void ForcedToEnumeratorDoesntEnumerate()
+        {
+            var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ZipLink((x, y) => x + y);
+            // Don't insist on this behaviour, but check it's correct if it happens
+            var en = iterator as IEnumerator<int>;
+            Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
+        public void RunOnce()
+        {
+            IEnumerable<int?> source = new[] { 1, 2, (int?)null, 4, 5 };
+            Func<int?, int?, int?> func = (x, y) => x + y;
+            IEnumerable<int?> expected = new int?[] { 3, null, null, 9 };
+
+            Assert.Equal(expected, source.RunOnce().ZipLink(func));
+        }
+    }
+}


### PR DESCRIPTION
The `ZipLink` extension zips each pair of adjacent elements in an `IEnumerable` using a selector.

This is very useful if the list contains a "series of values" and you need to pair them into "Diffs", and allows for very short code that iterates the `IEnumerable` only once, when otherwise using only LINQ extensions you'd need two:

```cs
public IEnumerable<Vector3D> GetPolygonalChain(Point3D[] points) {
  return points.Skip(1).Zip(points, (x1, x0) => x1 - x0);
}

public IEnumerable<Vector3D> GetPolygonalChain(Point3D[] points) {
  return points.ZipLink((x0, x1) => x1 - x0);
}
```

```cs
public IEnumerable<Diff> GetDiffs(IEnumerable<Frame> frames) {
  var fr = frames.ToList(); // Avoid multiple enumeration of "frames"
  return fr.Skip(1).Zip(fr, (next, prev) => Diff.Create(prev, next));
}

public IEnumerable<Diff> GetDiffs(IEnumerable<Frame> frames) {
  return frames.ZipLink(Diff.Create);
}
```