### PR TITLE
Implement IList<T> for EmptyPartition, RangeIterator and RepeatIterator.

### DIFF
--- a/src/System.Linq/src/Resources/Strings.resx
+++ b/src/System.Linq/src/Resources/Strings.resx
@@ -72,4 +72,7 @@
   <data name="NoMatch" xml:space="preserve">
     <value>Sequence contains no matching element</value>
   </data>
+  <data name="ArrayPlusOffTooSmall" xml:space="preserve">
+    <value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
+  </data>
 </root>

--- a/src/System.Linq/src/System/Linq/Partition.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Partition.SpeedOpt.cs
@@ -17,7 +17,7 @@ namespace System.Linq
     /// Returning an instance of this type is useful to quickly handle scenarios where it is known
     /// that an operation will result in zero elements.
     /// </remarks>
-    internal sealed class EmptyPartition<TElement> : IPartition<TElement>, IEnumerator<TElement>
+    internal sealed class EmptyPartition<TElement> : IPartition<TElement>, IEnumerator<TElement>, IList<TElement>, IReadOnlyList<TElement>
     {
         /// <summary>
         /// A cached, immutable instance of an empty enumerable.
@@ -27,6 +27,31 @@ namespace System.Linq
         private EmptyPartition()
         {
         }
+
+        public int Count => 0;
+
+        public bool IsReadOnly => true;
+
+        public TElement this[int index]
+        { 
+            get => ThrowHelper.ThrowArgumentOutOfRangeException<TElement>(ExceptionArgument.index);
+            set => ThrowHelper.ThrowNotSupportedException();
+        }
+
+        public void CopyTo(TElement[] array, int arrayIndex)
+        {
+            // Do nothing.
+        }
+
+        public bool Contains(TElement item) => false;            
+
+        public int IndexOf(TElement item) => -1;
+
+        void ICollection<TElement>.Add(TElement item) => ThrowHelper.ThrowNotSupportedException();
+        bool ICollection<TElement>.Remove(TElement item) => ThrowHelper.ThrowNotSupportedException<bool>();
+        void ICollection<TElement>.Clear() => ThrowHelper.ThrowNotSupportedException();
+        void IList<TElement>.Insert(int index, TElement item) => ThrowHelper.ThrowNotSupportedException();
+        void IList<TElement>.RemoveAt(int index) => ThrowHelper.ThrowNotSupportedException();
 
         public IEnumerator<TElement> GetEnumerator() => this;
 

--- a/src/System.Linq/src/System/Linq/Range.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Range.SpeedOpt.cs
@@ -28,16 +28,7 @@ namespace System.Linq
                 return array;
             }
 
-            public List<int> ToList()
-            {
-                List<int> list = new List<int>(_end - _start);
-                for (int cur = _start; cur != _end; cur++)
-                {
-                    list.Add(cur);
-                }
-
-                return list;
-            }
+            public List<int> ToList() => new List<int>(this);
 
             public int GetCount(bool onlyIfCheap) => unchecked(_end - _start);
 

--- a/src/System.Linq/src/System/Linq/Repeat.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.SpeedOpt.cs
@@ -24,16 +24,7 @@ namespace System.Linq
                 return array;
             }
 
-            public List<TResult> ToList()
-            {
-                List<TResult> list = new List<TResult>(_count);
-                for (int i = 0; i != _count; ++i)
-                {
-                    list.Add(_current);
-                }
-
-                return list;
-            }
+            public List<TResult> ToList() => new List<TResult>(this);
 
             public int GetCount(bool onlyIfCheap) => _count;
 

--- a/src/System.Linq/src/System/Linq/Repeat.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.cs
@@ -28,7 +28,7 @@ namespace System.Linq
         /// An iterator that yields the same item multiple times. 
         /// </summary>
         /// <typeparam name="TResult">The type of the item.</typeparam>
-        private sealed partial class RepeatIterator<TResult> : Iterator<TResult>
+        private sealed partial class RepeatIterator<TResult> : Iterator<TResult>, IList<TResult>, IReadOnlyList<TResult>
         {
             private readonly int _count;
 
@@ -38,6 +38,55 @@ namespace System.Linq
                 _current = element;
                 _count = count;
             }
