### PR TITLE
Fix VS Configurations for all projects in corefx

### DIFF
--- a/src/Common/tests/StaticTestGenerator/StaticTestGenerator.csproj
+++ b/src/Common/tests/StaticTestGenerator/StaticTestGenerator.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -9,12 +8,14 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn />
     <NullableContextOptions>enable</NullableContextOptions>
+    <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
-
+  <PropertyGroup>
+    <ProjectGuid>{67648882-2D9D-451A-BAC2-D16DE96895C2}</ProjectGuid>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="2.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
@@ -23,5 +24,4 @@
     <PackageReference Include="xunit.core" Version="2.4.1" />
     <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
   </ItemGroup>
-
 </Project>

--- a/src/CoreFx.Private.TestUtilities/CoreFx.Private.TestUtilities.sln
+++ b/src/CoreFx.Private.TestUtilities/CoreFx.Private.TestUtilities.sln
@@ -34,10 +34,10 @@ Global
 		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{EBDB0247-CA43-4226-B7A1-8FEF21061D09}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{E2E59C98-998F-9965-991D-99411166AF6F}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{E2E59C98-998F-9965-991D-99411166AF6F}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.Bcl.AsyncInterfaces/Microsoft.Bcl.AsyncInterfaces.sln
+++ b/src/Microsoft.Bcl.AsyncInterfaces/Microsoft.Bcl.AsyncInterfaces.sln
@@ -2,12 +2,19 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bcl.AsyncInterfaces.Tests", "tests\Microsoft.Bcl.AsyncInterfaces.Tests.csproj", "{72E21903-0FBA-444E-9855-3B4F05DFC1F9}"
+	ProjectSection(ProjectDependencies) = postProject
+		{96A7CE75-B5E8-421B-BDF0-C4651D97D8CA} = {96A7CE75-B5E8-421B-BDF0-C4651D97D8CA}
+	EndProjectSection
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bcl.AsyncInterfaces", "src\Microsoft.Bcl.AsyncInterfaces.csproj", "{96A7CE75-B5E8-421B-BDF0-C4651D97D8CA}"
 	ProjectSection(ProjectDependencies) = postProject
 		{6371299B-8F39-4A0A-A9CD-70F80FF205F6} = {6371299B-8F39-4A0A-A9CD-70F80FF205F6}
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bcl.AsyncInterfaces", "ref\Microsoft.Bcl.AsyncInterfaces.csproj", "{6371299B-8F39-4A0A-A9CD-70F80FF205F6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
 EndProject
@@ -19,6 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{72E21903-0FBA-444E-9855-3B4F05DFC1F9}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{72E21903-0FBA-444E-9855-3B4F05DFC1F9}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{72E21903-0FBA-444E-9855-3B4F05DFC1F9}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{72E21903-0FBA-444E-9855-3B4F05DFC1F9}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{96A7CE75-B5E8-421B-BDF0-C4651D97D8CA}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{96A7CE75-B5E8-421B-BDF0-C4651D97D8CA}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{96A7CE75-B5E8-421B-BDF0-C4651D97D8CA}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
@@ -32,6 +43,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{72E21903-0FBA-444E-9855-3B4F05DFC1F9} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{96A7CE75-B5E8-421B-BDF0-C4651D97D8CA} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{6371299B-8F39-4A0A-A9CD-70F80FF205F6} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection

--- a/src/Microsoft.CSharp/Microsoft.CSharp.sln
+++ b/src/Microsoft.CSharp/Microsoft.CSharp.sln
@@ -4,10 +4,10 @@ VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CSharp.Tests", "tests\Microsoft.CSharp.Tests.csproj", "{82B54697-0251-47A1-8546-FC507D0F3B08}"
 	ProjectSection(ProjectDependencies) = postProject
-		{96AA2060-C846-4E56-9509-E8CB9C114C8F} = {96AA2060-C846-4E56-9509-E8CB9C114C8F}
+		{149D7DFE-2FAC-4A38-89AD-E24CE63AACB8} = {149D7DFE-2FAC-4A38-89AD-E24CE63AACB8}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CSharp", "src\Microsoft.CSharp.csproj", "{96AA2060-C846-4E56-9509-E8CB9C114C8F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CSharp", "src\Microsoft.CSharp.csproj", "{149D7DFE-2FAC-4A38-89AD-E24CE63AACB8}"
 	ProjectSection(ProjectDependencies) = postProject
 		{1427906B-FF3D-422A-8278-F2B7E89DE12A} = {1427906B-FF3D-422A-8278-F2B7E89DE12A}
 	EndProjectSection
@@ -30,10 +30,10 @@ Global
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{96AA2060-C846-4E56-9509-E8CB9C114C8F}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{96AA2060-C846-4E56-9509-E8CB9C114C8F}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{96AA2060-C846-4E56-9509-E8CB9C114C8F}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{96AA2060-C846-4E56-9509-E8CB9C114C8F}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{149D7DFE-2FAC-4A38-89AD-E24CE63AACB8}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{149D7DFE-2FAC-4A38-89AD-E24CE63AACB8}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{149D7DFE-2FAC-4A38-89AD-E24CE63AACB8}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{149D7DFE-2FAC-4A38-89AD-E24CE63AACB8}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{1427906B-FF3D-422A-8278-F2B7E89DE12A}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{1427906B-FF3D-422A-8278-F2B7E89DE12A}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{1427906B-FF3D-422A-8278-F2B7E89DE12A}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
@@ -44,7 +44,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{82B54697-0251-47A1-8546-FC507D0F3B08} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
-		{96AA2060-C846-4E56-9509-E8CB9C114C8F} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{149D7DFE-2FAC-4A38-89AD-E24CE63AACB8} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{1427906B-FF3D-422A-8278-F2B7E89DE12A} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/src/Microsoft.CSharp/src/Microsoft.CSharp.csproj
+++ b/src/Microsoft.CSharp/src/Microsoft.CSharp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <ProjectGuid>{96AA2060-C846-4E56-9509-E8CB9C114C8F}</ProjectGuid>
+    <ProjectGuid>{149D7DFE-2FAC-4A38-89AD-E24CE63AACB8}</ProjectGuid>
     <AssemblyName>Microsoft.CSharp</AssemblyName>
     <RootNamespace>Microsoft.CSharp</RootNamespace>
     <!-- dotnet/corefx#3128 tracks removing this exclusion -->

--- a/src/Microsoft.VisualBasic.Core/Microsoft.VisualBasic.Core.sln
+++ b/src/Microsoft.VisualBasic.Core/Microsoft.VisualBasic.Core.sln
@@ -1,13 +1,13 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28805.205
+# Visual Studio 15
+VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualBasic.Core.Tests", "tests\Microsoft.VisualBasic.Core.Tests.csproj", "{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}"
 	ProjectSection(ProjectDependencies) = postProject
-		{A32671B6-5470-4F9C-9CD8-4094B9AB0799} = {A32671B6-5470-4F9C-9CD8-4094B9AB0799}
+		{a32671b6-5470-4f9c-9cd8-4094b9ab0799} = {a32671b6-5470-4f9c-9cd8-4094b9ab0799}
 	EndProjectSection
 EndProject
-Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.VisualBasic.Core", "src\Microsoft.VisualBasic.Core.vbproj", "{A32671B6-5470-4F9C-9CD8-4094B9AB0799}"
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.VisualBasic.Core", "src\Microsoft.VisualBasic.Core.vbproj", "{a32671b6-5470-4f9c-9cd8-4094b9ab0799}"
 	ProjectSection(ProjectDependencies) = postProject
 		{82A4357C-0A9F-4970-AAEA-216A73D8A73E} = {82A4357C-0A9F-4970-AAEA-216A73D8A73E}
 	EndProjectSection
@@ -24,41 +24,27 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		Windows_NT-Debug|Any CPU = Windows_NT-Debug|Any CPU
-		Windows_NT-Release|Any CPU = Windows_NT-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}.Windows_NT-Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}.Windows_NT-Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}.Windows_NT-Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}.Windows_NT-Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{A32671B6-5470-4F9C-9CD8-4094B9AB0799}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{A32671B6-5470-4F9C-9CD8-4094B9AB0799}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{A32671B6-5470-4F9C-9CD8-4094B9AB0799}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{A32671B6-5470-4F9C-9CD8-4094B9AB0799}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{A32671B6-5470-4F9C-9CD8-4094B9AB0799}.Windows_NT-Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
-		{A32671B6-5470-4F9C-9CD8-4094B9AB0799}.Windows_NT-Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{A32671B6-5470-4F9C-9CD8-4094B9AB0799}.Windows_NT-Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
-		{A32671B6-5470-4F9C-9CD8-4094B9AB0799}.Windows_NT-Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
+		{a32671b6-5470-4f9c-9cd8-4094b9ab0799}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{a32671b6-5470-4f9c-9cd8-4094b9ab0799}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{a32671b6-5470-4f9c-9cd8-4094b9ab0799}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{a32671b6-5470-4f9c-9cd8-4094b9ab0799}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{82A4357C-0A9F-4970-AAEA-216A73D8A73E}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{82A4357C-0A9F-4970-AAEA-216A73D8A73E}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{82A4357C-0A9F-4970-AAEA-216A73D8A73E}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{82A4357C-0A9F-4970-AAEA-216A73D8A73E}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{82A4357C-0A9F-4970-AAEA-216A73D8A73E}.Windows_NT-Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{82A4357C-0A9F-4970-AAEA-216A73D8A73E}.Windows_NT-Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{82A4357C-0A9F-4970-AAEA-216A73D8A73E}.Windows_NT-Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{82A4357C-0A9F-4970-AAEA-216A73D8A73E}.Windows_NT-Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
-		{A32671B6-5470-4F9C-9CD8-4094B9AB0799} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{a32671b6-5470-4f9c-9cd8-4094b9ab0799} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{82A4357C-0A9F-4970-AAEA-216A73D8A73E} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/src/System.Buffers/System.Buffers.sln
+++ b/src/System.Buffers/System.Buffers.sln
@@ -34,10 +34,10 @@ Global
 		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{11AE73F7-3532-47B9-8FF6-B4F22D76456C}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Buffers/ref/System.Buffers.csproj
+++ b/src/System.Buffers/ref/System.Buffers.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-  	<!-- Must match version supported by frameworks which support 4.0.* inbox.
+    <!-- Must match version supported by frameworks which support 4.0.* inbox.
          Can be removed when API is added and this assembly is versioned to 4.1.* -->
     <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <ProjectGuid>{11AE73F7-3532-47B9-8FF6-B4F22D76456C}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Buffers.cs" />

--- a/src/System.Data.DataSetExtensions/System.Data.DataSetExtensions.sln
+++ b/src/System.Data.DataSetExtensions/System.Data.DataSetExtensions.sln
@@ -4,10 +4,10 @@ VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Data.DataSetExtensions.Tests", "tests\System.Data.DataSetExtensions.Tests.csproj", "{2B38992F-9979-485F-B104-38C476D0B706}"
 	ProjectSection(ProjectDependencies) = postProject
