### PR TITLE
Fix Vector.cs compilation failures in corefx

### DIFF
--- a/src/Common/src/CoreLib/System/Numerics/Vector.cs
+++ b/src/Common/src/CoreLib/System/Numerics/Vector.cs
@@ -59,10 +59,10 @@ namespace System.Numerics
             [Intrinsic]
             get
             {
-                return s_count;
+                ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+                return Unsafe.SizeOf<Vector<T>>() / Unsafe.SizeOf<T>();
             }
         }
-        private static readonly int s_count = InitializeCount();
 
         /// <summary>
         /// Returns a vector containing all zeroes.
@@ -100,71 +100,6 @@ namespace System.Numerics
         }
         private static readonly Vector<T> s_allOnes = new Vector<T>(GetAllBitsSetValue());
         #endregion Static Members
-
-        #region Static Initialization
-        private struct VectorSizeHelper
-        {
-            internal Vector<T> _placeholder;
-            internal byte _byte;
-        }
-
-        // Calculates the size of this struct in bytes, by computing the offset of a field in a structure
-        private static unsafe int InitializeCount()
-        {
-            VectorSizeHelper vsh;
-            byte* vectorBase = &vsh._placeholder.register.byte_0;
-            byte* byteBase = &vsh._byte;
-            int vectorSizeInBytes = (int)(byteBase - vectorBase);
-
-            int typeSizeInBytes = -1;
-            if (typeof(T) == typeof(byte))
-            {
-                typeSizeInBytes = sizeof(byte);
-            }
-            else if (typeof(T) == typeof(sbyte))
-            {
-                typeSizeInBytes = sizeof(sbyte);
-            }
-            else if (typeof(T) == typeof(ushort))
-            {
-                typeSizeInBytes = sizeof(ushort);
-            }
-            else if (typeof(T) == typeof(short))
-            {
-                typeSizeInBytes = sizeof(short);
-            }
-            else if (typeof(T) == typeof(uint))
-            {
-                typeSizeInBytes = sizeof(uint);
-            }
-            else if (typeof(T) == typeof(int))
-            {
-                typeSizeInBytes = sizeof(int);
-            }
-            else if (typeof(T) == typeof(ulong))
-            {
-                typeSizeInBytes = sizeof(ulong);
-            }
-            else if (typeof(T) == typeof(long))
-            {
-                typeSizeInBytes = sizeof(long);
-            }
-            else if (typeof(T) == typeof(float))
-            {
-                typeSizeInBytes = sizeof(float);
-            }
-            else if (typeof(T) == typeof(double))
-            {
-                typeSizeInBytes = sizeof(double);
-            }
-            else
-            {
-                throw new NotSupportedException(SR.Arg_TypeNotSupported);
-            }
-
-            return vectorSizeInBytes / typeSizeInBytes;
-        }
-        #endregion Static Initialization
 
         #region Constructors
         /// <summary>
@@ -779,37 +714,81 @@ namespace System.Numerics
 
 #if netcoreapp
         /// <summary>
-        /// Constructs a vector from the given span. The span must contain at least Vector'T.Count elements.
+        /// Constructs a vector from the given <see cref="ReadOnlySpan{Byte}"/>. The span must contain at least <see cref="Vector{Byte}.Count"/> elements.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Vector(ReadOnlySpan<byte> values)
+            : this()
+        {
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+            if (values.Length < Vector<byte>.Count)
+            {
+                Vector.ThrowInsufficientNumberOfElementsException(Vector<byte>.Count);
+            }
+            this = Unsafe.ReadUnaligned<Vector<T>>(ref MemoryMarshal.GetReference(values));
+        }
+        
+        /// <summary>
+        /// Constructs a vector from the given <see cref="ReadOnlySpan{T}"/>. The span must contain at least <see cref="Vector{T}.Count"/> elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Vector(ReadOnlySpan<T> values)
+            : this()
+        {
+            if (values.Length < Count)
+            {
+                Vector.ThrowInsufficientNumberOfElementsException(Vector<T>.Count);
+            }
+            this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+        }
+
+        /// <summary>
+        /// Constructs a vector from the given <see cref="Span{T}"/>. The span must contain at least <see cref="Vector{T}.Count"/> elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector(Span<T> values)
             : this()
         {
-            if ((typeof(T) == typeof(byte))
-                || (typeof(T) == typeof(sbyte))
-                || (typeof(T) == typeof(ushort))
-                || (typeof(T) == typeof(short))
-                || (typeof(T) == typeof(uint))
-                || (typeof(T) == typeof(int))
-                || (typeof(T) == typeof(ulong))
-                || (typeof(T) == typeof(long))
-                || (typeof(T) == typeof(float))
-                || (typeof(T) == typeof(double)))
+            if (values.Length < Count)
             {
-                if (values.Length < Count)
-                {
-                    throw new IndexOutOfRangeException(SR.Format(SR.Arg_InsufficientNumberOfElements, Vector<T>.Count, nameof(values)));
-                }
-                this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+                Vector.ThrowInsufficientNumberOfElementsException(Vector<T>.Count);
             }
-            else
-            {
-                throw new NotSupportedException(SR.Arg_TypeNotSupported);
-            }
+            this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
         }
 #endif
         #endregion Constructors
 
         #region Public Instance Methods
