### PR TITLE
make invalidUri more invalid

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2619,7 +2619,8 @@ namespace System.Net.Http.Functional.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue(11057)]
         public async Task GetAsync_InvalidUrl_ExpectedExceptionThrown()
         {
-            string invalidUri = $"http://{Guid.NewGuid().ToString("N")}";
+            string invalidUri = $"http://_{Guid.NewGuid().ToString("N")}";
+            _output.WriteLine($"{DateTime.Now} connecting to {invalidUri}");
             using (HttpClient client = CreateHttpClient())
             {
                 await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(invalidUri));


### PR DESCRIPTION
This is small test improvement to GetAsync_InvalidUrl_ExpectedExceptionThrown()
This test was failing for me and after some investigation I found root cause -> my ISP.

This test generates URI from guid assuming that it would be invalid (instead of using known invalid name) 
However in my case ISP resolves names (and probably tries to serve ads for mistyped hosts)

```
        Output:
          4/22/2019 10:13:39 PM connecting to http://e3e88f4d7635459a99c5eef499931512
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandlerTest.GetAsync_InvalidUrl_ExpectedExceptionThrown [FAIL]


furt@Ubuntu16:~/github/wfurt-corefx-max/src/System.Net.Http/tests/FunctionalTests$ nslookup e3e88f4d7635459a99c5eef499931512.
Server:		10.211.55.1
Address:	10.211.55.1#53

Non-authoritative answer:
Name:	e3e88f4d7635459a99c5eef499931512
Address: 198.105.254.23
Name:	e3e88f4d7635459a99c5eef499931512
Address: 198.105.244.23

and tcpdump:

22:13:25.604873 ethertype IPv4 (0x0800), length 74: 10.211.55.17.48348 > 198.105.244.23.443: Flags [S], seq 4187127244, win 29200, options [mss 1460,sackOK,TS val 5584185 ecr 0,nop,wscale 7], length 0
22:13:25.672991 ethertype IPv4 (0x0800), length 54: 198.105.244.23.443 > 10.211.55.17.48348: Flags [R.], seq 3970218873, ack 4187127245, win 8192, length 0

```
adding '_' makes invalidUri truly invalid and it fails as it should and test does pass. 
 