### PR TITLE
SqlClient reduce lock contention

### DIFF
--- a/src/Common/src/System/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Common/src/System/Data/ProviderBase/DbConnectionFactory.cs
@@ -246,7 +246,7 @@ namespace System.Data.ProviderBase
                         try
                         {
                             connectionPoolGroup = newConnectionPoolGroup;
-                            _connectionPoolGroups = newConnectionPoolGroups;
+                            Interlocked.Exchange(ref _connectionPoolGroups, newConnectionPoolGroups);
                         }
                         finally
                         {
@@ -351,7 +351,7 @@ namespace System.Data.ProviderBase
                         }
                     }
                 }
-                _connectionPoolGroups = newConnectionPoolGroups;
+                Interlocked.Exchange(ref _connectionPoolGroups, newConnectionPoolGroups);
             }
             finally
             {


### PR DESCRIPTION
relates to https://github.com/dotnet/corefx/issues/30430 and https://github.com/dotnet/corefx/issues/25132

Profiling shows that getting sql connections out of the pool can hit hot locks and potentially limit maximum throughput. I've used the DataAccessPerformance benchmark based on the TechEmpower benchmarks available [here](https://github.com/aspnet/DataAccessPerformance) to review and make some small changes which roughly halve the contention.

before:
![dataaccessperf-master](https://user-images.githubusercontent.com/13322696/56694853-98466080-66df-11e9-8276-26f3adbcd918.PNG)

after:
![dataaccessperf-locking](https://user-images.githubusercontent.com/13322696/56694856-9bd9e780-66df-11e9-87c6-6e36ba89b78e.PNG)

 - In `DbConnectionFactory` I changed from using lock to a `ReaderWriterLockSlim` which completely eliminates Set_Connection from the contention in this benchmark.
- In DbConnectionPoolGroup I've changed the state transition to be lock free which will matter when pooling is not enabled. I've attempted to reduce the work done under the lock when creating a pool but I don't believe this can be eliminated entirely, if you don't start the pool inside the lock you may end up in a highly contended scenario starting a large number of pools which will then try to create a lot of connections each which would be a massive drain on resources when only one of those pools can be used. The Startup() call must be called as little as possible from when I can see.
- Some of the ReadAsync and ExecuteDbReaderAsync will be improved with another PR I have in the pipeline

Functional manual and load testing with the benchmark all pass without problems. This is all about locking though so please review carefully.
/cc all the area people @afsanehr, @tarikulsabbir, @Gary-Zh , @david-engel and interested people @saurabh500 @roji 