### PR TITLE
Revert "Add FlushAsync in XDocument.SaveAsync to prevent blocking calls in Dispose"

### DIFF
--- a/src/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
+++ b/src/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
@@ -638,7 +638,6 @@ namespace System.Xml.Linq
             using (XmlWriter w = XmlWriter.Create(stream, ws))
             {
                 await WriteToAsync(w, cancellationToken).ConfigureAwait(false);
-                await w.FlushAsync().ConfigureAwait(false);
             }
         }
         
@@ -711,7 +710,6 @@ namespace System.Xml.Linq
             using (XmlWriter w = XmlWriter.Create(textWriter, ws))
             {
                 await WriteToAsync(w, cancellationToken).ConfigureAwait(false);
-                await w.FlushAsync().ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
Reverts dotnet/corefx#37458to
<div class="LI-profile-badge"  data-version="v1" data-size="medium" data-locale="en_US" data-type'>Mandy Latson