### PR TITLE
Improve null handling and test coverage for Json (de)serializer

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -283,7 +283,7 @@
     <value>Expected depth to be zero at the end of the JSON payload. There is an open JSON object or array that should be closed.</value>
   </data>
   <data name="DeserializeCannotBeNull" xml:space="preserve">
-    <value>The JSON value from {0} cannot be null.</value>
+    <value>The JSON value cannot be null.</value>
   </data>
   <data name="DeserializeDataRemaining" xml:space="preserve">
     <value>The provided data of length {0} has remaining bytes {1}.</value>

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
@@ -28,10 +28,14 @@ namespace System.Text.Json.Serialization
             // Convert interfaces to concrete types.
             if (propertyType.IsInterface && jsonInfo.ClassType == ClassType.Dictionary)
             {
-                Type newPropertyType = jsonInfo.ElementClassInfo.GetPolicyProperty().GetConcreteType(propertyType);
-                if (propertyType != newPropertyType)
+                // If a polymorphic case, we have to wait until run-time values are processed.
+                if (jsonInfo.ElementClassInfo.ClassType != ClassType.Unknown)
                 {
-                    jsonInfo = CreateProperty(propertyType, newPropertyType, propertyInfo, classType, options);
+                    Type newPropertyType = jsonInfo.ElementClassInfo.GetPolicyProperty().GetDictionaryConcreteType();
+                    if (propertyType != newPropertyType)
+                    {
+                        jsonInfo = CreateProperty(propertyType, newPropertyType, propertyInfo, classType, options);
+                    }
                 }
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -324,9 +324,8 @@ namespace System.Text.Json.Serialization
                         {
                             elementType = args[1];
                         }
-                        else if (args.Length >= 1) // It is >= 1 in case there is an IEnumerable<T, TSomeExtension>.
+                        else if (GetClassType(propertyType) == ClassType.Enumerable && args.Length >= 1) // It is >= 1 in case there is an IEnumerable<T, TSomeExtension>.
                         {
-                            Debug.Assert(GetClassType(propertyType) == ClassType.Enumerable);
                             elementType = args[0];
                         }
                     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -259,11 +259,9 @@ namespace System.Text.Json.Serialization
             return (TAttribute)PropertyInfo?.GetCustomAttribute(typeof(TAttribute), inherit: false);
         }
 
-        public abstract void ApplyNullValue(JsonSerializerOptions options, ref ReadStack state, ref Utf8JsonReader reader);
-
         public abstract IList CreateConverterList();
 
-        public abstract Type GetConcreteType(Type interfaceType);
+        public abstract Type GetDictionaryConcreteType();
 
         public abstract void Read(JsonTokenType tokenType, JsonSerializerOptions options, ref ReadStack state, ref Utf8JsonReader reader);
         public abstract void ReadEnumerable(JsonTokenType tokenType, JsonSerializerOptions options, ref ReadStack state, ref Utf8JsonReader reader);
@@ -271,7 +269,7 @@ namespace System.Text.Json.Serialization
 
         public abstract void Write(JsonSerializerOptions options, ref WriteStackFrame current, Utf8JsonWriter writer);
 
-        public abstract void WriteDictionary(JsonSerializerOptions options, ref WriteStackFrame current, Utf8JsonWriter writer);
+        public virtual void WriteDictionary(JsonSerializerOptions options, ref WriteStackFrame current, Utf8JsonWriter writer) { }
         public abstract void WriteEnumerable(JsonSerializerOptions options, ref WriteStackFrame current, Utf8JsonWriter writer);
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -92,16 +92,9 @@ namespace System.Text.Json.Serialization
             return new List<TDeclaredProperty>();
         }
 
