### PR TITLE
Switch to newer, explicit atomic API

### DIFF
--- a/src/Native/Unix/System.Native/pal_random.c
+++ b/src/Native/Unix/System.Native/pal_random.c
@@ -51,7 +51,8 @@ void SystemNative_GetNonCryptographicallySecureRandomBytes(uint8_t* buffer, int3
 
             if (fd != -1)
             {
-                if (!__sync_bool_compare_and_swap(&rand_des, -1, fd))
+                int expected = -1;
+                if (!__atomic_compare_exchange_n(&rand_des, &expected, fd, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST))
                 {
                     // Another thread has already set the rand_des
                     close(fd);


### PR DESCRIPTION
Starting with clang 8, the older __sync atomic functions [produce a warning](https://reviews.llvm.org/D51084) for implicit strong memory barriers. This switches to the newer __atomic API where memory ordering is explicitly specified. Note [these GCC docs](https://gcc.gnu.org/wiki/Atomic/GCCMM#From___sync_to___atomic) recommending that __sync be replaced with __atomic, with the former considered deprecated.

Note that the only usage in the corefx codebase is completely non-perf-sensitive (initialization of the /dev/random file descriptor), so sequential consistency seems appropriate.

Fixes #37174