### PR TITLE
Use Coreclr transport packages

### DIFF
--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
     <NoWarn>$(NoWarn);NU1603;NU1605</NoWarn>
+    <SwapNativeForIL Condition="'$(SwapNativeForIL)' == '' AND ('$(ConfigurationGroup)' == 'Debug' OR '$(Coverage)' == 'true')">true</SwapNativeForIL>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsAOT)'=='true'">
     <!-- System.Private.* can't be on the ILCInputFolder since ilc.exe needs to use the matching one from its toolchain. -->
@@ -45,19 +46,6 @@
     <FileToExclude Include="apphost" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- For IL rewrite tools of crossgen dll from CoreClr we need the respective IL and respective pdbs -->
-    <!-- For crossgen dlls save respective pdbs too -->
-    <AdditionalBinPlaceConfiguration Condition="'$(BinPlaceTestSharedFramework)' == 'true'" Include="$(Configuration)">
-      <ItemName>CoreCLRILFiles</ItemName>
-      <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)il</RuntimePath>
-    </AdditionalBinPlaceConfiguration>
-    <AdditionalBinPlaceConfiguration Condition="'$(BinPlaceTestSharedFramework)' == 'true'" Include="$(Configuration)">
-      <ItemName>CoreCLRCrossGenFiles</ItemName>
-      <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)ni</RuntimePath>
-    </AdditionalBinPlaceConfiguration>
-  </ItemGroup>
-
   <!-- Setup the testing shared framework host -->
   <Target Name="SetupTestingHost" AfterTargets="AfterResolveReferences" Condition="'$(BinPlaceTestSharedFramework)' == 'true'">
 
@@ -87,7 +75,25 @@
     <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(OS)' != 'Windows_NT'"/>
   </Target>
 
-  <Target Name="CalculateCoreCLRPackagePath" DependsOnTargets="ResolveAssemblyReferences">
+  <Target Name="OverrideRuntime"
+          Condition="'$(CoreCLROverridePath)' != ''"
+          AfterTargets="AfterResolveReferences;FilterNugetPackages">
+    <Error Condition="!Exists('$(CoreCLROverridePath)')" Text="The path provided to CoreCLROverridePath ($(CoreCLROverridePath)) does not exist." />
+    <PropertyGroup>
+      <CoreCLRPDBOverridePath Condition="'$(CoreCLRPDBOverridePath)' == '' and Exists('$(CoreCLROverridePath)/PDB')">$(CoreCLROverridePath)/PDB</CoreCLRPDBOverridePath>
+    </PropertyGroup>
+    <ItemGroup>
+      <CoreCLRFiles Include="$(CoreCLROverridePath)/*.*" />
+      <CoreCLRFiles Condition="'$(CoreCLRPDBOverridePath)' != ''" Include="$(CoreCLRPDBOverridePath)/*.pdb;$(CoreCLRPDBOverridePath)/*.dbg" />
+
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRFiles->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
+      <ReferenceCopyLocalPaths Include="@(CoreCLRFiles)" />
+    </ItemGroup>
+
+    <Error Condition="'@(CoreCLRFiles)' == ''" Text="The path provided to CoreCLROverridePath ($(CoreCLROverridePath)) does not contain any files." />
+  </Target>
+
+  <Target Name="GetCoreLibPackagePath" Condition="'$(CoreCLROverridePath)' == ''" DependsOnTargets="ResolveAssemblyReferences">
     <ItemGroup>
       <_CoreLibFile Include="@(ReferenceCopyLocalPaths)" Condition="'%(FileName)' == 'System.Private.CoreLib'" />
     </ItemGroup>
@@ -95,52 +101,27 @@
       <_CoreLibFilePath>%(_CoreLibFile.FullPath)</_CoreLibFilePath>
       <_CoreLibPackagePath>$(_CoreLibFilePath.SubString(0, $(_CoreLibFilePath.IndexOf('runtimes'))))</_CoreLibPackagePath>
     </PropertyGroup>
