### PR TITLE
Fix bad usage of ArrayPool in TdsParserStateObject

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using System.Text;
 using System.Security;
 using System.Runtime.InteropServices;
-using System.Buffers;
 
 namespace System.Data.SqlClient
 {
@@ -1644,14 +1643,12 @@ namespace System.Data.SqlClient
             int cBytes = length << 1;
             byte[] buf;
             int offset = 0;
-            bool rentedBuffer = false;
 
             if (((_inBytesUsed + cBytes) > _inBytesRead) || (_inBytesPacket < cBytes))
             {
                 if (_bTmp == null || _bTmp.Length < cBytes)
                 {
-                    _bTmp = ArrayPool<byte>.Shared.Rent(cBytes);
-                    rentedBuffer = true;
+                    _bTmp = new byte[cBytes];
                 }
 
                 if (!TryReadByteArray(_bTmp, cBytes))
@@ -1677,10 +1674,6 @@ namespace System.Data.SqlClient
             }
 
             value = System.Text.Encoding.Unicode.GetString(buf, offset, cBytes);
-            if (rentedBuffer)
-            {
-                 ArrayPool<byte>.Shared.Return(_bTmp, clearArray: true);
-            }
             return true;
         }
 
@@ -1713,7 +1706,6 @@ namespace System.Data.SqlClient
             }
             byte[] buf = null;
             int offset = 0;
-            bool rentedBuffer = false;
 
             if (isPlp)
             {
@@ -1731,8 +1723,7 @@ namespace System.Data.SqlClient
                 {
                     if (_bTmp == null || _bTmp.Length < length)
                     {
-                        _bTmp = ArrayPool<byte>.Shared.Rent(length);
-                        rentedBuffer = true;
+                        _bTmp = new byte[length];
                     }
 
                     if (!TryReadByteArray(_bTmp, length))
@@ -1760,10 +1751,6 @@ namespace System.Data.SqlClient
 
             // BCL optimizes to not use char[] underneath
             value = encoding.GetString(buf, offset, length);
-            if (rentedBuffer)
-            {
-                ArrayPool<byte>.Shared.Return(_bTmp, clearArray: true);
-            }
             return true;
         }
 


### PR DESCRIPTION
If TdsParserStateObject.TryReadString or
TdsParserStateObject.TryReadStringWithEncoding hit the growth case they
would rent an array, save it into a field, use the array, return the array to the pool,
but keep it assigned to the field and continue using it.

Since other writes to _bTmp use fresh arrays in an instance-cached-growth
pattern, this change restores these two methods to that same approach, rather
than renting to a local buffer and not renting into a field.