### PR TITLE
disable UDS tests on Nano

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.netcoreapp.cs
@@ -445,7 +445,7 @@ namespace System.Net.Sockets.Tests
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     // UDS support added in April 2018 Update
-                    if (!PlatformDetection.IsWindows10Version1803OrGreater)
+                    if (!PlatformDetection.IsWindows10Version1803OrGreater || PlatformDetection.IsWindowsNanoServer)
                     {
                         return false;
                     }


### PR DESCRIPTION
Currently we exclude Nano via !PlatformDetection.IsWindows10Version1803OrGreater
However new Nano images do pass that check and fail with 
```
System.Net.Sockets.SocketException : An address incompatible with the requested protocol was used.
```