+
+           public int Count => _count;
+
+            public bool IsReadOnly => true;
+
+            public TResult this[int index]
+            {
+                get
+                {
+                    if ((uint)index >= (uint)_count)
+                    {
+                        ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
+                    }
+                    return _current;
+                }
+                
+                set => ThrowHelper.ThrowNotSupportedException();
+            }
+
+            public void CopyTo(TResult[] array, int arrayIndex)
+            {
+                if (array is null)
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+
+                if ((uint)arrayIndex >= (uint)array.Length)
+                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.arrayIndex);
+
+                unchecked
+                {
+                    if (array.Length - arrayIndex < Count)
+                        ThrowHelper.ThrowArgumentArrayPlusOffTooSmall();
+
+                    int end = arrayIndex + Count;
+                    for (int index = arrayIndex; index < end; index++)
+                    {
+                        array[index] = _current;
+                    }
+                }
+            }
+
+            public bool Contains(TResult item) => EqualityComparer<TResult>.Default.Equals(_current, item);            
+
+            public int IndexOf(TResult item) => EqualityComparer<TResult>.Default.Equals(_current, item) ? 0 : -1;      
+
+            void ICollection<TResult>.Add(TResult item) => ThrowHelper.ThrowNotSupportedException();
+            bool ICollection<TResult>.Remove(TResult item) => ThrowHelper.ThrowNotSupportedException<bool>();
+            void ICollection<TResult>.Clear() => ThrowHelper.ThrowNotSupportedException();
+            void IList<TResult>.Insert(int index, TResult item) => ThrowHelper.ThrowNotSupportedException();
+            void IList<TResult>.RemoveAt(int index) => ThrowHelper.ThrowNotSupportedException();
 
             public override Iterator<TResult> Clone()
             {

--- a/src/System.Linq/src/System/Linq/ThrowHelper.cs
+++ b/src/System.Linq/src/System/Linq/ThrowHelper.cs
@@ -13,6 +13,10 @@ namespace System.Linq
 
         internal static void ThrowArgumentOutOfRangeException(ExceptionArgument argument) => throw new ArgumentOutOfRangeException(GetArgumentString(argument));
 
+        internal static T ThrowArgumentOutOfRangeException<T>(ExceptionArgument argument) => throw new ArgumentOutOfRangeException(GetArgumentString(argument));
+
+        internal static void ThrowArgumentArrayPlusOffTooSmall() => throw new ArgumentException(SR.ArrayPlusOffTooSmall);
+
         internal static void ThrowMoreThanOneElementException() => throw new InvalidOperationException(SR.MoreThanOneElement);
 
         internal static void ThrowMoreThanOneMatchException() => throw new InvalidOperationException(SR.MoreThanOneMatch);
@@ -22,6 +26,8 @@ namespace System.Linq
         internal static void ThrowNoMatchException() => throw new InvalidOperationException(SR.NoMatch);
 
         internal static void ThrowNotSupportedException() => throw new NotSupportedException();
+
+        internal static T ThrowNotSupportedException<T>() => throw new NotSupportedException();
 
         private static string GetArgumentString(ExceptionArgument argument)
         {
@@ -44,6 +50,8 @@ namespace System.Linq
                 case ExceptionArgument.second: return nameof(ExceptionArgument.second);
                 case ExceptionArgument.selector: return nameof(ExceptionArgument.selector);
                 case ExceptionArgument.source: return nameof(ExceptionArgument.source);
+                case ExceptionArgument.array: return nameof(ExceptionArgument.array);
+                case ExceptionArgument.arrayIndex: return nameof(ExceptionArgument.arrayIndex);
                 default:
                     Debug.Fail("The ExceptionArgument value is not defined.");
                     return string.Empty;
@@ -70,5 +78,7 @@ namespace System.Linq
         second,
         selector,
         source,
+        array,
+        arrayIndex,
     }
 }

