### PR TITLE
Ensure that invalid AIA, CDP, and OCSP extensions don't throw.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CrlCache.cs
@@ -237,13 +237,17 @@ namespace Internal.Cryptography.Pal
                         }
                     }
                 }
-
-                return null;
+            }
+            catch (CryptographicException)
+            {
+                // Treat any ASN errors as if the extension was missing.
             }
             finally
             {
                 ArrayPool<byte>.Shared.Return(crlDistributionPoints.Array);
             }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Fixes #36606.