### PR TITLE
handle Http2Stream add/remove better 

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -260,7 +260,10 @@ namespace System.Net.Http
             }
             catch (Exception e)
             {
-                Abort(e);
+                if (!_disposed)
+                {
+                    Abort(e);
+                }
             }
         }
 


### PR DESCRIPTION
This seems to be old problem exposed by recent changes. 

We can call RemoveStream() either when we hit exception or when we process frame with endStream bit set. 
Since we do not have any synchronization with background ProcessIncomingFramesAsync(), we may call it twice for same stream. We are vulnerable especially in tests for error conditions. 

We have similar issue for AddStream(). Depending on timing, we could call Abort() in ProcessIncomingFramesAsync() before we have chance to propagate _abortException to caller. 
Also note, that the retry mechanism does not work for Http2LoopbackServer. We may bring connection down and retry behind scenes in SendWithRetryAsync(), but none of the existing loopback tests can handle it. 

I was able to hit #37455 and #37453 in ~ 100 runs. 
With the change, I did 500+ runs without any issue. 

fixes  #37455 
fixes #37453

this also fixes #37445  