-        // Map interfaces to a well-known implementation.
-        public override Type GetConcreteType(Type interfaceType)
+        public override Type GetDictionaryConcreteType()
         {
-            if (interfaceType.IsAssignableFrom(typeof(IDictionary<string, TRuntimeProperty>)) ||
-                interfaceType.IsAssignableFrom(typeof(IReadOnlyDictionary<string, TRuntimeProperty>)))
-            {
-                return typeof(Dictionary<string, TRuntimeProperty>);
-            }
-
-            return interfaceType;
+            return typeof(Dictionary<string, TRuntimeProperty>);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
@@ -31,13 +31,9 @@ namespace System.Text.Json.Serialization
 
         public override void Read(JsonTokenType tokenType, JsonSerializerOptions options, ref ReadStack state, ref Utf8JsonReader reader)
         {
-            if (ElementClassInfo != null)
-            {
-                // Forward the setter to the value-based JsonPropertyInfo.
-                JsonPropertyInfo propertyInfo = ElementClassInfo.GetPolicyProperty();
-                propertyInfo.ReadEnumerable(tokenType, options, ref state, ref reader);
-            }
-            else if (ShouldDeserialize)
+            Debug.Assert(ElementClassInfo == null);
+
+            if (ShouldDeserialize)
             {
                 if (ValueConverter != null)
                 {
@@ -68,18 +64,10 @@ namespace System.Text.Json.Serialization
                 return;
             }
 
-            // Converting to TProperty? here lets us share a common ApplyValue() with ApplyNullValue().
             TProperty? nullableValue = new TProperty?(value);
             JsonSerializer.ApplyValueToEnumerable(ref nullableValue, options, ref state, ref reader);
         }
 
-        public override void ApplyNullValue(JsonSerializerOptions options, ref ReadStack state, ref Utf8JsonReader reader)
-        {
-            TProperty? nullableValue = null;
-            JsonSerializer.ApplyValueToEnumerable(ref nullableValue, options, ref state, ref reader);
-        }
-
-        // todo: have the caller check if current.Enumerator != null and call WriteEnumerable of the underlying property directly to avoid an extra virtual call.
         public override void Write(JsonSerializerOptions options, ref WriteStackFrame current, Utf8JsonWriter writer)
         {
             if (current.Enumerator != null)
@@ -102,11 +90,9 @@ namespace System.Text.Json.Serialization
 
                 if (value == null)
                 {
-                    if (_escapedName == null)
-                    {
-                        writer.WriteNullValue();
-                    }
-                    else if (!IgnoreNullValues)
+                    Debug.Assert(_escapedName != null);
+
+                    if (!IgnoreNullValues)
                     {
                         writer.WriteNull(_escapedName);
                     }
@@ -123,11 +109,6 @@ namespace System.Text.Json.Serialization
                     }
                 }
             }
-        }
-
-        public override void WriteDictionary(JsonSerializerOptions options, ref WriteStackFrame current, Utf8JsonWriter writer)
-        {
-            JsonSerializer.WriteDictionary(ValueConverter, options, ref current, writer);
         }
 
         public override void WriteEnumerable(JsonSerializerOptions options, ref WriteStackFrame current, Utf8JsonWriter writer)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -38,7 +38,8 @@ namespace System.Text.Json.Serialization
 
             if (state.Current.IsPropertyEnumerable)
             {
-                state.Current.JsonPropertyInfo.ApplyNullValue(options, ref state, ref reader);
+                bool setPropertyToNull = !state.Current.EnumerableCreated;
+                ApplyObjectToEnumerable(null, options, ref state, ref reader, setPropertyDirectly: setPropertyToNull);
                 return false;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -28,13 +28,11 @@ namespace System.Text.Json.Serialization
                 if (state.Current.IsDictionary)
                 {
                     // Verify that the Dictionary can be deserialized by having <string> as first generic argument.
-                    Debug.Assert(state.Current.JsonClassInfo.Type.GetGenericArguments().Length >= 1);
-                    if (state.Current.JsonClassInfo.Type.GetGenericArguments()[0].UnderlyingSystemType != typeof(string))
+                    Type[] args = state.Current.JsonClassInfo.Type.GetGenericArguments();
+                    if (args.Length == 0 || args[0].UnderlyingSystemType != typeof(string))
                     {
                         ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type, reader, state.PropertyPath);
                     }
-
-                    ClassType classType = state.Current.JsonClassInfo.ElementClassInfo.ClassType;
 
                     if (state.Current.ReturnValue == null)
                     {
@@ -44,9 +42,15 @@ namespace System.Text.Json.Serialization
                     }
                     else
                     {
-                        Debug.Assert(classType == ClassType.Object || classType == ClassType.Dictionary);
+                        ClassType classType = state.Current.JsonClassInfo.ElementClassInfo.ClassType;
 
-                        // A nested object or dictionary.
+                        // Verify that the second parameter is not a value.
+                        if (state.Current.JsonClassInfo.ElementClassInfo.ClassType == ClassType.Value)
+                        {
+                            ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type, reader, state.PropertyPath);
+                        }
+
+                        // A nested object, dictionary or enumerable.
                         JsonClassInfo classInfoTemp = state.Current.JsonClassInfo;
                         state.Push();
                         state.Current.JsonClassInfo = classInfoTemp.ElementClassInfo;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -27,8 +27,14 @@ namespace System.Text.Json.Serialization
 
             if (state.Current.Enumerator == null)
             {
-                IEnumerable enumerable = (IEnumerable)jsonPropertyInfo.GetValueAsObject(state.Current.CurrentValue);
+                // Verify that the Dictionary can be serialized by having <string> as first generic argument.
+                Type[] args = jsonPropertyInfo.RuntimePropertyType.GetGenericArguments();
+                if (args.Length == 0 || args[0].UnderlyingSystemType != typeof(string))
+                {
+                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(state.Current.JsonClassInfo.Type, state.PropertyPath);
+                }
 
+                IEnumerable enumerable = (IEnumerable)jsonPropertyInfo.GetValueAsObject(state.Current.CurrentValue);
                 if (enumerable == null)
                 {
                     // Write a null object or enumerable.

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleEnumerable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleEnumerable.cs
@@ -30,8 +30,12 @@ namespace System.Text.Json.Serialization
 
                 if (enumerable == null)
                 {
-                    // Write a null object or enumerable.
-                    state.Current.WriteObjectOrArrayStart(ClassType.Enumerable, writer, writeNull: true);
+                    if (!state.Current.JsonPropertyInfo.IgnoreNullValues)
+                    {
+                        // Write a null object or enumerable.
+                        state.Current.WriteObjectOrArrayStart(ClassType.Enumerable, writer, writeNull: true);
+                    }
+
                     return true;
                 }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -63,5 +63,42 @@ namespace System.Text.Json.Serialization
             Debug.Assert(_index > 0);
             Current = _previous[--_index];
         }
+
+        // Return a property path in the form of: [FullNameOfType].FirstProperty.SecondProperty.LastProperty
+        public string PropertyPath
+        {
+            get
+            {
+                StringBuilder path = new StringBuilder();
+
+                if (_previous == null || _index == 0)
+                {
+                    path.Append($"[{Current.JsonClassInfo.Type.FullName}]");
+                }
+                else
+                {
+                    path.Append($"[{_previous[0].JsonClassInfo.Type.FullName}]");
+
+                    for (int i = 0; i < _index; i++)
+                    {
+                        path.Append(GetPropertyName(_previous[i]));
+                    }
+                }
+
+                path.Append(GetPropertyName(Current));
+
+                return path.ToString();
+            }
+        }
+
+        private string GetPropertyName(in WriteStackFrame frame)
+        {
+            if (frame.JsonPropertyInfo != null && frame.JsonClassInfo.ClassType == ClassType.Object)
+            {
+                return $".{frame.JsonPropertyInfo.PropertyInfo.Name}";
+            }
+
+            return string.Empty;
+        }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 
@@ -24,15 +23,16 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowJsonException_DeserializeCannotBeNull(in Utf8JsonReader reader, string path)
+        public static void ThrowJsonException_DeserializeUnableToConvertValue(Type propertyType, string path)
         {
-            ThowJsonException(SR.DeserializeCannotBeNull, in reader, path);
+            string message = SR.Format(SR.DeserializeUnableToConvertValue, propertyType.FullName) + $" Path: {path}.";
+            throw new JsonException(message, path, null, null);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowObjectDisposedException(string name)
+        public static void ThrowJsonException_DeserializeCannotBeNull(in Utf8JsonReader reader, string path)
         {
-            throw new ObjectDisposedException(name);
+            ThowJsonException(SR.DeserializeCannotBeNull, in reader, path);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -19,6 +19,51 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(0, list.Count);
         }
 
+
+        public static IEnumerable<object[]> ReadNullJson
+        {
+            get
+            {
+                yield return new object[] { $"[null, null, null]", true, true, true };
+                yield return new object[] { $"[null, null, {SimpleTestClass.s_json}]", true, true, false };
+                yield return new object[] { $"[null, {SimpleTestClass.s_json}, null]", true, false, true };
+                yield return new object[] { $"[null, {SimpleTestClass.s_json}, {SimpleTestClass.s_json}]", true, false, false };
+                yield return new object[] { $"[{SimpleTestClass.s_json}, {SimpleTestClass.s_json}, {SimpleTestClass.s_json}]", false, false, false };
+                yield return new object[] { $"[{SimpleTestClass.s_json}, {SimpleTestClass.s_json}, null]", false, false, true };
+                yield return new object[] { $"[{SimpleTestClass.s_json}, null, {SimpleTestClass.s_json}]", false, true, false };
+                yield return new object[] { $"[{SimpleTestClass.s_json}, null, null]", false, true, true };
+            }
+        }
+
+        private static void VerifyReadNull(SimpleTestClass obj, bool isNull)
+        {
+            if (isNull)
+            {
+                Assert.Null(obj);
+            }
+            else
+            {
+                obj.Verify();
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ReadNullJson))]
+        public static void ReadNull(string json, bool element0Null, bool element1Null, bool element2Null)
+        {
+            SimpleTestClass[] arr = JsonSerializer.Parse<SimpleTestClass[]>(json);
+            Assert.Equal(3, arr.Length);
+            VerifyReadNull(arr[0], element0Null);
+            VerifyReadNull(arr[1], element1Null);
+            VerifyReadNull(arr[2], element2Null);
+
+            List<SimpleTestClass> list = JsonSerializer.Parse<List<SimpleTestClass>>(json);
+            Assert.Equal(3, list.Count);
+            VerifyReadNull(list[0], element0Null);
+            VerifyReadNull(list[1], element1Null);
+            VerifyReadNull(list[2], element2Null);
+        }
+
         [Fact]
         public static void ReadClassWithStringArray()
         {

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
 using Xunit;
 
@@ -264,6 +265,46 @@ namespace System.Text.Json.Serialization.Tests
                 // Verify the name is unescaped after deserialize.
                 obj = JsonSerializer.Parse<Dictionary<string, int>>(json);
                 Assert.Equal(1, obj[longPropertyName]);
+            }
+        }
+
+        [Fact]
+        public static void ObjectToStringFail()
+        {
+            string json = @"{""MyDictionary"":{""Key"":""Value""}}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<Dictionary<string, string>>(json));
+        }
+
+        [Fact]
+        public static void HashtableFail()
+        {
+            {
+                string json = @"{""Key"":""Value""}";
+
+                // Verify we can deserialize into Dictionary<,>
+                JsonSerializer.Parse<Dictionary<string, string>>(json);
+
+                // We don't support non-generic IDictionary
+                Assert.Throws<JsonException>(() => JsonSerializer.Parse<Hashtable>(json));
+            }
+
+            {
+                Hashtable ht = new Hashtable();
+                ht.Add("Key", "Value");
+                Assert.Throws<JsonException>(() => JsonSerializer.ToString(ht));
+            }
+
+            {
+                string json = @"{""Key"":""Value""}";
+
+                // We don't support non-generic IDictionary
+                Assert.Throws<JsonException>(() => JsonSerializer.Parse<IDictionary>(json));
+            }
+
+            {
+                IDictionary ht = new Hashtable();
+                ht.Add("Key", "Value");
+                Assert.Throws<JsonException>(() => JsonSerializer.ToString(ht));
             }
         }
     }

