### PR TITLE
Use Dns.GetHostAddresses in Socket.Connect

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -899,7 +899,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                IPAddress[] addresses = Dns.GetHostAddressesAsync(host).GetAwaiter().GetResult();
+                IPAddress[] addresses = Dns.GetHostAddresses(host);
                 Connect(addresses, port);
             }
 


### PR DESCRIPTION
Replace `Dns.GetHostAddressesAsync` with `Dns.GetHostAddresses` in Socket.Connect.

`Dns.GetHostAddressesAsync(host).GetAwaiter().GetResult()` was born at 6/10/2016 in `Socket.Connect(string host, int port)`. `Dns.GetHostAddresses` was born at 9/23/2016 in System.Net.NameResolution. It's time to ring out the old and ring in the new.