### PR TITLE
Use Arcade DotNetTool and NuGetPackageRoot

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -114,19 +114,6 @@
 
     <!-- Use msbuild path functions as that property is used in bash scripts. -->
     <SourceDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'src'))</SourceDir>
-
-    <!-- Input Directories -->
-    <PackagesDir>$(DotNetRestorePackagesPath)</PackagesDir>
-    <PackagesDir Condition="'$(PackagesDir)'=='' AND '$(NuGetPackageRoot)' != ''">$([MSBuild]::EnsureTrailingSlash('$(NuGetPackageRoot)'))</PackagesDir>
-    <PackagesDir Condition="'$(PackagesDir)'==''">$(RepoRoot).packages/</PackagesDir>
-    <!-- Respect environment variable for the .NET install directory if set; otherwise, use the current default location -->
-    <DotNetRoot Condition="'$(DotNetRoot)' == ''">$(DOTNET_INSTALL_DIR)</DotNetRoot>
-    <DotNetRoot Condition="'$(DotNetRoot)' == ''">$(RepoRoot).dotnet\</DotNetRoot>
-    <DotNetRoot Condition="!HasTrailingSlash('$(DotNetRoot)')">$(DotNetRoot)\</DotNetRoot>
-    <DotnetCliPath Condition="'$(DotnetCliPath)'==''">$(DotNetRoot)</DotnetCliPath>
-    <ToolHostCmd Condition="'$(ToolHostCmd)'==''">"$(DotNetRoot)dotnet"</ToolHostCmd>
-    <DotNetCmd>$(DotNetRoot)dotnet</DotNetCmd>
-    <DotNetCmd Condition="'$(OS)' == 'Windows_NT'">$(DotNetCmd).exe</DotNetCmd>
   </PropertyGroup>
 
   <!-- workaround https://github.com/dotnet/sdk/issues/2288

--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -14,7 +14,7 @@
 
     <XmlDocPackage>Microsoft.Private.Intellisense</XmlDocPackage>
     <XmlDocPackageVersion>3.0.0-preview3-190305-0</XmlDocPackageVersion>
-    <XmlDocFileRoot>$(PackagesDir)$(XmlDocPackage.ToLowerInvariant())/$(XmlDocPackageVersion)/xmldocs/netcoreapp</XmlDocFileRoot>
+    <XmlDocFileRoot>$(NuGetPackageRoot)$(XmlDocPackage.ToLowerInvariant())/$(XmlDocPackageVersion)/xmldocs/netcoreapp</XmlDocFileRoot>
     <XmlDocDir>$(ArtifactsBinDir)docs</XmlDocDir>
 
     <!-- By default the packaging targets will package desktop facades as ref,

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -10,11 +10,6 @@
 
     <!-- Need to keep in sync with CodeAnalysis.targets file. -->
     <AnalyzerPropsFile>$(ArtifactsToolsetDir)Common\Tools.Analyzers.props</AnalyzerPropsFile>
-
-    <DotNetRoot Condition="'$(DotNetRoot)' == ''">$([MSBuild]::NormalizeDirectory('$(RepoRoot)', '.dotnet'))</DotNetRoot>
-    <DotNetCmd>$(DotNetRoot)dotnet</DotNetCmd>
-    <DotNetCmd Condition="'$(OS)' == 'Windows_NT'">$(DotNetCmd).exe</DotNetCmd>
-    <DotNetCmd>"$(DotNetCmd)"</DotNetCmd>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)dependencies.props" />
@@ -81,7 +76,7 @@
       <OptionalToolProjectPath>$(OptionalToolDir)Tools.csproj</OptionalToolProjectPath>
     </PropertyGroup>
 
-    <Exec Command="$(DotNetCmd) restore &quot;$(OptionalToolProjectPath)&quot; --interactive --ignore-failed-sources /p:TargetGroup=$(TargetGroup)"
+    <Exec Command="&quot;$(DotNetTool)&quot; restore &quot;$(OptionalToolProjectPath)&quot; --interactive --ignore-failed-sources /p:TargetGroup=$(TargetGroup)"
           WorkingDirectory="$(RepoRoot)" />
 
   </Target>
@@ -95,7 +90,7 @@
 
     <!-- List all global tools and save the output. -->
     <Exec Condition="Exists('$(GlobalToolsDir)')"
-          Command="$(DotNetCmd) tool list --tool-path &quot;$(GlobalToolsDir)&quot;"
+          Command="&quot;$(DotNetTool)&quot; tool list --tool-path &quot;$(GlobalToolsDir)&quot;"
           WorkingDirectory="$(RepoRoot)"
           ConsoleToMsBuild="true"
           ContinueOnError="WarnAndContinue">
@@ -104,7 +99,7 @@
 
     <!-- Uninstall the global tool if it exists with a different version. -->
     <Exec Condition="Exists('$(GlobalToolsDir)') AND $(DotNetListToolsOutput.Contains('%(RepoTool.Identity)')) AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$(DotNetListToolsOutput)', '$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Identity)'))\s+$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Version)'))'))"
