### PR TITLE
Run Microsoft.VisualBasic.Core.Tests sequentially

### DIFF
--- a/src/Microsoft.VisualBasic.Core/tests/AssemblyAttributes.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/AssemblyAttributes.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+// Tests that use ProjectData or AssemblyData rely on shared state
+// and should not be run in parallel.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/src/Microsoft.VisualBasic.Core/tests/Microsoft.VisualBasic.Core.Tests.csproj
+++ b/src/Microsoft.VisualBasic.Core/tests/Microsoft.VisualBasic.Core.Tests.csproj
@@ -5,6 +5,7 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyAttributes.cs" />
     <Compile Include="ByteTypeTests.cs" />
     <Compile Include="CharTypeTests.cs" />
     <Compile Include="CollectionsTests.cs" />


### PR DESCRIPTION
Tests that use `ProjectData` or `AssemblyData` rely on shared state and should not be run in parallel.

Fixes https://github.com/dotnet/corefx/issues/37341