+        /// <summary>
+        /// Copies the vector to the given <see cref="Span{Byte}"/>. The destination span must be at least size <see cref="Vector{Byte}.Count"/>.
+        /// </summary>
+        /// <param name="destination">The destination span which the values are copied into</param>
+        /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination span</exception>
+        public void CopyTo(Span<byte> destination)
+        {
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+            if ((uint)destination.Length < (uint)Vector<byte>.Count)
+            {
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+            }
+            Unsafe.WriteUnaligned<Vector<T>>(ref MemoryMarshal.GetReference(destination), this);
+        }
+
+        /// <summary>
+        /// Copies the vector to the given <see cref="Span{T}"/>. The destination span must be at least size <see cref="Vector{T}.Count"/>.
+        /// </summary>
+        /// <param name="destination">The destination span which the values are copied into</param>
+        /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination span</exception>
+        public void CopyTo(Span<T> destination)
+        {
+            if ((uint)destination.Length < (uint)Count)
+            {
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+            }
+
+            Unsafe.WriteUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), this);
+        }
+
         /// <summary>
         /// Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
         /// </summary>
@@ -1590,6 +1569,41 @@ namespace System.Numerics
             sb.Append(((IFormattable)this[Count - 1]).ToString(format, formatProvider));
             sb.Append('>');
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Attempts to copy the vector to the given <see cref="Span{Byte}"/>. The destination span must be at least size <see cref="Vector{Byte}.Count"/>.
+        /// </summary>
+        /// <param name="destination">The destination span which the values are copied into</param>
+        /// <returns>True if the source vector was successfully copied to <paramref name="destination"/>. False if
+        /// <paramref name="destination"/> is not large enough to hold the source vector.</returns>
+        public bool TryCopyTo(Span<byte> destination)
+        {
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+            if ((uint)destination.Length < (uint)Vector<byte>.Count)
+            {
+                return false;
+            }
+
+            Unsafe.WriteUnaligned<Vector<T>>(ref MemoryMarshal.GetReference(destination), this);
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to copy the vector to the given <see cref="Span{T}"/>. The destination span must be at least size <see cref="Vector{T}.Count"/>.
+        /// </summary>
+        /// <param name="destination">The destination span which the values are copied into</param>
+        /// <returns>True if the source vector was successfully copied to <paramref name="destination"/>. False if
+        /// <paramref name="destination"/> is not large enough to hold the source vector.</returns>
+        public bool TryCopyTo(Span<T> destination)
+        {
+            if ((uint)destination.Length < (uint)Count)
+            {
+                return false;
+            }
+
+            Unsafe.WriteUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), this);
+            return true;
         }
         #endregion Public Instance Methods
 
@@ -5335,5 +5349,12 @@ namespace System.Numerics
         }
 
         #endregion Same-Size Conversion
+
+        #region Throw Helpers
+        internal static void ThrowInsufficientNumberOfElementsException(int requiredElementCount)
+        {
+            throw new IndexOutOfRangeException(SR.Format(SR.Arg_InsufficientNumberOfElements, requiredElementCount, "values"));
+        }
+        #endregion
     }
 }

