### PR TITLE
Re-using the Utf8JsonWriter instance within the Serializer

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -172,11 +172,14 @@ namespace System.Text.Json
         False = (byte)6,
         Null = (byte)7,
     }
-    public partial struct JsonWriterOptions
+    public partial struct JsonWriterOptions : IEquatable<JsonWriterOptions>
     {
         private int _dummyPrimitive;
         public bool Indented { get { throw null; } set { } }
         public bool SkipValidation { get { throw null; } set { } }
+        public bool Equals(JsonWriterOptions other) { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override int GetHashCode() { throw null; }
     }
     public ref partial struct Utf8JsonReader
     {

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -43,6 +43,7 @@
     <Compile Include="System\Text\Json\Reader\Utf8JsonReader.cs" />
     <Compile Include="System\Text\Json\Reader\Utf8JsonReader.MultiSegment.cs" />
     <Compile Include="System\Text\Json\Reader\Utf8JsonReader.TryGet.cs" />
+    <Compile Include="System\Text\Json\Serialization\CachedUtf8JsonWriter.cs" />
     <Compile Include="System\Text\Json\Serialization\ClassMaterializer.cs" />
     <Compile Include="System\Text\Json\Serialization\ClassType.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\DefaultArrayConverter.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/CachedUtf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/CachedUtf8JsonWriter.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+
+namespace System.Text.Json.Serialization
+{
+    internal sealed class CachedUtf8JsonWriter
+    {
+        [ThreadStatic]
+        private static CachedUtf8JsonWriter s_cachedInstance;
+
+        private readonly Utf8JsonWriter _writer;
+
+#if DEBUG
+        private bool _inUse;
+#endif
+
+        private CachedUtf8JsonWriter(IBufferWriter<byte> stream, JsonWriterOptions writerOptions)
+        {
+            _writer = new Utf8JsonWriter(stream, writerOptions);
+        }
+
+        public static CachedUtf8JsonWriter Get(IBufferWriter<byte> stream, JsonWriterOptions writerOptions)
+        {
+            var writer = s_cachedInstance ?? new CachedUtf8JsonWriter(stream, writerOptions);
+
+            // Taken off the thread static
+            s_cachedInstance = null;
+#if DEBUG
+            if (writer._inUse)
+            {
+                throw new InvalidOperationException("The writer wasn't returned!");
+            }
+
+            writer._inUse = true;
+#endif
+            writer._writer.Reset(stream);
+            return writer;
+        }
+
+        public static void Return(CachedUtf8JsonWriter writer)
+        {
+            s_cachedInstance = writer;
+            writer._writer.Reset();
+
+#if DEBUG
+            writer._inUse = false;
+#endif
+        }
+
+        public Utf8JsonWriter GetJsonWriter()
+        {
+            return _writer;
+        }
+    }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/CachedUtf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/CachedUtf8JsonWriter.cs
@@ -17,14 +17,14 @@ namespace System.Text.Json.Serialization
         private bool _inUse;
 #endif
 
-        private CachedUtf8JsonWriter(IBufferWriter<byte> stream, JsonWriterOptions writerOptions)
+        private CachedUtf8JsonWriter(IBufferWriter<byte> output, JsonWriterOptions writerOptions)
         {
-            _writer = new Utf8JsonWriter(stream, writerOptions);
+            _writer = new Utf8JsonWriter(output, writerOptions);
         }
 
-        public static CachedUtf8JsonWriter Get(IBufferWriter<byte> stream, JsonWriterOptions writerOptions)
+        public static CachedUtf8JsonWriter Get(IBufferWriter<byte> output, JsonWriterOptions writerOptions)
         {
-            var writer = s_cachedInstance ?? new CachedUtf8JsonWriter(stream, writerOptions);
+            var writer = s_cachedInstance ?? new CachedUtf8JsonWriter(output, writerOptions);
 
             // Taken off the thread static
             s_cachedInstance = null;
@@ -36,7 +36,7 @@ namespace System.Text.Json.Serialization
 
             writer._inUse = true;
 #endif
-            writer._writer.Reset(stream);
+            writer._writer.Reset(output);
             return writer;
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -94,11 +94,11 @@ namespace System.Text.Json.Serialization
         {
             Debug.Assert(type != null || value == null);
 
-            var cachedWriter = CachedUtf8JsonWriter.Get(output, options.GetWriterOptions());
+            CachedUtf8JsonWriter cachedWriter = CachedUtf8JsonWriter.Get(output, options.GetWriterOptions());
 
             try
             {
-                var writer = cachedWriter.GetJsonWriter();
+                Utf8JsonWriter writer = cachedWriter.GetJsonWriter();
 
                 if (value == null)
                 {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -94,37 +94,28 @@ namespace System.Text.Json.Serialization
         {
             Debug.Assert(type != null || value == null);
 
-            CachedUtf8JsonWriter cachedWriter = CachedUtf8JsonWriter.Get(output, options.GetWriterOptions());
+            Utf8JsonWriter writer = CachedUtf8JsonWriter.Get(output, options.GetWriterOptions());
 
-            try
+            if (value == null)
             {
-                Utf8JsonWriter writer = cachedWriter.GetJsonWriter();
-
-                if (value == null)
+                writer.WriteNullValue();
+            }
+            else
+            {
+                //  We treat typeof(object) special and allow polymorphic behavior.
+                if (type == typeof(object))
                 {
-                    writer.WriteNullValue();
-                }
-                else
-                {
-                    //  We treat typeof(object) special and allow polymorphic behavior.
-                    if (type == typeof(object))
-                    {
-                        type = value.GetType();
-                    }
-
-                    WriteStack state = default;
-                    state.Current.Initialize(type, options);
-                    state.Current.CurrentValue = value;
-
-                    Write(writer, -1, options, ref state);
+                    type = value.GetType();
                 }
 
-                writer.Flush();
+                WriteStack state = default;
+                state.Current.Initialize(type, options);
+                state.Current.CurrentValue = value;
+
+                Write(writer, -1, options, ref state);
             }
-            finally
-            {
-                CachedUtf8JsonWriter.Return(cachedWriter);
-            }
+
+            writer.Flush();
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -50,52 +50,60 @@ namespace System.Text.Json.Serialization
                 options = JsonSerializerOptions.s_defaultOptions;
             }
 
-            JsonWriterOptions writerOptions = options.GetWriterOptions();
-
             using (var bufferWriter = new PooledBufferWriter<byte>(options.DefaultBufferSize))
-            using (var writer = new Utf8JsonWriter(bufferWriter, writerOptions))
             {
-                if (value == null)
+                var cachedWriter = CachedUtf8JsonWriter.Get(bufferWriter, options.GetWriterOptions());
+
+                try
                 {
-                    writer.WriteNullValue();
-                    writer.Flush();
+                    var writer = cachedWriter.GetJsonWriter();
+
+                    if (value == null)
+                    {
+                        writer.WriteNullValue();
+                        writer.Flush();
 
 #if BUILDING_INBOX_LIBRARY
-                    await utf8Json.WriteAsync(bufferWriter.WrittenMemory, cancellationToken).ConfigureAwait(false);
+                        await utf8Json.WriteAsync(bufferWriter.WrittenMemory, cancellationToken).ConfigureAwait(false);
 #else
                     // todo: stackalloc or pool here?
                     await utf8Json.WriteAsync(bufferWriter.WrittenMemory.ToArray(), 0, bufferWriter.WrittenMemory.Length, cancellationToken).ConfigureAwait(false);
 #endif
-                    return;
-                }
+                        return;
+                    }
 
-                if (type == null)
-                {
-                    type = value.GetType();
-                }
+                    if (type == null)
+                    {
+                        type = value.GetType();
+                    }
 
-                WriteStack state = default;
-                state.Current.Initialize(type, options);
-                state.Current.CurrentValue = value;
+                    WriteStack state = default;
+                    state.Current.Initialize(type, options);
+                    state.Current.CurrentValue = value;
 
-                bool isFinalBlock;
+                    bool isFinalBlock;
 
-                int flushThreshold;
-                do
-                {
-                    flushThreshold = (int)(bufferWriter.Capacity * .9); //todo: determine best value here
+                    int flushThreshold;
+                    do
+                    {
+                        flushThreshold = (int)(bufferWriter.Capacity * .9); //todo: determine best value here
 
-                    isFinalBlock = Write(writer, flushThreshold, options, ref state);
-                    writer.Flush();
+                        isFinalBlock = Write(writer, flushThreshold, options, ref state);
+                        writer.Flush();
 
 #if BUILDING_INBOX_LIBRARY
-                    await utf8Json.WriteAsync(bufferWriter.WrittenMemory, cancellationToken).ConfigureAwait(false);
+                        await utf8Json.WriteAsync(bufferWriter.WrittenMemory, cancellationToken).ConfigureAwait(false);
 #else
                     // todo: use pool here to avod extra alloc?
                     await utf8Json.WriteAsync(bufferWriter.WrittenMemory.ToArray(), 0, bufferWriter.WrittenMemory.Length, cancellationToken).ConfigureAwait(false);
 #endif
-                    bufferWriter.Clear();
-                } while (!isFinalBlock);
+                        bufferWriter.Clear();
+                    } while (!isFinalBlock);
+                }
+                finally
+                {
+                    CachedUtf8JsonWriter.Return(cachedWriter);
+                }
             }
             
             // todo: verify that we do want to call FlushAsync here (or above). It seems like leaving it to the caller would be best.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterOptions.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json
     /// any indentation or extra white space. Also, the <see cref="Utf8JsonWriter"/> will
     /// throw an exception if the user attempts to write structurally invalid JSON.
     /// </summary>
-    public struct JsonWriterOptions
+    public struct JsonWriterOptions : IEquatable<JsonWriterOptions>
     {
         private int _optionsMask;
 
@@ -65,5 +65,39 @@ namespace System.Text.Json
 
         private const int IndentBit = 1;
         private const int SkipValidationBit = 2;
+
+        /// <summary>
+        /// Returns a value that indicates whether this instance is equal to a specified object
+        /// </summary>
+        /// <param name="other">The object to compare with this instance</param>
+        /// <returns>true if other is an instance of <see cref="JsonWriterOptions"/> and equals the value of the instance; otherwise, false</returns>
+        public bool Equals(JsonWriterOptions other)
+        {
+            return _optionsMask == other._optionsMask;
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether this instance is equal to a specified object
+        /// </summary>
+        /// <param name="obj">The object to compare with this instance</param>
+        /// <returns>true if obj is an instance of <see cref="JsonWriterOptions"/> and equals the value of the instance; otherwise, false</returns>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is JsonWriterOptions))
+            {
+                return false;
+            }
+
+            return Equals((JsonWriterOptions)obj);
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code</returns>
+        public override int GetHashCode()
+        {
+            return _optionsMask.GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
According to #37335

I've added the similar class to reuse Utf8Json Writer with small changes. What do you think about that?
Should it replace ReusableUtf8JsonWriter from Microsoft.AspNetCore.Http.Connections.Common in the future?

Please review.
Thank you in advance