-		{C7CB4B69-2A11-4A20-A21E-5C954855AE5A} = {C7CB4B69-2A11-4A20-A21E-5C954855AE5A}
+		{50D18478-BE75-4F54-8080-A5C3047D776B} = {50D18478-BE75-4F54-8080-A5C3047D776B}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Data.DataSetExtensions", "src\System.Data.DataSetExtensions.csproj", "{C7CB4B69-2A11-4A20-A21E-5C954855AE5A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Data.DataSetExtensions", "src\System.Data.DataSetExtensions.csproj", "{50D18478-BE75-4F54-8080-A5C3047D776B}"
 	ProjectSection(ProjectDependencies) = postProject
 		{50A5A8BC-C6A9-4000-8B52-667BEE00459D} = {50A5A8BC-C6A9-4000-8B52-667BEE00459D}
 	EndProjectSection
@@ -30,21 +30,21 @@ Global
 		{2B38992F-9979-485F-B104-38C476D0B706}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{2B38992F-9979-485F-B104-38C476D0B706}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{2B38992F-9979-485F-B104-38C476D0B706}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{C7CB4B69-2A11-4A20-A21E-5C954855AE5A}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{C7CB4B69-2A11-4A20-A21E-5C954855AE5A}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{C7CB4B69-2A11-4A20-A21E-5C954855AE5A}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{C7CB4B69-2A11-4A20-A21E-5C954855AE5A}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{50A5A8BC-C6A9-4000-8B52-667BEE00459D}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{50A5A8BC-C6A9-4000-8B52-667BEE00459D}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{50A5A8BC-C6A9-4000-8B52-667BEE00459D}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{50A5A8BC-C6A9-4000-8B52-667BEE00459D}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{50D18478-BE75-4F54-8080-A5C3047D776B}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{50D18478-BE75-4F54-8080-A5C3047D776B}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{50D18478-BE75-4F54-8080-A5C3047D776B}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{50D18478-BE75-4F54-8080-A5C3047D776B}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{50A5A8BC-C6A9-4000-8B52-667BEE00459D}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{50A5A8BC-C6A9-4000-8B52-667BEE00459D}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{50A5A8BC-C6A9-4000-8B52-667BEE00459D}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{50A5A8BC-C6A9-4000-8B52-667BEE00459D}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{2B38992F-9979-485F-B104-38C476D0B706} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
-		{C7CB4B69-2A11-4A20-A21E-5C954855AE5A} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{50D18478-BE75-4F54-8080-A5C3047D776B} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{50A5A8BC-C6A9-4000-8B52-667BEE00459D} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/src/System.Data.DataSetExtensions/ref/System.Data.DataSetExtensions.csproj
+++ b/src/System.Data.DataSetExtensions/ref/System.Data.DataSetExtensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{50A5A8BC-C6A9-4000-8B52-667BEE00459D}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
     <IsPartialFacadeAssembly Condition="'$(TargetsNETStandard)' != 'true'">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Data.DataSetExtensions/src/System.Data.DataSetExtensions.csproj
+++ b/src/System.Data.DataSetExtensions/src/System.Data.DataSetExtensions.csproj
@@ -4,6 +4,9 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
   </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{50D18478-BE75-4F54-8080-A5C3047D776B}</ProjectGuid>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />
     <Reference Include="System.Diagnostics.Debug" />

--- a/src/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
+++ b/src/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{F3E72F35-0351-4D67-2209-725BCAD807BA}</ProjectGuid>
     <DefineConstants Condition="'$(TargetsWindows)' == 'true'">$(DefineConstants);TargetsWindows</DefineConstants>
-    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-FreeBSD-Debug;netcoreapp-FreeBSD-Release;netcoreapp-Linux-Debug;netcoreapp-Linux-Release;netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DependencyCheckTest.cs" />

--- a/src/System.Data.OleDb/System.Data.Oledb.sln
+++ b/src/System.Data.OleDb/System.Data.Oledb.sln
@@ -30,10 +30,10 @@ Global
 		{73C7A14F-C3C5-44EA-AB02-05BFBA55722C}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{73C7A14F-C3C5-44EA-AB02-05BFBA55722C}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{73C7A14F-C3C5-44EA-AB02-05BFBA55722C}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{D909B69D-8F3B-4551-A355-8FFF6A308CF6}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
-		{D909B69D-8F3B-4551-A355-8FFF6A308CF6}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
-		{D909B69D-8F3B-4551-A355-8FFF6A308CF6}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
-		{D909B69D-8F3B-4551-A355-8FFF6A308CF6}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
+		{D909B69D-8F3B-4551-A355-8FFF6A308CF6}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
+		{D909B69D-8F3B-4551-A355-8FFF6A308CF6}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
+		{D909B69D-8F3B-4551-A355-8FFF6A308CF6}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
+		{D909B69D-8F3B-4551-A355-8FFF6A308CF6}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
 		{EF4F0844-7AAD-4B0C-A29C-37E1F92D2D78}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{EF4F0844-7AAD-4B0C-A29C-37E1F92D2D78}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{EF4F0844-7AAD-4B0C-A29C-37E1F92D2D78}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU

--- a/src/System.Data.OleDb/src/System.Data.OleDb.csproj
+++ b/src/System.Data.OleDb/src/System.Data.OleDb.csproj
@@ -8,9 +8,9 @@
     <DefineConstants>$(DefineConstants);</DefineConstants>
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(OSGroup)' == 'AnyOS' AND '$(TargetsNetStandard)' == 'true'">SR.PlatformNotSupported_OleDb</GeneratePlatformNotSupportedAssemblyMessage>
-    <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard-Unix-Debug;netstandard-Unix-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
+    <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <EnablePinvokeUWPAnalyzer>false</EnablePinvokeUWPAnalyzer> 
+    <EnablePinvokeUWPAnalyzer>false</EnablePinvokeUWPAnalyzer>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true' AND '$(TargetsWindows)' == 'true'">
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
@@ -19,64 +19,64 @@
     <Compile Include="$(CommonPath)\System\Data\Common\MultipartIdentifier.cs">
       <Link>Common\System\Data\Common\MultipartIdentifier.cs</Link>
     </Compile>
-     <Compile Include="AdapterSwitches.cs"/>
-     <Compile Include="ColumnBinding.cs"/>
-     <Compile Include="DBBindings.cs"/>
-     <Compile Include="DbConnectionOptions.cs"/>
-     <Compile Include="DbConnectionStringCommon.cs"/>
-     <Compile Include="DbParameterHelper.cs"/>
-     <Compile Include="DbPropSet.cs"/>
-     <Compile Include="NativeMethods.cs"/>
-     <Compile Include="OleDb_Enum.cs"/>
-     <Compile Include="OleDb_Util.cs"/>
-     <Compile Include="OleDbCommand.cs"/>
-     <Compile Include="OleDbCommandBuilder.cs"/>
-     <Compile Include="OleDbConnection.cs"/>
-     <Compile Include="OleDbConnectionFactory.cs"/>
-     <Compile Include="OleDbConnectionInternal.cs"/>
-     <Compile Include="OleDbConnectionPoolGroupProviderInfo.cs"/>
-     <Compile Include="OleDbConnectionString.cs"/>
-     <Compile Include="OleDbConnectionStringBuilder.cs"/>
-     <Compile Include="OleDbDataAdapter.cs"/>
-     <Compile Include="OleDbDataReader.cs"/>
-     <Compile Include="OleDbEnumerator.cs"/>
-     <Compile Include="OleDbError.cs"/>
-     <Compile Include="OleDbErrorCollection.cs"/>
-     <Compile Include="OleDbException.cs"/>
-     <Compile Include="OleDbFactory.cs"/>
-     <Compile Include="OleDbHResult.cs"/>
-     <Compile Include="OleDbInfoMessageEvent.cs"/>
-     <Compile Include="OleDbInfoMessageEventHandler.cs"/>
-     <Compile Include="OleDbLiteral.cs"/>
-     <Compile Include="OleDbMetadataCollectionNames.cs"/>
-     <Compile Include="OleDbMetadataColumnNames.cs"/>
-     <Compile Include="OleDbMetaDataFactory.cs"/>
-     <Compile Include="OleDbParameter.cs"/>
-     <Compile Include="OleDbParameterCollection.cs"/>
-     <Compile Include="OleDbParameterCollectionHelper.cs"/>
-     <Compile Include="OleDbPropertySetGuid.cs"/>
-     <Compile Include="OleDbPropertyStatus.cs"/>
-     <Compile Include="OleDbReferenceCollection.cs"/>
-     <Compile Include="OleDbRowUpdatedEvent.cs"/>
-     <Compile Include="OleDbRowUpdatedEventHandler.cs"/>
-     <Compile Include="OleDbRowUpdatingEvent.cs"/>
-     <Compile Include="OleDbRowUpdatingEventHandler.cs"/>
-     <Compile Include="OleDbSchemaGuid.cs"/>
-     <Compile Include="OleDbStruct.cs"/>
-     <Compile Include="OleDbTransaction.cs"/>
-     <Compile Include="OleDbType.cs"/>
-     <Compile Include="OleDbWrapper.cs"/>
-     <Compile Include="PropertyIDSet.cs"/>
-     <Compile Include="PropertyInfoSet.cs"/>
-     <Compile Include="RowBinding.cs"/>
-     <Compile Include="SafeHandles.cs"/>
-     <Compile Include="SafeNativeMethods.cs"/>
-     <Compile Include="UnsafeNativeMethods.cs"/>
+    <Compile Include="AdapterSwitches.cs" />
+    <Compile Include="ColumnBinding.cs" />
+    <Compile Include="DBBindings.cs" />
+    <Compile Include="DbConnectionOptions.cs" />
+    <Compile Include="DbConnectionStringCommon.cs" />
+    <Compile Include="DbParameterHelper.cs" />
+    <Compile Include="DbPropSet.cs" />
+    <Compile Include="NativeMethods.cs" />
+    <Compile Include="OleDb_Enum.cs" />
+    <Compile Include="OleDb_Util.cs" />
+    <Compile Include="OleDbCommand.cs" />
+    <Compile Include="OleDbCommandBuilder.cs" />
+    <Compile Include="OleDbConnection.cs" />
+    <Compile Include="OleDbConnectionFactory.cs" />
+    <Compile Include="OleDbConnectionInternal.cs" />
+    <Compile Include="OleDbConnectionPoolGroupProviderInfo.cs" />
+    <Compile Include="OleDbConnectionString.cs" />
+    <Compile Include="OleDbConnectionStringBuilder.cs" />
+    <Compile Include="OleDbDataAdapter.cs" />
+    <Compile Include="OleDbDataReader.cs" />
+    <Compile Include="OleDbEnumerator.cs" />
+    <Compile Include="OleDbError.cs" />
+    <Compile Include="OleDbErrorCollection.cs" />
+    <Compile Include="OleDbException.cs" />
+    <Compile Include="OleDbFactory.cs" />
+    <Compile Include="OleDbHResult.cs" />
+    <Compile Include="OleDbInfoMessageEvent.cs" />
+    <Compile Include="OleDbInfoMessageEventHandler.cs" />
+    <Compile Include="OleDbLiteral.cs" />
+    <Compile Include="OleDbMetadataCollectionNames.cs" />
+    <Compile Include="OleDbMetadataColumnNames.cs" />
+    <Compile Include="OleDbMetaDataFactory.cs" />
+    <Compile Include="OleDbParameter.cs" />
+    <Compile Include="OleDbParameterCollection.cs" />
+    <Compile Include="OleDbParameterCollectionHelper.cs" />
+    <Compile Include="OleDbPropertySetGuid.cs" />
+    <Compile Include="OleDbPropertyStatus.cs" />
+    <Compile Include="OleDbReferenceCollection.cs" />
+    <Compile Include="OleDbRowUpdatedEvent.cs" />
+    <Compile Include="OleDbRowUpdatedEventHandler.cs" />
+    <Compile Include="OleDbRowUpdatingEvent.cs" />
+    <Compile Include="OleDbRowUpdatingEventHandler.cs" />
+    <Compile Include="OleDbSchemaGuid.cs" />
+    <Compile Include="OleDbStruct.cs" />
+    <Compile Include="OleDbTransaction.cs" />
+    <Compile Include="OleDbType.cs" />
+    <Compile Include="OleDbWrapper.cs" />
+    <Compile Include="PropertyIDSet.cs" />
+    <Compile Include="PropertyInfoSet.cs" />
+    <Compile Include="RowBinding.cs" />
+    <Compile Include="SafeHandles.cs" />
+    <Compile Include="SafeNativeMethods.cs" />
+    <Compile Include="UnsafeNativeMethods.cs" />
     <Compile Include="System\Data\Common\AdapterUtil.cs" />
     <Compile Include="System\Data\Common\DataCommonEventSource.cs" />
-    <Compile Include="System\Data\Common\DbConnectionPoolKey.cs" /> 
+    <Compile Include="System\Data\Common\DbConnectionPoolKey.cs" />
     <Compile Include="System\Data\Common\FieldNameLookup.cs" />
-    <Compile Include="System\Data\Common\NameValuePair.cs" /> 
+    <Compile Include="System\Data\Common\NameValuePair.cs" />
     <Compile Include="System\Data\Common\SR.cs" />
     <Compile Include="System\Data\ProviderBase\DbBuffer.cs" />
     <Compile Include="System\Data\ProviderBase\DbConnectionClosed.cs" />

--- a/src/System.Data.SqlClient/System.Data.SqlClient.sln
+++ b/src/System.Data.SqlClient/System.Data.SqlClient.sln
@@ -86,10 +86,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F3E72F35-0351-4D67-9388-725BCAD807BA}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{F3E72F35-0351-4D67-9388-725BCAD807BA}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{F3E72F35-0351-4D67-9388-725BCAD807BA}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{F3E72F35-0351-4D67-9388-725BCAD807BA}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{F3E72F35-0351-4D67-9388-725BCAD807BA}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{F3E72F35-0351-4D67-9388-725BCAD807BA}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{F3E72F35-0351-4D67-9388-725BCAD807BA}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{F3E72F35-0351-4D67-9388-725BCAD807BA}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{D1392B54-998A-4F27-BC17-4CE149117BCC}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{D1392B54-998A-4F27-BC17-4CE149117BCC}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{D1392B54-998A-4F27-BC17-4CE149117BCC}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU

--- a/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/System.Data.SqlClient.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{F3E72F35-0351-4D67-9388-725BCAD807BA}</ProjectGuid>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <Configurations>netstandard-Unix-Debug;netstandard-Unix-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netstandard-Unix-Debug;netstandard-Unix-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AADAccessTokenTest.cs" />