--- a/src/Common/src/CoreLib/System/Numerics/Vector.cs
+++ b/src/Common/src/CoreLib/System/Numerics/Vector.cs
@@ -759,6 +759,7 @@ namespace System.Numerics
         #endregion Constructors
 
         #region Public Instance Methods
+#if netcoreapp
         /// <summary>
         /// Copies the vector to the given <see cref="Span{Byte}"/>. The destination span must be at least size <see cref="Vector{Byte}.Count"/>.
         /// </summary>
@@ -788,6 +789,7 @@ namespace System.Numerics
 
             Unsafe.WriteUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), this);
         }
+#endif
 
         /// <summary>
         /// Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
@@ -1571,6 +1573,7 @@ namespace System.Numerics
             return sb.ToString();
         }
 
+#if netcoreapp
         /// <summary>
         /// Attempts to copy the vector to the given <see cref="Span{Byte}"/>. The destination span must be at least size <see cref="Vector{Byte}.Count"/>.
         /// </summary>
@@ -1605,6 +1608,7 @@ namespace System.Numerics
             Unsafe.WriteUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), this);
             return true;
         }
+#endif
         #endregion Public Instance Methods
 
         #region Arithmetic Operators

--- a/src/Common/src/CoreLib/System/Numerics/Vector.tt
+++ b/src/Common/src/CoreLib/System/Numerics/Vector.tt
@@ -64,10 +64,10 @@ namespace System.Numerics
             [Intrinsic]
             get
             {
-                return s_count;
+                ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+                return Unsafe.SizeOf<Vector<T>>() / Unsafe.SizeOf<T>();
             }
         }
-        private static readonly int s_count = InitializeCount();
 
         /// <summary>
         /// Returns a vector containing all zeroes.
@@ -105,42 +105,6 @@ namespace System.Numerics
         }
         private static readonly Vector<T> s_allOnes = new Vector<T>(GetAllBitsSetValue());
         #endregion Static Members
