### PR TITLE
Fix serialization of Dictionary<string, object>

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -51,7 +51,7 @@ namespace System.Text.Json.Serialization
                 // Check for polymorphism.
                 if (elementClassInfo.ClassType == ClassType.Unknown)
                 {
-                    object currentValue = ((IDictionaryEnumerator)state.Current.Enumerator).Entry;
+                    object currentValue = ((IDictionaryEnumerator)state.Current.Enumerator).Entry.Value;
                     GetRuntimeClassInfo(currentValue, ref elementClassInfo, options);
                 }
 
@@ -110,6 +110,11 @@ namespace System.Text.Json.Serialization
                 // Avoid boxing for strongly-typed enumerators such as returned from IDictionary<string, TRuntimeProperty>
                 value = enumerator.Current.Value;
                 key = enumerator.Current.Key;
+            }
+            else if (current.Enumerator is IEnumerator<KeyValuePair<string, object>> polymorphicEnumerator)
+            {
+                value = (TProperty)polymorphicEnumerator.Current.Value;
+                key = polymorphicEnumerator.Current.Key;
             }
             else
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -52,8 +52,11 @@ namespace System.Text.Json.Serialization
                     return false;
                 }
 
+                // We've got a property info. If we're a Value or polymorphic Value
+                // (ClassType.Unknown), return true.
                 ClassType type = JsonPropertyInfo.ClassType;
-                return type == ClassType.Value || type == ClassType.Unknown;
+                return type == ClassType.Value || type == ClassType.Unknown
+                    || (type == ClassType.Dictionary && KeyName != null && JsonClassInfo.ElementClassInfo.ClassType == ClassType.Unknown);
             }
         }
 

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -65,9 +65,39 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void DictionaryOfObjectFail()
+        public static void DictionaryOfObject()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<Dictionary<string, object>>(@"{""Key1"":1"));
+            Dictionary<string, object> obj = JsonSerializer.Parse<Dictionary<string, object>>(@"{""Key1"":1}");
+            Assert.Equal(1, obj.Count);
+            JsonElement element = (JsonElement)obj["Key1"];
+            Assert.Equal(JsonValueType.Number, element.Type);
+            Assert.Equal(1, element.GetInt32());
+
+            string json = JsonSerializer.ToString(obj);
+            Assert.Equal(@"{""Key1"":1}", json);
+        }
+
+        [Fact]
+        public static void DictionaryOfObject_37569()
+        {
+            // https://github.com/dotnet/corefx/issues/37569
+            Dictionary<string, object> dictionary = new Dictionary<string, object>
+            {
+                ["key"] = new Poco { Id = 10 },
+            };
+
+            string json = JsonSerializer.ToString(dictionary);
+            Assert.Equal(@"{""key"":{""Id"":10}}", json);
+
+            dictionary = JsonSerializer.Parse<Dictionary<string, object>>(json);
+            Assert.Equal(1, dictionary.Count);
+            JsonElement element = (JsonElement)dictionary["key"];
+            Assert.Equal(@"{""Id"":10}", element.ToString());
+        }
+
+        class Poco
+        {
+            public int Id { get; set; }
         }
 
         [Fact]


### PR DESCRIPTION
We didn't drill into the value type (of the key/value pair, i.e. "object") properly when serializing.

Fixes #37569