### PR TITLE
Give SocketsHttpHandler more descriptive error messages

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -326,6 +326,45 @@
   <data name="net_http_invalid_response" xml:space="preserve">
     <value>The server returned an invalid or unrecognized response.</value>
   </data>
+  <data name="net_http_invalid_response_premature_eof" xml:space="preserve">
+    <value>The response ended prematurely.</value>
+  </data>
+  <data name="net_http_invalid_response_premature_eof_bytecount" xml:space="preserve">
+    <value>The response ended prematurely, with at least {0} additional bytes expected.</value>
+  </data>
+  <data name="net_http_invalid_response_chunk_header_invalid" xml:space="preserve">
+    <value>Received chunk header length could not be parsed: '{0}'.</value>
+  </data>
+  <data name="net_http_invalid_response_chunk_extension_invalid" xml:space="preserve">
+    <value>Received an invalid chunk extension: '{0}'.</value>
+  </data>
+  <data name="net_http_invalid_response_chunk_terminator_invalid" xml:space="preserve">
+    <value>Received an invalid chunk terminator: '{0}'.</value>
+  </data>
+  <data name="net_http_invalid_response_status_line" xml:space="preserve">
+    <value>Received an invalid status line: '{0}'.</value>
+  </data>
+  <data name="net_http_invalid_response_status_code" xml:space="preserve">
+    <value>Received an invalid status code: '{0}'.</value>
+  </data>
+  <data name="net_http_invalid_response_status_reason" xml:space="preserve">
+    <value>Received status phrase could not be decoded with iso-8859-1: '{0}'.</value>
+  </data>
+  <data name="net_http_invalid_response_header_folder" xml:space="preserve">
+    <value>Received an invalid folded header.</value>
+  </data>
+  <data name="net_http_invalid_response_header_line" xml:space="preserve">
+    <value>Received an invalid header line: '{0}'.</value>
+  </data>
+  <data name="net_http_invalid_response_header_name" xml:space="preserve">
+    <value>Received an invalid header name: '{0}'.</value>
+  </data>
+  <data name="net_http_request_aborted" xml:space="preserve">
+    <value>The request was aborted.</value>
+  </data>
+  <data name="net_http_invalid_response_pseudo_header_in_trailer" xml:space="preserve">
+    <value>Received an HTTP/2 pseudo-header as a trailing header.</value>
+  </data>
   <data name="net_http_unix_handler_disposed" xml:space="preserve">
     <value>The handler was disposed of while active operations were in progress.</value>
   </data>
@@ -391,6 +430,9 @@
   </data>
   <data name="net_ssl_app_protocols_invalid" xml:space="preserve">
     <value>The application protocol list is invalid.</value>
+  </data>
+  <data name="net_ssl_http2_requires_tls12" xml:space="preserve">
+    <value>HTTP/2 requires TLS 1.2 or newer, but '{0}' was negotiated.</value>
   </data>
   <data name="IO_PathTooLong_Path" xml:space="preserve">
     <value>The path '{0}' is too long, or a component of the specified path is too long.</value>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -39,7 +39,7 @@ namespace System.Net.Http
                 if (bytesRead <= 0)
                 {
                     // Unexpected end of response stream.
-                    throw new IOException(SR.net_http_invalid_response);
+                    throw new IOException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _contentBytesRemaining));
                 }
 
                 Debug.Assert((ulong)bytesRead <= _contentBytesRemaining);
@@ -101,7 +101,7 @@ namespace System.Net.Http
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // Unexpected end of response stream.
-                    throw new IOException(SR.net_http_invalid_response);
+                    throw new IOException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, _contentBytesRemaining));
                 }
 
                 Debug.Assert((ulong)bytesRead <= _contentBytesRemaining);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -715,7 +715,7 @@ namespace System.Net.Http
             // If the connection has been aborted, then fail now instead of trying to send more data.
             if (IsAborted())
             {
-                throw new IOException(SR.net_http_invalid_response);
+                throw new IOException(SR.net_http_request_aborted);
             }
         }
 
