### PR TITLE
Send to helix only when previous steps succeeded

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -190,7 +190,7 @@ jobs:
             - template: /eng/pipelines/helix.yml
               parameters:
                 # send tests to helix only on public builds, official scheduled builds or manual official builds.
-                condition: ${{ or(eq(parameters.isOfficialBuild, 'false'), notIn(variables['Build.Reason'], 'BatchedCI', 'IndividualCI')) }}
+                condition: or(eq(${{ parameters.isOfficialBuild }}, 'false'), notIn(variables['Build.Reason'], 'BatchedCI', 'IndividualCI'))
                 targetOS: ${{ parameters.targetOS }}
                 archGroup: $(_architecture)
                 configuration: $(_BuildConfig)

--- a/eng/pipelines/helix.yml
+++ b/eng/pipelines/helix.yml
@@ -33,6 +33,6 @@ steps:
             /p:EnableAzurePipelinesReporter=${{ parameters.enableAzurePipelinesReporter }}
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/SendToHelix.binlog
     displayName: Send to Helix
-    condition: ${{ parameters.condition }}
+    condition: and(succeeded(), ${{ parameters.condition }})
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops


### PR DESCRIPTION
I missed the succeeded evaluation in the send to helix step, so if something previously like restore or build sources failed, it will try to send to helix and it will fail, poluting the build logs.

cc: @ViktorHofer 