### PR TITLE
Plumb cancellation through SslStream.AuthenticateAsXxAsync

### DIFF
--- a/src/Common/tests/System/Net/VirtualNetwork/VirtualNetwork.cs
+++ b/src/Common/tests/System/Net/VirtualNetwork/VirtualNetwork.cs
@@ -27,12 +27,12 @@ namespace System.Net.Test.Common
         private bool _connectionBroken = false;
 
         public byte[] ReadFrame(bool server) =>
-            ReadFrameCoreAsync(server, sync: true).GetAwaiter().GetResult();
+            ReadFrameCoreAsync(server, sync: true, cancellationToken: default).GetAwaiter().GetResult();
 
-        public Task<byte[]> ReadFrameAsync(bool server) =>
-            ReadFrameCoreAsync(server, sync: false);
+        public Task<byte[]> ReadFrameAsync(bool server, CancellationToken cancellationToken) =>
+            ReadFrameCoreAsync(server, sync: false, cancellationToken);
 
-        private async Task<byte[]> ReadFrameCoreAsync(bool server, bool sync)
+        private async Task<byte[]> ReadFrameCoreAsync(bool server, bool sync, CancellationToken cancellationToken)
         {
             if (_connectionBroken)
             {
@@ -54,8 +54,8 @@ namespace System.Net.Test.Common
             }
 
             bool successfulWait = sync ?
-                semaphore.Wait(WaitForReadDataTimeoutMilliseconds) :
-                await semaphore.WaitAsync(WaitForReadDataTimeoutMilliseconds).ConfigureAwait(false);
+                semaphore.Wait(WaitForReadDataTimeoutMilliseconds, cancellationToken) :
+                await semaphore.WaitAsync(WaitForReadDataTimeoutMilliseconds, cancellationToken).ConfigureAwait(false);
             if (!successfulWait)
             {
                 throw new TimeoutException("VirtualNetwork: Timeout reading the next frame.");
@@ -84,7 +84,7 @@ namespace System.Net.Test.Common
                 }
                 else
                 {
-                    await Task.Delay(backOffDelayMilliseconds).ConfigureAwait(false);
+                    await Task.Delay(backOffDelayMilliseconds, cancellationToken).ConfigureAwait(false);
                 }
             }
             while (remainingTries > 0);

--- a/src/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
+++ b/src/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
@@ -89,10 +89,10 @@ namespace System.Net.Test.Common
             {
                 if (_readStream == null || (_readStream.Position >= _readStream.Length))
                 {
-                    _readStream = new MemoryStream(await _network.ReadFrameAsync(_isServer).ConfigureAwait(false));
+                    _readStream = new MemoryStream(await _network.ReadFrameAsync(_isServer, cancellationToken).ConfigureAwait(false));
                 }
 
-                return await _readStream.ReadAsync(buffer, offset, count).ConfigureAwait(false);
+                return await _readStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             }
             finally
             {

--- a/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
+++ b/src/System.Net.Security/src/System/Net/FixedSizeReader.cs
@@ -54,7 +54,7 @@ namespace System.Net
                 int remainingCount = request.Count, offset = request.Offset;
                 do
                 {
-                    int bytes = await transport.ReadAsync(new Memory<byte>(request.Buffer, offset, remainingCount), CancellationToken.None).ConfigureAwait(false);
+                    int bytes = await transport.ReadAsync(new Memory<byte>(request.Buffer, offset, remainingCount), request.CancellationToken).ConfigureAwait(false);
                     if (bytes == 0)
                     {
                         if (remainingCount != request.Count)

--- a/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
+++ b/src/System.Net.Security/src/System/Net/HelperAsyncResults.cs
@@ -34,12 +34,13 @@ namespace System.Net
         public LazyAsyncResult UserAsyncResult;
         public int Result;
         public object AsyncState;
+        public readonly CancellationToken CancellationToken;
 
         public byte[] Buffer; // Temporary buffer reused by a protocol.
         public int Offset;
         public int Count;
 
-        public AsyncProtocolRequest(LazyAsyncResult userAsyncResult)
+        public AsyncProtocolRequest(LazyAsyncResult userAsyncResult, CancellationToken cancellationToken = default)
         {
             if (userAsyncResult == null)
             {
@@ -50,6 +51,7 @@ namespace System.Net
                 NetEventSource.Fail(this, "userAsyncResult is already completed.");
             }
             UserAsyncResult = userAsyncResult;
+            CancellationToken = cancellationToken;
         }
 
         public void SetNextRequest(byte[] buffer, int offset, int count, AsyncProtocolCallback callback)

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.Adapters.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.Adapters.cs
@@ -13,12 +13,14 @@ namespace System.Net.Security
         {
             Task LockAsync();
             ValueTask WriteAsync(byte[] buffer, int offset, int count);
+            CancellationToken CancellationToken { get; }
         }
 
         private interface ISslReadAdapter
         {
             ValueTask<int> ReadAsync(byte[] buffer, int offset, int count);
             ValueTask<int> LockAsync(Memory<byte> buffer);
+            CancellationToken CancellationToken { get; }
         }
 
         private readonly struct SslReadAsync : ISslReadAdapter
@@ -35,6 +37,8 @@ namespace System.Net.Security
             public ValueTask<int> ReadAsync(byte[] buffer, int offset, int count) => _sslStream.InnerStream.ReadAsync(new Memory<byte>(buffer, offset, count), _cancellationToken);
 
             public ValueTask<int> LockAsync(Memory<byte> buffer) => _sslStream.CheckEnqueueReadAsync(buffer);
+
+            public CancellationToken CancellationToken => _cancellationToken;
         }
 
         private readonly struct SslReadSync : ISslReadAdapter
@@ -46,6 +50,8 @@ namespace System.Net.Security
             public ValueTask<int> ReadAsync(byte[] buffer, int offset, int count) => new ValueTask<int>(_sslStream.InnerStream.Read(buffer, offset, count));
 
             public ValueTask<int> LockAsync(Memory<byte> buffer) => new ValueTask<int>(_sslStream.CheckEnqueueRead(buffer));
+
+            public CancellationToken CancellationToken => default;
         }
 
         private readonly struct SslWriteAsync : ISslWriteAdapter
@@ -62,6 +68,8 @@ namespace System.Net.Security
             public Task LockAsync() => _sslStream.CheckEnqueueWriteAsync();
 
             public ValueTask WriteAsync(byte[] buffer, int offset, int count) => _sslStream.InnerStream.WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), _cancellationToken);
