### PR TITLE
Fix test asset publishing when retrying

### DIFF
--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -135,7 +135,8 @@
                     ManifestCommit="$(ManifestCommit)"
                     ManifestBuildData="$(ManifestBuildData)"
                     ManifestRepoUri="$(ManifestRepoUri)"
-                    AssetManifestPath="$(AssetManifestFilePath)" />
+                    AssetManifestPath="$(AssetManifestFilePath)"
+                    Overwrite="true" />
 
     <ItemGroup>
       <_ManifestToPush Remove="@(_ManifestToPush)" />
@@ -155,6 +156,7 @@
                     ManifestCommit="$(ManifestCommit)"
                     ManifestBuildData="$(ManifestBuildData)"
                     ManifestRepoUri="$(ManifestRepoUri)"
-                    AssetManifestPath="$(AssetManifestDir)ManifestUpload.xml" />
+                    AssetManifestPath="$(AssetManifestDir)ManifestUpload.xml"
+                    Overwrite="true" />
   </Target>
 </Project>


### PR DESCRIPTION
Fixes official builds that are retried, i.e.: https://dev.azure.com/dnceng/internal/_build/results?buildId=165244

The capability to overwrite is exposed here: https://github.com/dotnet/arcade/blob/334225fbbdb0aa87f793dab0db6b7a78d01baa3d/src/Microsoft.DotNet.Build.Tasks.Feed/src/PushToBlobFeed.cs#L28