### PR TITLE
 React to APICompat changes enabling reverse APICompat for facades

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
     <UseSharedCompilation>true</UseSharedCompilation>
 
     <ToolSetCommonDirectory>$(MSBuildThisFileDirectory)artifacts\toolset\Common\</ToolSetCommonDirectory>
-    <IsSourceProject Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectDirectory), 'src%24'))">true</IsSourceProject>
+    <IsSourceProject>$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectDirectory), 'src%24'))</IsSourceProject>
   </PropertyGroup>
 
   <!-- Define vNext UAP Moniker -->
@@ -167,7 +167,8 @@
     <OutputType>Library</OutputType>
     <!-- Default any assembly not specifying a key to use the Open Key -->
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <RunApiCompat>true</RunApiCompat>
+    <RunApiCompatForSrc>$(IsSourceProject)</RunApiCompatForSrc>
+    <RunMatchingRefApiCompat>$(IsSourceProject)</RunMatchingRefApiCompat>
     <ApiCompatExcludeAttributeList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</ApiCompatExcludeAttributeList>
     <!-- Build as portable by default -->
     <PortableBuild Condition="'$(PortableBuild)' == ''">true</PortableBuild>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -46,9 +46,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>a7a250e9c13147134543c35fef2fb81f19592edf</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19229.8">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19256.12">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>1b8589bbf53b9a5e819460798eff59830f39a3be</Sha>
+      <Sha>c31fac9f6899094226cb5cd77c85b8f60ecafa3d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19254.1">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview6-27705-72">
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview6-27707-71">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>08136a667d1a30c242f40731b3b0b299e4167220</Sha>
+      <Sha>c2e71fd5e711ca150e238741015a1a0229606793</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview6-27705-72">
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview6-27707-71">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>08136a667d1a30c242f40731b3b0b299e4167220</Sha>
+      <Sha>c2e71fd5e711ca150e238741015a1a0229606793</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview6-27705-72">
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview6-27707-71">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>08136a667d1a30c242f40731b3b0b299e4167220</Sha>
+      <Sha>c2e71fd5e711ca150e238741015a1a0229606793</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview6-27707-71">
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview6-27705-72">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>c2e71fd5e711ca150e238741015a1a0229606793</Sha>
+      <Sha>08136a667d1a30c242f40731b3b0b299e4167220</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview6-27707-71">
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview6-27705-72">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>c2e71fd5e711ca150e238741015a1a0229606793</Sha>
+      <Sha>08136a667d1a30c242f40731b3b0b299e4167220</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview6-27707-71">
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview6-27705-72">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>c2e71fd5e711ca150e238741015a1a0229606793</Sha>
+      <Sha>08136a667d1a30c242f40731b3b0b299e4167220</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19229.8</MicrosoftDotNetApiCompatPackageVersion>
+    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19256.12</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19254.1</MicrosoftDotNetCodeAnalysisPackageVersion>
     <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19254.1</MicrosoftDotNetGenAPIPackageVersion>
     <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19254.1</MicrosoftDotNetGenFacadesPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,8 +40,8 @@
     <MicrosoftNETCoreDotNetHostPackageVersion>3.0.0-preview6-27706-03</MicrosoftNETCoreDotNetHostPackageVersion>
     <MicrosoftNETCoreDotNetHostPolicyPackageVersion>3.0.0-preview6-27706-03</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
     <!-- Coreclr dependencies -->
-    <MicrosoftNETCoreILAsmPackageVersion>3.0.0-preview6-27705-72</MicrosoftNETCoreILAsmPackageVersion>
-    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview6-27705-72</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
+    <MicrosoftNETCoreILAsmPackageVersion>3.0.0-preview6-27707-71</MicrosoftNETCoreILAsmPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview6-27707-71</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <!-- Corefx dependencies -->
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview6.19256.1</MicrosoftNETCorePlatformsPackageVersion>
     <runtimenativeSystemIOPortsPackageVersion>4.6.0-preview6.19256.1</runtimenativeSystemIOPortsPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,8 +40,8 @@
     <MicrosoftNETCoreDotNetHostPackageVersion>3.0.0-preview6-27706-03</MicrosoftNETCoreDotNetHostPackageVersion>
     <MicrosoftNETCoreDotNetHostPolicyPackageVersion>3.0.0-preview6-27706-03</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
     <!-- Coreclr dependencies -->
