### PR TITLE
SqlClient: fix BulkCopy double and single null widening handling

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
@@ -891,10 +891,10 @@ namespace System.Data.SqlClient
                                     value = _SqlDataReaderRowSource.GetSqlDecimal(sourceOrdinal);
                                     break;
                                 case ValueMethod.SqlTypeSqlDouble:
-                                    value = new SqlDecimal(_SqlDataReaderRowSource.GetSqlDouble(sourceOrdinal).Value);
+                                    value = (SqlDecimal)_SqlDataReaderRowSource.GetSqlDouble(sourceOrdinal); // use cast to handle IsNull correctly because no public constructor allows it
                                     break;
                                 case ValueMethod.SqlTypeSqlSingle:
-                                    value = new SqlDecimal(_SqlDataReaderRowSource.GetSqlSingle(sourceOrdinal).Value);
+                                    value = (SqlDecimal)_SqlDataReaderRowSource.GetSqlSingle(sourceOrdinal); // use cast to handle IsNull correctly because no public constructor allows it
                                     break;
                                 default:
                                     Debug.Fail($"Current column is marked as being a SqlType, but no SqlType compatible method was provided. Method: {_currentRowMetadata[destRowIndex].Method}");

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyWidenNullInexactNumerics.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyWidenNullInexactNumerics.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Data.SqlClient.ManualTesting.Tests
@@ -24,7 +27,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     }
                 );
 
-
                 RunCommands(destinationConnection,
                     new[]
                     {
@@ -32,7 +34,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                         "create table dbo.__SqlBulkCopyBug_Destination (floatVal decimal(18,10) null,realVal decimal(18,10) null)"
                     }
                 );
-
 
                 Exception error = null;
                 try
@@ -67,7 +68,6 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                 }
 
                 Assert.Null(error);
-
             }
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyWidenNullInexactNumerics.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyWidenNullInexactNumerics.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace System.Data.SqlClient.ManualTesting.Tests
+{
+    public class CopyWidenNullInexactNumerics
+    {
+        public static void Test(string sourceDatabaseConnectionString, string destinationDatabaseConnectionString)
+        {
+            // this test copies float and real inexact numeric types into decimal targets using bulk copy to check that the widening of the type succeeds.
+
+            using (var sourceConnection = new SqlConnection(sourceDatabaseConnectionString))
+            using (var destinationConnection = new SqlConnection(destinationDatabaseConnectionString))
+            {
+                sourceConnection.Open();
+                destinationConnection.Open();
+
+                RunCommands(sourceConnection,
+                    new[]
+                    {
+                        "drop table if exists dbo.__SqlBulkCopyBug_Source",
+                        "create table dbo.__SqlBulkCopyBug_Source (floatVal float null, realVal real null)",
+                        "insert dbo.__SqlBulkCopyBug_Source(floatVal,realVal) values(1,1),(2,2),(null,null),(0.00000000000001,0.00000000000001)"
+                    }
+                );
+
+
+                RunCommands(destinationConnection,
+                    new[]
+                    {
+                        "drop table if exists dbo.__SqlBulkCopyBug_Destination",
+                        "create table dbo.__SqlBulkCopyBug_Destination (floatVal decimal(18,10) null,realVal decimal(18,10) null)"
+                    }
+                );
+
+
+                Exception error = null;
+                try
+                {
+                    var bulkCopy = new SqlBulkCopy(destinationConnection, SqlBulkCopyOptions.Default, null);
+                    bulkCopy.DestinationTableName = "dbo.__SqlBulkCopyBug_Destination";
+                    using (var sourceCommand = new SqlCommand("select * from dbo.__SqlBulkCopyBug_Source", sourceConnection, null))
+                    using (var sourceReader = sourceCommand.ExecuteReader())
+                    {
+                        bulkCopy.WriteToServer(sourceReader);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    error = ex;
+                }
+                finally
+                {
+                    try
+                    {
+                        RunCommands(sourceConnection,
+                            new[]
+                            {
+                                "drop table if exists dbo.__SqlBulkCopyBug_Source",
+                                "drop table if exists dbo.__SqlBulkCopyBug_Destination",
+                            }
+                        );
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                Assert.Null(error);
+
+            }
+        }
+
+        public static void RunCommands(SqlConnection connection, IEnumerable<string> commands)
+        {
+            using (var sqlCommand = connection.CreateCommand())
+            {
+                foreach (var command in commands)
+                {
+                    Helpers.TryExecute(sqlCommand, command);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/SqlBulkCopyTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/SqlBulkCopyTest.cs
@@ -187,6 +187,12 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             ColumnCollation.Test(dstConstr, AddGuid("SqlBulkCopyTest_ColumnCollation"));
         }
 
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public void CopyWidenNullInexactNumericsTest()
+        {
+            CopyWidenNullInexactNumerics.Test(srcConstr, dstConstr);
+        }
+
         [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup))]
         public void CopyAllFromReaderAsyncTest()
         {

--- a/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/System.Data.SqlClient/tests/ManualTests/System.Data.SqlClient.ManualTesting.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{45DB5F86-7AE3-45C6-870D-F9357B66BDB5}</ProjectGuid>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
@@ -60,6 +60,7 @@
     <Compile Include="SQL\MARSTest\MARSTest.cs" />
     <Compile Include="SQL\MirroringTest\ConnectionOnMirroringTest.cs" />
     <Compile Include="SQL\ParallelTransactionsTest\ParallelTransactionsTest.cs" />
+    <Compile Include="SQL\SqlBulkCopyTest\CopyWidenNullInexactNumerics.cs" />
     <Compile Include="SQL\SqlCredentialTest\SqlCredentialTest.cs" />
     <Compile Include="SQL\SqlSchemaInfoTest\SqlSchemaInfoTest.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\AdjustPrecScaleForBulkCopy.cs" />


### PR DESCRIPTION
fixes https://github.com/dotnet/corefx/issues/37465

When using bulk copy with an inexact numeric source which is null and a decimal target the conversion from numeric to decimal creates an appropriately typed source variable and then attempts to pass that into a `SqlDecimal` constructor using the source `Value` property. This action fails when the source field is null because the `Value` property throws on null. 

`SqlDecimal` does not expose a public constructor that allows setting null. It does have explicit conversion operators defined that do handle null values correctly so I have changed it to use these and noted why in the source. I have added a test which contains both real and float types. Manual and functional tests pass. This should be simple to pull up into Micosoft.Data.SqlServer.

/cc area owners @afsanehr, @Gary-Zh , @david-engel and problem reporter @sergii-kryzh