### PR TITLE
Fix DateTime(Offset) formatting bugs in Utf8JsonWriter

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
@@ -29,6 +29,11 @@ namespace System.Text.Json
                 buffer.Length == (JsonConstants.MaximumFormatDateTimeLength + 1) ||
                 buffer.Length == JsonConstants.MaximumFormatDateTimeOffsetLength);
 
+            if (buffer.Length == JsonConstants.MaximumFormatDateTimeOffsetLength)
+            {
+                Debug.Assert(buffer[30] == JsonConstants.Colon);
+            }
+
             uint digit7 = buffer[26] - (uint)'0';
             uint digit6 = buffer[25] - (uint)'0';
             uint digit5 = buffer[24] - (uint)'0';
@@ -90,14 +95,14 @@ namespace System.Text.Json
                     // Last index of the offset
                     int bufferEnd = curIndex + 5;
 
-                    // Temporary offset characters to prevent their values from being overwritten
-                    byte offsetMinDigit2 = buffer[32];
+                    // Cache offset characters to prevent them from being overwritten
+                    // The second minute digit is never at risk
                     byte offsetMinDigit1 = buffer[31];
                     byte offsetHourDigit2 = buffer[29];
                     byte offsetHourDigit1 = buffer[28];
 
                     // Write offset characters
-                    buffer[bufferEnd] = offsetMinDigit2;
+                    buffer[bufferEnd] = buffer[32];
                     buffer[bufferEnd - 1] = offsetMinDigit1;
                     buffer[bufferEnd - 2] = JsonConstants.Colon;
                     buffer[bufferEnd - 3] = offsetHourDigit2;

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Date.cs
@@ -61,7 +61,8 @@ namespace System.Text.Json
                 int fractionEnd = 19 + numFractionDigits;
 
                 // Write fraction
-                for (int i = fractionEnd; i >= curIndex; i--)
+                // Leading zeros are written because the fraction becomes zero when it's their turn
+                for (int i = fractionEnd; i > curIndex; i--)
                 {
                     buffer[i] = (byte)((fraction % 10) + (uint)'0');
                     fraction /= 10;
@@ -89,11 +90,18 @@ namespace System.Text.Json
                     // Last index of the offset
                     int bufferEnd = curIndex + 5;
 
-                    buffer[bufferEnd] = buffer[32];
-                    buffer[bufferEnd - 1] = buffer[31];
-                    buffer[bufferEnd - 2] = buffer[30];
-                    buffer[bufferEnd - 3] = buffer[29];
-                    buffer[bufferEnd - 4] = buffer[28];
+                    // Temporary offset characters to prevent their values from being overwritten
+                    byte offsetMinDigit2 = buffer[32];
+                    byte offsetMinDigit1 = buffer[31];
+                    byte offsetHourDigit2 = buffer[29];
+                    byte offsetHourDigit1 = buffer[28];
+
+                    // Write offset characters
+                    buffer[bufferEnd] = offsetMinDigit2;
+                    buffer[bufferEnd - 1] = offsetMinDigit1;
+                    buffer[bufferEnd - 2] = JsonConstants.Colon;
+                    buffer[bufferEnd - 3] = offsetHourDigit2;
+                    buffer[bufferEnd - 4] = offsetHourDigit1;
 
                     // bytes written is the last index of the offset + 1
                     bytesWritten = bufferEnd + 1;

--- a/src/System.Text.Json/tests/JsonDateTimeTestData.cs
+++ b/src/System.Text.Json/tests/JsonDateTimeTestData.cs
@@ -220,5 +220,39 @@ namespace System.Text.Json.Tests
             // Proper format but invalid calendar date, time, or time zone designator fields 1997-00-16
             yield return new object[] { "\"\\u0031\\u0039\\u0039\\u0037\\u002d\\u0030\\u0030\\u002d\\u0031\\u0036\"" };
         }