--- a/src/System.Linq/tests/EmptyPartitionTests.cs
+++ b/src/System.Linq/tests/EmptyPartitionTests.cs
@@ -106,5 +106,78 @@ namespace System.Linq.Tests
             en.Reset();
             en.Reset();
         }
+
+        [Fact]
+        public void ICollection_IsReadOnly()
+        {
+            var emptyPartition = GetEmptyPartition<int>() as ICollection<int>;
+
+            Assert.Equal(true, emptyPartition.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => emptyPartition.Add(0));
+            Assert.Throws<NotSupportedException>(() => emptyPartition.Remove(0));
+            Assert.Throws<NotSupportedException>(() => emptyPartition.Clear());
+        }
+
+        [Fact]
+        public void ICollection_Count()
+        {
+            var emptyPartition = GetEmptyPartition<int>() as ICollection<int>;
+
+            Assert.Equal(0, emptyPartition.Count);
+        }
+
+        [Fact]
+        public void ICollection_CopyTo_ProduceCorrectSequence()
+        {
+            var emptyPartition = GetEmptyPartition<int>() as ICollection<int>;
+
+            var arrayIndex = 5;
+            var array = Enumerable.Range(0, 10).ToArray();
+            emptyPartition.CopyTo(array, arrayIndex);
+            
+            for (var index = 0; index < 10; index++)
+            {
+                Assert.Equal(index, array[index]);
+            }
+        }
+
+        [Fact]
+        public void ICollection_Contains()
+        {
+            var emptyPartition = GetEmptyPartition<int>() as ICollection<int>;
+
+            Assert.Equal(false, emptyPartition.Contains(int.MinValue));
+            Assert.Equal(false, emptyPartition.Contains(0));
+            Assert.Equal(false, emptyPartition.Contains(int.MaxValue));
+        }
+
+        [Fact]
+        public void IList_IsReadOnly()
+        {
+            var emptyPartition = GetEmptyPartition<int>() as IList<int>;
+
+            Assert.Throws<NotSupportedException>(() => emptyPartition.Insert(0, 0));
+            Assert.Throws<NotSupportedException>(() => emptyPartition.RemoveAt(0));
+        }
+
+        [Fact]
+        public void IList_Indexer_ThrowExceptionOnOutOfRangeIndex()
+        {
+            var emptyPartition = GetEmptyPartition<int>() as IList<int>;
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => emptyPartition[int.MinValue]);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => emptyPartition[0]);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => emptyPartition[int.MaxValue]);
+        }
+
+        [Fact]
+        public void IList_IndexOf()
+        {
+            var emptyPartition = GetEmptyPartition<int>() as IList<int>;
+
+            Assert.Equal(-1, emptyPartition.IndexOf(int.MinValue));
+            Assert.Equal(-1, emptyPartition.IndexOf(0));
+            Assert.Equal(-1, emptyPartition.IndexOf(int.MaxValue));
+        }    
     }
 }

--- a/src/System.Linq/tests/RangeTests.cs
+++ b/src/System.Linq/tests/RangeTests.cs
@@ -225,5 +225,144 @@ namespace System.Linq.Tests
         {
             Assert.Equal(int.MaxValue - 101, Enumerable.Range(-100, int.MaxValue).LastOrDefault());
         }
