### PR TITLE
Fix condition for send to helix step in public builds

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -190,7 +190,7 @@ jobs:
             - template: /eng/pipelines/helix.yml
               parameters:
                 # send tests to helix only on public builds, official scheduled builds or manual official builds.
-                condition: or(eq(${{ parameters.isOfficialBuild }}, 'false'), notIn(variables['Build.Reason'], 'BatchedCI', 'IndividualCI'))
+                condition: or(eq(${{ parameters.isOfficialBuild }}, False), notIn(variables['Build.Reason'], 'BatchedCI', 'IndividualCI'))
                 targetOS: ${{ parameters.targetOS }}
                 archGroup: $(_architecture)
                 configuration: $(_BuildConfig)


### PR DESCRIPTION
The ${{ parameters.isOfficialBuild }} within the condition evaluates as a boolean rather than a string, so I need to compare against `False`. 

Tested in: https://dnceng.visualstudio.com/public/_build/results?buildId=175564

cc: @ViktorHofer 