### PR TITLE
Allow uppercase HTTP_PROXY and NO_PROXY variables

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -73,7 +73,7 @@ namespace System.Net.Http
             int idx = value.IndexOf(':');
             if (idx != -1)
             {
-                password = value.Substring(idx+1);
+                password = value.Substring(idx + 1);
                 value = value.Substring(0, idx);
             }
 
@@ -81,7 +81,7 @@ namespace System.Net.Http
             if (idx != -1)
             {
                 domain = value.Substring(0, idx);
-                value = value.Substring(idx+1);
+                value = value.Substring(idx + 1);
             }
 
             return new NetworkCredential(value, password, domain);
@@ -93,9 +93,12 @@ namespace System.Net.Http
         private const string EnvAllProxyUC = "ALL_PROXY";
         private const string EnvAllProxyLC = "all_proxy";
         private const string EnvHttpProxyLC = "http_proxy";
+        private const string EnvHttpProxyUC = "HTTP_PROXY";
         private const string EnvHttpsProxyLC = "https_proxy";
         private const string EnvHttpsProxyUC = "HTTPS_PROXY";
         private const string EnvNoProxyLC = "no_proxy";
+        private const string EnvNoProxyUC = "NO_PROXY";
+        private const string EnvCGI = "GATEWAY_INTERFACE"; // Running in a CGI environment.
 
         private Uri _httpProxyUri;      // String URI for HTTP requests
         private Uri _httpsProxyUri;     // String URI for HTTPS requests
@@ -107,9 +110,13 @@ namespace System.Net.Http
             // Get environmental variables. Protocol specific take precedence over
             // general all_*, lower case variable has precedence over upper case.
             // Note that curl uses HTTPS_PROXY but not HTTP_PROXY.
-            // For http, only http_proxy and generic variables are used.
 
             Uri httpProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpProxyLC));
+            if (httpProxy == null && Environment.GetEnvironmentVariable(EnvCGI) == null)
+            {
+                httpProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpProxyUC));
+            }
+
             Uri httpsProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpsProxyLC)) ??
                              GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpsProxyUC));
 
@@ -136,7 +143,10 @@ namespace System.Net.Http
                 return false;
             }
 
-            proxy = new HttpEnvironmentProxy(httpProxy, httpsProxy, Environment.GetEnvironmentVariable(EnvNoProxyLC));
+            string noProxy = Environment.GetEnvironmentVariable(EnvNoProxyLC) ??
+                Environment.GetEnvironmentVariable(EnvNoProxyUC);
+            proxy = new HttpEnvironmentProxy(httpProxy, httpsProxy, noProxy);
+
             return true;
         }
 

--- a/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -21,9 +21,12 @@ namespace System.Net.Http.Tests
         // to be sure they do not interfere with the test.
         private void CleanEnv()
         {
-            List<string>  vars = new List<string>() { "http_proxy", "HTTPS_PROXY", "https_proxy",
-                                                      "all_proxy", "ALL_PROXY",
-                                                      "NO_PROXY" };
+            List<string> vars = new List<string>() { "http_proxy", "HTTP_PROXY",
+                                                     "https_proxy", "HTTPS_PROXY",
+                                                     "all_proxy", "ALL_PROXY",
+                                                     "no_proxy", "NO_PROXY",
+                                                     "GATEWAY_INTERFACE" };
+
             foreach (string v in vars)
             {
                 Environment.SetEnvironmentVariable(v, null);
@@ -115,7 +118,7 @@ namespace System.Net.Http.Tests
         [InlineData("HTTP://ABC.COM/", "abc.com", "80", null, null)]
         [InlineData("http://10.30.62.64:7890/", "10.30.62.64", "7890", null, null)]
         [InlineData("http://1.2.3.4:8888/foo", "1.2.3.4", "8888", null, null)]
-        public void HttpProxy_Uri_Parsing(string _input, string _host, string _port, string _user , string _password)
+        public void HttpProxy_Uri_Parsing(string _input, string _host, string _port, string _user, string _password)
         {
             RemoteExecutor.Invoke((input, host, port, user, password) =>
             {
@@ -149,7 +152,7 @@ namespace System.Net.Http.Tests
                 }
 
                 return RemoteExecutor.SuccessExitCode;
-            }, _input, _host, _port, _user ?? "null" , _password ?? "null").Dispose();
+            }, _input, _host, _port, _user ?? "null", _password ?? "null").Dispose();
         }
 
         [Fact]
@@ -205,7 +208,84 @@ namespace System.Net.Http.Tests
                 Assert.True(p.IsBypassed(new Uri("http://www.test.com")));
 
                 return RemoteExecutor.SuccessExitCode;