+
+        [Fact]
+        public void ICollection_IsReadOnly()
+        {
+            var rangeSequence = Enumerable.Range(1, 100) as ICollection<int>;
+
+            Assert.Equal(true, rangeSequence.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => rangeSequence.Add(0));
+            Assert.Throws<NotSupportedException>(() => rangeSequence.Remove(0));
+            Assert.Throws<NotSupportedException>(() => rangeSequence.Clear());
+        }
+
+        [Fact]
+        public void ICollection_Count()
+        {
+            var rangeSequence = Enumerable.Range(1, 100) as ICollection<int>;
+
+            Assert.Equal(100, rangeSequence.Count);
+        }
+
+        [Fact]
+        public void ICollection_CopyTo_ProduceCorrectSequence()
+        {
+            var rangeSequence = Enumerable.Range(1, 100) as ICollection<int>;
+
+            var arrayIndex = 10;
+            var array = new int[rangeSequence.Count + arrayIndex];
+            rangeSequence.CopyTo(array, arrayIndex);
+            
+            int expected = 0;
+            for (var index = arrayIndex; index < rangeSequence.Count + arrayIndex; index++)
+            {
+                expected++;
+                Assert.Equal(expected, array[index]);
+            }
+
+            Assert.Equal(100, expected);
+        }
+
+        [Fact]
+        public void ICollection_CopyTo_ThrowExceptionOnNullArray()
+        {
+            var rangeSequence = Enumerable.Range(1, 100) as ICollection<int>;
+
+            AssertExtensions.Throws<ArgumentNullException>("array", () => rangeSequence.CopyTo(null, 0));
+        }
+
+        [Fact]
+        public void ICollection_CopyTo_ThrowExceptionOnOutOfRangeArrayIndex()
+        {
+            var rangeSequence = Enumerable.Range(1, 100) as ICollection<int>;
+            var array = new int[100];
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("arrayIndex", () => rangeSequence.CopyTo(array, int.MinValue));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("arrayIndex", () => rangeSequence.CopyTo(array, -1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("arrayIndex", () => rangeSequence.CopyTo(array, 100));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("arrayIndex", () => rangeSequence.CopyTo(array, int.MaxValue));
+        }
+
+        [Fact]
+        public void ICollection_CopyTo_ThrowExceptionOnArrayOverflow()
+        {
+            var rangeSequence = Enumerable.Range(1, 100) as ICollection<int>;
+            var array = new int[100];
+
+            Assert.Throws<ArgumentException>(() => rangeSequence.CopyTo(array, 1));
+        }
+
+        [Fact]
+        public void ICollection_Contains()
+        {
+            var emptyRangeSequence = Enumerable.Range(0, 0) as ICollection<int>;
+
+            Assert.Equal(false, emptyRangeSequence.Contains(int.MinValue));
+            Assert.Equal(false, emptyRangeSequence.Contains(0));
+            Assert.Equal(false, emptyRangeSequence.Contains(int.MaxValue));
+
+            var rangeSequence = Enumerable.Range(1, 100) as ICollection<int>;
+
+            Assert.Equal(false, rangeSequence.Contains(int.MinValue));
+            Assert.Equal(false, rangeSequence.Contains(0));
+            Assert.Equal(true, rangeSequence.Contains(1));
+            Assert.Equal(true, rangeSequence.Contains(100));
+            Assert.Equal(false, rangeSequence.Contains(101));
+            Assert.Equal(false, rangeSequence.Contains(int.MaxValue));
+        }
+
+        [Fact]
+        public void IList_IsReadOnly()
+        {
+            var rangeSequence = Enumerable.Range(0, 100) as IList<int>;
+
+            Assert.Throws<NotSupportedException>(() => rangeSequence.Insert(0, 0));
+            Assert.Throws<NotSupportedException>(() => rangeSequence.RemoveAt(0));
+        }
+
+        [Fact]
+        public void IList_Indexer_ProduceCorrectSequence()
+        {
+            var rangeSequence = Enumerable.Range(1, 100) as IList<int>;
+            int expected = 0;
+            for (var index = 0; index < rangeSequence.Count; index++)
+            {
+                expected++;
+                Assert.Equal(expected, rangeSequence[index]);
+            }
+
+            Assert.Equal(100, expected);
+        }
+
+        [Fact]
+        public void IList_Indexer_ThrowExceptionOnOutOfRangeIndex()
+        {
+            var rangeSequence = Enumerable.Range(0, 100) as IList<int>;
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => rangeSequence[int.MinValue]);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => rangeSequence[-1]);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => rangeSequence[100]);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => rangeSequence[int.MaxValue]);
+        }
+
+        [Fact]
+        public void IList_IndexOf()
+        {
+            var emptyRangeSequence = Enumerable.Range(0, 0) as IList<int>;
+
+            Assert.Equal(-1, emptyRangeSequence.IndexOf(int.MinValue));
+            Assert.Equal(-1, emptyRangeSequence.IndexOf(0));
+            Assert.Equal(-1, emptyRangeSequence.IndexOf(int.MaxValue));
+
+            var rangeSequence = Enumerable.Range(1, 100) as IList<int>;
+
+            Assert.Equal(-1, rangeSequence.IndexOf(int.MinValue));
+            Assert.Equal(-1, rangeSequence.IndexOf(0));
+            Assert.Equal(0, rangeSequence.IndexOf(1));
+            Assert.Equal(99, rangeSequence.IndexOf(100));
+            Assert.Equal(-1, rangeSequence.IndexOf(101));
+            Assert.Equal(-1, rangeSequence.IndexOf(int.MaxValue));
+        }    
     }
 }