-          Command="$(DotNetCmd) tool uninstall --tool-path &quot;$(GlobalToolsDir)&quot; %(RepoTool.Identity)"
+          Command="&quot;$(DotNetTool)&quot; tool uninstall --tool-path &quot;$(GlobalToolsDir)&quot; %(RepoTool.Identity)"
           WorkingDirectory="$(RepoRoot)"
           ContinueOnError="WarnAndContinue" />
 
@@ -113,7 +108,7 @@
       Creates the global tools folder automatically if it doesn't exist.
     -->
     <Exec Condition="!Exists('$(GlobalToolsDir)') OR !$([System.Text.RegularExpressions.Regex]::IsMatch('$(DotNetListToolsOutput)', '$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Identity)'))\s+$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Version)'))'))"
-          Command="$(DotNetCmd) tool install --tool-path &quot;$(GlobalToolsDir)&quot; %(RepoTool.Identity) --version %(RepoTool.Version) --add-source https:%2F%2Fapi.nuget.org/v3/index.json"
+          Command="&quot;$(DotNetTool)&quot; tool install --tool-path &quot;$(GlobalToolsDir)&quot; %(RepoTool.Identity) --version %(RepoTool.Version) --add-source https:%2F%2Fapi.nuget.org/v3/index.json"
           WorkingDirectory="$(RepoRoot)"
           ContinueOnError="WarnAndContinue" />
 

--- a/eng/configure-toolset.ps1
+++ b/eng/configure-toolset.ps1
@@ -1,5 +1,0 @@
-# We depend on a local cli for a number of our buildtool
-# commands like init-tools so for now we need to disable
-# using the globally installed dotnet
-
-$script:useInstalledDotNetCli = $false

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -1,5 +1,0 @@
-# We depend on a local cli for a number of our buildtool
-# commands like init-tools so for now we need to disable
-# using the globally installed dotnet
-
-useInstalledDotNetCli=false

--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
-  <Import Project="$(PackagesDir)/$(PublishSymbolsPackage.ToLower())/$(PublishSymbolsPackageVersion)/build/PublishSymbols.targets" />
+  <Import Project="$(NuGetPackageRoot)/$(PublishSymbolsPackage.ToLower())/$(PublishSymbolsPackageVersion)/build/PublishSymbols.targets" />
 
   <!-- We need to import Directory.Build.targets at the beginning because there is where we import the restored tools targets, in 
   this case we need Microsoft.DotNet.Build.Tasks.Feed targets to be imported. -->

