### PR TITLE
Allow trailing trivia in JsonSerializer.Parse and Read #37500

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -33,7 +33,7 @@ namespace System.Text.Json.Serialization
 
                         if (HandleValue(tokenType, options, ref reader, ref state))
                         {
-                            break;
+                            continue;
                         }
                     }
                     else if (tokenType == JsonTokenType.PropertyName)
@@ -82,14 +82,14 @@ namespace System.Text.Json.Serialization
                         }
                         else if (HandleValue(tokenType, options, ref reader, ref state))
                         {
-                            break;
+                            continue;
                         }
                     }
                     else if (tokenType == JsonTokenType.EndObject)
                     {
                         if (HandleEndObject(options, ref state, ref reader))
                         {
-                            break;
+                            continue;
                         }
                     }
                     else if (tokenType == JsonTokenType.StartArray)
@@ -100,21 +100,21 @@ namespace System.Text.Json.Serialization
                         }
                         else if (HandleValue(tokenType, options, ref reader, ref state))
                         {
-                            break;
+                            continue;
                         }
                     }
                     else if (tokenType == JsonTokenType.EndArray)
                     {
                         if (HandleEndArray(options, ref state, ref reader))
                         {
-                            break;
+                            continue;
                         }
                     }
                     else if (tokenType == JsonTokenType.Null)
                     {
                         if (HandleNull(ref reader, ref state, options))
                         {
-                            break;
+                            continue;
                         }
                     }
                 }
@@ -125,43 +125,7 @@ namespace System.Text.Json.Serialization
                 ThrowHelper.ReThrowWithPath(e, state.PropertyPath);
             }
 
-            // Ensure any trailing whitespace or comments (if allowed) are cleaned up
-            ConsumeTrailingWhitespaceAndComments(ref reader, options);
-
             return;
-        }
-
-        private static void ConsumeTrailingWhitespaceAndComments(ref Utf8JsonReader reader, JsonSerializerOptions options)
-        {
-            try
-            {
-                while (reader.Read())
-                {
-                    switch (reader.TokenType)
-                    {
-                        case JsonTokenType.None:
-                            // Consume whitespace
-                            continue;
-
-                        case JsonTokenType.Comment:
-                            // Consume comments if allowed
-                            if (options.ReadCommentHandling != JsonCommentHandling.Disallow)
-                            {
-                                continue;
-                            }
-                            goto default;
-
-                        default:
-                            // Stop at any other token we find
-                            return;
-                    }
-                }
-            }
-            catch (JsonReaderException e)
-            {
-                // Re-throw without path information (outside of an object)
-                ThrowHelper.ReThrowWithPath(e, "<none>");
-            }
         }
 
         private static ReadOnlySpan<byte> GetUnescapedString(ReadOnlySpan<byte> utf8Source, int idx)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -53,15 +53,21 @@ namespace System.Text.Json.Serialization
         {
             get
             {
-                StringBuilder path = new StringBuilder();
+                StringBuilder path;
 
                 if (_previous == null || _index == 0)
                 {
-                    path.Append($"[{Current.JsonClassInfo.Type.FullName}]");
+                    // No path if we've walked beyond the end of our JSON document
+                    if (Current.JsonClassInfo == null)
+                    {
+                        return "<none>";
+                    }
+
+                    path = new StringBuilder($"[{Current.JsonClassInfo.Type.FullName}]");
                 }
                 else
                 {
-                    path.Append($"[{_previous[0].JsonClassInfo.Type.FullName}]");
+                    path = new StringBuilder($"[{_previous[0].JsonClassInfo.Type.FullName}]");
 
                     for (int i = 0; i < _index; i++)
                     {

--- a/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
@@ -72,5 +72,24 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal("null", obj);
             }
         }
+
+        [Fact]
+        public static void NullAcceptsLeadingAndTrailingTrivia()
+        {
+            {
+                TestClassWithNull obj = JsonSerializer.Parse<TestClassWithNull>(" null");
+                Assert.Null(obj);
+            }
+
+            {
+                object obj = JsonSerializer.Parse<object>("null ");
+                Assert.Null(obj);
+            }
+
+            {
+                object obj = JsonSerializer.Parse<object>(" null\t");
+                Assert.Null(obj);
+            }
+        }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -71,6 +71,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("", "\t\t\t\n// Both\n/* Comments */")]
         [InlineData(" ", "")]
         [InlineData("\t ", "")]
+        [InlineData(" \t", " \n")]
         [InlineData("// Leading Comment\n", "")]
         [InlineData("/* Multi\nLine\nComment */ ", "")]
         [InlineData("/* Multi\nLine\nComment */ ", "\t// trailing comment\n ")]

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -63,29 +63,23 @@ namespace System.Text.Json.Serialization.Tests
             obj.Verify();
         }
 