+
+        public static IEnumerable<object[]> DateTimeFractionTrimBaseTests()
+        {
+            yield return new object[] { "2019-04-24T14:50:17.0000000", "2019-04-24T14:50:17" };
+            yield return new object[] { "2019-04-24T14:50:17.1000000", "2019-04-24T14:50:17.1" };
+            yield return new object[] { "2019-04-24T14:50:17.1100000", "2019-04-24T14:50:17.11" };
+            yield return new object[] { "2019-04-24T14:50:17.1110000", "2019-04-24T14:50:17.111" };
+            yield return new object[] { "2019-04-24T14:50:17.1111000", "2019-04-24T14:50:17.1111" };
+            yield return new object[] { "2019-04-24T14:50:17.1111100", "2019-04-24T14:50:17.11111" };
+            yield return new object[] { "2019-04-24T14:50:17.1111110", "2019-04-24T14:50:17.111111" };
+            yield return new object[] { "2019-04-24T14:50:17.1111111", "2019-04-24T14:50:17.1111111" };
+            yield return new object[] { "2019-04-24T14:50:17.0000001", "2019-04-24T14:50:17.0000001" };
+            yield return new object[] { "2019-04-24T14:50:17.0000010", "2019-04-24T14:50:17.000001" };
+            yield return new object[] { "2019-04-24T14:50:17.0000100", "2019-04-24T14:50:17.00001" };
+            yield return new object[] { "2019-04-24T14:50:17.0001000", "2019-04-24T14:50:17.0001" };
+            yield return new object[] { "2019-04-24T14:50:17.0010000", "2019-04-24T14:50:17.001" };
+            yield return new object[] { "2019-04-24T14:50:17.0100000", "2019-04-24T14:50:17.01" };
+        }
+
+        public static IEnumerable<object[]> DateTimeFractionTrimUtcOffsetTests()
+        {
+            foreach (object[] test in DateTimeFractionTrimBaseTests())
+            {
+                yield return new object[] { $"{(string)(test[0])}Z", $"{(string)(test[1])}Z" };
+            }
+        }
+
+        public static IEnumerable<object[]> DateTimeOffsetFractionTrimTests()
+        {
+            foreach (object[] test in DateTimeFractionTrimBaseTests())
+            {
+                yield return new object[] { $"{(string)(test[0])}+01:00", $"{(string)(test[1])}+01:00" };
+            }
+        }
     }
 }

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -3340,6 +3340,50 @@ namespace System.Text.Json.Tests
             WriteTooLargeHelper(options, key.Slice(0, 10_000_000 / 3), value.Slice(0, 10_000_000 / 3), noThrow: true);
         }
 