+
+            public CancellationToken CancellationToken => _cancellationToken;
         }
 
         private readonly struct SslWriteSync : ISslWriteAdapter
@@ -81,6 +89,8 @@ namespace System.Net.Security
                 _sslStream.InnerStream.Write(buffer, offset, count);
                 return default;
             }
+
+            public CancellationToken CancellationToken => default;
         }
     }
 }

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -283,7 +283,7 @@ namespace System.Net.Security
         // This method assumes that a SSPI context is already in a good shape.
         // For example it is either a fresh context or already authenticated context that needs renegotiation.
         //
-        private void ProcessAuthentication(LazyAsyncResult lazyResult)
+        private void ProcessAuthentication(LazyAsyncResult lazyResult, CancellationToken cancellationToken)
         {
             if (Interlocked.Exchange(ref _nestedAuth, 1) == 1)
             {
@@ -296,7 +296,7 @@ namespace System.Net.Security
                 AsyncProtocolRequest asyncRequest = null;
                 if (lazyResult != null)
                 {
-                    asyncRequest = new AsyncProtocolRequest(lazyResult);
+                    asyncRequest = new AsyncProtocolRequest(lazyResult, cancellationToken);
                     asyncRequest.Buffer = null;
 #if DEBUG
                     lazyResult._debugAsyncChain = asyncRequest;
@@ -342,7 +342,7 @@ namespace System.Net.Security
         //
         // This is used to reply on re-handshake when received SEC_I_RENEGOTIATE on Read().
         //
-        private void ReplyOnReAuthentication(byte[] buffer)
+        private void ReplyOnReAuthentication(byte[] buffer, CancellationToken cancellationToken)
         {
             lock (SyncLock)
             {
@@ -362,7 +362,7 @@ namespace System.Net.Security
             // Forcing async mode.  The caller will queue another Read as soon as we return using its preferred
             // calling convention, which will be woken up when the handshake completes.  The callback is just
             // to capture any SocketErrors that happen during the handshake so they can be surfaced from the Read.
-            AsyncProtocolRequest asyncRequest = new AsyncProtocolRequest(new LazyAsyncResult(this, null, new AsyncCallback(RehandshakeCompleteCallback)));
+            AsyncProtocolRequest asyncRequest = new AsyncProtocolRequest(new LazyAsyncResult(this, null, new AsyncCallback(RehandshakeCompleteCallback)), cancellationToken);
             // Buffer contains a result from DecryptMessage that will be passed to ISC/ASC
             asyncRequest.Buffer = buffer;
             ForceAuthentication(false, buffer, asyncRequest);
@@ -504,7 +504,7 @@ namespace System.Net.Security
                 else
                 {
                     asyncRequest.AsyncState = message;
-                    Task t = InnerStream.WriteAsync(message.Payload, 0, message.Size);
+                    Task t = InnerStream.WriteAsync(message.Payload, 0, message.Size, asyncRequest.CancellationToken);
                     if (t.IsCompleted)
                     {
                         t.GetAwaiter().GetResult();
@@ -717,7 +717,7 @@ namespace System.Net.Security
             else
             {
                 asyncRequest.AsyncState = exception;
-                Task t = InnerStream.WriteAsync(message.Payload, 0, message.Size);
+                Task t = InnerStream.WriteAsync(message.Payload, 0, message.Size, asyncRequest.CancellationToken);
                 if (t.IsCompleted)
                 {
                     t.GetAwaiter().GetResult();
@@ -1405,7 +1405,7 @@ namespace System.Net.Security
                                 throw new IOException(SR.net_ssl_io_renego);
                             }
 
-                            ReplyOnReAuthentication(extraBuffer);
+                            ReplyOnReAuthentication(extraBuffer, adapter.CancellationToken);
 
                             // Loop on read.
                             continue;
@@ -1425,7 +1425,7 @@ namespace System.Net.Security
             {
                 FinishRead(null);
 
-                if (e is IOException)
+                if (e is IOException || (e is OperationCanceledException && adapter.CancellationToken.IsCancellationRequested))
                 {
                     throw;
                 }
@@ -1524,7 +1524,7 @@ namespace System.Net.Security
             {
                 FinishWrite();
 
-                if (e is IOException)
+                if (e is IOException || (e is OperationCanceledException && writeAdapter.CancellationToken.IsCancellationRequested))
                 {
                     throw;
                 }

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -222,7 +222,7 @@ namespace System.Net.Security
             return BeginAuthenticateAsClient(options, CancellationToken.None, asyncCallback, asyncState);
         }
 
-        internal virtual IAsyncResult BeginAuthenticateAsClient(SslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken, AsyncCallback asyncCallback, object asyncState)
+        internal IAsyncResult BeginAuthenticateAsClient(SslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken, AsyncCallback asyncCallback, object asyncState)
         {
             SetAndVerifyValidationCallback(sslClientAuthenticationOptions.RemoteCertificateValidationCallback);
             SetAndVerifySelectionCallback(sslClientAuthenticationOptions.LocalCertificateSelectionCallback);
@@ -230,7 +230,7 @@ namespace System.Net.Security
             ValidateCreateContext(sslClientAuthenticationOptions, _certValidationDelegate, _certSelectionDelegate);
 
             LazyAsyncResult result = new LazyAsyncResult(this, asyncState, asyncCallback);
-            ProcessAuthentication(result);
+            ProcessAuthentication(result, cancellationToken);
             return result;
         }
 
@@ -277,13 +277,13 @@ namespace System.Net.Security
             ValidateCreateContext(CreateAuthenticationOptions(sslServerAuthenticationOptions));
 
             LazyAsyncResult result = new LazyAsyncResult(this, asyncState, asyncCallback);
-            ProcessAuthentication(result);
+            ProcessAuthentication(result, cancellationToken);
             return result;
         }
 
         public virtual void EndAuthenticateAsServer(IAsyncResult asyncResult) => EndProcessAuthentication(asyncResult);
 
-        internal virtual IAsyncResult BeginShutdown(AsyncCallback asyncCallback, object asyncState)
+        internal IAsyncResult BeginShutdown(AsyncCallback asyncCallback, object asyncState)
         {
             CheckThrow(authSuccessCheck: true, shutdownCheck: true);
 
@@ -291,7 +291,7 @@ namespace System.Net.Security
             return TaskToApm.Begin(InnerStream.WriteAsync(message.Payload, 0, message.Payload.Length), asyncCallback, asyncState);
         }
 
-        internal virtual void EndShutdown(IAsyncResult asyncResult)
+        internal void EndShutdown(IAsyncResult asyncResult)
         {
             CheckThrow(authSuccessCheck: true, shutdownCheck: true);
 
@@ -334,7 +334,7 @@ namespace System.Net.Security
             SetAndVerifySelectionCallback(sslClientAuthenticationOptions.LocalCertificateSelectionCallback);
 
             ValidateCreateContext(sslClientAuthenticationOptions, _certValidationDelegate, _certSelectionDelegate);
-            ProcessAuthentication(null);
+            ProcessAuthentication(null, default);
         }
 
         public virtual void AuthenticateAsServer(X509Certificate serverCertificate)
@@ -366,7 +366,7 @@ namespace System.Net.Security
             SetAndVerifyValidationCallback(sslServerAuthenticationOptions.RemoteCertificateValidationCallback);
 
             ValidateCreateContext(CreateAuthenticationOptions(sslServerAuthenticationOptions));
-            ProcessAuthentication(null);
+            ProcessAuthentication(null, default);
         }
         #endregion
 

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.netcoreapp.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.netcoreapp.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Net.Sockets;
+using System.Net.Test.Common;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Security.Tests
+{
+    using Configuration = System.Net.Test.Common.Configuration;
+
+    public sealed class SslStreamStreamToStreamTest_MemoryAsync : SslStreamStreamToStreamTest_CancelableReadWriteAsync
+    {
+        protected override async Task DoHandshake(SslStream clientSslStream, SslStream serverSslStream)
+        {
+            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            {
+                Task t1 = clientSslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions() { TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false) }, CancellationToken.None);
+                Task t2 = serverSslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions() { ServerCertificate = certificate }, CancellationToken.None);
+                await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2);
+            }
+        }
+
+        protected override Task<int> ReadAsync(Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            stream.ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+
+        protected override Task WriteAsync(Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            stream.WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+
+        [Fact]
+        public async Task Authenticate_Precanceled_ThrowsOperationCanceledException()
+        {
+            var network = new VirtualNetwork();
+            using (var clientSslStream = new SslStream(new VirtualNetworkStream(network, isServer: false), false, AllowAnyServerCertificate))
+            using (var serverSslStream = new SslStream(new VirtualNetworkStream(network, isServer: true)))
+            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            {
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => clientSslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions() { TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false) }, new CancellationToken(true)));
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => serverSslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions() { ServerCertificate = certificate }, new CancellationToken(true)));
+            }
+        }
+
+        [Fact]
+        public async Task AuthenticateAsClientAsync_VirtualNetwork_CanceledAfterStart_ThrowsOperationCanceledException()
+        {
+            var network = new VirtualNetwork();
+            using (var clientSslStream = new SslStream(new VirtualNetworkStream(network, isServer: false), false, AllowAnyServerCertificate))
+            using (var serverSslStream = new SslStream(new VirtualNetworkStream(network, isServer: true)))
+            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            {
+                var cts = new CancellationTokenSource();
+                Task t = clientSslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions() { TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false) }, cts.Token);
+                cts.Cancel();
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t);
+            }
+        }
+
+        [Fact]
+        public async Task AuthenticateAsClientAsync_Sockets_CanceledAfterStart_ThrowsOperationCanceledException()
+        {
+            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listener.Listen(1);
+
+                await client.ConnectAsync(listener.LocalEndPoint);
+                using (Socket server = await listener.AcceptAsync())
+                using (var clientSslStream = new SslStream(new NetworkStream(client), false, AllowAnyServerCertificate))
+                using (var serverSslStream = new SslStream(new NetworkStream(server)))
+                using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+                {
+                    var cts = new CancellationTokenSource();
+                    Task t = clientSslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions() { TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false) }, cts.Token);
+                    cts.Cancel();
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task AuthenticateAsServerAsync_VirtualNetwork_CanceledAfterStart_ThrowsOperationCanceledException()
+        {
+            var network = new VirtualNetwork();
+            using (var clientSslStream = new SslStream(new VirtualNetworkStream(network, isServer: false), false, AllowAnyServerCertificate))
+            using (var serverSslStream = new SslStream(new VirtualNetworkStream(network, isServer: true)))
+            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            {
+                var cts = new CancellationTokenSource();
+                Task t = serverSslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions() { ServerCertificate = certificate }, cts.Token);
+                cts.Cancel();
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t);
+            }
+        }
+
+        [Fact]
+        public async Task AuthenticateAsServerAsync_Sockets_CanceledAfterStart_ThrowsOperationCanceledException()
+        {
+            using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            using (var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listener.Listen(1);
+
+                await client.ConnectAsync(listener.LocalEndPoint);
+                using (Socket server = await listener.AcceptAsync())
+                using (var clientSslStream = new SslStream(new NetworkStream(client), false, AllowAnyServerCertificate))
+                using (var serverSslStream = new SslStream(new NetworkStream(server)))
+                using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+                {
+                    var cts = new CancellationTokenSource();
+                    Task t = serverSslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions() { ServerCertificate = certificate }, cts.Token);
+                    cts.Cancel();
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => t);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="SslStreamSchSendAuxRecordTest.cs" />
     <Compile Include="SslStreamCredentialCacheTest.cs" />
     <Compile Include="SslStreamSystemDefaultsTest.cs" />
+    <Compile Include="SslStreamStreamToStreamTest.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="LoggingTest.cs" />

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
@@ -4,6 +4,7 @@
 
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.Net.Security
@@ -64,7 +65,7 @@ namespace System.Net.Security
         // This method assumes that a SSPI context is already in a good shape.
         // For example it is either a fresh context or already authenticated context that needs renegotiation.
         //
-        private void ProcessAuthentication(LazyAsyncResult lazyResult)
+        private void ProcessAuthentication(LazyAsyncResult lazyResult, CancellationToken cancellationToken)
         {
         }
 


### PR DESCRIPTION
We accept a CancellationToken into several of the overloads, but it's then dropped and not actually used.  This fixes that to ensure it's passed through to the underlying Read/WriteAsync operations.

Fixes https://github.com/dotnet/corefx/issues/25206
cc: @davidsh, @geoffkizer, @wfurt, @Drawaes, @benaadams 