+    <Error Condition="'$(_CoreLibPackagePath)' == '' OR !Exists('$(_CoreLibPackagePath)')" 
+           Text="Could not locate the CoreClr package." />
   </Target>
-  
-  <Target Name="BinPlaceCoreCLRSymbols"
-          AfterTargets="AfterResolveReferences"
-          DependsOnTargets="CalculateCoreCLRPackagePath"
-          Condition="'$(CoreCLROverridePath)' == '' AND '$(DownloadCoreCLRSymbols)' != 'false'">
-      <ItemGroup>
-        <ReferenceCopyLocalPaths Include="$(_CoreLibPackagePath)/**/native/*.pdb;$(_CoreLibPackagePath)/**/native/*.dbg" />
 
-        <CoreCLRILFiles Include="$(_CoreLibPackagePath)/**/il/*.*" />
-        <CoreCLRILFiles>
-          <CrossGenAssemblyPath>$([System.IO.Path]::GetFullPath('%(RootDir)%(Directory)../native/'))</CrossGenAssemblyPath>
-        </CoreCLRILFiles>
-        <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename)%(Extension)')" />
-        <CoreCLRCrossGenFiles Condition="'$(OSGroup)'=='Windows_NT'" Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename).ni.pdb')" />
-        <CoreCLRILFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename).pdb')" />
+  <Target Name="GetCoreCLRILFiles" DependsOnTargets="GetCoreLibPackagePath">
+    <ItemGroup>
+      <CoreCLRILFiles Condition="'$(CoreCLROverridePath)' == ''" Include="$(_CoreLibPackagePath)/**/il/*.*" />
+      <CoreCLRILFiles Condition="'$(CoreCLROverridePath)' != ''" Include="$(CoreCLROverridePath)/IL/*.*" />
+    </ItemGroup>
+    <Error Condition="'@(CoreCLRILFiles)' == ''" Text="Could not locate CoreCLR IL files." />
+  </Target>
+
+  <Target Name="SwapNativeForIL"
+          AfterTargets="AfterResolveReferences"
+          DependsOnTargets="GetCoreCLRILFiles;OverrideRuntime"
+          Condition="'$(SwapNativeForIL)' == 'true'">
+      <ItemGroup>
+        <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRILFiles->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
+        <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRILFiles->'%(FileName).ni%(Extension)')' == '%(FileName)%(Extension)'" />
+        <ReferenceCopyLocalPaths Include="@(CoreCLRILFiles)" />
       </ItemGroup>
   </Target>