--- a/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{A7922FA3-306A-41B9-B8DC-CC4DBE685A85}</ProjectGuid>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <Configurations>netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;netstandard1.3-Debug;netstandard1.3-Release;netstandard1.5-Debug;netstandard1.5-Release</Configurations>
+    <Configurations>netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetGroup)' != 'netfx'">
     <Compile Include="DiagnosticSourceEventSourceBridgeTests.cs" />

--- a/src/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.csproj
@@ -3,7 +3,7 @@
     <RootNamespace>System.Diagnostics.TextWriterTraceListener</RootNamespace>
     <AssemblyName>System.Diagnostics.TextWriterTraceListener</AssemblyName>
     <ProjectGuid>{315929D9-D76E-47E9-BE82-C787FB3A7876}</ProjectGuid>
-    <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FxCopBaseline.cs" />

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/System.Diagnostics.TextWriterTraceListener.Tests.csproj
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/System.Diagnostics.TextWriterTraceListener.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{92A9467A-9F7E-4294-A7D5-7B59F2E54ABE}</ProjectGuid>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <Configurations>netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestTraceFilter.cs" />

--- a/src/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
+++ b/src/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>System.Diagnostics.TraceSource</AssemblyName>
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <ProjectGuid>{5380420C-EB1D-4C53-9CFC-916578C18334}</ProjectGuid>
-    <Configurations>netcoreapp-FreeBSD-Debug;netcoreapp-FreeBSD-Release;netcoreapp-Linux-Debug;netcoreapp-Linux-Release;netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-FreeBSD-Debug;netcoreapp-FreeBSD-Release;netcoreapp-Linux-Debug;netcoreapp-Linux-Release;netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="FxCopBaseline.cs" />

--- a/src/System.Drawing.Common/System.Drawing.Common.sln
+++ b/src/System.Drawing.Common/System.Drawing.Common.sln
@@ -34,10 +34,10 @@ Global
 		{191B3618-FECD-4ABD-9D6B-5AC90DC33621}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{191B3618-FECD-4ABD-9D6B-5AC90DC33621}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{191B3618-FECD-4ABD-9D6B-5AC90DC33621}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{D7AEA698-275D-441F-B7A7-8491D1F0EFF0}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{D7AEA698-275D-441F-B7A7-8491D1F0EFF0}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{D7AEA698-275D-441F-B7A7-8491D1F0EFF0}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{D7AEA698-275D-441F-B7A7-8491D1F0EFF0}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{D7AEA698-275D-441F-B7A7-8491D1F0EFF0}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{D7AEA698-275D-441F-B7A7-8491D1F0EFF0}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{D7AEA698-275D-441F-B7A7-8491D1F0EFF0}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{D7AEA698-275D-441F-B7A7-8491D1F0EFF0}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Globalization.Calendars/src/System.Globalization.Calendars.csproj
+++ b/src/System.Globalization.Calendars/src/System.Globalization.Calendars.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>System.Globalization.Calendars</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <ProjectGuid>{7126BEDB-0903-454A-8A2B-8BE1CBDF8F2E}</ProjectGuid>
-    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{77E702D9-C6D8-4CE4-9941-D3056C3CCBED}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netcoreapp-Linux-Debug;netcoreapp-Linux-Release;netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-FreeBSD-Debug;netcoreapp-FreeBSD-Release;netcoreapp-Linux-Debug;netcoreapp-Linux-Release;netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\HResults.cs" />

--- a/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/src/System.IO.Pipelines.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{1032D5F6-5AE7-4002-A0E4-FEBEADFEA977}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Debug;netcoreapp-Release;netcoreapp-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\CoreLib\System\Threading\Tasks\TaskToApm.cs">

--- a/src/System.IO.Ports/src/System.IO.Ports.csproj
+++ b/src/System.IO.Ports/src/System.IO.Ports.csproj
@@ -6,7 +6,7 @@
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard' AND '$(TargetsWindows)' != 'true' AND '$(TargetsLinux)' != 'true' AND '$(TargetsOSX)' != 'true'">SR.PlatformNotSupported_IOPorts</GeneratePlatformNotSupportedAssemblyMessage>
     <DefineConstants>$(DefineConstants);NOSPAN</DefineConstants>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
-    <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;netstandard-Linux-Debug;netstandard-Linux-Release</Configurations>
+    <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Linux-Debug;netstandard-Linux-Release;netstandard-OSX-Debug;netstandard-OSX-Release;netstandard-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true' AND ('$(TargetsWindows)' == 'true' OR '$(TargetsLinux)' == 'true' OR '$(TargetsOSX)' == 'true')">

--- a/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
+++ b/src/System.IO.Ports/tests/System.IO.Ports.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{4259DCE9-3480-40BB-B08A-64A2D446264B}</ProjectGuid>
-    <Configurations>netfx-Debug;netfx-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;netstandard-Linux-Debug;netstandard-Linux-Release;netstandard-OSX-Debug;netstandard-OSX-Release</Configurations>
+    <Configurations>netfx-Debug;netfx-Release;netstandard-Linux-Debug;netstandard-Linux-Release;netstandard-OSX-Debug;netstandard-OSX-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/src/System.IO/System.IO.sln
+++ b/src/System.IO/System.IO.sln
@@ -4,10 +4,10 @@ VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO.Tests", "tests\System.IO.Tests.csproj", "{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}"
 	ProjectSection(ProjectDependencies) = postProject
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0} = {07390899-C8F6-4E83-A3A9-6867B8CB46A0}
+		{07390899-C8F6-4e83-A3A9-6867B8CB46A0} = {07390899-C8F6-4e83-A3A9-6867B8CB46A0}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO", "src\System.IO.csproj", "{07390899-C8F6-4E83-A3A9-6867B8CB46A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.IO", "src\System.IO.csproj", "{07390899-C8F6-4e83-A3A9-6867B8CB46A0}"
 	ProjectSection(ProjectDependencies) = postProject
 		{88883C57-83BE-4E93-A363-4CFC716F248F} = {88883C57-83BE-4E93-A363-4CFC716F248F}
 	EndProjectSection
@@ -30,10 +30,10 @@ Global
 		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Debug|Any CPU.ActiveCfg = uapaot-Windows_NT-Debug|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Debug|Any CPU.Build.0 = uapaot-Windows_NT-Debug|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Release|Any CPU.ActiveCfg = uap-Windows_NT-Release|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Release|Any CPU.Build.0 = uap-Windows_NT-Release|Any CPU
+		{07390899-C8F6-4e83-A3A9-6867B8CB46A0}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{07390899-C8F6-4e83-A3A9-6867B8CB46A0}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{07390899-C8F6-4e83-A3A9-6867B8CB46A0}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{07390899-C8F6-4e83-A3A9-6867B8CB46A0}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{88883C57-83BE-4E93-A363-4CFC716F248F}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{88883C57-83BE-4E93-A363-4CFC716F248F}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{88883C57-83BE-4E93-A363-4CFC716F248F}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
@@ -44,7 +44,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{492EC54D-D2C4-4B3F-AC1F-646B3F7EBB02} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{07390899-C8F6-4e83-A3A9-6867B8CB46A0} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{88883C57-83BE-4E93-A363-4CFC716F248F} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/src/System.Memory/src/System.Memory.csproj
+++ b/src/System.Memory/src/System.Memory.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{4BBC8F69-D03E-4432-AA8A-D458FA5B235A}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
     <!-- ArrayBufferWriter is publicly exposed from the System.Memory ref and only it should define this constant as true.  -->
     <DefineConstants>$(DefineConstants);MAKE_ABW_PUBLIC</DefineConstants>
   </PropertyGroup>

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -5,7 +5,7 @@
     <IncludePartialFacadeTests Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">true</IncludePartialFacadeTests>
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition="'$(IncludePartialFacadeTests)' == 'true'">
     <!-- Tests specific to netcoreapp and uap -->
@@ -253,7 +253,6 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="Span\Indexer.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="Base64\Base64DecoderUnitTests.cs" />
     <Compile Include="Base64\Base64EncoderUnitTests.cs" />

--- a/src/System.Net.Http.WinHttpHandler/System.Net.Http.WinHttpHandler.sln
+++ b/src/System.Net.Http.WinHttpHandler/System.Net.Http.WinHttpHandler.sln
@@ -35,10 +35,10 @@ Global
 		{17D5CC82-F72C-4DD2-B6DB-DE7FB2F19C34}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{17D5CC82-F72C-4DD2-B6DB-DE7FB2F19C34}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
 		{17D5CC82-F72C-4DD2-B6DB-DE7FB2F19C34}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
-		{A2ECDEDB-12B7-402C-9230-152B7601179F}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{A2ECDEDB-12B7-402C-9230-152B7601179F}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{A2ECDEDB-12B7-402C-9230-152B7601179F}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{A2ECDEDB-12B7-402C-9230-152B7601179F}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{A2ECDEDB-12B7-402C-9230-152B7601179F}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{A2ECDEDB-12B7-402C-9230-152B7601179F}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{A2ECDEDB-12B7-402C-9230-152B7601179F}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{A2ECDEDB-12B7-402C-9230-152B7601179F}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{F75E3008-0562-42DF-BE72-C1384F12157E}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{F75E3008-0562-42DF-BE72-C1384F12157E}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{F75E3008-0562-42DF-BE72-C1384F12157E}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -4,7 +4,7 @@
     <NoWarn>$(NoWarn);0436</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
-    <Configurations>netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <DefaultReferenceExclusions Include="System.Net.Http.WinHttpHandler" />

--- a/src/System.Net.Http/System.Net.Http.sln
+++ b/src/System.Net.Http/System.Net.Http.sln
@@ -35,10 +35,10 @@ Global
 		{C85CF035-7804-41FF-9557-48B7C948B58D}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{C85CF035-7804-41FF-9557-48B7C948B58D}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{C85CF035-7804-41FF-9557-48B7C948B58D}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{5F9C3C9F-652E-461E-B2D6-85D264F5A733}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -4,7 +4,7 @@
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
+    <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <!-- Do not reference these assemblies from the TargetingPack since we are building part of the source code for tests. -->
   <ItemGroup>

--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <ProjectGuid>{3CA89D6C-F8D1-4813-9775-F8D249686E31}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netcoreapp-Linux-Debug;netcoreapp-Linux-Release;netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-FreeBSD-Debug;netcoreapp-FreeBSD-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-FreeBSD-Debug;netcoreapp-FreeBSD-Release;netcoreapp-Linux-Debug;netcoreapp-Linux-Release;netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Net\NetworkInformation\DuplicateAddressDetectionState.cs" />

--- a/src/System.Net.Sockets/System.Net.Sockets.sln
+++ b/src/System.Net.Sockets/System.Net.Sockets.sln
@@ -1,13 +1,13 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28725.219
+# Visual Studio 15
+VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Net.Sockets.Tests", "tests\FunctionalTests\System.Net.Sockets.Tests.csproj", "{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}"
 	ProjectSection(ProjectDependencies) = postProject
 		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B} = {43311AFB-D7C4-4E5A-B1DE-855407F90D1B}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Net.Sockets.Async.PerformanceTests", "tests\ManualPerformanceTests\System.Net.Sockets.Async.PerformanceTests.csproj", "{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Net.Sockets.Async.Stress.Tests", "tests\ManualPerformanceTests\System.Net.Sockets.Async.Stress.Tests.csproj", "{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}"
 	ProjectSection(ProjectDependencies) = postProject
 		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B} = {43311AFB-D7C4-4E5A-B1DE-855407F90D1B}
 	EndProjectSection
