### PR TITLE
Avoid GetLowerBound() calls in Array.Copy

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeManager.cs
@@ -212,7 +212,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                     if (src != dst)
                     {
                         CType[] dsts = new CType[srcs.Length];
-                        Array.Copy(srcs, dsts, i);
+                        Array.Copy(srcs, 0, dsts, 0, i);
                         dsts[i] = dst;
                         while (++i < srcs.Length)
                         {

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicComposition.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AtomicComposition.cs
@@ -319,7 +319,7 @@ namespace System.ComponentModel.Composition.Hosting
                 var newQueries = new KeyValuePair<object, object>[_valueCount == 0 ? 5 : _valueCount * 2];
                 if (_values != null)
                 {
-                    Array.Copy(_values, newQueries, _valueCount);
+                    Array.Copy(_values, 0, newQueries, 0, _valueCount);
                 }
                 _values = newQueries;
             }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/CultureInfoConverter.cs
@@ -196,7 +196,7 @@ namespace System.ComponentModel
                     array = new CultureInfo[installedCultures.Length + 1];
                 }
 
-                Array.Copy(installedCultures, array, installedCultures.Length);
+                Array.Copy(installedCultures, 0, array, 0, installedCultures.Length);
                 Array.Sort(array, new CultureComparer(this));
                 Debug.Assert(array[0] == null);
                 if (array[0] == null)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/PropertyDescriptor.cs
@@ -299,8 +299,8 @@ namespace System.ComponentModel
                 {
                     Type[] newTypes = new Type[_editorTypes.Length * 2];
                     object[] newEditors = new object[_editors.Length * 2];
-                    Array.Copy(_editorTypes, newTypes, _editorTypes.Length);
-                    Array.Copy(_editors, newEditors, _editors.Length);
+                    Array.Copy(_editorTypes, 0, newTypes, 0, _editorTypes.Length);
+                    Array.Copy(_editors, 0, newEditors, 0, _editors.Length);
                     _editorTypes = newTypes;
                     _editors = newEditors;
                 }

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeListConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeListConverter.cs
@@ -99,7 +99,7 @@ namespace System.ComponentModel
                 if (_types != null)
                 {
                     objTypes = new object[_types.Length];
-                    Array.Copy(_types, objTypes, _types.Length);
+                    Array.Copy(_types, 0, objTypes, 0, _types.Length);
                 }
                 else
                 {

--- a/src/System.Data.Common/src/System/Data/Common/DbConnectionStringBuilder.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbConnectionStringBuilder.cs
@@ -548,7 +548,7 @@ namespace System.Data.Common
 
             // Create a new array that only contains the filtered properties
             PropertyDescriptor[] filteredPropertiesArray = new PropertyDescriptor[index];
-            Array.Copy(propertiesArray, filteredPropertiesArray, index);
+            Array.Copy(propertiesArray, 0, filteredPropertiesArray, 0, index);
 
             return new PropertyDescriptorCollection(filteredPropertiesArray);
         }

