### PR TITLE
Don't copy state unnecessarily

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -57,9 +57,9 @@ namespace System.Text.Json.Serialization
             var reader = new Utf8JsonReader(utf8Json, isFinalBlock: true, readerState);
             object result = ReadCore(returnType, options, ref reader);
 
-            readerState = reader.CurrentState;
-            if (readerState.BytesConsumed != utf8Json.Length)
+            if (reader.BytesConsumed != utf8Json.Length)
             {
+                readerState = reader.CurrentState;
                 throw new JsonReaderException(SR.Format(SR.DeserializeDataRemaining,
                     utf8Json.Length, utf8Json.Length - readerState.BytesConsumed), readerState);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -73,9 +73,9 @@ namespace System.Text.Json.Serialization
             var reader = new Utf8JsonReader(jsonBytes, isFinalBlock: true, readerState);
             object result = ReadCore(returnType, options, ref reader);
 
-            readerState = reader.CurrentState;
-            if (readerState.BytesConsumed != jsonBytes.Length)
+            if (reader.BytesConsumed != jsonBytes.Length)
             {
+                readerState = reader.CurrentState;
                 throw new JsonReaderException(SR.Format(SR.DeserializeDataRemaining,
                     jsonBytes.Length, jsonBytes.Length - readerState.BytesConsumed), readerState);
             }


### PR DESCRIPTION
This was showing up in dottrace. `CurrentState` is relatively expensive for just needing to access a single field.