### PR TITLE
Fix two more System.Net async instead of sync calls

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -327,7 +327,7 @@ namespace System.Net.Sockets
             IPEndPoint ipEndPoint = null;
             if (hostname != null && port != 0)
             {
-                IPAddress[] addresses = Dns.GetHostAddressesAsync(hostname).GetAwaiter().GetResult();
+                IPAddress[] addresses = Dns.GetHostAddresses(hostname);
 
                 int i = 0;
                 for (; i < addresses.Length && !IsAddressFamilyCompatible(addresses[i].AddressFamily); i++)

--- a/src/System.Net.WebProxy/src/System/Net/WebProxy.cs
+++ b/src/System.Net.WebProxy/src/System/Net/WebProxy.cs
@@ -184,7 +184,7 @@ namespace System.Net
             // Perf note: The .NET Framework caches this and then uses network change notifications to track
             // whether the set should be recomputed.  We could consider doing the same if this is observed as
             // a bottleneck, but that tracking has its own costs.
-            IPAddress[] localAddresses = Dns.GetHostEntryAsync(Dns.GetHostName()).GetAwaiter().GetResult().AddressList; // TODO: Use synchronous GetHostEntry when available
+            IPAddress[] localAddresses = Dns.GetHostEntry(Dns.GetHostName()).AddressList;
             for (int i = 0; i < localAddresses.Length; i++)
             {
                 if (ipAddress.Equals(localAddresses[i]))


### PR DESCRIPTION
These were written as sync-over-async before the sync APIs were available.  Now that the sync APIs are available, use them.

Follow-up to https://github.com/dotnet/corefx/pull/37324.

cc: @davidsh, @wfurt