--- a/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
+++ b/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
@@ -832,7 +832,7 @@ namespace System.Diagnostics
             if (largestNumber > insertionStrings.Length)
             {
                 string[] newStrings = new string[largestNumber];
-                Array.Copy(insertionStrings, newStrings, insertionStrings.Length);
+                Array.Copy(insertionStrings, 0, newStrings, 0, insertionStrings.Length);
                 for (int i = insertionStrings.Length; i < newStrings.Length; i++)
                 {
                     newStrings[i] = "%" + (i + 1);

--- a/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -167,8 +167,8 @@ namespace System.Diagnostics
                                 {
                                     int[] adjustedCounterIndexes = new int[index3];
                                     int[] adjustedHelpIndexes = new int[index3];
-                                    Array.Copy(newCategoryEntry.CounterIndexes, adjustedCounterIndexes, index3);
-                                    Array.Copy(newCategoryEntry.HelpIndexes, adjustedHelpIndexes, index3);
+                                    Array.Copy(newCategoryEntry.CounterIndexes, 0, adjustedCounterIndexes, 0, index3);
+                                    Array.Copy(newCategoryEntry.HelpIndexes, 0, adjustedHelpIndexes, 0, index3);
                                     newCategoryEntry.CounterIndexes = adjustedCounterIndexes;
                                     newCategoryEntry.HelpIndexes = adjustedHelpIndexes;
                                 }
@@ -896,7 +896,7 @@ namespace System.Diagnostics
             if (index2 < counters.Length)
             {
                 string[] adjustedCounters = new string[index2];
-                Array.Copy(counters, adjustedCounters, index2);
+                Array.Copy(counters, 0, adjustedCounters, 0, index2);
                 counters = adjustedCounters;
             }
 

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreKey.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreKey.cs
@@ -39,7 +39,7 @@ namespace System.DirectoryServices.AccountManagement
 
             // Make a copy of the SID, since a byte[] is mutable
             _sid = new byte[sid.Length];
-            Array.Copy(sid, _sid, sid.Length);
+            Array.Copy(sid, 0, _sid, 0, sid.Length);
 
             _domainName = domainName;
             _wellKnownSid = true;

--- a/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreKey.cs
+++ b/src/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreKey.cs
@@ -22,7 +22,7 @@ namespace System.DirectoryServices.AccountManagement
 
             // Make a copy of the SID, since a byte[] is mutable
             _sid = new byte[sid.Length];
-            Array.Copy(sid, _sid, sid.Length);
+            Array.Copy(sid, 0, _sid, 0, sid.Length);
 
             GlobalDebug.WriteLineIf(
                             GlobalDebug.Info,

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeCompletion.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeCompletion.cs
@@ -77,7 +77,7 @@ namespace System.IO.Pipelines
             if (newLength == _callbacks.Length)
             {
                 PipeCompletionCallback[] newArray = s_completionCallbackPool.Rent(_callbacks.Length * 2);
-                Array.Copy(_callbacks, newArray, _callbacks.Length);
+                Array.Copy(_callbacks, 0, newArray, 0, _callbacks.Length);
                 s_completionCallbackPool.Return(_callbacks, clearArray: true);
                 _callbacks = newArray;
             }

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlCanonicalWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlCanonicalWriter.cs
@@ -164,7 +164,7 @@ namespace System.Xml
             else if (_depth == _scopes.Length)
             {
                 Scope[] newScopes = new Scope[_depth * 2];
-                Array.Copy(_scopes, newScopes, _depth);
+                Array.Copy(_scopes, 0, newScopes, 0, _depth);
                 _scopes = newScopes;
             }
             _scopes[_depth].xmlnsAttributeCount = _xmlnsAttributeCount;
@@ -736,7 +736,7 @@ namespace System.Xml
             else if (_attributeCount == _attributes.Length)
             {
                 Attribute[] newAttributes = new Attribute[_attributeCount * 2];
-                Array.Copy(_attributes, newAttributes, _attributeCount);
+                Array.Copy(_attributes, 0, newAttributes, 0, _attributeCount);
                 _attributes = newAttributes;
             }
 
@@ -756,7 +756,7 @@ namespace System.Xml
             else if (_xmlnsAttributes.Length == _xmlnsAttributeCount)
             {
                 XmlnsAttribute[] newXmlnsAttributes = new XmlnsAttribute[_xmlnsAttributeCount * 2];
-                Array.Copy(_xmlnsAttributes, newXmlnsAttributes, _xmlnsAttributeCount);
+                Array.Copy(_xmlnsAttributes, 0, newXmlnsAttributes, 0, _xmlnsAttributeCount);
                 _xmlnsAttributes = newXmlnsAttributes;
             }
 

--- a/src/System.Private.Xml/src/System/Xml/BitStack.cs
+++ b/src/System.Private.Xml/src/System/Xml/BitStack.cs
@@ -96,7 +96,7 @@ namespace System.Xml
             if (_stackPos >= len)
             {
                 uint[] bitStackNew = new uint[2 * len];
-                Array.Copy(_bitStack, bitStackNew, len);
+                Array.Copy(_bitStack, 0, bitStackNew, 0, len);
                 _bitStack = bitStackNew;
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -1706,7 +1706,7 @@ namespace System.Xml
         {
             Debug.Assert(_lastMarkPos + 1 == _textContentMarks.Length);
             int[] newTextContentMarks = new int[_textContentMarks.Length * 2];
-            Array.Copy(_textContentMarks, newTextContentMarks, _textContentMarks.Length);
+            Array.Copy(_textContentMarks, 0, newTextContentMarks, 0, _textContentMarks.Length);
             _textContentMarks = newTextContentMarks;
         }
         // Write NewLineChars to the specified buffer position and return an updated position.

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlTextWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlTextWriter.cs
@@ -1507,7 +1507,7 @@ namespace System.Xml
             if (nsIndex == _nsStack.Length)
             {
                 Namespace[] newStack = new Namespace[nsIndex * 2];
-                Array.Copy(_nsStack, newStack, nsIndex);
+                Array.Copy(_nsStack, 0, newStack, 0, nsIndex);
                 _nsStack = newStack;
             }
             _nsStack[nsIndex].Set(prefix, ns, declared);
@@ -1767,7 +1767,7 @@ namespace System.Xml
             if (_top == _stack.Length - 1)
             {
                 TagInfo[] na = new TagInfo[_stack.Length + 10];
-                if (_top > 0) Array.Copy(_stack, na, _top + 1);
+                if (_top > 0) Array.Copy(_stack, 0, na, 0, _top + 1);
                 _stack = na;
             }
 

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriter.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriter.cs
@@ -494,7 +494,7 @@ namespace System.Xml
                 if (top == _elemScopeStack.Length)
                 {
                     ElementScope[] newStack = new ElementScope[top * 2];
-                    Array.Copy(_elemScopeStack, newStack, top);
+                    Array.Copy(_elemScopeStack, 0, newStack, 0, top);
                     _elemScopeStack = newStack;
                 }
                 _elemScopeStack[top].Set(prefix, localName, ns, _nsTop);
@@ -1835,7 +1835,7 @@ namespace System.Xml
             if (top == _nsStack.Length)
             {
                 Namespace[] newStack = new Namespace[top * 2];
-                Array.Copy(_nsStack, newStack, top);
+                Array.Copy(_nsStack, 0, newStack, 0, top);
                 _nsStack = newStack;
             }
             _nsStack[top].Set(prefix, ns, kind);
@@ -2206,7 +2206,7 @@ namespace System.Xml
             if (top == _attrStack.Length)
             {
                 AttrName[] newStack = new AttrName[top * 2];
-                Array.Copy(_attrStack, newStack, top);
+                Array.Copy(_attrStack, 0, newStack, 0, top);
                 _attrStack = newStack;
             }
             _attrStack[top].Set(prefix, localName, namespaceName);

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
@@ -292,7 +292,7 @@ namespace System.Xml
                 if (top == _elemScopeStack.Length)
                 {
                     ElementScope[] newStack = new ElementScope[top * 2];
-                    Array.Copy(_elemScopeStack, newStack, top);
+                    Array.Copy(_elemScopeStack, 0, newStack, 0, top);
                     _elemScopeStack = newStack;
                 }
                 _elemScopeStack[top].Set(prefix, localName, ns, _nsTop);

--- a/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterHelpers.cs
+++ b/src/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterHelpers.cs
@@ -511,7 +511,7 @@ namespace System.Xml
                 else if (_items.Length == newItemIndex)
                 {
                     Item[] newItems = new Item[newItemIndex * 2];
-                    Array.Copy(_items, newItems, newItemIndex);
+                    Array.Copy(_items, 0, newItems, 0, newItemIndex);
                     _items = newItems;
                 }
                 if (_items[newItemIndex] == null)

--- a/src/System.Private.Xml/src/System/Xml/Resolvers/XmlPreloadedResolver.cs
+++ b/src/System.Private.Xml/src/System/Xml/Resolvers/XmlPreloadedResolver.cs
@@ -351,7 +351,7 @@ namespace System.Xml.Resolvers
                 }
                 int size = checked((int)ms.Position);
                 byte[] bytes = new byte[size];
-                Array.Copy(ms.ToArray(), bytes, size);
+                Array.Copy(ms.ToArray(), 0, bytes, 0, size);
                 Add(uri, new ByteArrayChunk(bytes));
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Schema/BitSet.cs
+++ b/src/System.Private.Xml/src/System/Xml/Schema/BitSet.cs
@@ -243,7 +243,7 @@ namespace System.Xml.Schema
                 if (request < nRequiredLength)
                     request = nRequiredLength;
                 uint[] newBits = new uint[request];
-                Array.Copy(_bits, newBits, _bits.Length);
+                Array.Copy(_bits, 0, newBits, 0, _bits.Length);
                 _bits = newBits;
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationGeneratedCode.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationGeneratedCode.cs
@@ -95,7 +95,7 @@ namespace System.Xml.Serialization
             if (a == null) return new TypeMapping[32];
             if (index < a.Length) return a;
             TypeMapping[] b = new TypeMapping[a.Length + 32];
-            Array.Copy(a, b, index);
+            Array.Copy(a, 0, b, 0, index);
             return b;
         }
 

--- a/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilList.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/QIL/QilList.cs
@@ -123,7 +123,7 @@ namespace System.Xml.Xsl.Qil
             if (_count == _members.Length)
             {
                 QilNode[] membersNew = new QilNode[_count * 2];
-                Array.Copy(_members, membersNew, _count);
+                Array.Copy(_members, 0, membersNew, 0, _count);
                 _members = membersNew;
             }
 

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlAttributeCache.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlAttributeCache.cs
@@ -363,7 +363,7 @@ namespace System.Xml.Xsl.Runtime
                 // Resize caching array
                 Debug.Assert(_numEntries == _arrAttrs.Length);
                 AttrNameVal[] arrNew = new AttrNameVal[_numEntries * 2];
-                Array.Copy(_arrAttrs, arrNew, _numEntries);
+                Array.Copy(_arrAttrs, 0, arrNew, 0, _numEntries);
                 _arrAttrs = arrNew;
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlNavigatorStack.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Runtime/XmlNavigatorStack.cs
@@ -39,7 +39,7 @@ namespace System.Xml.Xsl.Runtime
                     // Resize the stack
                     XPathNavigator[] stkOld = _stkNav;
                     _stkNav = new XPathNavigator[2 * _sp];
-                    Array.Copy(stkOld, _stkNav, _sp);
+                    Array.Copy(stkOld, 0, _stkNav, 0, _sp);
                 }
             }
 

