### PR TITLE
Add JsonEncodedText with Utf8JsonWriter overloads that accept it

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -101,14 +101,14 @@ namespace System.Text.Json
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         }
     }
-    public readonly partial struct JsonEncodedText : IEquatable<JsonEncodedText>
+    public readonly partial struct JsonEncodedText : System.IEquatable<System.Text.Json.JsonEncodedText>
     {
-        public static JsonEncodedText Encode(string value) { throw null; }
-        public static JsonEncodedText Encode(ReadOnlySpan<char> value) { throw null; }
-        public static JsonEncodedText Encode(ReadOnlySpan<byte> utf8Value) { throw null; }
-        public ReadOnlySpan<byte> EncodedUtf8Bytes { get { throw null; } }
-        public bool Equals(JsonEncodedText other) { throw null; }
+        public System.ReadOnlySpan<byte> EncodedUtf8Bytes { get { throw null; } }
+        public static System.Text.Json.JsonEncodedText Encode(System.ReadOnlySpan<byte> utf8Value) { throw null; }
+        public static System.Text.Json.JsonEncodedText Encode(System.ReadOnlySpan<char> value) { throw null; }
+        public static System.Text.Json.JsonEncodedText Encode(string value) { throw null; }
         public override bool Equals(object obj) { throw null; }
+        public bool Equals(System.Text.Json.JsonEncodedText other) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
     }

--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -103,6 +103,7 @@ namespace System.Text.Json
     }
     public readonly partial struct JsonEncodedText : System.IEquatable<System.Text.Json.JsonEncodedText>
     {
+        private readonly object _dummy;
         public System.ReadOnlySpan<byte> EncodedUtf8Bytes { get { throw null; } }
         public static System.Text.Json.JsonEncodedText Encode(System.ReadOnlySpan<byte> utf8Value) { throw null; }
         public static System.Text.Json.JsonEncodedText Encode(System.ReadOnlySpan<char> value) { throw null; }

--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -101,6 +101,17 @@ namespace System.Text.Json
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw null; }
         }
     }
+    public readonly partial struct JsonEncodedText : IEquatable<JsonEncodedText>
+    {
+        public static JsonEncodedText Encode(string value) { throw null; }
+        public static JsonEncodedText Encode(ReadOnlySpan<char> value) { throw null; }
+        public static JsonEncodedText Encode(ReadOnlySpan<byte> utf8Value) { throw null; }
+        public ReadOnlySpan<byte> EncodedUtf8Bytes { get { throw null; } }
+        public bool Equals(JsonEncodedText other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public override string ToString() { throw null; }
+    }
     public readonly partial struct JsonProperty
     {
         private readonly object _dummy;

--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -236,6 +236,7 @@ namespace System.Text.Json
         public void WriteBoolean(System.ReadOnlySpan<byte> utf8PropertyName, bool value) { }
         public void WriteBoolean(System.ReadOnlySpan<char> propertyName, bool value) { }
         public void WriteBoolean(string propertyName, bool value) { }
+        public void WriteBoolean(JsonEncodedText propertyName, bool value) { }
         public void WriteBooleanValue(bool value) { }
         public void WriteCommentValue(System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteCommentValue(System.ReadOnlySpan<char> value) { }
@@ -245,6 +246,7 @@ namespace System.Text.Json
         public void WriteNull(System.ReadOnlySpan<byte> utf8PropertyName) { }
         public void WriteNull(System.ReadOnlySpan<char> propertyName) { }
         public void WriteNull(string propertyName) { }
+        public void WriteNull(JsonEncodedText propertyName) { }
         public void WriteNullValue() { }
         public void WriteNumber(System.ReadOnlySpan<byte> utf8PropertyName, decimal value) { }
         public void WriteNumber(System.ReadOnlySpan<byte> utf8PropertyName, double value) { }
@@ -273,6 +275,15 @@ namespace System.Text.Json
         public void WriteNumber(string propertyName, uint value) { }
         [System.CLSCompliantAttribute(false)]
         public void WriteNumber(string propertyName, ulong value) { }
+        public void WriteNumber(JsonEncodedText propertyName, decimal value) { }
+        public void WriteNumber(JsonEncodedText propertyName, double value) { }
+        public void WriteNumber(JsonEncodedText propertyName, int value) { }
+        public void WriteNumber(JsonEncodedText propertyName, long value) { }
+        public void WriteNumber(JsonEncodedText propertyName, float value) { }
+        [System.CLSCompliantAttribute(false)]
+        public void WriteNumber(JsonEncodedText propertyName, uint value) { }
+        [System.CLSCompliantAttribute(false)]
+        public void WriteNumber(JsonEncodedText propertyName, ulong value) { }
         public void WriteNumberValue(decimal value) { }
         public void WriteNumberValue(double value) { }
         public void WriteNumberValue(int value) { }
@@ -286,34 +297,47 @@ namespace System.Text.Json
         public void WriteStartArray(System.ReadOnlySpan<byte> utf8PropertyName) { }
         public void WriteStartArray(System.ReadOnlySpan<char> propertyName) { }
         public void WriteStartArray(string propertyName) { }
+        public void WriteStartArray(JsonEncodedText propertyName) { }
         public void WriteStartObject() { }
         public void WriteStartObject(System.ReadOnlySpan<byte> utf8PropertyName) { }
         public void WriteStartObject(System.ReadOnlySpan<char> propertyName) { }
         public void WriteStartObject(string propertyName) { }
+        public void WriteStartObject(JsonEncodedText propertyName) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.DateTime value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.DateTimeOffset value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.Guid value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.ReadOnlySpan<char> value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, string value) { }
+        public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, JsonEncodedText value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.DateTime value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.DateTimeOffset value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.Guid value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.ReadOnlySpan<char> value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, string value) { }
+        public void WriteString(System.ReadOnlySpan<char> propertyName, JsonEncodedText value) { }
         public void WriteString(string propertyName, System.DateTime value) { }
         public void WriteString(string propertyName, System.DateTimeOffset value) { }
         public void WriteString(string propertyName, System.Guid value) { }
         public void WriteString(string propertyName, System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteString(string propertyName, System.ReadOnlySpan<char> value) { }
         public void WriteString(string propertyName, string value) { }
+        public void WriteString(string propertyName, JsonEncodedText value) { }
+        public void WriteString(JsonEncodedText propertyName, System.DateTime value) { }
+        public void WriteString(JsonEncodedText propertyName, System.DateTimeOffset value) { }
+        public void WriteString(JsonEncodedText propertyName, System.Guid value) { }
+        public void WriteString(JsonEncodedText propertyName, System.ReadOnlySpan<byte> utf8Value) { }
+        public void WriteString(JsonEncodedText propertyName, System.ReadOnlySpan<char> value) { }
+        public void WriteString(JsonEncodedText propertyName, string value) { }
+        public void WriteString(JsonEncodedText propertyName, JsonEncodedText value) { }
         public void WriteStringValue(System.DateTime value) { }
         public void WriteStringValue(System.DateTimeOffset value) { }
         public void WriteStringValue(System.Guid value) { }
         public void WriteStringValue(System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteStringValue(System.ReadOnlySpan<char> value) { }
         public void WriteStringValue(string value) { }
+        public void WriteStringValue(JsonEncodedText value) { }
     }
 }
 namespace System.Text.Json.Serialization

--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -236,7 +236,7 @@ namespace System.Text.Json
         public void WriteBoolean(System.ReadOnlySpan<byte> utf8PropertyName, bool value) { }
         public void WriteBoolean(System.ReadOnlySpan<char> propertyName, bool value) { }
         public void WriteBoolean(string propertyName, bool value) { }
-        public void WriteBoolean(JsonEncodedText propertyName, bool value) { }
+        public void WriteBoolean(System.Text.Json.JsonEncodedText propertyName, bool value) { }
         public void WriteBooleanValue(bool value) { }
         public void WriteCommentValue(System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteCommentValue(System.ReadOnlySpan<char> value) { }
@@ -246,7 +246,7 @@ namespace System.Text.Json
         public void WriteNull(System.ReadOnlySpan<byte> utf8PropertyName) { }
         public void WriteNull(System.ReadOnlySpan<char> propertyName) { }
         public void WriteNull(string propertyName) { }
-        public void WriteNull(JsonEncodedText propertyName) { }
+        public void WriteNull(System.Text.Json.JsonEncodedText propertyName) { }
         public void WriteNullValue() { }
         public void WriteNumber(System.ReadOnlySpan<byte> utf8PropertyName, decimal value) { }
         public void WriteNumber(System.ReadOnlySpan<byte> utf8PropertyName, double value) { }
@@ -275,15 +275,15 @@ namespace System.Text.Json
         public void WriteNumber(string propertyName, uint value) { }
         [System.CLSCompliantAttribute(false)]
         public void WriteNumber(string propertyName, ulong value) { }
-        public void WriteNumber(JsonEncodedText propertyName, decimal value) { }
-        public void WriteNumber(JsonEncodedText propertyName, double value) { }
-        public void WriteNumber(JsonEncodedText propertyName, int value) { }
-        public void WriteNumber(JsonEncodedText propertyName, long value) { }
-        public void WriteNumber(JsonEncodedText propertyName, float value) { }
+        public void WriteNumber(System.Text.Json.JsonEncodedText propertyName, decimal value) { }
+        public void WriteNumber(System.Text.Json.JsonEncodedText propertyName, double value) { }
+        public void WriteNumber(System.Text.Json.JsonEncodedText propertyName, int value) { }
+        public void WriteNumber(System.Text.Json.JsonEncodedText propertyName, long value) { }
+        public void WriteNumber(System.Text.Json.JsonEncodedText propertyName, float value) { }
         [System.CLSCompliantAttribute(false)]
-        public void WriteNumber(JsonEncodedText propertyName, uint value) { }
+        public void WriteNumber(System.Text.Json.JsonEncodedText propertyName, uint value) { }
         [System.CLSCompliantAttribute(false)]
-        public void WriteNumber(JsonEncodedText propertyName, ulong value) { }
+        public void WriteNumber(System.Text.Json.JsonEncodedText propertyName, ulong value) { }
         public void WriteNumberValue(decimal value) { }
         public void WriteNumberValue(double value) { }
         public void WriteNumberValue(int value) { }
@@ -297,47 +297,47 @@ namespace System.Text.Json
         public void WriteStartArray(System.ReadOnlySpan<byte> utf8PropertyName) { }
         public void WriteStartArray(System.ReadOnlySpan<char> propertyName) { }
         public void WriteStartArray(string propertyName) { }
-        public void WriteStartArray(JsonEncodedText propertyName) { }
+        public void WriteStartArray(System.Text.Json.JsonEncodedText propertyName) { }
         public void WriteStartObject() { }
         public void WriteStartObject(System.ReadOnlySpan<byte> utf8PropertyName) { }
         public void WriteStartObject(System.ReadOnlySpan<char> propertyName) { }
         public void WriteStartObject(string propertyName) { }
-        public void WriteStartObject(JsonEncodedText propertyName) { }
+        public void WriteStartObject(System.Text.Json.JsonEncodedText propertyName) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.DateTime value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.DateTimeOffset value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.Guid value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.ReadOnlySpan<char> value) { }
         public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, string value) { }