-        [Fact]
-        public static void ReadClassWithTrailingWhitespace()
-        {
-            ClassWithComplexObjects obj = JsonSerializer.Parse<ClassWithComplexObjects>(ClassWithComplexObjects.s_json + " \r\n\t");
-            obj.Verify();
-            string reserialized = JsonSerializer.ToString(obj);
-
-            // Properties in the exported json will be in the order that they were reflected, doing a quick check to see that
-            // we end up with the same length (i.e. same amount of data) to start.
-            Assert.Equal(ClassWithComplexObjects.s_json.StripWhitespace().Length, reserialized.Length);
-
-            // Shoving it back through the parser should validate round tripping.
-            obj = JsonSerializer.Parse<ClassWithComplexObjects>(reserialized);
-            obj.Verify();
-        }
-
-        [Fact]
-        public static void ReadClassWithTrailingComments()
+        [Theory]
+        [InlineData("", " ")]
+        [InlineData("", "\t ")]
+        [InlineData("", "//Single Line Comment\r\n")]
+        [InlineData("", "/* Multi\nLine Comment */")]
+        [InlineData("", "\t\t\t\n// Both\n/* Comments */")]
+        [InlineData(" ", "")]
+        [InlineData("\t ", "")]
+        [InlineData("// Leading Comment\n", "")]
+        [InlineData("/* Multi\nLine\nComment */ ", "")]
+        [InlineData("/* Multi\nLine\nComment */ ", "\t// trailing comment\n ")]
+        public static void ReadClassIgnoresLeadingOrTrailingTrivia(string leadingTrivia, string trailingTrivia)
         {
             var options = new JsonSerializerOptions();
             options.ReadCommentHandling = JsonCommentHandling.Skip;
 
-            ClassWithComplexObjects obj = JsonSerializer.Parse<ClassWithComplexObjects>(ClassWithComplexObjects.s_json + "// Single Line\n/* Multi\nLine Comment */ ", options);
+            ClassWithComplexObjects obj = JsonSerializer.Parse<ClassWithComplexObjects>(leadingTrivia + ClassWithComplexObjects.s_json + trailingTrivia, options);
             obj.Verify();
         }
 

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -64,6 +64,32 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ReadClassWithTrailingWhitespace()
+        {
+            ClassWithComplexObjects obj = JsonSerializer.Parse<ClassWithComplexObjects>(ClassWithComplexObjects.s_json + " \r\n\t");
+            obj.Verify();
+            string reserialized = JsonSerializer.ToString(obj);
+
+            // Properties in the exported json will be in the order that they were reflected, doing a quick check to see that
+            // we end up with the same length (i.e. same amount of data) to start.
+            Assert.Equal(ClassWithComplexObjects.s_json.StripWhitespace().Length, reserialized.Length);
+
+            // Shoving it back through the parser should validate round tripping.
+            obj = JsonSerializer.Parse<ClassWithComplexObjects>(reserialized);
+            obj.Verify();
+        }
+
+        [Fact]
+        public static void ReadClassWithTrailingComments()
+        {
+            var options = new JsonSerializerOptions();
+            options.ReadCommentHandling = JsonCommentHandling.Skip;
+
+            ClassWithComplexObjects obj = JsonSerializer.Parse<ClassWithComplexObjects>(ClassWithComplexObjects.s_json + "// Single Line\n/* Multi\nLine Comment */ ", options);
+            obj.Verify();
+        }
+
+        [Fact]
         public static void ReadEmpty()
         {
             SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>("{}");

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -15,6 +15,37 @@ namespace System.Text.Json.Serialization.Tests
             obj.Verify();
         }
 
