### PR TITLE
Re-enable some Http Diagnostic tracing tests

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -175,7 +175,6 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [ActiveIssue(23771, TestPlatforms.AnyUnix)]
         [OuterLoop("Uses external server")]
         [Theory]
         [InlineData(false)]
@@ -274,7 +273,6 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [ActiveIssue(23209)]
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticCancelledLogging()
@@ -994,7 +992,6 @@ namespace System.Net.Http.Functional.Tests
             }, UseSocketsHttpHandler.ToString()).Dispose();
         }
 
-        [ActiveIssue(23209)]
         [OuterLoop("Uses external server")]
         [Fact]
         public void SendAsync_ExpectedDiagnosticCancelledActivityLogging()


### PR DESCRIPTION
Some of these tests were disabled a long time ago and only on Linux.
Since that time, the tests were improved.

I re-enabled the tests plus some others that appear to be stable now.

Closes #23209
Closes #23771