### PR TITLE
Fix SocketsHttpHandler system proxy usage logic

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
@@ -63,10 +63,9 @@ namespace System.Net.Http
 
         public bool AutoSettingsUsed => AutoDetect || !string.IsNullOrEmpty(AutoConfigUrl);
 
-        public bool ManualSettingsOnly =>
-            !AutoDetect && string.IsNullOrEmpty(AutoConfigUrl) && !string.IsNullOrEmpty(Proxy);
-
         public bool ManualSettingsUsed => !string.IsNullOrEmpty(Proxy);
+
+        public bool ManualSettingsOnly => !AutoSettingsUsed && ManualSettingsUsed;
 
         public string Proxy { get; private set; }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
@@ -57,29 +57,20 @@ namespace System.Net.Http
             }
         }
 
-        public string AutoConfigUrl { get; set; }
+        public string AutoConfigUrl { get; private set; }
 
-        public bool AutoDetect { get; set; }
+        public bool AutoDetect { get; private set; }
 
-        public bool AutoSettingsUsed
-        {
-            get
-            {
-                return AutoDetect || !string.IsNullOrEmpty(AutoConfigUrl);
-            }
-        }
+        public bool AutoSettingsUsed => AutoDetect || !string.IsNullOrEmpty(AutoConfigUrl);
 
-        public bool ManualSettingsOnly
-        {
-            get
-            {
-                return !AutoDetect && string.IsNullOrEmpty(AutoConfigUrl) && !string.IsNullOrEmpty(Proxy);
-            }
-        }
+        public bool ManualSettingsOnly =>
+            !AutoDetect && string.IsNullOrEmpty(AutoConfigUrl) && !string.IsNullOrEmpty(Proxy);
 
-        public string Proxy { get; set; }
+        public bool ManualSettingsUsed => !string.IsNullOrEmpty(Proxy);
 
