### PR TITLE
Update Helix SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19229.8",
-    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19257.4",
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19257.3",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview6-27705-72"
   }
 }

--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19229.8",
-    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19229.8",
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19257.4",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview6-27705-72"
   }
 }


### PR DESCRIPTION
Needed to not break test runs in the coming Python3 conversion.