-        public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, JsonEncodedText value) { }
+        public void WriteString(System.ReadOnlySpan<byte> utf8PropertyName, System.Text.Json.JsonEncodedText value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.DateTime value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.DateTimeOffset value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.Guid value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, System.ReadOnlySpan<char> value) { }
         public void WriteString(System.ReadOnlySpan<char> propertyName, string value) { }
-        public void WriteString(System.ReadOnlySpan<char> propertyName, JsonEncodedText value) { }
+        public void WriteString(System.ReadOnlySpan<char> propertyName, System.Text.Json.JsonEncodedText value) { }
         public void WriteString(string propertyName, System.DateTime value) { }
         public void WriteString(string propertyName, System.DateTimeOffset value) { }
         public void WriteString(string propertyName, System.Guid value) { }
         public void WriteString(string propertyName, System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteString(string propertyName, System.ReadOnlySpan<char> value) { }
         public void WriteString(string propertyName, string value) { }
-        public void WriteString(string propertyName, JsonEncodedText value) { }
-        public void WriteString(JsonEncodedText propertyName, System.DateTime value) { }
-        public void WriteString(JsonEncodedText propertyName, System.DateTimeOffset value) { }
-        public void WriteString(JsonEncodedText propertyName, System.Guid value) { }
-        public void WriteString(JsonEncodedText propertyName, System.ReadOnlySpan<byte> utf8Value) { }
-        public void WriteString(JsonEncodedText propertyName, System.ReadOnlySpan<char> value) { }
-        public void WriteString(JsonEncodedText propertyName, string value) { }
-        public void WriteString(JsonEncodedText propertyName, JsonEncodedText value) { }
+        public void WriteString(string propertyName, System.Text.Json.JsonEncodedText value) { }
+        public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.DateTime value) { }
+        public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.DateTimeOffset value) { }
+        public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.Guid value) { }
+        public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.ReadOnlySpan<byte> utf8Value) { }
+        public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.ReadOnlySpan<char> value) { }
+        public void WriteString(System.Text.Json.JsonEncodedText propertyName, string value) { }
+        public void WriteString(System.Text.Json.JsonEncodedText propertyName, System.Text.Json.JsonEncodedText value) { }
         public void WriteStringValue(System.DateTime value) { }
         public void WriteStringValue(System.DateTimeOffset value) { }
         public void WriteStringValue(System.Guid value) { }
         public void WriteStringValue(System.ReadOnlySpan<byte> utf8Value) { }
         public void WriteStringValue(System.ReadOnlySpan<char> value) { }
         public void WriteStringValue(string value) { }
-        public void WriteStringValue(JsonEncodedText value) { }
+        public void WriteStringValue(System.Text.Json.JsonEncodedText value) { }
     }
 }
 namespace System.Text.Json.Serialization

--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -138,11 +138,14 @@
   <data name="CannotTranscodeInvalidUtf8" xml:space="preserve">
     <value>Cannot transcode invalid UTF-8 JSON text to UTF-16 string.</value>
   </data>