--- a/external/ILLink/ILLink.depproj
+++ b/external/ILLink/ILLink.depproj
@@ -14,14 +14,14 @@
   <Target Name="IncludeToolsFiles"
           AfterTargets="ResolvePackageAssets">
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(PackagesDir)\$(ILLinkTasksPackageId)\$(ILLinkTasksPackageVersion)\tools\netcoreapp2.0\*.*">
+      <ReferenceCopyLocalPaths Include="$(NuGetPackageRoot)$(ILLinkTasksPackageId)\$(ILLinkTasksPackageVersion)\tools\netcoreapp2.0\*.*">
         <NuGetPackageId>$(ILLinkTasksPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(ILLinkTasksPackageVersion)</NuGetPackageVersion>
         <SubFolder>/netcoreapp2.0/</SubFolder>
       </ReferenceCopyLocalPaths>
     </ItemGroup>
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(PackagesDir)\$(ILLinkTasksPackageId)\$(ILLinkTasksPackageVersion)\tools\net46\*.*">
+      <ReferenceCopyLocalPaths Include="$(NuGetPackageRoot)$(ILLinkTasksPackageId)\$(ILLinkTasksPackageVersion)\tools\net46\*.*">
         <NuGetPackageId>$(ILLinkTasksPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(ILLinkTasksPackageVersion)</NuGetPackageVersion>
         <SubFolder>/net46/</SubFolder>

--- a/external/netfx/netfx.depproj
+++ b/external/netfx/netfx.depproj
@@ -6,7 +6,7 @@
     <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
     <NETStandardSupportPackageId>NETStandard.Library.NETFramework</NETStandardSupportPackageId>
     <NETStandardSupportPackageVersion>2.0.1-servicing-26011-01</NETStandardSupportPackageVersion>
-    <NETStandardSupportRoot>$(PackagesDir)$(NETStandardSupportPackageId.ToLower())\$(NETStandardSupportPackageVersion)\build</NETStandardSupportRoot>
+    <NETStandardSupportRoot>$(NuGetPackageRoot)$(NETStandardSupportPackageId.ToLower())\$(NETStandardSupportPackageVersion)\build</NETStandardSupportRoot>
     <AddNetStandardSupportPackage Condition="'$(TargetGroup)' == 'net461' OR '$(TargetGroup)' == 'net462' OR '$(TargetGroup)' == 'net47'">true</AddNetStandardSupportPackage>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsNetFx)' != 'true'">

--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -77,7 +77,7 @@
 
   <Target Name="AddNETStandard21Refs" AfterTargets="ResolveReferences">
     <PropertyGroup>
-      <_NETStandard21RefFolder>$(PackagesDir)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\netstandard2.1\ref</_NETStandard21RefFolder>
+      <_NETStandard21RefFolder>$(NuGetPackageRoot)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\netstandard2.1\ref</_NETStandard21RefFolder>
     </PropertyGroup>
 
     <ItemGroup>
@@ -94,7 +94,7 @@
   <Target Name="AddNETStandard20Refs" AfterTargets="ResolveReferences"
           Condition="'$(_NETStandardTFMFolder)' != ''">
     <PropertyGroup>
-      <_NETStandardRefFolder>$(PackagesDir)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\$(_NETStandardTFMFolder)\ref</_NETStandardRefFolder>
+      <_NETStandardRefFolder>$(NuGetPackageRoot)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\$(_NETStandardTFMFolder)\ref</_NETStandardRefFolder>
     </PropertyGroup>
 
     <ItemGroup>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -282,11 +282,11 @@
   <Target Name="AddRemoteExecutorLib"
           BeforeTargets="ResolveReferences">
 
-    <Error Condition="!Exists('$(PackagesDir)$(MicrosoftDotNetRemoteExecutorPackage)\$(MicrosoftDotNetRemoteExecutorPackageVersion)\lib\netstandard2.0\Microsoft.DotNet.RemoteExecutor.dll')"
-           Text="Error: looks the package $(PackagesDir)$(MicrosoftDotNetRemoteExecutorPackage)\$(MicrosoftDotNetRemoteExecutorPackageVersion) not restored or missing Microsoft.DotNet.RemoteExecutor.dll." />
+    <Error Condition="!Exists('$(NuGetPackageRoot)$(MicrosoftDotNetRemoteExecutorPackage)\$(MicrosoftDotNetRemoteExecutorPackageVersion)\lib\netstandard2.0\Microsoft.DotNet.RemoteExecutor.dll')"
+           Text="Error: looks the package $(NuGetPackageRoot)$(MicrosoftDotNetRemoteExecutorPackage)\$(MicrosoftDotNetRemoteExecutorPackageVersion) not restored or missing Microsoft.DotNet.RemoteExecutor.dll." />
 
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(PackagesDir)$(MicrosoftDotNetRemoteExecutorPackage)\$(MicrosoftDotNetRemoteExecutorPackageVersion)\lib\netstandard2.0\*.*">
+      <ReferenceCopyLocalPaths Include="$(NuGetPackageRoot)$(MicrosoftDotNetRemoteExecutorPackage)\$(MicrosoftDotNetRemoteExecutorPackageVersion)\lib\netstandard2.0\*.*">
         <Private>false</Private>
         <NuGetPackageId>$(MicrosoftDotNetRemoteExecutorPackage)</NuGetPackageId>
         <NuGetPackageVersion>$(MicrosoftDotNetRemoteExecutorPackageVersion)</NuGetPackageVersion>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -98,7 +98,7 @@
           AfterTargets="AfterResolveReferences">
 
     <ItemGroup>
-      <TraceEventNativeFiles Include="$(PackagesDir)\$(MicrosoftDiagnosticsTracingTraceEventPackageName)\$(TraceEventPackageVersion)\lib\native\**\*.*" />
+      <TraceEventNativeFiles Include="$(NuGetPackageRoot)$(MicrosoftDiagnosticsTracingTraceEventPackageName)\$(TraceEventPackageVersion)\lib\native\**\*.*" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -127,7 +127,7 @@
           AfterTargets="AfterResolveReferences">
 
     <PropertyGroup>
-      <UAPToolsFolder Condition="'$(UAPToolsFolder)'==''">$(PackagesDir)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion)\Tools\$(ArchGroup)</UAPToolsFolder>
+      <UAPToolsFolder Condition="'$(UAPToolsFolder)'==''">$(NuGetPackageRoot)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion)\Tools\$(ArchGroup)</UAPToolsFolder>
       <UAPToolsFolder>$(UAPToolsFolder.Replace('/', '\'))</UAPToolsFolder>
     </PropertyGroup>
 
@@ -162,7 +162,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_microsoftNetTestSdkAssets Include="$(PackagesDir)$(MicrosoftNetTestSdkPackageName)\$(MicrosoftNETTestSdkPackageVersion)\build\$(TestSdkTFM)\*.*" />
+      <_microsoftNetTestSdkAssets Include="$(NuGetPackageRoot)$(MicrosoftNetTestSdkPackageName)\$(MicrosoftNETTestSdkPackageVersion)\build\$(TestSdkTFM)\*.*" />
       <ReferenceCopyLocalPaths Include="@(_microsoftNetTestSdkAssets)">
         <Private>false</Private>
         <NuGetPackageId>$(MicrosoftNetTestSdkPackageName)</NuGetPackageId>
@@ -171,7 +171,7 @@
     </ItemGroup>
 
     <Error Condition="'@(_microsoftNetTestSdkAssets)' == ''"
-           Text="Error: no assets for test sdk package were found under: $(PackagesDir)$(MicrosoftNetTestSdkPackageName)\$(MicrosoftNETTestSdkPackageVersion)\build\$(TestSdkTFM)\*.*" />
+           Text="Error: no assets for test sdk package were found under: $(NuGetPackageRoot)$(MicrosoftNetTestSdkPackageName)\$(MicrosoftNETTestSdkPackageVersion)\build\$(TestSdkTFM)\*.*" />
 
   </Target>
 
@@ -179,25 +179,25 @@
           Condition="'$(TargetGroup)' == 'netcoreapp'"
           BeforeTargets="ResolveReferences">
 
-    <Error Condition="!Exists('$(PackagesDir)$(MicrosoftDotNetXUnitConsoleRunnerPackage)\$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)\lib\netcoreapp2.0\$(XUnitRunner).dll')"
-           Text="Error: looks the package $(PackagesDir)$(MicrosoftDotNetXUnitConsoleRunnerPackage)\$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion) not restored or missing $(XUnitRunner).dll." />
-    <Error Condition="'$(EnableVSTestReferences)' == 'true' AND !Exists('$(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\netcoreapp1.0\$(XUnitAdapter).dll')"
-           Text="Error: looks the package $(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion) not restored or missing $(XUnitAdapter).dll." />
-    <Error Condition="'$(EnableVSTestReferences)' == 'true' AND !Exists('$(PackagesDir)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion)\lib\netstandard1.5\$(TestPlatformHost).dll')"
-           Text="Error: looks the package $(PackagesDir)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion) not restored or missing $(TestPlatformHost).dll." />
+    <Error Condition="!Exists('$(NuGetPackageRoot)$(MicrosoftDotNetXUnitConsoleRunnerPackage)\$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)\lib\netcoreapp2.0\$(XUnitRunner).dll')"
+           Text="Error: looks the package $(NuGetPackageRoot)$(MicrosoftDotNetXUnitConsoleRunnerPackage)\$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion) not restored or missing $(XUnitRunner).dll." />
+    <Error Condition="'$(EnableVSTestReferences)' == 'true' AND !Exists('$(NuGetPackageRoot)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\netcoreapp1.0\$(XUnitAdapter).dll')"
+           Text="Error: looks the package $(NuGetPackageRoot)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion) not restored or missing $(XUnitAdapter).dll." />
+    <Error Condition="'$(EnableVSTestReferences)' == 'true' AND !Exists('$(NuGetPackageRoot)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion)\lib\netstandard1.5\$(TestPlatformHost).dll')"
+           Text="Error: looks the package $(NuGetPackageRoot)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion) not restored or missing $(TestPlatformHost).dll." />
 
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(PackagesDir)$(MicrosoftDotNetXUnitConsoleRunnerPackage)\$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)\lib\netcoreapp2.0\*.*">
+      <ReferenceCopyLocalPaths Include="$(NuGetPackageRoot)$(MicrosoftDotNetXUnitConsoleRunnerPackage)\$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)\lib\netcoreapp2.0\*.*">
         <Private>false</Private>
         <NuGetPackageId>$(MicrosoftDotNetXUnitConsoleRunnerPackage)</NuGetPackageId>
         <NuGetPackageVersion>$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)</NuGetPackageVersion>
       </ReferenceCopyLocalPaths>
