### PR TITLE
Pick up last build runtime.native.System.IO.Ports during testing

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -30,6 +30,10 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>8c7afe67ee2e9bd21a4412265b66f875cfafaede</Sha>
     </Dependency>
+    <Dependency Name="runtime.native.System.IO.Ports" Version="4.6.0-preview6.19225.1">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>18cd561127e35841db2775dc7a85adad70363e18</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19224.9">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>e02c88fca482f1141a9bb310c97be20b0ebd0465</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,6 +45,7 @@
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview6-27624-71</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <!-- Corefx dependencies -->
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview6.19225.1</MicrosoftNETCorePlatformsPackageVersion>
+    <runtimenativeSystemIOPortsPackageVersion>4.6.0-preview6.19225.1</runtimenativeSystemIOPortsPackageVersion>
     <!-- Standard dependencies -->
     <NETStandardLibraryPackageVersion>2.1.0-prerelease.19224.1</NETStandardLibraryPackageVersion>
     <!-- dotnet-optimization dependencies -->

--- a/pkg/test/packageSettings/System.IO.Ports/netcoreapp1.0/workaroundDowngrade.targets
+++ b/pkg/test/packageSettings/System.IO.Ports/netcoreapp1.0/workaroundDowngrade.targets
@@ -1,6 +1,0 @@
-<Project>
-  <ItemGroup>
-    <!-- issue https://github.com/dotnet/corefx/issues/28551 -->
-    <PackageReference Include="runtime.native.System.IO.Ports" Version="0.0.0" NoWarn="NU1605" />
-  </ItemGroup>
-</Project>

--- a/pkg/test/packageSettings/System.IO.Ports/workaroundDowngrade.targets
+++ b/pkg/test/packageSettings/System.IO.Ports/workaroundDowngrade.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <!-- We cannot reference the current build of runtime.native.System.IO.Ports because its built across multiple machines -->
+    <PackageReference Include="runtime.native.System.IO.Ports" Version="$(runtimenativeSystemIOPortsPackageVersion)" NoWarn="NU1605" />
+  </ItemGroup>
+</Project>

--- a/pkg/test/packageTest.targets
+++ b/pkg/test/packageTest.targets
@@ -15,7 +15,7 @@
 
   <Import Project="tools\build\Packaging.common.targets" />
   <Import Project="tools\dependencies.props" />
-  <Import Project="tools\eng\versions.props" />
+  <Import Project="tools\eng\Versions.props" />
   <Import Project="frameworkSettings\$(_targetFrameworkIdentifier)\*.targets" />
   <Import Project="frameworkSettings\$(TargetFramework)\*.targets" />
   <Import Project="packageSettings\$(TestPackageId)\*.targets" />

--- a/pkg/test/testPackages.proj
+++ b/pkg/test/testPackages.proj
@@ -3,7 +3,7 @@
 
   <ItemGroup>
     <TestPackages Condition="'$(TestPackages)' != ''" Include="$(TestPackages)" />
-    <ExcludePackages Include="CoreFx.Private.TestUtilities;System.IO.Ports;runtime.native.System.IO.Ports" />
+    <ExcludePackages Include="CoreFx.Private.TestUtilities" />
     <ExcludePackages Include="$(ExcludePackages)" />
 
     <PackageReports Condition="'@(TestPackages)' == ''" Include="$(PackageReportDir)*.json" Exclude="@(ExcludePackages->'$(PackageReportDir)%(Identity).json')"/>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/35599