-  <data name="CannotWriteInvalidUTF16" xml:space="preserve">
-    <value>Cannot write invalid UTF-16 text as JSON. Invalid surrogate value: '{0}'.</value>
+  <data name="CannotTranscodeInvalidUtf16" xml:space="preserve">
+    <value>Cannot transcode invalid UTF-16 string to UTF-8 JSON text.</value>
   </data>
-  <data name="CannotWriteInvalidUTF8" xml:space="preserve">
-    <value>Cannot write invalid UTF-8 text as JSON. Invalid input: '{0}'.</value>
+  <data name="CannotEncodeInvalidUTF16" xml:space="preserve">
+    <value>Cannot encode invalid UTF-16 text as JSON. Invalid surrogate value: '{0}'.</value>
+  </data>
+  <data name="CannotEncodeInvalidUTF8" xml:space="preserve">
+    <value>Cannot encode invalid UTF-8 text as JSON. Invalid input: '{0}'.</value>
   </data>
   <data name="CannotWritePropertyWithinArray" xml:space="preserve">
     <value>Cannot write a JSON property within an array or as the first JSON token. Current token type is '{0}'.</value>
@@ -238,7 +241,7 @@
     <value>The maximum configured depth of {0} has been exceeded. Cannot read next JSON object.</value>
   </data>
   <data name="PropertyNameTooLarge" xml:space="preserve">
-    <value>The JSON property name of length {0} is too large and not supported by the JSON writer.</value>
+    <value>The JSON property name of length {0} is too large and not supported.</value>
   </data>
   <data name="FormatDecimal" xml:space="preserve">
     <value>The JSON value is either too large or too small for a Decimal.</value>
@@ -274,7 +277,7 @@
     <value>.NET number values such as positive and negative infinity cannot be written as valid JSON.</value>
   </data>
   <data name="ValueTooLarge" xml:space="preserve">
-    <value>The JSON value of length {0} is too large and not supported by the JSON writer.</value>
+    <value>The JSON value of length {0} is too large and not supported.</value>
   </data>
   <data name="ZeroDepthAtEnd" xml:space="preserve">
     <value>Expected depth to be zero at the end of the JSON payload. There is an open JSON object or array that should be closed.</value>

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -14,6 +14,7 @@
     <Compile Include="System\Text\Json\BitStack.cs" />
     <Compile Include="System\Text\Json\JsonCommentHandling.cs" />
     <Compile Include="System\Text\Json\JsonConstants.cs" />
+    <Compile Include="System\Text\Json\JsonEncodedText.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Date.cs" />
     <Compile Include="System\Text\Json\JsonTokenType.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
@@ -7,11 +7,20 @@ using System.Diagnostics;
 
 namespace System.Text.Json
 {
+    /// <summary>
+    /// Provides a way to transform UTF-8 or UTF-16 encoded text into a form that is suitable for JSON.
+    /// </summary>
+    /// <remarks>
+    /// This can be used to cache and store known strings used for writing JSON ahead of time by pre-encoding them up front.
+    /// </remarks>
     public readonly struct JsonEncodedText : IEquatable<JsonEncodedText>
     {
         private readonly byte[] _utf8Value;
         private readonly string _value;
 
+        /// <summary>
+        /// Returns the UTF-8 encoded representation of the pre-encoded JSON text.
+        /// </summary>
         public ReadOnlySpan<byte> EncodedUtf8Bytes => _utf8Value;
 
         private JsonEncodedText(byte[] utf8Value)
@@ -22,6 +31,16 @@ namespace System.Text.Json
             _utf8Value = utf8Value;
         }
 
+        /// <summary>
+        /// Encodes the string text value as a JSON string.
+        /// </summary>
+        /// <param name="value">The UTF-16 encoded value to be transformed as JSON encoded text.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if value is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified value is too large or if it contains invalid UTF-16 characters.
+        /// </exception>
         public static JsonEncodedText Encode(string value)
         {
             if (value == null)
@@ -30,6 +49,13 @@ namespace System.Text.Json
             return Encode(value.AsSpan());
         }
 
+        /// <summary>
+        /// Encodes the UTF-16 text value as a JSON string.
+        /// </summary>
+        /// <param name="value">The UTF-16 encoded value to be transformed as JSON encoded text.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified value is too large or if it contains invalid UTF-16 characters.
+        /// </exception>
         public static JsonEncodedText Encode(ReadOnlySpan<char> value)
         {
             if (value.Length == 0)
@@ -63,6 +89,13 @@ namespace System.Text.Json
             return encodedText;
         }
 
+        /// <summary>
+        /// Encodes the UTF-8 text value as a JSON string.
+        /// </summary>
+        /// <param name="utf8Value">The UTF-8 encoded value to be transformed as JSON encoded text.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified value is too large or if it contains invalid UTF-8 bytes.
+        /// </exception>
         public static JsonEncodedText Encode(ReadOnlySpan<byte> utf8Value)
         {
             if (utf8Value.Length == 0)
@@ -113,6 +146,12 @@ namespace System.Text.Json
             return escapedString;
         }
 
+        /// <summary>
+        /// Determines whether this instance and another specified <see cref="JsonEncodedText"/> instance have the same value.
+        /// </summary>
+        /// <remarks>
+        /// Default instances of <see cref="JsonEncodedText"/> are treated as equal.
+        /// </remarks>
         public bool Equals(JsonEncodedText other)
         {
             if (_value == null)
@@ -125,6 +164,12 @@ namespace System.Text.Json
             }
         }
 
+        /// <summary>
+        /// Determines whether this instance and a specified object, which must also be a <see cref="JsonEncodedText"/> instance, have the same value.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="obj"/> is null, the method returns false.
+        /// </remarks>
         public override bool Equals(object obj)
         {
             if (obj is JsonEncodedText encodedText)
@@ -134,9 +179,24 @@ namespace System.Text.Json
             return false;
         }
 
+        /// <summary>
+        /// Converts the value of this instance to a <see cref="string"/>.
+        /// </summary>
+        /// <remarks>
+        /// Returns the underlying UTF-16 encoded string.
+        /// </remarks>
+        /// <remarks>
+        /// Returns an empty string on a default instance of <see cref="JsonEncodedText"/>.
+        /// </remarks>
         public override string ToString()
             => _value ?? string.Empty;
 
+        /// <summary>
+        /// Returns the hash code for this <see cref="JsonEncodedText"/>.
+        /// </summary>
+        /// <remarks>
+        /// Returns 0 on a default instance of <see cref="JsonEncodedText"/>.
+        /// </remarks>
         public override int GetHashCode()
             => _value == null ? 0 : _value.GetHashCode();
     }

--- a/src/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
@@ -53,16 +53,11 @@ namespace System.Text.Json
             finally
             {
                 // On the basis that this is user data, go ahead and clear it.
-                ClearAndReturn(utf8Bytes, expectedByteCount);
+                utf8Bytes.AsSpan(0, expectedByteCount).Clear();
+                ArrayPool<byte>.Shared.Return(utf8Bytes);
             }
 
             return encodedText;
