### PR TITLE
Improve test coverage for SequenceReader.

### DIFF
--- a/src/System.Memory/tests/SequenceReader/Advance.cs
+++ b/src/System.Memory/tests/SequenceReader/Advance.cs
@@ -37,6 +37,21 @@ namespace System.Memory.Tests.SequenceReader
             Assert.Equal(3, skipReader.AdvancePastAny(new byte[] { 2, 3, 1 }));
             Assert.True(skipReader.TryRead(out value));
             Assert.Equal(4, value);
+            skipReader.Rewind(skipReader.Consumed);
+            Assert.Equal(0, skipReader.AdvancePast(2));
+            Assert.Equal(3, skipReader.AdvancePastAny(2, 3, 1));
+            Assert.True(skipReader.TryRead(out value));
+            Assert.Equal(4, value);
+            skipReader.Rewind(skipReader.Consumed);
+            Assert.Equal(0, skipReader.AdvancePast(2));
+            Assert.Equal(3, skipReader.AdvancePastAny(2, 3, 1, 7));
+            Assert.True(skipReader.TryRead(out value));
+            Assert.Equal(4, value);
+            skipReader.Rewind(skipReader.Consumed - 1);
+            Assert.Equal(0, skipReader.AdvancePast(1));
+            Assert.Equal(2, skipReader.AdvancePastAny(2, 3));
+            Assert.True(skipReader.TryRead(out value));
+            Assert.Equal(4, value);
         }
 
         [Fact]

--- a/src/System.Memory/tests/SequenceReader/CopyTo.cs
+++ b/src/System.Memory/tests/SequenceReader/CopyTo.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using Xunit;
+
+namespace System.Memory.Tests.SequenceReader
+{
+    public class CopyTo
+    {
+        [Fact]
+        public void TryCopyTo_Empty()
+        {
+            var reader = new SequenceReader<char>(ReadOnlySequence<char>.Empty);
+
+            // Nothing to nothing is always possible
+            Assert.True(reader.TryCopyTo(Span<char>.Empty));
+
+            // Nothing to something doesn't work
+            Assert.False(reader.TryCopyTo(new char[1]));
+        }
+
+        [Fact]
+        public void TryCopyTo_Multisegment()
+        {
+            ReadOnlySequence<char> chars = SequenceFactory.Create(new char[][] {
+                new char[] { 'A'           },
+                new char[] { 'B', 'C'      },
+                new char[] { 'D', 'E', 'F' }
+            });
+
+            ReadOnlySpan<char> linear = new char[] { 'A', 'B', 'C', 'D', 'E', 'F' };
+
+            var reader = new SequenceReader<char>(chars);
+
+            // Something to nothing is always possible
+            Assert.True(reader.TryCopyTo(Span<char>.Empty));
+            Span<char> buffer;
+
+            // Read out ABCDEF, ABCDE, etc.
+            for (int i = linear.Length; i > 0; i--)
+            {
+                buffer = new char[i];
+                Assert.True(reader.TryCopyTo(buffer));
+                Assert.True(buffer.SequenceEqual(linear.Slice(0, i)));
+            }
+
+            buffer = new char[1];
+
+            // Read out one at a time and move through
+            for (int i = 0; i < linear.Length; i++)
+            {
+                Assert.True(reader.TryCopyTo(buffer));
+                Assert.True(reader.TryRead(out char value));
+                Assert.Equal(buffer[0], value);
+            }
+
+            // Trying to get more data than there is will fail
+            Assert.False(reader.TryCopyTo(new char[reader.Remaining + 1]));
+        }
+    }
+}

