### PR TITLE
Unit tests for Path.Join overloads

### DIFF
--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -1424,8 +1424,11 @@ namespace System.IO
         public static bool IsPathRooted(string path) { throw null; }
         public static string Join(System.ReadOnlySpan<char> path1, System.ReadOnlySpan<char> path2) { throw null; }
         public static string Join(System.ReadOnlySpan<char> path1, System.ReadOnlySpan<char> path2, System.ReadOnlySpan<char> path3) { throw null; }
+        public static string Join(System.ReadOnlySpan<char> path1, System.ReadOnlySpan<char> path2, System.ReadOnlySpan<char> path3, System.ReadOnlySpan<char> path4) { throw null; }
         public static string Join(string path1, string path2) { throw null; }
         public static string Join(string path1, string path2, string path3) { throw null; }
+        public static string Join(string path1, string path2, string path3, string path4) { throw null; }
+        public static string Join(params string[] paths) { throw null; }
         public static bool TryJoin(System.ReadOnlySpan<char> path1, System.ReadOnlySpan<char> path2, System.ReadOnlySpan<char> path3, System.Span<char> destination, out int charsWritten) { throw null; }
         public static bool TryJoin(System.ReadOnlySpan<char> path1, System.ReadOnlySpan<char> path2, System.Span<char> destination, out int charsWritten) { throw null; }
     }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
@@ -191,7 +191,7 @@ namespace System.IO.Tests
         [Fact]
         public void JoinStringArray_ZeroLengthArray()
         {
-            Assert.Equal("", Path.Join(new string[0]));
+            Assert.Equal(string.Empty, Path.Join(new string[0]));
         }
 
         [Theory, MemberData(nameof(TestData_JoinTwoPaths))]

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
@@ -117,5 +117,77 @@ namespace System.IO.Tests
                 Assert.Equal(output, new char[output.Length]);
             }
         }
+
+        public static TheoryData<string, string, string, string, string> TestData_JoinFourPaths = new TheoryData<string, string, string, string, string>
+        {
+            { "", "", "", "", "" },
+            { Sep, Sep, Sep, Sep, $"{Sep}{Sep}{Sep}{Sep}" },
+            { AltSep, AltSep, AltSep, AltSep, $"{AltSep}{AltSep}{AltSep}{AltSep}" },
+            { "a", "", "", "", "a" },
+            { "", "a", "", "", "a" },
+            { "", "", "a", "", "a" },
+            { "", "", "", "a", "a" },
+            { "a", "b", "", "", $"a{Sep}b" },
+            { "a", "", "b", "", $"a{Sep}b" },
+            { "a", "", "", "b", $"a{Sep}b" },
+            { "a", "b", "c", "", $"a{Sep}b{Sep}c" },
+            { "a", "b", "", "c", $"a{Sep}b{Sep}c" },
+            { "a", "", "b", "c", $"a{Sep}b{Sep}c" },
+            { "", "a", "b", "c", $"a{Sep}b{Sep}c" },
+            { "a", "b", "c", "d", $"a{Sep}b{Sep}c{Sep}d" },
+            { "a", Sep, "b", "", $"a{Sep}b" },
+            { "a", Sep, "", "b", $"a{Sep}b" },
+            { "a", "", Sep, "b", $"a{Sep}b" },
+            { $"a{Sep}", "b", "", "", $"a{Sep}b" },
+            { $"a{Sep}", "", "b", "", $"a{Sep}b" },
+            { $"a{Sep}", "", "", "b", $"a{Sep}b" },
+            { "", $"a{Sep}", "b", "", $"a{Sep}b" },
+            { "", $"a{Sep}", "", "b", $"a{Sep}b" },
+            { "", "", $"a{Sep}", "b", $"a{Sep}b" },
+            { "a", $"{Sep}b", "", "", $"a{Sep}b" },
+            { "a", "", $"{Sep}b", "", $"a{Sep}b" },
+            { "a", "", "", $"{Sep}b", $"a{Sep}b" },
+            { $"a{AltSep}", "b", "", "", $"a{AltSep}b" },
+            { $"a{AltSep}", "", "b", "", $"a{AltSep}b" },
+            { $"a{AltSep}", "", "", "b", $"a{AltSep}b" },
+            { "", $"a{AltSep}", "b", "", $"a{AltSep}b" },
+            { "", $"a{AltSep}", "", "b", $"a{AltSep}b" },
+            { "", "", $"a{AltSep}", "b", $"a{AltSep}b" },
+            { "a", $"{AltSep}b", "", "", $"a{AltSep}b" },
+            { "a", "", $"{AltSep}b", "", $"a{AltSep}b" },
+            { "a", "", "", $"{AltSep}b", $"a{AltSep}b" },
+            { null, null, null, null, "" },
+            { "a", null, null, null, "a" },
+            { null, "a", null, null, "a" },
+            { null, null, "a", null, "a" },
+            { null, null, null, "a", "a" },
+            { "a", null, "b", null, $"a{Sep}b" },
+            { "a", null, null, "b", $"a{Sep}b" }
+        };
+
+        [Theory, MemberData(nameof(TestData_JoinFourPaths))]
+        public void JoinFourPaths(string path1, string path2, string path3, string path4, string expected)
+        {   
+            Assert.Equal(expected, Path.Join(path1.AsSpan(), path2.AsSpan(), path3.AsSpan(), path4.AsSpan()));
+            Assert.Equal(expected, Path.Join(path1, path2, path3, path4));
+        }
+
+        [Theory, MemberData(nameof(TestData_JoinTwoPaths))]
+        public void JoinStringArray_2(string path1, string path2, string expected)
+        {
+            Assert.Equal(expected, Path.Join(new string[] { path1, path2 }));
+        }
+
+        [Theory, MemberData(nameof(TestData_JoinThreePaths))]
+        public void JoinStringArray_3(string path1, string path2, string path3, string expected)
+        {
+            Assert.Equal(expected, Path.Join(new string[] { path1, path2, path3 }));
+        }
+
+        [Theory, MemberData(nameof(TestData_JoinFourPaths))]
+        public void JoinStringArray_4(string path1, string path2, string path3, string path4, string expected)
+        {
+            Assert.Equal(expected, Path.Join(new string[] { path1, path2, path3, path4 }));
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
@@ -207,9 +207,8 @@ namespace System.IO.Tests
         }
 
         [Theory, MemberData(nameof(TestData_JoinFourPaths))]