-        }
-
-        private static void ClearAndReturn(byte[] utf8Bytes, int written)
-        {
-            utf8Bytes.AsSpan(0, written).Clear();
-            ArrayPool<byte>.Shared.Return(utf8Bytes);
         }
 
         public static JsonEncodedText Encode(ReadOnlySpan<byte> utf8Value)

--- a/src/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
@@ -1,0 +1,153 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+
+namespace System.Text.Json
+{
+    public readonly struct JsonEncodedText : IEquatable<JsonEncodedText>
+    {
+        private readonly byte[] _utf8Value;
+        private readonly string _value;
+
+        public ReadOnlySpan<byte> EncodedUtf8Bytes => _utf8Value;
+
+        public static JsonEncodedText Encode(string value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            return Encode(value.AsSpan());
+        }
+
+        public static JsonEncodedText Encode(ReadOnlySpan<char> value)
+        {
+            if (value.Length == 0)
+            {
+                return new JsonEncodedText(Array.Empty<byte>());
+            }
+
+            return TranscodeAndEncode(value);
+        }
+
+        private static JsonEncodedText TranscodeAndEncode(ReadOnlySpan<char> value)
+        {
+            JsonWriterHelper.ValidateValue(value);
+
+            int expectedByteCount = JsonReaderHelper.GetUtf8ByteCount(value);
+            byte[] utf8Bytes = ArrayPool<byte>.Shared.Rent(expectedByteCount);
+
+            JsonEncodedText encodedText;
+
+            try
+            {
+                // Since GetUtf8ByteCount above already throws on invalid input, the transcoding
+                // to UTF-8 is guaranteed to succeed here. Therefore, there's no need for a catch block.
+                int actualByteCount = JsonReaderHelper.GetUtf8FromText(value, utf8Bytes);
+                Debug.Assert(expectedByteCount == actualByteCount);
+
+                encodedText = EncodeHelper(utf8Bytes.AsSpan(0, actualByteCount));
+            }
+            finally
+            {
+                // On the basis that this is user data, go ahead and clear it.
+                ClearAndReturn(utf8Bytes, expectedByteCount);
+            }
+
+            return encodedText;
+        }
+
+        private static void ClearAndReturn(byte[] utf8Bytes, int written)
+        {
+            utf8Bytes.AsSpan(0, written).Clear();
+            ArrayPool<byte>.Shared.Return(utf8Bytes);
+        }
+
+        public static JsonEncodedText Encode(ReadOnlySpan<byte> utf8Value)
+        {
+            if (utf8Value.Length == 0)
+            {
+                return new JsonEncodedText(Array.Empty<byte>());
+            }
+
+            JsonWriterHelper.ValidateValue(utf8Value);
+            return EncodeHelper(utf8Value);
+        }
+
+        private static JsonEncodedText EncodeHelper(ReadOnlySpan<byte> utf8Value)
+        {
+            int idx = JsonWriterHelper.NeedsEscaping(utf8Value);
+
+            if (idx != -1)
+            {
+                return new JsonEncodedText(GetEscapedString(utf8Value, idx));
+            }
+            else
+            {
+                return new JsonEncodedText(utf8Value.ToArray());
+            }
+        }
+
+        private JsonEncodedText(byte[] utf8Value)
+        {
+            Debug.Assert(utf8Value != null);
+
+            _value = JsonReaderHelper.GetTextFromUtf8(utf8Value);
+            _utf8Value = utf8Value;
+        }
+
+        private static byte[] GetEscapedString(ReadOnlySpan<byte> utf8Value, int firstEscapeIndexVal)
+        {
+            Debug.Assert(int.MaxValue / JsonConstants.MaxExpansionFactorWhileEscaping >= utf8Value.Length);
+            Debug.Assert(firstEscapeIndexVal >= 0 && firstEscapeIndexVal < utf8Value.Length);
+
+            byte[] valueArray = null;
+
+            int length = JsonWriterHelper.GetMaxEscapedLength(utf8Value.Length, firstEscapeIndexVal);
+
+            Span<byte> escapedValue = length <= JsonConstants.StackallocThreshold ?
+                stackalloc byte[length] :
+                (valueArray = ArrayPool<byte>.Shared.Rent(length));
+
+            JsonWriterHelper.EscapeString(utf8Value, escapedValue, firstEscapeIndexVal, out int written);
+
+            byte[] escapedString = escapedValue.Slice(0, written).ToArray();
+
+            if (valueArray != null)
+            {
+                ArrayPool<byte>.Shared.Return(valueArray);
+            }
+
+            return escapedString;
+        }
+
+        public bool Equals(JsonEncodedText other)
+        {
+            if (_value == null)
+            {
+                return other._value == null;
+            }
+            else
+            {
+                return _value.Equals(other._value);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is JsonEncodedText encodedText)
+            {
+                return Equals(encodedText);
+            }
+            return false;
+        }
+
+        public override string ToString()
+            => _value ?? string.Empty;
+
+        public override int GetHashCode()
+            => _value == null ? 0 : _value.GetHashCode();
+    }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -94,7 +94,7 @@ namespace System.Text.Json.Serialization
         {
             Debug.Assert(type != null || value == null);
 
-            var writer = new Utf8JsonWriter(output, options.GetWriterOptions());
+            using var writer = new Utf8JsonWriter(output, options.GetWriterOptions());
 
             if (value == null)
             {

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -373,12 +373,12 @@ namespace System.Text.Json
                 builder.Append("...");
             }
 
-            throw new ArgumentException(SR.Format(SR.CannotWriteInvalidUTF8, builder));
+            throw new ArgumentException(SR.Format(SR.CannotEncodeInvalidUTF8, builder));
         }
 
         public static void ThrowArgumentException_InvalidUTF16(int charAsInt)
         {
-            throw new ArgumentException(SR.Format(SR.CannotWriteInvalidUTF16, $"0x{charAsInt:X2}"));
+            throw new ArgumentException(SR.Format(SR.CannotEncodeInvalidUTF16, $"0x{charAsInt:X2}"));
         }
 
         public static void ThrowInvalidOperationException_ReadInvalidUTF16(int charAsInt)
@@ -394,6 +394,11 @@ namespace System.Text.Json
         public static InvalidOperationException GetInvalidOperationException_ReadInvalidUTF8(DecoderFallbackException innerException)
         {
             return new InvalidOperationException(SR.CannotTranscodeInvalidUtf8, innerException);
+        }
+
+        public static ArgumentException GetArgumentException_ReadInvalidUTF16(EncoderFallbackException innerException)
+        {
+            return new ArgumentException(SR.CannotTranscodeInvalidUtf16, innerException);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -116,6 +116,13 @@ namespace System.Text.Json
             }
         }
 
