### PR TITLE
Unix: make Backspace work when Console.ReadLine has wrapped lines

### DIFF
--- a/src/Native/Unix/System.Native/pal_random.c
+++ b/src/Native/Unix/System.Native/pal_random.c
@@ -51,7 +51,8 @@ void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* buffer, int3
 
             if (fd != -1)
             {
-                if (!__sync_bool_compare_and_swap(&rand_des, -1, fd))
+                int expected = -1;
+                if (!__atomic_compare_exchange_n(&rand_des, &expected, fd, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST))
                 {
                     // Another thread has already set the rand_des
                     close(fd);

--- a/src/System.Console/src/FxCopBaseline.cs
+++ b/src/System.Console/src/FxCopBaseline.cs
@@ -14,7 +14,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.IO.SyncTextReader.#ReadKey(System.Boolean&):System.ConsoleKeyInfo")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.IO.SyncTextReader.#get_KeyAvailable():System.Boolean")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#ResetColor()")]
-[assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#GetCursorPosition(System.Int32&,System.Int32&)")]
+[assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#TryGetCursorPosition(System.Int32&,System.Int32&,System.Boolean):System.Boolean")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#RefreshColors(System.ConsoleColor&,System.ConsoleColor)")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#EnsureInitializedCore()")]
 [assembly: SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockOnObjectsWithWeakIdentity", Scope = "member", Target = "System.ConsolePal.#WriteStdoutAnsiString(System.String,System.Boolean)")]

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -1004,6 +1004,8 @@ namespace System
             public readonly string CursorAddress;
             /// <summary>The format string to use to move the cursor to the left.</summary>
             public readonly string CursorLeft;
+            /// <summary>The format string to use to clear to the end of line.</summary>
+            public readonly string ClrEol;
             /// <summary>The ANSI-compatible string for the Cursor Position report request.</summary>
             /// <remarks>
             /// This should really be in user string 7 in the terminfo file, but some terminfo databases
@@ -1042,6 +1044,7 @@ namespace System
                 CursorInvisible = db.GetString(TermInfo.WellKnownStrings.CursorInvisible);
                 CursorAddress = db.GetString(TermInfo.WellKnownStrings.CursorAddress);
                 CursorLeft = db.GetString(TermInfo.WellKnownStrings.CursorLeft);
+                ClrEol = db.GetString(TermInfo.WellKnownStrings.ClrEol);
 
                 Title = GetTitle(db);
 

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -442,6 +442,9 @@ namespace System
         private static bool s_firstCursorPositionRequest = true;
 
         /// <summary>Gets the current cursor position.  This involves both writing to stdout and reading stdin.</summary>
+        /// <param name="left">Cursor column.</param>
+        /// <param name="top">Cursor row.</param>
+        /// <param name="reinitializeForRead">Indicates whether this method is called as part of a on-going Read operation.</param>
         internal static unsafe bool TryGetCursorPosition(out int left, out int top, bool reinitializeForRead = false)
         {
             left = top = 0;

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -412,7 +412,7 @@ namespace System
             get
             {
                 int left, top;
-                GetCursorPosition(out left, out top);
+                TryGetCursorPosition(out left, out top);
                 return left;
             }
         }
@@ -422,7 +422,7 @@ namespace System
             get
             {
                 int left, top;
-                GetCursorPosition(out left, out top);
+                TryGetCursorPosition(out left, out top);
                 return top;
             }
         }
@@ -442,7 +442,7 @@ namespace System
         private static bool s_firstCursorPositionRequest = true;
 
         /// <summary>Gets the current cursor position.  This involves both writing to stdout and reading stdin.</summary>
-        private static unsafe void GetCursorPosition(out int left, out int top)
+        internal static unsafe bool TryGetCursorPosition(out int left, out int top, bool reinitializeForRead = false)
         {
             left = top = 0;
 
@@ -450,7 +450,7 @@ namespace System
             // parsing a response string from the terminal.  So if anything is redirected, bail.
             if (Console.IsInputRedirected || Console.IsOutputRedirected)
             {
-                return;
+                return false;
             }
 
             int cursorVersion;
@@ -458,7 +458,7 @@ namespace System
             {
                 if (TryGetCachedCursorPosition(out left, out top))
                 {
-                    return;
+                    return true;
                 }
 
                 cursorVersion = s_cursorVersion;
@@ -525,7 +525,7 @@ namespace System
                         // back to the StdInReader's extra buffer, treating it all as user input,
                         // and exit having not computed a valid cursor position.
                         TransferBytes(readBytes.Slice(readBytesPos), r);
-                        return;
+                        return false;
                     }
 
                     // At this point, readBytes starts with \ESC and ends with 'R'.
@@ -561,10 +561,16 @@ namespace System
                 }
                 finally
                 {
-                    Interop.Sys.UninitializeConsoleAfterRead();
+                    if (reinitializeForRead)
+                    {
+                        Interop.Sys.InitializeConsoleBeforeRead();
+                    }
+                    else
+                    {
+                        Interop.Sys.UninitializeConsoleAfterRead();
+                    }
                     s_firstCursorPositionRequest = false;
                 }
-
 
                 bool BufferUntil(byte toFind, StdInReader src, ref Span<byte> dst, ref int dstPos, out int foundPos)
                 {
@@ -667,6 +673,7 @@ namespace System
             lock (Console.Out)
             {
                 SetCachedCursorPosition(left, top, cursorVersion);
+                return true;
             }
         }
 
@@ -1359,7 +1366,7 @@ namespace System
         /// <summary>Writes a terminfo-based ANSI escape string to stdout.</summary>
         /// <param name="value">The string to write.</param>
         /// <param name="mayChangeCursorPosition">Writing this value may change the cursor position.</param>
-        private static unsafe void WriteStdoutAnsiString(string value, bool mayChangeCursorPosition = true)
+        internal static unsafe void WriteStdoutAnsiString(string value, bool mayChangeCursorPosition = true)
         {
             if (string.IsNullOrEmpty(value))
                 return;

--- a/src/System.Console/src/System/IO/StdInReader.cs
+++ b/src/System.Console/src/System/IO/StdInReader.cs
@@ -141,7 +141,21 @@ namespace System.IO
                                     string moveLeft = ConsolePal.TerminalFormatStrings.Instance.CursorLeft;
                                     s_moveLeftString = !string.IsNullOrEmpty(moveLeft) ? moveLeft + " " + moveLeft : string.Empty;
                                 }
-                                Console.Write(s_moveLeftString);
+
+                                // The ReadLine input may wrap accross terminal rows and we need to handle that.
+                                // note: ConsolePal will cache the cursor position to avoid making many slow cursor position fetch operations.
+                                if (ConsolePal.TryGetCursorPosition(out int left, out int top, reinitializeForRead: true) &&
+                                    left == 0 && top > 0)
+                                {
+                                    // Move to end of previous line
+                                    ConsolePal.SetCursorPosition(ConsolePal.WindowWidth - 1, top - 1);
+                                    // Clear from cursor to end of the line
+                                    ConsolePal.WriteStdoutAnsiString("\x1B[K", mayChangeCursorPosition: false);
+                                }
+                                else
+                                {
+                                    Console.Write(s_moveLeftString);
+                                }
                             }
                         }
                     }

--- a/src/System.Console/src/System/TermInfo.cs
+++ b/src/System.Console/src/System/TermInfo.cs
@@ -24,6 +24,7 @@ namespace System
         {
             Bell = 1,
             Clear = 5,
+            ClrEol = 6,
             CursorAddress = 10,
             CursorLeft = 14,
             CursorPositionReport = 294,

--- a/src/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/System.Console/tests/ManualTests/ManualTests.cs
@@ -23,6 +23,18 @@ namespace System
             AssertUserExpectedResults("the characters you typed properly echoed as you typed");
         }
 
+        [Fact]
+        public static void ReadLine_BackSpaceCanMoveAccrossWrappedLines()
+        {
+            Console.WriteLine("Please press 'a' until it wraps to the next terminal line, then press 'Backspace' until the input is erased, and then type a single 'a' and press 'Enter'.");
+            Console.Write("Input: ");
+            Console.Out.Flush();
+
+            string result = Console.ReadLine();
+            Assert.Equal("a", result);
+            AssertUserExpectedResults("the previous line is 'Input: a'");
+        }
+
         [ConditionalFact(nameof(ManualTestsEnabled))]
         public static void InPeek()
         {

--- a/src/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/System.Console/tests/ManualTests/ManualTests.cs
@@ -23,7 +23,7 @@ namespace System
             AssertUserExpectedResults("the characters you typed properly echoed as you typed");
         }
 
-        [Fact]
+        [ConditionalFact(nameof(ManualTestsEnabled))]
         public static void ReadLine_BackSpaceCanMoveAccrossWrappedLines()
         {
             Console.WriteLine("Please press 'a' until it wraps to the next terminal line, then press 'Backspace' until the input is erased, and then type a single 'a' and press 'Enter'.");


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/37056

There are a number of things that should work:

```
Console.Write("Enter your name: ");
Console.ReadLine();
```
In this case we don't want backspace to delete the prompt.

And, when the user is typing at the bottom of the terminal, we don't want weird behaviour because the cursor position where editing started will move up as lines are wrapping.

I was looking for a way to avoid calling `TryGetCursorPosition` but I think it is needed to make these scenarios work. Thanks to the caching in `PalConsole`, we won't be fetching multiple times.

@stephentoub @wtgodbe ptal