+        [Theory]
+        [InlineData("", " ")]
+        [InlineData("", "\t ")]
+        [InlineData("", "//Single Line Comment\r\n")]
+        [InlineData("", "/* Multi\nLine Comment */")]
+        [InlineData("", "\t\t\t\n// Both\n/* Comments */")]
+        [InlineData(" ", "")]
+        [InlineData("\t ", "")]
+        [InlineData(" \t", " \n")]
+        [InlineData("// Leading Comment\n", "")]
+        [InlineData("/* Multi\nLine\nComment */ ", "")]
+        [InlineData("/* Multi\nLine\nComment */ ", "\t// trailing comment\n ")]
+        public static void ReadSimpleClassIgnoresLeadingOrTrailingTrivia(string leadingTrivia, string trailingTrivia)
+        {
+            {
+                var options = new JsonSerializerOptions();
+                options.ReadCommentHandling = JsonCommentHandling.Skip;
+
+                SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(leadingTrivia + SimpleTestClass.s_json + trailingTrivia, options);
+                obj.Verify();
+            }
+
+            {
+                var options = new JsonSerializerOptions();
+                options.ReadCommentHandling = JsonCommentHandling.Allow;
+
+                SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(leadingTrivia + SimpleTestClass.s_json + trailingTrivia, options);
+                obj.Verify();
+            }
+        }
+
         [Fact]
         public static void ReadSimpleClassWithObject()
         {
@@ -29,6 +60,18 @@ namespace System.Text.Json.Serialization.Tests
             // Shoving it back through the parser should validate round tripping.
             obj = JsonSerializer.Parse<SimpleTestClassWithSimpleObject>(reserialized);
             obj.Verify();
+        }
+
+        [Theory]
+        [InlineData("", "//Single Line Comment\r\n")]
+        [InlineData("", "/* Multi\nLine Comment */")]
+        [InlineData("", "\t\t\t\n// Both\n/* Comments */")]
+        [InlineData("// Leading Comment\n", "")]
+        [InlineData("/* Multi\nLine\nComment */ ", "")]
+        [InlineData("/* Multi\nLine\nComment */ ", "\t// trailing comment\n ")]
+        public static void ReadClassWithCommentsThrowsIfDisallowed(string leadingTrivia, string trailingTrivia)
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ClassWithComplexObjects>(leadingTrivia + ClassWithComplexObjects.s_json + trailingTrivia));
         }
 
         [Fact]
@@ -75,13 +118,20 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("// Leading Comment\n", "")]
         [InlineData("/* Multi\nLine\nComment */ ", "")]
         [InlineData("/* Multi\nLine\nComment */ ", "\t// trailing comment\n ")]
