### PR TITLE
Add interleaved comments to JsonSerializer tests

### DIFF
--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -135,6 +135,16 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ReadClassWithNestedComments()
+        {
+            var options = new JsonSerializerOptions();
+            options.ReadCommentHandling = JsonCommentHandling.Skip;
+
+            TestClassWithNestedObjectCommentsOuter obj = JsonSerializer.Parse<TestClassWithNestedObjectCommentsOuter>(TestClassWithNestedObjectCommentsOuter.s_data, options);
+            obj.Verify();
+        }
+
+        [Fact]
         public static void ReadEmpty()
         {
             SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>("{}");

--- a/src/System.Text.Json/tests/Serialization/TestClasses.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.cs
@@ -1274,4 +1274,53 @@ namespace System.Text.Json.Serialization.Tests
         // A 400 character property name with a unicode character making it 401 bytes.
         public int Aѧ34567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 { get; set; }
     }
+
+    public class TestClassWithNestedObjectCommentsInner : ITestClass
+    {
+        public SimpleTestClass MyData { get; set; }
+
+        public static readonly string s_json =
+            @"{" +
+                @"""MyData"":" + SimpleTestClass.s_json + " // Trailing comment\n" +
+                "/* Multi\nLine Comment with } */\n" +
+            @"}";
+
+        public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
+
+        public void Initialize()
+        {
+            MyData = new SimpleTestClass();
+            MyData.Initialize();
+        }
+
+        public void Verify()
+        {
+            Assert.NotNull(MyData);
+            MyData.Verify();
+        }
+    }
+
+    public class TestClassWithNestedObjectCommentsOuter : ITestClass
+    {
+        public TestClassWithNestedObjectCommentsInner MyData { get; set; }
+
+        public static readonly byte[] s_data = Encoding.UTF8.GetBytes(
+            @"{" +
+                " // This } will be ignored\n" +
+                @"""MyData"":" + TestClassWithNestedObjectCommentsInner.s_json +
+                " /* As will this [ */\n" +
+            @"}");
+
+        public void Initialize()
+        {
+            MyData = new TestClassWithNestedObjectCommentsInner();
+            MyData.Initialize();
+        }
+
+        public void Verify()
+        {
+            Assert.NotNull(MyData);
+            MyData.Verify();
+        }
+    }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -310,6 +310,19 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(4, i[1][1]);
         }
 
+        [Fact]
+        public static void ReadArrayWithInterleavedComments()
+        {
+            var options = new JsonSerializerOptions();
+            options.ReadCommentHandling = JsonCommentHandling.Skip;
+
+            int[][] i = JsonSerializer.Parse<int[][]>(Encoding.UTF8.GetBytes("[[1,2] // Inline [\n,[3, /* Multi\n]] Line*/4]]"), options);
+            Assert.Equal(1, i[0][0]);
+            Assert.Equal(2, i[0][1]);
+            Assert.Equal(3, i[1][0]);
+            Assert.Equal(4, i[1][1]);
+        }
+
         public class TestClassWithBadData
         {
             public TestChildClassWithBadData[] Children { get; set; }


### PR DESCRIPTION
Per this PR comment https://github.com/dotnet/corefx/pull/37549#discussion_r283069971 this adds tests for interleaved comments within JSON objects and arrays.

cc @ahsonkhan 