### PR TITLE
Disable flaky Dns GetHostName tests on OSX

### DIFF
--- a/src/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/GetHostByNameTest.cs
@@ -102,6 +102,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Equal(IPAddress.IPv6Loopback, entry.AddressList[0]);
         }
 
+        [ActiveIssue(37362, TestPlatforms.OSX)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(32797)]
         public void DnsObsoleteGetHostByName_EmptyString_ReturnsHostName()
         {
@@ -111,6 +112,7 @@ namespace System.Net.NameResolution.Tests
             Assert.Contains(Dns.GetHostName(), entry.HostName, StringComparison.OrdinalIgnoreCase);
         }
 
+        [ActiveIssue(37362, TestPlatforms.OSX)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(32797)]
         public void DnsObsoleteBeginEndGetHostByName_EmptyString_ReturnsHostName()
         {

--- a/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -20,11 +20,13 @@ namespace System.Net.NameResolution.Tests
             await TestGetHostEntryAsync(() => Dns.GetHostEntryAsync(localIPAddress));
         }
 
+        [ActiveIssue(37362, TestPlatforms.OSX)]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(32797)]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]
         public Task Dns_GetHostEntry_HostString_Ok(string hostName) => TestGetHostEntryAsync(() => Task.FromResult(Dns.GetHostEntry(hostName)));
 
+        [ActiveIssue(37362, TestPlatforms.OSX)]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(32797)]
         [InlineData("")]
         [InlineData(TestSettings.LocalHost)]


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/37362

cc @davidsh  @wfurt 