### PR TITLE
Tweak preferLocal value in System.Net.Sockets

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -255,7 +255,7 @@ namespace System.Net.Sockets
                     // we can't pool the object, as ProcessQueue may still have a reference to it, due to
                     // using a pattern whereby it takes the lock to grab an item, but then releases the lock
                     // to do further processing on the item that's still in the list.
-                    ThreadPool.UnsafeQueueUserWorkItem(o => ((AsyncOperation)o).InvokeCallback(allowPooling: false), this);
+                    ThreadPool.UnsafeQueueUserWorkItem(s => s.InvokeCallback(allowPooling: false), this, preferLocal: true);
                 }
 
                 Trace("Exit");
@@ -276,7 +276,7 @@ namespace System.Net.Sockets
                 else
                 {
                     // Async operation.  Process the IO on the threadpool.
-                    ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
+                    ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: true);
                 }
             }
 


### PR DESCRIPTION
These ThreadPool.UnsafeQueueUserWorkItem calls come from a non-thread pool thread, and as such currently the preferLocal argument has no effect and was defaulted to false when this was written.  But logically it makes sense for it to be true, and it could start to have an effect if we make a change to the thread pool that allows threads to share their local queues.

cc: @vsadov, @geoffkizer 