-
-        #region Static Initialization
-        private struct VectorSizeHelper
-        {
-            internal Vector<T> _placeholder;
-            internal byte _byte;
-        }
-
-        // Calculates the size of this struct in bytes, by computing the offset of a field in a structure
-        private static unsafe int InitializeCount()
-        {
-            VectorSizeHelper vsh;
-            byte* vectorBase = &vsh._placeholder.register.byte_0;
-            byte* byteBase = &vsh._byte;
-            int vectorSizeInBytes = (int)(byteBase - vectorBase);
-
-            int typeSizeInBytes = -1;
-<#
-    foreach (Type type in supportedTypes)
-    {
-#>
-            <#=GenerateIfStatementHeader(type)#>
-            {
-                typeSizeInBytes = sizeof(<#=typeAliases[type]#>);
-            }
-<#
-    }
-#>
-            else
-            {
-                throw new NotSupportedException(SR.Arg_TypeNotSupported);
-            }
-
-            return vectorSizeInBytes / typeSizeInBytes;
-        }
-        #endregion Static Initialization
 
         #region Constructors
         /// <summary>
@@ -305,28 +269,81 @@ namespace System.Numerics
 
 #if netcoreapp
         /// <summary>
-        /// Constructs a vector from the given span. The span must contain at least Vector'T.Count elements.
+        /// Constructs a vector from the given <see cref="ReadOnlySpan{Byte}"/>. The span must contain at least <see cref="Vector{Byte}.Count"/> elements.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Vector(ReadOnlySpan<byte> values)
+            : this()
+        {
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+            if (values.Length < Vector<byte>.Count)
+            {
+                Vector.ThrowInsufficientNumberOfElementsException(Vector<byte>.Count);
+            }
+            this = Unsafe.ReadUnaligned<Vector<T>>(ref MemoryMarshal.GetReference(values));
+        }
+        
+        /// <summary>
+        /// Constructs a vector from the given <see cref="ReadOnlySpan{T}"/>. The span must contain at least <see cref="Vector{T}.Count"/> elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Vector(ReadOnlySpan<T> values)
+            : this()
+        {
+            if (values.Length < Count)
+            {
+                Vector.ThrowInsufficientNumberOfElementsException(Vector<T>.Count);
+            }
+            this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+        }
+
+        /// <summary>
+        /// Constructs a vector from the given <see cref="Span{T}"/>. The span must contain at least <see cref="Vector{T}.Count"/> elements.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Vector(Span<T> values)
             : this()
         {
-            <#=GenerateIfConditionAllTypes(supportedTypes)#>
+            if (values.Length < Count)
             {
-                if (values.Length < Count)
-                {
-                    throw new IndexOutOfRangeException(SR.Format(SR.Arg_InsufficientNumberOfElements, Vector<T>.Count, nameof(values)));
-                }
-                this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+                Vector.ThrowInsufficientNumberOfElementsException(Vector<T>.Count);
             }
-            else
-            {
-                throw new NotSupportedException(SR.Arg_TypeNotSupported);
-            }
+            this = Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
         }
 #endif
         #endregion Constructors
 
         #region Public Instance Methods
+        /// <summary>
+        /// Copies the vector to the given <see cref="Span{Byte}"/>. The destination span must be at least size <see cref="Vector{Byte}.Count"/>.
+        /// </summary>
+        /// <param name="destination">The destination span which the values are copied into</param>
+        /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination span</exception>
+        public void CopyTo(Span<byte> destination)
+        {
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+            if ((uint)destination.Length < (uint)Vector<byte>.Count)
+            {
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+            }
+            Unsafe.WriteUnaligned<Vector<T>>(ref MemoryMarshal.GetReference(destination), this);
+        }
+
+        /// <summary>
+        /// Copies the vector to the given <see cref="Span{T}"/>. The destination span must be at least size <see cref="Vector{T}.Count"/>.
+        /// </summary>
+        /// <param name="destination">The destination span which the values are copied into</param>
+        /// <exception cref="ArgumentException">If number of elements in source vector is greater than those available in destination span</exception>
+        public void CopyTo(Span<T> destination)
+        {
+            if ((uint)destination.Length < (uint)Count)
+            {
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+            }
+
+            Unsafe.WriteUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), this);
+        }
+
         /// <summary>
         /// Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
         /// </summary>
@@ -619,6 +636,41 @@ namespace System.Numerics
             sb.Append(((IFormattable)this[Count - 1]).ToString(format, formatProvider));
             sb.Append('>');
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Attempts to copy the vector to the given <see cref="Span{Byte}"/>. The destination span must be at least size <see cref="Vector{Byte}.Count"/>.
+        /// </summary>
+        /// <param name="destination">The destination span which the values are copied into</param>
+        /// <returns>True if the source vector was successfully copied to <paramref name="destination"/>. False if
+        /// <paramref name="destination"/> is not large enough to hold the source vector.</returns>
+        public bool TryCopyTo(Span<byte> destination)
+        {
+            ThrowHelper.ThrowForUnsupportedVectorBaseType<T>();
+            if ((uint)destination.Length < (uint)Vector<byte>.Count)
+            {
+                return false;
+            }
+
+            Unsafe.WriteUnaligned<Vector<T>>(ref MemoryMarshal.GetReference(destination), this);
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to copy the vector to the given <see cref="Span{T}"/>. The destination span must be at least size <see cref="Vector{T}.Count"/>.
+        /// </summary>
+        /// <param name="destination">The destination span which the values are copied into</param>
+        /// <returns>True if the source vector was successfully copied to <paramref name="destination"/>. False if
+        /// <paramref name="destination"/> is not large enough to hold the source vector.</returns>
+        public bool TryCopyTo(Span<T> destination)
+        {
+            if ((uint)destination.Length < (uint)Count)
+            {
+                return false;
+            }
+
+            Unsafe.WriteUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), this);
+            return true;
         }
         #endregion Public Instance Methods
 
@@ -1836,5 +1888,12 @@ namespace System.Numerics
     }
 #>
         #endregion Same-Size Conversion
+
+        #region Throw Helpers
+        internal static void ThrowInsufficientNumberOfElementsException(int requiredElementCount)
+        {
+            throw new IndexOutOfRangeException(SR.Format(SR.Arg_InsufficientNumberOfElements, requiredElementCount, "values"));
+        }
+        #endregion
     }
 }

