### PR TITLE
SqlClient optimize SqlDataReader async method allocations

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -4287,7 +4287,7 @@ namespace System.Data.SqlClient
                     Debug.Assert(resumable.source != null, "resumable.source shuld not be null when continuing");
                     // setup for cleanup\completing
                     retryTask.ContinueWith(
-                        continuationAction: Resumable<int>.s_completeCallback.Value,
+                        continuationAction: Resumable<int>.s_completeCallback,
                         state: resumable,
                         TaskScheduler.Default
                     );
@@ -4739,13 +4739,9 @@ namespace System.Data.SqlClient
 
         private abstract class Resumable<T> : IDisposable
         {
-            internal static readonly Lazy<Action<Task<T>, object>> s_completeCallback = new Lazy<Action<Task<T>, object>>(
-                () => SqlDataReader.CompleteResumableCallback<T>
-            );
+            internal static readonly Action<Task<T>, object> s_completeCallback = SqlDataReader.CompleteResumableCallback<T>;
 
-            internal static readonly Lazy<Func<Task, object, Task<T>>> s_continueCallback = new Lazy<Func<Task, object, Task<T>>>(
-                () => SqlDataReader.ContinueResumableCallback<T>
-            );
+            internal static readonly Func<Task, object, Task<T>> s_continueCallback = SqlDataReader.ContinueResumableCallback<T>;
 
             internal SqlDataReader reader;
             internal TaskCompletionSource<T> source;
@@ -4927,7 +4923,7 @@ namespace System.Data.SqlClient
             else
             {
                 return completionSource.Task.ContinueWith(
-                    continuationFunction: Resumable<T>.s_continueCallback.Value,
+                    continuationFunction: Resumable<T>.s_continueCallback,
                     state: resumable,
                     TaskScheduler.Default
                 ).Unwrap();
@@ -5015,7 +5011,7 @@ namespace System.Data.SqlClient
                 else
                 {
                     task.ContinueWith(
-                        continuationAction: Resumable<T>.s_completeCallback.Value,
+                        continuationAction: Resumable<T>.s_completeCallback,
                         state: resumable,
                         TaskScheduler.Default
                     );


### PR DESCRIPTION
Profiling the DataAccessPerformance project which emulates the TechEmpower fortunes benchmark shows that common async operations like ReadAsync generate context objects and delegates each time they are called which are then dropped for the GC to handle.

This PR changes the implementation of a common pattern used in similar async functions. This is currently implemented using `InvokeRetryable` `ContinueRetryable` and `CompleteRetryable`. It took some time to work out just what these functions were doing and how data flows between them and having done so I chose to rename them to Resumable instead of Retryable because retry is commonly (though you could argue incorrectly) used in contexts where we mean that an exception has occurred and we are going to try again which is not how these functions work, any exception is immediate and not retried.

When [ReadAsync](https://github.com/dotnet/corefx/blob/610fa286999c78b841e17ea0c301c0986426635d/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs#L4268) is called the function attempts to satisfy the call synchronously if possible. If it is not possible it [generates](https://github.com/dotnet/corefx/blob/610fa286999c78b841e17ea0c301c0986426635d/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs#L4381) an async closure and func and then passes those to the retry functions. This generation of closure and function is currently per-call.

I have removed all uses of the context closures by wrapping the common pattern in an abstract `Resumable<T>` class which contains common functionality. This class is then inherited and context data added to it for each of the changed async method, Because each operation now has a dedicated class static funcs can be created for the callback removing the repeated allocation of the func. The objects themselves may be reused because the `SqlDataReader` only allows a single async operation to be active so I have added cached objects for `IsDBNullAsync` and `ReadAsync` which means that only the first call to each will allocate the cached object after that they will be reused. Less commonly used async functions like `HasNextAsync` and `ReadBytesAsync` are not cached, `GetfieldValueAsync<T>` is not cached because the range of T is unbounded.

Profiles before:
![readerasync-master](https://user-images.githubusercontent.com/13322696/56855757-beb90580-6944-11e9-8e3e-5722e6123379.PNG)

After:
![readerasync-branch](https://user-images.githubusercontent.com/13322696/56855759-c082c900-6944-11e9-9066-c643a8631a29.PNG)

benchmark results are small because of the prevalence of snapshot allocations, but worth having.

| name | sync | threads | TPS  | stdev | description |
| ---- | ---- | ------- | ---: | ----: | :---------- |
|ado-sqlclient+async+64|async|64|59190|1675|asyncread master|
|ado-sqlclient+async+64|async|64|60073|1650|asyncread branch|

so a 1.5% throughput increase.

Manual and functional test pass in native mode. DataAccessPerfomance under pure load and profilers has no problems.
/cc area owners @AfsanehR, @tarikulsabbir, @Gary-Zh , @David-Engel , people interested in perf @divega @roji @saurabh500