### PR TITLE
Cleanup some WebSocket tests

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/CancelTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/CancelTest.cs
@@ -14,7 +14,7 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public CancelTest(ITestOutputHelper output) : base(output) { }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ConnectAsync_Cancel_ThrowsWebSocketExceptionWithMessage(Uri server)
         {
@@ -38,7 +38,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendAsync_Cancel_Success(Uri server)
         {
@@ -53,7 +53,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         [ActiveIssue(13302)]
         public async Task ReceiveAsync_Cancel_Success(Uri server)
@@ -76,7 +76,8 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Cancellation sometimes throw wrong exceptions, dotnet/corefx #28777")]
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseAsync_Cancel_Success(Uri server)
         {
@@ -98,7 +99,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task CloseOutputAsync_Cancel_Success(Uri server)
         {
@@ -121,7 +122,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, server);
         }
         
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ReceiveAsync_CancelThenReceive_ThrowsOperationCanceledException(Uri server)
         {
@@ -136,8 +137,9 @@ namespace System.Net.WebSockets.Client.Tests
                 await Assert.ThrowsAnyAsync<OperationCanceledException>(() => receive);
             }
         }
-        
-        [OuterLoop] // TODO: Issue #11345
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Cancellation sometimes throw wrong exceptions, dotnet/corefx #26635")]
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ReceiveAsync_ReceiveThenCancel_ThrowsOperationCanceledException(Uri server)
         {
@@ -153,7 +155,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
         
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ReceiveAsync_AfterCancellationDoReceiveAsync_ThrowsWebSocketException(Uri server)
         {

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketTestBase.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketTestBase.cs
@@ -82,12 +82,6 @@ namespace System.Net.WebSockets.Client.Tests
                 }
                 catch (WebSocketException exception)
                 {
-                    Assert.Equal(ResourceHelper.GetExceptionMessage(
-                        "net_WebSockets_InvalidState_ClosedOrAborted",
-                        "System.Net.WebSockets.InternalClientWebSocket",
-                        "Aborted"),
-                        exception.Message);
-
                     Assert.Equal(WebSocketError.InvalidState, exception.WebSocketErrorCode);
                     Assert.Equal(WebSocketState.Aborted, cws.State);
                 }

--- a/src/System.Net.WebSockets.Client/tests/KeepAliveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/KeepAliveTest.cs
@@ -16,7 +16,6 @@ namespace System.Net.WebSockets.Client.Tests
     {
         public KeepAliveTest(ITestOutputHelper output) : base(output) { }
 
-        [ActiveIssue(23204, TargetFrameworkMonikers.Uap)]
         [ConditionalFact(nameof(WebSocketsSupported))]
         [OuterLoop] // involves long delay
         public async Task KeepAlive_LongDelayBetweenSendReceives_Succeeds()

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -32,7 +32,7 @@ namespace System.Net.WebSockets.Client.Tests
 
         public SendReceiveTest(ITestOutputHelper output) : base(output) { }
 
-        [OuterLoop("Uses external server")]
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendReceive_PartialMessageDueToSmallReceiveBuffer_Success(Uri server)
         {
@@ -69,7 +69,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported), nameof(PartialMessagesSupported)), MemberData(nameof(EchoServers))]
         public async Task SendReceive_PartialMessageBeforeCompleteMessageArrives_Success(Uri server)
         {
@@ -111,7 +111,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendAsync_SendCloseMessageType_ThrowsArgumentExceptionWithMessage(Uri server)
         {
@@ -139,8 +139,8 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [ActiveIssue(33401, TargetFrameworkMonikers.NetFramework)]
-        [OuterLoop] // TODO: Issue #11345
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Skip due to bugs in NETFX WebSocket, dotnet/corefx #33401")]
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendAsync_MultipleOutstandingSendOperations_Throws(Uri server)
         {
@@ -199,7 +199,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ReceiveAsync_MultipleOutstandingReceiveOperations_Throws(Uri server)
         {
@@ -263,7 +263,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendAsync_SendZeroLengthPayloadAsEndOfMessage_Success(Uri server)
         {
@@ -302,7 +302,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendReceive_VaryingLengthBuffers_Success(Uri server)
         {
@@ -342,7 +342,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task SendReceive_Concurrent_Success(Uri server)
         {
@@ -371,7 +371,7 @@ namespace System.Net.WebSockets.Client.Tests
             }
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalFact(nameof(WebSocketsSupported))]
         public async Task SendReceive_ConnectionClosedPrematurely_ReceiveAsyncFailsAndWebSocketStateUpdated()
         {
@@ -440,7 +440,7 @@ namespace System.Net.WebSockets.Client.Tests
             }, options);
         }
 
-        [OuterLoop] // TODO: Issue #11345
+        [OuterLoop("Uses external servers")]
         [ConditionalTheory(nameof(WebSocketsSupported)), MemberData(nameof(EchoServers))]
         public async Task ZeroByteReceive_CompletesWhenDataAvailable(Uri server)
         {


### PR DESCRIPTION
Skip some tests on .NET Framework due to bugs in .NET Framework.

Modify the TestCancellation helper method for the WebSocket client tests to not check for string matching in exception messages. This makes the test too brittle. We're already checking for other important fields in the WebSocket object.

Re-enable some UAP tests since the fixes are in master branch.

Closes #13302
Closes #22635
Closes #23204
Closes #28777
Closes #33401