### PR TITLE
Shrink System.Diagnostics.Activity by 40 bytes

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -34,20 +34,20 @@ namespace System.Diagnostics
         public string OperationName { get { throw null; } }
         public System.Diagnostics.Activity Parent { get { throw null; } }
         public string ParentId { get { throw null; } }
-        public ref readonly System.Diagnostics.ActivitySpanId ParentSpanId { get { throw null; } }
+        public System.Diagnostics.ActivitySpanId ParentSpanId { get { throw null; } }
         public bool Recorded { get { throw null; } }
         public string RootId { get { throw null; } }
-        public ref readonly System.Diagnostics.ActivitySpanId SpanId { get { throw null; } }
+        public System.Diagnostics.ActivitySpanId SpanId { get { throw null; } }
         public System.DateTime StartTimeUtc { get { throw null; } }
         public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> Tags { get { throw null; } }
-        public ref readonly System.Diagnostics.ActivityTraceId TraceId { get { throw null; } }
+        public System.Diagnostics.ActivityTraceId TraceId { get { throw null; } }
         public string TraceStateString { get { throw null; } set { } }
         public System.Diagnostics.ActivityTraceFlags ActivityTraceFlags { get { throw null; } set { } }
         public System.Diagnostics.Activity AddBaggage(string key, string value) { throw null; }
         public System.Diagnostics.Activity AddTag(string key, string value) { throw null; }
         public string GetBaggageItem(string key) { throw null; }
         public System.Diagnostics.Activity SetEndTime(System.DateTime endTimeUtc) { throw null; }
-        public System.Diagnostics.Activity SetParentId(in System.Diagnostics.ActivityTraceId traceId, in System.Diagnostics.ActivitySpanId spanId, ActivityTraceFlags activityTraceFlags = ActivityTraceFlags.None) { throw null; }
+        public System.Diagnostics.Activity SetParentId(System.Diagnostics.ActivityTraceId traceId, System.Diagnostics.ActivitySpanId spanId, ActivityTraceFlags activityTraceFlags = ActivityTraceFlags.None) { throw null; }
         public System.Diagnostics.Activity SetParentId(string parentId) { throw null; }
         public System.Diagnostics.Activity SetStartTime(System.DateTime startTimeUtc) { throw null; }
         public System.Diagnostics.Activity Start() { throw null; }
@@ -65,7 +65,6 @@ namespace System.Diagnostics
     public readonly partial struct ActivitySpanId : System.IEquatable<System.Diagnostics.ActivitySpanId>
     {
         private readonly object _dummy;
-        private readonly int _dummyPrimitive;
         public void CopyTo(System.Span<byte> destination) { }
         public static System.Diagnostics.ActivitySpanId CreateFromBytes(System.ReadOnlySpan<byte> idData) { throw null; }
         public static System.Diagnostics.ActivitySpanId CreateFromString(System.ReadOnlySpan<char> idData) { throw null; }
@@ -74,8 +73,8 @@ namespace System.Diagnostics
         public bool Equals(System.Diagnostics.ActivitySpanId spanId) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(in System.Diagnostics.ActivitySpanId spanId1, in System.Diagnostics.ActivitySpanId spandId2) { throw null; }
-        public static bool operator !=(in System.Diagnostics.ActivitySpanId spanId1, in System.Diagnostics.ActivitySpanId spandId2) { throw null; }
+        public static bool operator ==(System.Diagnostics.ActivitySpanId spanId1, System.Diagnostics.ActivitySpanId spandId2) { throw null; }
+        public static bool operator !=(System.Diagnostics.ActivitySpanId spanId1, System.Diagnostics.ActivitySpanId spandId2) { throw null; }
         public string ToHexString() { throw null; }
         public override string ToString() { throw null; }
     }
@@ -85,7 +84,6 @@ namespace System.Diagnostics
     public readonly partial struct ActivityTraceId : System.IEquatable<System.Diagnostics.ActivityTraceId>
     {
         private readonly object _dummy;
-        private readonly int _dummyPrimitive;
         public void CopyTo(System.Span<byte> destination) { }
         public static System.Diagnostics.ActivityTraceId CreateFromBytes(System.ReadOnlySpan<byte> idData) { throw null; }
         public static System.Diagnostics.ActivityTraceId CreateFromString(System.ReadOnlySpan<char> idData) { throw null; }
@@ -94,8 +92,8 @@ namespace System.Diagnostics
         public bool Equals(System.Diagnostics.ActivityTraceId traceId) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
-        public static bool operator ==(in System.Diagnostics.ActivityTraceId traceId1, in System.Diagnostics.ActivityTraceId traceId2) { throw null; }
-        public static bool operator !=(in System.Diagnostics.ActivityTraceId traceId1, in System.Diagnostics.ActivityTraceId traceId2) { throw null; }
+        public static bool operator ==(System.Diagnostics.ActivityTraceId traceId1, System.Diagnostics.ActivityTraceId traceId2) { throw null; }
+        public static bool operator !=(System.Diagnostics.ActivityTraceId traceId1, System.Diagnostics.ActivityTraceId traceId2) { throw null; }
         public string ToHexString() { throw null; }
         public override string ToString() { throw null; }
     }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Current.net46.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.Current.net46.cs
@@ -8,6 +8,8 @@ namespace System.Diagnostics
 {
     public partial class Activity
     {
+        private static readonly AsyncLocal<Activity> s_current = new AsyncLocal<Activity>();
+
         /// <summary>
         /// Gets or sets the current operation (Activity) for the current thread.  This flows 
         /// across async calls.
@@ -24,13 +26,9 @@ namespace System.Diagnostics
             }
         }
 
-#region private
         private static void SetCurrent(Activity activity)
         {
             s_current.Value = activity;
         }
