### PR TITLE
Process: don't wait for stdout/err EOF in WaitForExit

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -212,18 +212,6 @@ namespace System.Diagnostics
             bool exited = GetWaitState().WaitForExit(milliseconds);
             Debug.Assert(exited || milliseconds != Timeout.Infinite);
 
-            if (exited && milliseconds == Timeout.Infinite) // if we have a hard timeout, we cannot wait for the streams
-            {
-                if (_output != null)
-                {
-                    _output.WaitUtilEOF();
-                }
-                if (_error != null)
-                {
-                    _error.WaitUtilEOF();
-                }
-            }
-
             return exited;
         }
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -172,13 +172,6 @@ namespace System.Diagnostics
             }
             finally
             {
-                // If we have a hard timeout, we cannot wait for the streams
-                if (_output != null && milliseconds == Timeout.Infinite)
-                    _output.WaitUtilEOF();
-
-                if (_error != null && milliseconds == Timeout.Infinite)
-                    _error.WaitUtilEOF();
-
                 handle?.Dispose();
             }
         }


### PR DESCRIPTION
Experiment for https://github.com/dotnet/corefx/issues/36783 to see what test fail if this doesn't happen

CC @krwq 