### PR TITLE
Fix System.Diagnostics.Process.[x]ProcessorTime on macOS

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveNonExitedId);
                 Interop.libproc.rusage_info_v3 info = Interop.libproc.proc_pid_rusage(_processId);
-                return new TimeSpan(Convert.ToInt64(info.ri_system_time) / NanoSecondsTo100NanoSecondsFactor);
+                return new TimeSpan(Convert.ToInt64(info.ri_system_time / NanoSecondsTo100NanoSecondsFactor));
             }
         }
 
@@ -92,7 +92,7 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveNonExitedId);
                 Interop.libproc.rusage_info_v3 info = Interop.libproc.proc_pid_rusage(_processId);
-                return new TimeSpan(Convert.ToInt64(info.ri_user_time) / NanoSecondsTo100NanoSecondsFactor);
+                return new TimeSpan(Convert.ToInt64(info.ri_user_time / NanoSecondsTo100NanoSecondsFactor));
             }
         }
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
@@ -9,6 +9,8 @@ namespace System.Diagnostics
 {
     public partial class Process
     {
+        private const int NanoSecondsTo100NanoSecondsFactor = 100;
+
         /// <summary>Gets the amount of time the process has spent running code inside the operating system core.</summary>
         public TimeSpan PrivilegedProcessorTime
         {
@@ -16,7 +18,7 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveNonExitedId);
                 Interop.libproc.rusage_info_v3 info = Interop.libproc.proc_pid_rusage(_processId);
-                return new TimeSpan(Convert.ToInt64(info.ri_system_time));
+                return new TimeSpan(Convert.ToInt64(info.ri_system_time) / NanoSecondsTo100NanoSecondsFactor);
             }
         }
 
@@ -76,7 +78,7 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveNonExitedId);
                 Interop.libproc.rusage_info_v3 info = Interop.libproc.proc_pid_rusage(_processId);
-                return new TimeSpan(Convert.ToInt64(info.ri_system_time + info.ri_user_time));
+                return new TimeSpan(Convert.ToInt64((info.ri_system_time + info.ri_user_time) / NanoSecondsTo100NanoSecondsFactor));
             }
         }
 
@@ -90,7 +92,7 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveNonExitedId);
                 Interop.libproc.rusage_info_v3 info = Interop.libproc.proc_pid_rusage(_processId);
-                return new TimeSpan(Convert.ToInt64(info.ri_user_time));
+                return new TimeSpan(Convert.ToInt64(info.ri_user_time) / NanoSecondsTo100NanoSecondsFactor);
             }
         }
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
@@ -9,7 +9,7 @@ namespace System.Diagnostics
 {
     public partial class Process
     {
-        private const int NanoSecondsTo100NanoSecondsFactor = 100;
+        private const int NanoSecondsTo100NanosecondsFactor = 100;
 
         /// <summary>Gets the amount of time the process has spent running code inside the operating system core.</summary>
         public TimeSpan PrivilegedProcessorTime
@@ -18,7 +18,7 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveNonExitedId);
                 Interop.libproc.rusage_info_v3 info = Interop.libproc.proc_pid_rusage(_processId);
-                return new TimeSpan(Convert.ToInt64(info.ri_system_time / NanoSecondsTo100NanoSecondsFactor));
+                return new TimeSpan(Convert.ToInt64(info.ri_system_time / NanoSecondsTo100NanosecondsFactor));
             }
         }
 
@@ -78,7 +78,7 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveNonExitedId);
                 Interop.libproc.rusage_info_v3 info = Interop.libproc.proc_pid_rusage(_processId);
-                return new TimeSpan(Convert.ToInt64((info.ri_system_time + info.ri_user_time) / NanoSecondsTo100NanoSecondsFactor));
+                return new TimeSpan(Convert.ToInt64((info.ri_system_time + info.ri_user_time) / NanoSecondsTo100NanosecondsFactor));
             }
         }
 
@@ -92,7 +92,7 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveNonExitedId);
                 Interop.libproc.rusage_info_v3 info = Interop.libproc.proc_pid_rusage(_processId);
-                return new TimeSpan(Convert.ToInt64(info.ri_user_time / NanoSecondsTo100NanoSecondsFactor));
+                return new TimeSpan(Convert.ToInt64(info.ri_user_time / NanoSecondsTo100NanosecondsFactor));
             }
         }
 

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -755,7 +755,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        public void TotalProcessorTime_PerformLoop_TotalProcessorTimValid()
+        public void TotalProcessorTime_PerformLoop_TotalProcessorTimeValid()
         {
             CreateDefaultProcess();
 

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -755,6 +755,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue(31908, TargetFrameworkMonikers.Uap)]
         public void TotalProcessorTime_PerformLoop_TotalProcessorTimeValid()
         {
             CreateDefaultProcess();

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -770,13 +770,13 @@ namespace System.Diagnostics.Tests
                 i--;
             }
 