-
-        private static readonly AsyncLocal<Activity> s_current = new AsyncLocal<Activity>();
-#endregion // private
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -129,7 +129,7 @@ namespace System.Diagnostics
                 {
                     // Convert flags to binary.  
                     Span<char> flagsChars = stackalloc char[2];
-                    ActivityTraceId.ByteToHexDigits(flagsChars, _w3CIdFlags);
+                    ActivityTraceId.ByteToHexDigits(flagsChars, (byte)((~ActivityTraceFlagsIsSet) & _w3CIdFlags));
                     string id = "00-" + _traceId + "-" + _spanId + "-" + flagsChars.ToString();
 
                     Interlocked.CompareExchange(ref _id, id, null);

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 
@@ -32,6 +33,43 @@ namespace System.Diagnostics
     {
         private static readonly IEnumerable<KeyValuePair<string, string>> s_emptyBaggageTags = new KeyValuePair<string, string>[0]; // Array.Empty<T>() doesn't exist in all configurations
 
+        private const int RequestIdMaxLength = 1024;
+
+        // Used to generate an ID it represents the machine and process we are in.  
+        private static readonly string s_uniqSuffix = "-" + GetRandomNumber().ToString("x") + ".";
+
+        // A unique number inside the appdomain, randomized between appdomains. 
+        // Int gives enough randomization and keeps hex-encoded s_currentRootId 8 chars long for most applications
+        private static readonly long s_currentRootId = (uint)GetRandomNumber();
+        private static ActivityIdFormat s_defaultIdFormat;
+        /// <summary>
+        /// Normally if the ParentID is defined, the format of that is used to determine the
+        /// format used by the Activity.   However if ForceDefaultFormat is set to true, the
+        /// ID format will always be the DefaultIdFormat even if the ParentID is define and is
+        /// a different format. 
+        /// </summary>
+        public static bool ForceDefaultIdFormat { get; set; }
+
+        private string _traceState;
+        private State _state;
+        private int _currentChildId;  // A unique number for all children of this activity.
+
+        // State associated with ID. 
+        private string _id;
+        private string _rootId;
+        // State associated with ParentId.
+        private string _parentId;
+
+        // W3C formats
+        private string _parentSpanId;
+        private string _traceId;
+        private string _spanId;
+
+        private byte _w3CIdFlags;
+
+        private KeyValueListNode _tags;
+        private KeyValueListNode _baggage;
+
         /// <summary>
         /// An operation name is a COARSEST name that is useful grouping/filtering. 
         /// The name is typically a compile-time constant.   Names of Rest APIs are
@@ -39,6 +77,27 @@ namespace System.Diagnostics
         /// the name but rather in the tags.  
         /// </summary>
         public string OperationName { get; }
+
+        /// <summary>
+        /// If the Activity that created this activity is from the same process you can get 
+        /// that Activity with Parent.  However, this can be null if the Activity has no
+        /// parent (a root activity) or if the Parent is from outside the process.
+        /// </summary>
+        /// <seealso cref="ParentId"/>
+        public Activity Parent { get; private set; }
+
+        /// <summary>
+        /// If the Activity has ended (<see cref="Stop"/> or <see cref="SetEndTime"/> was called) then this is the delta
+        /// between <see cref="StartTimeUtc"/> and end.   If Activity is not ended and <see cref="SetEndTime"/> was not called then this is 
+        /// <see cref="TimeSpan.Zero"/>.
+        /// </summary>
+        public TimeSpan Duration { get; private set; }
+
+        /// <summary>
+        /// The time that operation started.  It will typically be initialized when <see cref="Start"/>
+        /// is called, but you can set at any time via <see cref="SetStartTime(DateTime)"/>.
+        /// </summary>
+        public DateTime StartTimeUtc { get; private set; }
 
         /// <summary>
         /// This is an ID that is specific to a particular request.   Filtering
@@ -65,31 +124,17 @@ namespace System.Diagnostics
             {
                 // if we represented it as a traceId-spanId, convert it to a string.  
                 // We can do this concatenation with a stackalloced Span<char> if we actually used Id a lot.  
-                if (_id == null && _spanIdSet)
+                if (_id == null && SpanIdSet)
                 {
                     // Convert flags to binary.  
                     Span<char> flagsChars = stackalloc char[2];
                     ActivityTraceId.ByteToHexDigits(flagsChars, _w3CIdFlags);
-                    _id = "00-" + _traceId.ToHexString() + "-" + _spanId.ToHexString() + "-" + flagsChars.ToString();
+                    _id = "00-" + _traceId + "-" + _spanId + "-" + flagsChars.ToString();
 
                 }
                 return _id;
             }
         }
-
-        /// <summary>
-        /// The time that operation started.  It will typically be initialized when <see cref="Start"/>
-        /// is called, but you can set at any time via <see cref="SetStartTime(DateTime)"/>.
-        /// </summary>
-        public DateTime StartTimeUtc { get; private set; }
-
-        /// <summary>
-        /// If the Activity that created this activity is from the same process you can get 
-        /// that Activity with Parent.  However, this can be null if the Activity has no
-        /// parent (a root activity) or if the Parent is from outside the process.
-        /// </summary>
-        /// <seealso cref="ParentId"/>
-        public Activity Parent { get; private set; }
 
         /// <summary>
         /// If the parent for this activity comes from outside the process, the activity
@@ -106,8 +151,8 @@ namespace System.Diagnostics
                 // if we represented it as a traceId-spanId, convert it to a string.  
                 if (_parentId == null)
                 {
-                    if (_parentSpanIdSet)
-                        _parentId = "00-" + _traceId.ToHexString() + "-" + _parentSpanId.ToHexString() + "-00";
+                    if (ParentSpanIdSet)
+                        _parentId = "00-" + _traceId + "-" + _parentSpanId + "-00";
                     else if (Parent != null)
                         _parentId = Parent.Id;
                 }
@@ -280,7 +325,7 @@ namespace System.Diagnostics
             {
                 NotifyError(new InvalidOperationException($"Trying to set {nameof(ParentId)} on activity which has {nameof(Parent)}"));
             }
-            else if (ParentId != null || _parentSpanIdSet)
+            else if (ParentId != null || ParentSpanIdSet)
             {
                 NotifyError(new InvalidOperationException($"{nameof(ParentId)} is already set"));
             }
@@ -299,24 +344,24 @@ namespace System.Diagnostics
         /// Set the parent ID using the W3C convention using a TraceId and a SpanId.   This
         /// constructor has the advantage that no string manipulation is needed to set the ID.  
         /// </summary>
-        public Activity SetParentId(in ActivityTraceId traceId, in ActivitySpanId spanId, ActivityTraceFlags activityTraceFlags = ActivityTraceFlags.None)
+        public Activity SetParentId(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags activityTraceFlags = ActivityTraceFlags.None)
         {
             if (Parent != null)
             {
                 NotifyError(new InvalidOperationException($"Trying to set {nameof(ParentId)} on activity which has {nameof(Parent)}"));
             }
-            else if (ParentId != null || _parentSpanIdSet)
+            else if (ParentId != null || ParentSpanIdSet)
             {
                 NotifyError(new InvalidOperationException($"{nameof(ParentId)} is already set"));
             }
             else
             {
-                _traceId = traceId;     // The child will share the parent's traceId.  
-                _traceIdSet = true;
-                _parentSpanId = spanId;
-                _parentSpanIdSet = true;
+                _traceId = traceId.ToHexString();     // The child will share the parent's traceId.  
+                TraceIdSet = true;
+                _parentSpanId = spanId.ToHexString();
+                ParentSpanIdSet = true;
                 _w3CIdFlags = (byte)activityTraceFlags;
-                _w3CIdFlagsSet = true;
+                W3CIdFlagsSet = true;
             }
             return this;
         }
@@ -362,13 +407,6 @@ namespace System.Diagnostics
         }
 
         /// <summary>
