### PR TITLE
Add proxy environment variables support for Windows

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -216,6 +216,7 @@
   <!-- SocketsHttpHandler platform parts -->
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Unix.cs" />
     <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Unix.cs">
       <Link>Common\System\Net\ContextAwareResult.Unix.cs</Link>
     </Compile>
@@ -301,6 +302,8 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Windows.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpSystemProxy.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -258,7 +258,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And '$(TargetsOSX)' != 'true' And '$(TargetGroup)' == 'netcoreapp'">
-    <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Linux.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs" />

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -258,7 +258,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And '$(TargetsOSX)' != 'true' And '$(TargetGroup)' == 'netcoreapp'">
-    <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Linux.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs" />

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.Unix.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal sealed partial class HttpEnvironmentProxy : IWebProxy
+    {
+        public static bool TryCreate(out IWebProxy proxy)
+        {
+            // Get environment variables. Protocol specific take precedence over
+            // general all_*, lower case variable has precedence over upper case.
+            // Note that curl uses HTTPS_PROXY but not HTTP_PROXY.
+
+            Uri httpProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpProxyLC));
+            if (httpProxy == null && Environment.GetEnvironmentVariable(EnvCGI) == null)
+            {
+                httpProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpProxyUC));
+            }
+
+            Uri httpsProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpsProxyLC)) ??
+                             GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpsProxyUC));
+
+            if (httpProxy == null || httpsProxy == null)
+            {
+                Uri allProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvAllProxyLC)) ??
+                                GetUriFromString(Environment.GetEnvironmentVariable(EnvAllProxyUC));
+
+                if (httpProxy == null)
+                {
+                    httpProxy = allProxy;
+                }
+
+                if (httpsProxy == null)
+                {
+                    httpsProxy = allProxy;
+                }
+            }
+
+            // Do not instantiate if nothing is set.
+            // Caller may pick some other proxy type.
+            if (httpProxy == null && httpsProxy == null)
+            {
+                proxy = null;
+                return false;
+            }
+
+            string noProxy = Environment.GetEnvironmentVariable(EnvNoProxyLC) ??
+                Environment.GetEnvironmentVariable(EnvNoProxyUC);
+            proxy = new HttpEnvironmentProxy(httpProxy, httpsProxy, noProxy);
+
+            return true;
+        }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.Windows.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal sealed partial class HttpEnvironmentProxy : IWebProxy
+    {
+        public static bool TryCreate(out IWebProxy proxy)
+        {
+            // Get environment variables. Protocol specific take precedence over
+            // general all_*. On Windows, environment variables are case insensitive.
+
+            Uri httpProxy = null;
+            if (Environment.GetEnvironmentVariable(EnvCGI) == null)
+            {
+                httpProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpProxyUC));
+            }
+
+            Uri httpsProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpsProxyUC));
+
+            if (httpProxy == null || httpsProxy == null)
+            {
+                Uri allProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvAllProxyUC));
+
+                if (httpProxy == null)
+                {
+                    httpProxy = allProxy;
+                }
+
+                if (httpsProxy == null)
+                {
+                    httpsProxy = allProxy;
+                }
+            }
+
+            // Do not instantiate if nothing is set.
+            // Caller may pick some other proxy type.
+            if (httpProxy == null && httpsProxy == null)
+            {
+                proxy = null;
+                return false;
+            }
+
+            string noProxy = Environment.GetEnvironmentVariable(EnvNoProxyUC);
+            proxy = new HttpEnvironmentProxy(httpProxy, httpsProxy, noProxy);
+
+            return true;
+        }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
@@ -88,7 +88,7 @@ namespace System.Net.Http
         }
     }
 
