### PR TITLE
Add FlushAsync in XDocument.SaveAsync to prevent blocking calls in Dispose

### DIFF
--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
@@ -638,6 +638,7 @@ namespace System.Xml.Linq
             using (XmlWriter w = XmlWriter.Create(stream, ws))
             {
                 await WriteToAsync(w, cancellationToken).ConfigureAwait(false);
+                await w.FlushAsync().ConfigureAwait(false);
             }
         }
         
@@ -710,6 +711,7 @@ namespace System.Xml.Linq
             using (XmlWriter w = XmlWriter.Create(textWriter, ws))
             {
                 await WriteToAsync(w, cancellationToken).ConfigureAwait(false);
+                await w.FlushAsync().ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
/fix #37457 