-    <MicrosoftNETCoreILAsmPackageVersion>3.0.0-preview6-27707-71</MicrosoftNETCoreILAsmPackageVersion>
-    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview6-27707-71</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
+    <MicrosoftNETCoreILAsmPackageVersion>3.0.0-preview6-27705-72</MicrosoftNETCoreILAsmPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview6-27705-72</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <!-- Corefx dependencies -->
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview6.19256.1</MicrosoftNETCorePlatformsPackageVersion>
     <runtimenativeSystemIOPortsPackageVersion>4.6.0-preview6.19256.1</runtimenativeSystemIOPortsPackageVersion>

--- a/eng/references.targets
+++ b/eng/references.targets
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-    <ContractOutputPath>$(RefPath)</ContractOutputPath>
-    <FrameworkPathOverride>$(ContractOutputPath)</FrameworkPathOverride>
-    <AssemblySearchPaths>$(AssemblySearchPaths);$(ContractOutputPath);{RawFileName}</AssemblySearchPaths>
+    <ContractDependencyPaths>$(RefPath)</ContractDependencyPaths>
+    <FrameworkPathOverride>$(RefPath)</FrameworkPathOverride>
+    <AssemblySearchPaths>$(AssemblySearchPaths);$(RefPath);{RawFileName}</AssemblySearchPaths>
     <!-- Disable RAR from transitively discovering dependencies for References -->
     <_FindDependencies>false</_FindDependencies>
     <!--

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -2,7 +2,10 @@
   <PropertyGroup Condition="'$(IsSourceProject)' == 'true'">
     <ContractProject Condition="'$(ContractProject)' == ''">$(SourceDir)/$(MSBuildProjectName)/ref/$(MSBuildProjectName).csproj</ContractProject>
     <HasMatchingContract Condition="'$(HasMatchingContract)' == '' and Exists('$(ContractProject)')">true</HasMatchingContract>
-    <ContractAssemblyPath Condition="'$(ContractAssemblyPath)' == ''">$(ContractOutputPath)/$(MSBuildProjectName).dll</ContractAssemblyPath>
+    <ContractAssemblyPath Condition="'$(ContractAssemblyPath)' == ''">$(RefPath)/$(MSBuildProjectName).dll</ContractAssemblyPath>
+
+    <!-- Disable API compat if the project doesn't have reference assembly -->
+    <RunApiCompat Condition="'$(HasMatchingContract)' != 'true'">false</RunApiCompat>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(HasMatchingContract)' == 'true'">
@@ -16,8 +19,4 @@
 
   <!-- intentionally empty since we no longer need a target -->
   <Target Name="ResolveMatchingContract" />
-
-  <Target Name="VerifyMatchingContract" AfterTargets="ResolveReferences">
-    <Error Condition="'$(HasMatchingContract)' == 'true' and !Exists('%(ResolvedMatchingContract.Identity)')" Text="ResolveMatchingContract could not find a matching contract '%(ResolvedMatchingContract.Identity)' not found." />
-  </Target>
 </Project>

--- a/eng/resolveContract.targets
+++ b/eng/resolveContract.targets
@@ -19,4 +19,14 @@
 
   <!-- intentionally empty since we no longer need a target -->
   <Target Name="ResolveMatchingContract" />
+
+  <!-- Disable matching ref API compat for aot runtime refencing libs, these have a lot of public API
+         only by implementation and we don't intend to start new API development on AOT -->
+  <Target Name="DisableRunMatchingRefApiCompat" 
+          BeforeTargets="CoreCompile"
+          Condition="'$(TargetsAot)' == 'true' AND '@(ReferenceFromRuntime)' != ''">
+    <PropertyGroup>
+      <RunMatchingRefApiCompat>False</RunMatchingRefApiCompat>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/global.json
+++ b/global.json
@@ -5,6 +5,6 @@
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19229.8",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19257.3",
-    "Microsoft.NET.Sdk.IL": "3.0.0-preview6-27705-72"
+    "Microsoft.NET.Sdk.IL": "3.0.0-preview6-27707-71"
   }
 }

--- a/global.json
+++ b/global.json
@@ -5,6 +5,6 @@
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19229.8",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19257.3",
-    "Microsoft.NET.Sdk.IL": "3.0.0-preview6-27707-71"
+    "Microsoft.NET.Sdk.IL": "3.0.0-preview6-27705-72"
   }
 }

--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -27,6 +27,7 @@ namespace System
         public static void ThrowsAny<TFirstExceptionType, TSecondExceptionType, TThirdExceptionType>(System.Action action) where TFirstExceptionType : System.Exception where TSecondExceptionType : System.Exception where TThirdExceptionType : System.Exception { }
         public static System.Threading.Tasks.Task<T> ThrowsAsync<T>(string paramName, System.Func<System.Threading.Tasks.Task> testCode) where T : System.ArgumentException { throw null; }
         public static void ThrowsIf<T>(bool condition, System.Action action) where T : System.Exception { }
