### PR TITLE
Make ZipFileUtils use of ArrayPool more reliable

### DIFF
--- a/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Utils.cs
+++ b/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Utils.cs
@@ -66,8 +66,10 @@ namespace System.IO.Compression
                 int newCapacity = buffer.Length * 2;
                 if (newCapacity < min)
                     newCapacity = min;
-                ArrayPool<char>.Shared.Return(buffer);
+
+                char[] oldBuffer = buffer;
                 buffer = ArrayPool<char>.Shared.Rent(newCapacity);
+                ArrayPool<char>.Shared.Return(oldBuffer);
             }
         }
 


### PR DESCRIPTION
If the Rent call tried to allocate and OOM'd, we would end up returning the same buffer to the pool twice, once here and once in the caller's finally.

cc: @bartonjs