### PR TITLE
release/3.0: fix ReadAtLeastAsync (#37130)

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1483,7 +1483,7 @@ namespace System.Net.Http
             int totalBytesRead = 0;
             while (totalBytesRead < minReadBytes)
             {
-                int bytesRead = await stream.ReadAsync(buffer).ConfigureAwait(false);
+                int bytesRead = await stream.ReadAsync(buffer.Slice(totalBytesRead)).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
                     throw new IOException(SR.net_http_invalid_response);


### PR DESCRIPTION
This fixes data corruption on HTTP2 responses. 

port of #37130 to release/3.0