### PR TITLE
Add readonly modifiers to SequenceReader.

### DIFF
--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -199,7 +199,6 @@ namespace System.Buffers
     public readonly partial struct ReadOnlySequence<T>
     {
         private readonly object _dummy;
-        private readonly int _dummyPrimitive;
         public static readonly System.Buffers.ReadOnlySequence<T> Empty;
         public ReadOnlySequence(System.Buffers.ReadOnlySequenceSegment<T> startSegment, int startIndex, System.Buffers.ReadOnlySequenceSegment<T> endSegment, int endIndex) { throw null; }
         public ReadOnlySequence(System.ReadOnlyMemory<T> memory) { throw null; }
@@ -246,16 +245,17 @@ namespace System.Buffers
     }
     public ref partial struct SequenceReader<T> where T : unmanaged, System.IEquatable<T>
     {
+        private readonly object _dummy;
         public SequenceReader(System.Buffers.ReadOnlySequence<T> sequence) { throw null; }
-        public long Consumed { get { throw null; } }
-        public System.ReadOnlySpan<T> CurrentSpan { get { throw null; } }
-        public int CurrentSpanIndex { get { throw null; } }
-        public bool End { get { throw null; } }
-        public long Length { get { throw null; } }
-        public System.SequencePosition Position { get { throw null; } }
-        public long Remaining { get { throw null; } }
-        public System.Buffers.ReadOnlySequence<T> Sequence { get { throw null; } }
-        public System.ReadOnlySpan<T> UnreadSpan { get { throw null; } }
+        public readonly long Consumed { get { throw null; } }
+        public readonly System.ReadOnlySpan<T> CurrentSpan { get { throw null; }  }
+        public readonly int CurrentSpanIndex { get { throw null; } }
+        public readonly bool End { get { throw null; } }
+        public readonly long Length { get { throw null; } }
+        public readonly System.SequencePosition Position { get { throw null; } }
+        public readonly long Remaining { get { throw null; } }
+        public readonly System.Buffers.ReadOnlySequence<T> Sequence { get { throw null; } }
+        public readonly System.ReadOnlySpan<T> UnreadSpan { get { throw null; } }
         public void Advance(long count) { }
         public long AdvancePast(T value) { throw null; }
         public long AdvancePastAny(System.ReadOnlySpan<T> values) { throw null; }
@@ -267,8 +267,8 @@ namespace System.Buffers
         public void Rewind(long count) { }
         public bool TryAdvanceTo(T delimiter, bool advancePastDelimiter = true) { throw null; }
         public bool TryAdvanceToAny(System.ReadOnlySpan<T> delimiters, bool advancePastDelimiter = true) { throw null; }
-        public bool TryCopyTo(System.Span<T> destination) { throw null; }
-        public bool TryPeek(out T value) { throw null; }
+        public readonly bool TryCopyTo(System.Span<T> destination) { throw null; }
+        public readonly bool TryPeek(out T value) { throw null; }
         public bool TryRead(out T value) { throw null; }
         public bool TryReadTo(out System.Buffers.ReadOnlySequence<T> sequence, System.ReadOnlySpan<T> delimiter, bool advancePastDelimiter = true) { throw null; }
         public bool TryReadTo(out System.Buffers.ReadOnlySequence<T> sequence, T delimiter, bool advancePastDelimiter = true) { throw null; }

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -199,6 +199,7 @@ namespace System.Buffers
     public readonly partial struct ReadOnlySequence<T>
     {
         private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public static readonly System.Buffers.ReadOnlySequence<T> Empty;
         public ReadOnlySequence(System.Buffers.ReadOnlySequenceSegment<T> startSegment, int startIndex, System.Buffers.ReadOnlySequenceSegment<T> endSegment, int endIndex) { throw null; }
         public ReadOnlySequence(System.ReadOnlyMemory<T> memory) { throw null; }

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -245,10 +245,10 @@ namespace System.Buffers
     }
     public ref partial struct SequenceReader<T> where T : unmanaged, System.IEquatable<T>
     {
-        private readonly object _dummy;
+        private object _dummy;
         public SequenceReader(System.Buffers.ReadOnlySequence<T> sequence) { throw null; }
         public readonly long Consumed { get { throw null; } }
-        public readonly System.ReadOnlySpan<T> CurrentSpan { get { throw null; }  }
+        public readonly System.ReadOnlySpan<T> CurrentSpan { get { throw null; } }
         public readonly int CurrentSpanIndex { get { throw null; } }
         public readonly bool End { get { throw null; } }
         public readonly long Length { get { throw null; } }

--- a/src/System.Memory/ref/System.Memory.cs
+++ b/src/System.Memory/ref/System.Memory.cs
@@ -247,6 +247,7 @@ namespace System.Buffers
     public ref partial struct SequenceReader<T> where T : unmanaged, System.IEquatable<T>
     {
         private object _dummy;
+        private int _dummyPrimitive;
         public SequenceReader(System.Buffers.ReadOnlySequence<T> sequence) { throw null; }
         public readonly long Consumed { get { throw null; } }
         public readonly System.ReadOnlySpan<T> CurrentSpan { get { throw null; } }

--- a/src/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -84,7 +84,7 @@ namespace System.Buffers
         /// <summary>
         /// Count of <typeparamref name="T"/> in the reader's <see cref="Sequence"/>.
         /// </summary>
-        public long Length { readonly get; private set; }
+        public readonly long Length { get; }
 
         /// <summary>
         /// Peeks at the next value without advancing the reader.

--- a/src/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -12,7 +12,6 @@ namespace System.Buffers
         private SequencePosition _currentPosition;
         private SequencePosition _nextPosition;
         private bool _moreData;
-        private long _length;
 
         /// <summary>
         /// Create a <see cref="SequenceReader{T}"/> over the given <see cref="ReadOnlySequence{T}"/>.
@@ -24,7 +23,7 @@ namespace System.Buffers
             Consumed = 0;
             Sequence = sequence;
             _currentPosition = sequence.Start;
-            _length = -1;
+            Length = Sequence.Length;
 
             sequence.GetFirstSpan(out ReadOnlySpan<T> first, out _nextPosition);
             CurrentSpan = first;
@@ -40,33 +39,33 @@ namespace System.Buffers
         /// <summary>
         /// True when there is no more data in the <see cref="Sequence"/>.
         /// </summary>
-        public bool End => !_moreData;
+        public readonly bool End => !_moreData;
 
         /// <summary>
         /// The underlying <see cref="ReadOnlySequence{T}"/> for the reader.
         /// </summary>
-        public ReadOnlySequence<T> Sequence { get; }
+        public readonly ReadOnlySequence<T> Sequence { get; }
 
         /// <summary>
         /// The current position in the <see cref="Sequence"/>.
         /// </summary>
-        public SequencePosition Position
+        public readonly SequencePosition Position
             => Sequence.GetPosition(CurrentSpanIndex, _currentPosition);
 
         /// <summary>
         /// The current segment in the <see cref="Sequence"/> as a span.
         /// </summary>
-        public ReadOnlySpan<T> CurrentSpan { get; private set; }
+        public ReadOnlySpan<T> CurrentSpan { readonly get; private set; }
 
         /// <summary>
         /// The index in the <see cref="CurrentSpan"/>.
         /// </summary>
-        public int CurrentSpanIndex { get; private set; }
+        public int CurrentSpanIndex { readonly get; private set; }
 
         /// <summary>
         /// The unread portion of the <see cref="CurrentSpan"/>.
         /// </summary>
-        public ReadOnlySpan<T> UnreadSpan
+        public readonly ReadOnlySpan<T> UnreadSpan
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => CurrentSpan.Slice(CurrentSpanIndex);
@@ -75,28 +74,17 @@ namespace System.Buffers
         /// <summary>
         /// The total number of <typeparamref name="T"/>'s processed by the reader.
         /// </summary>
-        public long Consumed { get; private set; }
+        public long Consumed { readonly get; private set; }
 
         /// <summary>
         /// Remaining <typeparamref name="T"/>'s in the reader's <see cref="Sequence"/>.
         /// </summary>
-        public long Remaining => Length - Consumed;
+        public readonly long Remaining => Length - Consumed;
 
         /// <summary>
         /// Count of <typeparamref name="T"/> in the reader's <see cref="Sequence"/>.
         /// </summary>
-        public long Length
-        {
-            get
-            {
-                if (_length < 0)
-                {
-                    // Cache the length
-                    _length = Sequence.Length;
-                }
-                return _length;
-            }
-        }
+        public long Length { readonly get; private set; }
 
         /// <summary>
         /// Peeks at the next value without advancing the reader.
@@ -104,7 +92,7 @@ namespace System.Buffers
         /// <param name="value">The next value or default if at the end.</param>
         /// <returns>False if at the end of the reader.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryPeek(out T value)
+        public readonly bool TryPeek(out T value)
         {
             if (_moreData)
             {
@@ -153,7 +141,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Rewind(long count)
         {
-            if (count < 0 || count > Consumed)
+            if ((ulong)count > (ulong)Consumed)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count);
             }
@@ -337,7 +325,7 @@ namespace System.Buffers
         /// <param name="destination">Destination span to copy to.</param>
         /// <returns>True if there is enough data to completely fill the <paramref name="destination"/> span.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryCopyTo(Span<T> destination)
+        public readonly bool TryCopyTo(Span<T> destination)
         {
             // This API doesn't advance to facilitate conditional advancement based on the data returned.
             // We don't provide an advance option to allow easier utilizing of stack allocated destination spans.
@@ -354,7 +342,7 @@ namespace System.Buffers
             return TryCopyMultisegment(destination);
         }
 
-        internal bool TryCopyMultisegment(Span<T> destination)
+        internal readonly bool TryCopyMultisegment(Span<T> destination)
         {
             // If we don't have enough to fill the requested buffer, return false
             if (Remaining < destination.Length)

--- a/src/System.Memory/src/System/Buffers/SequenceReader.cs
+++ b/src/System.Memory/src/System/Buffers/SequenceReader.cs
@@ -91,7 +91,7 @@ namespace System.Buffers
         {
             get
             {
-                if (_length == -1)
+                if (_length < 0)
                 {
                     // Cast-away readonly to initialize lazy field
                     Volatile.Write(ref Unsafe.AsRef(_length), Sequence.Length);

--- a/src/System.Memory/tests/SequenceReader/Rewind.cs
+++ b/src/System.Memory/tests/SequenceReader/Rewind.cs
@@ -80,7 +80,29 @@ namespace System.Memory.Tests.SequenceReader
             Assert.Throws<ArgumentOutOfRangeException>(() => new SequenceReader<byte>(bytes).Rewind(-1));
 
             // Can't pull more than we consumed
-            Assert.Throws<ArgumentOutOfRangeException>(() => new SequenceReader<byte>(bytes).Rewind(1));
+            SequenceReader<byte> reader = new SequenceReader<byte>(bytes);
+            try
+            {
+                reader.Rewind(1);
+                Assert.True(false, "no exception thrown");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // Expected
+            }
+            Assert.Equal(0, reader.Consumed);
+
+            reader.Advance(1);
+            try
+            {
+                reader.Rewind(2);
+                Assert.True(false, "no exception thrown");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // Expected
+            }
+            Assert.Equal(1, reader.Consumed);
         }
 
         [Fact]

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="SequenceReader\Advance.cs" />
     <Compile Include="SequenceReader\BasicTests.cs" />
     <Compile Include="SequenceReader\BinaryExtensions.cs" />
+    <Compile Include="SequenceReader\CopyTo.cs" />
     <Compile Include="SequenceReader\IsNext.cs" />
     <Compile Include="SequenceReader\OwnedArray.cs" />
     <Compile Include="SequenceReader\ReadTo.cs" />
@@ -38,7 +39,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AllocationHelper.cs" />
-    <Compile Include="SequenceReader\CopyTo.cs" />
     <Compile Include="TInt.cs" />
     <Compile Include="TestException.cs" />
     <Compile Include="TestHelpers.cs" />


### PR DESCRIPTION
Clearly marking where we don't mutate faciliates passing stack allocated spans and allows composing additional helpers that also want to describe that they don't mutate.

Also expand on a rewind test.