--- a/src/System.Linq/tests/RepeatTests.cs
+++ b/src/System.Linq/tests/RepeatTests.cs
@@ -240,5 +240,132 @@ namespace System.Linq.Tests
         {
             Assert.Equal(42, Enumerable.Repeat("Test", 42).Count());
         }
+
+        [Fact]
+        public void ICollection_IsReadOnly()
+        {
+            var repeatSequence = Enumerable.Repeat("Test", 100) as ICollection<string>;
+
+            Assert.Equal(true, repeatSequence.IsReadOnly);
+            Assert.Throws<NotSupportedException>(() => repeatSequence.Add(null));
+            Assert.Throws<NotSupportedException>(() => repeatSequence.Remove(null));
+            Assert.Throws<NotSupportedException>(() => repeatSequence.Clear());
+        }
+
+        [Fact]
+        public void ICollection_Count()
+        {
+            var repeatSequence = Enumerable.Repeat("Test", 100) as ICollection<string>;
+
+            Assert.Equal(100, repeatSequence.Count);
+        }
+
+        [Fact]
+        public void ICollection_CopyTo_ProduceCorrectSequence()
+        {
+            var repeatSequence = Enumerable.Repeat("Test", 100) as ICollection<string>;
+
+            var arrayIndex = 10;
+            var array = new string[repeatSequence.Count + arrayIndex];
+            repeatSequence.CopyTo(array, arrayIndex);
+            
+            int count = 0;
+            for (var index = arrayIndex; index < repeatSequence.Count + arrayIndex; index++)
+            {
+                count++;
+                Assert.Equal("Test", array[index]);
+            }
+
+            Assert.Equal(100, count);
+        }
+
+        [Fact]
+        public void ICollection_CopyTo_ThrowExceptionOnNullArray()
+        {
+            var repeatSequence = Enumerable.Repeat("Test", 100) as ICollection<string>;
+
+            AssertExtensions.Throws<ArgumentNullException>("array", () => repeatSequence.CopyTo(null, 0));
+        }
+
+        [Fact]
+        public void ICollection_CopyTo_ThrowExceptionOnOutOfRangeArrayIndex()
+        {
+            var repeatSequence = Enumerable.Repeat("Test", 100) as ICollection<string>;
+            var array = new string[100];
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("arrayIndex", () => repeatSequence.CopyTo(array, int.MinValue));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("arrayIndex", () => repeatSequence.CopyTo(array, -1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("arrayIndex", () => repeatSequence.CopyTo(array, 100));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("arrayIndex", () => repeatSequence.CopyTo(array, int.MaxValue));
+        }
+
+        [Fact]
+        public void ICollection_CopyTo_ThrowExceptionOnArrayOverflow()
+        {
+            var repeatSequence = Enumerable.Repeat("Test", 100) as ICollection<string>;
+            var array = new string[100];
+
+            Assert.Throws<ArgumentException>(() => repeatSequence.CopyTo(array, 1));
+        }
+
+        [Fact]
+        public void ICollection_Contains()
+        {
+            var emptyRepeatSequence = Enumerable.Repeat("Test", 0) as IList<string>;
+
+            Assert.Equal(false, emptyRepeatSequence.Contains("Test"));
+
+            var repeatSequence = Enumerable.Repeat("Test", 100) as ICollection<string>;
+
+            Assert.Equal(false, repeatSequence.Contains("AnotherTest"));
+            Assert.Equal(true, repeatSequence.Contains("Test"));
+        }
+
+        [Fact]
+        public void IList_IsReadOnly()
+        {
+            var repeatSequence = Enumerable.Repeat("Test", 100) as IList<string>;
+
+            Assert.Throws<NotSupportedException>(() => repeatSequence.Insert(0, null));
+            Assert.Throws<NotSupportedException>(() => repeatSequence.RemoveAt(0));
+        }
+
+        [Fact]
+        public void IList_Indexer_ProduceCorrectSequence()
+        {
+            var repeatSequence = Enumerable.Repeat("Test", 100) as IList<string>;
+            int count = 0;
+            for (var index = 0; index < repeatSequence.Count; index++)
+            {
+                count++;
+                Assert.Equal("Test", repeatSequence[index]);
+            }
+
+            Assert.Equal(100, count);
+        }
+
+        [Fact]
+        public void IList_Indexer_ThrowExceptionOnOutOfRangeIndex()
+        {
+            var repeatSequence = Enumerable.Repeat("Test", 100) as IList<string>;
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => repeatSequence[int.MinValue]);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => repeatSequence[-1]);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => repeatSequence[100]);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => repeatSequence[int.MaxValue]);
+        }
+
+        [Fact]
+        public void IList_IndexOf()
+        {
+            var emptyRepeatSequence = Enumerable.Repeat("Test", 0) as IList<string>;
+
+            Assert.Equal(-1, emptyRepeatSequence.IndexOf("Test"));
+
+            var repeatSequence = Enumerable.Repeat("Test", 100) as IList<string>;
+
+            Assert.Equal(-1, repeatSequence.IndexOf("AnotherTest"));
+            Assert.Equal(0, repeatSequence.IndexOf("Test"));
+        }    
     }
 }


