### PR TITLE
update tests using "localhost" to be more liberal on verification of response address.

### DIFF
--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -46,26 +46,36 @@ namespace System.Net.NetworkInformation.Tests
 
         private void PingResultValidator(PingReply pingReply, IPAddress localIpAddress)
         {
+            PingResultValidator(pingReply, new IPAddress[] { localIpAddress });
+        }
+
+        private void PingResultValidator(PingReply pingReply, IPAddress[] localIpAddresses)
+        {
             if (pingReply.Status == IPStatus.TimedOut)
             {
                 // Workaround OSX ping6 bug, refer issue #15018
-                Assert.Equal(AddressFamily.InterNetworkV6, localIpAddress.AddressFamily);
+                Assert.Equal(AddressFamily.InterNetworkV6, pingReply.Address.AddressFamily);
                 Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
                 return;
             }
 
             Assert.Equal(IPStatus.Success, pingReply.Status);
-            if (!pingReply.Address.Equals(localIpAddress))
+            foreach (IPAddress localIpAddress in localIpAddresses)
             {
-                // Test is going to fail. Collect some more info.
-                _output.WriteLine($"Reply address {pingReply.Address} is not expected {localIpAddress}");
-                IPHostEntry hostEntry = Dns.GetHostEntry(TestSettings.LocalHost);
-                foreach (IPAddress address in hostEntry.AddressList)
+                if (pingReply.Address.Equals(localIpAddress))
                 {
-                    _output.WriteLine($"Local address {address}");
+                    return;
                 }
             }
-            Assert.True(pingReply.Address.Equals(localIpAddress));
+            // We did not find response address in given list.
+            // Test is going to fail. Collect some more info.
+            _output.WriteLine($"Reply address {pingReply.Address} is not expected local address.");
+            foreach (IPAddress address in localIpAddresses)
+            {
+                _output.WriteLine($"Local address {address}");
+            }
+
+            Assert.Contains(pingReply.Address, localIpAddresses); ///, "Reply address {pingReply.Address} is not expected local address.");
         }
 
         [Fact]
@@ -401,52 +411,52 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void SendPingWithHost()
         {
-            IPAddress localIpAddress = TestSettings.GetLocalIPAddress();
+            IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
 
             SendBatchPing(
                 (ping) => ping.Send(TestSettings.LocalHost),
                 (pingReply) =>
                 {
-                    PingResultValidator(pingReply, localIpAddress);
+                    PingResultValidator(pingReply, localIpAddresses);
                 });
         }
 
         [Fact]
         public async Task SendPingAsyncWithHost()
         {
-            IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
+            IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(TestSettings.LocalHost),
                 (pingReply) =>
                 {
-                    PingResultValidator(pingReply, localIpAddress);
+                    PingResultValidator(pingReply, localIpAddresses);
                 });
         }
 
         [Fact]
         public void SendPingWithHostAndTimeout()
         {
-            IPAddress localIpAddress = TestSettings.GetLocalIPAddress();
+            IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
 
             SendBatchPing(
                 (ping) => ping.Send(TestSettings.LocalHost, TestSettings.PingTimeout),
                 (pingReply) =>
                 {
-                    PingResultValidator(pingReply, localIpAddress);
+                    PingResultValidator(pingReply, localIpAddresses);
                 });
         }
 
         [Fact]
         public async Task SendPingAsyncWithHostAndTimeout()
         {
-            IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
+            IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(TestSettings.LocalHost, TestSettings.PingTimeout),
                 (pingReply) =>
                 {
-                    PingResultValidator(pingReply, localIpAddress);
+                    PingResultValidator(pingReply, localIpAddresses);
                 });
         }
 