-    internal sealed class HttpEnvironmentProxy : IWebProxy
+    internal sealed partial class HttpEnvironmentProxy : IWebProxy
     {
         private const string EnvAllProxyUC = "ALL_PROXY";
         private const string EnvAllProxyLC = "all_proxy";
@@ -104,51 +104,6 @@ namespace System.Net.Http
         private Uri _httpsProxyUri;     // String URI for HTTPS requests
         private string[] _bypass = null;// list of domains not to proxy
         private ICredentials _credentials;
-
-        public static bool TryCreate(out IWebProxy proxy)
-        {
-            // Get environmental variables. Protocol specific take precedence over
-            // general all_*, lower case variable has precedence over upper case.
-            // Note that curl uses HTTPS_PROXY but not HTTP_PROXY.
-
-            Uri httpProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpProxyLC));
-            if (httpProxy == null && Environment.GetEnvironmentVariable(EnvCGI) == null)
-            {
-                httpProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpProxyUC));
-            }
-
-            Uri httpsProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpsProxyLC)) ??
-                             GetUriFromString(Environment.GetEnvironmentVariable(EnvHttpsProxyUC));
-
-            if (httpProxy == null || httpsProxy == null)
-            {
-                Uri allProxy = GetUriFromString(Environment.GetEnvironmentVariable(EnvAllProxyLC)) ??
-                                GetUriFromString(Environment.GetEnvironmentVariable(EnvAllProxyUC));
-
-                if (httpProxy == null)
-                {
-                    httpProxy = allProxy;
-                }
-                if (httpsProxy == null)
-                {
-                    httpsProxy = allProxy;
-                }
-            }
-
-            // Do not instantiate if nothing is set.
-            // Caller may pick some other proxy type.
-            if (httpProxy == null && httpsProxy == null)
-            {
-                proxy = null;
-                return false;
-            }
-
-            string noProxy = Environment.GetEnvironmentVariable(EnvNoProxyLC) ??
-                Environment.GetEnvironmentVariable(EnvNoProxyUC);
-            proxy = new HttpEnvironmentProxy(httpProxy, httpsProxy, noProxy);
-
-            return true;
-        }
 
         private HttpEnvironmentProxy(Uri httpProxy, Uri httpsProxy, string bypassList)
         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Linux.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Linux.cs
