### PR TITLE
update HTTP2 responce header processing

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -186,7 +186,7 @@ namespace System.Net.Http
                         // if the header can't be added, we silently drop it.
                         if (_state == StreamState.ExpectingTrailingHeaders)
                         {
-                            _response.TrailingHeaders.TryAddWithoutValidation(descriptor, headerValue);
+                            _response.TrailingHeaders.TryAddWithoutValidation(descriptor.HeaderType == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue);
                         }
                         else if (descriptor.HeaderType == HttpHeaderType.Content)
                         {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -194,7 +194,7 @@ namespace System.Net.Http
                         }
                         else
                         {
-                            _response.Headers.TryAddWithoutValidation(descriptor, headerValue);
+                            _response.Headers.TryAddWithoutValidation(descriptor.HeaderType == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue);
                         }
                     }
                 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -202,6 +202,28 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(value, headers.GetValues("Expires").First());
         }
 
+        [Theory]
+        [InlineData("Accept-Encoding", "identity,gzip")]
+        public async Task SendAsync_RequestHeaderInResponse_Success(string name, string value)
+        {
+            await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
+            {
+                using (HttpClient client = CreateHttpClient())
+                {
+                    var message = new HttpRequestMessage(HttpMethod.Get, uri) { Version = VersionFromUseHttp2 };
+                    HttpResponseMessage response = await client.SendAsync(message);
+
+                    Assert.Equal(value, response.Headers.GetValues(name).First());
+                }
+            },
+            async server =>
+            {
+                IList<HttpHeaderData> headers = new HttpHeaderData[] { new HttpHeaderData(name, value) };
+
+                HttpRequestData requestData = await server.HandleRequestAsync(HttpStatusCode.OK, headers);
+            });
+        }
+
         [OuterLoop("Uses external server")]
         [Theory]
         [InlineData(false)]

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -536,6 +536,7 @@ namespace System.Net.Http.Functional.Tests
         protected static readonly IList<HttpHeaderData> TrailingHeaders = new HttpHeaderData[] {
             new HttpHeaderData("MyCoolTrailerHeader", "amazingtrailer"),
             new HttpHeaderData("EmptyHeader", ""),
+            new HttpHeaderData("Accept-Encoding", "identity,gzip"),
             new HttpHeaderData("Hello", "World") };
 
         protected static Frame MakeDataFrame(int streamId, byte[] data, bool endStream = false) =>
@@ -570,6 +571,7 @@ namespace System.Net.Http.Functional.Tests
                             "data\r\n" +
                             "0\r\n" +
                             "MyCoolTrailerHeader: amazingtrailer\r\n" +
+                            "Accept-encoding: identity,gzip\r\n" +
                             "Hello: World\r\n" +
                             "\r\n"));
 
@@ -587,6 +589,7 @@ namespace System.Net.Http.Functional.Tests
 
                         Assert.Contains("amazingtrailer", response.TrailingHeaders.GetValues("MyCoolTrailerHeader"));
                         Assert.Contains("World", response.TrailingHeaders.GetValues("Hello"));
+                        Assert.Contains("identity,gzip", response.TrailingHeaders.GetValues("Accept-encoding"));
 
                         string data = await response.Content.ReadAsStringAsync();
                         Assert.Contains("data", data);


### PR DESCRIPTION
Without this change, we can hit Debug.Assert() when response contains request header for some reason. 
(I bump to this with gRPC testing) 

I updated code to do exactly what we do for HTTP1.x

```
  Assertion Failed

     at System.Net.Http.Headers.HttpHeaders.CreateAndAddHeaderToStore(HeaderDescriptor descriptor) in /home/furt/github/wfurt-corefx-h2/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs:line 730
     at System.Net.Http.Headers.HttpHeaders.GetOrCreateHeaderInfo(HeaderDescriptor descriptor, Boolean parseRawValues) in /home/furt/github/wfurt-corefx-h2/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs:line 717
     at System.Net.Http.Headers.HttpHeaders.TryAddWithoutValidation(HeaderDescriptor descriptor, String value) in /home/furt/github/wfurt-corefx-h2/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs:line 138
     at System.Net.Http.Http2Connection.Http2Stream.OnResponseHeader(ReadOnlySpan`1 name, ReadOnlySpan`1 value) in /home/furt/github/wfurt-corefx-h2/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs:line 197
     at System.Net.Http.Http2Connection.<>c.<.cctor>b__87_0(Object state, ReadOnlySpan`1 name, ReadOnlySpan`1 value) in /home/furt/github/wfurt-corefx-h2/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs:line 293
     at System.Net.Http.HPack.HPackDecoder.OnHeaderComplete(HeaderCallback onHeader, Object onHeaderState, ReadOnlySpan`1 headerName, ReadOnlySpan`1 headerValue) in /home/furt/github/wfurt-corefx-h2/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs:line 401
     at System.Net.Http.HPack.HPackDecoder.Decode(ReadOnlySpan`1 data, HeaderCallback onHeader, Object onHeaderState) in /home/furt/github/wfurt-corefx-h2/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs:line 294
     at System.Net.Http.Http2Connection.ProcessHeadersFrame(FrameHeader frameHeader) in /home/furt/github/wfurt-corefx-h2/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs:line 312
     at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine) in /__w/1/s/src/System.Private.CoreLib/shared/System/Runtime/CompilerServices/AsyncMethodBuilder.cs:line 1012

```