+        public static T Throws<T>(System.Action action) where T : System.Exception { throw null; }
         public static void Throws<T>(System.Action action, string message) where T : System.Exception { }
         public static T Throws<T>(string paramName, System.Action action) where T : System.ArgumentException { throw null; }
         public static T Throws<T>(string paramName, System.Func<object> testCode) where T : System.ArgumentException { throw null; }
@@ -42,13 +43,13 @@ namespace System
         public static bool ClientWebSocketPartialMessagesSupported { get { throw null; } }
         public static bool HasWindowsShell { get { throw null; } }
         public static System.Version ICUVersion { get { throw null; } }
+        public static bool Is32BitProcess { get { throw null; } }
         public static bool IsAlpine { get { throw null; } }
         public static bool IsArgIteratorNotSupported { get { throw null; } }
         public static bool IsArgIteratorSupported { get { throw null; } }
         public static bool IsArm64Process { get { throw null; } }
         public static bool IsArmOrArm64Process { get { throw null; } }
         public static bool IsArmProcess { get { throw null; } }
-        public static bool Is32BitProcess { get { throw null; } }
         public static bool IsCentos6 { get { throw null; } }
         public static bool IsDebian { get { throw null; } }
         public static bool IsDebian8 { get { throw null; } }
@@ -156,6 +157,7 @@ namespace System.IO
     public abstract partial class FileCleanupTestBase : System.IDisposable
     {
         protected FileCleanupTestBase() { }
+        protected static bool IsProcessElevated { get { throw null; } }
         protected string TestDirectory { get { throw null; } }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }

--- a/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
+++ b/src/CoreFx.Private.TestUtilities/src/CoreFx.Private.TestUtilities.csproj
@@ -8,6 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CS1573</NoWarn>
     <EnablePInvokeAnalyzer>false</EnablePInvokeAnalyzer>
+    <RunMatchingRefApiCompat>false</RunMatchingRefApiCompat>
     <NoWarn Condition="'$(TargetGroup)' == 'netstandard'">$(NoWarn);CS3021</NoWarn>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard'">Test Utilities are not supported on this platform</GeneratePlatformNotSupportedAssemblyMessage>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp2.0-Unix-Debug;netcoreapp2.0-Unix-Release;netcoreapp2.0-Windows_NT-Debug;netcoreapp2.0-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>

--- a/src/System.AppContext/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.AppContext/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,9 @@
+Compat issues with assembly System.AppContext:
+MembersMustExist : Member 'System.AppContext.add_FirstChanceException(System.EventHandler<System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.add_ProcessExit(System.EventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.add_UnhandledException(System.UnhandledExceptionEventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.remove_FirstChanceException(System.EventHandler<System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.remove_ProcessExit(System.EventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.remove_UnhandledException(System.UnhandledExceptionEventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.SetData(System.String, System.Object)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 7

--- a/src/System.Collections/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Collections/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,8 @@
+Compat issues with assembly System.Collections:
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.TypeDependencyAttribute' exists on 'System.Collections.Generic.Comparer<T>' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.TypeDependencyAttribute' exists on 'System.Collections.Generic.EqualityComparer<T>' in the implementation but not the reference.
+TypesMustExist : Type 'System.Collections.Generic.SortedDictionary<TKey, TValue>.KeyValuePairComparer' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Collections.Generic.SortedList<TKey, TValue>.KeyList' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Collections.Generic.SortedList<TKey, TValue>.ValueList' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Collections.Generic.TreeSet<T>' does not exist in the reference but it does exist in the implementation.
+Total Issues: 6

--- a/src/System.Diagnostics.Debug/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Diagnostics.Debug/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,3 @@
+Compat issues with assembly System.Diagnostics.Debug:
+MembersMustExist : Member 'System.Diagnostics.Debug.SetProvider(System.Diagnostics.DebugProvider)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 1

--- a/src/System.Diagnostics.Tracing/src/ApiCompatBaseline.netfx.txt
+++ b/src/System.Diagnostics.Tracing/src/ApiCompatBaseline.netfx.txt
@@ -1,4 +1,0 @@
-Compat issues with assembly System.Diagnostics.Tracing:
-MembersMustExist : Member 'System.Diagnostics.Tracing.EventSource.add_EventCommandExecuted(System.EventHandler<System.Diagnostics.Tracing.EventCommandEventArgs>)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Diagnostics.Tracing.EventSource.remove_EventCommandExecuted(System.EventHandler<System.Diagnostics.Tracing.EventCommandEventArgs>)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 2