@@ -31,10 +31,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}.Debug|Any CPU.ActiveCfg = netcoreapp-Unix-Debug|Any CPU
-		{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}.Debug|Any CPU.Build.0 = netcoreapp-Unix-Debug|Any CPU
-		{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}.Release|Any CPU.ActiveCfg = netcoreapp-Unix-Release|Any CPU
-		{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}.Release|Any CPU.Build.0 = netcoreapp-Unix-Release|Any CPU
+		{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU

--- a/src/System.Numerics.Tensors/System.Numerics.Tensors.sln
+++ b/src/System.Numerics.Tensors/System.Numerics.Tensors.sln
@@ -1,24 +1,24 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.28224.57
+VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{87920B79-6C7A-4815-89F4-1DA09FAFF411}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D221B689-1AF1-4595-B37B-85D478B94EAD}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{559061C0-F6A9-4522-992E-3C95AAF852DB}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "pkg", "pkg", "{7CCC80FC-70B2-4026-BE52-FA2451FAA83D}"
-	ProjectSection(SolutionItems) = preProject
-		pkg\System.Numerics.Tensors.pkgproj = pkg\System.Numerics.Tensors.pkgproj
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Numerics.Tensors.Tests", "tests\System.Numerics.Tensors.Tests.csproj", "{D4718CD3-8492-4734-94B7-E31A39AA6275}"
+	ProjectSection(ProjectDependencies) = postProject
+		{BE0F13BE-9140-49A8-9FDD-994D0D8A3805} = {BE0F13BE-9140-49A8-9FDD-994D0D8A3805}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Numerics.Tensors", "ref\System.Numerics.Tensors.csproj", "{AEE6F10B-B34C-4D0A-A94D-277AE02F06E8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Numerics.Tensors", "src\System.Numerics.Tensors.csproj", "{BE0F13BE-9140-49A8-9FDD-994D0D8A3805}"
+	ProjectSection(ProjectDependencies) = postProject
+		{F64208FC-83DA-4C94-973F-1DDDE4354AFF} = {F64208FC-83DA-4C94-973F-1DDDE4354AFF}
+	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Numerics.Tensors", "src\System.Numerics.Tensors.csproj", "{34B7B42D-ADE0-419D-A636-80180244875D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Numerics.Tensors", "ref\System.Numerics.Tensors.csproj", "{F64208FC-83DA-4C94-973F-1DDDE4354AFF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Numerics.Tensors.Tests", "tests\System.Numerics.Tensors.Tests.csproj", "{1725EFB4-DE6C-4EBA-8E94-78D3E46F6B37}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,26 +26,26 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{AEE6F10B-B34C-4D0A-A94D-277AE02F06E8}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{AEE6F10B-B34C-4D0A-A94D-277AE02F06E8}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{AEE6F10B-B34C-4D0A-A94D-277AE02F06E8}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{AEE6F10B-B34C-4D0A-A94D-277AE02F06E8}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{34B7B42D-ADE0-419D-A636-80180244875D}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{34B7B42D-ADE0-419D-A636-80180244875D}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{34B7B42D-ADE0-419D-A636-80180244875D}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{34B7B42D-ADE0-419D-A636-80180244875D}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{1725EFB4-DE6C-4EBA-8E94-78D3E46F6B37}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{1725EFB4-DE6C-4EBA-8E94-78D3E46F6B37}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{1725EFB4-DE6C-4EBA-8E94-78D3E46F6B37}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{1725EFB4-DE6C-4EBA-8E94-78D3E46F6B37}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{D4718CD3-8492-4734-94B7-E31A39AA6275}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{D4718CD3-8492-4734-94B7-E31A39AA6275}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{D4718CD3-8492-4734-94B7-E31A39AA6275}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{D4718CD3-8492-4734-94B7-E31A39AA6275}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{BE0F13BE-9140-49A8-9FDD-994D0D8A3805}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{BE0F13BE-9140-49A8-9FDD-994D0D8A3805}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{BE0F13BE-9140-49A8-9FDD-994D0D8A3805}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{BE0F13BE-9140-49A8-9FDD-994D0D8A3805}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{F64208FC-83DA-4C94-973F-1DDDE4354AFF}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{F64208FC-83DA-4C94-973F-1DDDE4354AFF}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{F64208FC-83DA-4C94-973F-1DDDE4354AFF}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{F64208FC-83DA-4C94-973F-1DDDE4354AFF}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{AEE6F10B-B34C-4D0A-A94D-277AE02F06E8} = {87920B79-6C7A-4815-89F4-1DA09FAFF411}
-		{34B7B42D-ADE0-419D-A636-80180244875D} = {D221B689-1AF1-4595-B37B-85D478B94EAD}
-		{1725EFB4-DE6C-4EBA-8E94-78D3E46F6B37} = {559061C0-F6A9-4522-992E-3C95AAF852DB}
+		{D4718CD3-8492-4734-94B7-E31A39AA6275} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{BE0F13BE-9140-49A8-9FDD-994D0D8A3805} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{F64208FC-83DA-4C94-973F-1DDDE4354AFF} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {13D12508-D252-4FD4-A8AA-1DD44F666914}

--- a/src/System.Numerics.Tensors/ref/System.Numerics.Tensors.csproj
+++ b/src/System.Numerics.Tensors/ref/System.Numerics.Tensors.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release</Configurations>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{F64208FC-83DA-4C94-973F-1DDDE4354AFF}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Numerics.Tensors.cs" />

--- a/src/System.Numerics.Tensors/src/System.Numerics.Tensors.csproj
+++ b/src/System.Numerics.Tensors/src/System.Numerics.Tensors.csproj
@@ -1,9 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release</Configurations>
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
     <RootNamespace>System.Numerics.Tensors</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{BE0F13BE-9140-49A8-9FDD-994D0D8A3805}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\InternalsVisibleTo.cs" />

--- a/src/System.Numerics.Tensors/tests/System.Numerics.Tensors.Tests.csproj
+++ b/src/System.Numerics.Tensors/tests/System.Numerics.Tensors.Tests.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{D4718CD3-8492-4734-94B7-E31A39AA6275}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NativeMemory.cs" />

--- a/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
+++ b/src/System.ObjectModel/tests/System.ObjectModel.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{43841228-2A2B-4215-B97F-33006995E486}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release;uapaot-Debug;uapaot-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerableTest.cs">
@@ -44,7 +44,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'=='netcoreapp'">
-    <Compile Include="ObservableCollection\ObservableCollection_MethodTests.netcoreapp.cs" />    
+    <Compile Include="ObservableCollection\ObservableCollection_MethodTests.netcoreapp.cs" />
     <Compile Include="ObservableCollection\ObservableCollection_SkipCollectionChangedTests.netcoreapp.cs" />
     <Compile Include="KeyedCollection\TestMethods.netcoreapp.cs" />
     <Compile Include="System\Collections\ObjectModel\KeyedCollectionTests.netcoreapp.cs" />

--- a/src/System.Private.Uri/System.Private.Uri.sln
+++ b/src/System.Private.Uri/System.Private.Uri.sln
@@ -37,10 +37,10 @@ Global
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{B0FFC4A8-BAC3-4A7F-8FD5-5B680209371C}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{96AF3242-A368-4F13-B006-A722CC3B8517}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{96AF3242-A368-4F13-B006-A722CC3B8517}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{96AF3242-A368-4F13-B006-A722CC3B8517}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{96AF3242-A368-4F13-B006-A722CC3B8517}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{96AF3242-A368-4F13-B006-A722CC3B8517}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{96AF3242-A368-4F13-B006-A722CC3B8517}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{96AF3242-A368-4F13-B006-A722CC3B8517}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{96AF3242-A368-4F13-B006-A722CC3B8517}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{4AC5343E-6E31-4BA5-A795-0493AE7E9008}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{4AC5343E-6E31-4BA5-A795-0493AE7E9008}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{4AC5343E-6E31-4BA5-A795-0493AE7E9008}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU

--- a/src/System.Private.Xml.Linq/System.Private.Xml.Linq.sln
+++ b/src/System.Private.Xml.Linq/System.Private.Xml.Linq.sln
@@ -119,10 +119,10 @@ Global
 		{979510CE-9042-4F8D-9C74-EE03B89194CC}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{979510CE-9042-4F8D-9C74-EE03B89194CC}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{979510CE-9042-4F8D-9C74-EE03B89194CC}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{5D4FB9ED-C3AC-4EFA-9FEE-619ED4B4B92D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5D4FB9ED-C3AC-4EFA-9FEE-619ED4B4B92D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5D4FB9ED-C3AC-4EFA-9FEE-619ED4B4B92D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5D4FB9ED-C3AC-4EFA-9FEE-619ED4B4B92D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D4FB9ED-C3AC-4EFA-9FEE-619ED4B4B92D}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{5D4FB9ED-C3AC-4EFA-9FEE-619ED4B4B92D}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{5D4FB9ED-C3AC-4EFA-9FEE-619ED4B4B92D}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{5D4FB9ED-C3AC-4EFA-9FEE-619ED4B4B92D}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{6E1C5358-7F04-4791-8B5F-6A5A4E42ABF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6E1C5358-7F04-4791-8B5F-6A5A4E42ABF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6E1C5358-7F04-4791-8B5F-6A5A4E42ABF1}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/System.Private.Xml.Linq/tests/xNodeBuilder/System.Xml.Linq.xNodeBuilder.Tests.csproj
+++ b/src/System.Private.Xml.Linq/tests/xNodeBuilder/System.Xml.Linq.xNodeBuilder.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{5D4FB9ED-C3AC-4EFA-9FEE-619ED4B4B92D}</ProjectGuid>
-    <Configurations>Debug;Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">

--- a/src/System.Reflection.DispatchProxy/System.Reflection.DispatchProxy.sln
+++ b/src/System.Reflection.DispatchProxy/System.Reflection.DispatchProxy.sln
@@ -34,10 +34,10 @@ Global
 		{1E689C1B-690C-4799-BDE9-6E7990585894}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{1E689C1B-690C-4799-BDE9-6E7990585894}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{1E689C1B-690C-4799-BDE9-6E7990585894}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{7DF3C428-AAD6-41C7-98E6-6CACFD5C391E}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{7DF3C428-AAD6-41C7-98E6-6CACFD5C391E}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{7DF3C428-AAD6-41C7-98E6-6CACFD5C391E}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{7DF3C428-AAD6-41C7-98E6-6CACFD5C391E}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{7DF3C428-AAD6-41C7-98E6-6CACFD5C391E}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{7DF3C428-AAD6-41C7-98E6-6CACFD5C391E}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{7DF3C428-AAD6-41C7-98E6-6CACFD5C391E}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{7DF3C428-AAD6-41C7-98E6-6CACFD5C391E}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Reflection.DispatchProxy/ref/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/ref/System.Reflection.DispatchProxy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{7DF3C428-AAD6-41C7-98E6-6CACFD5C391E}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release;uap-Debug;uap-Release;uap10.0.16299-Debug;uap10.0.16299-Release;netcoreapp-Debug;netcoreapp-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release;uap10.0.16299-Debug;uap10.0.16299-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Reflection.DispatchProxy.cs" />

--- a/src/System.Reflection/System.Reflection.sln
+++ b/src/System.Reflection/System.Reflection.sln
@@ -67,7 +67,22 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Reflection.CoreCLR.T
 		{68F87E68-E13F-4354-A6D6-B44727FE53EE} = {68F87E68-E13F-4354-A6D6-B44727FE53EE}
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ForwardedTypesAssembly", "tests\ForwardedTypesAssembly\ForwardedTypesAssembly.csproj", "{FA12CC14-C4A5-495D-B7AA-651E4BCC1027}"
+	ProjectSection(ProjectDependencies) = postProject
+		{68F87E68-E13F-4354-A6D6-B44727FE53EE} = {68F87E68-E13F-4354-A6D6-B44727FE53EE}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestAssembly", "tests\TestAssembly\TestAssembly.csproj", "{0CD33916-DD1D-4DF3-B579-2896ACE43E45}"
+	ProjectSection(ProjectDependencies) = postProject
+		{68F87E68-E13F-4354-A6D6-B44727FE53EE} = {68F87E68-E13F-4354-A6D6-B44727FE53EE}
+	EndProjectSection
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Reflection.TestExe", "tests\TestExe\System.Reflection.TestExe.csproj", "{8C19B991-41E9-4B38-9602-E19375397F1D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{68F87E68-E13F-4354-A6D6-B44727FE53EE} = {68F87E68-E13F-4354-A6D6-B44727FE53EE}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnloadableAssembly", "tests\UnloadableAssembly\UnloadableAssembly.csproj", "{7FFD1B55-D69A-4469-B775-6CBEB1CE50B0}"
 	ProjectSection(ProjectDependencies) = postProject
 		{68F87E68-E13F-4354-A6D6-B44727FE53EE} = {68F87E68-E13F-4354-A6D6-B44727FE53EE}
 	EndProjectSection
@@ -91,10 +106,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B027C72E-F04E-42E0-A7F7-993AEF8400D2}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{B027C72E-F04E-42E0-A7F7-993AEF8400D2}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{B027C72E-F04E-42E0-A7F7-993AEF8400D2}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{B027C72E-F04E-42E0-A7F7-993AEF8400D2}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{B027C72E-F04E-42E0-A7F7-993AEF8400D2}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{B027C72E-F04E-42E0-A7F7-993AEF8400D2}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{B027C72E-F04E-42E0-A7F7-993AEF8400D2}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{B027C72E-F04E-42E0-A7F7-993AEF8400D2}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{5B003EB4-DD06-4BC6-B2E9-A9F0E445CB86}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{5B003EB4-DD06-4BC6-B2E9-A9F0E445CB86}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{5B003EB4-DD06-4BC6-B2E9-A9F0E445CB86}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
@@ -143,10 +158,22 @@ Global
 		{C8049356-559D-4F34-AC17-56F3AE62C897}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{C8049356-559D-4F34-AC17-56F3AE62C897}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{C8049356-559D-4F34-AC17-56F3AE62C897}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{FA12CC14-C4A5-495D-B7AA-651E4BCC1027}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{FA12CC14-C4A5-495D-B7AA-651E4BCC1027}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{FA12CC14-C4A5-495D-B7AA-651E4BCC1027}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{FA12CC14-C4A5-495D-B7AA-651E4BCC1027}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{0CD33916-DD1D-4DF3-B579-2896ACE43E45}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{0CD33916-DD1D-4DF3-B579-2896ACE43E45}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{0CD33916-DD1D-4DF3-B579-2896ACE43E45}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{0CD33916-DD1D-4DF3-B579-2896ACE43E45}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{8C19B991-41E9-4B38-9602-E19375397F1D}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{8C19B991-41E9-4B38-9602-E19375397F1D}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{8C19B991-41E9-4B38-9602-E19375397F1D}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{8C19B991-41E9-4B38-9602-E19375397F1D}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{7FFD1B55-D69A-4469-B775-6CBEB1CE50B0}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{7FFD1B55-D69A-4469-B775-6CBEB1CE50B0}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{7FFD1B55-D69A-4469-B775-6CBEB1CE50B0}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{7FFD1B55-D69A-4469-B775-6CBEB1CE50B0}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{68F87E68-E13F-4354-A6D6-B44727FE53EE}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{68F87E68-E13F-4354-A6D6-B44727FE53EE}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{68F87E68-E13F-4354-A6D6-B44727FE53EE}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
@@ -173,7 +200,10 @@ Global
 		{68AD3675-F57E-4FB3-9943-49E602678BCA} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{42E66302-6F46-47BE-936B-4264DFD6004F} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{C8049356-559D-4F34-AC17-56F3AE62C897} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{FA12CC14-C4A5-495D-B7AA-651E4BCC1027} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{0CD33916-DD1D-4DF3-B579-2896ACE43E45} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{8C19B991-41E9-4B38-9602-E19375397F1D} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{7FFD1B55-D69A-4469-B775-6CBEB1CE50B0} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{68F87E68-E13F-4354-A6D6-B44727FE53EE} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{23B83DCB-45FD-4C8F-A6FB-C6799FB52BA6} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection

--- a/src/System.Resources.Extensions/System.Resources.Extensions.sln
+++ b/src/System.Resources.Extensions/System.Resources.Extensions.sln
@@ -1,45 +1,51 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28621.142
+# Visual Studio 15
+VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Resources.Extensions", "src\System.Resources.Extensions.csproj", "{694389E4-6F68-4E0A-A8AC-2B85416C0742}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Resources.Extensions.Tests", "tests\System.Resources.Extensions.Tests.csproj", "{9003846C-EE54-4E58-B01E-6AA177E046C5}"
+	ProjectSection(ProjectDependencies) = postProject
+		{6773D354-A573-4D9C-9A67-C7FAE579DA50} = {6773D354-A573-4D9C-9A67-C7FAE579DA50}
+	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Resources.Extensions", "ref\System.Resources.Extensions.csproj", "{CD6088BF-DDA2-4097-A505-D786E8968A76}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Resources.Extensions", "src\System.Resources.Extensions.csproj", "{6773D354-A573-4D9C-9A67-C7FAE579DA50}"
+	ProjectSection(ProjectDependencies) = postProject
+		{D8C148D2-FAB2-4D8C-ACA3-D201665F7255} = {D8C148D2-FAB2-4D8C-ACA3-D201665F7255}
+	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Resources.Extensions.Tests", "tests\System.Resources.Extensions.Tests.csproj", "{9359E7DF-50C8-471B-AF9E-706FE2C4B326}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Resources.Extensions", "ref\System.Resources.Extensions.csproj", "{D8C148D2-FAB2-4D8C-ACA3-D201665F7255}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{606176E0-E028-42B8-8FBA-3DA36A65E6FC}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E5D875A9-7379-4393-A808-E52B1AB05D66}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		netstandard-Debug|Any CPU = netstandard-Debug|Any CPU
-		netstandard-Release|Any CPU = netstandard-Release|Any CPU
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{694389E4-6F68-4E0A-A8AC-2B85416C0742}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{694389E4-6F68-4E0A-A8AC-2B85416C0742}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{694389E4-6F68-4E0A-A8AC-2B85416C0742}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{694389E4-6F68-4E0A-A8AC-2B85416C0742}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{CD6088BF-DDA2-4097-A505-D786E8968A76}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{CD6088BF-DDA2-4097-A505-D786E8968A76}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{CD6088BF-DDA2-4097-A505-D786E8968A76}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{CD6088BF-DDA2-4097-A505-D786E8968A76}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{9359E7DF-50C8-471B-AF9E-706FE2C4B326}.netstandard-Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{9359E7DF-50C8-471B-AF9E-706FE2C4B326}.netstandard-Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{9359E7DF-50C8-471B-AF9E-706FE2C4B326}.netstandard-Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{9359E7DF-50C8-471B-AF9E-706FE2C4B326}.netstandard-Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{9003846C-EE54-4E58-B01E-6AA177E046C5}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{9003846C-EE54-4E58-B01E-6AA177E046C5}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{9003846C-EE54-4E58-B01E-6AA177E046C5}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{9003846C-EE54-4E58-B01E-6AA177E046C5}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{6773D354-A573-4D9C-9A67-C7FAE579DA50}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{6773D354-A573-4D9C-9A67-C7FAE579DA50}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{6773D354-A573-4D9C-9A67-C7FAE579DA50}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{6773D354-A573-4D9C-9A67-C7FAE579DA50}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{D8C148D2-FAB2-4D8C-ACA3-D201665F7255}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{D8C148D2-FAB2-4D8C-ACA3-D201665F7255}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{D8C148D2-FAB2-4D8C-ACA3-D201665F7255}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{D8C148D2-FAB2-4D8C-ACA3-D201665F7255}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{694389E4-6F68-4E0A-A8AC-2B85416C0742} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
-		{CD6088BF-DDA2-4097-A505-D786E8968A76} = {606176E0-E028-42B8-8FBA-3DA36A65E6FC}
-		{9359E7DF-50C8-471B-AF9E-706FE2C4B326} = {E5D875A9-7379-4393-A808-E52B1AB05D66}
+		{9003846C-EE54-4E58-B01E-6AA177E046C5} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{6773D354-A573-4D9C-9A67-C7FAE579DA50} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{D8C148D2-FAB2-4D8C-ACA3-D201665F7255} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {046617DD-67EB-43A1-BE4E-22CCFC3EC15F}

--- a/src/System.Resources.Extensions/ref/System.Resources.Extensions.csproj
+++ b/src/System.Resources.Extensions/ref/System.Resources.Extensions.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{D8C148D2-FAB2-4D8C-ACA3-D201665F7255}</ProjectGuid>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Resources.Extensions.cs" />
   </ItemGroup>

--- a/src/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -4,6 +4,9 @@
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
     <DefineConstants>$(DefineConstants);RESOURCES_EXTENSIONS</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{6773D354-A573-4D9C-9A67-C7FAE579DA50}</ProjectGuid>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\System\Resources\ResourceWriter.cs" Link="System\Resources\Extensions\ResourceWriter.cs" />
     <Compile Include="$(CommonPath)\CoreLib\System\IO\PinnedBufferMemoryStream.cs" Link="System\IO\PinnedBufferMemoryStream.cs" />
@@ -14,7 +17,7 @@
     <Compile Include="BinaryReaderExtensions.cs" />
     <Compile Include="System\Resources\Extensions\DeserializingResourceReader.cs" />
     <Compile Include="System\Resources\Extensions\PreserializedResourceWriter.cs" />
-    <Compile Include="System\Resources\Extensions\SerializationFormat.cs" />    
+    <Compile Include="System\Resources\Extensions\SerializationFormat.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Memory" />

--- a/src/System.Resources.Extensions/tests/System.Resources.Extensions.Tests.csproj
+++ b/src/System.Resources.Extensions/tests/System.Resources.Extensions.Tests.csproj
@@ -4,6 +4,9 @@
     <TestDataPackageVersion>1.0.9</TestDataPackageVersion>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
   </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{9003846C-EE54-4E58-B01E-6AA177E046C5}</ProjectGuid>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="MyResourceType.cs" />
     <Compile Include="TestData.cs" />
@@ -11,7 +14,6 @@
     <SupplementalTestData Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\**\*.*" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <EmbeddedResource Include="TestData.resources" WithCulture="false" Type="Non-Resx" />
   </ItemGroup>
-  
   <!-- use the following target to regenerate the test resources file
        This is done from a test application and checked in so that we don't run
        product code during the build -->
@@ -20,10 +22,7 @@
       <_executor>Microsoft.DotNet.RemoteExecutorHost.dll</_executor>
     </PropertyGroup>
     <ItemGroup>
-      <ExecuteMethod Class="System.Resources.Extensions.Tests.TestData"
-                     Include="WriteResources" 
-                     Parameters="$(MSBuildProjectDirectory)\TestData.resources" />
-
+      <ExecuteMethod Class="System.Resources.Extensions.Tests.TestData" Include="WriteResources" Parameters="$(MSBuildProjectDirectory)\TestData.resources" />
       <ExecuteMethod>
         <ExceptionFile>$(TargetDir)%(Class)%(Identity).exception.txt</ExceptionFile>
       </ExecuteMethod>
@@ -31,7 +30,6 @@
         <Command>$(TestHostRootPath)dotnet $(_executor) $(AssemblyName) %(Class) %(Identity) %(ExceptionFile) %(Parameters)</Command>
       </ExecuteMethod>
     </ItemGroup>
-    
     <Exec Command="%(ExecuteMethod.Command)" WorkingDirectory="$(TargetDir)" />
   </Target>
 </Project>

--- a/src/System.Resources.ResourceManager/System.Resources.ResourceManager.sln
+++ b/src/System.Resources.ResourceManager/System.Resources.ResourceManager.sln
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{1D51A16C-B6D8-4E8F-98DE-21AD9A7062A1}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{1D51A16C-B6D8-4E8F-98DE-21AD9A7062A1}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{1D51A16C-B6D8-4E8F-98DE-21AD9A7062A1}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{1D51A16C-B6D8-4E8F-98DE-21AD9A7062A1}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{1D51A16C-B6D8-4E8F-98DE-21AD9A7062A1}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{1D51A16C-B6D8-4E8F-98DE-21AD9A7062A1}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{1D51A16C-B6D8-4E8F-98DE-21AD9A7062A1}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{1D51A16C-B6D8-4E8F-98DE-21AD9A7062A1}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{3E7810B2-2802-4867-B223-30427F3F2D5B}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{3E7810B2-2802-4867-B223-30427F3F2D5B}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{3E7810B2-2802-4867-B223-30427F3F2D5B}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/System.Runtime.InteropServices.RuntimeInformation.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{9B4D1DA9-AA4C-428F-9F66-D45C924025A5}</ProjectGuid>
-    <Configurations>netstandard-Unix-Debug;netstandard-Unix-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release</Configurations>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netstandard-Unix-Debug;netstandard-Unix-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CheckArchitectureTests.cs" />

--- a/src/System.Runtime.Intrinsics/System.Runtime.Intrinsics.sln
+++ b/src/System.Runtime.Intrinsics/System.Runtime.Intrinsics.sln
@@ -2,12 +2,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.Intrinsics", "src\System.Runtime.Intrinsics.csproj", "{543FBFE5-E9E4-4631-8242-911A707FE818}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.Intrinsics", "src\System.Runtime.Intrinsics.csproj", "{315E3C60-A5D9-4F47-A940-D57395EED606}"
 	ProjectSection(ProjectDependencies) = postProject
-		{4074AF8C-8C65-486C-960E-F45DAAB0BE0D} = {4074AF8C-8C65-486C-960E-F45DAAB0BE0D}
+		{F9097917-AFA3-4E3E-A592-BFA2C483C7E2} = {F9097917-AFA3-4E3E-A592-BFA2C483C7E2}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.Intrinsics", "ref\System.Runtime.Intrinsics.csproj", "{4074AF8C-8C65-486C-960E-F45DAAB0BE0D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.Intrinsics", "ref\System.Runtime.Intrinsics.csproj", "{F9097917-AFA3-4E3E-A592-BFA2C483C7E2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
 EndProject
@@ -19,21 +19,21 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{543FBFE5-E9E4-4631-8242-911A707FE818}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
-		{543FBFE5-E9E4-4631-8242-911A707FE818}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
-		{543FBFE5-E9E4-4631-8242-911A707FE818}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
-		{543FBFE5-E9E4-4631-8242-911A707FE818}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{4074AF8C-8C65-486C-960E-F45DAAB0BE0D}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{4074AF8C-8C65-486C-960E-F45DAAB0BE0D}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{4074AF8C-8C65-486C-960E-F45DAAB0BE0D}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{4074AF8C-8C65-486C-960E-F45DAAB0BE0D}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{315E3C60-A5D9-4F47-A940-D57395EED606}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{315E3C60-A5D9-4F47-A940-D57395EED606}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{315E3C60-A5D9-4F47-A940-D57395EED606}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{315E3C60-A5D9-4F47-A940-D57395EED606}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
+		{F9097917-AFA3-4E3E-A592-BFA2C483C7E2}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{F9097917-AFA3-4E3E-A592-BFA2C483C7E2}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{F9097917-AFA3-4E3E-A592-BFA2C483C7E2}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{F9097917-AFA3-4E3E-A592-BFA2C483C7E2}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{543FBFE5-E9E4-4631-8242-911A707FE818} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
-		{4074AF8C-8C65-486C-960E-F45DAAB0BE0D} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+		{315E3C60-A5D9-4F47-A940-D57395EED606} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{F9097917-AFA3-4E3E-A592-BFA2C483C7E2} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2E88FB02-CE53-4D6E-8D60-CDCD578E1871}

--- a/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.csproj
+++ b/src/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ClsCompliant>false</ClsCompliant>
-    <ProjectGuid>{4074AF8C-8C65-486C-960E-F45DAAB0BE0D}</ProjectGuid>
+    <ProjectGuid>{F9097917-AFA3-4E3E-A592-BFA2C483C7E2}</ProjectGuid>
     <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Runtime.Intrinsics/src/System.Runtime.Intrinsics.csproj
+++ b/src/System.Runtime.Intrinsics/src/System.Runtime.Intrinsics.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>System.Runtime.Intrinsics</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <ClsCompliant>false</ClsCompliant>
-    <ProjectGuid>{543FBFE5-E9E4-4631-8242-911A707FE818}</ProjectGuid>
+    <ProjectGuid>{315E3C60-A5D9-4F47-A940-D57395EED606}</ProjectGuid>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Runtime.Loader/System.Runtime.Loader.sln
+++ b/src/System.Runtime.Loader/System.Runtime.Loader.sln
@@ -7,12 +7,27 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.Loader.Tests
 		{485A65F0-51C9-4B95-A7A8-A4860C231E67} = {485A65F0-51C9-4B95-A7A8-A4860C231E67}
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.Loader.Test.ContextualReflectionDependency", "tests\ContextualReflectionDependency\System.Runtime.Loader.Test.ContextualReflectionDependency.csproj", "{95DBE3B0-AA86-4366-BB8A-E04B534365F3}"
+	ProjectSection(ProjectDependencies) = postProject
+		{485A65F0-51C9-4B95-A7A8-A4860C231E67} = {485A65F0-51C9-4B95-A7A8-A4860C231E67}
+	EndProjectSection
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.Loader.DefaultContext.Tests", "tests\DefaultContext\System.Runtime.Loader.DefaultContext.Tests.csproj", "{701CB3BC-00DC-435D-BDE4-C5FC29A708A8}"
 	ProjectSection(ProjectDependencies) = postProject
 		{485A65F0-51C9-4B95-A7A8-A4860C231E67} = {485A65F0-51C9-4B95-A7A8-A4860C231E67}
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.Loader.RefEmitLoadContext.Tests", "tests\RefEmitLoadContext\System.Runtime.Loader.RefEmitLoadContext.Tests.csproj", "{701CB3BC-00DC-435D-BDE4-C5FC29A708A9}"
+	ProjectSection(ProjectDependencies) = postProject
+		{485A65F0-51C9-4B95-A7A8-A4860C231E67} = {485A65F0-51C9-4B95-A7A8-A4860C231E67}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReferencedClassLib", "tests\ReferencedClassLib\ReferencedClassLib.csproj", "{2CD5A44C-65B4-4C51-AC7B-B2938307848A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{485A65F0-51C9-4B95-A7A8-A4860C231E67} = {485A65F0-51C9-4B95-A7A8-A4860C231E67}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReferencedClassLibNeutralIsSatellite", "tests\ReferencedClassLibNeutralIsSatellite\ReferencedClassLibNeutralIsSatellite.csproj", "{7FA764E6-47A3-42B5-923B-7D5DBC611E8E}"
 	ProjectSection(ProjectDependencies) = postProject
 		{485A65F0-51C9-4B95-A7A8-A4860C231E67} = {485A65F0-51C9-4B95-A7A8-A4860C231E67}
 	EndProjectSection
@@ -60,6 +75,10 @@ Global
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A7}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A7}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A7}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
+		{95DBE3B0-AA86-4366-BB8A-E04B534365F3}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{95DBE3B0-AA86-4366-BB8A-E04B534365F3}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{95DBE3B0-AA86-4366-BB8A-E04B534365F3}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{95DBE3B0-AA86-4366-BB8A-E04B534365F3}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A8}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A8}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A8}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
@@ -68,6 +87,14 @@ Global
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A9}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A9}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A9}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{2CD5A44C-65B4-4C51-AC7B-B2938307848A}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{2CD5A44C-65B4-4C51-AC7B-B2938307848A}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{2CD5A44C-65B4-4C51-AC7B-B2938307848A}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{2CD5A44C-65B4-4C51-AC7B-B2938307848A}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{7FA764E6-47A3-42B5-923B-7D5DBC611E8E}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{7FA764E6-47A3-42B5-923B-7D5DBC611E8E}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{7FA764E6-47A3-42B5-923B-7D5DBC611E8E}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{7FA764E6-47A3-42B5-923B-7D5DBC611E8E}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{396D6EBF-60BD-4DAF-8783-FB403E070A57}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{396D6EBF-60BD-4DAF-8783-FB403E070A57}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{396D6EBF-60BD-4DAF-8783-FB403E070A57}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
@@ -98,8 +125,11 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A7} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{95DBE3B0-AA86-4366-BB8A-E04B534365F3} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A8} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A9} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{2CD5A44C-65B4-4C51-AC7B-B2938307848A} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{7FA764E6-47A3-42B5-923B-7D5DBC611E8E} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{396D6EBF-60BD-4DAF-8783-FB403E070A57} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{E3C33774-AA3D-4CED-A7A6-BDF9A7F100DF} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{FBF73A8E-7889-4C7D-AFC3-509B821D0FC6} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}

