### PR TITLE
Added failing test case for issue #37610 - [System.Text.Json] Serializing class that has array of children of the same class throws StackOverflowException

### DIFF
--- a/src/System.Text.Json/tests/Serialization/CyclicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CyclicTests.cs
@@ -17,5 +17,14 @@ namespace System.Text.Json.Serialization.Tests
             // We don't allow cycles; we throw InvalidOperation instead of an unrecoverable StackOverflow.
             Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(obj));
         }
+
+        [Fact]
+        public static void WriteCyclicFail()
+        {
+            TestClassWithArrayWithElementsOfSameClass obj = new TestClassWithArrayWithElementsOfSameClass();
+
+            //It shouldn't throw when there is no real cycle reference, and just empty object is created
+            Assert.Null(Record.Exception(() => JsonSerializer.ToString(obj)));
+        }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/CyclicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CyclicTests.cs
@@ -19,13 +19,14 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-		[ActiveIssue(37313)]
+        [ActiveIssue(37313)]
         public static void WriteTestClassWithArrayOfElementsOfTheSameClassWithoutCyclesDoesNotFail()
         {
             TestClassWithArrayOfElementsOfTheSameClass obj = new TestClassWithArrayOfElementsOfTheSameClass();
 
             //It shouldn't throw when there is no real cycle reference, and just empty object is created
-            Assert.Throws<StackOverflowException>(() => JsonSerializer.ToString(obj));
+            string json = JsonSerializer.ToString(obj);
+            Assert.Equal(@"{}", json);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/CyclicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CyclicTests.cs
@@ -19,9 +19,9 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void WriteCyclicFail()
+        public static void WriteTestClassWithArrayOfElementsOfTheSameClassWithoutCyclesDoesNotFail()
         {
-            TestClassWithArrayWithElementsOfSameClass obj = new TestClassWithArrayWithElementsOfSameClass();
+            TestClassWithArrayOfElementsOfTheSameClass obj = new TestClassWithArrayOfElementsOfTheSameClass();
 
             //It shouldn't throw when there is no real cycle reference, and just empty object is created
             Assert.Null(Record.Exception(() => JsonSerializer.ToString(obj)));

--- a/src/System.Text.Json/tests/Serialization/CyclicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CyclicTests.cs
@@ -19,12 +19,13 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+		[ActiveIssue(37313)]
         public static void WriteTestClassWithArrayOfElementsOfTheSameClassWithoutCyclesDoesNotFail()
         {
             TestClassWithArrayOfElementsOfTheSameClass obj = new TestClassWithArrayOfElementsOfTheSameClass();
 
             //It shouldn't throw when there is no real cycle reference, and just empty object is created
-            Assert.Null(Record.Exception(() => JsonSerializer.ToString(obj)));
+            Assert.Throws<StackOverflowException>(() => JsonSerializer.ToString(obj));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.cs
@@ -396,6 +396,11 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
+    public class TestClassWithArrayWithElementsOfSameClass
+    {
+        public TestClassWithArrayWithElementsOfSameClass[] Array { get; set; }
+    }
+
     public class TestClassWithGenericList : ITestClass
     {
         public List<string> MyData { get; set; }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.cs
@@ -396,9 +396,9 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
-    public class TestClassWithArrayWithElementsOfSameClass
+    public class TestClassWithArrayOfElementsOfTheSameClass
     {
-        public TestClassWithArrayWithElementsOfSameClass[] Array { get; set; }
+        public TestClassWithArrayOfElementsOfTheSameClass[] Array { get; set; }
     }
 
     public class TestClassWithGenericList : ITestClass


### PR DESCRIPTION
Added failing test case for issue #37610 - Serializing class that has array of children of the same class throws StackOverflowException.

`JsonSerializer.ToString`  should not fail when there is no real cycle reference, and just empty object is created, even if class has array of element of the same class.