+        public static void ThrowInvalidOperationException(int currentDepth)
+        {
+            currentDepth &= JsonConstants.RemoveFlagsBitMask;
+            Debug.Assert(currentDepth >= JsonConstants.MaxWriterDepth);
+            ThrowInvalidOperationException(SR.Format(SR.DepthTooLarge, currentDepth, JsonConstants.MaxWriterDepth));
+        }
+
         public static void ThrowInvalidOperationException(string message)
         {
             throw GetInvalidOperationException(message);

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
@@ -10,6 +10,20 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="DateTime"/> value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a JSON string as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="DateTime"/> using the round-trippable ('O') <see cref="StandardFormat"/> , for example: 2017-06-12T05:30:45.7680000.
+        /// </remarks>
         public void WriteString(JsonEncodedText propertyName, DateTime value)
             => WriteStringHelper(propertyName.EncodedUtf8Bytes, value);
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
@@ -10,6 +10,19 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        public void WriteString(JsonEncodedText propertyName, DateTime value)
+            => WriteStringHelper(propertyName.EncodedUtf8Bytes, value);
+
+        private void WriteStringHelper(ReadOnlySpan<byte> utf8PropertyName, DateTime value)
+        {
+            Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxTokenSize);
+
+            WriteStringByOptions(utf8PropertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.String;
+        }
+
         /// <summary>
         /// Writes the property name and <see cref="DateTime"/> value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -10,6 +10,19 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        public void WriteString(JsonEncodedText propertyName, DateTimeOffset value)
+            => WriteStringHelper(propertyName.EncodedUtf8Bytes, value);
+
+        private void WriteStringHelper(ReadOnlySpan<byte> utf8PropertyName, DateTimeOffset value)
+        {
+            Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxTokenSize);
+
+            WriteStringByOptions(utf8PropertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.String;
+        }
+
         /// <summary>
         /// Writes the property name and <see cref="DateTimeOffset"/> value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -10,6 +10,20 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="DateTimeOffset"/> value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a JSON string as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="DateTimeOffset"/> using the round-trippable ('O') <see cref="StandardFormat"/> , for example: 2017-06-12T05:30:45.7680000-07:00.
+        /// </remarks>
         public void WriteString(JsonEncodedText propertyName, DateTimeOffset value)
             => WriteStringHelper(propertyName.EncodedUtf8Bytes, value);
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Decimal.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Decimal.cs
@@ -10,6 +10,19 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        public void WriteNumber(JsonEncodedText propertyName, decimal value)
+            => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
+
+        private void WriteNumberHelper(ReadOnlySpan<byte> utf8PropertyName, decimal value)
+        {
+            Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxTokenSize);
+
+            WriteNumberByOptions(utf8PropertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.Number;
+        }
+
         /// <summary>
         /// Writes the property name and <see cref="decimal"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Decimal.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Decimal.cs
@@ -10,6 +10,20 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="decimal"/> value (as a JSON number) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="decimal"/> using the default <see cref="StandardFormat"/> (i.e. 'G').
+        /// </remarks>
         public void WriteNumber(JsonEncodedText propertyName, decimal value)
             => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
@@ -10,6 +10,20 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="double"/> value (as a JSON number) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="double"/> using the default <see cref="StandardFormat"/> (i.e. 'G').
+        /// </remarks>
         public void WriteNumber(JsonEncodedText propertyName, double value)
             => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
@@ -10,6 +10,21 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        public void WriteNumber(JsonEncodedText propertyName, double value)
+            => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
+
+        private void WriteNumberHelper(ReadOnlySpan<byte> utf8PropertyName, double value)
+        {
+            Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxTokenSize);
+
+            JsonWriterHelper.ValidateDouble(value);
+
+            WriteNumberByOptions(utf8PropertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.Number;
+        }
+
         /// <summary>
         /// Writes the property name and <see cref="double"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
@@ -10,6 +10,20 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="float"/> value (as a JSON number) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="float"/> using the default <see cref="StandardFormat"/> (i.e. 'G').
+        /// </remarks>
         public void WriteNumber(JsonEncodedText propertyName, float value)
             => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
@@ -10,6 +10,21 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        public void WriteNumber(JsonEncodedText propertyName, float value)
+            => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
+
+        private void WriteNumberHelper(ReadOnlySpan<byte> utf8PropertyName, float value)
+        {
+            Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxTokenSize);
+
+            JsonWriterHelper.ValidateSingle(value);
+
+            WriteNumberByOptions(utf8PropertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.Number;
+        }
+
         /// <summary>
         /// Writes the property name and <see cref="float"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
@@ -10,6 +10,20 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="Guid"/> value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a JSON string as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="Guid"/> using the default <see cref="StandardFormat"/> (i.e. 'D'), as the form: nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn.
+        /// </remarks>
         public void WriteString(JsonEncodedText propertyName, Guid value)
             => WriteStringHelper(propertyName.EncodedUtf8Bytes, value);
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
@@ -10,6 +10,19 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        public void WriteString(JsonEncodedText propertyName, Guid value)
+            => WriteStringHelper(propertyName.EncodedUtf8Bytes, value);
+
+        private void WriteStringHelper(ReadOnlySpan<byte> utf8PropertyName, Guid value)
+        {
+            Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxTokenSize);
+
+            WriteStringByOptions(utf8PropertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.String;
+        }
+
         /// <summary>
         /// Writes the property name and <see cref="Guid"/> value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Helpers.cs
@@ -26,6 +26,13 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ValidateDepth()
+        {
+            if (CurrentDepth >= JsonConstants.MaxWriterDepth)
+                ThrowHelper.ThrowInvalidOperationException(_currentDepth);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ValidateWritingProperty()
         {
             if (!Options.SkipValidation)

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Literal.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Literal.cs
@@ -9,6 +9,21 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        public void WriteNull(JsonEncodedText propertyName)
+        {
+            WriteLiteralHelper(propertyName.EncodedUtf8Bytes, JsonConstants.NullValue);
+            _tokenType = JsonTokenType.Null;
+        }
+
+        private void WriteLiteralHelper(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> value)
+        {
+            Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxTokenSize);
+
+            WriteLiteralByOptions(utf8PropertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+        }
+
         /// <summary>
         /// Writes the property name and the JSON literal "null" as part of a name/value pair of a JSON object.
         /// </summary>
@@ -73,6 +88,20 @@ namespace System.Text.Json
 
             SetFlagToAddListSeparatorBeforeNextItem();
             _tokenType = JsonTokenType.Null;
+        }
+
+        public void WriteBoolean(JsonEncodedText propertyName, bool value)
+        {
+            if (value)
+            {
+                WriteLiteralHelper(propertyName.EncodedUtf8Bytes, JsonConstants.TrueValue);
+                _tokenType = JsonTokenType.True;
+            }
+            else
+            {
+                WriteLiteralHelper(propertyName.EncodedUtf8Bytes, JsonConstants.FalseValue);
+                _tokenType = JsonTokenType.False;
+            }
         }
 
         /// <summary>

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Literal.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Literal.cs
@@ -9,6 +9,16 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        /// <summary>
+        /// Writes the pre-encoded property name and the JSON literal "null" as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteNull(JsonEncodedText propertyName)
         {
             WriteLiteralHelper(propertyName.EncodedUtf8Bytes, JsonConstants.NullValue);
@@ -90,6 +100,17 @@ namespace System.Text.Json
             _tokenType = JsonTokenType.Null;
         }
 
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="bool"/> value (as a JSON literal "true" or "false") as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a JSON literal "true" or "false" as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteBoolean(JsonEncodedText propertyName, bool value)
         {
             if (value)

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
@@ -10,6 +10,19 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        public void WriteNumber(JsonEncodedText propertyName, long value)
+            => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
+
+        private void WriteNumberHelper(ReadOnlySpan<byte> utf8PropertyName, long value)
+        {
+            Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxTokenSize);
+
+            WriteNumberByOptions(utf8PropertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.Number;
+        }
+
         /// <summary>
         /// Writes the property name and <see cref="long"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
@@ -83,6 +96,9 @@ namespace System.Text.Json
             SetFlagToAddListSeparatorBeforeNextItem();
             _tokenType = JsonTokenType.Number;
         }
+
+        public void WriteNumber(JsonEncodedText propertyName, int value)
+            => WriteNumber(propertyName, (long)value);
 
         /// <summary>
         /// Writes the property name and <see cref="int"/> value (as a JSON number) as part of a name/value pair of a JSON object.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
@@ -10,6 +10,20 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="long"/> value (as a JSON number) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="long"/> using the default <see cref="StandardFormat"/> (i.e. 'G'), for example: 32767.
+        /// </remarks>
         public void WriteNumber(JsonEncodedText propertyName, long value)
             => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
 
@@ -97,6 +111,20 @@ namespace System.Text.Json
             _tokenType = JsonTokenType.Number;
         }
 
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="int"/> value (as a JSON number) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="int"/> using the default <see cref="StandardFormat"/> (i.e. 'G'), for example: 32767.
+        /// </remarks>
         public void WriteNumber(JsonEncodedText propertyName, int value)
             => WriteNumber(propertyName, (long)value);
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
@@ -9,6 +9,17 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        /// <summary>
+        /// Writes the pre-encoded property name and pre-encoded value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The JSON encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name and value should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteString(JsonEncodedText propertyName, JsonEncodedText value)
             => WriteStringHelper(propertyName.EncodedUtf8Bytes, value.EncodedUtf8Bytes);
 
@@ -22,6 +33,20 @@ namespace System.Text.Json
             _tokenType = JsonTokenType.String;
         }
 
