### PR TITLE
Fixes relative path at configSource on linux

### DIFF
--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/BaseConfigurationRecord.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/BaseConfigurationRecord.cs
@@ -3224,7 +3224,7 @@ namespace System.Configuration
             if (configSource.IndexOf('\\') != -1 || configSource.IndexOf('/') != -1) // string.Contains(char) is .NetCore2.1+ specific
             {
                 string newConfigSource = configSource.Replace('\\', '/');
-                if (ConfigPathUtility.IsValid(newConfigSource))
+                if (!ConfigPathUtility.IsValid(newConfigSource))
                     throw new ConfigurationErrorsException(SR.Config_source_invalid_format, errorInfo);
             }
 

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/BaseConfigurationRecord.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/BaseConfigurationRecord.cs
@@ -3218,11 +3218,15 @@ namespace System.Configuration
             if (trimmedConfigSource.Length != configSource.Length)
                 throw new ConfigurationErrorsException(SR.Config_source_invalid_format, errorInfo);
 
-            if (configSource.IndexOf('/') != -1) // string.Contains(char) is .NetCore2.1+ specific
-                throw new ConfigurationErrorsException(SR.Config_source_invalid_chars, errorInfo);
-
             if (string.IsNullOrEmpty(configSource) || Path.IsPathRooted(configSource))
                 throw new ConfigurationErrorsException(SR.Config_source_invalid_format, errorInfo);
+
+            if (configSource.IndexOf('\\') != -1 || configSource.IndexOf('/') != -1) // string.Contains(char) is .NetCore2.1+ specific
+            {
+                string newConfigSource = configSource.Replace('\\', '/');
+                if (ConfigPathUtility.IsValid(newConfigSource))
+                    throw new ConfigurationErrorsException(SR.Config_source_invalid_format, errorInfo);
+            }
 
             return configSource;
         }

--- a/src/System.Configuration.ConfigurationManager/src/System/Configuration/UrlPath.cs
+++ b/src/System.Configuration.ConfigurationManager/src/System/Configuration/UrlPath.cs
@@ -29,10 +29,10 @@ namespace System.Configuration
 
             // Compare up to but not including trailing backslash
             int lDir = dir.Length;
-            if (dir[lDir - 1] == '\\') lDir -= 1;
+            if (dir[lDir - 1] == '\\' || dir[lDir - 1] == '/') lDir -= 1;
 
             int lSubdir = subdir.Length;
-            if (subdir[lSubdir - 1] == '\\') lSubdir -= 1;
+            if (subdir[lSubdir - 1] == '\\' || dir[lDir - 1] == '/') lSubdir -= 1;
 
             if (lSubdir < lDir)
                 return false;
@@ -41,7 +41,7 @@ namespace System.Configuration
                 return false;
 
             // Check subdir that character following length of dir is a backslash
-            return (lSubdir <= lDir) || (subdir[lDir] == '\\');
+            return (lSubdir <= lDir) || (subdir[lDir] == '\\') || (subdir[lDir] == '/');
         }
 
         // NOTE: This function is also present in fx\src\xsp\system\web\util\urlpath.cs

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/AppSettingsTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/AppSettingsTests.cs
@@ -142,22 +142,22 @@ namespace System.ConfigurationTests
 
         public static IEnumerable<object[]> ConfigPaths = new List<object[]>()
         {
-            new object[] { @"../Config/foo.config", typeof(ArgumentException) },
-            new object[] { @"..\Config\foo.config", typeof(ArgumentException) },
-            new object[] { @"\Config\foo.config", typeof(ConfigurationErrorsException) },
-            new object[] { @"/Config/foo.config", typeof(ConfigurationErrorsException) },
-            new object[] { @"\..\Config\foo.config", typeof(ConfigurationErrorsException) },
-            new object[] { @"/../Config/foo.config", typeof(ConfigurationErrorsException) },
+            new object[] { @"../Config/foo.config" },
+            new object[] { @"..\Config\foo.config" },
+            new object[] { @"\Config\foo.config" },
+            new object[] { @"/Config/foo.config" },
+            new object[] { @"\..\Config\foo.config" },
+            new object[] { @"/../Config/foo.config" },
         };
 
         [Theory]
         [MemberData(nameof(ConfigPaths))]