@@ -6,7 +6,7 @@ namespace System.Net.Http
 {
     internal static class SystemProxyInfo
     {
-        // On Unix we get default proxy configuration from environment variables.
+        // On Linux we get default proxy configuration from environment variables.
         public static IWebProxy ConstructSystemProxy()
         {
             return HttpEnvironmentProxy.TryCreate(out IWebProxy proxy) ? proxy : null;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.OSX.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.OSX.cs
@@ -6,7 +6,7 @@ namespace System.Net.Http
 {
     internal static class SystemProxyInfo
     {
-        // On Unix we get default proxy configuration from environment variables
+        // On OSX we get default proxy configuration from either environment variables or the OSX system proxy.
         public static IWebProxy ConstructSystemProxy()
         {
             return HttpEnvironmentProxy.TryCreate(out IWebProxy proxy) ? proxy : new MacProxy();

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Unix.cs
@@ -6,7 +6,7 @@ namespace System.Net.Http
 {
     internal static class SystemProxyInfo
     {
-        // On Linux we get default proxy configuration from environment variables.
+        // On Unix (except for OSX) we get default proxy configuration from environment variables.
         public static IWebProxy ConstructSystemProxy()
         {
             return HttpEnvironmentProxy.TryCreate(out IWebProxy proxy) ? proxy : null;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Unix.cs
@@ -6,11 +6,10 @@ namespace System.Net.Http
 {
     internal static class SystemProxyInfo
     {
-        // On Unix we get default proxy configuration from environment variables
+        // On Unix we get default proxy configuration from environment variables.
         public static IWebProxy ConstructSystemProxy()
         {
             return HttpEnvironmentProxy.TryCreate(out IWebProxy proxy) ? proxy : null;
         }
     }
 }
-

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Windows.cs
@@ -6,10 +6,17 @@ namespace System.Net.Http
 {
     internal static class SystemProxyInfo
     {
+        // On Windows we get default proxy configuration from either environment variables or the Windows system proxy.
         public static IWebProxy ConstructSystemProxy()
         {
-            return HttpSystemProxy.TryCreate(out IWebProxy proxy) ? proxy : null;
+            if (HttpEnvironmentProxy.TryCreate(out IWebProxy proxy))
+            {
+                return proxy;
+            }
+            
+            HttpSystemProxy.TryCreate(out proxy);
+            
+            return proxy;
         }
     }
 }
-

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Windows.cs
@@ -9,13 +9,11 @@ namespace System.Net.Http
         // On Windows we get default proxy configuration from either environment variables or the Windows system proxy.
         public static IWebProxy ConstructSystemProxy()
         {
-            if (HttpEnvironmentProxy.TryCreate(out IWebProxy proxy))
+            if (!HttpEnvironmentProxy.TryCreate(out IWebProxy proxy))
             {
-                return proxy;
+                HttpSystemProxy.TryCreate(out proxy);
             }
-            
-            HttpSystemProxy.TryCreate(out proxy);
-            
+
             return proxy;
         }
     }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Proxy.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Proxy.cs
@@ -7,6 +7,9 @@ using System.Net.Test.Common;
 using System.Text;
 using System.Threading.Tasks;
 
+using Microsoft.DotNet.XUnitExtensions;
+using Microsoft.DotNet.RemoteExecutor;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -99,6 +102,35 @@ namespace System.Net.Http.Functional.Tests
                     }
                 }
             }
+        }
+
+        [OuterLoop("Uses external server")]
+        [ConditionalFact]
+        public void Proxy_UseEnvironmentVariableToSetSystemProxy_RequestGoesThruProxy()
+        {
+            if (!UseSocketsHttpHandler)
+            {
+                throw new SkipTestException("Test needs SocketsHttpHandler");
+            }
+
+            RemoteExecutor.Invoke(async useSocketsHttpHandlerString =>
+            {
+                var options = new LoopbackProxyServer.Options { AddViaRequestHeader = true };
+                using (LoopbackProxyServer proxyServer = LoopbackProxyServer.Create(options))
+                {
+                    Environment.SetEnvironmentVariable("http_proxy", proxyServer.Uri.AbsoluteUri.ToString());
+
+                    using (HttpClient client = CreateHttpClient(useSocketsHttpHandlerString))
+                    using (HttpResponseMessage response = await client.GetAsync(Configuration.Http.RemoteEchoServer))
+                    {
+                        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                        string body = await response.Content.ReadAsStringAsync();
+                        Assert.Contains(proxyServer.ViaHeader, body);
+                    }
+
+                    return RemoteExecutor.SuccessExitCode;
+                }
+            }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
         [ActiveIssue(32809)]

--- a/src/System.Net.Http/tests/UnitTests/Configurations.props
+++ b/src/System.Net.Http/tests/UnitTests/Configurations.props
@@ -1,7 +1,9 @@
 ﻿<Project DefaultTargets="Build">
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp;
+      netcoreapp-OSX;
+      netcoreapp-Unix;
+      netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Net.Http/tests/UnitTests/Fakes/MacProxy.cs
+++ b/src/System.Net.Http/tests/UnitTests/Fakes/MacProxy.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal sealed class MacProxy : IWebProxy
+    {
+        public ICredentials Credentials
+        {
+            get => throw NotImplemented.ByDesignWithMessage("Mac Proxy not implemented");
+            set => throw NotImplemented.ByDesignWithMessage("Mac Proxy not implemented");
+        }
+
+        public Uri GetProxy(Uri targetUri)
+        {
+            throw NotImplemented.ByDesignWithMessage("Mac Proxy not implemented");
+        }
+
+        public bool IsBypassed(Uri targetUri)
+        {
+            throw NotImplemented.ByDesignWithMessage("Mac Proxy not implemented");
+        }
+    }
+}

--- a/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -21,13 +21,13 @@ namespace System.Net.Http.Tests
         // to be sure they do not interfere with the test.
         private void CleanEnv()
         {
-            List<string> vars = new List<string>() { "http_proxy", "HTTP_PROXY",
-                                                     "https_proxy", "HTTPS_PROXY",
-                                                     "all_proxy", "ALL_PROXY",
-                                                     "no_proxy", "NO_PROXY",
-                                                     "GATEWAY_INTERFACE" };
+            var envVars = new List<string>() { "http_proxy", "HTTP_PROXY",
+                                               "https_proxy", "HTTPS_PROXY",
+                                               "all_proxy", "ALL_PROXY",
+                                               "no_proxy", "NO_PROXY",
+                                               "GATEWAY_INTERFACE" };
 
-            foreach (string v in vars)
+            foreach (string v in envVars)
             {
                 Environment.SetEnvironmentVariable(v, null);
             }
@@ -248,14 +248,13 @@ namespace System.Net.Http.Tests
         {
             foreach (bool cgi in new object[] { false, true })
             {
-                yield return new object[] { "http_proxy", cgi, true };
+                yield return new object[] { "http_proxy", cgi, !cgi || !PlatformDetection.IsWindows };
                 yield return new object[] { "HTTP_PROXY", cgi, !cgi };
             }
         }
 
         [Theory]
         [MemberData(nameof(HttpProxyCgiEnvVarMemberData))]
-        [PlatformSpecific(~TestPlatforms.Windows)]
         public void HttpProxy_TryCreateAndPossibleCgi_HttpProxyUpperCaseDisabledInCgi(
             string proxyEnvVar, bool cgi, bool expectedProxyUse)
         {

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -297,6 +297,12 @@
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Unix.cs" Condition=" '$(TargetsUnix)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Unix.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Windows.cs" Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Windows.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HPack\HeaderField.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HPack\HeaderField.cs</Link>
     </Compile>
@@ -309,11 +315,21 @@
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HPack\StaticTable.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HPack\StaticTable.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs" Condition=" '$(TargetsOSX)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs" Condition=" '$(TargetsUnix)' == 'true' And '$(TargetsOSX)' != 'true' And '$(TargetGroup)' == 'netcoreapp'">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs</Link>
+    </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs" Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs">
       <Link>ProductionCode\System\Net\Http\HttpHandlerDefaults.cs</Link>
     </Compile>
     <Compile Include="DigestAuthenticationTests.cs" />
     <Compile Include="Fakes\HttpClientHandler.cs" />
+    <Compile Include="Fakes\MacProxy.cs" Condition=" '$(TargetsOSX)' == 'true' And '$(TargetGroup)' == 'netcoreapp'" />
     <Compile Include="Headers\AuthenticationHeaderValueTest.cs" />
     <Compile Include="Headers\ByteArrayHeaderParserTest.cs" />
     <Compile Include="Headers\CacheControlHeaderParserTest.cs" />
@@ -373,6 +389,7 @@
     <Compile Include="StreamToStreamCopyTest.cs" />
     <Compile Include="HttpEnvironmentProxyTest.cs" />
     <Compile Include="HttpSystemProxyTest.cs" />
+    <Compile Include="SystemProxyInfoTest.cs" />
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpSystemProxy.cs">
       <Link>ProductionCode\System\Net\Http\HttpSystemProxy.cs</Link>
     </Compile>

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -318,8 +318,8 @@
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs" Condition=" '$(TargetsOSX)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs</Link>
     </Compile>
-    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Linux.cs" Condition=" '$(TargetsUnix)' == 'true' And '$(TargetsOSX)' != 'true' And '$(TargetGroup)' == 'netcoreapp'">
-      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Linux.cs</Link>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs" Condition=" '$(TargetsUnix)' == 'true' And '$(TargetsOSX)' != 'true' And '$(TargetGroup)' == 'netcoreapp'">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs" Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs</Link>

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -318,8 +318,8 @@
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs" Condition=" '$(TargetsOSX)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs</Link>
     </Compile>
-    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs" Condition=" '$(TargetsUnix)' == 'true' And '$(TargetsOSX)' != 'true' And '$(TargetGroup)' == 'netcoreapp'">
-      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs</Link>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Linux.cs" Condition=" '$(TargetsUnix)' == 'true' And '$(TargetsOSX)' != 'true' And '$(TargetGroup)' == 'netcoreapp'">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Linux.cs</Link>
     </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs" Condition=" '$(TargetsWindows)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs</Link>

--- a/src/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Net.Http;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace System.Net.Http.Tests
+{
+    public class SystemProxyInfoTest
+    {
+        // This will clean specific environmental variables
+        // to be sure they do not interfere with the test.
+        private void CleanEnv()
+        {
+            var envVars = new List<string> { "http_proxy", "HTTP_PROXY",
+                                             "https_proxy", "HTTPS_PROXY",
+                                             "all_proxy", "ALL_PROXY",
+                                             "no_proxy", "NO_PROXY",
+                                             "GATEWAY_INTERFACE" };
+
+            foreach (string v in envVars)
+            {
+                Environment.SetEnvironmentVariable(v, null);
+            }
+        }
+
+        public SystemProxyInfoTest()
+        {
+            CleanEnv();
+        }
+
+        [Fact]
+        public void Ctor_NoEnvironmentVariables_NotHttpEnvironmentProxy()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                IWebProxy proxy = SystemProxyInfo.ConstructSystemProxy();
+                HttpEnvironmentProxy envProxy = proxy as HttpEnvironmentProxy;
+                Assert.Null(envProxy);
+
+                return RemoteExecutor.SuccessExitCode;
+            }).Dispose();
+        }
+
+        [Fact]
+        public void Ctor_ProxyEnvironmentVariableSet_IsHttpEnvironmentProxy()
+        {
+            var options = new RemoteInvokeOptions();
+            options.StartInfo.EnvironmentVariables.Add("http_proxy", "http://proxy.contoso.com");
+            RemoteExecutor.Invoke(() =>
+            {
+                IWebProxy proxy = SystemProxyInfo.ConstructSystemProxy();
+                HttpEnvironmentProxy envProxy = proxy as HttpEnvironmentProxy;
+                Assert.NotNull(envProxy);
+
+                return RemoteExecutor.SuccessExitCode;
+            }, options).Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Changed the Windows version of SocketsHttpHandler so that it will honor the same environment
variables similar to the Linux and OSX versions. If the environment variables are not set
then it reverts back to the Windows WinInet/IE settings behavior.

I added several kinds of unit and end-to-end tests to verify the SystemProxyInfo class is
making the correct choice for all the different platforms regarding whether the
HttpEnvironmentProxy or platform proxy (HttpSystemProxy for Windows and MacProxy for OSX)
is used.

Fixes https://github.com/dotnet/corefx/issues/37187