--- a/src/System.Diagnostics.Tracing/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Diagnostics.Tracing/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,6 @@
+Compat issues with assembly System.Diagnostics.Tracing:
+MembersMustExist : Member 'System.Diagnostics.Tracing.EventCounter.Flush()' does not exist in the reference but it does exist in the implementation.
+CannotMakeTypeAbstract : Type 'System.Diagnostics.Tracing.EventListener' is abstract in the reference but is not abstract in the implementation.
+CannotMakeMoreVisible : Visibility of member 'System.Diagnostics.Tracing.EventListener..ctor()' is 'Family' in the reference but 'Public' in the implementation.
+CannotMakeMoreVisible : Visibility of member 'System.Diagnostics.Tracing.EventListener.EventSourceIndex(System.Diagnostics.Tracing.EventSource)' is 'Family' in the reference but 'Public' in the implementation.
+Total Issues: 4

--- a/src/System.Diagnostics.Tracing/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Diagnostics.Tracing/src/MatchingRefApiCompatBaseline.txt
@@ -1,6 +1,9 @@
 Compat issues with assembly System.Diagnostics.Tracing:
+CannotSealType : Type 'System.Diagnostics.Tracing.DiagnosticCounter' is effectively (has a private constructor) sealed in the reference but not sealed in the implementation.
+MembersMustExist : Member 'System.Diagnostics.Tracing.DiagnosticCounter..ctor(System.String, System.Diagnostics.Tracing.EventSource)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Diagnostics.Tracing.DiagnosticCounter.WritePayload(System.Single, System.Int32)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Diagnostics.Tracing.EventCounter.Flush()' does not exist in the reference but it does exist in the implementation.
 CannotMakeTypeAbstract : Type 'System.Diagnostics.Tracing.EventListener' is abstract in the reference but is not abstract in the implementation.
 CannotMakeMoreVisible : Visibility of member 'System.Diagnostics.Tracing.EventListener..ctor()' is 'Family' in the reference but 'Public' in the implementation.
 CannotMakeMoreVisible : Visibility of member 'System.Diagnostics.Tracing.EventListener.EventSourceIndex(System.Diagnostics.Tracing.EventSource)' is 'Family' in the reference but 'Public' in the implementation.
-Total Issues: 4
+Total Issues: 7

--- a/src/System.Diagnostics.Tracing/src/MatchingRefApiCompatBaseline.uap.txt
+++ b/src/System.Diagnostics.Tracing/src/MatchingRefApiCompatBaseline.uap.txt
@@ -1,0 +1,8 @@
+Compat issues with assembly System.Diagnostics.Tracing:
+CannotRemoveBaseTypeOrInterface : Type 'System.Diagnostics.Tracing.EventCounter' does not inherit from base type 'System.Diagnostics.Tracing.DiagnosticCounter' in the reference but it does in the implementation.
+MembersMustExist : Member 'System.Diagnostics.Tracing.EventCounter.Flush()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Diagnostics.Tracing.EventCounter.WriteMetric(System.Double)' does not exist in the reference but it does exist in the implementation.
+CannotMakeTypeAbstract : Type 'System.Diagnostics.Tracing.EventListener' is abstract in the reference but is not abstract in the implementation.
+CannotMakeMoreVisible : Visibility of member 'System.Diagnostics.Tracing.EventListener..ctor()' is 'Family' in the reference but 'Public' in the implementation.
+CannotMakeMoreVisible : Visibility of member 'System.Diagnostics.Tracing.EventListener.EventSourceIndex(System.Diagnostics.Tracing.EventSource)' is 'Family' in the reference but 'Public' in the implementation.
+Total Issues: 6

--- a/src/System.Linq.Expressions/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Linq.Expressions/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,18 @@
+Compat issues with assembly System.Linq.Expressions:
+CannotMakeTypeAbstract : Type 'System.Linq.Expressions.DynamicExpressionVisitor' is abstract in the reference but is not abstract in the implementation.
+CannotMakeMoreVisible : Visibility of member 'System.Linq.Expressions.DynamicExpressionVisitor..ctor()' is 'Family' in the reference but 'Public' in the implementation.
+MembersMustExist : Member 'System.Linq.Expressions.ElementInit.ArgumentCount.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Linq.Expressions.ElementInit.GetArgument(System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Linq.Expressions.IndexExpression.ArgumentCount.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Linq.Expressions.IndexExpression.GetArgument(System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Linq.Expressions.InvocationExpression.ArgumentCount.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Linq.Expressions.InvocationExpression.GetArgument(System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Linq.Expressions.MethodCallExpression.ArgumentCount.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Linq.Expressions.MethodCallExpression.GetArgument(System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Linq.Expressions.NewExpression.ArgumentCount.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Linq.Expressions.NewExpression.GetArgument(System.Int32)' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Linq.Expressions.Interpreter.LightLambda' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.CompilerServices.CallSiteOps' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.CompilerServices.Closure' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.CompilerServices.RuntimeOps' does not exist in the reference but it does exist in the implementation.
+Total Issues: 16