--- a/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
@@ -35,6 +35,8 @@ namespace System.Text.Json.Serialization.Tests
             TestClassWithInitializedProperties obj = JsonSerializer.Parse<TestClassWithInitializedProperties>(TestClassWithInitializedProperties.s_null_json);
             Assert.Equal(null, obj.MyString);
             Assert.Equal(null, obj.MyInt);
+            Assert.Equal(null, obj.MyIntArray);
+            Assert.Equal(null, obj.MyIntList);
         }
 
         [Fact]
@@ -46,6 +48,8 @@ namespace System.Text.Json.Serialization.Tests
             TestClassWithInitializedProperties obj = JsonSerializer.Parse<TestClassWithInitializedProperties>(TestClassWithInitializedProperties.s_null_json, options);
             Assert.Equal("Hello", obj.MyString);
             Assert.Equal(1, obj.MyInt);
+            Assert.Equal(1, obj.MyIntArray[0]);
+            Assert.Equal(1, obj.MyIntList[0]);
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/Null.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.WriteTests.cs
@@ -14,10 +14,14 @@ namespace System.Text.Json.Serialization.Tests
             var obj = new TestClassWithInitializedProperties();
             obj.MyString = null;
             obj.MyInt = null;
+            obj.MyIntArray = null;
+            obj.MyIntList = null;
 
             string json = JsonSerializer.ToString(obj);
             Assert.Contains(@"""MyString"":null", json);
             Assert.Contains(@"""MyInt"":null", json);
+            Assert.Contains(@"""MyIntArray"":null", json);
+            Assert.Contains(@"""MyIntList"":null", json);
         }
 
         [Fact]
@@ -29,6 +33,8 @@ namespace System.Text.Json.Serialization.Tests
             var obj = new TestClassWithInitializedProperties();
             obj.MyString = null;
             obj.MyInt = null;
+            obj.MyIntArray = null;
+            obj.MyIntList = null;
 
             string json = JsonSerializer.ToString(obj, options);
             Assert.Equal(@"{}", json);

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
@@ -55,6 +55,7 @@ namespace System.Text.Json.Serialization.Tests
         public Dictionary<string, string> MyStringToStringDict { get; set; }
         public IDictionary<string, string> MyStringToStringIDict { get; set; }
         public IReadOnlyDictionary<string, string> MyStringToStringIReadOnlyDict { get; set; }
+        public List<string> MyListOfNullString { get; set; }
 
         public static readonly string s_json = $"{{{s_partialJsonProperties},{s_partialJsonArrays}}}";
         public static readonly string s_json_flipped = $"{{{s_partialJsonArrays},{s_partialJsonProperties}}}";
@@ -106,7 +107,8 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyStringIListT"" : [""Hello""]," +
                 @"""MyStringICollectionT"" : [""Hello""]," +
                 @"""MyStringIReadOnlyCollectionT"" : [""Hello""]," +
-                @"""MyStringIReadOnlyListT"" : [""Hello""]";
+                @"""MyStringIReadOnlyListT"" : [""Hello""]," +
+                @"""MyListOfNullString"" : [null]";
 
         public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
 
@@ -160,6 +162,7 @@ namespace System.Text.Json.Serialization.Tests
             MyStringToStringDict = new Dictionary<string, string> { { "key", "value" } };
             MyStringToStringIDict = new Dictionary<string, string> { { "key", "value" } };
             MyStringToStringIReadOnlyDict = new Dictionary<string, string> { { "key", "value" } };
+            MyListOfNullString = new List<string> { null };
         }
 
         public void Verify()
@@ -212,6 +215,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("value", MyStringToStringDict["key"]);
             Assert.Equal("value", MyStringToStringIDict["key"]);
             Assert.Equal("value", MyStringToStringIReadOnlyDict["key"]);
+            Assert.Null(MyListOfNullString[0]);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClassWithNullables.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClassWithNullables.cs
@@ -44,6 +44,7 @@ namespace System.Text.Json.Serialization.Tests
         public DateTimeOffset?[] MyDateTimeOffsetArray { get; set; }
         public SampleEnum?[] MyEnumArray { get; set; }
         public Dictionary<string, string> MyStringToStringDict { get; set; }
+        public List<int?> MyListOfNullInt { get; set; }
     }
 
     public class SimpleTestClassWithNulls : SimpleBaseClassWithNullables, ITestClass
@@ -90,6 +91,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Null(MyDateTimeOffsetArray);
             Assert.Null(MyEnumArray);
             Assert.Null(MyStringToStringDict);
+            Assert.Null(MyListOfNullInt);
         }
         public static readonly string s_json =
                 @"{" +
@@ -127,7 +129,8 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyDateTimeArray"" : null," +
                 @"""MyDateTimeOffsetArray"" : null," +
                 @"""MyEnumArray"" : null," +
-                @"""MyStringToStringDict"" : null" +
+                @"""MyStringToStringDict"" : null," +
+                @"""MyListOfNullInt"" : null" +
                 @"}";
 
         public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
@@ -171,7 +174,8 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyDateTimeArray"" : [""2019-01-30T12:01:02.0000000Z""]," +
                 @"""MyDateTimeOffsetArray"" : [""2019-01-30T12:01:02.0000000+01:00""]," +
                 @"""MyEnumArray"" : [2]," +
-                @"""MyStringToStringDict"" : {""key"" : ""value""}" +
+                @"""MyStringToStringDict"" : {""key"" : ""value""}," +
+                @"""MyListOfNullInt"" : [null]" +
                 @"}";
 
         public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
@@ -214,6 +218,7 @@ namespace System.Text.Json.Serialization.Tests
             MyDateTimeOffsetArray = new DateTimeOffset?[] { new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)) };
             MyEnumArray = new SampleEnum?[] { SampleEnum.Two };
             MyStringToStringDict = new Dictionary<string, string> { { "key", "value" } };
+            MyListOfNullInt = new List<int?> { null };
         }
 
         public void Verify()
@@ -254,6 +259,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)), MyDateTimeOffsetArray[0]);
             Assert.Equal(SampleEnum.Two, MyEnumArray[0]);
             Assert.Equal("value", MyStringToStringDict["key"]);
+            Assert.Null(MyListOfNullInt[0]);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.cs
@@ -30,11 +30,6 @@ namespace System.Text.Json.Serialization.Tests
 
         public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
 
-        public void Initialize()
-        {
-            MyString = null;
-        }
-
         public void Verify()
         {
             Assert.Equal(MyString, null);
@@ -45,10 +40,14 @@ namespace System.Text.Json.Serialization.Tests
     {
         public string MyString { get; set; } = "Hello";
         public int? MyInt { get; set; } = 1;
+        public int[] MyIntArray { get; set; } = new int[] { 1 };
+        public List<int> MyIntList { get; set; } = new List<int> { 1 };
         public static readonly string s_null_json =
                 @"{" +
                 @"""MyString"" : null," +
-                @"""MyInt"" : null" +
+                @"""MyInt"" : null," +
+                @"""MyIntArray"" : null," +
+                @"""MyIntList"" : null" +
                 @"}";
 
         public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_null_json);
