### PR TITLE
Propagate System.Runtime.WindowsRuntime package build targets though transitive references.

### DIFF
--- a/src/System.Runtime.WindowsRuntime/pkg/System.Runtime.WindowsRuntime.pkgproj
+++ b/src/System.Runtime.WindowsRuntime/pkg/System.Runtime.WindowsRuntime.pkgproj
@@ -62,6 +62,15 @@
     </PackageFile>
     <PackageFile Include=".\build\net461\System.Runtime.WindowsRuntime.targets">
       <TargetPath>\build\net461\</TargetPath>
+    </PackageFile> 
+    <PackageFile Include=".\build\net45\System.Runtime.WindowsRuntime.targets">
+      <TargetPath>\buildTransitive\net45\</TargetPath>
+    </PackageFile>
+    <PackageFile Include=".\build\net451\System.Runtime.WindowsRuntime.targets">
+      <TargetPath>\buildTransitive\net451\</TargetPath>
+    </PackageFile>
+    <PackageFile Include=".\build\net461\System.Runtime.WindowsRuntime.targets">
+      <TargetPath>\buildTransitive\net461\</TargetPath>
     </PackageFile>
 
     <!-- this package is part of the implementation closure of NETStandard.Library

--- a/src/System.Runtime.WindowsRuntime/pkg/System.Runtime.WindowsRuntime.pkgproj
+++ b/src/System.Runtime.WindowsRuntime/pkg/System.Runtime.WindowsRuntime.pkgproj
@@ -54,24 +54,11 @@
         The included build targets explicitly reference System.Runtime
         and add the facade references to the compiler.
     -->
-    <PackageFile Include=".\build\net45\System.Runtime.WindowsRuntime.targets">
-      <TargetPath>\build\net45\</TargetPath>
-    </PackageFile>
-    <PackageFile Include=".\build\net451\System.Runtime.WindowsRuntime.targets">
-      <TargetPath>\build\net451\</TargetPath>
-    </PackageFile>
-    <PackageFile Include=".\build\net461\System.Runtime.WindowsRuntime.targets">
-      <TargetPath>\build\net461\</TargetPath>
-    </PackageFile> 
-    <PackageFile Include=".\build\net45\System.Runtime.WindowsRuntime.targets">
-      <TargetPath>\buildTransitive\net45\</TargetPath>
-    </PackageFile>
-    <PackageFile Include=".\build\net451\System.Runtime.WindowsRuntime.targets">
-      <TargetPath>\buildTransitive\net451\</TargetPath>
-    </PackageFile>
-    <PackageFile Include=".\build\net461\System.Runtime.WindowsRuntime.targets">
-      <TargetPath>\buildTransitive\net461\</TargetPath>
-    </PackageFile>
+    <_buildTargetsTFMs Include="net45;net451;net461" 
+                    TFM="%(Identity)"
+                    SourceFile=".\build\%(TFM)\$(Id).targets" />
+    <PackageFile Include="@(_buildTargetsTFMs->'%(SourceFile)')" TargetPath="build\%(TFM)\" />
+    <PackageFile Include="@(_buildTargetsTFMs->'%(SourceFile)')" TargetPath="buildTransitive\%(TFM)\" />
 
     <!-- this package is part of the implementation closure of NETStandard.Library
          therefore it cannot reference NETStandard.Library -->


### PR DESCRIPTION
Fixes #35034 