-
-  <Target Name="OverrideRuntime"
-          Condition="'$(CoreCLROverridePath)' != ''"
-          AfterTargets="AfterResolveReferences;FilterNugetPackages">
-    <Warning Condition="!Exists('$(CoreCLROverridePath)')" Text="The path provided to CoreCLROverridePath ($(CoreCLROverridePath)) does not exist." />
-    <PropertyGroup>
-      <CoreCLRPDBOverridePath Condition="'$(CoreCLRPDBOverridePath)' == '' and Exists('$(CoreCLROverridePath)/PDB')">$(CoreCLROverridePath)/PDB</CoreCLRPDBOverridePath>
-      <ExcludeNativeImages Condition="'$(ExcludeNativeImages)' == '' and '$(Coverage)' == 'true'">true</ExcludeNativeImages>
-    </PropertyGroup>
-    <ItemGroup>
-      <CoreCLRFiles Include="$(CoreCLROverridePath)/*.*" />
-      <CoreCLRILFiles Include="$(CoreCLROverridePath)/IL/*.*" />
-      <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '$(CoreCLROverridePath)/%(Filename)%(Extension)')" />
-      <CoreCLRILFiles Include="@(CoreCLRILFiles -> '$(CoreCLRPDBOverridePath)/%(Filename).pdb')" />
-      <CoreCLRCrossGenFiles Condition="'$(OSGroup)'=='Windows_NT'" Include="@(CoreCLRCrossGenFiles -> '$(CoreCLRPDBOverridePath)/%(Filename).ni.pdb')" />
-      <CoreCLRPDBFiles Condition="'$(CoreCLRPDBOverridePath)' != ''" Include="$(CoreCLRPDBOverridePath)/*.pdb" />
-
-      <_ReferenceCopyLocalPathsToRemove Include="@(ReferenceCopyLocalPaths)" Condition="'@(CoreCLRFiles->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
-      <ReferenceCopyLocalPaths Remove="@(_ReferenceCopyLocalPathsToRemove)" />
-      <ReferenceCopyLocalPaths Include="@(CoreCLRFiles);@(CoreCLRPDBFiles)" />
-    </ItemGroup>
-
-    <Warning Condition="Exists('$(CoreCLROverridePath)') And '@(CoreCLRFiles)' == ''" Text="The path provided to CoreCLROverridePath ($(CoreCLROverridePath)) does not contain any files." />
-
-    <ItemGroup Condition="'$(ExcludeNativeImages)' == 'true'">
-      <ReferenceCopyLocalPathsNativeImages Remove="@(ReferenceCopyLocalPaths)" Condition="$([System.String]::Copy('%(Filename)%(Extension)').Contains('.ni.'))" />
-      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPathsNativeImages)" />
-    </ItemGroup>
-
-  </Target>
+  
 </Project>

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -30,7 +30,7 @@
 
   <ItemGroup Condition="'$(TargetsAOT)'!='true'">
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="$(MicrosoftNETCorePlatformsPackageVersion)" />
-    <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR">
+    <PackageReference Include="transport.Microsoft.NETCore.Runtime.CoreCLR">
       <Version>$(MicrosoftNETCoreRuntimeCoreCLRPackageVersion)</Version>
       <!-- Following is version used in release/uwp6.0 -->
       <Version Condition="'$(TargetGroup)'=='uap10.0.16299'">2.1.0-b-uwp6-25707-02</Version>
@@ -87,52 +87,26 @@
     <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(OS)' != 'Windows_NT'"/>
   </Target>
 
-  <PropertyGroup>
-    <SymbolPackagesDir>$(PackagesDir)symbolpackages/</SymbolPackagesDir>
-    <DotNetAssetRootUrl Condition="'$(DotNetAssetRootUrl)' == ''">https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/assets/</DotNetAssetRootUrl>
-  </PropertyGroup>
-
-  <Target Name="CalculateCoreCLRSymbolPackageProperties"
-          BeforeTargets="DownloadAndUnzipSymbolPackage">
-
+  <Target Name="CalculateCoreCLRPackagePath" DependsOnTargets="ResolveAssemblyReferences">
     <ItemGroup>
-      <_CoreCLRSymbolPackagesToDownload Include="@(ReferenceCopyLocalPaths->'%(NuGetPackageId)')" Condition="$([System.String]::Copy('%(Identity)').EndsWith('System.Private.CoreLib.dll'))">
-        <Url>$(DotNetAssetRootUrl)symbols/%(NuGetPackageId).%(NuGetPackageVersion).symbols.nupkg</Url>
-        <DestinationFile>%(NuGetPackageId).%(NuGetPackageVersion).symbols.nupkg.zip</DestinationFile>
-        <UnzipDestinationDir>$(SymbolPackagesDir)/%(NuGetPackageId).%(NuGetPackageVersion)</UnzipDestinationDir>
-      </_CoreCLRSymbolPackagesToDownload>
+      <_CoreLibFile Include="@(ReferenceCopyLocalPaths)" Condition="'%(FileName)' == 'System.Private.CoreLib'" />
     </ItemGroup>
-
-    <!-- Calculate the packages to download incrementally if we haven't downloaded them -->
-    <ItemGroup>
-      <SymbolPackagesToDownload Include="@(_CoreCLRSymbolPackagesToDownload)" Condition="!Exists('%(UnzipDestinationDir)')" />
-    </ItemGroup>
+    <PropertyGroup>
+      <_CoreLibFilePath>%(_CoreLibFile.FullPath)</_CoreLibFilePath>
+      <_CoreLibPackagePath>$(_CoreLibFilePath.SubString(0, $(_CoreLibFilePath.IndexOf('runtimes'))))</_CoreLibPackagePath>
+    </PropertyGroup>
   </Target>
   