--- a/src/System.Runtime.Serialization.Formatters/System.Runtime.Serialization.Formatters.sln
+++ b/src/System.Runtime.Serialization.Formatters/System.Runtime.Serialization.Formatters.sln
@@ -26,14 +26,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{13CE5E71-D373-4EA6-B3CB-166FF089A42A}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{13CE5E71-D373-4EA6-B3CB-166FF089A42A}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{13CE5E71-D373-4EA6-B3CB-166FF089A42A}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{13CE5E71-D373-4EA6-B3CB-166FF089A42A}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{CF80D24A-787A-43DB-B9E7-10BCA02D10EA}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{CF80D24A-787A-43DB-B9E7-10BCA02D10EA}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{CF80D24A-787A-43DB-B9E7-10BCA02D10EA}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{CF80D24A-787A-43DB-B9E7-10BCA02D10EA}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{13CE5E71-D373-4EA6-B3CB-166FF089A42A}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{13CE5E71-D373-4EA6-B3CB-166FF089A42A}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{13CE5E71-D373-4EA6-B3CB-166FF089A42A}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{13CE5E71-D373-4EA6-B3CB-166FF089A42A}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{CF80D24A-787A-43DB-B9E7-10BCA02D10EA}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{CF80D24A-787A-43DB-B9E7-10BCA02D10EA}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{CF80D24A-787A-43DB-B9E7-10BCA02D10EA}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{CF80D24A-787A-43DB-B9E7-10BCA02D10EA}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{4413B319-3D48-4516-A45B-375F4650EF0D}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{4413B319-3D48-4516-A45B-375F4650EF0D}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{4413B319-3D48-4516-A45B-375F4650EF0D}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU

--- a/src/System.Runtime/System.Runtime.sln
+++ b/src/System.Runtime/System.Runtime.sln
@@ -7,12 +7,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Runtime.Tests", "tes
 		{56B9D0A9-44D3-488E-8B42-C14A6E30CAB2} = {56B9D0A9-44D3-488E-8B42-C14A6E30CAB2}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ForwardedTypesAssembly", "tests\ForwardedTypesAssembly\ForwardedTypesAssembly.csproj", "{3A3DE9F8-6295-4B68-BAAB-406F1CA0CD9C}"
-	ProjectSection(ProjectDependencies) = postProject
-		{56B9D0A9-44D3-488E-8B42-C14A6E30CAB2} = {56B9D0A9-44D3-488E-8B42-C14A6E30CAB2}
-	EndProjectSection
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestAssembly", "tests\TestAssembly\TestAssembly.csproj", "{2EF7D710-A7BD-4BB3-8EF6-3F0298CD4986}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestCollectibleAssembly", "tests\TestCollectibleAssembly\TestCollectibleAssembly.csproj", "{F9C30DC5-30C1-45DA-9336-F7BE358C367C}"
 	ProjectSection(ProjectDependencies) = postProject
 		{56B9D0A9-44D3-488E-8B42-C14A6E30CAB2} = {56B9D0A9-44D3-488E-8B42-C14A6E30CAB2}
 	EndProjectSection
@@ -23,11 +18,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestLoadAssembly", "tests\T
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Reflection.TestModule", "tests\TestModule\System.Reflection.TestModule.ilproj", "{3B7489C4-65DB-4E69-BE01-F6234133400C}"
-	ProjectSection(ProjectDependencies) = postProject
-		{56B9D0A9-44D3-488E-8B42-C14A6E30CAB2} = {56B9D0A9-44D3-488E-8B42-C14A6E30CAB2}
-	EndProjectSection
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnloadableAssembly", "tests\UnloadableAssembly\UnloadableAssembly.csproj", "{CA43AAD6-59A6-4BEB-AC9E-52DC9FD04B8B}"
 	ProjectSection(ProjectDependencies) = postProject
 		{56B9D0A9-44D3-488E-8B42-C14A6E30CAB2} = {56B9D0A9-44D3-488E-8B42-C14A6E30CAB2}
 	EndProjectSection
@@ -51,30 +41,22 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{3A3DE9F8-6295-4B68-BAAB-406F1CA0CD9C}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{3A3DE9F8-6295-4B68-BAAB-406F1CA0CD9C}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{3A3DE9F8-6295-4B68-BAAB-406F1CA0CD9C}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{3A3DE9F8-6295-4B68-BAAB-406F1CA0CD9C}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{2EF7D710-A7BD-4BB3-8EF6-3F0298CD4986}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{2EF7D710-A7BD-4BB3-8EF6-3F0298CD4986}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{2EF7D710-A7BD-4BB3-8EF6-3F0298CD4986}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{2EF7D710-A7BD-4BB3-8EF6-3F0298CD4986}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
+		{F9C30DC5-30C1-45DA-9336-F7BE358C367C}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{F9C30DC5-30C1-45DA-9336-F7BE358C367C}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{F9C30DC5-30C1-45DA-9336-F7BE358C367C}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{F9C30DC5-30C1-45DA-9336-F7BE358C367C}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{71DE1A1F-F8E2-452A-9D54-0385F6099DD3}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{71DE1A1F-F8E2-452A-9D54-0385F6099DD3}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{71DE1A1F-F8E2-452A-9D54-0385F6099DD3}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{71DE1A1F-F8E2-452A-9D54-0385F6099DD3}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{3B7489C4-65DB-4E69-BE01-F6234133400C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3B7489C4-65DB-4E69-BE01-F6234133400C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3B7489C4-65DB-4E69-BE01-F6234133400C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3B7489C4-65DB-4E69-BE01-F6234133400C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CA43AAD6-59A6-4BEB-AC9E-52DC9FD04B8B}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{CA43AAD6-59A6-4BEB-AC9E-52DC9FD04B8B}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{CA43AAD6-59A6-4BEB-AC9E-52DC9FD04B8B}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{CA43AAD6-59A6-4BEB-AC9E-52DC9FD04B8B}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{3B7489C4-65DB-4E69-BE01-F6234133400C}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{3B7489C4-65DB-4E69-BE01-F6234133400C}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{3B7489C4-65DB-4E69-BE01-F6234133400C}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{3B7489C4-65DB-4E69-BE01-F6234133400C}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{56B9D0A9-44D3-488E-8B42-C14A6E30CAB2}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{56B9D0A9-44D3-488E-8B42-C14A6E30CAB2}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{56B9D0A9-44D3-488E-8B42-C14A6E30CAB2}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
@@ -89,11 +71,9 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B1BF7CE0-CAB5-4FA2-A39C-450B05D5DB1C} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
-		{3A3DE9F8-6295-4B68-BAAB-406F1CA0CD9C} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
-		{2EF7D710-A7BD-4BB3-8EF6-3F0298CD4986} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{F9C30DC5-30C1-45DA-9336-F7BE358C367C} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{71DE1A1F-F8E2-452A-9D54-0385F6099DD3} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{3B7489C4-65DB-4E69-BE01-F6234133400C} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
-		{CA43AAD6-59A6-4BEB-AC9E-52DC9FD04B8B} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{56B9D0A9-44D3-488E-8B42-C14A6E30CAB2} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{ADBCF120-3454-4A3C-9D1D-AC4293E795D6} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -5,7 +5,7 @@
     <NoWarn>1718</NoWarn>
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release;uapaot-Debug;uapaot-Release</Configurations>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release;uapaot-Debug;uapaot-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\EnumTypes.cs">
@@ -272,7 +272,8 @@
     <Compile Include="System\ComponentModel\DefaultValueAttributeTests.netcoreapp.cs" />
     <Compile Include="System\Reflection\BindingFlagsDoNotWrap.netcoreapp.cs" />
     <Compile Include="System\Reflection\InvokeRefReturn.netcoreapp.cs" />