@@ -486,17 +496,17 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void SendPingWithHostAndTimeoutAndBuffer_Unix()
         {
-            IPAddress localIpAddress = TestSettings.GetLocalIPAddress();
+            IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
 
             byte[] buffer = TestSettings.PayloadAsBytes;
             SendBatchPing(
                 (ping) => ping.Send(TestSettings.LocalHost, TestSettings.PingTimeout, buffer),
                 (pingReply) =>
                 {
-                    PingResultValidator(pingReply, localIpAddress);
+                    PingResultValidator(pingReply, localIpAddresses);
 
                     // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily))
+                    if (Capability.CanUseRawSockets(pingReply.Address.AddressFamily))
                     {
                         Assert.Equal(buffer, pingReply.Buffer);
                     }
@@ -511,17 +521,17 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public async Task SendPingAsyncWithHostAndTimeoutAndBuffer_Unix()
         {
-            IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
+            IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
             byte[] buffer = TestSettings.PayloadAsBytes;
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(TestSettings.LocalHost, TestSettings.PingTimeout, buffer),
                 (pingReply) =>
                 {
-                    PingResultValidator(pingReply, localIpAddress);
+                    PingResultValidator(pingReply, localIpAddresses);
 
                     // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily))
+                    if (Capability.CanUseRawSockets(pingReply.Address.AddressFamily))
                     {
                         Assert.Equal(buffer, pingReply.Buffer);
                     }
@@ -570,17 +580,17 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public void SendPingWithHostAndTimeoutAndBufferAndPingOptions_Unix()
         {
-            IPAddress localIpAddress = TestSettings.GetLocalIPAddress();
+            IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
 
             byte[] buffer = TestSettings.PayloadAsBytes;
             SendBatchPing(
                 (ping) => ping.Send(TestSettings.LocalHost, TestSettings.PingTimeout, buffer, new PingOptions()),
                 (pingReply) =>
                 {
-                    PingResultValidator(pingReply, localIpAddress);
+                    PingResultValidator(pingReply, localIpAddresses);
 
                     // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily))
+                    if (Capability.CanUseRawSockets(pingReply.Address.AddressFamily))
                     {
                         Assert.Equal(buffer, pingReply.Buffer);
                     }
@@ -595,17 +605,17 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public async Task SendPingAsyncWithHostAndTimeoutAndBufferAndPingOptions_Unix()
         {
-            IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
+            IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
             byte[] buffer = TestSettings.PayloadAsBytes;
             await SendBatchPingAsync(
                 (ping) => ping.SendPingAsync(TestSettings.LocalHost, TestSettings.PingTimeout, buffer, new PingOptions()),
                 (pingReply) =>
                 {
-                    PingResultValidator(pingReply, localIpAddress);
+                    PingResultValidator(pingReply, localIpAddresses);
 
                     // Non-root pings cannot send arbitrary data in the buffer, and do not receive it back in the PingReply.
-                    if (Capability.CanUseRawSockets(localIpAddress.AddressFamily))
+                    if (Capability.CanUseRawSockets(pingReply.Address.AddressFamily))
                     {
                         Assert.Equal(buffer, pingReply.Buffer);
                     }
@@ -619,14 +629,14 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public async Task SendPings_ReuseInstance_Hostname()
         {
-            IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
+            IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
             using (Ping p = new Ping())
             {
                 for (int i = 0; i < 3; i++)
                 {
                     PingReply pingReply = await p.SendPingAsync(TestSettings.LocalHost);
-                    PingResultValidator(pingReply, localIpAddress);
+                    PingResultValidator(pingReply, localIpAddresses);
                 }
             }
         }
@@ -634,14 +644,14 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public async Task Sends_ReuseInstance_Hostname()
         {
-            IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
+            IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
             using (Ping p = new Ping())
             {
                 for (int i = 0; i < 3; i++)
                 {
                     PingReply pingReply = p.Send(TestSettings.LocalHost);
-                    PingResultValidator(pingReply, localIpAddress);
+                    PingResultValidator(pingReply, localIpAddresses);
                 }
             }
         }
@@ -649,7 +659,7 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public async Task SendAsyncs_ReuseInstance_Hostname()
         {
-            IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
+            IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
             using (Ping p = new Ping())
             {
@@ -674,7 +684,7 @@ namespace System.Net.NetworkInformation.Tests
                     await tcs.Task;
 
                     Assert.NotNull(ea);
-                    PingResultValidator(ea.Reply, localIpAddress);
+                    PingResultValidator(ea.Reply, localIpAddresses);
                 }
 
                 // Several canceled iterations
@@ -784,7 +794,7 @@ namespace System.Net.NetworkInformation.Tests
         [InlineData(false)]
         public async Task SendPingAsyncWithHostAndTtlAndFragmentPingOptions(bool fragment)
         {
-            IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
+            IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
 
             byte[] buffer = TestSettings.PayloadAsBytes;
 
@@ -796,7 +806,7 @@ namespace System.Net.NetworkInformation.Tests
                 (ping) => ping.SendPingAsync(TestSettings.LocalHost, TestSettings.PingTimeout, buffer, options),
                 (pingReply) =>
                 {
-                    PingResultValidator(pingReply, localIpAddress);
+                    PingResultValidator(pingReply, localIpAddresses);
                 });
         }
 

--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.XUnitExtensions;
+using System.Linq;
 using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Runtime.InteropServices;
@@ -60,12 +61,10 @@ namespace System.Net.NetworkInformation.Tests
             }
 
             Assert.Equal(IPStatus.Success, pingReply.Status);
-            foreach (IPAddress localIpAddress in localIpAddresses)
+            if (localIpAddresses.Any(addr => pingReply.Address.Equals(addr)))
             {
-                if (pingReply.Address.Equals(localIpAddress))
-                {
-                    return;
-                }
+                // response did come from expected address. Test will pass.
+                return;
             }
             // We did not find response address in given list.
             // Test is going to fail. Collect some more info.


### PR DESCRIPTION
This is test only change. 
I updated tests using `localhost` to accept any address `localhost` resolves to as valid instead of trying to make assumption which address will be used. 
This was primarily problematic on OSX.

fixes #36474