-        public static void ReadClassIgnoresLeadingOrTrailingTrivia(string leadingTrivia, string trailingTrivia)
+        public static void ReadComplexClassIgnoresLeadingOrTrailingTrivia(string leadingTrivia, string trailingTrivia)
         {
             var options = new JsonSerializerOptions();
             options.ReadCommentHandling = JsonCommentHandling.Skip;
 
             ClassWithComplexObjects obj = JsonSerializer.Parse<ClassWithComplexObjects>(leadingTrivia + ClassWithComplexObjects.s_json + trailingTrivia, options);
             obj.Verify();
+
+            // Throws due to JsonDocument.TryParse not supporting Allow
+            //var options = new JsonSerializerOptions();
+            //options.ReadCommentHandling = JsonCommentHandling.Allow;
+            //
+            //obj = JsonSerializer.Parse<ClassWithComplexObjects>(leadingTrivia + ClassWithComplexObjects.s_json + trailingTrivia, options);
+            //obj.Verify();
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
@@ -33,6 +33,23 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static async Task ReadSimpleObjectWithTrailingTriviaAsync()
+        {
+            byte[] data = Encoding.UTF8.GetBytes(SimpleTestClass.s_json + " /* Multi\r\nLine Comment */\t");
+            using (MemoryStream stream = new MemoryStream(data))
+            {
+                JsonSerializerOptions options = new JsonSerializerOptions
+                {
+                    DefaultBufferSize = 1,
+                    ReadCommentHandling = JsonCommentHandling.Skip,
+                };
+
+                SimpleTestClass obj = await JsonSerializer.ReadAsync<SimpleTestClass>(stream, options);
+                obj.Verify();
+            }
+        }
+
+        [Fact]
         public static async Task ReadPrimitivesAsync()
         {
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(@"1")))
@@ -40,6 +57,22 @@ namespace System.Text.Json.Serialization.Tests
                 JsonSerializerOptions options = new JsonSerializerOptions
                 {
                     DefaultBufferSize = 1
+                };
+
+                int i = await JsonSerializer.ReadAsync<int>(stream, options);
+                Assert.Equal(1, i);
+            }
+        }
+
+        [Fact]
+        public static async Task ReadPrimitivesWithTrailingTriviaAsync()
+        {
+            using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(" 1\t// Comment\r\n/* Multi\r\nLine */")))
+            {
+                JsonSerializerOptions options = new JsonSerializerOptions
+                {
+                    DefaultBufferSize = 1,
+                    ReadCommentHandling = JsonCommentHandling.Skip,
                 };
 
                 int i = await JsonSerializer.ReadAsync<int>(stream, options);

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -57,6 +57,12 @@ namespace System.Text.Json.Serialization.Tests
 
             string s2 = JsonSerializer.Parse<string>(@"  ""Hello"" ");
             Assert.Equal("Hello", s2);
+
+            bool b = JsonSerializer.Parse<bool>(" \ttrue ");
+            Assert.Equal(true, b);
+
+            bool b2 = JsonSerializer.Parse<bool>(" false\n");
+            Assert.Equal(false, b2);
         }
 
         [Fact]
@@ -109,6 +115,8 @@ namespace System.Text.Json.Serialization.Tests
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[]>("[2] {3}"));
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[2] {3}")));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<string>(@"""Hello"" 42"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<string>(Encoding.UTF8.GetBytes(@"""Hello"" 42")));
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -35,6 +35,31 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ReadPrimitivesWithWhitespace()
+        {
+            int i = JsonSerializer.Parse<int>(Encoding.UTF8.GetBytes(@" 1 "));
+            Assert.Equal(1, i);
+
+            int i2 = JsonSerializer.Parse<int>("2\t");
+            Assert.Equal(2, i2);
+
+            int? i3 = JsonSerializer.Parse<int?>("\r\nnull");
+            Assert.Null(i3);
+
+            long l = JsonSerializer.Parse<long>(Encoding.UTF8.GetBytes("\t" + long.MaxValue.ToString()));
+            Assert.Equal(long.MaxValue, l);
+
+            long l2 = JsonSerializer.Parse<long>(long.MaxValue.ToString() + " \r\n");
+            Assert.Equal(long.MaxValue, l2);
+
+            string s = JsonSerializer.Parse<string>(Encoding.UTF8.GetBytes(@"""Hello"" "));
+            Assert.Equal("Hello", s);
+
+            string s2 = JsonSerializer.Parse<string>(@"  ""Hello"" ");
+            Assert.Equal("Hello", s2);
+        }
+
+        [Fact]
         public static void ReadPrimitivesFail()
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<int>(Encoding.UTF8.GetBytes(@"a")));


### PR DESCRIPTION
This fixes #37500 by consuming all leading and trailing trivia in `JsonSerializer.ReadCore`. Comments are only consumed if `JsonCommentHandling` is not Disallow.