### PR TITLE
deal with empty response headers for HTTP2

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -260,7 +260,16 @@ namespace System.Net.Http.HPack
 
                         if (_integerDecoder.StartDecode((byte)(b & ~HuffmanMask), StringLengthPrefix))
                         {
-                            OnStringLength(_integerDecoder.Value, nextState: State.HeaderValue);
+                            if (_integerDecoder.Value > 0)
+                            {
+                                OnStringLength(_integerDecoder.Value, nextState: State.HeaderValue);
+                            }
+                            else
+                            {
+                                OnString(nextState: State.Ready);
+                                var headerNameSpan = new ReadOnlySpan<byte>(_headerName, 0, _headerNameLength);
+                                onHeader(onHeaderState, headerNameSpan, new ReadOnlySpan<byte>());
+                            }
                         }
                         else
                         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -266,9 +266,8 @@ namespace System.Net.Http.HPack
                             }
                             else
                             {
-                                OnString(nextState: State.Ready);
-                                var headerNameSpan = new ReadOnlySpan<byte>(_headerName, 0, _headerNameLength);
-                                onHeader(onHeaderState, headerNameSpan, new ReadOnlySpan<byte>());
+                                OnStringLength(_integerDecoder.Value, nextState: State.Ready);
+                                OnHeaderComplete(onHeader, onHeaderState, new ReadOnlySpan<byte>(_headerName, 0, _headerNameLength), new ReadOnlySpan<byte>());
                             }
                         }
                         else
@@ -294,12 +293,7 @@ namespace System.Net.Http.HPack
                             var headerNameSpan = new ReadOnlySpan<byte>(_headerName, 0, _headerNameLength);
                             var headerValueSpan = new ReadOnlySpan<byte>(_headerValueOctets, 0, _headerValueLength);
 
-                            onHeader(onHeaderState, headerNameSpan, headerValueSpan);
-
-                            if (_index)
-                            {
-                                _dynamicTable.Insert(headerNameSpan, headerValueSpan);
-                            }
+                            OnHeaderComplete(onHeader, onHeaderState, headerNameSpan, headerValueSpan);
                         }
 
                         break;
@@ -396,6 +390,18 @@ namespace System.Net.Http.HPack
             }
 
             _state = nextState;
+        }
+
+        // Called when we have complete header with name and value.
+        private void OnHeaderComplete(HeaderCallback onHeader, object onHeaderState, ReadOnlySpan<byte> headerName, ReadOnlySpan<byte> headerValue)
+        {
+            // Call provided callback.
+            onHeader(onHeaderState, headerName, headerValue);
+
+            if (_index)
+            {
+                _dynamicTable.Insert(headerName, headerValue);
+            }
         }
 
         private HeaderField GetHeader(int index)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -98,6 +98,31 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        public async Task SendAsync_EmptyResponseHeader_Success()
+        {
+            await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
+            {
+                using (var client = CreateHttpClient())
+                {
+                    var message = new HttpRequestMessage(HttpMethod.Get, uri);
+                    var response = await  client.SendAsync(message).ConfigureAwait(false);
+
+                    Assert.Equal(3, response.Headers.Count());
+                    Assert.NotNull(response.Headers.GetValues("x-empty"));
+                }
+            },
+            async server =>
+            {
+                IList<HttpHeaderData> headers = new HttpHeaderData[] {
+                                new HttpHeaderData("x-test", "SendAsync_EmptyHeader_Success"),
+                                new HttpHeaderData("x-empty", ""),
+                                new HttpHeaderData("x-last", "bye") };
+
+                HttpRequestData requestData = await server.HandleRequestAsync(HttpStatusCode.OK, headers);
+            });
+        }
+
+        [Fact]
         public async Task GetAsync_MissingExpires_ReturnNull()
         {
              await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -98,27 +98,25 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public async Task SendAsync_EmptyResponseHeader_Success()
+        public async Task GetAsync_EmptyResponseHeader_Success()
         {
+            IList<HttpHeaderData> headers = new HttpHeaderData[] {
+                                                new HttpHeaderData("x-test", "SendAsync_EmptyHeader_Success"),
+                                                new HttpHeaderData("x-empty", ""),
+                                                new HttpHeaderData("x-last", "bye") };
+
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
-                using (var client = CreateHttpClient())
+                using (HttpClient client = CreateHttpClient())
                 {
-                    var message = new HttpRequestMessage(HttpMethod.Get, uri);
-                    var response = await  client.SendAsync(message).ConfigureAwait(false);
-
-                    // HTTP/1.1 adds Connection: close and Date
-                    Assert.Equal(UseHttp2LoopbackServer ? 3 : 5, response.Headers.Count());
+                    HttpResponseMessage response = await  client.GetAsync(uri).ConfigureAwait(false);
+                    // HTTP/1.1 LoopbackServer adds Connection: close and Date to responses.
+                    Assert.Equal(UseHttp2LoopbackServer ?  headers.Count : headers.Count + 2, response.Headers.Count());
                     Assert.NotNull(response.Headers.GetValues("x-empty"));
                 }
             },
             async server =>
             {
-                IList<HttpHeaderData> headers = new HttpHeaderData[] {
-                                new HttpHeaderData("x-test", "SendAsync_EmptyHeader_Success"),
-                                new HttpHeaderData("x-empty", ""),
-                                new HttpHeaderData("x-last", "bye") };
-
                 HttpRequestData requestData = await server.HandleRequestAsync(HttpStatusCode.OK, headers);
             });
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -107,7 +107,8 @@ namespace System.Net.Http.Functional.Tests
                     var message = new HttpRequestMessage(HttpMethod.Get, uri);
                     var response = await  client.SendAsync(message).ConfigureAwait(false);
 