+        /// <summary>
+        /// Writes the property name and pre-encoded value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The JSON encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <remarks>
+        /// The value should already be escaped when the instance of <see cref="JsonEncodedText"/> was created. The property name is escaped before writing.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified property name is too large.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteString(string propertyName, JsonEncodedText value)
             => WriteString(propertyName.AsSpan(), value);
 
@@ -90,9 +115,37 @@ namespace System.Text.Json
             _tokenType = JsonTokenType.String;
         }
 
+        /// <summary>
+        /// Writes the pre-encoded property name and string text value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created. The value is escaped before writing.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified value is too large.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteString(JsonEncodedText propertyName, string value)
             => WriteString(propertyName, value.AsSpan());
 
+        /// <summary>
+        /// Writes the pre-encoded property name and UTF-16 text value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created. The value is escaped before writing.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified value is too large.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteString(JsonEncodedText propertyName, ReadOnlySpan<char> value)
             => WriteStringHelperEscapeValue(propertyName.EncodedUtf8Bytes, value);
 
@@ -160,6 +213,20 @@ namespace System.Text.Json
             _tokenType = JsonTokenType.String;
         }
 
+        /// <summary>
+        /// Writes the pre-encoded property name and UTF-8 text value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="utf8Value">The UTF-8 encoded value to be written as a JSON string as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created. The value is escaped before writing.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified value is too large.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteString(JsonEncodedText propertyName, ReadOnlySpan<byte> utf8Value)
             => WriteStringHelperEscapeValue(propertyName.EncodedUtf8Bytes, utf8Value);
 
@@ -227,6 +294,20 @@ namespace System.Text.Json
             _tokenType = JsonTokenType.String;
         }
 
+        /// <summary>
+        /// Writes the UTF-16 property name and pre-encoded value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The JSON encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <remarks>
+        /// The value should already be escaped when the instance of <see cref="JsonEncodedText"/> was created. The property name is escaped before writing.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified property name is too large.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteString(ReadOnlySpan<char> propertyName, JsonEncodedText value)
             => WriteStringHelperEscapeProperty(propertyName, value.EncodedUtf8Bytes);
 
@@ -270,6 +351,20 @@ namespace System.Text.Json
         public void WriteString(ReadOnlySpan<char> propertyName, string value)
             => WriteString(propertyName, value.AsSpan());
 
+        /// <summary>
+        /// Writes the UTF-8 property name and pre-encoded value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="utf8PropertyName">The UTF-8 encoded property name of the JSON object to be written.</param>
+        /// <param name="value">The JSON encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <remarks>
+        /// The value should already be escaped when the instance of <see cref="JsonEncodedText"/> was created. The property name is escaped before writing.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the specified property name is too large.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteString(ReadOnlySpan<byte> utf8PropertyName, JsonEncodedText value)
             => WriteStringHelperEscapeProperty(utf8PropertyName, value.EncodedUtf8Bytes);
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.UnsignedNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.UnsignedNumber.cs
@@ -10,6 +10,20 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        [CLSCompliant(false)]
+        public void WriteNumber(JsonEncodedText propertyName, ulong value)
+            => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
+
+        private void WriteNumberHelper(ReadOnlySpan<byte> utf8PropertyName, ulong value)
+        {
+            Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxTokenSize);
+
+            WriteNumberByOptions(utf8PropertyName, value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.Number;
+        }
+
         /// <summary>
         /// Writes the property name and <see cref="ulong"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
@@ -86,6 +100,10 @@ namespace System.Text.Json
             SetFlagToAddListSeparatorBeforeNextItem();
             _tokenType = JsonTokenType.Number;
         }
+
+        [CLSCompliant(false)]
+        public void WriteNumber(JsonEncodedText propertyName, uint value)
+            => WriteNumber(propertyName, (ulong)value);
 
         /// <summary>
         /// Writes the property name and <see cref="uint"/> value (as a JSON number) as part of a name/value pair of a JSON object.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.UnsignedNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.UnsignedNumber.cs
@@ -10,6 +10,20 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="ulong"/> value (as a JSON number) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="ulong"/> using the default <see cref="StandardFormat"/> (i.e. 'G'), for example: 32767.
+        /// </remarks>
         [CLSCompliant(false)]
         public void WriteNumber(JsonEncodedText propertyName, ulong value)
             => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
@@ -101,6 +115,20 @@ namespace System.Text.Json
             _tokenType = JsonTokenType.Number;
         }
 
