### PR TITLE
Tweak SendRecv_NoBuffering_Success test to gather more details

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -798,8 +798,8 @@ namespace System.Net.Sockets.Tests
                         if (received <= 0) break;
                         totalReceived += received;
                     }
-                    Assert.Equal(sendBuffer.Length, totalReceived);
                     await sendTask;
+                    Assert.Equal(sendBuffer.Length, totalReceived);
                 }
             }
         }


### PR DESCRIPTION
The test failed from the `Assert.Equal(sendBuffer.Length, totalReceived)` with `totalReceived == 0`.  The only way that should happen, short of buggy product code, is if somehow the connection was torn down from the client side such that the server side read 0 bytes.  Under the theory that maybe that was somehow caused by the send operation failing, we should wait on the send task from the client before doing the assert.