-    <Compile Include="System\Reflection\IsCollectibleTests.cs" Condition="'$(TargetGroup)' != 'uapaot'" /><!-- missing method 'AssemblyLoadContext..ctor(bool) -->
+    <Compile Include="System\Reflection\IsCollectibleTests.cs" Condition="'$(TargetGroup)' != 'uapaot'" />
+    <!-- missing method 'AssemblyLoadContext..ctor(bool) -->
     <Compile Include="System\Reflection\MethodBaseTests.netcoreapp.cs" />
     <Compile Include="System\Reflection\SignatureTypes.netcoreapp.cs" />
     <Compile Include="System\Reflection\TypeDelegatorTests.netcoreapp.cs" />

--- a/src/System.Runtime/tests/TestCollectibleAssembly/TestCollectibleAssembly.csproj
+++ b/src/System.Runtime/tests/TestCollectibleAssembly/TestCollectibleAssembly.csproj
@@ -4,6 +4,9 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{F9C30DC5-30C1-45DA-9336-F7BE358C367C}</ProjectGuid>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestCollectibleAssembly.cs" />
   </ItemGroup>

--- a/src/System.Runtime/tests/TestModule/System.Reflection.TestModule.ilproj
+++ b/src/System.Runtime/tests/TestModule/System.Reflection.TestModule.ilproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <ProjectGuid>{3B7489C4-65DB-4E69-BE01-F6234133400C}</ProjectGuid>
-    <Configurations>Debug;Release</Configurations>
+    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
     <TestStrongNameKeyId>Microsoft</TestStrongNameKeyId>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Security.AccessControl/System.Security.AccessControl.sln
+++ b/src/System.Security.AccessControl/System.Security.AccessControl.sln
@@ -34,10 +34,10 @@ Global
 		{D27FFA1F-B446-4D24-B60A-1F88385CDB6D}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{D27FFA1F-B446-4D24-B60A-1F88385CDB6D}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{D27FFA1F-B446-4D24-B60A-1F88385CDB6D}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{F80C478C-48EE-46A5-89C4-EE0CFB23A14F}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{F80C478C-48EE-46A5-89C4-EE0CFB23A14F}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{F80C478C-48EE-46A5-89C4-EE0CFB23A14F}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{F80C478C-48EE-46A5-89C4-EE0CFB23A14F}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{F80C478C-48EE-46A5-89C4-EE0CFB23A14F}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{F80C478C-48EE-46A5-89C4-EE0CFB23A14F}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{F80C478C-48EE-46A5-89C4-EE0CFB23A14F}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{F80C478C-48EE-46A5-89C4-EE0CFB23A14F}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Security.AccessControl/ref/System.Security.AccessControl.csproj
+++ b/src/System.Security.AccessControl/ref/System.Security.AccessControl.csproj
@@ -5,7 +5,7 @@
     <!-- Must match version supported by frameworks which support 4.1.* inbox.
          Can be removed when API is added and this assembly is versioned to 4.2.* -->
     <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.1.1.0</AssemblyVersion>
-    <Configurations>net461-Debug;net461-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>net461-Debug;net461-Release;netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.AccessControl.cs" />

--- a/src/System.Security.Permissions/System.Security.Permissions.sln
+++ b/src/System.Security.Permissions/System.Security.Permissions.sln
@@ -30,14 +30,14 @@ Global
 		{7517F1E9-EEB4-4676-A054-CE4A44A66B66}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{7517F1E9-EEB4-4676-A054-CE4A44A66B66}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
 		{7517F1E9-EEB4-4676-A054-CE4A44A66B66}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
-		{07CAF142-B259-418E-86EF-C4BD8B50253E}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{07CAF142-B259-418E-86EF-C4BD8B50253E}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{07CAF142-B259-418E-86EF-C4BD8B50253E}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{07CAF142-B259-418E-86EF-C4BD8B50253E}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{07390899-C8F6-4E83-A3A9-6867B8CB46A0}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{07CAF142-B259-418E-86EF-C4BD8B50253E}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{07CAF142-B259-418E-86EF-C4BD8B50253E}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{07CAF142-B259-418E-86EF-C4BD8B50253E}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{07CAF142-B259-418E-86EF-C4BD8B50253E}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{07CAF142-B259-418E-86EF-C4BD8B50253E}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
-    <Configurations>net461-Debug;net461-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>net461-Debug;net461-Release;netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Permissions.cs" />

--- a/src/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>System.Security.Permissions</RootNamespace>
     <AssemblyName>System.Security.Permissions</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <Configurations>net461-Debug;net461-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>net461-Debug;net461-Release;netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' != 'true'">
     <Compile Include="System\ApplicationIdentity.cs" />

--- a/src/System.Security.Principal.Windows/System.Security.Principal.Windows.sln
+++ b/src/System.Security.Principal.Windows/System.Security.Principal.Windows.sln
@@ -34,10 +34,10 @@ Global
 		{F9E9894E-2513-4085-9046-311AD49D8AE6}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{F9E9894E-2513-4085-9046-311AD49D8AE6}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
 		{F9E9894E-2513-4085-9046-311AD49D8AE6}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
-		{25A02E40-D12C-4184-B599-E4F954D142DB}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{25A02E40-D12C-4184-B599-E4F954D142DB}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{25A02E40-D12C-4184-B599-E4F954D142DB}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{25A02E40-D12C-4184-B599-E4F954D142DB}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{25A02E40-D12C-4184-B599-E4F954D142DB}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{25A02E40-D12C-4184-B599-E4F954D142DB}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{25A02E40-D12C-4184-B599-E4F954D142DB}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{25A02E40-D12C-4184-B599-E4F954D142DB}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/ref/System.Security.Principal.Windows.csproj
@@ -5,7 +5,7 @@
     <!-- Must match version supported by frameworks which support 4.1.* inbox.
          Can be removed when API is added and this assembly is versioned to 4.2.* -->
     <AssemblyVersion Condition="'$(TargetsNetFx)' != 'true'">4.1.1.0</AssemblyVersion>
-    <Configurations>net461-Debug;net461-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>net461-Debug;net461-Release;netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <SuppressPackageTargetFrameworkCompatibility Include="$(UAPvNextTFM)" />

--- a/src/System.Security.Principal/System.Security.Principal.sln
+++ b/src/System.Security.Principal/System.Security.Principal.sln
@@ -19,10 +19,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{FBE16BC8-AE2D-422C-861E-861814F53AF7}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{FBE16BC8-AE2D-422C-861E-861814F53AF7}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{FBE16BC8-AE2D-422C-861E-861814F53AF7}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{FBE16BC8-AE2D-422C-861E-861814F53AF7}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{FBE16BC8-AE2D-422C-861E-861814F53AF7}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{FBE16BC8-AE2D-422C-861E-861814F53AF7}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{FBE16BC8-AE2D-422C-861E-861814F53AF7}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{FBE16BC8-AE2D-422C-861E-861814F53AF7}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
 		{06ECBECD-4100-474D-8F3C-21A0F66A92A6}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{06ECBECD-4100-474D-8F3C-21A0F66A92A6}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{06ECBECD-4100-474D-8F3C-21A0F66A92A6}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU

--- a/src/System.Security.Principal/src/System.Security.Principal.csproj
+++ b/src/System.Security.Principal/src/System.Security.Principal.csproj
@@ -4,7 +4,7 @@
     <ProjectGuid>{FBE16BC8-AE2D-422C-861E-861814F53AF7}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <ItemGroup>

--- a/src/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.csproj
+++ b/src/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>System.Text.Encoding.Extensions</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <ProjectGuid>{72BFA60D-4F91-4F84-AC6A-910B587DA1BF}</ProjectGuid>
-    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/System.Text.Encodings.Web/System.Text.Encodings.Web.sln
+++ b/src/System.Text.Encodings.Web/System.Text.Encodings.Web.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28829.227
+# Visual Studio 15
+VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Encodings.Web.Tests", "tests\System.Text.Encodings.Web.Tests.csproj", "{2337A55E-7077-4FBE-8132-2CD8DDC18671}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -8,14 +8,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Encodings.Web.T
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Encodings.Web", "src\System.Text.Encodings.Web.csproj", "{B7EDBF00-765A-48E8-B593-CD668288E274}"
+	ProjectSection(ProjectDependencies) = postProject
+		{41648C6D-D431-478D-8228-7EB68714541C} = {41648C6D-D431-478D-8228-7EB68714541C}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Encodings.Web", "ref\System.Text.Encodings.Web.csproj", "{41648C6D-D431-478D-8228-7EB68714541C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{E70569F3-C1DA-4EDE-A850-328BDBFDC59A}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Encodings.Web", "ref\System.Text.Encodings.Web.csproj", "{41648C6D-D431-478D-8228-7EB68714541C}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -42,7 +45,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{2337A55E-7077-4FBE-8132-2CD8DDC18671} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{B7EDBF00-765A-48E8-B593-CD668288E274} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
-		{41648C6D-D431-478D-8228-7EB68714541C} = {E70569F3-C1DA-4EDE-A850-328BDBFDC59A}
+		{41648C6D-D431-478D-8228-7EB68714541C} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2EFFAFC0-87C3-45D1-88AF-35F0AC866D70}

--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{B7EDBF00-765A-48E8-B593-CD668288E274}</ProjectGuid>
     <RootNamespace>System.Text.Encodings.Web</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Text\Encodings\Web\AllowedCharactersBitmap.cs" />

--- a/src/System.Text.Encodings.Web/tests/System.Text.Encodings.Web.Tests.csproj
+++ b/src/System.Text.Encodings.Web/tests/System.Text.Encodings.Web.Tests.csproj
@@ -6,7 +6,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Configurations>netstandard-Debug;netstandard-Release;netcoreapp-Debug;netcoreapp-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">

--- a/src/System.Text.Json/System.Text.Json.sln
+++ b/src/System.Text.Json/System.Text.Json.sln
@@ -9,10 +9,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Json.Tests", "t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Json", "src\System.Text.Json.csproj", "{79E7EE4E-E8DF-4D67-B103-6930DAAF6EF4}"
 	ProjectSection(ProjectDependencies) = postProject
-		{6371299B-8F39-4A0A-A9CD-70F80FF205F6} = {6371299B-8F39-4A0A-A9CD-70F80FF205F6}
+		{9F155052-2DDE-4DBD-9F31-ADB45C9FE628} = {9F155052-2DDE-4DBD-9F31-ADB45C9FE628}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Json", "ref\System.Text.Json.csproj", "{6371299B-8F39-4A0A-A9CD-70F80FF205F6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.Json", "ref\System.Text.Json.csproj", "{9F155052-2DDE-4DBD-9F31-ADB45C9FE628}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
 EndProject
@@ -34,10 +34,10 @@ Global
 		{79E7EE4E-E8DF-4D67-B103-6930DAAF6EF4}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{79E7EE4E-E8DF-4D67-B103-6930DAAF6EF4}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{79E7EE4E-E8DF-4D67-B103-6930DAAF6EF4}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{6371299B-8F39-4A0A-A9CD-70F80FF205F6}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{6371299B-8F39-4A0A-A9CD-70F80FF205F6}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{6371299B-8F39-4A0A-A9CD-70F80FF205F6}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{6371299B-8F39-4A0A-A9CD-70F80FF205F6}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{9F155052-2DDE-4DBD-9F31-ADB45C9FE628}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{9F155052-2DDE-4DBD-9F31-ADB45C9FE628}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{9F155052-2DDE-4DBD-9F31-ADB45C9FE628}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{9F155052-2DDE-4DBD-9F31-ADB45C9FE628}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -45,7 +45,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{5F553243-042C-45C0-8E49-C739131E11C3} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{79E7EE4E-E8DF-4D67-B103-6930DAAF6EF4} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
-		{6371299B-8F39-4A0A-A9CD-70F80FF205F6} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
+		{9F155052-2DDE-4DBD-9F31-ADB45C9FE628} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F758B7B4-BD9F-4228-A700-5D94D738E7FE}