+        /// <summary>
+        /// Writes the pre-encoded property name and <see cref="uint"/> value (as a JSON number) as part of a name/value pair of a JSON object.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
+        /// <remarks>
+        /// Writes the <see cref="uint"/> using the default <see cref="StandardFormat"/> (i.e. 'G'), for example: 32767.
+        /// </remarks>
         [CLSCompliant(false)]
         public void WriteNumber(JsonEncodedText propertyName, uint value)
             => WriteNumber(propertyName, (ulong)value);

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
@@ -9,6 +9,16 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        /// <summary>
+        /// Writes the pre-encoded text value (as a JSON string) as an element of a JSON array.
+        /// </summary>
+        /// <param name="value">The JSON encoded value to be written as a UTF-8 transcoded JSON string element of a JSON array.</param>
+        /// <remarks>
+        /// The value should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteStringValue(JsonEncodedText value)
             => WriteStringValueHelper(value.EncodedUtf8Bytes);
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
@@ -9,6 +9,19 @@ namespace System.Text.Json
 {
     public sealed partial class Utf8JsonWriter
     {
+        public void WriteStringValue(JsonEncodedText value)
+            => WriteStringValueHelper(value.EncodedUtf8Bytes);
+
+        private void WriteStringValueHelper(ReadOnlySpan<byte> utf8Value)
+        {
+            Debug.Assert(utf8Value.Length <= JsonConstants.MaxTokenSize);
+
+            WriteStringByOptions(utf8Value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.String;
+        }
+
         /// <summary>
         /// Writes the string text value (as a JSON string) as an element of a JSON array.
         /// </summary>

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -548,12 +548,34 @@ namespace System.Text.Json
             output[BytesPending++] = token;
         }
 
+        /// <summary>
+        /// Writes the beginning of a JSON array with a pre-encoded property name as the key.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON array to be transcoded and written as UTF-8.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the depth of the JSON has exceeded the maximum depth of 1000 
+        /// OR if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteStartArray(JsonEncodedText propertyName)
         {
             WriteStartHelper(propertyName.EncodedUtf8Bytes, JsonConstants.OpenBracket);
             _tokenType = JsonTokenType.StartArray;
         }
 
+        /// <summary>
+        /// Writes the beginning of a JSON object with a pre-encoded property name as the key.
+        /// </summary>
+        /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <remarks>
+        /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the depth of the JSON has exceeded the maximum depth of 1000 
+        /// OR if this would result in an invalid JSON to be written (while validation is enabled).
+        /// </exception>
         public void WriteStartObject(JsonEncodedText propertyName)
         {
             WriteStartHelper(propertyName.EncodedUtf8Bytes, JsonConstants.OpenBrace);

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -548,6 +548,31 @@ namespace System.Text.Json
             output[BytesPending++] = token;
         }
 
+        public void WriteStartArray(JsonEncodedText propertyName)
+        {
+            WriteStartHelper(propertyName.EncodedUtf8Bytes, JsonConstants.OpenBracket);
+            _tokenType = JsonTokenType.StartArray;
+        }
+
+        public void WriteStartObject(JsonEncodedText propertyName)
+        {
+            WriteStartHelper(propertyName.EncodedUtf8Bytes, JsonConstants.OpenBrace);
+            _tokenType = JsonTokenType.StartObject;
+        }
+
+        private void WriteStartHelper(ReadOnlySpan<byte> utf8PropertyName, byte token)
+        {
+            Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxTokenSize);
+
+            ValidateDepth();
+
+            WriteStartByOptions(utf8PropertyName, token);
+
+            _currentDepth &= JsonConstants.RemoveFlagsBitMask;
+            _currentDepth++;
+            _isNotPrimitive = true;
+        }
+
         /// <summary>
         /// Writes the beginning of a JSON array with a property name as the key.
         /// </summary>

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -1437,7 +1437,7 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void CheckInvalidString()
         {
-            Assert.Throws<EncoderFallbackException>(() => JsonDocument.Parse("{ \"unpaired\uDFFE\": true }"));
+            Assert.Throws<ArgumentException>(() => JsonDocument.Parse("{ \"unpaired\uDFFE\": true }"));
         }
 
         [Theory]
@@ -1750,6 +1750,17 @@ namespace System.Text.Json.Tests
                 AssertExtensions.Throws<ArgumentNullException>(
                     "propertyName",
                     () => doc.RootElement.TryGetProperty((string)null, out _));
+            }
+        }
+
+        [Fact]
+        public static void GetPropertyInvalidUtf16()
+        {
+            using (JsonDocument doc = JsonDocument.Parse("{\"name\":\"value\"}"))
+            {
+                Assert.Throws<ArgumentException>(() => doc.RootElement.GetProperty("unpaired\uDFFE"));
+
+                Assert.Throws<ArgumentException>(() => doc.RootElement.TryGetProperty("unpaired\uDFFE", out _));
             }
         }
 

--- a/src/System.Text.Json/tests/JsonEncodedTextTests.cs
+++ b/src/System.Text.Json/tests/JsonEncodedTextTests.cs
@@ -43,7 +43,7 @@ namespace System.Text.Json.Tests
             JsonEncodedText text = JsonEncodedText.Encode(message);
             JsonEncodedText textCopy = text;
             JsonEncodedText textDuplicate = JsonEncodedText.Encode(message);
-            JsonEncodedText textDuplicateDiffStringRef = JsonEncodedText.Encode("message");
+            JsonEncodedText textDuplicateDiffStringRef = JsonEncodedText.Encode(string.Concat("mess", "age"));
             JsonEncodedText differentText = JsonEncodedText.Encode("message1");
 
             Assert.True(text.Equals(text));
@@ -69,7 +69,7 @@ namespace System.Text.Json.Tests
             JsonEncodedText text = JsonEncodedText.Encode(message);
             object textCopy = text;
             object textDuplicate = JsonEncodedText.Encode(message);
-            object textDuplicateDiffStringRef = JsonEncodedText.Encode("message");
+            object textDuplicateDiffStringRef = JsonEncodedText.Encode(string.Concat("mess", "age"));
             object differentText = JsonEncodedText.Encode("message1");
 
             Assert.True(text.Equals(text));
@@ -97,7 +97,7 @@ namespace System.Text.Json.Tests
             JsonEncodedText text = JsonEncodedText.Encode(message);
             JsonEncodedText textCopy = text;
             JsonEncodedText textDuplicate = JsonEncodedText.Encode(message);
-            JsonEncodedText textDuplicateDiffStringRef = JsonEncodedText.Encode("message");
+            JsonEncodedText textDuplicateDiffStringRef = JsonEncodedText.Encode(string.Concat("mess", "age"));
             JsonEncodedText differentText = JsonEncodedText.Encode("message1");
 
             int expectedHashCode = text.GetHashCode();
