### PR TITLE
Disable GetPropertyValues_NotStoredProperty_ValueEqualsNull test

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/LocalFileSettingsProviderTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/LocalFileSettingsProviderTests.cs
@@ -15,6 +15,7 @@ namespace System.ConfigurationTests
             ["SettingsKey"] = "SettingsKeyFoo"
         };
 
+        [ActiveIssue(37364)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void GetPropertyValues_NotStoredProperty_ValueEqualsNull()
         {

--- a/src/System.Configuration.ConfigurationManager/tests/System/Configuration/LocalFileSettingsProviderTests.cs
+++ b/src/System.Configuration.ConfigurationManager/tests/System/Configuration/LocalFileSettingsProviderTests.cs
@@ -31,6 +31,7 @@ namespace System.ConfigurationTests
             Assert.Equal(null, propertyValues["PropertyName"].PropertyValue);
         }
 
+        [ActiveIssue(37364)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetNativeRunningAsConsoleApp))]
         public void GetPropertyValues_NotStoredConnectionStringProperty_ValueEqualsEmptyString()
         {


### PR DESCRIPTION
#37364 
cc: @ViktorHofer, @JeremyKuhne 