### PR TITLE
Use LoopbackServer for HttpWebRequestTests

### DIFF
--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -225,6 +225,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Loopback server with TLS has problems on UWP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ContentLength_Get_ExpectSameAsGetResponseStream(bool useSsl)
@@ -1190,6 +1191,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Loopback server with TLS has problems on UWP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task GetResponseAsync_GetResponseStream_ContainsHost(bool useSsl)
@@ -1237,6 +1239,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Loopback server with TLS has problems on UWP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task GetResponseAsync_PostRequestStream_ContainsData(bool useSsl)
@@ -1282,6 +1285,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Loopback server with TLS has problems on UWP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task GetResponseAsync_UseDefaultCredentials_ExpectSuccess(bool useSsl)
@@ -1321,6 +1325,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Loopback server with TLS has problems on UWP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task HaveResponse_GetResponseAsync_ExpectTrue(bool useSsl)
@@ -1339,6 +1344,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Loopback server with TLS has problems on UWP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task Headers_GetResponseHeaders_ContainsExpectedValue(bool useSsl)
@@ -1350,7 +1356,7 @@ namespace System.Net.Tests
             {
                 HttpWebRequest request = WebRequest.CreateHttp(uri);
                 request.ServerCertificateValidationCallback = delegate { return true; };
-                request.Headers[HttpRequestHeader.ContentType] = HeadersPartialContent;
+                request.ContentType = HeadersPartialContent;
 
                 using WebResponse response = await request.GetResponseAsync();
                 string headersString = response.Headers.ToString();
@@ -1440,6 +1446,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Loopback server with TLS has problems on UWP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ResponseUri_GetResponseAsync_ExpectSameUri(bool useSsl)
@@ -1463,6 +1470,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Loopback server with TLS has problems on UWP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task SimpleScenario_UseGETVerb_Success(bool useSsl)
@@ -1479,6 +1487,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Loopback server with TLS has problems on UWP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task SimpleScenario_UsePOSTVerb_Success(bool useSsl)
@@ -1501,6 +1510,7 @@ namespace System.Net.Tests
         }
 
         [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "Loopback server with TLS has problems on UWP")]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ContentType_AddHeaderWithNoContent_SendRequest_HeaderGetsSent(bool useSsl)

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{E520B5FD-C6FF-46CF-8079-6C8098013EA3}</ProjectGuid>
     <StringResourcesPath>../src/Resources/Strings.resx</StringResourcesPath>
@@ -42,5 +42,8 @@
     <Compile Include="LoggingTest.cs" />
     <Compile Include="HttpRequestCachePolicyTest.cs" />
     <Compile Include="HttpWebResponseHeaderTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.net.testdata\1.0.2\content\**\*.*" DestinationDir="TestData" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/22849
Fixes https://github.com/dotnet/corefx/issues/37430

Enabling a few tests which weren't running.

I left the synchronous tests as they were as I wasn't sure what the pattern for testing with the  LoopBackServer synchronously is.