--- a/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XsltInput.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/Xslt/XsltInput.cs
@@ -90,7 +90,7 @@ namespace System.Xml.Xsl.Xslt
                     newSize = position + 1;
                 }
                 Record[] tmp = new Record[newSize];
-                Array.Copy(_records, tmp, _records.Length);
+                Array.Copy(_records, 0, tmp, 0, _records.Length);
                 _records = tmp;
             }
         }

--- a/src/System.Private.Xml/src/System/Xml/Xsl/XsltOld/BuilderInfo.cs
+++ b/src/System.Private.Xml/src/System/Xml/Xsl/XsltOld/BuilderInfo.cs
@@ -67,7 +67,7 @@ namespace System.Xml.Xsl.XsltOld
             if (this.TextInfo.Length < newSize)
             {
                 string[] newArr = new string[newSize * 2];
-                Array.Copy(this.TextInfo, newArr, this.TextInfoCount);
+                Array.Copy(this.TextInfo, 0, newArr, 0, this.TextInfoCount);
                 this.TextInfo = newArr;
             }
         }

--- a/src/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyBase.cs
+++ b/src/System.Reflection.Context/src/System/Reflection/Context/Virtual/VirtualPropertyBase.cs
@@ -122,7 +122,7 @@ namespace System.Reflection.Context.Virtual
             {
                 args = new object[index.Length + 1];
 
-                Array.Copy(index, args, index.Length);
+                Array.Copy(index, 0, args, 0, index.Length);
 
                 args[index.Length] = value;
             }