### PR DESCRIPTION
## `Empty`

`Enumerable.Empty<T>` has two implementations. The `SizeOpt` version returns `Array.Empty<T>`, while the `SpeedOpt` version returns `EmptyPartition<T>.Instance`. 

Besides the different optimizations, there's another difference: `Array.Empty<T>` returns an implementation of `IList<T>`, while `EmptyPartition<T>.Instance` returns an implementation of `IEnumerable<T>`.

This difference may cause some confusion as it behaves differently in different platforms, not only between different versions, as already reported in #32645.

@natemcmaster This PR adds the implementation of `IList<T>` as discussed on #32645. It also adds `IReadOnlyList<T>`.

## `Range` and `Repeat`

These LINQ operations return implementations of `Iterator<T>` which implements `IEnumerable<T>`. But, for both these operations, `Count` is well known and the items can be inferred from the `index` value. This means that these iterators can implement `IList<T>`.

The advantage is that `ICollection<T>` and `IList<T>` allow much better performance than `IEnumerable<T>` in many situations. Many optimizations based on these interfaces can be found in this same repository and in many third-parties.

Some of these cases may be overloaded by even better optimizations (`SpeedOpt` and `SizeOpt`) but these are not used in all platforms. Still, these changes, take advantage of existing code. No new cases are created.

This PR adds implementation of `IList<T>` and `IReadOnlyList<T>` to the iterators `RangeIterator` and `RepeatIterator<T>`.

Both `Range` and `Repeat` return `Empty<T>()` when `count` is zero. That's one other reason why it's important `EmptyIterator<T>` also implements `IList<T>`, reducing confusion.

## `ToList()`

One of the cases that is overloaded in `SpeedOpt`, is the `ToList()`method for both `RangeIterator` and `RepeatIterator<T>`. They simply create a `List<T>` and add the elements to it. Here's the [implementation for Range](https://github.com/dotnet/corefx/blob/81c8c68d81daad033251d643e230061f38a9ae3a/src/System.Linq/src/System/Linq/Range.SpeedOpt.cs#L31):

