### PR TITLE
Don't reference netstandard.dll by wildcard

### DIFF
--- a/src/shims/generated/Directory.Build.props
+++ b/src/shims/generated/Directory.Build.props
@@ -14,7 +14,7 @@
     <!-- reference everything but self -->
     <ReferencePath
       Include="$(RefPath)*.dll"
-      Exclude="$(RefPath)$(MSBuildProjectName).dll" />
+      Exclude="$(RefPath)$(MSBuildProjectName).dll;$(RefPath)netstandard.dll" />
 
     <!-- required by compiler to resolve core types -->
     <ProjectReference Condition="'$(MSBuildProjectName)' != 'netstandard'"


### PR DESCRIPTION
NetStandard.dll is built during the same phase as the other generated shims.
We use a ProjectReference to correctly sequence it before other generated
shims.  Make sure that building a generated shim after building
netstandard.csproj doesn't result in 2 netstandard.dll's being passed to
the compiler.