--- a/src/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/Helpers.cs
+++ b/src/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/Helpers.cs
@@ -22,7 +22,7 @@ namespace System.Reflection.TypeLoading
             // We want to return the exact type of T[] even if "original" is a type of T2[] (due to array variance.)
             // The arrays produced by this helper are usually passed directly to app code.
             T[] copy = new T[original.Length];
-            Array.Copy(sourceArray: original, destinationArray: copy, length: original.Length);
+            Array.Copy(sourceArray: original, sourceIndex: 0, destinationArray: copy, destinationIndex: 0, length: original.Length);
             return copy;
         }
 

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/FormatterServices.cs
@@ -71,7 +71,7 @@ namespace System.Runtime.Serialization
                     if (allMembers != null && allMembers.Count > 0)
                     {
                         var membersTemp = new FieldInfo[allMembers.Count + typeMembers.Length];
-                        Array.Copy(typeMembers, membersTemp, typeMembers.Length);
+                        Array.Copy(typeMembers, 0, membersTemp, 0, typeMembers.Length);
                         allMembers.CopyTo(membersTemp, typeMembers.Length);
                         typeMembers = membersTemp;
                     }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
@@ -303,7 +303,7 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(names));
  
             string[] algorithmNames = new string[names.Length];
-            Array.Copy(names, algorithmNames, algorithmNames.Length);
+            Array.Copy(names, 0, algorithmNames, 0, algorithmNames.Length);
  
             // Pre-check the algorithm names for validity so that we don't add a few of the names and then
             // throw an exception if we find an invalid name partway through the list.