+        [Theory]
+        [InlineData("2019-04-24T14:50:17.0000000", "\"2019-04-24T14:50:17\"")]
+        [InlineData("2019-04-24T14:50:17.1000000", "\"2019-04-24T14:50:17.1\"")]
+        [InlineData("2019-04-24T14:50:17.0001000", "\"2019-04-24T14:50:17.0001\"")]
+        [InlineData("2019-04-24T14:50:17.0001500", "\"2019-04-24T14:50:17.00015\"")]
+        [InlineData("2019-04-24T14:50:17.0996100", "\"2019-04-24T14:50:17.09961\"")]
+        [InlineData("2019-04-24T14:50:17.0996141", "\"2019-04-24T14:50:17.0996141\"")]
+        [InlineData("2019-04-24T14:50:17.0000000Z", "\"2019-04-24T14:50:17Z\"")]
+        [InlineData("2019-04-24T14:50:17.1000000Z", "\"2019-04-24T14:50:17.1Z\"")]
+        [InlineData("2019-04-24T14:50:17.0001000Z", "\"2019-04-24T14:50:17.0001Z\"")]
+        [InlineData("2019-04-24T14:50:17.0001500Z", "\"2019-04-24T14:50:17.00015Z\"")]
+        [InlineData("2019-04-24T14:50:17.0996100Z", "\"2019-04-24T14:50:17.09961Z\"")]
+        [InlineData("2019-04-24T14:50:17.0996141Z", "\"2019-04-24T14:50:17.0996141Z\"")]
+        public void WriteDateTime_TrimsFractionCorrectly(string testStr, string expectedStr)
+        {
+            var options = new JsonWriterOptions { Indented = false, SkipValidation = false };
+            var output = new ArrayBufferWriter<byte>(1024);
+            var jsonUtf8 = new Utf8JsonWriter(output, options);
+
+            jsonUtf8.WriteStringValue(DateTime.ParseExact(testStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
+            jsonUtf8.Flush();
+
+            AssertContents(expectedStr, output);
+        }
+
+        [Theory]
+        [InlineData("2019-04-24T14:50:17.0000000+01:00", "\"2019-04-24T14:50:17+01:00\"")]
+        [InlineData("2019-04-24T14:50:17.1000000+01:00", "\"2019-04-24T14:50:17.1+01:00\"")]
+        [InlineData("2019-04-24T14:50:17.0001000+01:00", "\"2019-04-24T14:50:17.0001+01:00\"")]
+        [InlineData("2019-04-24T14:50:17.0001500+01:00", "\"2019-04-24T14:50:17.00015+01:00\"")]
+        [InlineData("2019-04-24T14:50:17.0996100+01:00", "\"2019-04-24T14:50:17.09961+01:00\"")]
+        [InlineData("2019-04-24T14:50:17.0996141+01:00", "\"2019-04-24T14:50:17.0996141+01:00\"")]
+        public void WriteDateTimeOffset_TrimsFractionCorrectly(string testStr, string expectedStr)
+        {
+            var options = new JsonWriterOptions { Indented = false, SkipValidation = false };
+            var output = new ArrayBufferWriter<byte>(1024);
+            var jsonUtf8 = new Utf8JsonWriter(output, options);
+
+            jsonUtf8.WriteStringValue(DateTimeOffset.ParseExact(testStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
+            jsonUtf8.Flush();
+
+            AssertContents(expectedStr, output);
+        }
+
         private static void WriteTooLargeHelper(JsonWriterOptions options, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, bool noThrow = false)
         {
             // Resizing is too slow, even for outerloop tests, so initialize to a large output size up front.

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -3341,47 +3341,37 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("2019-04-24T14:50:17.0000000", "\"2019-04-24T14:50:17\"")]
-        [InlineData("2019-04-24T14:50:17.1000000", "\"2019-04-24T14:50:17.1\"")]
-        [InlineData("2019-04-24T14:50:17.0001000", "\"2019-04-24T14:50:17.0001\"")]
-        [InlineData("2019-04-24T14:50:17.0001500", "\"2019-04-24T14:50:17.00015\"")]
-        [InlineData("2019-04-24T14:50:17.0996100", "\"2019-04-24T14:50:17.09961\"")]
-        [InlineData("2019-04-24T14:50:17.0996141", "\"2019-04-24T14:50:17.0996141\"")]
-        [InlineData("2019-04-24T14:50:17.0000000Z", "\"2019-04-24T14:50:17Z\"")]
-        [InlineData("2019-04-24T14:50:17.1000000Z", "\"2019-04-24T14:50:17.1Z\"")]
-        [InlineData("2019-04-24T14:50:17.0001000Z", "\"2019-04-24T14:50:17.0001Z\"")]
-        [InlineData("2019-04-24T14:50:17.0001500Z", "\"2019-04-24T14:50:17.00015Z\"")]
-        [InlineData("2019-04-24T14:50:17.0996100Z", "\"2019-04-24T14:50:17.09961Z\"")]
-        [InlineData("2019-04-24T14:50:17.0996141Z", "\"2019-04-24T14:50:17.0996141Z\"")]
+        [MemberData(nameof(JsonDateTimeTestData.DateTimeFractionTrimBaseTests), MemberType = typeof(JsonDateTimeTestData))]
+        [MemberData(nameof(JsonDateTimeTestData.DateTimeFractionTrimUtcOffsetTests), MemberType = typeof(JsonDateTimeTestData))]
         public void WriteDateTime_TrimsFractionCorrectly(string testStr, string expectedStr)
         {
-            var options = new JsonWriterOptions { Indented = false, SkipValidation = false };
             var output = new ArrayBufferWriter<byte>(1024);
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output);
 
             jsonUtf8.WriteStringValue(DateTime.ParseExact(testStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
             jsonUtf8.Flush();
 
-            AssertContents(expectedStr, output);
+            AssertContents($"\"{expectedStr}\"", output);
         }
 
         [Theory]
-        [InlineData("2019-04-24T14:50:17.0000000+01:00", "\"2019-04-24T14:50:17+01:00\"")]
-        [InlineData("2019-04-24T14:50:17.1000000+01:00", "\"2019-04-24T14:50:17.1+01:00\"")]
-        [InlineData("2019-04-24T14:50:17.0001000+01:00", "\"2019-04-24T14:50:17.0001+01:00\"")]
-        [InlineData("2019-04-24T14:50:17.0001500+01:00", "\"2019-04-24T14:50:17.00015+01:00\"")]
-        [InlineData("2019-04-24T14:50:17.0996100+01:00", "\"2019-04-24T14:50:17.09961+01:00\"")]
-        [InlineData("2019-04-24T14:50:17.0996141+01:00", "\"2019-04-24T14:50:17.0996141+01:00\"")]
+        [MemberData(nameof(JsonDateTimeTestData.DateTimeOffsetFractionTrimTests), MemberType = typeof(JsonDateTimeTestData))]
         public void WriteDateTimeOffset_TrimsFractionCorrectly(string testStr, string expectedStr)
         {
-            var options = new JsonWriterOptions { Indented = false, SkipValidation = false };
             var output = new ArrayBufferWriter<byte>(1024);
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output);
 
             jsonUtf8.WriteStringValue(DateTimeOffset.ParseExact(testStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
             jsonUtf8.Flush();
 
-            AssertContents(expectedStr, output);
+            AssertContents($"\"{expectedStr}\"", output);
+        }
+
+        [Fact]
+        public void WriteDateTime_TrimsFractionCorrectly_SerializerRoundtrip()
+        {
+            DateTime utcNow = DateTime.UtcNow;
+            Assert.Equal(utcNow, Serialization.JsonSerializer.Parse(Serialization.JsonSerializer.ToBytes(utcNow), typeof(DateTime)));
         }
 
         private static void WriteTooLargeHelper(JsonWriterOptions options, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, bool noThrow = false)


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/37147.

- The period token was being overwritten by a '0' token for some inputs.
- Some offset tokens were being overwritten for some inputs.

cc @BrennanConroy 