### PR TITLE
Speed optimization of ToList() for Range() and Repeat() operations

### DIFF
--- a/src/System.Linq/src/System/Linq/Range.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Range.SpeedOpt.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -28,16 +29,7 @@ namespace System.Linq
                 return array;
             }
 
-            public List<int> ToList()
-            {
-                List<int> list = new List<int>(_end - _start);
-                for (int cur = _start; cur != _end; cur++)
-                {
-                    list.Add(cur);
-                }
-
-                return list;
-            }
+            public List<int> ToList() => new List<int>(new ToListCollection(this));
 
             public int GetCount(bool onlyIfCheap) => unchecked(_end - _start);
 
@@ -85,6 +77,41 @@ namespace System.Linq
                 found = true;
                 return _end - 1;
             }
+
+            private class ToListCollection : ICollection<int>
+            {
+                readonly int _start;
+                readonly int _count;
+
+                public ToListCollection(RangeIterator source)
+                {
+                    _start = source._start;
+                    _count = source._end - source._start;
+                }
+
+                public int Count => _count;
+
+                public bool IsReadOnly => true;
+
+                public void CopyTo(int[] array, int _)
+                {
+                    unchecked
+                    {
+                        for(int index = 0; index < _count; index++)
+                        {
+                            array[index] = _start + index;
+                        }
+                    }
+                }
+
+                IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
+                IEnumerator<int> IEnumerable<int>.GetEnumerator() => throw new NotSupportedException();
+                void ICollection<int>.Add(int item) => throw new NotSupportedException();
+                bool ICollection<int>.Remove(int item) => throw new NotSupportedException();
+                void ICollection<int>.Clear() => throw new NotSupportedException();
+                bool ICollection<int>.Contains(int item) => throw new NotSupportedException();
+            }
+
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Repeat.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.SpeedOpt.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -16,7 +17,7 @@ namespace System.Linq
             public TResult[] ToArray()
             {
                 TResult[] array = new TResult[_count];
-                if (_current != null)
+                if (_current is object) // not null
                 {
                     Array.Fill(array, _current);
                 }
@@ -24,16 +25,7 @@ namespace System.Linq
                 return array;
             }
 
-            public List<TResult> ToList()
-            {
-                List<TResult> list = new List<TResult>(_count);
-                for (int i = 0; i != _count; ++i)
-                {
-                    list.Add(_current);
-                }
-
-                return list;
-            }
+            public List<TResult> ToList() => new List<TResult>(new ToListCollection(this));
 
             public int GetCount(bool onlyIfCheap) => _count;
 
@@ -80,6 +72,44 @@ namespace System.Linq
                 found = true;
                 return _current;
             }
+
+            private class ToListCollection : ICollection<TResult>
+            {
+                readonly TResult _current;
+                readonly int _count;
+
+                public ToListCollection(RepeatIterator<TResult> source)
+                {
+                    _current = source._current;
+                    _count = source._count;
+                }
+
+                public int Count => _count;
+
+                public bool IsReadOnly => true;
+
+                public void CopyTo(TResult[] array, int _)
+                {
+                    if (_current is object) // not null
+                    {
+                        unchecked
+                        {
+                            for(int index = 0; index < _count; index++)
+                            {
+                                array[index] = _current;
+                            }
+                        }
+                    }
+                }
+
+                IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
+                IEnumerator<TResult> IEnumerable<TResult>.GetEnumerator() => throw new NotSupportedException();
+                void ICollection<TResult>.Add(TResult item) => throw new NotSupportedException();
+                bool ICollection<TResult>.Remove(TResult item) => throw new NotSupportedException();
+                void ICollection<TResult>.Clear() => throw new NotSupportedException();
+                bool ICollection<TResult>.Contains(TResult item) => throw new NotSupportedException();
+            }
+
         }
     }
 }


### PR DESCRIPTION
The `Range()` and `Repeat()` operations already have a speed optimization for its `ToList()` method. They simply create a `List<T>` and add the elements to it. Here's the [implementation for Range](https://github.com/dotnet/corefx/blob/81c8c68d81daad033251d643e230061f38a9ae3a/src/System.Linq/src/System/Linq/Range.SpeedOpt.cs#L31):

```csharp
public List<int> ToList()
{
   List<int> list = new List<int>(_end - _start);
   for (int cur = _start; cur != _end; cur++)
   {
       list.Add(cur);
   }

   return list;
}
```

Although the length is passed as the `capacity` for the new `List<T>`, the `Add()` method still performs version increment, buffer length validation and size increment. This is performed for every element, which is unnecessary and penalizing.

```csharp
public void Add(T item)
{
    _version++;
    T[] array = _items;
    int size = _size;
    if ((uint)size < (uint)array.Length)
    {
        _size = size + 1;
        array[size] = item;
    }
    else
    {
        AddWithResize(item);
    }
}
```

As an alternative, the `List<T>(IEnumerable<T>)` constructor can be used, which has the following implementation:

```csharp
public List(IEnumerable<T> collection)
{
    if (collection == null)
        ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collection);

    if (collection is ICollection<T> c)
    {
        int count = c.Count;
        if (count == 0)
        {
            _items = s_emptyArray;
        }
        else
        {
            _items = new T[count];
            c.CopyTo(_items, 0);
            _size = count;
        }
    }
    else
    {
        _size = 0;
        _items = s_emptyArray;
        using (IEnumerator<T> en = collection.GetEnumerator())
        {
            while (en.MoveNext())
            {
                Add(en.Current);
            }
        }
    }
}
```

When `collection` is not a `ICollection<T>`, which would be the case, `Add()` is still called for each element. But, when it's a non-empty `ICollection<T>`, it simply allocates an array, calls `ICollection<T>.CopyTo()` and sets the size. Only once!

**This pull request takes advantage of this to improve the speed optimization of `ToList()` for `Range` and `Repeat`.**

It adds private minimal implementations of `ICollection<T>` where the `CopyTo()` implementation simply uses a `for` loop to set the elements. With no validations!

Here's the implementation for `Range`:

```csharp
public void CopyTo(int[] array, int _)
{
    unchecked
    {
        for(int index = 0; index < _count; index++)
        {
            array[index] = _start + index;
        }
    }
}
```

Here's the implementation for `Repeat`:

```csharp
public void CopyTo(TResult[] array, int _)
{
    if (_current is object) // not null
    {
        unchecked
        {
            for(int index = 0; index < _count; index++)
            {
                array[index] = _current;
            }
        }
    }
}
```

The only side-effect is that an instance of the `ICollection<T>` has to be created but it will be very short lived.