-        /// If the Activity has ended (<see cref="Stop"/> or <see cref="SetEndTime"/> was called) then this is the delta
-        /// between <see cref="StartTimeUtc"/> and end.   If Activity is not ended and <see cref="SetEndTime"/> was not called then this is 
-        /// <see cref="TimeSpan.Zero"/>.
-        /// </summary>
-        public TimeSpan Duration { get; private set; }
-
-        /// <summary>
         /// Starts activity
         /// <list type="bullet">
         /// <item>Sets <see cref="Parent"/> to hold <see cref="Current"/>.</item>
@@ -383,13 +421,13 @@ namespace System.Diagnostics
         public Activity Start()
         {
             // Has the ID already been set (have we called Start()).  
-            if (_id != null || _spanIdSet)
+            if (_id != null || SpanIdSet)
             {
                 NotifyError(new InvalidOperationException("Trying to start an Activity that was already started"));
             }
             else
             {
-                if (_parentId == null && !_parentSpanIdSet)
+                if (_parentId == null && !ParentSpanIdSet)
                 {
                     Activity parent = Current;
                     if (parent != null)
@@ -401,7 +439,7 @@ namespace System.Diagnostics
                     }
                 }
 
-                if (StartTimeUtc == default(DateTime))
+                if (StartTimeUtc == default)
                     StartTimeUtc = GetUtcNow();
 
                 // Figure out what format to use.  
@@ -409,7 +447,7 @@ namespace System.Diagnostics
                     IdFormat = DefaultIdFormat;
                 else if (Parent != null)
                     IdFormat = Parent.IdFormat;
-                else if (_parentSpanIdSet)
+                else if (ParentSpanIdSet)
                     IdFormat = ActivityIdFormat.W3C;
                 else if (_parentId != null)
                     IdFormat = IsW3CId(_parentId) ? ActivityIdFormat.W3C : ActivityIdFormat.Hierarchical;
@@ -442,9 +480,9 @@ namespace System.Diagnostics
                 return;
             }
 
