### PR TITLE
No-op LongProcessNamesAreSupported test on Alpine

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1897,6 +1897,11 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void LongProcessNamesAreSupported()
         {
+            if (PlatformDetection.IsAlpine)
+            {
+                return; // https://github.com/dotnet/corefx/issues/37054
+            }
+
             string programPath = GetProgramPath("sleep");
 
             if (programPath == null)


### PR DESCRIPTION
Failed here: https://dev.azure.com/dnceng/public/_build/results?buildId=175980&view=ms.vss-test-web.build-test-results-tab&runId=4214020&resultId=261743&paneView=debug

There is also an issue open to fix it for alpine: https://github.com/dotnet/corefx/issues/37054

cc: @stephentoub @ViktorHofer @danmosemsft 