--- a/src/System.Numerics.Vectors/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Numerics.Vectors/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,8 @@
+Compat issues with assembly System.Numerics.Vectors:
+MembersMustExist : Member 'System.Numerics.Vector<T>..ctor(System.ReadOnlySpan<System.Byte>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Numerics.Vector<T>..ctor(System.ReadOnlySpan<T>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Numerics.Vector<T>.CopyTo(System.Span<System.Byte>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Numerics.Vector<T>.CopyTo(System.Span<T>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Numerics.Vector<T>.TryCopyTo(System.Span<System.Byte>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Numerics.Vector<T>.TryCopyTo(System.Span<T>)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 6

--- a/src/System.Reflection.Emit.ILGeneration/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Reflection.Emit.ILGeneration/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,8 @@
+Compat issues with assembly System.Reflection.Emit.ILGeneration:
+MembersMustExist : Member 'System.Reflection.Emit.ILGenerator.MarkSequencePoint(System.Diagnostics.SymbolStore.ISymbolDocumentWriter, System.Int32, System.Int32, System.Int32, System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.LocalBuilder.SetLocalSymInfo(System.String)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.LocalBuilder.SetLocalSymInfo(System.String, System.Int32, System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ParameterBuilder.GetToken()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.SignatureHelper.GetMethodSigHelper(System.Reflection.Module, System.Runtime.InteropServices.CallingConvention, System.Type)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.SignatureHelper.GetMethodSigHelper(System.Runtime.InteropServices.CallingConvention, System.Type)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 6

