### PR TITLE
Log exceptions from asynchronously failing Expect: 100-continue sends

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -557,7 +557,7 @@ namespace System.Net.Http
             Task.Factory.StartNew(
                 s => {
                     var whrs = (WinHttpRequestState)s;
-                    _ = whrs.Handler.StartRequest(whrs);
+                    _ = whrs.Handler.StartRequestAsync(whrs);
                 },
                 state,
                 CancellationToken.None,
@@ -789,7 +789,7 @@ namespace System.Net.Http
             }
         }
 
-        private async Task StartRequest(WinHttpRequestState state)
+        private async Task StartRequestAsync(WinHttpRequestState state)
         {
             if (state.CancellationToken.IsCancellationRequested)
             {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -557,7 +557,7 @@ namespace System.Net.Http
             Task.Factory.StartNew(
                 s => {
                     var whrs = (WinHttpRequestState)s;
-                    whrs.Handler.StartRequest(whrs);
+                    _ = whrs.Handler.StartRequest(whrs);
                 },
                 state,
                 CancellationToken.None,
@@ -789,7 +789,7 @@ namespace System.Net.Http
             }
         }
 
-        private async void StartRequest(WinHttpRequestState state)
+        private async Task StartRequest(WinHttpRequestState state)
         {
             if (state.CancellationToken.IsCancellationRequested)
             {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -139,7 +139,7 @@ namespace System.Net.Http
 
             _expectingSettingsAck = true;
 
-            _ = ProcessIncomingFrames();
+            _ = ProcessIncomingFramesAsync();
         }
 
         private async Task EnsureIncomingBytesAsync(int minReadBytes)
@@ -199,7 +199,7 @@ namespace System.Net.Http
             return frameHeader;
         }
 
-        private async Task ProcessIncomingFrames()
+        private async Task ProcessIncomingFramesAsync()
         {
             try
             {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -139,7 +139,7 @@ namespace System.Net.Http
 
             _expectingSettingsAck = true;
 
-            ProcessIncomingFrames();
+            _ = ProcessIncomingFrames();
         }
 
         private async Task EnsureIncomingBytesAsync(int minReadBytes)
@@ -199,7 +199,7 @@ namespace System.Net.Http
             return frameHeader;
         }
 
-        private async void ProcessIncomingFrames()
+        private async Task ProcessIncomingFrames()
         {
             try
             {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -52,14 +52,14 @@ namespace System.Net.Http
                     // Start the asynchronous drain.
                     // It may complete synchronously, in which case the connection will be put back in the pool synchronously.
                     // Skip the call to base.Dispose -- it will be deferred until DrainOnDisposeAsync finishes.
-                    DrainOnDisposeAsync();
+                    _ = DrainOnDisposeAsync();
                     return;
                 }
 
                 base.Dispose(disposing);
             }
 
-            private async void DrainOnDisposeAsync()
+            private async Task DrainOnDisposeAsync()
             {
                 HttpConnection connection = _connection;        // Will be null after drain succeeds
 


### PR DESCRIPTION
When Expect: 100-continue is used, the sending of the request body content is allowed to run concurrently with the receipt of the response headers.  If the processing of the response headers encounters an exception, we currently fail to ever join with that send task, which results in a TaskScheduler.UnobservedTaskException event.  This PR changes to observe the exception in such cases and log it.

(In doing so, I also came across an async void method, and changed all of the remaining ones in the assembly to be async Task instead.  The current implementation of async void isn't any cheaper than async Task, and is actually more expensive in certain ways, plus it unnecessarily interacts with any SynchronizationContext that may exist.)

Fixes https://github.com/dotnet/corefx/issues/37386
cc: @davidsh, @wfurt, @geoffkizer 