### PR TITLE
disable ParallelQueryCombinationTests on ARM systems with high core count

### DIFF
--- a/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
+++ b/src/System.Linq.Parallel/tests/Combinatorial/ParallelQueryCombinationTests.cs
@@ -2,13 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Parallel.Tests
 {
+    [ConditionalClass(typeof(ParallelQueryCombinationTests), nameof(RunSlowTests))]
     public static partial class ParallelQueryCombinationTests
     {
+        // on ARM platforms many available cores makes this unbearably slow: #36494
+        static public bool RunSlowTests => PlatformDetection.IsNotArmNorArm64Process || Environment.ProcessorCount <= 8;
+
         [Theory]
         [MemberData(nameof(UnaryOperations))]
         [MemberData(nameof(BinaryOperations))]


### PR DESCRIPTION
System.Linq.Parallel tests are currently failing on every official run.  This change conditionally disables part of the test when running on ARM with high core count. 
The test will light up if we ver run on limited container or ARM with less cores.

Root cause for #36494 needs to be investigated. 

related to  #36494