@@ -461,7 +461,7 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(names));
  
             string[] oidNames = new string[names.Length];
-            Array.Copy(names, oidNames, oidNames.Length);
+            Array.Copy(names, 0, oidNames, 0, oidNames.Length);
  
             // Pre-check the input names for validity, so that we don't add a few of the names and throw an
             // exception if an invalid name is found further down the array. 

--- a/src/System.Transactions.Local/src/System/Transactions/Transaction.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/Transaction.cs
@@ -487,7 +487,7 @@ namespace System.Transactions
             }
 
             byte[] toReturn = new byte[internalPromotedToken.Length];
-            Array.Copy(internalPromotedToken, toReturn, toReturn.Length);
+            Array.Copy(internalPromotedToken, 0, toReturn, 0, toReturn.Length);
             return toReturn;
         }
 

--- a/src/System.Transactions.Local/src/System/Transactions/TransactionInterop.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/TransactionInterop.cs
@@ -305,7 +305,7 @@ namespace System.Transactions
             }
 
             byte[] propagationTokenCopy = new byte[propagationToken.Length];
-            Array.Copy(propagationToken, propagationTokenCopy, propagationToken.Length);
+            Array.Copy(propagationToken, 0, propagationTokenCopy, 0, propagationToken.Length);
 
             return DistributedTransactionManager.GetDistributedTransactionFromTransmitterPropagationToken(propagationTokenCopy);
         }

--- a/src/System.Transactions.Local/src/System/Transactions/TransactionState.cs
+++ b/src/System.Transactions.Local/src/System/Transactions/TransactionState.cs
@@ -492,7 +492,9 @@ namespace System.Transactions
                 {
                     Array.Copy(
                         enlistments._volatileEnlistments,
+                        0,
                         newEnlistments,
+                        0,
                         enlistments._volatileEnlistmentSize
                         );
                 }

--- a/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -283,7 +283,7 @@ namespace System.Web.Util
             if (decodedBytesCount < decodedBytes.Length)
             {
                 byte[] newDecodedBytes = new byte[decodedBytesCount];
-                Array.Copy(decodedBytes, newDecodedBytes, decodedBytesCount);
+                Array.Copy(decodedBytes, 0, newDecodedBytes, 0, decodedBytesCount);
                 decodedBytes = newDecodedBytes;
             }
 

--- a/src/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
+++ b/src/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
@@ -498,7 +498,7 @@ namespace System.Media
                     if (_streamData.Length < _currentPos + BlockSize)
                     {
                         byte[] newData = new byte[_streamData.Length * 2];
-                        Array.Copy(_streamData, newData, _streamData.Length);
+                        Array.Copy(_streamData, 0, newData, 0, _streamData.Length);
                         _streamData = newData;
                     }
                     readBytes = await _stream.ReadAsync(_streamData, _currentPos, BlockSize, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Just a little cleanup.  When we're working with T[]s, use Array.Copy that takes a lower bound, explicitly passing in 0, rather than forcing the implementation to query GetLowerBound() on each array.