### PR TITLE
Harden several SocketsHttpHandler streams against unexpected Dispose

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
@@ -18,18 +18,19 @@ namespace System.Net.Http
 
             public override int Read(Span<byte> buffer)
             {
-                if (_connection == null || buffer.Length == 0)
+                HttpConnection connection = _connection;
+                if (connection == null || buffer.Length == 0)
                 {
                     // Response body fully consumed or the caller didn't ask for any data
                     return 0;
                 }
 
-                int bytesRead = _connection.Read(buffer);
+                int bytesRead = connection.Read(buffer);
                 if (bytesRead == 0)
                 {
                     // We cannot reuse this connection, so close it.
-                    _connection.Dispose();
                     _connection = null;
+                    connection.Dispose();
                 }
 
                 return bytesRead;
@@ -39,13 +40,14 @@ namespace System.Net.Http
             {
                 CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
-                if (_connection == null || buffer.Length == 0)
+                HttpConnection connection = _connection;
+                if (connection == null || buffer.Length == 0)
                 {
                     // Response body fully consumed or the caller didn't ask for any data
                     return 0;
                 }
 
-                ValueTask<int> readTask = _connection.ReadAsync(buffer);
+                ValueTask<int> readTask = connection.ReadAsync(buffer);
                 int bytesRead;
                 if (readTask.IsCompletedSuccessfully)
                 {
@@ -53,7 +55,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    CancellationTokenRegistration ctr = _connection.RegisterCancellation(cancellationToken);
+                    CancellationTokenRegistration ctr = connection.RegisterCancellation(cancellationToken);
                     try
                     {
                         bytesRead = await readTask.ConfigureAwait(false);
@@ -79,8 +81,8 @@ namespace System.Net.Http
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // We cannot reuse this connection, so close it.
-                    _connection.Dispose();
                     _connection = null;
+                    connection.Dispose();
                 }
 
                 return bytesRead;
@@ -95,25 +97,26 @@ namespace System.Net.Http
                     return Task.FromCanceled(cancellationToken);
                 }
 
-                if (_connection == null)
+                HttpConnection connection = _connection;
+                if (connection == null)
                 {
                     // null if response body fully consumed
                     return Task.CompletedTask;
                 }
 
-                Task copyTask = _connection.CopyToUntilEofAsync(destination, bufferSize, cancellationToken);
+                Task copyTask = connection.CopyToUntilEofAsync(destination, bufferSize, cancellationToken);
                 if (copyTask.IsCompletedSuccessfully)
                 {
-                    Finish();
+                    Finish(connection);
                     return Task.CompletedTask;
                 }
 
-                return CompleteCopyToAsync(copyTask, cancellationToken);
+                return CompleteCopyToAsync(copyTask, connection, cancellationToken);
             }
 
-            private async Task CompleteCopyToAsync(Task copyTask, CancellationToken cancellationToken)
+            private async Task CompleteCopyToAsync(Task copyTask, HttpConnection connection, CancellationToken cancellationToken)
             {
-                CancellationTokenRegistration ctr = _connection.RegisterCancellation(cancellationToken);
+                CancellationTokenRegistration ctr = connection.RegisterCancellation(cancellationToken);
                 try
                 {
                     await copyTask.ConfigureAwait(false);
@@ -133,14 +136,14 @@ namespace System.Net.Http
                 // been requested, we assume the copy completed due to cancellation and throw.
                 CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
-                Finish();
+                Finish(connection);
             }
 
-            private void Finish()
+            private void Finish(HttpConnection connection)
             {
                 // We cannot reuse this connection, so close it.
-                _connection.Dispose();
                 _connection = null;
+                connection.Dispose();
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
@@ -18,12 +18,12 @@ namespace System.Net.Http
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ignored) // token ignored as it comes from SendAsync
             {
-                Debug.Assert(_connection._currentRequest != null);
-
                 // Have the connection write the data, skipping the buffer. Importantly, this will
                 // force a flush of anything already in the buffer, i.e. any remaining request headers
                 // that are still buffered.
-                return new ValueTask(_connection.WriteAsync(buffer));
+                HttpConnection connection = GetConnectionOrThrow();
+                Debug.Assert(connection._currentRequest != null);
+                return new ValueTask(connection.WriteAsync(buffer));
             }
 
             public override Task FinishAsync()

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -599,12 +599,10 @@ namespace System.Net.Http
                 public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
                 {
                     Http2Stream http2Stream = _http2Stream;
-                    if (http2Stream == null)
-                    {
-                        return new ValueTask(Task.FromException(new ObjectDisposedException(nameof(Http2WriteStream))));
-                    }
-
-                    return new ValueTask(http2Stream.SendDataAsync(buffer, cancellationToken));
+                    Task t = http2Stream != null ?
+                        http2Stream.SendDataAsync(buffer, cancellationToken) :
+                        Task.FromException(new ObjectDisposedException(nameof(Http2WriteStream)));
+                    return new ValueTask(t);
                 }
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentStream.cs
@@ -26,5 +26,16 @@ namespace System.Net.Http
 
             base.Dispose(disposing);
         }
+
+        protected HttpConnection GetConnectionOrThrow()
+        {
+            return _connection ??
+                // This should only ever happen if the user-code that was handed this instance disposed of
+                // it, which is misuse, or held onto it and tried to use it later after we've disposed of it,
+                // which is also misuse.
+                ThrowObjectDisposedException();
+        }
+
+        private HttpConnection ThrowObjectDisposedException() => throw new ObjectDisposedException(GetType().Name);
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentWriteStream.cs
@@ -20,10 +20,15 @@ namespace System.Net.Http
             public sealed override bool CanWrite => true;
 
             public sealed override void Flush() =>
-                _connection.Flush();
+                _connection?.Flush();
 
-            public sealed override Task FlushAsync(CancellationToken ignored) =>
-                _connection.FlushAsync().AsTask();
+            public sealed override Task FlushAsync(CancellationToken ignored)
+            {
+                HttpConnection connection = _connection;
+                return connection != null ?
+                    connection.FlushAsync().AsTask() :
+                    default;
+            }
 
             public sealed override int Read(Span<byte> buffer) => throw new NotSupportedException();
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -22,18 +22,19 @@ namespace System.Net.Http
 
             public override int Read(Span<byte> buffer)
             {
-                if (_connection == null || buffer.Length == 0)
+                HttpConnection connection = _connection;
+                if (connection == null || buffer.Length == 0)
                 {
                     // Response body fully consumed or the caller didn't ask for any data
                     return 0;
                 }
 
-                int bytesRead = _connection.ReadBuffered(buffer);
+                int bytesRead = connection.ReadBuffered(buffer);
                 if (bytesRead == 0)
                 {
                     // We cannot reuse this connection, so close it.
-                    _connection.Dispose();
                     _connection = null;
+                    connection.Dispose();
                 }
 
                 return bytesRead;
@@ -43,13 +44,14 @@ namespace System.Net.Http
             {
                 CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
-                if (_connection == null || buffer.Length == 0)
+                HttpConnection connection = _connection;
+                if (connection == null || buffer.Length == 0)
                 {
                     // Response body fully consumed or the caller didn't ask for any data
                     return 0;
                 }
 
-                ValueTask<int> readTask = _connection.ReadBufferedAsync(buffer);
+                ValueTask<int> readTask = connection.ReadBufferedAsync(buffer);
                 int bytesRead;
                 if (readTask.IsCompletedSuccessfully)
                 {
@@ -57,7 +59,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    CancellationTokenRegistration ctr = _connection.RegisterCancellation(cancellationToken);
+                    CancellationTokenRegistration ctr = connection.RegisterCancellation(cancellationToken);
                     try
                     {
                         bytesRead = await readTask.ConfigureAwait(false);
@@ -78,8 +80,8 @@ namespace System.Net.Http
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // We cannot reuse this connection, so close it.
-                    _connection.Dispose();
                     _connection = null;
+                    connection.Dispose();
                 }
 
                 return bytesRead;
@@ -94,25 +96,26 @@ namespace System.Net.Http
                     return Task.FromCanceled(cancellationToken);
                 }
 
-                if (_connection == null)
+                HttpConnection connection = _connection;
+                if (connection == null)
                 {
                     // null if response body fully consumed
                     return Task.CompletedTask;
                 }
 
-                Task copyTask = _connection.CopyToUntilEofAsync(destination, bufferSize, cancellationToken);
+                Task copyTask = connection.CopyToUntilEofAsync(destination, bufferSize, cancellationToken);
                 if (copyTask.IsCompletedSuccessfully)
                 {
-                    Finish();
+                    Finish(connection);
                     return Task.CompletedTask;
                 }
 
-                return CompleteCopyToAsync(copyTask, cancellationToken);
+                return CompleteCopyToAsync(copyTask, connection, cancellationToken);
             }
 
-            private async Task CompleteCopyToAsync(Task copyTask, CancellationToken cancellationToken)
+            private async Task CompleteCopyToAsync(Task copyTask, HttpConnection connection, CancellationToken cancellationToken)
             {
-                CancellationTokenRegistration ctr = _connection.RegisterCancellation(cancellationToken);
+                CancellationTokenRegistration ctr = connection.RegisterCancellation(cancellationToken);
                 try
                 {
                     await copyTask.ConfigureAwait(false);
@@ -132,13 +135,13 @@ namespace System.Net.Http
                 // been requested, we assume the copy completed due to cancellation and throw.
                 CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
-                Finish();
+                Finish(connection);
             }
 
-            private void Finish()
+            private void Finish(HttpConnection connection)
             {
                 // We cannot reuse this connection, so close it.
-                _connection.Dispose();
+                connection.Dispose();
                 _connection = null;
             }
 
@@ -150,14 +153,15 @@ namespace System.Net.Http
 
             public override void Write(ReadOnlySpan<byte> buffer)
             {
-                if (_connection == null)
+                HttpConnection connection = _connection;
+                if (connection == null)
                 {
                     throw new IOException(SR.ObjectDisposed_StreamClosed);
                 }
 
                 if (buffer.Length != 0)
                 {
-                    _connection.WriteWithoutBuffering(buffer);
+                    connection.WriteWithoutBuffering(buffer);
                 }
             }
 
@@ -168,7 +172,8 @@ namespace System.Net.Http
                     return new ValueTask(Task.FromCanceled(cancellationToken));
                 }
 
-                if (_connection == null)
+                HttpConnection connection = _connection;
+                if (connection == null)
                 {
                     return new ValueTask(Task.FromException(new IOException(SR.ObjectDisposed_StreamClosed)));
                 }
@@ -178,10 +183,10 @@ namespace System.Net.Http
                     return default;
                 }
 
-                ValueTask writeTask = _connection.WriteWithoutBufferingAsync(buffer);
+                ValueTask writeTask = connection.WriteWithoutBufferingAsync(buffer);
                 return writeTask.IsCompleted ?
                     writeTask :
-                    new ValueTask(WaitWithConnectionCancellationAsync(writeTask, cancellationToken));
+                    new ValueTask(WaitWithConnectionCancellationAsync(writeTask, connection, cancellationToken));
             }
 
             public override void Flush() => _connection?.Flush();
