### PR TITLE
Delete stale compilation constants from AsyncIteratorMethodBuilder

### DIFF
--- a/src/Common/src/CoreLib/System/Runtime/CompilerServices/AsyncIteratorMethodBuilder.cs
+++ b/src/Common/src/CoreLib/System/Runtime/CompilerServices/AsyncIteratorMethodBuilder.cs
@@ -42,11 +42,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="stateMachine">The state machine instance, passed by reference.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void MoveNext<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine =>
-#if CORERT || MICROSOFT_BCL_ASYNCINTERFACES_PACKAGE
-            _methodBuilder.Start(ref stateMachine);
-#else
             AsyncMethodBuilderCore.Start(ref stateMachine);
-#endif
 
         /// <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
         /// <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
@@ -71,9 +67,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>Marks iteration as being completed, whether successfully or otherwise.</summary>
         public void Complete() => _methodBuilder.SetResult();
 
-#if !MICROSOFT_BCL_ASYNCINTERFACES_PACKAGE
         /// <summary>Gets an object that may be used to uniquely identify this builder to the debugger.</summary>
         internal object ObjectIdForDebugger => _methodBuilder.ObjectIdForDebugger;
-#endif
     }
 }


### PR DESCRIPTION
I accidentally left these MICROSOFT_BCL_ASYNCINTERFACES_PACKAGE references in as part of some recent churn.  This compilation constant isn't set anywhere.

And the CORERT ifdef is no longer needed now that we've consolidated the code to shared.

cc: @jkotas