@@ -135,15 +135,15 @@ namespace System.Text.Json.Tests
         {
             {
                 var message = new string('a', stringLength);
-                var expectedMessge = new string('a', stringLength);
+                var expectedMessage = new string('a', stringLength);
 
                 JsonEncodedText text = JsonEncodedText.Encode(message);
                 JsonEncodedText textSpan = JsonEncodedText.Encode(message.AsSpan());
                 JsonEncodedText textUtf8Span = JsonEncodedText.Encode(Encoding.UTF8.GetBytes(message));
 
-                Assert.Equal(expectedMessge, text.ToString());
-                Assert.Equal(expectedMessge, textSpan.ToString());
-                Assert.Equal(expectedMessge, textUtf8Span.ToString());
+                Assert.Equal(expectedMessage, text.ToString());
+                Assert.Equal(expectedMessage, textSpan.ToString());
+                Assert.Equal(expectedMessage, textUtf8Span.ToString());
 
                 Assert.True(text.Equals(textSpan));
                 Assert.True(text.Equals(textUtf8Span));
@@ -157,15 +157,15 @@ namespace System.Text.Json.Tests
                 {
                     builder.Append("\\u003e");
                 }
-                string expectedMessge = builder.ToString();
+                string expectedMessage = builder.ToString();
 
                 JsonEncodedText text = JsonEncodedText.Encode(message);
                 JsonEncodedText textSpan = JsonEncodedText.Encode(message.AsSpan());
                 JsonEncodedText textUtf8Span = JsonEncodedText.Encode(Encoding.UTF8.GetBytes(message));
 
-                Assert.Equal(expectedMessge, text.ToString());
-                Assert.Equal(expectedMessge, textSpan.ToString());
-                Assert.Equal(expectedMessge, textUtf8Span.ToString());
+                Assert.Equal(expectedMessage, text.ToString());
+                Assert.Equal(expectedMessage, textSpan.ToString());
+                Assert.Equal(expectedMessage, textUtf8Span.ToString());
 
                 Assert.True(text.Equals(textSpan));
                 Assert.True(text.Equals(textUtf8Span));

--- a/src/System.Text.Json/tests/JsonEncodedTextTests.cs
+++ b/src/System.Text.Json/tests/JsonEncodedTextTests.cs
@@ -110,10 +110,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("", "")]
-        [InlineData("message", "message")]
-        [InlineData("mess\"age", "mess\\u0022age")]
-        [InlineData(">>>>>", "\\u003e\\u003e\\u003e\\u003e\\u003e")]
+        [MemberData(nameof(JsonEncodedTextStrings))]
         public static void ToStringTest(string message, string expectedMessage)
         {
             JsonEncodedText text = JsonEncodedText.Encode(message);
@@ -131,7 +128,6 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData(10)]
         [InlineData(100)]
         [InlineData(1_000)]
         [InlineData(10_000)]
@@ -179,10 +175,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("", "")]
-        [InlineData("message", "message")]
-        [InlineData("mess\"age", "mess\\u0022age")]
-        [InlineData(">>>>>", "\\u003e\\u003e\\u003e\\u003e\\u003e")]
+        [MemberData(nameof(JsonEncodedTextStrings))]
         public static void GetUtf8BytesTest(string message, string expectedMessage)
         {
             byte[] expectedBytes = Encoding.UTF8.GetBytes(expectedMessage);
@@ -202,7 +195,6 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData(10)]
         [InlineData(100)]
         [InlineData(1_000)]
         [InlineData(10_000)]
@@ -310,6 +302,22 @@ namespace System.Text.Json.Tests
                     new object[] { new byte[] { 34, 97, 0xf0, 0x28, 0x8c, 0xbc, 98, 34 } },
                     new object[] { new byte[] { 34, 97, 0xf0, 0x90, 0x28, 0xbc, 98, 34 } },
                     new object[] { new byte[] { 34, 97, 0xf0, 0x28, 0x8c, 0x28, 98, 34 } },
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> JsonEncodedTextStrings
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] {"", "" },
+                    new object[] { "message", "message" },
+                    new object[] { "mess\"age", "mess\\u0022age" },
+                    new object[] { "mess\\u0022age", "mess\\\\u0022age" },
+                    new object[] { ">>>>>", "\\u003e\\u003e\\u003e\\u003e\\u003e" },
+                    new object[] { "\\u003e\\u003e\\u003e\\u003e\\u003e", "\\\\u003e\\\\u003e\\\\u003e\\\\u003e\\\\u003e" },
                 };
             }
         }

--- a/src/System.Text.Json/tests/JsonEncodedTextTests.cs
+++ b/src/System.Text.Json/tests/JsonEncodedTextTests.cs
@@ -22,6 +22,17 @@ namespace System.Text.Json.Tests
             JsonEncodedText defaultText = default;
             object obj = defaultText;
             Assert.True(text.Equals(obj));
+
+            JsonEncodedText textByteEmpty = JsonEncodedText.Encode(Array.Empty<byte>());
+            Assert.True(textByteEmpty.EncodedUtf8Bytes.IsEmpty);
+            Assert.Equal("", textByteEmpty.ToString());
+
+            JsonEncodedText textCharEmpty = JsonEncodedText.Encode(Array.Empty<char>());
+            Assert.True(textCharEmpty.EncodedUtf8Bytes.IsEmpty);
+            Assert.Equal("", textCharEmpty.ToString());
+
+            Assert.True(textCharEmpty.Equals(textByteEmpty));
+            Assert.Equal(textByteEmpty.GetHashCode(), textCharEmpty.GetHashCode());
         }
 
         [Fact]
@@ -270,6 +281,7 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
+        [OuterLoop]
         public static void InvalidLargeEncode()
         {
             char[] largeValue = new char[400_000_000];

--- a/src/System.Text.Json/tests/JsonEncodedTextTests.cs
+++ b/src/System.Text.Json/tests/JsonEncodedTextTests.cs
@@ -18,10 +18,14 @@ namespace System.Text.Json.Tests
             Assert.Equal(0, text.GetHashCode());
             Assert.Equal("", text.ToString());
             Assert.True(text.Equals(default));
+            Assert.True(text.Equals(text));
+            Assert.False(text.Equals(null));
 
             JsonEncodedText defaultText = default;
             object obj = defaultText;
             Assert.True(text.Equals(obj));
+            Assert.True(text.Equals(defaultText));
+            Assert.True(defaultText.Equals(text));
 
             JsonEncodedText textByteEmpty = JsonEncodedText.Encode(Array.Empty<byte>());
             Assert.True(textByteEmpty.EncodedUtf8Bytes.IsEmpty);

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -14,6 +14,7 @@
     <Compile Include="InvalidBufferWriter.cs" />
     <Compile Include="JsonDateTimeTestData.cs" />
     <Compile Include="JsonDocumentTests.cs" />
+    <Compile Include="JsonEncodedTextTests.cs" />
     <Compile Include="JsonElementCloneTests.cs" />
     <Compile Include="JsonElementWriteTests.cs" />
     <Compile Include="JsonGuidTestData.cs" />

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -14,9 +14,9 @@
     <Compile Include="InvalidBufferWriter.cs" />
     <Compile Include="JsonDateTimeTestData.cs" />
     <Compile Include="JsonDocumentTests.cs" />
-    <Compile Include="JsonEncodedTextTests.cs" />
     <Compile Include="JsonElementCloneTests.cs" />
     <Compile Include="JsonElementWriteTests.cs" />
+    <Compile Include="JsonEncodedTextTests.cs" />
     <Compile Include="JsonGuidTestData.cs" />
     <Compile Include="JsonNumberTestData.cs" />
     <Compile Include="JsonReaderStateAndOptionsTests.cs" />


### PR DESCRIPTION
Addresses parts of https://github.com/dotnet/corefx/issues/37192.

**TODO:**
- ~Add XML comments to public surface area (WIP - this PR)~
- Add JavascriptEncoder extension point (Subsequent PR)
   - Change Encode methods to accept an optional `JavascriptEncoder`
  - Add `JavascriptEncoder` to `JsonWriterOptions`
  - Add  `JavascriptEncoder` to `JsonSerializerOptions`
  - Depends on `TextEncoder`/`JavaScriptEncoder` being in-box

cc @GrabYourPitchforks, @bartonjs, @steveharter, @stephentoub, @ycrumeyrolle, @KrzysztofCwalina, @BrennanConroy, @JeremyKuhne, @layomia 