### PR TITLE
handle EPROTOTYPE error on OSX

### DIFF
--- a/src/Native/Unix/System.Native/pal_networking.c
+++ b/src/Native/Unix/System.Native/pal_networking.c
@@ -1268,7 +1268,12 @@ int32_t SystemNative_SendMessage(intptr_t socket, MessageHeader* messageHeader, 
     ConvertMessageHeaderToMsghdr(&header, messageHeader, fd);
 
     ssize_t res;
+#if defined(__APPLE__) && __APPLE__
+    // possible OSX kernel bug:  #31927
+    while ((res = sendmsg(fd, &header, socketFlags)) < 0 && (errno == EINTR || errno == EPROTOTYPE));
+#else
     while ((res = sendmsg(fd, &header, socketFlags)) < 0 && errno == EINTR);
+#endif
     if (res != -1)
     {
         *sent = res;


### PR DESCRIPTION
I could not reproducer the issue. (maybe I did not try long enough or timing is different on my machine)
However I did review all linked discussions and proposed fix and it makes sense to me. 
This should be very low risk because:
-  man page for sendmsg() on OSX does not list EPROTOTYPE
- general error EPROTOTYPE is trying to describe should not be applicable to  IP sockets. 
- limited only to OSX.

With the new code, if the race condition happens and we get this specific error we will retry.
This is solution other projects converted to. 
 
fixes #31927 