### PR TITLE
Tweak asserts used in GetGCMemoryInfo test to be more informative

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
@@ -36,11 +36,11 @@ namespace System.Tests
 
                 GCMemoryInfo memoryInfo1 = GC.GetGCMemoryInfo();
 
-                Assert.True(memoryInfo1.HighMemoryLoadThresholdBytes > 0);
-                Assert.True(memoryInfo1.MemoryLoadBytes > 0);
-                Assert.True(memoryInfo1.TotalAvailableMemoryBytes > 0);
-                Assert.True(memoryInfo1.HeapSizeBytes > 0);
-                Assert.True(memoryInfo1.FragmentedBytes >= 0);
+                Assert.InRange(memoryInfo1.HighMemoryLoadThresholdBytes, 1, long.MaxValue);
+                Assert.InRange(memoryInfo1.MemoryLoadBytes, 1, long.MaxValue);
+                Assert.InRange(memoryInfo1.TotalAvailableMemoryBytes, 1, long.MaxValue);
+                Assert.InRange(memoryInfo1.HeapSizeBytes, 1, long.MaxValue);
+                Assert.InRange(memoryInfo1.FragmentedBytes, 0, long.MaxValue);
 
                 GCHandle[] gch = new GCHandle[64 * 1024];
                 for (int i = 0; i < gch.Length * 2; ++i)
@@ -57,11 +57,11 @@ namespace System.Tests
 
                 GCMemoryInfo memoryInfo2 = GC.GetGCMemoryInfo();
 
-                Assert.True(memoryInfo2.HighMemoryLoadThresholdBytes == memoryInfo1.HighMemoryLoadThresholdBytes);
-                Assert.True(memoryInfo2.MemoryLoadBytes >= memoryInfo1.MemoryLoadBytes);
-                Assert.True(memoryInfo2.TotalAvailableMemoryBytes == memoryInfo1.TotalAvailableMemoryBytes);
-                Assert.True(memoryInfo2.HeapSizeBytes > memoryInfo1.HeapSizeBytes);
-                Assert.True(memoryInfo2.FragmentedBytes > memoryInfo1.FragmentedBytes);
+                Assert.Equal(memoryInfo2.HighMemoryLoadThresholdBytes, memoryInfo1.HighMemoryLoadThresholdBytes);
+                Assert.InRange(memoryInfo2.MemoryLoadBytes, memoryInfo1.MemoryLoadBytes, long.MaxValue);
+                Assert.Equal(memoryInfo2.TotalAvailableMemoryBytes, memoryInfo1.TotalAvailableMemoryBytes);
+                Assert.InRange(memoryInfo2.HeapSizeBytes, memoryInfo1.HeapSizeBytes + 1, long.MaxValue);
+                Assert.InRange(memoryInfo2.FragmentedBytes, memoryInfo1.FragmentedBytes + 1, long.MaxValue);
             }).Dispose();
         }
     }


### PR DESCRIPTION
With Assert.True, all we know is whether the test passed or failed.  With Assert.Equal and Assert.InRange, a failure will include information about the input values.

Contributes to https://github.com/dotnet/corefx/issues/37378
cc: @luhenry, @ViktorHofer 