-            DateTime endTime = DateTime.UtcNow;
             TimeSpan processorTimeAfterSpin = Process.GetCurrentProcess().TotalProcessorTime;
+            DateTime endTime = DateTime.UtcNow;
 
-            var timeDiff = (endTime - startTime).TotalMilliseconds;
-            var cpuTimeDiff = (processorTimeAfterSpin - processorTimeBeforeSpin).TotalMilliseconds;
+            double timeDiff = (endTime - startTime).TotalMilliseconds;
+            double cpuTimeDiff = (processorTimeAfterSpin - processorTimeBeforeSpin).TotalMilliseconds;
 
-            var cpuUsage = cpuTimeDiff / (timeDiff * Environment.ProcessorCount);
+            double cpuUsage = cpuTimeDiff / (timeDiff * Environment.ProcessorCount);
 
             Assert.InRange(cpuUsage, 0, 1);
         }

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -754,6 +754,32 @@ namespace System.Diagnostics.Tests
             Assert.InRange(processorTimeAtHalfSpin, processorTimeBeforeSpin, Process.GetCurrentProcess().TotalProcessorTime.TotalSeconds);
         }
 
+       [Fact]
+        public void TotalProcessorTime_PerformLoop_TotalProcessorTimValid()
+        {
+            CreateDefaultProcess();
+
+            DateTime startTime = DateTime.UtcNow;
+            TimeSpan processorTimeBeforeSpin = Process.GetCurrentProcess().TotalProcessorTime;
+           
+            // Perform loop to occupy cpu, takes less than a second.
+            int i = int.MaxValue / 16;
+            while (i > 0)
+            {
+                i--;
+            }
+
+            DateTime endTime = DateTime.UtcNow;
+            TimeSpan processorTimeAfterSpin = Process.GetCurrentProcess().TotalProcessorTime;
+
+            var timeDiff = (endTime - startTime).TotalMilliseconds;
+            var cpuTimeDiff = (processorTimeAfterSpin - processorTimeAfterSpin).TotalMilliseconds;
+
+            var cpuUsage = cpuTimeDiff / (timeDiff * Environment.ProcessorCount);
+
+            Assert.InRange(cpuUsage, 0, 1);
+        }
+
         [Fact]
         public void UserProcessorTime_GetNotStarted_ThrowsInvalidOperationException()
         {

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -773,7 +773,7 @@ namespace System.Diagnostics.Tests
             TimeSpan processorTimeAfterSpin = Process.GetCurrentProcess().TotalProcessorTime;
 
             var timeDiff = (endTime - startTime).TotalMilliseconds;
-            var cpuTimeDiff = (processorTimeAfterSpin - processorTimeAfterSpin).TotalMilliseconds;
+           var cpuTimeDiff = (processorTimeAfterSpin - processorTimeBeforeSpin).TotalMilliseconds;
 
             var cpuUsage = cpuTimeDiff / (timeDiff * Environment.ProcessorCount);
 

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -754,7 +754,7 @@ namespace System.Diagnostics.Tests
             Assert.InRange(processorTimeAtHalfSpin, processorTimeBeforeSpin, Process.GetCurrentProcess().TotalProcessorTime.TotalSeconds);
         }
 
-       [Fact]
+        [Fact]
         public void TotalProcessorTime_PerformLoop_TotalProcessorTimValid()
         {
             CreateDefaultProcess();

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -773,7 +773,7 @@ namespace System.Diagnostics.Tests
             TimeSpan processorTimeAfterSpin = Process.GetCurrentProcess().TotalProcessorTime;
 
             var timeDiff = (endTime - startTime).TotalMilliseconds;
-           var cpuTimeDiff = (processorTimeAfterSpin - processorTimeBeforeSpin).TotalMilliseconds;
+            var cpuTimeDiff = (processorTimeAfterSpin - processorTimeBeforeSpin).TotalMilliseconds;
 
             var cpuUsage = cpuTimeDiff / (timeDiff * Environment.ProcessorCount);
 


### PR DESCRIPTION
Fixes #37614

Affects on macOS:
- `Process.UserProcessorTime`
- `Process.PrivilegedProcessorTime`
- `Process.TotalProcessorTime`

Discussed with @stephentoub  in #37614, this PR implements the proposed fix.

Short summary (more in #37614):
The `rusage_info_v3` mac API uses nanoseconds unit, which was passed without any conversion to `TimeSpan`’s Int64-based constructor, which expects a value with a 100-nanosecond unit. Therfore values reported on macOS were 100x of the correct value.

Fix: we simply convert the `rusage_info_v3` nanosec values to 100-nanosec unit.

Also added a test, which fails with the original code on my machine and passes with the code in this PR. Since the `TestProcessorTime` test is disabled for UWP (https://github.com/dotnet/corefx/issues/31908) I suspect we will have similar problems with the new test. Let's see... 