### PR TITLE
Fix bug in ZipArchiveEntry data descriptor

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1022,6 +1022,9 @@ namespace System.IO.Compression
 
         private void WriteDataDescriptor()
         {
+            // We enter here because we cannot seek, so the data descriptor bit should be on
+            Debug.Assert((_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0);
+
             // data descriptor can be 32-bit or 64-bit sizes. 32-bit is more compatible, so use that if possible
             // signature is optional but recommended by the spec
 
@@ -1233,7 +1236,6 @@ namespace System.IO.Compression
                         // go back and finish writing
                         if (_entry._archive.ArchiveStream.CanSeek)
                             // finish writing local header if we have seek capabilities
-
                             _entry.WriteCrcAndSizesInLocalHeader(_usedZip64inLH);
                         else
                             // write out data descriptor if we don't have seek capabilities

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -823,7 +823,7 @@ namespace System.IO.Compression
                 }
                 else // if we are not in streaming mode, we have to decide if we want to write zip64 headers
                 {
-                    // When updating and when we can seek, the data descriptor bit needs to be flipped back to prevent corruption
+                    // We are in seekable mode so we will not need to write a data descriptor
                     _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
                     if (SizesTooLarge()
 #if DEBUG_FORCE_ZIP64

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -823,6 +823,8 @@ namespace System.IO.Compression
                 }
                 else // if we are not in streaming mode, we have to decide if we want to write zip64 headers
                 {
+                    // When updating and when we can seek, the data descriptor bit needs to be flipped back to prevent corruption
+                    _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
                     if (SizesTooLarge()
 #if DEBUG_FORCE_ZIP64
                         || (_archive._forceZip64 && _archive.Mode == ZipArchiveMode.Update)

--- a/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -198,13 +198,8 @@ namespace System.IO.Compression.Tests
         private static void AssertDataDescriptor(MemoryStream memoryStream, bool hasDataDescriptor)
         {
             byte[] fileBytes = memoryStream.ToArray();
-            AssertByte(fileBytes, 6, hasDataDescriptor ? 8 : 0);
-            AssertByte(fileBytes, 7, 0);
-        }
-
-        private static void AssertByte(byte[] fileBytes, int byteNumber, int byteValue)
-        {
-            Assert.Equal(byteValue, fileBytes[byteNumber]);
+            Assert.Equal(hasDataDescriptor ? 8 : 0, fileBytes[6]);
+            Assert.Equal(0, fileBytes[7]);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/29872

When a zip file is created using an unseekable stream, the data descriptor bit is turned on. If we update that same zip file, we should expect the data descriptor to get turned off. If it doesn't get turned off, the file gets in a bad state: we can open it with File Explorer or 7-Zip without problems, but we cannot drag-drop files into that zip file anymore; those programs say the file is corrupted.

Added a unit test to verify the data descriptor value is the expected one in the first local file header, after creating a zip file with an unseekable stream and after updating the zip file.