-           }).Dispose();
+            }).Dispose();
+        }
+
+        public static IEnumerable<object[]> HttpProxyNoProxyEnvVarMemberData()
+        {
+            yield return new object[] { "http_proxy", "no_proxy" };
+            yield return new object[] { "http_proxy", "NO_PROXY" };
+            yield return new object[] { "HTTP_PROXY", "no_proxy" };
+            yield return new object[] { "HTTP_PROXY", "NO_PROXY" };
+        }
+
+        [Theory]
+        [MemberData(nameof(HttpProxyNoProxyEnvVarMemberData))]
+        public void HttpProxy_TryCreate_CaseInsensitiveVariables(string proxyEnvVar, string noProxyEnvVar)
+        {
+            string proxy = "http://foo:bar@1.1.1.1:3000";
+
+            var options = new RemoteInvokeOptions();
+            options.StartInfo.EnvironmentVariables.Add(proxyEnvVar, proxy);
+            options.StartInfo.EnvironmentVariables.Add(noProxyEnvVar, ".test.com, foo.com");
+            RemoteExecutor.Invoke((proxy) =>
+            {
+                var directUri = new Uri("http://test.com");
+                var thruProxyUri = new Uri("http://atest.com");
+
+                Assert.True(HttpEnvironmentProxy.TryCreate(out IWebProxy p));
+                Assert.NotNull(p);
+
+                Assert.True(p.IsBypassed(directUri));
+                Assert.False(p.IsBypassed(thruProxyUri));
+                Assert.Equal(new Uri(proxy), p.GetProxy(thruProxyUri));
+
+                return RemoteExecutor.SuccessExitCode;
+            }, proxy, options).Dispose();
+        }
+
+        public static IEnumerable<object[]> HttpProxyCgiEnvVarMemberData()
+        {
+            foreach (bool cgi in new object[] { false, true })
+            {
+                yield return new object[] { "http_proxy", cgi, true };
+                yield return new object[] { "HTTP_PROXY", cgi, !cgi };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(HttpProxyCgiEnvVarMemberData))]
+        public void HttpProxy_TryCreateAndPossibleCgi_HttpProxyUpperCaseDisabledInCgi(
+            string proxyEnvVar, bool cgi, bool expectedProxyUse)
+        {
+            string proxy = "http://foo:bar@1.1.1.1:3000";
+
+            var options = new RemoteInvokeOptions();
+            options.StartInfo.EnvironmentVariables.Add(proxyEnvVar, proxy);
+            if (cgi)
+            {
+                options.StartInfo.EnvironmentVariables.Add("GATEWAY_INTERFACE", "CGI/1.1");
+            }
+
+            RemoteExecutor.Invoke((proxy, expectedProxyUseString) =>
+            {
+                bool expectedProxyUse = bool.Parse(expectedProxyUseString);
+                var destinationUri = new Uri("http://test.com");
+
+                bool created = HttpEnvironmentProxy.TryCreate(out IWebProxy p);
+                if (expectedProxyUse)
+                {
+                    Assert.True(created);
+                    Assert.NotNull(p);
+                    Assert.Equal(new Uri(proxy), p.GetProxy(destinationUri));
+                }
+                else
+                {
+                    Assert.False(created);
+                }
+
+                return RemoteExecutor.SuccessExitCode;
+            }, proxy, expectedProxyUse.ToString(), options).Dispose();
         }
     }
 }

--- a/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -255,6 +255,7 @@ namespace System.Net.Http.Tests
 
         [Theory]
         [MemberData(nameof(HttpProxyCgiEnvVarMemberData))]
+        [PlatformSpecific(~TestPlatforms.Windows)]
         public void HttpProxy_TryCreateAndPossibleCgi_HttpProxyUpperCaseDisabledInCgi(
             string proxyEnvVar, bool cgi, bool expectedProxyUse)
         {

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -383,7 +383,7 @@
       <Link>ProductionCode\System\Net\Http\WinInetProxyHelper.cs</Link>
     </Compile>
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\src\System\Net\Http\WinHttpTraceHelper.cs">
-      <Link>ProductionCode\System\Net\Http\WinInetProxyHelper.cs</Link>
+      <Link>ProductionCode\System\Net\Http\WinHttpTraceHelper.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
@@ -407,22 +407,22 @@
       <Link>Common\Interop\Windows\WinHttp\Interop.winhttp_types.cs</Link>
     </Compile>
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\tests\UnitTests\FakeInterop.cs">
-      <Link>ProductionCode\System\Net\Http\WinInetProxyHelper.cs</Link>
+      <Link>WinHttpHandler\UnitTests\FakeInterop.cs</Link>
     </Compile>
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\tests\UnitTests\FakeRegistry.cs">
-      <Link>ProductionCode\System\Net\Http\WinInetProxyHelper.cs</Link>
+      <Link>WinHttpHandler\UnitTests\FakeRegistry.cs</Link>
     </Compile>
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\tests\UnitTests\FakeSafeWinHttpHandle.cs">
-      <Link>ProductionCode\System\Net\Http\WinInetProxyHelper.cs</Link>
+      <Link>WinHttpHandler\UnitTests\FakeSafeWinHttpHandle.cs</Link>
     </Compile>
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\tests\UnitTests\TestControl.cs">
-      <Link>ProductionCode\System\Net\Http\WinInetProxyHelper.cs</Link>
+      <Link>WinHttpHandler\UnitTests\TestControl.cs</Link>
     </Compile>
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\tests\UnitTests\APICallHistory.cs">
-      <Link>ProductionCode\System\Net\Http\WinInetProxyHelper.cs</Link>
+      <Link>WinHttpHandler\UnitTests\APICallHistory.cs</Link>
     </Compile>
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\tests\UnitTests\TestServer.cs">
-      <Link>ProductionCode\System\Net\Http\WinInetProxyHelper.cs</Link>
+      <Link>WinHttpHandler\UnitTests\TestServer.cs</Link>
     </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is a redo of PR #35887.

Added support for uppercase HTTP_PROXY and NO_PROXY environment variables.
The uppercase versions are being used by Docker and other tools. This now
completes the set of environment variables that are already handling both
lower and upper case variants.

Note: This HttpEnvironmentProxy class is currently only used on Linux and OSX.
It is not used on Windows yet. I do plan to add support for this to Windows
at a later time, see #37187.

Added detection of CGI environments in order to suppress using the uppercase
HTTP_PROXY environment variable. See https://httpoxy.org/

Fixed some typos in the CSPROJ of the Http Unit Tests.