-      <ReferenceCopyLocalPaths Condition="'$(EnableVSTestReferences)' == 'true'" Include="$(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\netcoreapp1.0\*.*">
+      <ReferenceCopyLocalPaths Condition="'$(EnableVSTestReferences)' == 'true'" Include="$(NuGetPackageRoot)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\netcoreapp1.0\*.*">
         <Private>false</Private>
         <NuGetPackageId>$(XUnitTestAdapterPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(XUnitPackageVersion)</NuGetPackageVersion>
       </ReferenceCopyLocalPaths>
-      <ReferenceCopyLocalPaths Condition="'$(EnableVSTestReferences)' == 'true'" Include="$(PackagesDir)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion)\lib\netstandard1.5\$(TestPlatformHost).dll">
+      <ReferenceCopyLocalPaths Condition="'$(EnableVSTestReferences)' == 'true'" Include="$(NuGetPackageRoot)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion)\lib\netstandard1.5\$(TestPlatformHost).dll">
         <Private>false</Private>
         <NuGetPackageId>$(TestPlatformHostPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</NuGetPackageVersion>
@@ -210,18 +210,18 @@
           Condition="'$(TargetsUap)' == 'true'"
           BeforeTargets="ResolveReferences">
 
-    <Error Condition="'$(EnableVSTestReferences)' == 'true' AND !Exists('$(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\uap10.0\$(XUnitAdapter).dll')"
-            Text="Error: looks the package $(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion) not restored or missing $(XUnitAdapter).dll." />
-    <Error Condition="'$(EnableVSTestReferences)' == 'true' AND !Exists('$(PackagesDir)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion)\lib\uap10.0\$(TestPlatformHost).dll')"
-            Text="Error: looks the package $(PackagesDir)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion) not restored or missing $(TestPlatformHost).dll." />
+    <Error Condition="'$(EnableVSTestReferences)' == 'true' AND !Exists('$(NuGetPackageRoot)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\uap10.0\$(XUnitAdapter).dll')"
+            Text="Error: looks the package $(NuGetPackageRoot)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion) not restored or missing $(XUnitAdapter).dll." />
+    <Error Condition="'$(EnableVSTestReferences)' == 'true' AND !Exists('$(NuGetPackageRoot)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion)\lib\uap10.0\$(TestPlatformHost).dll')"
+            Text="Error: looks the package $(NuGetPackageRoot)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion) not restored or missing $(TestPlatformHost).dll." />
 
     <ItemGroup>
-      <ReferenceCopyLocalPaths Condition="'$(EnableVSTestReferences)' == 'true'" Include="$(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\uap10.0\*.dll">
+      <ReferenceCopyLocalPaths Condition="'$(EnableVSTestReferences)' == 'true'" Include="$(NuGetPackageRoot)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\uap10.0\*.dll">
         <Private>false</Private>
         <NuGetPackageId>$(XUnitTestAdapterPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(XUnitPackageVersion)</NuGetPackageVersion>
       </ReferenceCopyLocalPaths>
-      <ReferenceCopyLocalPaths Condition="'$(EnableVSTestReferences)' == 'true'" Include="$(PackagesDir)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion)\lib\uap10.0\$(TestPlatformHost).dll">
+      <ReferenceCopyLocalPaths Condition="'$(EnableVSTestReferences)' == 'true'" Include="$(NuGetPackageRoot)$(TestPlatformHostPackageId)\$(MicrosoftNETTestSdkPackageVersion)\lib\uap10.0\$(TestPlatformHost).dll">
         <Private>false</Private>
         <NuGetPackageId>$(TestPlatformHostPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</NuGetPackageVersion>
@@ -234,18 +234,18 @@
           Condition="'$(TargetsAot)' == 'true'"
           BeforeTargets="ResolveReferences">
 
-    <Error Condition="!Exists('$(PackagesDir)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion)\lib\netcoreapp2.0\$(XUnitRunner).dll')"
-           Text="Error: looks the package $(PackagesDir)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion) not restored or missing $(XUnitRunner).dll." />
-    <Error Condition="!Exists('$(PackagesDir)xunit.runner.utility\$(XUnitPackageVersion)\lib\netcoreapp1.0\xunit.runner.utility.netcoreapp10.dll')"
-           Text="Error: looks the package $(PackagesDir)xunit.runner.utility\$(XUnitPackageVersion) not restored or missing xunit.runner.utility.netcoreapp10.dll." />
+    <Error Condition="!Exists('$(NuGetPackageRoot)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion)\lib\netcoreapp2.0\$(XUnitRunner).dll')"
+           Text="Error: looks the package $(NuGetPackageRoot)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion) not restored or missing $(XUnitRunner).dll." />
+    <Error Condition="!Exists('$(NuGetPackageRoot)xunit.runner.utility\$(XUnitPackageVersion)\lib\netcoreapp1.0\xunit.runner.utility.netcoreapp10.dll')"
+           Text="Error: looks the package $(NuGetPackageRoot)xunit.runner.utility\$(XUnitPackageVersion) not restored or missing xunit.runner.utility.netcoreapp10.dll." />
 
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(PackagesDir)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion)\lib\netcoreapp2.0\*.dll">
+      <ReferenceCopyLocalPaths Include="$(PackaNuGetPackageRootgesDir)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion)\lib\netcoreapp2.0\*.dll">
         <Private>false</Private>
         <NuGetPackageId>$(MicrosoftDotNetUapTestToolsPackageName)</NuGetPackageId>
         <NuGetPackageVersion>$(MicrosoftDotNetUapTestToolsPackageVersion)</NuGetPackageVersion>
       </ReferenceCopyLocalPaths>
-      <ReferenceCopyLocalPaths Include="$(PackagesDir)xunit.runner.utility\$(XUnitPackageVersion)\lib\netcoreapp1.0\*.dll">
+      <ReferenceCopyLocalPaths Include="$(NuGetPackageRoot)xunit.runner.utility\$(XUnitPackageVersion)\lib\netcoreapp1.0\*.dll">
         <Private>false</Private>
         <NuGetPackageId>xunit.runner.utility</NuGetPackageId>
         <NuGetPackageVersion>$(XUnitPackageVersion)</NuGetPackageVersion>
@@ -258,19 +258,19 @@
           Condition="'$(TargetGroup)' == 'netfx'"
           BeforeTargets="ResolveReferences">
 
-    <Error Condition="!Exists('$(PackagesDir)$(XUnitRunnerConsolePackageName)\$(XUnitPackageVersion)\tools\net472\$(XUnitRunner).exe')"
-           Text="Error: looks the package $(PackagesDir)$(XUnitRunnerConsolePackageName)\$(XUnitPackageVersion) not restored or missing $(XUnitRunner).exe." />
-    <Error Condition="'$(EnableVSTestReferences)' == 'true' AND !Exists('$(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\_common\$(XUnitAdapter).dll')"
-           Text="Error: looks the package $(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion) not restored or missing $(XUnitAdapter).dll." />
+    <Error Condition="!Exists('$(NuGetPackageRoot)$(XUnitRunnerConsolePackageName)\$(XUnitPackageVersion)\tools\net472\$(XUnitRunner).exe')"
+           Text="Error: looks the package $(NuGetPackageRoot)$(XUnitRunnerConsolePackageName)\$(XUnitPackageVersion) not restored or missing $(XUnitRunner).exe." />
+    <Error Condition="'$(EnableVSTestReferences)' == 'true' AND !Exists('$(NuGetPackageRoot)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\_common\$(XUnitAdapter).dll')"
+           Text="Error: looks the package $(NuGetPackageRoot)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion) not restored or missing $(XUnitAdapter).dll." />
 
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(PackagesDir)$(XUnitRunnerConsolePackageName)\$(XUnitPackageVersion)\tools\net472\*.*"
-                               Exclude="$(PackagesDir)$(XUnitRunnerConsolePackageName)\$(XUnitPackageVersion)\tools\net472\xunit.console.*exe.config">
+      <ReferenceCopyLocalPaths Include="$(NuGetPackageRoot)$(XUnitRunnerConsolePackageName)\$(XUnitPackageVersion)\tools\net472\*.*"
+                               Exclude="$(NuGetPackageRoot)$(XUnitRunnerConsolePackageName)\$(XUnitPackageVersion)\tools\net472\xunit.console.*exe.config">
         <Private>false</Private>
         <NuGetPackageId>$(XUnitRunnerConsolePackageName)</NuGetPackageId>
         <NuGetPackageVersion>$(XUnitPackageVersion)</NuGetPackageVersion>
       </ReferenceCopyLocalPaths>
-      <ReferenceCopyLocalPaths Condition="'$(EnableVSTestReferences)' == 'true'" Include="$(PackagesDir)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\_common\*.*">
+      <ReferenceCopyLocalPaths Condition="'$(EnableVSTestReferences)' == 'true'" Include="$(NuGetPackageRoot)$(XUnitTestAdapterPackageId)\$(XUnitPackageVersion)\build\_common\*.*">
         <Private>false</Private>
         <NuGetPackageId>$(XUnitTestAdapterPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(XUnitPackageVersion)</NuGetPackageVersion>

--- a/external/test-runtime/XUnit.Runtime.depproj
+++ b/external/test-runtime/XUnit.Runtime.depproj
@@ -240,7 +240,7 @@
            Text="Error: looks the package $(NuGetPackageRoot)xunit.runner.utility\$(XUnitPackageVersion) not restored or missing xunit.runner.utility.netcoreapp10.dll." />
 
     <ItemGroup>
-      <ReferenceCopyLocalPaths Include="$(PackaNuGetPackageRootgesDir)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion)\lib\netcoreapp2.0\*.dll">
+      <ReferenceCopyLocalPaths Include="$(NuGetPackageRoot)$(MicrosoftDotNetUapTestToolsPackageName)\$(MicrosoftDotNetUapTestToolsPackageVersion)\lib\netcoreapp2.0\*.dll">
         <Private>false</Private>
         <NuGetPackageId>$(MicrosoftDotNetUapTestToolsPackageName)</NuGetPackageId>
         <NuGetPackageVersion>$(MicrosoftDotNetUapTestToolsPackageVersion)</NuGetPackageVersion>

--- a/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
+++ b/pkg/Microsoft.Private.PackageBaseline/Microsoft.Private.PackageBaseline.pkgproj
@@ -30,10 +30,10 @@
       <FrameworkLayout Include="$(UAPPackageRefPath)">
         <TargetFramework>$(UAPvNextTFM)</TargetFramework>
       </FrameworkLayout>
-      <FrameworkLayout Include="$(PackagesDir)$(NETStandardLibraryPackageId)\$(NETStandardLibraryPackageVersion)\build\netstandard2.0\ref">
+      <FrameworkLayout Include="$(NuGetPackageRoot)$(NETStandardLibraryPackageId)\$(NETStandardLibraryPackageVersion)\build\netstandard2.0\ref">
         <TargetFramework>netstandard2.0</TargetFramework>
       </FrameworkLayout>
-      <FrameworkLayout Include="$(PackagesDir)$(NETStandardLibraryPackageId)\$(NETStandardLibraryPackageVersion)\build\net461\ref">
+      <FrameworkLayout Include="$(NuGetPackageRoot)$(NETStandardLibraryPackageId)\$(NETStandardLibraryPackageVersion)\build\net461\ref">
         <TargetFramework>net461</TargetFramework>
       </FrameworkLayout>
     </ItemGroup>

--- a/pkg/frameworkPackage.targets
+++ b/pkg/frameworkPackage.targets
@@ -5,7 +5,7 @@
     <PreventImplementationReference Condition="'$(PackageTargetRuntime)' != ''">true</PreventImplementationReference>
 
     <NETStandardVersion Condition="'$(NETStandardVersion)' == ''">2.0</NETStandardVersion>
-    <NETStandardPackageRefPath Condition="'$(NETStandardPackageRefPath)' == ''">$(PackagesDir)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\netstandard$(NETStandardVersion)\ref</NETStandardPackageRefPath>
+    <NETStandardPackageRefPath Condition="'$(NETStandardPackageRefPath)' == ''">$(NuGetPackageRoot)$(NETStandardLibraryPackageId.ToLower())\$(NETStandardLibraryPackageVersion)\build\netstandard$(NETStandardVersion)\ref</NETStandardPackageRefPath>
 
     <IncludeReferenceFiles Condition="'$(IncludeReferenceFiles)' == '' AND '$(PackageTargetRuntime)' == ''">true</IncludeReferenceFiles>
     <IncludeLibFiles Condition="'$(IncludeLibFiles)' == '' AND '$(PackageTargetRuntime)' != ''">true</IncludeLibFiles>

--- a/pkg/test/testPackages.proj
+++ b/pkg/test/testPackages.proj
@@ -40,7 +40,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <TestSupportFiles Include="$(DotnetCliPath)\**\*.*" Exclude="$(DotnetCliPath)\sdk\NuGetFallbackFolder\**\*.*">
+    <TestSupportFiles Include="$(DotNetRoot)**\*.*" Exclude="$(DotNetRoot)sdk\NuGetFallbackFolder\**\*.*">
       <DestinationFolder>$(TestToolsDir)%(RecursiveDir)</DestinationFolder>
     </TestSupportFiles>
     <TestSupportFiles Include="$(SourceDir)shims\netfxreference.props">

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -153,7 +153,7 @@
     <Compile Include="XTypeDescriptionProviderTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.componentmodel.typeconverter.testdata\1.0.1\content\**\*.*">
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.componentmodel.typeconverter.testdata\1.0.1\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -86,22 +86,22 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\**\*.*">
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.drawing.common.testdata\$(TestDataPackageVersion)\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
-    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\48x48_multiple_entries_4bit.ico">
+    <EmbeddedResource Include="$(NuGetPackageRoot)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\48x48_multiple_entries_4bit.ico">
       <LogicalName>System.Drawing.Tests.48x48_multiple_entries_4bit.ico</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\bitmap_173x183_indexed_8bit.bmp">
+    <EmbeddedResource Include="$(NuGetPackageRoot)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\bitmap_173x183_indexed_8bit.bmp">
       <LogicalName>System.Drawing.Tests.bitmap_173x183_indexed_8bit.bmp</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\empty.file">
+    <EmbeddedResource Include="$(NuGetPackageRoot)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\empty.file">
       <LogicalName>System.Drawing.Tests.empty.file</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\invalid.ico">
+    <EmbeddedResource Include="$(NuGetPackageRoot)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\invalid.ico">
       <LogicalName>System.Drawing.Tests.invalid.ico</LogicalName>
     </EmbeddedResource>
-	<EmbeddedResource Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\256x256_one_entry_32bit.ico">
+	<EmbeddedResource Include="$(NuGetPackageRoot)system.drawing.common.testdata\$(TestDataPackageVersion)\content\bitmaps\256x256_one_entry_32bit.ico">
       <LogicalName>System.Drawing.Tests.Icon_toolboxBitmapAttributeTest</LogicalName>
     </EmbeddedResource>
     <Compile Include="Printing\MarginsTests.cs" />

--- a/src/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
+++ b/src/System.IO.Compression.Brotli/tests/System.IO.Compression.Brotli.Tests.csproj
@@ -28,7 +28,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.8\content\**\*.*">
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.io.compression.testdata\1.0.8\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -38,7 +38,7 @@
     <Compile Include="ZipFile.Extract.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.8\content\**\*.*">
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.io.compression.testdata\1.0.8\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -49,7 +49,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.io.compression.testdata\1.0.8\content\**\*.*">
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.io.compression.testdata\1.0.8\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>

--- a/src/System.IO.Packaging/tests/System.IO.Packaging.Tests.csproj
+++ b/src/System.IO.Packaging/tests/System.IO.Packaging.Tests.csproj
@@ -7,6 +7,6 @@
     <Compile Include="Tests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.io.packaging.testdata\1.0.1\content\**\*.*" />
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.io.packaging.testdata\1.0.1\content\**\*.*" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -172,7 +172,7 @@
     <Compile Include="XUnitAssemblyAttributes.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.net.testdata\1.0.2\content\**\*.*" DestinationDir="TestData" />
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.net.testdata\1.0.2\content\**\*.*" DestinationDir="TestData" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsOSX)'=='true'">
     <TestCommandLines Include="ulimit -Sn 4096" />

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -158,6 +158,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.net.testdata\1.0.2\content\**\*.*" DestinationDir="TestData" />
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.net.testdata\1.0.2\content\**\*.*" DestinationDir="TestData" />
   </ItemGroup>
 </Project>

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -61,6 +61,6 @@
     <Compile Include="WebSocketHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.net.testdata\1.0.2\content\**\*.*" DestinationDir="TestData" />
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.net.testdata\1.0.2\content\**\*.*" DestinationDir="TestData" />
   </ItemGroup>
 </Project>

--- a/src/System.Resources.Extensions/tests/System.Resources.Extensions.Tests.csproj
+++ b/src/System.Resources.Extensions/tests/System.Resources.Extensions.Tests.csproj
@@ -11,7 +11,7 @@
     <Compile Include="MyResourceType.cs" />
     <Compile Include="TestData.cs" />
     <Compile Include="BinaryResourceWriterUnitTest.cs" />
-    <SupplementalTestData Include="$(PackagesDir)system.drawing.common.testdata\$(TestDataPackageVersion)\content\**\*.*" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.drawing.common.testdata\$(TestDataPackageVersion)\content\**\*.*" Link="%(RecursiveDir)%(Filename)%(Extension)" />
     <EmbeddedResource Include="TestData.resources" WithCulture="false" Type="Non-Resx" />
   </ItemGroup>
   <!-- use the following target to regenerate the test resources file

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/pkg/System.Runtime.WindowsRuntime.UI.Xaml.pkgproj
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/pkg/System.Runtime.WindowsRuntime.UI.Xaml.pkgproj
@@ -19,7 +19,7 @@
 
     <!-- We can't harvest an asset from more than one path -->
      <!-- Disable support for netcoreapp1.0 - netcoreapp2.0 for now.  To support these we need to build the src project for the old TFMs 
-    <File Include="$(PackagesDir)\System.Runtime.WindowsRuntime.UI.Xaml\4.3.0\runtimes\win8\lib\netstandard1.3\System.Runtime.WindowsRuntime.UI.Xaml.dll">
+    <File Include="$(NuGetPackageRoot)System.Runtime.WindowsRuntime.UI.Xaml\4.3.0\runtimes\win8\lib\netstandard1.3\System.Runtime.WindowsRuntime.UI.Xaml.dll">
       <TargetPath>runtimes/win/lib/netcoreapp1.0</TargetPath>
       <TargetFramework>netcoreapp1.0</TargetFramework>
     </File>-->

--- a/src/System.Runtime.WindowsRuntime/pkg/System.Runtime.WindowsRuntime.pkgproj
+++ b/src/System.Runtime.WindowsRuntime/pkg/System.Runtime.WindowsRuntime.pkgproj
@@ -22,7 +22,7 @@
 
     <!-- We can't harvest an assert to more than one path -->
     <!-- Disable support for netcoreapp1.0 - netcoreapp2.0 for now.  To support these we need to build the src project for the old TFMs 
-    <File Include="$(PackagesDir)\System.Runtime.WindowsRuntime\4.3.0\runtimes\win8\lib\netstandard1.3\System.Runtime.WindowsRuntime.dll">
+    <File Include="$(NuGetPackageRoot)System.Runtime.WindowsRuntime\4.3.0\runtimes\win8\lib\netstandard1.3\System.Runtime.WindowsRuntime.dll">
       <TargetPath>runtimes/win/lib/netcoreapp1.0</TargetPath>
       <TargetFramework>netcoreapp1.0</TargetFramework>
     </File>  -->

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -128,6 +128,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.security.cryptography.x509certificates.testdata\1.0.3\content\**\*.*" DestinationDir="TestData" />
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.security.cryptography.x509certificates.testdata\1.0.3\content\**\*.*" DestinationDir="TestData" />
   </ItemGroup>
 </Project>

--- a/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
+++ b/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
@@ -25,10 +25,10 @@
     <Compile Include="System\Media\SystemSoundsTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)system.componentmodel.typeconverter.testdata\$(SystemComponentmodelTypeconverterTestdataVersion)\content\**\*.*">
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.componentmodel.typeconverter.testdata\$(SystemComponentmodelTypeconverterTestdataVersion)\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
-    <SupplementalTestData Include="$(PackagesDir)system.windows.extensions.testdata\$(SystemWindowsExtensionsTestdataVersion)\content\**\*.*">
+    <SupplementalTestData Include="$(NuGetPackageRoot)system.windows.extensions.testdata\$(SystemWindowsExtensionsTestdataVersion)\content\**\*.*">
       <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
     </SupplementalTestData>
   </ItemGroup>


### PR DESCRIPTION
Depends on https://github.com/dotnet/arcade/pull/2753

- Use global dotnet if applicable
- Remove dead dependency code
- Use Arcade props

For reviewing:
- Renamed all occurrences of `PackagesDir` to `NuGetPackageRoot`
- Removed configure-toolset scripts as we don't necessarily depend anymore on the local dotnet installation
- Replace `DotNetCmd` with `DotNetTool`