-        public void AppSettingsInvalidConfigSourcePath_Throws(string configPath, Type exception)
+        public void AppSettingsInvalidConfigSourcePath_Throws(string configPath)
         {
             using (var tempConfig = new TempConfig(TestData.EmptyConfig))
             {
                 var config = ConfigurationManager.OpenExeConfiguration(tempConfig.ExePath);
-                Assert.Throws(exception, () => config.AppSettings.SectionInformation.ConfigSource = configPath);
+                Assert.ThrowsAny<Exception>(() => config.AppSettings.SectionInformation.ConfigSource = configPath);
             }
         }
     }

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/AppSettingsTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/AppSettingsTests.cs
@@ -118,24 +118,24 @@ namespace System.ConfigurationTests
         {
             using (var tempConfig = new TempConfig(TestData.EmptyConfig))
             {
-                var tempConfigDirectory = Path.Combine(Path.GetDirectoryName(tempConfig.ConfigPath), "Config");
+                const string SubDirectory = "Config";
+                const string AppConfigFileName = "tempAppConfig.config";
+                string tempConfigDirectory = Path.Combine(Path.GetDirectoryName(tempConfig.ConfigPath), SubDirectory);
                 using (var tempDirectory = new TempDirectory(tempConfigDirectory))
                 {
                     // set configSource and save the config
                     var config = ConfigurationManager.OpenExeConfiguration(tempConfig.ExePath);
-                    config.AppSettings.SectionInformation.ConfigSource = @"Config\tempAppConfig.config";
+                    config.AppSettings.SectionInformation.ConfigSource = Path.Combine(SubDirectory, AppConfigFileName);
                     config.Save();
 
                     // write temporary appConfig
-                    var tempAppConfigPath = Path.Combine(tempConfigDirectory, "tempAppConfig.config");
+                    var tempAppConfigPath = Path.Combine(tempConfigDirectory, AppConfigFileName);
                     File.WriteAllText(tempAppConfigPath, AppSettingsConfig);
 
                     // load config and test the appSettings
                     config = ConfigurationManager.OpenExeConfiguration(tempConfig.ExePath);
                     Assert.NotEmpty(config.AppSettings.Settings);
                     Assert.Equal("AppSettingsValue", config.AppSettings.Settings["AppSettingsKey"].Value);
-
-                    Console.WriteLine("test");
                 }
             }
         }

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using Xunit;
@@ -144,6 +145,27 @@ namespace System.ConfigurationTests
         {
             bool test = UrlPath.IsEqualOrSubdirectory("C:\\Directory", "C:\\Directory\\");
             Assert.True(test);
+        }
+
+        public static IEnumerable<object[]> UnixDirectories = new List<object[]>()
+        {
+            new object[] { "/dir/sub", "/dir", false },     // no slash
+            new object[] { "/dir", "/dir/sub", true },      // no slash
+            new object[] { "/dir/", "/dir/sub/", true },    // both slash
+            new object[] { "/dir/", "/dir/sub", true },     // dir slash 
+            new object[] { "/dir", "/dir/sub/", true },     // subdir slash
+            new object[] { "/dir", "/dir", true },          // no slashes
+            new object[] { "/var/", "/var/", true },        // both slashes
+            new object[] { "/var/", "/var", true },         // first has slash
+            new object[] { "/var", "/var/", true },         // second has slash
+        };
+
+        [Theory]
+        [MemberData(nameof(UnixDirectories))]
+        public void IsEqualOrSubDirectory_UnixPath(string dir, string subdir, bool expected)
+        {
+            bool actual = UrlPath.IsEqualOrSubdirectory(dir, subdir);
+            Assert.Equal(expected, actual);
         }
     }
 }


### PR DESCRIPTION
Allows `/` to be used to imitate `file` attribute behavior, but disallows non-relative paths.
Fixes #29279

Description:
On linux/osx `System.Configuration.ConfigurationManager` is unable to load config files using `configSource` when those files are located at subfolders.
For example the following works:
`<appSettings file="Config/appSettings.config">`
`<appSettings configSource="appSettings.config">`
But this does not:
`<appSettings configSource="Config/appSettings.config">`

The proposed fix is to allow `/` and check if the path is valid to allow config load.

/cc @maryamariyan, @safern