--- a/src/Common/src/CoreLib/System/Numerics/Vector.tt
+++ b/src/Common/src/CoreLib/System/Numerics/Vector.tt
@@ -314,6 +314,7 @@ namespace System.Numerics
         #endregion Constructors
 
         #region Public Instance Methods
+#if netcoreapp
         /// <summary>
         /// Copies the vector to the given <see cref="Span{Byte}"/>. The destination span must be at least size <see cref="Vector{Byte}.Count"/>.
         /// </summary>
@@ -343,6 +344,7 @@ namespace System.Numerics
 
             Unsafe.WriteUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), this);
         }
+#endif
 
         /// <summary>
         /// Copies the vector to the given destination array. The destination array must be at least size Vector'T.Count.
@@ -638,6 +640,7 @@ namespace System.Numerics
             return sb.ToString();
         }
 
+#if netcoreapp
         /// <summary>
         /// Attempts to copy the vector to the given <see cref="Span{Byte}"/>. The destination span must be at least size <see cref="Vector{Byte}.Count"/>.
         /// </summary>
@@ -672,6 +675,7 @@ namespace System.Numerics
             Unsafe.WriteUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), this);
             return true;
         }
+#endif
         #endregion Public Instance Methods
 
         #region Arithmetic Operators

--- a/src/Common/src/CoreLib/System/ThrowHelper.cs
+++ b/src/Common/src/CoreLib/System/ThrowHelper.cs
@@ -404,6 +404,9 @@ namespace System
                 ThrowHelper.ThrowArgumentNullException(argName);
         }
 
+        // Throws if 'T' is disallowed in Vector<T> / Vector128<T> / other related types in the
+        // Numerics or Intrinsics namespaces. If 'T' is allowed, no-ops. JIT will elide the method
+        // entirely if 'T' is supported and we're on an optimized release build.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ThrowForUnsupportedVectorBaseType<T>() where T : struct
         {

--- a/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{53134B0C-0D57-481B-B84E-D1991E8D54FF}</ProjectGuid>
     <RootNamespace>System.Numerics</RootNamespace>
@@ -42,6 +42,7 @@
     <Compile Include="$(CommonPath)\CoreLib\System\Numerics\Vector_Operations.cs">
       <Link>System\Numerics\Vector_Operations.cs</Link>
     </Compile>
+    <Compile Include="System\ThrowHelper.cs" />
   </ItemGroup>
   <!-- Carry a copy of MathF where not available -->
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true' OR $(TargetGroup.StartsWith('netstandard'))">
@@ -97,6 +98,7 @@
     <Reference Include="System.Globalization" />
     <Reference Include="System.Resources.ResourceManager" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
     <Reference Include="System.Runtime.Extensions" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Numerics.Vectors/src/System/ThrowHelper.cs
+++ b/src/System.Numerics.Vectors/src/System/ThrowHelper.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    // partially copied from shared\System\ThrowHelper.cs
+    internal static partial class ThrowHelper
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void ThrowForUnsupportedVectorBaseType<T>() where T : struct
+        {
+            if (typeof(T) != typeof(byte) && typeof(T) != typeof(sbyte) &&
+                typeof(T) != typeof(short) && typeof(T) != typeof(ushort) &&
+                typeof(T) != typeof(int) && typeof(T) != typeof(uint) &&
+                typeof(T) != typeof(long) && typeof(T) != typeof(ulong) &&
+                typeof(T) != typeof(float) && typeof(T) != typeof(double))
+            {
+                ThrowArgTypeNotSupportedException();
+            }
+        }
+
+        private static void ThrowArgTypeNotSupportedException()
+        {
+            throw new NotSupportedException(SR.Arg_TypeNotSupported);
+        }
+    }
+}


### PR DESCRIPTION
Updating __Vector.cs__ and related files so that it compiles correctly in corefx. This PR is based on https://github.com/dotnet/corefx/pull/37291 (https://github.com/dotnet/corefx/pull/37291/commits/4fc1390d4080c9f303138e2020bfc2d27414ee51).