### PR TITLE
Implement HttpClient.DefaultProxy property

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/HttpWindowsProxyTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/HttpWindowsProxyTest.cs
@@ -9,14 +9,14 @@ using Xunit.Abstractions;
 
 namespace System.Net.Http.WinHttpHandlerUnitTests
 {
-    public class HttpSystemProxyTest
+    public class HttpWindowsProxyTest
     {
         private const string ManualSettingsProxyHost = "myproxy.local";
         private const string ManualSettingsProxyBypassList = "localhost;*.local";
 
         private readonly ITestOutputHelper _output;
 
-        public HttpSystemProxyTest(ITestOutputHelper output)
+        public HttpWindowsProxyTest(ITestOutputHelper output)
         {
             _output = output;
             TestControl.ResetAll();
@@ -32,7 +32,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         [Fact]
         public void TryCreate_WinInetProxySettingsAllOff_ReturnsFalse()
         {
-            Assert.False(HttpSystemProxy.TryCreate(out IWebProxy webProxy));
+            Assert.False(HttpWindowsProxy.TryCreate(out IWebProxy webProxy));
         }
 
         [Theory]
@@ -45,13 +45,13 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             FakeRegistry.WinInetProxySettings.ProxyBypass = ManualSettingsProxyBypassList;
             TestControl.PACFileNotDetectedOnNetwork = true;
 
-            Assert.True(HttpSystemProxy.TryCreate(out IWebProxy webProxy));
+            Assert.True(HttpWindowsProxy.TryCreate(out IWebProxy webProxy));
             
             // The first GetProxy() call will try using WinInetProxyHelper (and thus WinHTTP) since AutoDetect is on.
             Uri proxyUri1 = webProxy.GetProxy(destination);
             
             // The second GetProxy call will skip using WinHTTP since AutoDetect is on but
-            // there was a recent AutoDetect failure. This tests the codepath in HttpSystemProxy
+            // there was a recent AutoDetect failure. This tests the codepath in HttpWindowsProxy
             // which queries WinInetProxyHelper.RecentAutoDetectionFailure.
             Uri proxyUri2 = webProxy.GetProxy(destination);
 
@@ -75,7 +75,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             FakeRegistry.WinInetProxySettings.Proxy = ManualSettingsProxyHost;
             FakeRegistry.WinInetProxySettings.ProxyBypass = ManualSettingsProxyBypassList;
 
-            Assert.True(HttpSystemProxy.TryCreate(out IWebProxy webProxy));
+            Assert.True(HttpWindowsProxy.TryCreate(out IWebProxy webProxy));
             Uri proxyUri = webProxy.GetProxy(destination);
             if (bypassProxy)
             {
@@ -91,7 +91,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         public void IsBypassed_ReturnsFalse()
         {
             FakeRegistry.WinInetProxySettings.AutoDetect = true;
-            Assert.True(HttpSystemProxy.TryCreate(out IWebProxy webProxy));
+            Assert.True(HttpWindowsProxy.TryCreate(out IWebProxy webProxy));
             Assert.False(webProxy.IsBypassed(new Uri("http://www.microsoft.com/")));
         }
     }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -127,8 +127,8 @@
     <Compile Include="..\..\src\System\Net\Http\WinInetProxyHelper.cs">
       <Link>ProductionCode\WinInetProxyHelper.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\HttpSystemProxy.cs">
-      <Link>ProductionCode\HttpSystemProxy.cs</Link>
+    <Compile Include="..\..\..\System.Net.Http\src\System\Net\Http\SocketsHttpHandler\HttpWindowsProxy.cs">
+      <Link>ProductionCode\HttpWindowsProxy.cs</Link>
     </Compile>
     <Compile Include="APICallHistory.cs" />
     <Compile Include="ClientCertificateHelper.cs" />
@@ -138,7 +138,7 @@
     <Compile Include="FakeRegistry.cs" />
     <Compile Include="FakeSafeWinHttpHandle.cs" />
     <Compile Include="FakeX509Certificates.cs" />
-    <Compile Include="HttpSystemProxyTest.cs" />
+    <Compile Include="HttpWindowsProxyTest.cs" />
     <Compile Include="SafeWinHttpHandleTest.cs" />
     <Compile Include="SendRequestHelper.cs" />
     <Compile Include="TestServer.cs" />

--- a/src/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/System.Net.Http/ref/System.Net.Http.cs
@@ -38,6 +38,7 @@ namespace System.Net.Http
         public HttpClient(System.Net.Http.HttpMessageHandler handler) : base (default(System.Net.Http.HttpMessageHandler)) { }
         public HttpClient(System.Net.Http.HttpMessageHandler handler, bool disposeHandler) : base (default(System.Net.Http.HttpMessageHandler)) { }
         public System.Uri BaseAddress { get { throw null; } set { } }
+        public static System.Net.IWebProxy DefaultProxy { get { throw null; } set { } }
         public System.Net.Http.Headers.HttpRequestHeaders DefaultRequestHeaders { get { throw null; } }
         public long MaxResponseContentBufferSize { get { throw null; } set { } }
         public System.TimeSpan Timeout { get { throw null; } set { } }

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -93,6 +93,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\HPackEncoder.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\IntegerEncoder.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HPack\StaticTable.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs" />
     <Compile Include="$(CommonPath)\CoreLib\System\IO\StreamHelpers.CopyValidation.cs">
       <Link>Common\CoreLib\System\IO\StreamHelpers.CopyValidation.cs</Link>
     </Compile>
@@ -308,7 +309,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpEnvironmentProxy.Windows.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs" />
-    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpSystemProxy.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpWindowsProxy.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs">
       <Link>Common\Interop\Windows\SChannel\Interop.SecPkgContext_ApplicationProtocol.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -658,6 +658,7 @@
     <Compile Include="uap\System\Net\CookieHelper.cs" />
     <Compile Include="uap\System\Net\HttpHandlerToFilter.cs" />
     <Compile Include="System\Net\Http\HttpClientHandler.Core.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.uap.cs" />
     <Compile Include="uap\System\Net\HttpClientHandler.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">

--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -14,6 +14,7 @@ namespace System.Net.Http
     {
         #region Fields
 
+        private static IWebProxy s_defaultProxy;
         private static readonly TimeSpan s_defaultTimeout = TimeSpan.FromSeconds(100);
         private static readonly TimeSpan s_maxTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
         private static readonly TimeSpan s_infiniteTimeout = Threading.Timeout.InfiniteTimeSpan;
@@ -32,6 +33,27 @@ namespace System.Net.Http
         #endregion Fields
 
         #region Properties
+        public static IWebProxy DefaultProxy
+        {
+            get
+            {
+                if (s_defaultProxy == null)
+                {
+                    s_defaultProxy = SystemProxyInfo.Proxy;
+                }
+
+                return s_defaultProxy;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                s_defaultProxy = value;
+            }
+        }
 
         public HttpRequestHeaders DefaultRequestHeaders
         {

--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -35,23 +35,11 @@ namespace System.Net.Http
         #region Properties
         public static IWebProxy DefaultProxy
         {
-            get
-            {
-                if (s_defaultProxy == null)
-                {
-                    s_defaultProxy = SystemProxyInfo.Proxy;
-                }
+            get => LazyInitializer.EnsureInitialized(ref s_defaultProxy, () => SystemProxyInfo.Proxy);
 
-                return s_defaultProxy;
-            }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-
-                s_defaultProxy = value;
+                s_defaultProxy = value ?? throw new ArgumentNullException(nameof(value));
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -121,7 +121,7 @@ namespace System.Net.Http
             // Figure out proxy stuff.
             if (settings._useProxy)
             {
-                _proxy = settings._proxy ?? SystemProxyInfo.ConstructSystemProxy();
+                _proxy = settings._proxy ?? HttpClient.DefaultProxy;
                 if (_proxy != null)
                 {
                     _proxyCredentials = _proxy.Credentials ?? settings._defaultProxyCredentials;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpWindowsProxy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpWindowsProxy.cs
@@ -11,7 +11,7 @@ using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
 
 namespace System.Net.Http
 {
-    internal sealed class HttpSystemProxy : IWebProxy, IDisposable
+    internal sealed class HttpWindowsProxy : IWebProxy, IDisposable
     {
         private readonly Uri _insecureProxyUri;         // URI of the http system proxy if set
         private readonly Uri _secureProxyUri;         // URI of the https system proxy if set
@@ -55,11 +55,11 @@ namespace System.Net.Http
                 }
             }
 
-            proxy  = new HttpSystemProxy(proxyHelper, sessionHandle);
+            proxy  = new HttpWindowsProxy(proxyHelper, sessionHandle);
             return true;
         }
 
-        private HttpSystemProxy(WinInetProxyHelper proxyHelper, SafeWinHttpHandle sessionHandle)
+        private HttpWindowsProxy(WinInetProxyHelper proxyHelper, SafeWinHttpHandle sessionHandle)
         {
             _proxyHelper = proxyHelper;
             _sessionHandle = sessionHandle;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Unix.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Unix.cs
@@ -4,7 +4,7 @@
 
 namespace System.Net.Http
 {
-    internal static class SystemProxyInfo
+    internal static partial class SystemProxyInfo
     {
         // On Unix (except for OSX) we get default proxy configuration from environment variables. If the
         // environment variables are not defined, we return an IWebProxy object that effectively is

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Windows.cs
@@ -4,14 +4,14 @@
 
 namespace System.Net.Http
 {
-    internal static class SystemProxyInfo
+    internal static partial class SystemProxyInfo
     {
         // On Windows we get default proxy configuration from either environment variables or the Windows system proxy.
         public static IWebProxy ConstructSystemProxy()
         {
             if (!HttpEnvironmentProxy.TryCreate(out IWebProxy proxy))
             {
-                HttpSystemProxy.TryCreate(out proxy);
+                HttpWindowsProxy.TryCreate(out proxy);
             }
 
             return proxy ?? new HttpNoProxy();

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.cs
@@ -6,11 +6,8 @@ namespace System.Net.Http
 {
     internal static partial class SystemProxyInfo
     {
-        // On OSX we get default proxy configuration from either environment variables or the OSX system proxy.
-        public static IWebProxy ConstructSystemProxy()
-        {
-            return HttpEnvironmentProxy.TryCreate(out IWebProxy proxy) ? proxy : new MacProxy();
-        }
+        public static IWebProxy Proxy => s_proxy.Value;
+
+        private static readonly Lazy<IWebProxy> s_proxy = new Lazy<IWebProxy>(ConstructSystemProxy);
     }
 }
-

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.uap.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.uap.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal static partial class SystemProxyInfo
+    {
+        // For UAP this is currently not implemented.
+        public static IWebProxy ConstructSystemProxy()
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.netcoreapp.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.netcoreapp.cs
@@ -4,13 +4,39 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.Net.Http.Functional.Tests
 {
     public sealed partial class HttpClientTest
     {
+        [Fact]
+        public void DefaultProxy_SetNull_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => HttpClient.DefaultProxy = null );
+        }
+
+        [Fact]
+        public void DefaultProxy_Get_ReturnsNotNull()
+        {
+            IWebProxy proxy = HttpClient.DefaultProxy;
+            Assert.NotNull(proxy);
+        }
+
+        [Fact]
+        public void DefaultProxy_SetGet_Roundtrips()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                IWebProxy proxy = new WebProxy("http://localhost:3128/");
+                HttpClient.DefaultProxy = proxy;
+                Assert.True(Object.ReferenceEquals(proxy, HttpClient.DefaultProxy));
+
+                return RemoteExecutor.SuccessExitCode;
+            }).Dispose();
+        }
+
         [Fact]
         public async Task PatchAsync_Canceled_Throws()
         {

--- a/src/System.Net.Http/tests/UnitTests/HttpWindowsProxyTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HttpWindowsProxyTest.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Http.Tests
 {
-    public class HttpSystemProxyTest
+    public class HttpWindowsProxyTest
     {
         private readonly ITestOutputHelper _output;
         private const string FakeProxyString = "http://proxy.contoso.com";
@@ -23,7 +23,7 @@ namespace System.Net.Http.Tests
         private const string fooWs = "ws://foo.com";
         private const string fooWss = "wss://foo.com";
 
-        public HttpSystemProxyTest(ITestOutputHelper output)
+        public HttpWindowsProxyTest(ITestOutputHelper output)
         {
             _output = output;
         }
@@ -42,19 +42,19 @@ namespace System.Net.Http.Tests
         [InlineData("http=proxy.insecure.com;http=proxy.wrong.com", true, false)]
         [InlineData("http=http://proxy.insecure.com", true, false)]
         [InlineData("https=https://proxy.secure.com", false, true)]
-        public void HttpProxy_SystemProxy_Loaded(string rawProxyString, bool hasInsecureProxy, bool hasSecureProxy)
+        public void HttpProxy_WindowsProxy_Loaded(string rawProxyString, bool hasInsecureProxy, bool hasSecureProxy)
         {
             RemoteExecutor.Invoke((proxyString, insecureProxy, secureProxy) =>
             {
                 IWebProxy p;
 
                 FakeRegistry.Reset();
-                Assert.False(HttpSystemProxy.TryCreate(out p));
+                Assert.False(HttpWindowsProxy.TryCreate(out p));
 
                 FakeRegistry.WinInetProxySettings.Proxy = proxyString;
                 WinInetProxyHelper proxyHelper = new WinInetProxyHelper();
 
-                Assert.True(HttpSystemProxy.TryCreate(out p));
+                Assert.True(HttpWindowsProxy.TryCreate(out p));
                 Assert.NotNull(p);
 
                 Assert.Equal(Boolean.Parse(insecureProxy) ? new Uri(insecureProxyUri) : null, p.GetProxy(new Uri(fooHttp)));
@@ -68,7 +68,7 @@ namespace System.Net.Http.Tests
         [Theory]
         [InlineData("localhost:1234", "http://localhost:1234/")]
         [InlineData("123.123.123.123", "http://123.123.123.123/")]
-        public void HttpProxy_SystemProxy_Loaded(string rawProxyString, string expectedUri)
+        public void HttpProxy_WindowsProxy_Loaded(string rawProxyString, string expectedUri)
         {
             RemoteExecutor.Invoke((proxyString, expectedString) =>
             {
@@ -79,7 +79,7 @@ namespace System.Net.Http.Tests
                 FakeRegistry.WinInetProxySettings.Proxy = proxyString;
                 WinInetProxyHelper proxyHelper = new WinInetProxyHelper();
 
-                Assert.True(HttpSystemProxy.TryCreate(out p));
+                Assert.True(HttpWindowsProxy.TryCreate(out p));
                 Assert.NotNull(p);
                 Assert.Equal(expectedString, p.GetProxy(new Uri(fooHttp)).ToString());
                 Assert.Equal(expectedString, p.GetProxy(new Uri(fooHttps)).ToString());
@@ -117,7 +117,7 @@ namespace System.Net.Http.Tests
                 FakeRegistry.WinInetProxySettings.Proxy = insecureProxyUri;
                 FakeRegistry.WinInetProxySettings.ProxyBypass = "23.23.86.44;*.foo.com;<local>;BAR.COM; ; 162*;[2002::11];[*:f8b0:4005:80a::200e]; http://www.xn--mnchhausen-9db.at;http://*.xn--bb-bjab.eu;http://xn--bb-bjab.eu;";
 
-                Assert.True(HttpSystemProxy.TryCreate(out p));
+                Assert.True(HttpWindowsProxy.TryCreate(out p));
                 Assert.NotNull(p);
 
                 Uri u = new Uri(url);
@@ -144,10 +144,10 @@ namespace System.Net.Http.Tests
                 FakeRegistry.WinInetProxySettings.Proxy = insecureProxyUri;
                 FakeRegistry.WinInetProxySettings.ProxyBypass = bypassValue;
 
-                Assert.True(HttpSystemProxy.TryCreate(out p));
+                Assert.True(HttpWindowsProxy.TryCreate(out p));
                 Assert.NotNull(p);
 
-                HttpSystemProxy sp = p as HttpSystemProxy;
+                HttpWindowsProxy sp = p as HttpWindowsProxy;
                 Assert.NotNull(sp);
 
                 if (expectedCount > 0)
@@ -168,19 +168,19 @@ namespace System.Net.Http.Tests
         [InlineData("http://;")]
         [InlineData("http=;")]
         [InlineData("  ;  ")]
-        public void HttpProxy_InvalidSystemProxy_Null(string rawProxyString)
+        public void HttpProxy_InvalidWindowsProxy_Null(string rawProxyString)
         {
             RemoteExecutor.Invoke((proxyString) =>
             {
                 IWebProxy p;
 
                 FakeRegistry.Reset();
-                Assert.False(HttpSystemProxy.TryCreate(out p));
+                Assert.False(HttpWindowsProxy.TryCreate(out p));
 
                 FakeRegistry.WinInetProxySettings.Proxy = proxyString;
                 WinInetProxyHelper proxyHelper = new WinInetProxyHelper();
 
-                Assert.True(HttpSystemProxy.TryCreate(out p));
+                Assert.True(HttpWindowsProxy.TryCreate(out p));
                 Assert.NotNull(p);
 
                 Assert.Equal(null, p.GetProxy(new Uri(fooHttp)));

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -315,6 +315,9 @@
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HPack\StaticTable.cs">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\HPack\StaticTable.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs">
+      <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs" Condition=" '$(TargetsOSX)' == 'true' And '$(TargetGroup)' == 'netcoreapp'">
       <Link>ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs</Link>
     </Compile>
@@ -388,13 +391,13 @@
     <Compile Include="MockContent.cs" />
     <Compile Include="StreamToStreamCopyTest.cs" />
     <Compile Include="HttpEnvironmentProxyTest.cs" />
-    <Compile Include="HttpSystemProxyTest.cs" />
+    <Compile Include="HttpWindowsProxyTest.cs" />
     <Compile Include="SystemProxyInfoTest.cs" />
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs">
       <Link>ProductionCode\System\Net\Http\HttpNoProxy.cs</Link>
     </Compile>
-    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpSystemProxy.cs">
-      <Link>ProductionCode\System\Net\Http\HttpSystemProxy.cs</Link>
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\HttpWindowsProxy.cs">
+      <Link>ProductionCode\System\Net\Http\HttpWindowsProxy.cs</Link>
     </Compile>
     <Compile Include="..\..\..\System.Net.Http.WinHttpHandler\src\System\Net\Http\WinHttpException.cs">
       <Link>ProductionCode\System\Net\Http\WinHttpException.cs</Link>


### PR DESCRIPTION
This PR implements the new static HttpClient.DefaultProxy property which was approved
during API review.

Modify the SystemProxyInfo.ConstructSystemProxy method to a Singleton.

Modify SocketsHttpHandler to use the HttpClient.DefaultProxy property.

Rename the HttpSystemProxy class to HttpWindowsProxy.

Add some HttpClient tests for the new property.

Closes #36553