```csharp
public List<int> ToList()
{
   List<int> list = new List<int>(_end - _start);
   for (int cur = _start; cur != _end; cur++)
   {
       list.Add(cur);
   }

   return list;
}
```

Although the length is passed as the `capacity` for the new `List<T>`, the `Add()` method still performs version increment, buffer length validation and size increment. This is performed for every element, which is unnecessary and penalizing.

```csharp
public void Add(T item)
{
    _version++;
    T[] array = _items;
    int size = _size;
    if ((uint)size < (uint)array.Length)
    {
        _size = size + 1;
        array[size] = item;
    }
    else
    {
        AddWithResize(item);
    }
}
```

As an alternative, the `List<T>(IEnumerable<T>)` constructor can be used, which has the following implementation:

```csharp
public List(IEnumerable<T> collection)
{
    if (collection == null)
        ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collection);

    if (collection is ICollection<T> c)
    {
        int count = c.Count;
        if (count == 0)
        {
            _items = s_emptyArray;
        }
        else
        {
            _items = new T[count];
            c.CopyTo(_items, 0);
            _size = count;
        }
    }
    else
    {
        _size = 0;
        _items = s_emptyArray;
        using (IEnumerator<T> en = collection.GetEnumerator())
        {
            while (en.MoveNext())
            {
                Add(en.Current);
            }
        }
    }
}
```

When `collection` is a `ICollection<T>`, which is now the case, it simply allocates an array, calls `ICollection<T>.CopyTo()` and sets the size. 

This PR replaces the `for` loop with `List.Add()` calls by a single call to the `List<T>(IEnumerable<T>)` constructor.

## Benchmarks

These are the benchmarks for `Range` with multiple count values (0, 1, 10, 100, 1.000, 10.000). The first line values are for `master` branch and the second for this PR branch.

