### PR TITLE
Directory.Move behaves differently on Unix vs. Windows

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -349,6 +349,13 @@ namespace System.IO
                 destFullPath = PathInternal.TrimEndingDirectorySeparator(destFullPath);
             }
 
+            if (FileExists(destFullPath))
+            {
+                // Some Unix distros will overwrite the destination file if it already exists.
+                // Throwing IOException to match Windows behavior.
+                throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, destFullPath));
+            }
+
             if (Interop.Sys.Rename(sourceFullPath, destFullPath) < 0)
             {
                 Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();

--- a/src/System.IO.FileSystem/tests/Directory/Move.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Move.cs
@@ -315,8 +315,8 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]  // Moving to existing directory causes IOException
-        public void WindowsExistingDirectory()
+        // Moving to existing directory causes IOException
+        public void ExistingDirectory()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
             string testDirSource = Path.Combine(testDir.FullName, GetTestFileName());


### PR DESCRIPTION
Fixes #33486

@stephentoub @JeremyKuhne @danmosemsft Do we want to take this breaking change for the sake of consistency across operating systems?