@@ -1486,7 +1486,7 @@ namespace System.Net.Http
                 int bytesRead = await stream.ReadAsync(buffer.Slice(totalBytesRead)).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
-                    throw new IOException(SR.net_http_invalid_response);
+                    throw new IOException(SR.Format(SR.net_http_invalid_response_premature_eof_bytecount, minReadBytes));
                 }
 
                 totalBytesRead += bytesRead;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -135,17 +135,16 @@ namespace System.Net.Http
                         {
                             // Pseudo-headers not allowed in trailers.
                             if (NetEventSource.IsEnabled) _connection.Trace("Pseudo-header in trailer headers.");
-                            throw new HttpRequestException(SR.net_http_invalid_response);
+                            throw new HttpRequestException(SR.net_http_invalid_response_pseudo_header_in_trailer);
                         }
 
-                        if (value.Length != 3)
-                            throw new Exception("Invalid status code");
-
-                        // Copied from HttpConnection
-                        byte status1 = value[0], status2 = value[1], status3 = value[2];
-                        if (!IsDigit(status1) || !IsDigit(status2) || !IsDigit(status3))
+                        byte status1, status2, status3;
+                        if (value.Length != 3 ||
+                            !IsDigit(status1 = value[0]) ||
+                            !IsDigit(status2 = value[1]) ||
+                            !IsDigit(status3 = value[2]))
                         {
-                            throw new HttpRequestException(SR.net_http_invalid_response);
+                            throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, Encoding.ASCII.GetString(value)));
                         }
 
                         _response.SetStatusCodeWithoutValidation((HttpStatusCode)(100 * (status1 - '0') + 10 * (status2 - '0') + (status3 - '0')));
@@ -155,7 +154,7 @@ namespace System.Net.Http
                         if (!HeaderDescriptor.TryGet(name, out HeaderDescriptor descriptor))
                         {
                             // Invalid header name
-                            throw new HttpRequestException(SR.net_http_invalid_response);
+                            throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
                         }
 
                         string headerValue = descriptor.GetHeaderValue(value);
@@ -301,7 +300,7 @@ namespace System.Net.Http
 
                     if (_state == StreamState.Aborted)
                     {
-                        throw new IOException(SR.net_http_invalid_response);
+                        throw new IOException(SR.net_http_request_aborted);
                     }
                     else if (_state == StreamState.ExpectingHeaders)
                     {
@@ -394,7 +393,7 @@ namespace System.Net.Http
                     }
                     else if (_state == StreamState.Aborted)
                     {
-                        throw new IOException(SR.net_http_invalid_response);
+                        throw new IOException(SR.net_http_request_aborted);
                     }
 
                     Debug.Assert(_state == StreamState.ExpectingData || _state == StreamState.ExpectingTrailingHeaders);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -427,7 +427,7 @@ namespace System.Net.Http
 
                         if (sslStream.SslProtocol < SslProtocols.Tls12)
                         {
-                            throw new HttpRequestException(SR.net_http_invalid_response);
+                            throw new HttpRequestException(SR.Format(SR.net_ssl_http2_requires_tls12, sslStream.SslProtocol));
                         }
 
                         http2Connection = new Http2Connection(this, sslStream);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -152,7 +152,7 @@ namespace System.Net.Http
             {
                 if (_connection == null)
                 {
-                    throw new IOException(SR.net_http_io_write);
+                    throw new IOException(SR.ObjectDisposed_StreamClosed);
                 }
 
                 if (buffer.Length != 0)
@@ -170,7 +170,7 @@ namespace System.Net.Http
 
                 if (_connection == null)
                 {
-                    return new ValueTask(Task.FromException(new IOException(SR.net_http_io_write)));
+                    return new ValueTask(Task.FromException(new IOException(SR.ObjectDisposed_StreamClosed)));
                 }
 
                 if (buffer.Length == 0)


### PR DESCRIPTION
Currently lots of parsing failures just result in an exception stating "The server returned an invalid or unrecognized response."  We can instead be more descriptive about what the problem is in most cases.

cc: @davidsh, @geoffkizer, @wfurt 