@@ -193,20 +198,21 @@ namespace System.Net.Http
                     return Task.FromCanceled(cancellationToken);
                 }
 
-                if (_connection == null)
+                HttpConnection connection = _connection;
+                if (connection == null)
                 {
                     return Task.CompletedTask;
                 }
 
-                ValueTask flushTask = _connection.FlushAsync();
+                ValueTask flushTask = connection.FlushAsync();
                 return flushTask.IsCompleted ?
                     flushTask.AsTask() :
-                    WaitWithConnectionCancellationAsync(flushTask, cancellationToken);
+                    WaitWithConnectionCancellationAsync(flushTask, connection, cancellationToken);
             }
 
-            private async Task WaitWithConnectionCancellationAsync(ValueTask task, CancellationToken cancellationToken)
+            private static async Task WaitWithConnectionCancellationAsync(ValueTask task, HttpConnection connection, CancellationToken cancellationToken)
             {
-                CancellationTokenRegistration ctr = _connection.RegisterCancellation(cancellationToken);
+                CancellationTokenRegistration ctr = connection.RegisterCancellation(cancellationToken);
                 try
                 {
                     await task.ConfigureAwait(false);


### PR DESCRIPTION
A few tweaks:
- We hand out the ChunkedEncodingWriteStream and ContentLengthWriteStream to an HttpContent.SerializeToStreamAsync.  If that user code disposes of the Stream, then we end up null ref'ing when we try to finish the processing.  We should instead throw a more descriptive error about the misuse.
- Make the non-pooled response streams slightly more robust against concurrent disposal (which is not a supported use, but it happens).

Fixes https://github.com/dotnet/corefx/issues/37276
cc: @davidsh, @geoffkizer, @wfurt 