### PR TITLE
Fix deadlock in SystemEventsTests.CreateTimerTests

### DIFF
--- a/src/Microsoft.Win32.SystemEvents/tests/SystemEvents.CreateTimer.cs
+++ b/src/Microsoft.Win32.SystemEvents/tests/SystemEvents.CreateTimer.cs
@@ -125,6 +125,7 @@ namespace Microsoft.Win32.SystemEventsTests
             finally
             {
                 SystemEvents.TimerElapsed -= handler;
+                elapsed.Dispose();
             }
         }
 

--- a/src/Microsoft.Win32.SystemEvents/tests/SystemEvents.CreateTimer.cs
+++ b/src/Microsoft.Win32.SystemEvents/tests/SystemEvents.CreateTimer.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Win32.SystemEventsTests
@@ -78,24 +80,19 @@ namespace Microsoft.Win32.SystemEventsTests
         public void ConcurrentTimers()
         {
             const int NumConcurrentTimers = 10;
-            var timersSignalled = new Dictionary<IntPtr, bool>();
+            var timersSignaled = new ConcurrentDictionary<IntPtr, bool>();
             int numSignaled = 0;
-            var elapsed = new AutoResetEvent(false);
+            var elapsed = new ManualResetEventSlim();
 
             TimerElapsedEventHandler handler = (sender, args) =>
             {
-                bool signaled = false;
-                lock (timersSignalled)
+                // A timer might fire more than once.  When it fires the first time, track it by adding
+                // it to a set and then increment the number of timers that have ever fired.  When all
+                // timers have fired, set the event.
+                if (timersSignaled.TryAdd(args.TimerId, true) &&
+                    Interlocked.Increment(ref numSignaled) == NumConcurrentTimers)
                 {
-                    if (timersSignalled.TryGetValue(args.TimerId, out signaled) && !signaled)
-                    {
-                        timersSignalled[args.TimerId] = true;
-
-                        if (Interlocked.Increment(ref numSignaled) == NumConcurrentTimers)
-                        {
-                            elapsed.Set();
-                        }
-                    }
+                    elapsed.Set();
                 }
             };
 
@@ -104,33 +101,30 @@ namespace Microsoft.Win32.SystemEventsTests
             {
                 if (PlatformDetection.IsFullFramework)
                 {
-                    // desktop has a bug where it will allow EnsureSystemEvents to proceed without actually creating the HWND
+                    // netfx has a bug where it will allow EnsureSystemEvents to proceed without actually creating the HWND
                     SystemEventsTest.WaitForSystemEventsWindow();
                 }
 
+                // Create all the timers
+                var timers = new List<IntPtr>();
                 for (int i = 0; i < NumConcurrentTimers; i++)
                 {
-                    lock (timersSignalled)
-                    {
-                        timersSignalled[SystemEvents.CreateTimer(TimerInterval)] = false;
-                    }
+                    timers.Add(SystemEvents.CreateTimer(TimerInterval));
                 }
 
-                Assert.True(elapsed.WaitOne(TimerInterval * SystemEventsTest.ExpectedEventMultiplier));
+                // Wait for them all to fire
+                Assert.True(elapsed.Wait(TimerInterval * SystemEventsTest.ExpectedEventMultiplier));
 
-                lock (timersSignalled)
+                // Delete them all
+                foreach (IntPtr timer in timers)
                 {
-                    foreach (var timer in timersSignalled.Keys.ToArray())
-                    {
-                        Assert.True(timersSignalled[timer]);
-                        SystemEvents.KillTimer(timer);
-                    }
+                    Assert.True(timersSignaled.TryGetValue(timer, out _));
+                    SystemEvents.KillTimer(timer);
                 }
             }
             finally
             {
                 SystemEvents.TimerElapsed -= handler;
-                elapsed.Dispose();
             }
         }
 


### PR DESCRIPTION
The main thread in the ConcurrentTimers takes a lock on object timersSignaled and then calls CreateTimer while holding the lock.  CreateTimer tries to SendMessageW a message to be processed by the events window, and as a result won’t return until the window has processed the message.  Meanwhile, that window’s WindowThreadProc is handling a timer callback, which in the event handler in ConcurrentTimers tries to take the timersSignaled lock.  That lock is held by the main thread, that’s calling CreateTimer and doing the SendMessageW that will only wake up when this callback completes.  Deadlock.

The fix is to stop locking while performing such work (the locking was introduced a few months back in https://github.com/dotnet/corefx/pull/34790).

cc: @ViktorHofer, @maryamariyan, @ericstj 