--- a/src/System.Text.Json/ref/System.Text.Json.csproj
+++ b/src/System.Text.Json/ref/System.Text.Json.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <ProjectGuid>{6371299B-8F39-4A0A-A9CD-70F80FF205F6}</ProjectGuid>
+    <ProjectGuid>{9F155052-2DDE-4DBD-9F31-ADB45C9FE628}</ProjectGuid>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Threading.Channels/System.Threading.Channels.sln
+++ b/src/System.Threading.Channels/System.Threading.Channels.sln
@@ -26,18 +26,18 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{1AF01469-DBFC-4BA1-9331-8E39AA639FEE}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{1AF01469-DBFC-4BA1-9331-8E39AA639FEE}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{1AF01469-DBFC-4BA1-9331-8E39AA639FEE}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{1AF01469-DBFC-4BA1-9331-8E39AA639FEE}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{1AF01469-DBFC-4BA1-9331-8E39AA639FEE}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{1AF01469-DBFC-4BA1-9331-8E39AA639FEE}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{1AF01469-DBFC-4BA1-9331-8E39AA639FEE}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{1AF01469-DBFC-4BA1-9331-8E39AA639FEE}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{AAADA5D3-CF64-4E9D-943C-EFDC006D6366}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{AAADA5D3-CF64-4E9D-943C-EFDC006D6366}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{AAADA5D3-CF64-4E9D-943C-EFDC006D6366}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{AAADA5D3-CF64-4E9D-943C-EFDC006D6366}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{97DB4782-7AB3-4F4C-B716-CF722A0E6066}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{97DB4782-7AB3-4F4C-B716-CF722A0E6066}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{97DB4782-7AB3-4F4C-B716-CF722A0E6066}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{97DB4782-7AB3-4F4C-B716-CF722A0E6066}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{97DB4782-7AB3-4F4C-B716-CF722A0E6066}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{97DB4782-7AB3-4F4C-B716-CF722A0E6066}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{97DB4782-7AB3-4F4C-B716-CF722A0E6066}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{97DB4782-7AB3-4F4C-B716-CF722A0E6066}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Threading.Channels/src/System.Threading.Channels.csproj
+++ b/src/System.Threading.Channels/src/System.Threading.Channels.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{AAADA5D3-CF64-4E9D-943C-EFDC006D6366}</ProjectGuid>
     <RootNamespace>System.Threading.Channels</RootNamespace>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.3-Debug;netstandard1.3-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Debug;netcoreapp-Release;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.3-Debug;netstandard1.3-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\VoidResult.cs" />
@@ -40,7 +40,7 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Threading" />
-    <Reference Include="System.Threading.ThreadPool"  Condition="'$(TargetGroup)' == 'netcoreapp'" />
+    <Reference Include="System.Threading.ThreadPool" Condition="'$(TargetGroup)' == 'netcoreapp'" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>

--- a/src/System.Threading.Tasks.Dataflow/System.Threading.Tasks.Dataflow.sln
+++ b/src/System.Threading.Tasks.Dataflow/System.Threading.Tasks.Dataflow.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Threading.Tasks.Dataflow.Tests", "tests\System.Threading.Tasks.Dataflow.Tests.csproj", "{72E21903-0FBA-444E-9855-3B4F05DFC1F9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Threading.Tasks.Dataflow.Tests", "tests\System.Threading.Tasks.Dataflow.Tests.csproj", "{A7AA2FC3-855F-44BA-8735-AB2F43D118A5}"
 	ProjectSection(ProjectDependencies) = postProject
 		{2E2F7224-7C72-4A81-9625-A5241F8D836D} = {2E2F7224-7C72-4A81-9625-A5241F8D836D}
 	EndProjectSection
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{72E21903-0FBA-444E-9855-3B4F05DFC1F9}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{72E21903-0FBA-444E-9855-3B4F05DFC1F9}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{72E21903-0FBA-444E-9855-3B4F05DFC1F9}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{72E21903-0FBA-444E-9855-3B4F05DFC1F9}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{A7AA2FC3-855F-44BA-8735-AB2F43D118A5}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
+		{A7AA2FC3-855F-44BA-8735-AB2F43D118A5}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
+		{A7AA2FC3-855F-44BA-8735-AB2F43D118A5}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
+		{A7AA2FC3-855F-44BA-8735-AB2F43D118A5}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
 		{2E2F7224-7C72-4A81-9625-A5241F8D836D}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
 		{2E2F7224-7C72-4A81-9625-A5241F8D836D}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
 		{2E2F7224-7C72-4A81-9625-A5241F8D836D}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
@@ -43,7 +43,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{72E21903-0FBA-444E-9855-3B4F05DFC1F9} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{A7AA2FC3-855F-44BA-8735-AB2F43D118A5} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
 		{2E2F7224-7C72-4A81-9625-A5241F8D836D} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
 		{01F36E3F-7664-4A71-AE6E-B8B6BF724FD1} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection

--- a/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <ProjectGuid>{72E21903-0FBA-444E-9855-3B4F05DFC1F9}</ProjectGuid>
+    <ProjectGuid>{A7AA2FC3-855F-44BA-8735-AB2F43D118A5}</ProjectGuid>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>

--- a/src/System.Threading.Tasks.Extensions/System.Threading.Tasks.Extensions.sln
+++ b/src/System.Threading.Tasks.Extensions/System.Threading.Tasks.Extensions.sln
@@ -7,7 +7,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Threading.Tasks.Exte
 		{DE90AD0B-649D-4062-B8D9-9658DE140532} = {DE90AD0B-649D-4062-B8D9-9658DE140532}
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Threading.Tasks.Extensions", "src\SystemThreading.Tasks.Extensions.csproj", "{DE90AD0B-649D-4062-B8D9-9658DE140532}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Threading.Tasks.Extensions", "src\System.Threading.Tasks.Extensions.csproj", "{DE90AD0B-649D-4062-B8D9-9658DE140532}"
 	ProjectSection(ProjectDependencies) = postProject
 		{0DF7FA9A-E7D3-4CEF-862B-A37F5BBBB54C} = {0DF7FA9A-E7D3-4CEF-862B-A37F5BBBB54C}
 	EndProjectSection

--- a/src/System.Threading.Tasks.Extensions/ref/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/ref/System.Threading.Tasks.Extensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{0DF7FA9A-E7D3-4CEF-862B-A37F5BBBB54C}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'netcoreapp' Or '$(TargetGroup)' == 'uap'">true</IsPartialFacadeAssembly>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.0-Debug;netstandard1.0-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Threading.Tasks.Extensions.cs" />

--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{DE90AD0B-649D-4062-B8D9-9658DE140532}</ProjectGuid>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release;uapaot-Windows_NT-Debug;uapaot-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/System.Threading.Timer/System.Threading.Timer.sln
+++ b/src/System.Threading.Timer/System.Threading.Timer.sln
@@ -26,10 +26,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{ac20a28f-fda8-45e8-8728-058ead16e44c}.Debug|Any CPU.ActiveCfg = netstandard-Debug|Any CPU
-		{ac20a28f-fda8-45e8-8728-058ead16e44c}.Debug|Any CPU.Build.0 = netstandard-Debug|Any CPU
-		{ac20a28f-fda8-45e8-8728-058ead16e44c}.Release|Any CPU.ActiveCfg = netstandard-Release|Any CPU
-		{ac20a28f-fda8-45e8-8728-058ead16e44c}.Release|Any CPU.Build.0 = netstandard-Release|Any CPU
+		{ac20a28f-fda8-45e8-8728-058ead16e44c}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{ac20a28f-fda8-45e8-8728-058ead16e44c}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{ac20a28f-fda8-45e8-8728-058ead16e44c}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{ac20a28f-fda8-45e8-8728-058ead16e44c}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{0F8B87B4-0E61-4DC6-9E90-CD4863025272}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
 		{0F8B87B4-0E61-4DC6-9E90-CD4863025272}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
 		{0F8B87B4-0E61-4DC6-9E90-CD4863025272}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU

--- a/src/System.Utf8String.Experimental/System.Utf8String.Experimental.sln
+++ b/src/System.Utf8String.Experimental/System.Utf8String.Experimental.sln
@@ -8,14 +8,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Utf8String.Experimen
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Utf8String.Experimental", "src\System.Utf8String.Experimental.csproj", "{D4266847-6692-481B-9459-6141DB7DA339}"
+	ProjectSection(ProjectDependencies) = postProject
+		{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0} = {7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Utf8String.Experimental", "ref\System.Utf8String.Experimental.csproj", "{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7EC8921F-E96F-445B-AA33-453515641D93}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1A2F9F4A-A032-433E-B914-ADD5992BB178}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{8691446A-CA54-49FD-87B9-57A0C6B48095}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E107E9C1-E893-4E87-987E-04EF0DCEAEFD}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{FEB087F5-EF72-429D-8A0E-7636B84A1537}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2EDB-464B-9DF6-380BF4789AD4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,26 +26,26 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D4266847-6692-481B-9459-6141DB7DA339}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{D4266847-6692-481B-9459-6141DB7DA339}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{D4266847-6692-481B-9459-6141DB7DA339}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{D4266847-6692-481B-9459-6141DB7DA339}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
-		{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
-		{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
-		{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
-		{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 		{72E9FB32-4692-4692-A10B-9F053F8F1A88}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
 		{72E9FB32-4692-4692-A10B-9F053F8F1A88}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
 		{72E9FB32-4692-4692-A10B-9F053F8F1A88}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
 		{72E9FB32-4692-4692-A10B-9F053F8F1A88}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
+		{D4266847-6692-481B-9459-6141DB7DA339}.Debug|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Debug|Any CPU
+		{D4266847-6692-481B-9459-6141DB7DA339}.Debug|Any CPU.Build.0 = netcoreapp-Windows_NT-Debug|Any CPU
+		{D4266847-6692-481B-9459-6141DB7DA339}.Release|Any CPU.ActiveCfg = netcoreapp-Windows_NT-Release|Any CPU
+		{D4266847-6692-481B-9459-6141DB7DA339}.Release|Any CPU.Build.0 = netcoreapp-Windows_NT-Release|Any CPU
+		{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0}.Debug|Any CPU.ActiveCfg = netcoreapp-Debug|Any CPU
+		{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0}.Debug|Any CPU.Build.0 = netcoreapp-Debug|Any CPU
+		{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0}.Release|Any CPU.ActiveCfg = netcoreapp-Release|Any CPU
+		{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0}.Release|Any CPU.Build.0 = netcoreapp-Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{D4266847-6692-481B-9459-6141DB7DA339} = {7EC8921F-E96F-445B-AA33-453515641D93}
-		{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0} = {8691446A-CA54-49FD-87B9-57A0C6B48095}
-		{72E9FB32-4692-4692-A10B-9F053F8F1A88} = {FEB087F5-EF72-429D-8A0E-7636B84A1537}
+		{72E9FB32-4692-4692-A10B-9F053F8F1A88} = {1A2F9F4A-A032-433E-B914-ADD5992BB178}
+		{D4266847-6692-481B-9459-6141DB7DA339} = {E107E9C1-E893-4E87-987E-04EF0DCEAEFD}
+		{7AF57E6B-2CED-45C9-8BCA-5BBA60D018E0} = {2E666815-2EDB-464B-9DF6-380BF4789AD4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7196F6AB-8F22-4E4D-B6D1-3C2CFF86229C}

--- a/src/System.Utf8String.Experimental/src/System.Utf8String.Experimental.csproj
+++ b/src/System.Utf8String.Experimental/src/System.Utf8String.Experimental.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{D4266847-6692-481B-9459-6141DB7DA339}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;</Configurations>
+    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release</Configurations>
     <RootNamespace>System</RootNamespace>
   </PropertyGroup>
   <ItemGroup Condition="'$(IsPrerelease)' != 'false'">

--- a/src/System.Utf8String.Experimental/tests/System.Utf8String.Experimental.Tests.csproj
+++ b/src/System.Utf8String.Experimental/tests/System.Utf8String.Experimental.Tests.csproj
@@ -3,7 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{72E9FB32-4692-4692-A10B-9F053F8F1A88}</ProjectGuid>
     <IncludePartialFacadeTests Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">true</IncludePartialFacadeTests>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
     <TestRuntime>true</TestRuntime>
     <RootNamespace>System</RootNamespace>
   </PropertyGroup>

--- a/src/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/System.ValueTuple/src/System.ValueTuple.csproj
@@ -3,7 +3,7 @@
     <!-- rev'ed to 4.0.1.0 even though 4.0.0.0 never shipped so that we can drop pre-release down to beta -->
     <ProjectGuid>{4C2655DB-BD9E-4C86-83A6-744ECDDBDF29}</ProjectGuid>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />


### PR DESCRIPTION
@ericstj @stephentoub 

This is just the output of running `.dotnet\dotnet msbuild build.proj /t:UpdateVSConfigurations` from the root of corefx. A bunch of our projects and solutions where not up-to-date with respect to their Configurations.props, so this is fixing that so projects are easily opened with VS.