### PR TITLE
Enable CoreLib coverage

### DIFF
--- a/eng/dependencies.props
+++ b/eng/dependencies.props
@@ -38,7 +38,7 @@
 
     <!-- Code coverage package version -->
     <CoverletConsolePackageVersion>1.5.0</CoverletConsolePackageVersion>
-    <DotNetReportGeneratorGlobalToolPackageVersion>4.1.14</DotNetReportGeneratorGlobalToolPackageVersion>
+    <DotNetReportGeneratorGlobalToolPackageVersion>4.1.4</DotNetReportGeneratorGlobalToolPackageVersion>
 
     <MicrosoftDotNetIBCMergePackageVersion>4.6.0-alpha-00001</MicrosoftDotNetIBCMergePackageVersion>
     <TestILCAmd64retPackageVersion>$(ProjectNTfsTestILCPackageVersion)</TestILCAmd64retPackageVersion>

--- a/eng/dependencies.props
+++ b/eng/dependencies.props
@@ -37,8 +37,8 @@
     <MicrosoftDotNetUapTestToolsPackageVersion>1.0.31</MicrosoftDotNetUapTestToolsPackageVersion>
 
     <!-- Code coverage package version -->
-    <CoverletConsolePackageVersion>1.4.0</CoverletConsolePackageVersion>
-    <DotNetReportGeneratorGlobalToolPackageVersion>4.0.5</DotNetReportGeneratorGlobalToolPackageVersion>
+    <CoverletConsolePackageVersion>1.5.0</CoverletConsolePackageVersion>
+    <DotNetReportGeneratorGlobalToolPackageVersion>4.1.14</DotNetReportGeneratorGlobalToolPackageVersion>
 
     <MicrosoftDotNetIBCMergePackageVersion>4.6.0-alpha-00001</MicrosoftDotNetIBCMergePackageVersion>
     <TestILCAmd64retPackageVersion>$(ProjectNTfsTestILCPackageVersion)</TestILCAmd64retPackageVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,8 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Use IL version of System.Private.CoreLib and link to the testhost folder to probe additional assemblies. -->
-    <CoverageProbePath Include="shared\Microsoft.NETCore.App\9.9.9\il" />
+    <!-- Link to the testhost folder to probe additional assemblies. -->
     <CoverageProbePath Include="shared\Microsoft.NETCore.App\9.9.9" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/23588

Latest coverlet.console package is necessary to instrument CoreLib correctly. Also update the ReportGenerator version for bugfixes.