-            if (!isFinished)
+            if (!IsFinished)
             {
-                isFinished = true;
+                IsFinished = true;
 
                 if (Duration == TimeSpan.Zero)
                 {
@@ -490,55 +528,43 @@ namespace System.Diagnostics
 
         /// <summary>
         /// If the Activity has the W3C format, this returns the ID for the SPAN part of the Id.  
-        /// Otherwise it returns a zero SpanId. 
-        /// 
-        /// Note that this returns a readonly ref.   This is because SpanId has a cache of the
-        /// Hex string.   However for that cache to be available for subsequent conversions to
-        /// Hex, you have to be operating on the same instance.   Thus if you need the Hex string
-        /// you should store the SpanId in a ref local variable and call the AsHexString property
-        /// which will have the effect of updating Activity's instance so all subsequent uses
-        /// share the same converted string.  
+        /// Otherwise it returns a zero SpanId.
         /// </summary>
-        public ref readonly ActivitySpanId SpanId
+        public ActivitySpanId SpanId
         {
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
             [System.Security.SecuritySafeCriticalAttribute]
 #endif
             get
             {
-                if (!_spanIdSet)
+                if (!SpanIdSet)
                 {
                     if (_id != null && IdFormat == ActivityIdFormat.W3C)
                     {
-                        _spanId = ActivitySpanId.CreateFromString(_id.AsSpan(36, 16));
-                        _spanIdSet = true;
+                        ActivitySpanId spanId = ActivitySpanId.CreateFromString(_id.AsSpan(36, 16));
+                        _spanId = spanId.ToHexString();
+                        SpanIdSet = true;
+                        return spanId;
                     }
                 }
-                return ref _spanId;
+                return new ActivitySpanId(_spanId);
             }
         }
 
         /// <summary>
         /// If the Activity has the W3C format, this returns the ID for the TraceId part of the Id.  
         /// Otherwise it returns a zero TraceId. 
-        /// 
-        /// Note that this returns a readonly ref.   This is because TraceId has a cache of the
-        /// Hex string.   However for that cache to be available for subsequent conversions to
-        /// Hex, you have to be operating on the same instance.   Thus if you need the Hex string
-        /// you should store the TraceId in a ref local variable and call the AsHexString property
-        /// which will have the effect of updating Activity's instance so all subsequent uses
-        /// share the same converted string.  
         /// </summary>
-        public ref readonly ActivityTraceId TraceId
+        public ActivityTraceId TraceId
         {
             get
             {
-                if (!_traceIdSet)
+                if (!TraceIdSet)
                 {
                     TrySetTraceIdFromParent();
                 }
 
-                return ref _traceId;
+                return new ActivityTraceId(_traceId);
             }
         }
 
@@ -547,9 +573,6 @@ namespace System.Diagnostics
         /// </summary>
         public bool Recorded { get => (ActivityTraceFlags & ActivityTraceFlags.Recorded) != 0; }
 
-        byte _w3CIdFlags;
-        bool _w3CIdFlagsSet;
-
         /// <summary>
         /// Return the flags (defined by the W3C ID specification) associated with the activity.  
         /// </summary>
@@ -557,15 +580,15 @@ namespace System.Diagnostics
         {
             get
             {
-                if (!_w3CIdFlagsSet)
+                if (!W3CIdFlagsSet)
                 {
-                    _w3CIdFlagsSet = TrySetTraceFlagsFromParent();
+                    TrySetTraceFlagsFromParent();
                 }
                 return (ActivityTraceFlags)_w3CIdFlags;
             }
             set
             {
-                _w3CIdFlagsSet = true;
+                W3CIdFlagsSet = true;
                 _w3CIdFlags = (byte)value;
             }
         }
@@ -574,38 +597,33 @@ namespace System.Diagnostics
         /// If the parent Activity ID has the W3C format, this returns the ID for the SpanId part of the ParentId.  
         /// Otherwise it returns a zero SpanId. 
         /// </summary>
-        public ref readonly ActivitySpanId ParentSpanId
+        public ActivitySpanId ParentSpanId
         {
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
             [System.Security.SecuritySafeCriticalAttribute]
 #endif
             get
             {
-                if (!_parentSpanIdSet)
+                if (!ParentSpanIdSet)
                 {
                     if (_parentId != null && IsW3CId(_parentId))
                     {
                         try
                         {
-                            _parentSpanId = ActivitySpanId.CreateFromString(_parentId.AsSpan(36, 16));
+                            _parentSpanId = ActivitySpanId.CreateFromString(_parentId.AsSpan(36, 16)).ToHexString();
                         }
                         catch { }
-                        _parentSpanIdSet = true;
+                        ParentSpanIdSet = true;
                     }
                     else if (Parent != null && Parent.IdFormat == ActivityIdFormat.W3C)
                     {
-                        _parentSpanId = Parent.SpanId;
-                        _parentSpanIdSet = true;
+                        _parentSpanId = Parent.SpanId.ToHexString();
+                        ParentSpanIdSet = true;
                     }
                 }
-                return ref _parentSpanId;
+                return new ActivitySpanId(_parentSpanId);
             }
         }
-
-        /// <summary>
-        /// Returns the format for the ID.   
-        /// </summary>
-        public ActivityIdFormat IdFormat { get; private set; }
 
         /* static state (configuration) */
         /// <summary>
@@ -617,27 +635,18 @@ namespace System.Diagnostics
         {
             get
             {
-                if (s_DefaultIdFormat == ActivityIdFormat.Unknown)
-                    s_DefaultIdFormat = ActivityIdFormat.Hierarchical;
-                return s_DefaultIdFormat;
+                if (s_defaultIdFormat == ActivityIdFormat.Unknown)
+                    s_defaultIdFormat = ActivityIdFormat.Hierarchical;
+                return s_defaultIdFormat;
             }
             set
             {
                 if (!(ActivityIdFormat.Hierarchical <= value && value <= ActivityIdFormat.W3C))
                     throw new ArgumentException($"value must be a valid ActivityIDFormat value");
-                s_DefaultIdFormat = value;
+                s_defaultIdFormat = value;
             }
         }
 
-        /// <summary>
-        /// Normally if the ParentID is defined, the format of that is used to determine the
-        /// format used by the Activity.   However if ForceDefaultFormat is set to true, the
-        /// ID format will always be the DefaultIdFormat even if the ParentID is define and is
-        /// a different format. 
-        /// </summary>
-        public static bool ForceDefaultIdFormat { get; set; }
-
-        #region private 
         /// <summary>
         /// Returns true if 'id' has the format of a WC3 id see https://w3c.github.io/trace-context
         /// </summary>
@@ -664,23 +673,23 @@ namespace System.Diagnostics
         private void GenerateW3CId()
         {
             // Get the TraceId from the parent or make a new one.  
-            if (!_traceIdSet)
+            if (!TraceIdSet)
             {
                 if (!TrySetTraceIdFromParent())
                 {
-                    _traceId = ActivityTraceId.CreateRandom();
-                    _traceIdSet = true;
+                    _traceId = ActivityTraceId.CreateRandom().ToHexString();
+                    TraceIdSet = true;
                 }
             }
 
-            if (!_w3CIdFlagsSet)
+            if (!W3CIdFlagsSet)
             {
-                _w3CIdFlagsSet = TrySetTraceFlagsFromParent();
+                TrySetTraceFlagsFromParent();
             }
 
             // Create a new SpanID. 
-            _spanId = ActivitySpanId.CreateRandom();
-            _spanIdSet = true;
+            _spanId = ActivitySpanId.CreateRandom().ToHexString();
+            SpanIdSet = true;
         }
 
         private static void NotifyError(Exception exception)
@@ -789,7 +798,7 @@ namespace System.Diagnostics
 
         private static bool ValidateSetCurrent(Activity activity)
         {
-            bool canSet = activity == null || (activity.Id != null && !activity.isFinished);
+            bool canSet = activity == null || (activity.Id != null && !activity.IsFinished);
             if (!canSet)
             {
                 NotifyError(new InvalidOperationException("Trying to set an Activity that is not running"));
@@ -803,36 +812,36 @@ namespace System.Diagnostics
 #endif
         private bool TrySetTraceIdFromParent()
         {
-            Debug.Assert(!_traceIdSet);
+            Debug.Assert(!TraceIdSet);
 
             if (Parent != null && Parent.IdFormat == ActivityIdFormat.W3C)
             {
-                _traceId = Parent.TraceId;
-                _traceIdSet = true;
+                _traceId = Parent.TraceId.ToHexString();
+                TraceIdSet = true;
             }
             else if (_parentId != null && IsW3CId(_parentId))
             {
                 try
                 {
-                    _traceId = ActivityTraceId.CreateFromString(_parentId.AsSpan(3, 32));
-                    _traceIdSet = true;
+                    _traceId = ActivityTraceId.CreateFromString(_parentId.AsSpan(3, 32)).ToHexString();
+                    TraceIdSet = true;
                 }
                 catch
                 {
                 }
             }
 
-            return _traceIdSet;
+            return TraceIdSet;
         }
 
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
         [System.Security.SecuritySafeCriticalAttribute]
 #endif
-        private bool TrySetTraceFlagsFromParent()
+        private void TrySetTraceFlagsFromParent()
         {
-            Debug.Assert(!_w3CIdFlagsSet);
+            Debug.Assert(!W3CIdFlagsSet);
 
-            if (!_w3CIdFlagsSet)
+            if (!W3CIdFlagsSet)
             {
                 if (Parent != null)
                 {
@@ -841,25 +850,99 @@ namespace System.Diagnostics
                 else if (_parentId != null && IsW3CId(_parentId))
                 {
                     _w3CIdFlags = ActivityTraceId.HexByteFromChars(_parentId[53], _parentId[54]);
-                    _w3CIdFlagsSet = true;
+                    W3CIdFlagsSet = true;
                 }
             }
-
-            return _w3CIdFlagsSet;
         }
 
+        private bool TraceIdSet
+        {
+            get => (_state & State.TraceIdSet) != 0;
+            set
+            {
+                if (value)
+                {
+                    _state |= State.TraceIdSet;
+                }
+                else
+                {
+                    _state &= ~State.TraceIdSet;
+                }
+            }
+        }
 
-        private string _rootId;
-        private int _currentChildId;  // A unique number for all children of this activity.  
+        private bool SpanIdSet
+        {
+            get => (_state & State.SpanIdSet) != 0;
+            set
+            {
+                if (value)
+                {
+                    _state |= State.SpanIdSet;
+                }
+                else
+                {
+                    _state &= ~State.SpanIdSet;
+                }
+            }
+        }
 
-        // Used to generate an ID it represents the machine and process we are in.  
-        private static readonly string s_uniqSuffix = "-" + GetRandomNumber().ToString("x") + ".";
+        private bool ParentSpanIdSet
+        {
+            get => (_state & State.ParentSpanIdSet) != 0;
+            set
+            {
+                if (value)
+                {
+                    _state |= State.ParentSpanIdSet;
+                }
+                else
+                {
+                    _state &= ~State.ParentSpanIdSet;
+                }
+            }
+        }
 
-        //A unique number inside the appdomain, randomized between appdomains. 
-        //Int gives enough randomization and keeps hex-encoded s_currentRootId 8 chars long for most applications
-        private static long s_currentRootId = (uint)GetRandomNumber();
+        private bool W3CIdFlagsSet
+        {
+            get => (_state & State.W3CIdFlagsSet) != 0;
+            set
+            {
+                if (value)
+                {
+                    _state |= State.W3CIdFlagsSet;
+                }
+                else
+                {
+                    _state &= ~State.W3CIdFlagsSet;
+                }
+            }
+        }
 
-        private const int RequestIdMaxLength = 1024;
+        private bool IsFinished
+        {
+            get => (_state & State.IsFinished) != 0;
+            set
+            {
+                if (value)
+                {
+                    _state |= State.IsFinished;
+                }
+                else
+                {
+                    _state &= ~State.IsFinished;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the format for the ID.   
+        /// </summary>
+        public ActivityIdFormat IdFormat
+        {
+            get => (ActivityIdFormat)(_state & State.FormatFlags);
+            private set => _state = (_state & ~State.FormatFlags) | (State)((byte)value & (byte)State.FormatFlags);
+        }
 
         /// <summary>
         /// Having our own key-value linked list allows us to be more efficient  
@@ -870,26 +953,23 @@ namespace System.Diagnostics
             public KeyValueListNode Next;
         }
 
-        private static ActivityIdFormat s_DefaultIdFormat;
+        [Flags]
+        private enum State : byte
+        {
+            None = 0,
 
-        private KeyValueListNode _tags;
-        private KeyValueListNode _baggage;
-        private string _traceState;
+            FormatUnknown = 0b_0_00000_00,
+            FormatHierarchical = 0b_0_00000_01,
+            FormatW3C = 0b_0_00000_10,
+            FormatFlags = 0b_0_00000_11,
 
-        // State associated with ID.  It can be represented by a string or by TraceId, SpanId.  
-        private string _id;
-        private ActivityTraceId _traceId;
-        private bool _traceIdSet;
-        private ActivitySpanId _spanId;
-        private bool _spanIdSet;
+            TraceIdSet = 0b_0_00001_00,
+            SpanIdSet = 0b_0_00010_00,
+            ParentSpanIdSet = 0b_0_00100_00,
+            W3CIdFlagsSet = 0b_0_01000_00,
 
-        // State associated with ParentId.  It can be represented by a string or by TraceId, SpanId.  
-        private string _parentId;
-        private ActivitySpanId _parentSpanId;
-        private bool _parentSpanIdSet;
-
-        private bool isFinished;
-        #endregion // private
+            IsFinished = 0b_1_00000_00,
+        }
     }
 
     /// <summary>
@@ -907,9 +987,9 @@ namespace System.Diagnostics
     /// </summary>
     public enum ActivityIdFormat
     {
-        Unknown,      // ID format is not known.     
-        Hierarchical, //|XXXX.XX.X_X ... see https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format
-        W3C,          // 00-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXX-XX see https://w3c.github.io/trace-context/
+        Unknown = 0,      // ID format is not known.     
+        Hierarchical = 1, //|XXXX.XX.X_X ... see https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format
+        W3C = 2,          // 00-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXX-XX see https://w3c.github.io/trace-context/
     };
 
     /// <summary>
@@ -924,45 +1004,36 @@ namespace System.Diagnostics
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
         [System.Security.SecuritySafeCriticalAttribute]
 #endif
-    public unsafe readonly struct ActivityTraceId : IEquatable<ActivityTraceId>
+    public readonly struct ActivityTraceId : IEquatable<ActivityTraceId>
     {
+        private readonly string _hexString;
+
+        internal ActivityTraceId(string hexString) => _hexString = hexString;
+
         /// <summary>
         /// Create a new TraceId with at random number in it (very likely to be unique)
         /// </summary>
         public static ActivityTraceId CreateRandom()
         {
-            ActivityTraceId ret = new ActivityTraceId();
-            SetToRandomBytes(new Span<byte>(&ret._id1, sizeof(ulong) * 2));
-            return ret;
+            Span<byte> span = stackalloc byte[sizeof(ulong) * 2];
+            SetToRandomBytes(span);
+            return CreateFromBytes(span);
         }
         public static ActivityTraceId CreateFromBytes(ReadOnlySpan<byte> idData)
         {
             if (idData.Length != 16)
                 throw new ArgumentOutOfRangeException(nameof(idData));
 
-            ActivityTraceId ret = new ActivityTraceId();
-            idData.CopyTo(new Span<byte>(&ret._id1, sizeof(ulong) * 2));
-            return ret;
+            return new ActivityTraceId(SpanToHexString(idData));
         }
         public static ActivityTraceId CreateFromUtf8String(ReadOnlySpan<byte> idData) => new ActivityTraceId(idData);
 
         public static ActivityTraceId CreateFromString(ReadOnlySpan<char> idData)
         {
-            if (idData.Length != 32)
+            if (idData.Length != 32 || !ActivityTraceId.IsLowerCaseHexAndNotAllZeros(idData))
                 throw new ArgumentOutOfRangeException(nameof(idData));
 
-            ActivityTraceId ret = new ActivityTraceId();
-            ActivityTraceId.SetSpanFromHexChars(new Span<byte>(&ret._id1, sizeof(ulong) * 2), idData);
-            return ret;
-        }
-
-        /// <summary>
-        /// Copy the bytes of the TraceId (16 total) into the 'destination' span.
-        /// </summary>
-        public void CopyTo(Span<byte> destination)
-        {
-            fixed (ulong* idPtr = &_id1)
-                new ReadOnlySpan<byte>(idPtr, sizeof(ulong) * 2).CopyTo(destination);
+            return new ActivityTraceId(idData.ToString());
         }
 
         /// <summary>
@@ -970,17 +1041,7 @@ namespace System.Diagnostics
         /// </summary>
         public string ToHexString()
         {
-            if (_asHexString == null)
-            {
-                fixed (ulong* idPtr = &_id1)
-                {
-                    // Cast away the read-only-ness of _asHexString, and assign the converted value to it.  
-                    // We are OK with this because conceptually the class is still read-only.  
-                    ref string strRef = ref Unsafe.AsRef(in _asHexString);
-                    Interlocked.CompareExchange(ref strRef, SpanToHexString(new ReadOnlySpan<byte>(idPtr, sizeof(ulong) * 2)), null);
-                }
-            }
-            return _asHexString;
+            return _hexString ?? "00000000000000000000000000000000";
         }
 
         /// <summary>
@@ -988,57 +1049,64 @@ namespace System.Diagnostics
         /// </summary>
         public override string ToString() => ToHexString();
 
-        #region equality operators
-        public static bool operator ==(in ActivityTraceId traceId1, in ActivityTraceId traceId2)
+        public static bool operator ==(ActivityTraceId traceId1, ActivityTraceId traceId2)
         {
-            return traceId1._id1 == traceId2._id1 && traceId1._id2 == traceId2._id2;
+            return traceId1._hexString == traceId2._hexString;
         }
-        public static bool operator !=(in ActivityTraceId traceId1, in ActivityTraceId traceId2)
+        public static bool operator !=(ActivityTraceId traceId1, ActivityTraceId traceId2)
         {
-            return traceId1._id1 != traceId2._id1 || traceId1._id2 != traceId2._id2;
+            return traceId1._hexString != traceId2._hexString;
         }
         public bool Equals(ActivityTraceId traceId)
         {
-            return _id1 == traceId._id1 && _id2 == traceId._id2;
+            return _hexString == traceId._hexString;
         }
         public override bool Equals(object obj)
         {
             if (obj is ActivityTraceId traceId)
-                return _id1 == traceId._id1 && _id2 == traceId._id2;
+                return _hexString == traceId._hexString;
             return false;
         }
         public override int GetHashCode()
         {
-            return _id1.GetHashCode() + _id2.GetHashCode();
+            return ToHexString().GetHashCode();
         }
-        #endregion
 
-        #region private
         /// <summary>
         /// This is exposed as CreateFromUtf8String, but we are modifying fields, so the code needs to be in a constructor.  
         /// </summary>
         /// <param name="idData"></param>
         private ActivityTraceId(ReadOnlySpan<byte> idData)
         {
-            _id1 = 0;
-            _id2 = 0;
-            _asHexString = null;
             if (idData.Length != 32)
                 throw new ArgumentOutOfRangeException(nameof(idData));
-            Utf8Parser.TryParse(idData.Slice(0, 16), out _id1, out _, 'x');
-            Utf8Parser.TryParse(idData.Slice(16, 16), out _id2, out _, 'x');
+
+            Span<ulong> span = stackalloc ulong[2];
+
+            Utf8Parser.TryParse(idData.Slice(0, 16), out span[0], out _, 'x');
+            Utf8Parser.TryParse(idData.Slice(16, 16), out span[1], out _, 'x');
             if (BitConverter.IsLittleEndian)
             {
-                _id1 = BinaryPrimitives.ReverseEndianness(_id1);
-                _id2 = BinaryPrimitives.ReverseEndianness(_id2);
+                span[0] = BinaryPrimitives.ReverseEndianness(span[0]);
+                span[1] = BinaryPrimitives.ReverseEndianness(span[1]);
             }
+
+            _hexString = ActivityTraceId.SpanToHexString(MemoryMarshal.AsBytes(span));
+        }
+
+        /// <summary>
+        /// Copy the bytes of the TraceId (16 total) into the 'destination' span.
+        /// </summary>
+        public void CopyTo(Span<byte> destination)
+        {
+            ActivityTraceId.SetSpanFromHexChars(ToHexString().AsSpan(), destination);
         }
 
         /// <summary>
         /// Sets the bytes in 'outBytes' to be random values.   outBytes.Length must be less than or equal to 16
         /// </summary>
         /// <param name="outBytes"></param>
-        internal static void SetToRandomBytes(Span<byte> outBytes)
+        internal unsafe static void SetToRandomBytes(Span<byte> outBytes)
         {
             Debug.Assert(outBytes.Length <= sizeof(Guid));     // Guid is 16 bytes, and so is TraceId 
             Guid guid = Guid.NewGuid();
@@ -1046,7 +1114,7 @@ namespace System.Diagnostics
             guidBytes.Slice(0, outBytes.Length).CopyTo(outBytes);
         }
 
-        #region CONVERSION binary spans to hex spans, and hex spans to binary spans  
+        // CONVERSION binary spans to hex spans, and hex spans to binary spans  
         /* It would be nice to use generic Hex number conversion routines, but there 
          * is nothing that is exposed publicly and efficient */
         /// <summary>
@@ -1070,7 +1138,7 @@ namespace System.Diagnostics
         /// Converts 'idData' which is assumed to be HEX Unicode characters to binary
         /// puts it in 'outBytes'
         /// </summary>
-        internal static void SetSpanFromHexChars(Span<byte> outBytes, ReadOnlySpan<char> charData)
+        internal static void SetSpanFromHexChars(ReadOnlySpan<char> charData, Span<byte> outBytes)
         {
             Debug.Assert(outBytes.Length * 2 == charData.Length);
             for (int i = 0; i < outBytes.Length; i++)
@@ -1103,12 +1171,39 @@ namespace System.Diagnostics
             outChars[1] = BinaryToHexDigit(val & 0xF);
         }
 
-        #endregion
+        internal static bool IsLowerCaseHexAndNotAllZeros(ReadOnlySpan<char> idData)
+        {
+            // Verify lower-case hex and not all zeros https://w3c.github.io/trace-context/#field-value
+            bool isNonZero = false;
+            int i = 0;
+            for (; i < idData.Length; i++)
+            {
+                char c = idData[i];
+                if (!IsHexadecimalChar(c))
+                {
+                    break;
+                }
 
-        readonly ulong _id1;
-        readonly ulong _id2;
-        readonly string _asHexString;  // Caches the Hex string    
-        #endregion
+                if (c != '0')
+                {
+                    isNonZero = true;
+                }
+            }
+
+            if (i < idData.Length || !isNonZero)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsHexadecimalChar(char c)
+        {
+            // Between 0 - 9 or uppercased between a - f
+            return (uint)(c - '0') <= 9 || (uint)(c - 'a') <= ('f' - 'a');
+        }
     }
 
     /// <summary>
@@ -1123,44 +1218,36 @@ namespace System.Diagnostics
 #if ALLOW_PARTIALLY_TRUSTED_CALLERS
         [System.Security.SecuritySafeCriticalAttribute]
 #endif
-    public unsafe readonly struct ActivitySpanId : IEquatable<ActivitySpanId>
+    public readonly struct ActivitySpanId : IEquatable<ActivitySpanId>
     {
+        private readonly string _hexString;
+
+        internal ActivitySpanId(string hexString) => _hexString = hexString;
+
         /// <summary>
         /// Create a new SpanId with at random number in it (very likely to be unique)
         /// </summary>
-        public static ActivitySpanId CreateRandom()
+        public unsafe static ActivitySpanId CreateRandom()
         {
-            ActivitySpanId ret = new ActivitySpanId();
-            ActivityTraceId.SetToRandomBytes(new Span<byte>(&ret._id1, sizeof(ulong)));
-            return ret;
+            ulong id;
+            ActivityTraceId.SetToRandomBytes(new Span<byte>(&id, sizeof(ulong)));
+            return new ActivitySpanId(ActivityTraceId.SpanToHexString(new ReadOnlySpan<byte>(&id, sizeof(ulong))));
         }
         public static ActivitySpanId CreateFromBytes(ReadOnlySpan<byte> idData)
         {
             if (idData.Length != 8)
                 throw new ArgumentOutOfRangeException(nameof(idData));
 
-            ActivitySpanId ret = new ActivitySpanId();
-            idData.CopyTo(new Span<byte>(&ret._id1, sizeof(ulong)));
-            return ret;
+            return new ActivitySpanId(ActivityTraceId.SpanToHexString(idData));
         }
         public static ActivitySpanId CreateFromUtf8String(ReadOnlySpan<byte> idData) => new ActivitySpanId(idData);
+
         public static ActivitySpanId CreateFromString(ReadOnlySpan<char> idData)
         {
-            if (idData.Length != 16)
+            if (idData.Length != 16 || !ActivityTraceId.IsLowerCaseHexAndNotAllZeros(idData))
                 throw new ArgumentOutOfRangeException(nameof(idData));
 
-            ActivitySpanId ret = new ActivitySpanId();
-            ActivityTraceId.SetSpanFromHexChars(new Span<byte>(&ret._id1, sizeof(ulong)), idData);
-            return ret;
-        }
-
-        /// <summary>
-        /// Copy the bytes of the TraceId (8 bytes total) into the 'destination' span.
-        /// </summary>
-        public void CopyTo(Span<byte> destination)
-        {
-            fixed (ulong* idPtr = &_id1)
-                new ReadOnlySpan<byte>(idPtr, sizeof(ulong)).CopyTo(destination);
+            return new ActivitySpanId(idData.ToString());
         }
 
         /// <summary>
@@ -1169,17 +1256,7 @@ namespace System.Diagnostics
         /// <returns></returns>
         public string ToHexString()
         {
-            if (_asHexString == null)
-            {
-                fixed (ulong* idPtr = &_id1)
-                {
-                    // Cast away the read-only-ness of _asHexString, and assign the converted value to it.  
-                    // We are OK with this because conceptually the class is still read-only.  
-                    ref string strRef = ref Unsafe.AsRef(in _asHexString);
-                    Interlocked.CompareExchange(ref strRef, ActivityTraceId.SpanToHexString(new ReadOnlySpan<byte>(idPtr, sizeof(ulong))), null);
-                }
-            }
-            return _asHexString;
+            return _hexString ?? "0000000000000000";
         }
 
         /// <summary>
@@ -1187,47 +1264,55 @@ namespace System.Diagnostics
         /// </summary>
         public override string ToString() => ToHexString();
 
-        #region equality operators
-        public static bool operator ==(in ActivitySpanId spanId1, in ActivitySpanId spandId2)
+        public static bool operator ==(ActivitySpanId spanId1, ActivitySpanId spandId2)
         {
-            return spanId1._id1 == spandId2._id1;
+            return spanId1._hexString == spandId2._hexString;
         }
-        public static bool operator !=(in ActivitySpanId spanId1, in ActivitySpanId spandId2)
+        public static bool operator !=(ActivitySpanId spanId1, ActivitySpanId spandId2)
         {
-            return spanId1._id1 != spandId2._id1;
+            return spanId1._hexString != spandId2._hexString;
         }
         public bool Equals(ActivitySpanId spanId)
         {
-            return _id1 == spanId._id1;
+            return _hexString == spanId._hexString;
         }
         public override bool Equals(object obj)
         {
             if (!(obj is ActivitySpanId))
+            {
                 return false;
+            }
+
             ActivitySpanId spanId = (ActivitySpanId)obj;
-            return _id1 == spanId._id1;
+            return _hexString == spanId._hexString;
         }
         public override int GetHashCode()
         {
-            return _id1.GetHashCode();
+            return ToHexString().GetHashCode();
         }
-        #endregion
 
-        #region private
-
-        private ActivitySpanId(ReadOnlySpan<byte> idData)
+        private unsafe ActivitySpanId(ReadOnlySpan<byte> idData)
         {
-            _id1 = 0;
-            _asHexString = null;
             if (idData.Length != 16)
+            {
                 throw new ArgumentOutOfRangeException(nameof(idData));
-            Utf8Parser.TryParse(idData, out _id1, out _, 'x');
+            }
+
+            Utf8Parser.TryParse(idData, out ulong id, out _, 'x');
             if (BitConverter.IsLittleEndian)
-                _id1 = BinaryPrimitives.ReverseEndianness(_id1);
+            {
+                id = BinaryPrimitives.ReverseEndianness(id);
+            }
+
+            _hexString = ActivityTraceId.SpanToHexString(new ReadOnlySpan<byte>(&id, sizeof(ulong)));
         }
 
-        readonly ulong _id1;
-        readonly string _asHexString;   // Caches the Hex string  
-        #endregion
+        /// <summary>
+        /// Copy the bytes of the TraceId (8 bytes total) into the 'destination' span.
+        /// </summary>
+        public void CopyTo(Span<byte> destination)
+        {
+            ActivityTraceId.SetSpanFromHexChars(ToHexString().AsSpan(), destination);
+        }
     }
 }

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -134,7 +134,7 @@ namespace System.Diagnostics
             Name = name;
 
             // Insert myself into the list of all Listeners.   
-            lock (s_lock)
+            lock (s_allListenersLock)
             {
                 // Issue the callback for this new diagnostic listener.
                 var allListenerObservable = s_allListenerObservable;
@@ -160,7 +160,7 @@ namespace System.Diagnostics
         virtual public void Dispose()
         {
             // Remove myself from the list of all listeners.  
-            lock (s_lock)
+            lock (s_allListenersLock)
             {
                 if (_disposed)
                 {
@@ -350,7 +350,7 @@ namespace System.Diagnostics
         {
             public IDisposable Subscribe(IObserver<DiagnosticListener> observer)
             {
-                lock (s_lock)
+                lock (s_allListenersLock)
                 {
                     // Call back for each existing listener on the new callback (catch-up).   
                     for (DiagnosticListener cur = s_allListeners; cur != null; cur = cur._next)
@@ -368,7 +368,7 @@ namespace System.Diagnostics
             /// <param name="diagnosticListener"></param>
             internal void OnNewDiagnosticListener(DiagnosticListener diagnosticListener)
             {
-                Debug.Assert(Monitor.IsEntered(s_lock));     // We should only be called when we hold this lock
+                Debug.Assert(Monitor.IsEntered(s_allListenersLock));     // We should only be called when we hold this lock
 
                 // Simply send a callback to every subscriber that we have a new listener
                 for (var cur = _subscriptions; cur != null; cur = cur.Next)
@@ -382,7 +382,7 @@ namespace System.Diagnostics
             /// </summary>
             private bool Remove(AllListenerSubscription subscription)
             {
-                lock (s_lock)
+                lock (s_allListenersLock)
                 {
                     if (_subscriptions == subscription)
                     {
@@ -468,7 +468,7 @@ namespace System.Diagnostics
 
         private static DiagnosticListener s_allListeners;               // linked list of all instances of DiagnosticListeners.  
         private static AllListenerObservable s_allListenerObservable;   // to make callbacks to this object when listeners come into existence. 
-        private static readonly object s_lock = new object();           // A lock for  
+        private static readonly object s_allListenersLock = new object();
 #if false
         private static readonly DiagnosticListener s_default = new DiagnosticListener("DiagnosticListener.DefaultListener");
 #endif

--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -468,7 +468,7 @@ namespace System.Diagnostics
 
         private static DiagnosticListener s_allListeners;               // linked list of all instances of DiagnosticListeners.  
         private static AllListenerObservable s_allListenerObservable;   // to make callbacks to this object when listeners come into existence. 
-        private static object s_lock = new object();                    // A lock for  
+        private static readonly object s_lock = new object();           // A lock for  
 #if false
         private static readonly DiagnosticListener s_default = new DiagnosticListener("DiagnosticListener.DefaultListener");
 #endif


### PR DESCRIPTION
Shrinks Activity on x64 by 40 bytes from 152 bytes to 112 bytes

`ActivitySpanId` and `ActivityTraceId` are shrunk to pointer size and only used for exchange types; so the `in` and `readonly ref` are removed on the apis (needs API review?)

`ActivitySpanId` and `ActivityTraceId` are managed structs (contain both `string` and `ulong`s) so can't be Unsafe.Cast to extract the `ulong` data and the normal way to extract the data is via `.ToString` or `.ToHexString` (for headers) so we can just store them as strings in the first place and not bother the the `ulongs`.

The other way is via `.CopyTo`, however this only saves on allocation if the input is not a string (direct binary); and the fields are never used as a string, or output as string. That also comes with extra complexity in size of the struct; and requiring continuous passing via `in` or `readonly ref`.

If you read the values from Http Headers or add them to headers, then you go via strings both ways and save on allocations as the values are immediately what they are directly, as well as the smaller Activity.

Before
```
Type layout for 'Activity'
Size: 152 bytes. Paddings: 2 bytes (%1 of empty space)
|=============================================================|
| Object Header (8 bytes)                                     |
|-------------------------------------------------------------|
| Method Table Ptr (8 bytes)                                  |
|=============================================================|
|   0-7: String <OperationName>k__BackingField (8 bytes)      |
|-------------------------------------------------------------|
|  8-15: Activity <Parent>k__BackingField (8 bytes)           |
|-------------------------------------------------------------|
| 16-23: String _rootId (8 bytes)                             |
|-------------------------------------------------------------|
| 24-31: KeyValueListNode _tags (8 bytes)                     |
|-------------------------------------------------------------|
| 32-39: KeyValueListNode _baggage (8 bytes)                  |
|-------------------------------------------------------------|
| 40-47: String _traceState (8 bytes)                         |
|-------------------------------------------------------------|
| 48-55: String _id (8 bytes)                                 |
|-------------------------------------------------------------|
| 56-63: String _parentId (8 bytes)                           |
|-------------------------------------------------------------|
| 64-67: ActivityIdFormat <IdFormat>k__BackingField (4 bytes) |
|-------------------------------------------------------------|
| 68-71: Int32 _currentChildId (4 bytes)                      |
|-------------------------------------------------------------|
|    72: Byte _w3CIdFlags (1 byte)                            |
|-------------------------------------------------------------|
|    73: Boolean _w3CIdFlagsSet (1 byte)                      |
|-------------------------------------------------------------|
|    74: Boolean _traceIdSet (1 byte)                         |
|-------------------------------------------------------------|
|    75: Boolean _spanIdSet (1 byte)                          |
|-------------------------------------------------------------|
|    76: Boolean _parentSpanIdSet (1 byte)                    |
|-------------------------------------------------------------|
|    77: Boolean isFinished (1 byte)                          |
|-------------------------------------------------------------|
| 78-79: padding (2 bytes)                                    |
|-------------------------------------------------------------|
| 80-87: DateTime <StartTimeUtc>k__BackingField (8 bytes)     |
|-------------------------------------------------------------|
| 88-95: TimeSpan <Duration>k__BackingField (8 bytes)         |
|-------------------------------------------------------------|
| 96-119: ActivityTraceId _traceId (24 bytes)                 |
| |======================================|                    |
| |   0-7: String _asHexString (8 bytes) |                    |
| |--------------------------------------|                    |
| |  8-15: UInt64 _id1 (8 bytes)         |                    |
| |--------------------------------------|                    |
| | 16-23: UInt64 _id2 (8 bytes)         |                    |
| |======================================|                    |
|-------------------------------------------------------------|
| 120-135: ActivitySpanId _spanId (16 bytes)                  |
| |======================================|                    |
| |   0-7: String _asHexString (8 bytes) |                    |
| |--------------------------------------|                    |
| |  8-15: UInt64 _id1 (8 bytes)         |                    |
| |======================================|                    |
|-------------------------------------------------------------|
| 136-151: ActivitySpanId _parentSpanId (16 bytes)            |
| |======================================|                    |
| |   0-7: String _asHexString (8 bytes) |                    |
| |--------------------------------------|                    |
| |  8-15: UInt64 _id1 (8 bytes)         |                    |
| |======================================|                    |
|=============================================================|
```
After
```
Type layout for 'Activity'
Size: 112 bytes. Paddings: 2 bytes (%1 of empty space)
|===========================================================|
| Object Header (8 bytes)                                   |
|-----------------------------------------------------------|
| Method Table Ptr (8 bytes)                                |
|===========================================================|
|   0-7: String _traceState (8 bytes)                       |
|-----------------------------------------------------------|
|  8-15: String _id (8 bytes)                               |
|-----------------------------------------------------------|
| 16-23: String _rootId (8 bytes)                           |
|-----------------------------------------------------------|
| 24-31: String _parentId (8 bytes)                         |
|-----------------------------------------------------------|
| 32-39: String _parentSpanId (8 bytes)                     |
|-----------------------------------------------------------|
| 40-47: String _traceId (8 bytes)                          |
|-----------------------------------------------------------|
| 48-55: String _spanId (8 bytes)                           |
|-----------------------------------------------------------|
| 56-63: String <OperationName>k__BackingField (8 bytes)    |
|-----------------------------------------------------------|
| 64-71: Activity <Parent>k__BackingField (8 bytes)         |
|-----------------------------------------------------------|
| 72-79: KeyValueListNode _tags (8 bytes)                   |
|-----------------------------------------------------------|
| 80-87: KeyValueListNode _baggage (8 bytes)                |
|-----------------------------------------------------------|
| 88-91: Int32 _currentChildId (4 bytes)                    |
|-----------------------------------------------------------|
|    92: State _state (1 byte)                              |
|-----------------------------------------------------------|
|    93: Byte _w3CIdFlags (1 byte)                          |
|-----------------------------------------------------------|
| 94-95: padding (2 bytes)                                  |
|-----------------------------------------------------------|
| 96-103: TimeSpan <Duration>k__BackingField (8 bytes)      |
|-----------------------------------------------------------|
| 104-111: DateTime <StartTimeUtc>k__BackingField (8 bytes) |
|===========================================================|
```

cc: @SergeyKanzhelev @lmolkova @davidfowl @stephentoub 

Resolves https://github.com/dotnet/corefx/issues/37396
Resolves https://github.com/dotnet/corefx/issues/38486