-        public void JoinStringArray_8(string path1, string path2, string path3, string path4, string _)
-        {
-            string fourJoined = Path.Join(path1, path2, path3, path4);
+        public void JoinStringArray_8(string path1, string path2, string path3, string path4, string fourJoined)
+        {   
             Assert.Equal(Path.Join(fourJoined, fourJoined) , Path.Join(new string[] { path1, path2, path3, path4, path1, path2, path3, path4 }));
         }
     }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
@@ -14,7 +14,7 @@ namespace System.IO.Tests
             { Sep, Sep },
             { AltSep, AltSep },
             { "a", "a" },
-            { null, ""}
+            { null, "" }
         };
 
         public static TheoryData<string, string, string> TestData_JoinTwoPaths = new TheoryData<string, string, string>
@@ -186,7 +186,7 @@ namespace System.IO.Tests
 
         [Theory, MemberData(nameof(TestData_JoinFourPaths))]
         public void JoinFourPaths(string path1, string path2, string path3, string path4, string expected)
-        {   
+        {
             Assert.Equal(expected, Path.Join(path1.AsSpan(), path2.AsSpan(), path3.AsSpan(), path4.AsSpan()));
             Assert.Equal(expected, Path.Join(path1, path2, path3, path4));
         }
@@ -229,8 +229,8 @@ namespace System.IO.Tests
 
         [Theory, MemberData(nameof(TestData_JoinFourPaths))]
         public void JoinStringArray_8(string path1, string path2, string path3, string path4, string fourJoined)
-        {   
-            Assert.Equal(Path.Join(fourJoined, fourJoined) , Path.Join(new string[] { path1, path2, path3, path4, path1, path2, path3, path4 }));
+        {
+            Assert.Equal(Path.Join(fourJoined, fourJoined), Path.Join(new string[] { path1, path2, path3, path4, path1, path2, path3, path4 }));
         }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
@@ -8,6 +8,15 @@ namespace System.IO.Tests
 {
     public class PathTests_Join : PathTestsBase
     {
+        public static TheoryData<string, string> TestData_JoinOnePath = new TheoryData<string, string>
+        {
+            { "", "" },
+            { Sep, Sep },
+            { AltSep, AltSep },
+            { "a", "a" },
+            { null, ""}
+        };
+
         public static TheoryData<string, string, string> TestData_JoinTwoPaths = new TheoryData<string, string, string>
         {
             { "", "", "" },
@@ -192,6 +201,12 @@ namespace System.IO.Tests
         public void JoinStringArray_ZeroLengthArray()
         {
             Assert.Equal(string.Empty, Path.Join(new string[0]));
+        }
+
+        [Theory, MemberData(nameof(TestData_JoinOnePath))]
+        public void JoinStringArray_1(string path1, string expected)
+        {
+            Assert.Equal(expected, Path.Join(new string[] { path1 }));
         }
 
         [Theory, MemberData(nameof(TestData_JoinTwoPaths))]

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
@@ -188,6 +188,12 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentNullException>(() => Path.Join(null));
         }
 
+        [Fact]
+        public void JoinStringArray_ZeroLengthArray()
+        {
+            Assert.Equal("", Path.Join(new string[0]));
+        }
+
         [Theory, MemberData(nameof(TestData_JoinTwoPaths))]
         public void JoinStringArray_2(string path1, string path2, string expected)
         {

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Join.netcoreapp.cs
@@ -147,6 +147,16 @@ namespace System.IO.Tests
             { "a", $"{Sep}b", "", "", $"a{Sep}b" },
             { "a", "", $"{Sep}b", "", $"a{Sep}b" },
             { "a", "", "", $"{Sep}b", $"a{Sep}b" },
+            { $"{Sep}a", "", "", "", $"{Sep}a" },
+            { "", $"{Sep}a", "", "", $"{Sep}a" },
+            { "", "", $"{Sep}a", "", $"{Sep}a" },
+            { "", "", "", $"{Sep}a", $"{Sep}a" },
+            { $"{Sep}a", "b", "", "", $"{Sep}a{Sep}b" },
+            { "", $"{Sep}a", "b", "", $"{Sep}a{Sep}b" },
+            { "", "", $"{Sep}a", "b", $"{Sep}a{Sep}b" },
+            { $"a{Sep}", $"{Sep}b", "", "", $"a{Sep}{Sep}b" },
+            { $"a{Sep}", "", $"{Sep}b", "", $"a{Sep}{Sep}b" },
+            { $"a{Sep}", "", "", $"{Sep}b", $"a{Sep}{Sep}b" },
             { $"a{AltSep}", "b", "", "", $"a{AltSep}b" },
             { $"a{AltSep}", "", "b", "", $"a{AltSep}b" },
             { $"a{AltSep}", "", "", "b", $"a{AltSep}b" },
@@ -172,6 +182,12 @@ namespace System.IO.Tests
             Assert.Equal(expected, Path.Join(path1, path2, path3, path4));
         }
 
+        [Fact]
+        public void JoinStringArray_ThrowsArugmentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => Path.Join(null));
+        }
+
         [Theory, MemberData(nameof(TestData_JoinTwoPaths))]
         public void JoinStringArray_2(string path1, string path2, string expected)
         {
@@ -188,6 +204,13 @@ namespace System.IO.Tests
         public void JoinStringArray_4(string path1, string path2, string path3, string path4, string expected)
         {
             Assert.Equal(expected, Path.Join(new string[] { path1, path2, path3, path4 }));
+        }
+
+        [Theory, MemberData(nameof(TestData_JoinFourPaths))]
+        public void JoinStringArray_8(string path1, string path2, string path3, string path4, string _)
+        {
+            string fourJoined = Path.Join(path1, path2, path3, path4);
+            Assert.Equal(Path.Join(fourJoined, fourJoined) , Path.Join(new string[] { path1, path2, path3, path4, path1, path2, path3, path4 }));
         }
     }
 }


### PR DESCRIPTION
Unit tests for Path.Join overloads in corclr [PR 24307](https://github.com/dotnet/coreclr/pull/24307). corefx issue #32312