### PR TITLE
Fixed deserialization of null arrays for issue #37606

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -170,7 +170,7 @@ namespace System.Text.Json.Serialization
                 {
                     state.Current.TempEnumerableValues.Add(value);
                 }
-                else if (state.Current.ReturnValue != null)
+                else
                 {
                     ((IList)state.Current.ReturnValue).Add(value);
                 }
@@ -225,7 +225,7 @@ namespace System.Text.Json.Serialization
                 {
                     ((IList<TProperty>)state.Current.TempEnumerableValues).Add(value);
                 }
-                else if (state.Current.ReturnValue != null)
+                else
                 {
                     ((IList<TProperty>)state.Current.ReturnValue).Add(value);
                 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -170,7 +170,7 @@ namespace System.Text.Json.Serialization
                 {
                     state.Current.TempEnumerableValues.Add(value);
                 }
-                else
+                else if (state.Current.ReturnValue != null)
                 {
                     ((IList)state.Current.ReturnValue).Add(value);
                 }
@@ -225,7 +225,7 @@ namespace System.Text.Json.Serialization
                 {
                     ((IList<TProperty>)state.Current.TempEnumerableValues).Add(value);
                 }
-                else
+                else if (state.Current.ReturnValue != null)
                 {
                     ((IList<TProperty>)state.Current.ReturnValue).Add(value);
                 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -16,8 +16,8 @@ namespace System.Text.Json.Serialization
                 return false;
             }
 
-            // If we don't have a valid property, that means we read "null" for a root object so just return.
-            if (state.Current.JsonPropertyInfo == null)
+            // If null is read at the top level and the type is nullable, then the root is "null" so just return.
+            if (reader.CurrentDepth == 0 && (state.Current.JsonPropertyInfo == null || state.Current.JsonPropertyInfo.CanBeNull))
             {
                 Debug.Assert(state.IsLastFrame);
                 Debug.Assert(state.Current.ReturnValue == null);

--- a/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -17,7 +18,7 @@ namespace System.Text.Json.Serialization.Tests
 
         [Fact]
         public static void RootObjectIsNull()
-        {
+        { 
             {
                 TestClassWithNull obj = JsonSerializer.Parse<TestClassWithNull>("null");
                 Assert.Null(obj);
@@ -27,6 +28,22 @@ namespace System.Text.Json.Serialization.Tests
                 object obj = JsonSerializer.Parse<object>("null");
                 Assert.Null(obj);
             }
+
+            {
+                string obj = JsonSerializer.Parse<string>("null");
+                Assert.Null(obj);
+            }
+
+            {
+                IEnumerable<int> obj = JsonSerializer.Parse<IEnumerable<int>>("null");
+                Assert.Null(obj);
+            }
+
+            {
+                Dictionary<string, object> obj = JsonSerializer.Parse<Dictionary<string, object>>("null");
+                Assert.Null(obj);
+            }
+
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
@@ -30,6 +30,25 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void RootArrayIsNull()
+        {
+            {
+                int[] obj = JsonSerializer.Parse<int[]>("null");
+                Assert.Null(obj);
+            }
+
+            {
+                object[] obj = JsonSerializer.Parse<object[]>("null");
+                Assert.Null(obj);
+            }
+
+            {
+                TestClassWithNull[] obj = JsonSerializer.Parse<TestClassWithNull[]>("null");
+                Assert.Null(obj);
+            }
+        }
+
+        [Fact]
         public static void DefaultIgnoreNullValuesOnRead()
         {
             TestClassWithInitializedProperties obj = JsonSerializer.Parse<TestClassWithInitializedProperties>(TestClassWithInitializedProperties.s_null_json);


### PR DESCRIPTION
This fixes #37606 by checking for null before adding to `state.Current.ReturnValue`
Also added tests for deserializing null arrays. 
