### PR TITLE
Internal Http SystemProxyInfo object should never be null

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -260,6 +260,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' And '$(TargetsOSX)' != 'true' And '$(TargetGroup)' == 'netcoreapp'">
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
@@ -306,6 +307,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Windows.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpSystemProxy.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpNoProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpNoProxy.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal sealed class HttpNoProxy : IWebProxy
+    {
+        public HttpNoProxy() {}
+
+        public ICredentials Credentials { get; set; }
+        public Uri GetProxy(Uri destination) => null;
+        public bool IsBypassed(Uri host) => true;
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpNoProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpNoProxy.cs
@@ -6,8 +6,6 @@ namespace System.Net.Http
 {
     internal sealed class HttpNoProxy : IWebProxy
     {
-        public HttpNoProxy() {}
-
         public ICredentials Credentials { get; set; }
         public Uri GetProxy(Uri destination) => null;
         public bool IsBypassed(Uri host) => true;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Unix.cs
@@ -6,10 +6,12 @@ namespace System.Net.Http
 {
     internal static class SystemProxyInfo
     {
-        // On Unix (except for OSX) we get default proxy configuration from environment variables.
+        // On Unix (except for OSX) we get default proxy configuration from environment variables. If the
+        // environment variables are not defined, we return an IWebProxy object that effectively is
+        // the "no proxy" object.
         public static IWebProxy ConstructSystemProxy()
         {
-            return HttpEnvironmentProxy.TryCreate(out IWebProxy proxy) ? proxy : null;
+            return HttpEnvironmentProxy.TryCreate(out IWebProxy proxy) ? proxy : new HttpNoProxy();
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Windows.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http
                 HttpSystemProxy.TryCreate(out proxy);
             }
 
-            return proxy;
+            return proxy ?? new HttpNoProxy();
         }
     }
 }

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -390,6 +390,9 @@
     <Compile Include="HttpEnvironmentProxyTest.cs" />
     <Compile Include="HttpSystemProxyTest.cs" />
     <Compile Include="SystemProxyInfoTest.cs" />
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs">
+      <Link>ProductionCode\System\Net\Http\HttpNoProxy.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpSystemProxy.cs">
       <Link>ProductionCode\System\Net\Http\HttpSystemProxy.cs</Link>
     </Compile>

--- a/src/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.cs
@@ -38,6 +38,8 @@ namespace System.Net.Http.Tests
             RemoteExecutor.Invoke(() =>
             {
                 IWebProxy proxy = SystemProxyInfo.ConstructSystemProxy();
+                Assert.NotNull(proxy);
+
                 HttpEnvironmentProxy envProxy = proxy as HttpEnvironmentProxy;
                 Assert.Null(envProxy);
 


### PR DESCRIPTION
In order to provide a consistent experience with the HttpClient IWebProxy objects,
the returned internal proxy object which represent the system/platform proxy settings
should never be null. If the platform's settings indicate that no proxy is being used,
then return an instance of the internal HttpNoProxy object.

Note that even if the platform settings indicate that a proxy could be used, any
particular Http request might still not go thru a proxy. The final determination of
what proxy is being used for a request is still governed by the return of the
IWebProxy.IsBypassed and IWebProxy.GetProxy methods.

Contributes to #36553