``` ini

BenchmarkDotNet=v0.11.3.1003-nightly, OS=macOS Mojave 10.14.4 (18E226) [Darwin 18.5.0]
Intel Core i5-7360U CPU 2.30GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=3.0.100-preview4-011223
  [Host]     : .NET Core 3.0.0-preview4-27615-11 (CoreCLR 4.6.27615.73, CoreFX 4.700.19.21213), 64bit RyuJIT
  Job-CFRYCL : .NET Core e70c7a22-15eb-4e75-85bf-9200f5f40b1a (CoreCLR 4.6.27701.72, CoreFX 4.700.19.25201), 64bit RyuJIT
  Job-XREZYG : .NET Core 0ac558bb-ff95-4358-9e42-24ac416bfb32 (CoreCLR 4.6.27624.71, CoreFX 4.700.19.23001), 64bit RyuJIT

Runtime=Core  IterationTime=250.0000 ms  MaxIterationCount=20  
MinIterationCount=15  WarmupCount=1  

```
| Method |                                                                                                     Toolchain | Count |         Mean |      Error |     StdDev |       Median |          Min |          Max | Ratio | MannWhitney(10%) | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------- |-------------------------------------------------------------------------------------------------------------- |------ |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|------:|----------------- |--------:|------------:|------------:|------------:|--------------------:|
| **ToList** |          **/corefx/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun** |     **0** |     **20.25 ns** |  **1.2950 ns** |  **1.4913 ns** |     **20.13 ns** |     **18.46 ns** |     **22.86 ns** |  **1.04** |             **Same** |    **0.08** |      **0.1958** |           **-** |           **-** |                **32 B** |
| ToList | /corefx_upstream/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun |     0 |     19.47 ns |  0.5175 ns |  0.5959 ns |     19.28 ns |     18.77 ns |     20.66 ns |  1.00 |             Base |    0.00 |      0.1958 |           - |           - |                32 B |
|        |                                                                                                               |       |              |            |            |              |              |              |       |                  |         |             |             |             |                     |
| **ToList** |          **/corefx/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun** |     **1** |     **52.89 ns** |  **0.6164 ns** |  **0.5464 ns** |     **52.76 ns** |     **52.07 ns** |     **53.81 ns** |  **1.45** |           **Slower** |    **0.02** |      **0.3917** |           **-** |           **-** |                **64 B** |
| ToList | /corefx_upstream/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun |     1 |     36.52 ns |  0.2953 ns |  0.2762 ns |     36.45 ns |     36.23 ns |     37.18 ns |  1.00 |             Base |    0.00 |      0.3916 |           - |           - |                64 B |
|        |                                                                                                               |       |              |            |            |              |              |              |       |                  |         |             |             |             |                     |
| **ToList** |          **/corefx/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun** |    **10** |     **63.85 ns** |  **0.5476 ns** |  **0.4855 ns** |     **63.83 ns** |     **63.10 ns** |     **64.83 ns** |  **1.07** |             **Same** |    **0.02** |      **0.5873** |           **-** |           **-** |                **96 B** |
| ToList | /corefx_upstream/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun |    10 |     59.60 ns |  0.9767 ns |  0.8658 ns |     59.39 ns |     58.63 ns |     61.37 ns |  1.00 |             Base |    0.00 |      0.5874 |           - |           - |                96 B |
|        |                                                                                                               |       |              |            |            |              |              |              |       |                  |         |             |             |             |                     |
| **ToList** |          **/corefx/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun** |   **100** |    **200.93 ns** |  **2.2097 ns** |  **1.9589 ns** |    **200.56 ns** |    **198.80 ns** |    **205.87 ns** |  **0.69** |           **Faster** |    **0.04** |      **2.7855** |           **-** |           **-** |               **456 B** |
| ToList | /corefx_upstream/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun |   100 |    289.58 ns | 19.1209 ns | 18.7793 ns |    281.08 ns |    277.56 ns |    331.04 ns |  1.00 |             Base |    0.00 |      2.7853 |           - |           - |               456 B |
|        |                                                                                                               |       |              |            |            |              |              |              |       |                  |         |             |             |             |                     |
| **ToList** |          **/corefx/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun** |  **1000** |  **1,450.43 ns** | **14.6100 ns** | **13.6662 ns** |  **1,449.04 ns** |  **1,423.05 ns** |  **1,477.32 ns** |  **0.60** |           **Faster** |    **0.01** |     **24.3859** |           **-** |           **-** |              **4056 B** |
| ToList | /corefx_upstream/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun |  1000 |  2,426.86 ns | 22.6250 ns | 18.8929 ns |  2,420.40 ns |  2,397.13 ns |  2,461.57 ns |  1.00 |             Base |    0.00 |     24.3898 |           - |           - |              4056 B |
|        |                                                                                                               |       |              |            |            |              |              |              |       |                  |         |             |             |             |                     |
| **ToList** |          **/corefx/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun** | **10000** |  **8,182.43 ns** | **97.2001 ns** | **90.9211 ns** |  **8,176.24 ns** |  **8,079.06 ns** |  **8,427.27 ns** |  **0.46** |           **Faster** |    **0.01** |     **57.1382** |      **7.1382** |           **-** |             **40056 B** |
| ToList | /corefx_upstream/artifacts/bin/testhost/netcoreapp-OSX-Release-x64/shared/Microsoft.NETCore.App/9.9.9/corerun | 10000 | 17,766.04 ns | 98.3112 ns | 91.9603 ns | 17,780.30 ns | 17,573.70 ns | 17,901.24 ns |  1.00 |             Base |    0.00 |     57.1206 |      7.0781 |           - |             40056 B |

Please note that when `count` is zero, `Range` return `Empty<int>()`. The new version has the same performance.

For the other cases where `RangeIterator` is returned, there is an initialization overhead due to the cast and argument validation. It's noticeable for very small values of `count`. It's 45% times slower when `count` is 1. 

This overhead dilutes quickly when `count` increases. It takes more or less the same time when `count` is 10. It's 30% faster when `count` is 100, 40% faster when `count` is 1.000 and  54% faster when `count` is 10.000.

In absolute values, this means that, it's only 16ns slower when `count` is 1 but almost 10.000ns faster when `count` is 10.000.

There's no memory overhead added.
