### PR TITLE
fix ReadAtLeastAsync

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1483,7 +1483,7 @@ namespace System.Net.Http
             int totalBytesRead = 0;
             while (totalBytesRead < minReadBytes)
             {
-                int bytesRead = await stream.ReadAsync(buffer).ConfigureAwait(false);
+                int bytesRead = await stream.ReadAsync(buffer.Slice(totalBytesRead)).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
                     throw new IOException(SR.net_http_invalid_response);


### PR DESCRIPTION
we are hitting occasional assert while running HTTP2 tests agains real server (microsoft.com)
The issue is intermittent and hard to predictably reproduce. In one of the runs I collected following debug log:

 >  EnsureIncomingBytesAsync:  minBytes = 4072 **bytesRead = 4096**  bytesNeeded=4065 span=7 **Available=4089** 1363727842

The ReadAtLeastAsync() function read more bytes than Available space in buffer. And than Commit() is rightfully unhappy. 

It seems like the problem lives in ReadAtLeastAsync().
If we read least than needed bytes we will loop again but we would read into same buffer. That can corrupt data but also it can make totalBytesRead go beyond buffer size as we do not calculate remaining space anyhow. 

As this issue is very difficult to reproduce I could not verify actual fix. However since the ReadAtLeastAsync() is clearly wrong I'll assume it is unless we get another evidence. 

fixes #37015 
fixes #37008
 