### PR TITLE
Disable sporadically failing HttpClientHandler test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -135,6 +135,7 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(37250)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP won't send requests through a custom proxy")]
         [OuterLoop("Uses external server")]
         [Fact]


### PR DESCRIPTION
#37250
cc: @davidsh