--- a/src/System.Reflection.Emit/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Reflection.Emit/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,33 @@
+Compat issues with assembly System.Reflection.Emit:
+MembersMustExist : Member 'System.Reflection.Emit.AssemblyBuilder.DefineDynamicModule(System.String, System.Boolean)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ConstructorBuilder.GetModule()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ConstructorBuilder.GetToken()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ConstructorBuilder.Signature.get()' does not exist in the reference but it does exist in the implementation.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Emit.EnumBuilder' does not inherit from base type 'System.Reflection.TypeInfo' in the reference but it does in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.EnumBuilder.CreateType()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.EnumBuilder.IsAssignableFrom(System.Reflection.TypeInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.EnumBuilder.TypeToken.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.EventBuilder.GetEventToken()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.FieldBuilder.GetToken()' does not exist in the reference but it does exist in the implementation.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Emit.GenericTypeParameterBuilder' does not inherit from base type 'System.Reflection.TypeInfo' in the reference but it does in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.GenericTypeParameterBuilder.IsAssignableFrom(System.Reflection.TypeInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.MethodBuilder.GetModule()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.MethodBuilder.GetToken()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.MethodBuilder.Signature.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.DefineDocument(System.String, System.Guid, System.Guid, System.Guid)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetArrayMethodToken(System.Type, System.String, System.Reflection.CallingConventions, System.Type, System.Type[])' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetConstructorToken(System.Reflection.ConstructorInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetFieldToken(System.Reflection.FieldInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetMethodToken(System.Reflection.MethodInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetModuleHandleImpl()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetSignatureToken(System.Byte[], System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetSignatureToken(System.Reflection.Emit.SignatureHelper)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetStringConstant(System.String)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetTypeToken(System.String)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetTypeToken(System.Type)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.IsTransient()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.PropertyBuilder.PropertyToken.get()' does not exist in the reference but it does exist in the implementation.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Emit.TypeBuilder' does not inherit from base type 'System.Reflection.TypeInfo' in the reference but it does in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.TypeBuilder.IsAssignableFrom(System.Reflection.TypeInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.TypeBuilder.TypeToken.get()' does not exist in the reference but it does exist in the implementation.
+Total Issues: 31

--- a/src/System.Reflection.Emit/src/MatchingRefApiCompatBaseline.uap10.0.16299.txt
+++ b/src/System.Reflection.Emit/src/MatchingRefApiCompatBaseline.uap10.0.16299.txt
@@ -1,0 +1,34 @@
+Compat issues with assembly System.Reflection.Emit:
+MembersMustExist : Member 'System.Reflection.Emit.AssemblyBuilder.DefineDynamicModule(System.String, System.Boolean)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ConstructorBuilder.GetModule()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ConstructorBuilder.GetToken()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ConstructorBuilder.Signature.get()' does not exist in the reference but it does exist in the implementation.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Emit.EnumBuilder' does not inherit from base type 'System.Reflection.TypeInfo' in the reference but it does in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.EnumBuilder.CreateType()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.EnumBuilder.IsAssignableFrom(System.Reflection.TypeInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.EnumBuilder.TypeToken.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.EventBuilder.GetEventToken()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.FieldBuilder.GetToken()' does not exist in the reference but it does exist in the implementation.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Emit.GenericTypeParameterBuilder' does not inherit from base type 'System.Reflection.TypeInfo' in the reference but it does in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.GenericTypeParameterBuilder.IsAssignableFrom(System.Reflection.TypeInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.MethodBuilder.GetModule()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.MethodBuilder.GetToken()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.MethodBuilder.Signature.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.DefineDocument(System.String, System.Guid, System.Guid, System.Guid)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetArrayMethodToken(System.Type, System.String, System.Reflection.CallingConventions, System.Type, System.Type[])' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetConstructorToken(System.Reflection.ConstructorInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetFieldToken(System.Reflection.FieldInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetMethodToken(System.Reflection.MethodInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetModuleHandleImpl()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetSignatureToken(System.Byte[], System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetSignatureToken(System.Reflection.Emit.SignatureHelper)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetStringConstant(System.String)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetTypeToken(System.String)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.GetTypeToken(System.Type)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.ModuleBuilder.IsTransient()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.PropertyBuilder.PropertyToken.get()' does not exist in the reference but it does exist in the implementation.
+CannotRemoveBaseTypeOrInterface : Type 'System.Reflection.Emit.TypeBuilder' does not inherit from base type 'System.Reflection.TypeInfo' in the reference but it does in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.TypeBuilder.CreateType()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.TypeBuilder.IsAssignableFrom(System.Reflection.TypeInfo)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Reflection.Emit.TypeBuilder.TypeToken.get()' does not exist in the reference but it does exist in the implementation.
+Total Issues: 32

--- a/src/System.Reflection/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Reflection/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,7 @@
+Compat issues with assembly System.Reflection:
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAttribute' exists on 'System.Reflection.CustomAttributeNamedArgument' in the implementation but not the reference.
+TypeCannotChangeClassification : Type 'System.Reflection.CustomAttributeNamedArgument' is marked as readonly in the implementation so it must also be marked readonly in the reference.
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAttribute' exists on 'System.Reflection.CustomAttributeTypedArgument' in the implementation but not the reference.
+TypeCannotChangeClassification : Type 'System.Reflection.CustomAttributeTypedArgument' is marked as readonly in the implementation so it must also be marked readonly in the reference.
+MembersMustExist : Member 'System.Reflection.Module.GetModuleHandleImpl()' does not exist in the reference but it does exist in the implementation.
+Total Issues: 5

--- a/src/System.Resources.ResourceManager/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Resources.ResourceManager/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,4 @@
+Compat issues with assembly System.Resources.ResourceManager:
+MembersMustExist : Member 'System.String System.Resources.ResourceManager.BaseNameField' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Resources.IResourceReader System.Resources.ResourceSet.Reader' does not exist in the reference but it does exist in the implementation.
+Total Issues: 2

--- a/src/System.Runtime.Extensions/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.Extensions/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,4 @@
+Compat issues with assembly System.Runtime.Extensions:
+MembersMustExist : Member 'System.AppDomain.GetThreadPrincipal()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Environment.FailFast(System.String, System.Exception, System.String)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 2

--- a/src/System.Runtime.Extensions/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.Extensions/src/MatchingRefApiCompatBaseline.txt
@@ -1,4 +1,7 @@
 Compat issues with assembly System.Runtime.Extensions:
 MembersMustExist : Member 'System.AppDomain.GetThreadPrincipal()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Environment.FailFast(System.String, System.Exception, System.String)' does not exist in the reference but it does exist in the implementation.
-Total Issues: 2
+MembersMustExist : Member 'System.IO.Path.Join(System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>, System.ReadOnlySpan<System.Char>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.IO.Path.Join(System.String, System.String, System.String, System.String)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.IO.Path.Join(System.String[])' does not exist in the reference but it does exist in the implementation.
+Total Issues: 5

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,8 @@
+Compat issues with assembly System.Runtime.InteropServices.WindowsRuntime:
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken' does not implement interface 'System.IEquatable<System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken>' in the reference but it does in the implementation.
+MembersMustExist : Member 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken..ctor(System.UInt64)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken.Equals(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken.Value.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T>.RemoveEventHandler(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken, T)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal.GetUniqueObjectForIUnknownWithoutUnboxing(System.IntPtr)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 6

--- a/src/System.Runtime.InteropServices/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.InteropServices/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,11 @@
+Compat issues with assembly System.Runtime.InteropServices:
+TypesMustExist : Type 'System.Runtime.InteropServices.AssemblyRegistrationFlags' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.InteropServices.ExporterEventKind' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.InteropServices.IDispatchImplAttribute' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.InteropServices.IDispatchImplType' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.InteropServices.RegistrationClassContext' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.InteropServices.RegistrationConnectionType' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Runtime.InteropServices.SetWin32ContextInIDispatchAttribute' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute..ctor()' does not exist in the reference but it does exist in the implementation.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.InteropServices.ComTypes.IDataObject' in the implementation but not the reference.
+Total Issues: 9

--- a/src/System.Runtime.Intrinsics.Experimental/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.Intrinsics.Experimental/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,7 @@
+Compat issues with assembly System.Runtime.Intrinsics.Experimental:
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.Arm.Arm64.Aes' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.Arm.Arm64.Base' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.Arm.Arm64.Sha1' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.Arm.Arm64.Sha256' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.Arm.Arm64.Simd' in the implementation but not the reference.
+Total Issues: 5

--- a/src/System.Runtime.Intrinsics/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.Intrinsics/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,17 @@
+Compat issues with assembly System.Runtime.Intrinsics:
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Aes' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Avx' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Avx2' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Bmi1' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Bmi2' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Fma' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Lzcnt' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Pclmulqdq' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Popcnt' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Sse' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Sse2' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Sse3' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Sse41' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Sse42' in the implementation but not the reference.
+CannotRemoveAttribute : Attribute 'System.CLSCompliantAttribute' exists on 'System.Runtime.Intrinsics.X86.Ssse3' in the implementation but not the reference.
+Total Issues: 15

--- a/src/System.Runtime.Loader/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.Loader/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,11 @@
+Compat issues with assembly System.Runtime.Loader:
+MembersMustExist : Member 'System.Runtime.Loader.AssemblyLoadContext.add_AssemblyLoad(System.AssemblyLoadEventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Loader.AssemblyLoadContext.add_AssemblyResolve(System.ResolveEventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Loader.AssemblyLoadContext.add_ResourceResolve(System.ResolveEventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Loader.AssemblyLoadContext.add_TypeResolve(System.ResolveEventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Loader.AssemblyLoadContext.GetLoadedAssemblies()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Loader.AssemblyLoadContext.remove_AssemblyLoad(System.AssemblyLoadEventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Loader.AssemblyLoadContext.remove_AssemblyResolve(System.ResolveEventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Loader.AssemblyLoadContext.remove_ResourceResolve(System.ResolveEventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Loader.AssemblyLoadContext.remove_TypeResolve(System.ResolveEventHandler)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 9

--- a/src/System.Runtime.Serialization.Formatters/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.Serialization.Formatters/src/MatchingRefApiCompatBaseline.txt
@@ -1,3 +1,9 @@
 # Exposed publicly only in implementation for serialization compat
 TypesMustExist : Type 'System.Runtime.Serialization.SerializationEventHandler' does not exist in the reference but it does exist in the implementation.
 TypesMustExist : Type 'System.Runtime.Serialization.TypeLoadExceptionHolder' does not exist in the reference but it does exist in the implementation.
+
+MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.DeserializationInProgress.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.StartDeserialization()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.ThrowIfDeserializationInProgress()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.ThrowIfDeserializationInProgress(System.String, System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.UpdateValue(System.String, System.Object, System.Type)' does not exist in the reference but it does exist in the implementation.

--- a/src/System.Runtime.WindowsRuntime/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime.WindowsRuntime/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,5 @@
+Compat issues with assembly System.Runtime.WindowsRuntime:
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeBuffer' does not implement interface 'Windows.Storage.Streams.IBuffer' in the reference but it does in the implementation.
+TypesMustExist : Type 'System.Threading.DispatcherQueueHandler' does not exist in the reference but it does exist in the implementation.
+TypesMustExist : Type 'System.Threading.DispatcherQueuePriority' does not exist in the reference but it does exist in the implementation.
+Total Issues: 3

--- a/src/System.Runtime/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,28 @@
+Compat issues with assembly System.Runtime:
+MembersMustExist : Member 'System.AppContext.add_FirstChanceException(System.EventHandler<System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.add_ProcessExit(System.EventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.add_UnhandledException(System.UnhandledExceptionEventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.remove_FirstChanceException(System.EventHandler<System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.remove_ProcessExit(System.EventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.remove_UnhandledException(System.UnhandledExceptionEventHandler)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.AppContext.SetData(System.String, System.Object)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.WeakReference..ctor()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Collections.ObjectModel.Collection<T>.AddRange(System.Collections.Generic.IEnumerable<T>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Collections.ObjectModel.Collection<T>.InsertItemsRange(System.Int32, System.Collections.Generic.IEnumerable<T>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Collections.ObjectModel.Collection<T>.InsertRange(System.Int32, System.Collections.Generic.IEnumerable<T>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Collections.ObjectModel.Collection<T>.RemoveItemsRange(System.Int32, System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Collections.ObjectModel.Collection<T>.RemoveRange(System.Int32, System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Collections.ObjectModel.Collection<T>.ReplaceItemsRange(System.Int32, System.Int32, System.Collections.Generic.IEnumerable<T>)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Collections.ObjectModel.Collection<T>.ReplaceRange(System.Int32, System.Int32, System.Collections.Generic.IEnumerable<T>)' does not exist in the reference but it does exist in the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAttribute' exists on 'System.Reflection.CustomAttributeNamedArgument' in the implementation but not the reference.
+TypeCannotChangeClassification : Type 'System.Reflection.CustomAttributeNamedArgument' is marked as readonly in the implementation so it must also be marked readonly in the reference.
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAttribute' exists on 'System.Reflection.CustomAttributeTypedArgument' in the implementation but not the reference.
+TypeCannotChangeClassification : Type 'System.Reflection.CustomAttributeTypedArgument' is marked as readonly in the implementation so it must also be marked readonly in the reference.
+MembersMustExist : Member 'System.Reflection.Module.GetModuleHandleImpl()' does not exist in the reference but it does exist in the implementation.
+CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.Serialization.DeserializationBlockedException' does not inherit from base type 'System.Runtime.Serialization.SerializationException' in the reference but it does in the implementation.
+MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.DeserializationInProgress.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.StartDeserialization()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.ThrowIfDeserializationInProgress()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.ThrowIfDeserializationInProgress(System.String, System.Int32)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.UpdateValue(System.String, System.Object, System.Type)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 26

--- a/src/System.Threading.Tasks/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Threading.Tasks/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,5 @@
+Compat issues with assembly System.Threading.Tasks:
+MembersMustExist : Member 'System.Threading.Tasks.TaskExtensions.ConfigureAwait(System.IAsyncDisposable, System.Boolean)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Threading.Tasks.TaskExtensions.ConfigureAwait<T>(System.Collections.Generic.IAsyncEnumerable<T>, System.Boolean)' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Threading.Tasks.TaskExtensions.WithCancellation<T>(System.Collections.Generic.IAsyncEnumerable<T>, System.Threading.CancellationToken)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 3

--- a/src/System.Threading.ThreadPool/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Threading.ThreadPool/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,5 @@
+Compat issues with assembly System.Threading.ThreadPool:
+MembersMustExist : Member 'System.Threading.ThreadPool.CompletedWorkItemCount.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Threading.ThreadPool.PendingWorkItemCount.get()' does not exist in the reference but it does exist in the implementation.
+MembersMustExist : Member 'System.Threading.ThreadPool.ThreadCount.get()' does not exist in the reference but it does exist in the implementation.
+Total Issues: 3

--- a/src/System.Threading/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Threading/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,3 @@
+Compat issues with assembly System.Threading:
+MembersMustExist : Member 'System.Threading.Monitor.LockContentionCount.get()' does not exist in the reference but it does exist in the implementation.
+Total Issues: 1

--- a/src/System.Utf8String.Experimental/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Utf8String.Experimental/src/MatchingRefApiCompatBaseline.txt
@@ -1,0 +1,3 @@
+Compat issues with assembly System.Utf8String.Experimental:
+MembersMustExist : Member 'System.Utf8String.Substring(System.Index)' does not exist in the reference but it does exist in the implementation.
+Total Issues: 1


### PR DESCRIPTION
I made changes to API Compat that enable it for partial facades, this is the result.  We'll want to look through these baselines before RTM to understand if anything here needs to be exposed.

For things that need to be exposed that can happen in separate PRs since it may require API review + test additions. 

NO MERGE - this is using a private build of API compat.