--- a/src/System.Memory/tests/SequenceReader/Rewind.cs
+++ b/src/System.Memory/tests/SequenceReader/Rewind.cs
@@ -72,13 +72,32 @@ namespace System.Memory.Tests.SequenceReader
         public void Rewind_Exception()
         {
             ReadOnlySequence<byte> bytes = SequenceFactory.Create(new byte[][] {
-                new byte[] { 0          },
-                new byte[] { 1, 2       },
-                new byte[] { 3, 4       },
-                new byte[] { 5, 6, 7, 8 }
+                new byte[] { 0    },
+                new byte[] { 1, 2 }
             });
 
+            // Can't go negative
             Assert.Throws<ArgumentOutOfRangeException>(() => new SequenceReader<byte>(bytes).Rewind(-1));
+
+            // Can't pull more than we consumed
+            Assert.Throws<ArgumentOutOfRangeException>(() => new SequenceReader<byte>(bytes).Rewind(1));
+        }
+
+        [Fact]
+        public void RewindEmptyFirstSpan()
+        {
+            // This is to hit the "if (memory.Length == 0)" branch in ResetReader.
+            ReadOnlySequence<byte> bytes = SequenceFactory.Create(new byte[][] {
+                new byte[0],
+                new byte[] { 1, 2 },
+                new byte[] { 3, 4 }
+            });
+
+            var reader = new SequenceReader<byte>(bytes);
+            reader.Advance(3);
+            Assert.True(reader.IsNext(4));
+            reader.Rewind(2);
+            Assert.Equal(new byte[] { 1, 2 }, reader.CurrentSpan.ToArray());
         }
     }
 }

