### PR TITLE
Executing tests in a Serial order to avoid some Failure

### DIFF
--- a/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -3,6 +3,7 @@
     <ProjectGuid>{7669C397-C21C-4C08-83F1-BE6691911E88}</ProjectGuid>
     <!-- XUnit AppDomains BaseDirectory path doesn't contain a trailing slash, which impacts our tests. -->
     <XUnitNoAppdomain>true</XUnitNoAppdomain>
+    <XUnitMaxThreads>1</XUnitMaxThreads>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <Configurations>netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>


### PR DESCRIPTION
Related Issue https://github.com/dotnet/corefx/issues/15066

Before Change (12 threads)
```
 System.Configuration.ConfigurationManager.Tests  Total: 632, Errors: 0, Failed: 0, Skipped: 0, Time: 0.872s
```
After change (1 thread)
```
System.Configuration.ConfigurationManager.Tests  Total: 632, Errors: 0, Failed: 0, Skipped: 0, Time: 2.055s
```