-                    Assert.Equal(3, response.Headers.Count());
+                    // HTTP/1.1 adds Connection: close and Date
+                    Assert.Equal(UseHttp2LoopbackServer ? 3 : 5, response.Headers.Count());
                     Assert.NotNull(response.Headers.GetValues("x-empty"));
                 }
             },

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.TrailingHeaders.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.TrailingHeaders.cs
@@ -19,7 +19,9 @@ namespace System.Net.Http.Functional.Tests
     {
         private static byte[] s_dataBytes = Encoding.ASCII.GetBytes("data");
         private static IList<HttpHeaderData> s_trailingHeaders = new HttpHeaderData[] {
-            new HttpHeaderData("MyCoolTrailerHeader", "amazingtrailer"), new HttpHeaderData("Hello", "World") };
+            new HttpHeaderData("MyCoolTrailerHeader", "amazingtrailer"),
+            new HttpHeaderData("EmptyHeader", ""),
+            new HttpHeaderData("Hello", "World") };
 
         private static Frame MakeDataFrame(int streamId, byte[] data, bool endStream = false) =>
             new DataFrame(data, (endStream ? FrameFlags.EndStream : FrameFlags.None), 0, streamId);
@@ -278,6 +280,7 @@ namespace System.Net.Http.Functional.Tests
 
                 HttpResponseMessage response = await sendTask;
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal(s_trailingHeaders.Count, response.TrailingHeaders.Count());
                 Assert.Contains("amazingtrailer", response.TrailingHeaders.GetValues("MyCoolTrailerHeader"));
                 Assert.Contains("World", response.TrailingHeaders.GetValues("Hello"));
             }
@@ -343,6 +346,7 @@ namespace System.Net.Http.Functional.Tests
                 // Read data until EOF is reached
                 while (stream.Read(data, 0, data.Length) != 0);
 
+                Assert.Equal(s_trailingHeaders.Count, response.TrailingHeaders.Count());
                 Assert.Contains("amazingtrailer", response.TrailingHeaders.GetValues("MyCoolTrailerHeader"));
                 Assert.Contains("World", response.TrailingHeaders.GetValues("Hello"));
             }
@@ -366,7 +370,7 @@ namespace System.Net.Http.Functional.Tests
 
                 HttpResponseMessage response = await sendTask;
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
+                Assert.Equal(s_trailingHeaders.Count, response.TrailingHeaders.Count());
                 Assert.Contains("amazingtrailer", response.TrailingHeaders.GetValues("MyCoolTrailerHeader"));
                 Assert.Contains("World", response.TrailingHeaders.GetValues("Hello"));
             }


### PR DESCRIPTION
This issue happens when server sends back empty response header. We would transition to State.HeaderValue and never recover. 

Added test would fail same way as real server. 
With the fix, test passes as well as I can able to fetch page from www.wired.com via HTTP2.

fixes #37154