### PR TITLE
Fix remaining races in WriteAsync

### DIFF
--- a/src/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -233,7 +233,6 @@ namespace System.IO.Pipelines.Tests
             pipe.Reader.Complete();
         }
 
-        [ActiveIssue(37239)]
         [Fact]
         public async Task CompleteWithLargeWriteThrows()
         {


### PR DESCRIPTION
- Lock everything, this ensures Complete won't interfere with the copying or flushing

Fixes #37239