### PR TITLE
Fix NullReferenceException when a trusted cert chain fails usage

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/ChainPal.cs
@@ -212,11 +212,14 @@ namespace Internal.Cryptography.Pal
 
             if (!IsPolicyMatch(elements, applicationPolicy, certificatePolicy))
             {
-                Tuple<X509Certificate2, int> currentValue = elements[0];
+                for (int i = 0; i < elements.Length; i++)
+                {
+                    Tuple<X509Certificate2, int> currentValue = elements[i];
 
-                elements[0] = Tuple.Create(
-                    currentValue.Item1,
-                    currentValue.Item2 | (int)X509ChainStatusFlags.NotValidForUsage);
+                    elements[i] = Tuple.Create(
+                        currentValue.Item1,
+                        currentValue.Item2 | (int)X509ChainStatusFlags.NotValidForUsage);
+                }
             }
 
             FixupRevocationStatus(elements, revocationFlag);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -664,11 +664,14 @@ namespace Internal.Cryptography.Pal
 
                 AddUniqueStatus(overallStatus, ref chainStatus);
 
+                // No individual element can have seen more errors than the chain overall,
+                // so avoid regrowth of the list.
+                var elementStatus = new List<X509ChainStatus>(overallStatus.Count);
+
                 for (int i = 0; i < elements.Length; i++)
                 {
                     X509ChainElement element = elements[i];
-
-                    var elementStatus = new List<X509ChainStatus>(element.ChainElementStatus.Length + 1);
+                    elementStatus.Clear();
                     elementStatus.AddRange(element.ChainElementStatus);
 
                     AddUniqueStatus(elementStatus, ref chainStatus);

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -417,6 +417,49 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+        [ConditionalFact(nameof(TrustsMicrosoftDotComRoot))]
+        public static void BuildChain_FailOnlyApplicationPolicy()
+        {
+            using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
+            using (var microsoftDotComRoot = new X509Certificate2(TestData.MicrosoftDotComRootBytes))
+            using (ChainHolder holder = new ChainHolder())
+            {
+                holder.Chain.ChainPolicy.ApplicationPolicy.Add(new Oid("0.1.2.3.4", null));
+                holder.Chain.ChainPolicy.VerificationTime = microsoftDotCom.NotBefore.AddDays(1);
+
+                Assert.False(holder.Chain.Build(microsoftDotCom));
+
+                Assert.Equal(
+                    X509ChainStatusFlags.NotValidForUsage,
+                    holder.Chain.ChainStatus.Aggregate(
+                        X509ChainStatusFlags.NoError,
+                        (a, status) => a | status.Status));
+
+                Assert.Equal(3, holder.Chain.ChainElements.Count);
+
+                Assert.Equal(microsoftDotCom.RawData, holder.Chain.ChainElements[0].Certificate.RawData);
+                Assert.Equal(microsoftDotComRoot.RawData, holder.Chain.ChainElements[2].Certificate.RawData);
+
+                Assert.Equal(
+                    X509ChainStatusFlags.NotValidForUsage,
+                    holder.Chain.ChainElements[0].ChainElementStatus.Aggregate(
+                        X509ChainStatusFlags.NoError,
+                        (a, status) => a | status.Status));
+
+                Assert.Equal(
+                    X509ChainStatusFlags.NotValidForUsage,
+                    holder.Chain.ChainElements[1].ChainElementStatus.Aggregate(
+                        X509ChainStatusFlags.NoError,
+                        (a, status) => a | status.Status));
+
+                Assert.Equal(
+                    X509ChainStatusFlags.NotValidForUsage,
+                    holder.Chain.ChainElements[2].ChainElementStatus.Aggregate(
+                        X509ChainStatusFlags.NoError,
+                        (a, status) => a | status.Status));
+            }
+        }
+
         [ConditionalFact(nameof(TrustsMicrosoftDotComRoot), nameof(CanModifyStores))]
         [OuterLoop(/* Modifies user certificate store */)]
         public static void BuildChain_MicrosoftDotCom_WithRootCertInUserAndSystemRootCertStores()

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -426,6 +426,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             {
                 holder.Chain.ChainPolicy.ApplicationPolicy.Add(new Oid("0.1.2.3.4", null));
                 holder.Chain.ChainPolicy.VerificationTime = microsoftDotCom.NotBefore.AddDays(1);
+                holder.Chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
                 Assert.False(holder.Chain.Build(microsoftDotCom));
 


### PR DESCRIPTION
A previous change moved overallStatus to be created on demand, but if it made
it out to ProcessPolicy before finding the first error it didn't create it first.

While adding a test for that it was also discovered that the Windows and
Linux chains are inconsistent in where this particular error gets reported.