--- a/src/System.Memory/tests/SequenceReader/SkipDelimiter.cs
+++ b/src/System.Memory/tests/SequenceReader/SkipDelimiter.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Memory.Tests.SequenceReader
 {
-    class SkipDelimiter
+    public class SkipDelimiter
     {
         [Fact]
         public void TryReadTo_SkipDelimiter()
@@ -20,10 +20,20 @@ namespace System.Memory.Tests.SequenceReader
             Assert.Equal(expected, span.ToArray());
             Assert.True(reader.IsNext((byte)' '));
             Assert.Equal(30, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out ReadOnlySequence<byte> sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(expected, sequence.ToArray());
+            Assert.True(reader.IsNext((byte)' '));
+            Assert.Equal(30, reader.Consumed);
 
             reader = new SequenceReader<byte>(bytes);
             Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
+            Assert.Equal(29, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(expected, sequence.ToArray());
             Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(29, reader.Consumed);
 
@@ -34,10 +44,20 @@ namespace System.Memory.Tests.SequenceReader
             Assert.Equal(expected, span.ToArray());
             Assert.True(reader.IsNext((byte)' '));
             Assert.Equal(30, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(expected, sequence.ToArray());
+            Assert.True(reader.IsNext((byte)' '));
+            Assert.Equal(30, reader.Consumed);
 
             reader = new SequenceReader<byte>(bytes);
             Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
+            Assert.Equal(29, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(expected, sequence.ToArray());
             Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(29, reader.Consumed);
 
@@ -48,10 +68,20 @@ namespace System.Memory.Tests.SequenceReader
             Assert.Equal(expected, span.ToArray());
             Assert.True(reader.IsNext((byte)' '));
             Assert.Equal(30, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(expected, sequence.ToArray());
+            Assert.True(reader.IsNext((byte)' '));
+            Assert.Equal(30, reader.Consumed);
 
             reader = new SequenceReader<byte>(bytes);
             Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
+            Assert.Equal(29, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(expected, sequence.ToArray());
             Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(29, reader.Consumed);
 
@@ -62,10 +92,20 @@ namespace System.Memory.Tests.SequenceReader
             Assert.Equal(expected, span.ToArray());
             Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(29, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(expected, sequence.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
+            Assert.Equal(29, reader.Consumed);
 
             reader = new SequenceReader<byte>(bytes);
             Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
             Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.End);
+            Assert.Equal(30, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(expected, sequence.ToArray());
             Assert.True(reader.End);
             Assert.Equal(30, reader.Consumed);
 
@@ -74,15 +114,24 @@ namespace System.Memory.Tests.SequenceReader
             reader = new SequenceReader<byte>(bytes);
             Assert.False(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.Equal(0, reader.Consumed);
+            Assert.False(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(0, reader.Consumed);
 
             reader = new SequenceReader<byte>(bytes);
             Assert.False(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(0, reader.Consumed);
+            Assert.False(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
             Assert.Equal(0, reader.Consumed);
 
             bytes = SequenceFactory.CreateUtf8("abc^|de|");
             reader = new SequenceReader<byte>(bytes);
             Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
             Assert.Equal(Encoding.UTF8.GetBytes("abc^|de"), span.ToArray());
+            Assert.True(reader.End);
+            Assert.Equal(8, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(Encoding.UTF8.GetBytes("abc^|de"), sequence.ToArray());
             Assert.True(reader.End);
             Assert.Equal(8, reader.Consumed);
 
@@ -93,12 +142,22 @@ namespace System.Memory.Tests.SequenceReader
             Assert.Equal(Encoding.UTF8.GetBytes("^|a"), span.ToArray());
             Assert.True(reader.IsNext((byte)'b'));
             Assert.Equal(4, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(Encoding.UTF8.GetBytes("^|a"), sequence.ToArray());
+            Assert.True(reader.IsNext((byte)'b'));
+            Assert.Equal(4, reader.Consumed);
 
             // Delimiter starts second segment.
             bytes = SequenceFactory.CreateUtf8("^", "|a|b");
             reader = new SequenceReader<byte>(bytes);
             Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
             Assert.Equal(Encoding.UTF8.GetBytes("^|a"), span.ToArray());
+            Assert.True(reader.IsNext((byte)'b'));
+            Assert.Equal(4, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(Encoding.UTF8.GetBytes("^|a"), sequence.ToArray());
             Assert.True(reader.IsNext((byte)'b'));
             Assert.Equal(4, reader.Consumed);
         }
@@ -112,12 +171,22 @@ namespace System.Memory.Tests.SequenceReader
             Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), span.ToArray());
             Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(5, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out ReadOnlySequence<byte> sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), sequence.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
+            Assert.Equal(5, reader.Consumed);
 
             // Split after escape char
             bytes = SequenceFactory.CreateUtf8("abc^^", "|def");
             reader = new SequenceReader<byte>(bytes);
             Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), span.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
+            Assert.Equal(5, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), sequence.ToArray());
             Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(5, reader.Consumed);
 
@@ -128,11 +197,21 @@ namespace System.Memory.Tests.SequenceReader
             Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), span.ToArray());
             Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(5, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), sequence.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
+            Assert.Equal(5, reader.Consumed);
 
             // Check advance past delimiter
             reader = new SequenceReader<byte>(bytes);
             Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
             Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), span.ToArray());
+            Assert.True(reader.IsNext((byte)'d'));
+            Assert.Equal(6, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), sequence.ToArray());
             Assert.True(reader.IsNext((byte)'d'));
             Assert.Equal(6, reader.Consumed);
 
@@ -143,11 +222,19 @@ namespace System.Memory.Tests.SequenceReader
             Assert.Equal(Encoding.UTF8.GetBytes("^^"), span.ToArray());
             Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(2, reader.Consumed);
+            reader.Rewind(reader.Consumed);
+            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(Encoding.UTF8.GetBytes("^^"), sequence.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
+            Assert.Equal(2, reader.Consumed);
 
             // Leading run of 3
             bytes = SequenceFactory.CreateUtf8("^^^|abc");
             reader = new SequenceReader<byte>(bytes);
             Assert.False(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.True(reader.IsNext((byte)'^'));
+            Assert.Equal(0, reader.Consumed);
+            Assert.False(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.True(reader.IsNext((byte)'^'));
             Assert.Equal(0, reader.Consumed);
 
@@ -157,6 +244,9 @@ namespace System.Memory.Tests.SequenceReader
             Assert.False(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.True(reader.IsNext((byte)'a'));
             Assert.Equal(0, reader.Consumed);
+            Assert.False(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.True(reader.IsNext((byte)'a'));
+            Assert.Equal(0, reader.Consumed);
 
             // Trailing run of 3, split
             bytes = SequenceFactory.CreateUtf8("abc^^^", "|");
@@ -164,99 +254,9 @@ namespace System.Memory.Tests.SequenceReader
             Assert.False(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.True(reader.IsNext((byte)'a'));
             Assert.Equal(0, reader.Consumed);
-        }
-
-        [Fact]
-        public void TryReadTo_SkipDelimiter_ReadOnlySequence()
-        {
-            byte[] expected = Encoding.UTF8.GetBytes("This is our ^|understanding^|");
-            ReadOnlySequence<byte> bytes = SequenceFactory.CreateUtf8("This is our ^|understanding^|| you see.");
-            SequenceReader<byte> reader = new SequenceReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out ReadOnlySequence<byte> sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
-            Assert.Equal(expected, sequence.ToArray());
-            Assert.True(reader.IsNext((byte)' '));
-            Assert.Equal(30, reader.Consumed);
-
-            reader = new SequenceReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
-            Assert.Equal(expected, sequence.ToArray());
-            Assert.True(reader.IsNext((byte)'|'));
-            Assert.Equal(29, reader.Consumed);
-
-            // Put the skip delimiter in another segment
-            bytes = SequenceFactory.CreateUtf8("This is our ^|understanding", "^|| you see.");
-            reader = new SequenceReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
-            Assert.Equal(expected, sequence.ToArray());
-            Assert.True(reader.IsNext((byte)' '));
-            Assert.Equal(30, reader.Consumed);
-
-            reader = new SequenceReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
-            Assert.Equal(expected, sequence.ToArray());
-            Assert.True(reader.IsNext((byte)'|'));
-            Assert.Equal(29, reader.Consumed);
-
-            // Put the skip delimiter at the end of the segment
-            bytes = SequenceFactory.CreateUtf8("This is our ^|understanding^", "|| you see.");
-            reader = new SequenceReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
-            Assert.Equal(expected, sequence.ToArray());
-            Assert.True(reader.IsNext((byte)' '));
-            Assert.Equal(30, reader.Consumed);
-
-            reader = new SequenceReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
-            Assert.Equal(expected, sequence.ToArray());
-            Assert.True(reader.IsNext((byte)'|'));
-            Assert.Equal(29, reader.Consumed);
-
-            // No trailing data
-            bytes = SequenceFactory.CreateUtf8("This is our ^|understanding^||");
-            reader = new SequenceReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
-            Assert.Equal(expected, sequence.ToArray());
-            Assert.True(reader.IsNext((byte)'|'));
-            Assert.Equal(29, reader.Consumed);
-
-            reader = new SequenceReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
-            Assert.Equal(expected, sequence.ToArray());
-            Assert.True(reader.End);
-            Assert.Equal(30, reader.Consumed);
-
-            // All delimiters skipped
-            bytes = SequenceFactory.CreateUtf8("This is our ^|understanding^|");
-            reader = new SequenceReader<byte>(bytes);
             Assert.False(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.True(reader.IsNext((byte)'a'));
             Assert.Equal(0, reader.Consumed);
-
-            reader = new SequenceReader<byte>(bytes);
-            Assert.False(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
-            Assert.Equal(0, reader.Consumed);
-
-            bytes = SequenceFactory.CreateUtf8("abc^|de|");
-            reader = new SequenceReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
-            Assert.Equal(Encoding.UTF8.GetBytes("abc^|de"), sequence.ToArray());
-            Assert.True(reader.End);
-            Assert.Equal(8, reader.Consumed);
-
-            // Escape leads
-            bytes = SequenceFactory.CreateUtf8("^|a|b");
-            reader = new SequenceReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
-            Assert.Equal(Encoding.UTF8.GetBytes("^|a"), sequence.ToArray());
-            Assert.True(reader.IsNext((byte)'b'));
-            Assert.Equal(4, reader.Consumed);
-
-            // Delimiter starts second segment.
-            bytes = SequenceFactory.CreateUtf8("^", "|a|b");
-            reader = new SequenceReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out sequence, (byte)'|', (byte)'^', advancePastDelimiter: true));
-            Assert.Equal(Encoding.UTF8.GetBytes("^|a"), sequence.ToArray());
-            Assert.True(reader.IsNext((byte)'b'));
-            Assert.Equal(4, reader.Consumed);
         }
     }
 }

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -38,6 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AllocationHelper.cs" />
+    <Compile Include="SequenceReader\CopyTo.cs" />
     <Compile Include="TInt.cs" />
     <Compile Include="TestException.cs" />
     <Compile Include="TestHelpers.cs" />


### PR DESCRIPTION
One of the tests was inadvertently private. Added additional coverage and clarification text to TryCopyTo.

Also add a check for rewinding farther than consumed. The exception is no different than what we had, it just prevents getting the reader into a bad state.