-        public string ProxyBypass { get; set; }
+        public string Proxy { get; private set; }
+
+        public string ProxyBypass { get; private set; }
 
         public bool RecentAutoDetectionFailure =>
             _autoDetectionFailed &&

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/Configurations.props
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/Configurations.props
@@ -1,7 +1,7 @@
-﻿<Project DefaultTargets="Build">
+<Project DefaultTargets="Build">
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard-Windows_NT;
+      netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/HttpSystemProxyTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/HttpSystemProxyTest.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.WinHttpHandlerUnitTests
+{
+    public class HttpSystemProxyTest
+    {
+        private const string ManualSettingsProxyHost = "myproxy.local";
+        private const string ManualSettingsProxyBypassList = "localhost;*.local";
+
+        private readonly ITestOutputHelper _output;
+
+        public HttpSystemProxyTest(ITestOutputHelper output)
+        {
+            _output = output;
+            TestControl.ResetAll();
+        }
+
+        public static IEnumerable<object[]> ManualSettingsMemberData()
+        {
+            yield return new object[] { new Uri("http://example.org"), false };
+            yield return new object[] { new Uri("http://example.local"), true };
+            yield return new object[] { new Uri("http://localhost"), true };
+        }
+
+        [Fact]
+        public void TryCreate_WinInetProxySettingsAllOff_ReturnsFalse()
+        {
+            Assert.False(HttpSystemProxy.TryCreate(out IWebProxy webProxy));
+        }
+
+        [Theory]
+        [MemberData(nameof(ManualSettingsMemberData))]
+        public void GetProxy_BothAutoDetectAndManualSettingsButFailedAutoDetect_ManualSettingsUsed(
+            Uri destination, bool bypassProxy)
+        {
+            FakeRegistry.WinInetProxySettings.AutoDetect = true;
+            FakeRegistry.WinInetProxySettings.Proxy = ManualSettingsProxyHost;
+            FakeRegistry.WinInetProxySettings.ProxyBypass = ManualSettingsProxyBypassList;
+            TestControl.PACFileNotDetectedOnNetwork = true;
+
+            Assert.True(HttpSystemProxy.TryCreate(out IWebProxy webProxy));
+            
+            // The first GetProxy() call will try using WinInetProxyHelper (and thus WinHTTP) since AutoDetect is on.
+            Uri proxyUri1 = webProxy.GetProxy(destination);
+            
+            // The second GetProxy call will skip using WinHTTP since AutoDetect is on but
+            // there was a recent AutoDetect failure. This tests the codepath in HttpSystemProxy
+            // which queries WinInetProxyHelper.RecentAutoDetectionFailure.
+            Uri proxyUri2 = webProxy.GetProxy(destination);
+
+            if (bypassProxy)
+            {
+                Assert.Null(proxyUri1);
+                Assert.Null(proxyUri2);
+            }
+            else
+            {
+                Assert.Equal(ManualSettingsProxyHost, proxyUri1.Host);
+                Assert.Equal(ManualSettingsProxyHost, proxyUri2.Host);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ManualSettingsMemberData))]
+        public void GetProxy_ManualSettingsOnly_ManualSettingsUsed(
+            Uri destination, bool bypassProxy)
+        {
+            FakeRegistry.WinInetProxySettings.Proxy = ManualSettingsProxyHost;
+            FakeRegistry.WinInetProxySettings.ProxyBypass = ManualSettingsProxyBypassList;
+
+            Assert.True(HttpSystemProxy.TryCreate(out IWebProxy webProxy));
+            Uri proxyUri = webProxy.GetProxy(destination);
+            if (bypassProxy)
+            {
+                Assert.Null(proxyUri);
+            }
+            else
+            {
+                Assert.Equal(ManualSettingsProxyHost, proxyUri.Host);
+            }
+        }
+
+        [Fact]
+        public void IsBypassed_ReturnsFalse()
+        {
+            FakeRegistry.WinInetProxySettings.AutoDetect = true;
+            Assert.True(HttpSystemProxy.TryCreate(out IWebProxy webProxy));
+            Assert.False(webProxy.IsBypassed(new Uri("http://www.microsoft.com/")));
+        }
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -127,6 +127,9 @@
     <Compile Include="..\..\src\System\Net\Http\WinInetProxyHelper.cs">
       <Link>ProductionCode\WinInetProxyHelper.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\HttpSystemProxy.cs">
+      <Link>ProductionCode\HttpSystemProxy.cs</Link>
+    </Compile>
     <Compile Include="APICallHistory.cs" />
     <Compile Include="ClientCertificateHelper.cs" />
     <Compile Include="ClientCertificateScenarioTest.cs" />
@@ -135,6 +138,7 @@
     <Compile Include="FakeRegistry.cs" />
     <Compile Include="FakeSafeWinHttpHandle.cs" />
     <Compile Include="FakeX509Certificates.cs" />
+    <Compile Include="HttpSystemProxyTest.cs" />
     <Compile Include="SafeWinHttpHandleTest.cs" />
     <Compile Include="SendRequestHelper.cs" />
     <Compile Include="TestServer.cs" />


### PR DESCRIPTION
SocketsHttpHandler was not using the proxy bypass list specified in IE settings in cases where
there is a combination of both 'AutoDetect' and 'Manual' settings in the IE settings dialog.

SocketsHttpHandler uses WinHttpHandler's WinInetProxyHelper class as part of the HttpSystemProxy
class. But it was consuming it in an incorrect way. WinInetProxyHelper was originally written to
be used only with the rest of the WinHTTP stack for WinHttpHandler. When WinHTTP GetProxyForUrl()
was returning a ProxyBypass string, HttpSystemProxy was ignoring it. It was assuming that the
string for Proxy was correct. But in cases where ProxyBypass is returned, the Proxy string is only
used if the destination uri doesn't match any of the strings in the ProxyBypass list. That logic
would normally be handled automatically by WinHttpHandler. But HttpSystemProxy was simply
discarding the ProxyBypass string returned by WinHTTP GetProxyForUrl().

In order to address this fix, I added new tests for HttpSystemProxy. I utilized the existing mock
layers for registry and WinHTTP interop that are contained in the WinHttpHandler Unit Tests. It might
seem weird to have tests for the internal HttpSystemProxy class located in the WinHttpHandler folder.
But, we already pull in the source code for WinInetProxyHelper from WinHttpHandler into the
SocketsHttpHandler compilation. Using these Unit Tests with the mocking layers allows us to test a
broad range of scenarios (registry settings and network failures) that are normally difficult to test.
I have a plan, though, to refactor the system proxy code and tests as part of implementing #36553.
That will result in the system proxy code and tests ending up in a more logical place.

Fixes #33866