### PR TITLE
Allow Http2Connection header-related processing buffers to grow

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/Huffman.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/Huffman.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System.Net.Http.HPack
 {
     internal class Huffman
@@ -302,10 +304,13 @@ namespace System.Net.Http.HPack
         /// Decodes a Huffman encoded string from a byte array.
         /// </summary>
         /// <param name="src">The source byte array containing the encoded data.</param>
-        /// <param name="dst">The destination byte array to store the decoded data.</param>
+        /// <param name="dstArray">The destination byte array to store the decoded data.  This may grow if its size is insufficient.</param>
         /// <returns>The number of decoded symbols.</returns>
-        public static int Decode(ReadOnlySpan<byte> src, Span<byte> dst)
+        public static int Decode(ReadOnlySpan<byte> src, ref byte[] dstArray)
         {
+            Span<byte> dst = dstArray;
+            Debug.Assert(dst != null && dst.Length > 0);
+
             int i = 0;
             int j = 0;
             int lastDecodedBits = 0;
@@ -351,8 +356,8 @@ namespace System.Net.Http.HPack
 
                 if (j == dst.Length)
                 {
-                    // Destination is too small.
-                    throw new HuffmanDecodingException();
+                    Array.Resize(ref dstArray, dst.Length * 2);
+                    dst = dstArray;
                 }
 
                 dst[j++] = (byte)ch;

--- a/src/System.Net.Http/tests/FunctionalTests/HuffmanDecodingTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HuffmanDecodingTests.cs
@@ -11,7 +11,7 @@ namespace System.Net.Http.Functional.Tests
 {
     public class HuffmanDecodingTests
     {
-        delegate int DecodeDelegate(ReadOnlySpan<byte> src, Span<byte> dst);
+        delegate int DecodeDelegate(ReadOnlySpan<byte> src, ref byte[] dst);
 
         private static readonly DecodeDelegate s_decodeDelegate = GetDecodeDelegate();
 
@@ -23,9 +23,9 @@ namespace System.Net.Http.Functional.Tests
             return (DecodeDelegate)Delegate.CreateDelegate(typeof(DecodeDelegate), decodeMethod);
         }
 
-        private static int Decode(ReadOnlySpan<byte> source, Span<byte> destination)
+        private static int Decode(ReadOnlySpan<byte> source, ref byte[] destination)
         {
-            return s_decodeDelegate(source, destination);
+            return s_decodeDelegate(source, ref destination);
         }
 
         private static readonly (uint code, int bitLength)[] s_encodingTable = new (uint code, int bitLength)[]
@@ -347,7 +347,7 @@ namespace System.Net.Http.Functional.Tests
             // Worst case decoding is an output byte per 5 input bits, so make the decoded buffer 2 times as big
             byte[] decoded = new byte[encoded.Length * 2];
 
-            int decodedByteCount = Decode(new ReadOnlySpan<byte>(encoded, 0, encodedByteCount), decoded);
+            int decodedByteCount = Decode(new ReadOnlySpan<byte>(encoded, 0, encodedByteCount), ref decoded);
 
             Assert.Equal(input.Length, decodedByteCount);
             Assert.Equal(input, decoded.Take(decodedByteCount));
@@ -362,7 +362,7 @@ namespace System.Net.Http.Functional.Tests
             // Worst case decoding is an output byte per 5 input bits, so make the decoded buffer 2 times as big
             byte[] decoded = new byte[encoded.Length * 2];
 
-            Assert.Throws(s_huffmanDecodingExceptionType, () => Decode(encoded, decoded));
+            Assert.Throws(s_huffmanDecodingExceptionType, () => Decode(encoded, ref decoded));
         }
 
         // This input sequence will encode to 17 bits, thus offsetting the next character to encode


### PR DESCRIPTION
They're currently hard-coded to have a max size.  We need to allow them to grow to deal with arbitrarily large headers. (Separately we'll want to enforce the max header size limit.)

Fixes https://github.com/dotnet/corefx/issues/37166
Fixes https://github.com/dotnet/corefx/issues/35490
cc: @wfurt, @davidsh, @geoffkizer 