### PR TITLE
Don't ignore AsyncMethodBuilderAttribute for GenAPI/APICompat

### DIFF
--- a/eng/DefaultGenApiDocIds.txt
+++ b/eng/DefaultGenApiDocIds.txt
@@ -45,7 +45,6 @@ T:System.Runtime.CompilerServices.IntrinsicAttribute
 T:System.Runtime.CompilerServices.ExtensionAttribute
 T:System.Drawing.SRDescriptionAttribute
 T:System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute
-T:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute
 T:System.Reflection.DefaultMemberAttribute
 
 // These do not need to be persisted in the implementation


### PR DESCRIPTION
Fixes #35602