-  <Target Name="DownloadAndUnzipSymbolPackage"
-          Condition="'@(SymbolPackagesToDownload)' != ''">
-      <DownloadFile SourceUrl="%(SymbolPackagesToDownload.Url)"
-                    DestinationFolder="$(SymbolPackagesDir)"
-                    DestinationFileName="%(SymbolPackagesToDownload.DestinationFile)"
-                    ContinueOnError="WarnAndContinue" />
-      <Unzip SourceFiles="$(SymbolPackagesDir)\%(SymbolPackagesToDownload.DestinationFile)"
-             DestinationFolder="%(SymbolPackagesToDownload.UnzipDestinationDir)"
-             OverwriteReadOnlyFiles="true"
-             Condition="Exists('$(SymbolPackagesDir)\%(SymbolPackagesToDownload.DestinationFile)')" />
-  </Target>
-          
-
   <Target Name="BinPlaceCoreCLRSymbols"
           AfterTargets="AfterResolveReferences"
-          DependsOnTargets="CalculateCoreCLRSymbolPackageProperties;DownloadAndUnzipSymbolPackage"
+          DependsOnTargets="CalculateCoreCLRPackagePath"
           Condition="'$(CoreCLROverridePath)' == '' AND '$(DownloadCoreCLRSymbols)' != 'false'">
       <ItemGroup>
-        <_CoreCLRSymbolFiles Include="%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(RuntimeIdentifier)/native/*.pdb" />
-        <_CoreCLRSymbolFiles Include="%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(RuntimeIdentifier)/native/*.dbg" />
-        <ReferenceCopyLocalPaths Include="@(_CoreCLRSymbolFiles)"/>
+        <ReferenceCopyLocalPaths Include="$(_CoreLibPackagePath)/**/native/*.pdb;$(_CoreLibPackagePath)/**/native/*.dbg" />
 
-        <CoreCLRILFiles Include="%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(RuntimeIdentifier)/il/*.*">
-          <CrossGenAssemblyPath>%(_CoreCLRSymbolPackagesToDownload.UnzipDestinationDir)/runtimes/$(RuntimeIdentifier)/native/</CrossGenAssemblyPath>
+        <CoreCLRILFiles Include="$(_CoreLibPackagePath)/**/il/*.*" />
+        <CoreCLRILFiles>
+          <CrossGenAssemblyPath>$([System.IO.Path]::GetFullPath('%(RootDir)%(Directory)../native/'))</CrossGenAssemblyPath>
         </CoreCLRILFiles>
         <CoreCLRCrossGenFiles Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename)%(Extension)')" />
         <CoreCLRCrossGenFiles Condition="'$(OSGroup)'=='Windows_NT'" Include="@(CoreCLRILFiles -> '%(CrossGenAssemblyPath)%(Filename).ni.pdb')" />

--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -3,6 +3,8 @@
     <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
     <NoWarn>$(NoWarn);NU1603;NU1605</NoWarn>
     <SwapNativeForIL Condition="'$(SwapNativeForIL)' == '' AND ('$(ConfigurationGroup)' == 'Debug' OR '$(Coverage)' == 'true')">true</SwapNativeForIL>
+    <!-- uap10.0.16299 is missing IL -->
+    <SwapNativeForIL Condition="'$(TargetGroup)'=='uap10.0.16299' OR '$(TargetsAOT)'=='true'">false</SwapNativeForIL>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsAOT)'=='true'">
     <!-- System.Private.* can't be on the ILCInputFolder since ilc.exe needs to use the matching one from its toolchain. -->


### PR DESCRIPTION
We can avoid downloading symbols separately by using the transport packages.

I also chatted with @ViktorHofer and he said coverage doesn't need the IL /NI folders.