### PR TITLE
improve error reporting on OSX

### DIFF
--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -52,11 +52,9 @@ namespace System.Net.NetworkInformation.Tests
 
         private void PingResultValidator(PingReply pingReply, IPAddress[] localIpAddresses)
         {
-            if (pingReply.Status == IPStatus.TimedOut)
+            if (pingReply.Status == IPStatus.TimedOut && pingReply.Address.AddressFamily == AddressFamily.InterNetworkV6 && PlatformDetection.IsOSX)
             {
                 // Workaround OSX ping6 bug, refer issue #15018
-                Assert.Equal(AddressFamily.InterNetworkV6, pingReply.Address.AddressFamily);
-                Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
                 return;
             }
 


### PR DESCRIPTION
When Ping times out on OSX, will will assert on IPv6 and that produces confusing exception. This is also true for OS if we ever timeout on other OSes.  

With this we skip validation to avoid #15018 and we will hit Assert.Equal(IPStatus.Success, pingReply.Status);

related to #37370