@@ -108,6 +107,7 @@ namespace System.Text.Json.Serialization.Tests
             @"{" +
                 @"""MyData"":[" +
                     SimpleTestClass.s_json + "," +
+                    "null," +
                     SimpleTestClass.s_json +
                 @"]" +
             @"}");
@@ -122,6 +122,8 @@ namespace System.Text.Json.Serialization.Tests
                 MyData.Add(obj);
             }
 
+            MyData.Add(null);
+
             {
                 SimpleTestClass obj = new SimpleTestClass();
                 obj.Initialize();
@@ -131,9 +133,10 @@ namespace System.Text.Json.Serialization.Tests
 
         public void Verify()
         {
-            Assert.Equal(2, MyData.Count);
+            Assert.Equal(3, MyData.Count);
             MyData[0].Verify();
-            MyData[1].Verify();
+            Assert.Null(MyData[1]);
+            MyData[2].Verify();
         }
     }
 

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -72,6 +72,9 @@ namespace System.Text.Json.Serialization.Tests
             // Invalid data
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[1,""a""]")));
 
+            // Invalid data
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<List<int?>>(Encoding.UTF8.GetBytes(@"[1,""a""]")));
+
             // Multidimensional arrays currently not supported
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[,]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]")));
         }

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
@@ -18,6 +18,18 @@ namespace System.Text.Json.Serialization.Tests
             }
 
             {
+                int? value = 1;
+                string json = JsonSerializer.ToString(value);
+                Assert.Equal("1", json);
+            }
+
+            {
+                int? value = null;
+                string json = JsonSerializer.ToString(value);
+                Assert.Equal("null", json);
+            }
+
+            {
                 Span<byte> json = JsonSerializer.ToBytes(1);
                 Assert.Equal(Encoding.UTF8.GetBytes("1"), json.ToArray());
             }


### PR DESCRIPTION
- Improve tests coverage for System.Text.Json.Serialization.JsonPropertyInfoNullable and JsonPropertyInfoNotNullable to effectively 100% (ignoring line after ThrowHelper). Previously it was 80-90%.
- Refactor code that deals with null values.
- Add additional tests for null.
- Add additional tests for HashTable (not supported - only IDictionary<string,>) and corresponding code to detect this error case.
- Add PropertyPath functionality to the write side; currently this does not have good test coverage as there is only one exception. More will be added later.