### PR TITLE
Fix minor typo NanoSeconds -> nanoseconds

### DIFF
--- a/src/Common/src/Interop/FreeBSD/Interop.Process.cs
+++ b/src/Common/src/Interop/FreeBSD/Interop.Process.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
 {
     internal static partial class Process
     {
-        private const ulong SecondsToNanoSeconds = 1000000000;
+        private const ulong SecondsToNanoseconds = 1000000000;
 
         // Constants from sys/syslimits.h
         private const int PATH_MAX  = 1024;
@@ -412,8 +412,8 @@ internal static partial class Interop
                     {
                         ret.startTime = (int)info->ki_start.tv_sec;
                         ret.nice = info->ki_nice;
-                        ret.userTime = (ulong)info->ki_rusage.ru_utime.tv_sec * SecondsToNanoSeconds + (ulong)info->ki_rusage.ru_utime.tv_usec;
-                        ret.systemTime = (ulong)info->ki_rusage.ru_stime.tv_sec * SecondsToNanoSeconds + (ulong)info->ki_rusage.ru_stime.tv_usec;
+                        ret.userTime = (ulong)info->ki_rusage.ru_utime.tv_sec * SecondsToNanoseconds + (ulong)info->ki_rusage.ru_utime.tv_usec;
+                        ret.systemTime = (ulong)info->ki_rusage.ru_stime.tv_sec * SecondsToNanoseconds + (ulong)info->ki_rusage.ru_stime.tv_usec;
                     }
                     else
                     {
@@ -424,8 +424,8 @@ internal static partial class Interop
                             {
                                 ret.startTime = (int)list[i].ki_start.tv_sec;
                                 ret.nice = list[i].ki_nice;
-                                ret.userTime = (ulong)list[i].ki_rusage.ru_utime.tv_sec * SecondsToNanoSeconds + (ulong)list[i].ki_rusage.ru_utime.tv_usec;
-                                ret.systemTime = (ulong)list[i].ki_rusage.ru_stime.tv_sec * SecondsToNanoSeconds + (ulong)list[i].ki_rusage.ru_stime.tv_usec;
+                                ret.userTime = (ulong)list[i].ki_rusage.ru_utime.tv_sec * SecondsToNanoseconds + (ulong)list[i].ki_rusage.ru_utime.tv_usec;
+                                ret.systemTime = (ulong)list[i].ki_rusage.ru_stime.tv_sec * SecondsToNanoseconds + (ulong)list[i].ki_rusage.ru_stime.tv_usec;
                                 break;
                             }
                         }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
@@ -9,7 +9,7 @@ namespace System.Diagnostics
 {
     public partial class Process
     {
-        private const int NanoSecondsTo100NanosecondsFactor = 100;
+        private const int NanosecondsTo100NanosecondsFactor = 100;
 
         /// <summary>Gets the amount of time the process has spent running code inside the operating system core.</summary>
         public TimeSpan PrivilegedProcessorTime
@@ -18,7 +18,7 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveNonExitedId);
                 Interop.libproc.rusage_info_v3 info = Interop.libproc.proc_pid_rusage(_processId);
-                return new TimeSpan(Convert.ToInt64(info.ri_system_time / NanoSecondsTo100NanosecondsFactor));
+                return new TimeSpan(Convert.ToInt64(info.ri_system_time / NanosecondsTo100NanosecondsFactor));
             }
         }
 
@@ -78,7 +78,7 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveNonExitedId);
                 Interop.libproc.rusage_info_v3 info = Interop.libproc.proc_pid_rusage(_processId);
-                return new TimeSpan(Convert.ToInt64((info.ri_system_time + info.ri_user_time) / NanoSecondsTo100NanosecondsFactor));
+                return new TimeSpan(Convert.ToInt64((info.ri_system_time + info.ri_user_time) / NanosecondsTo100NanosecondsFactor));
             }
         }
 
@@ -92,7 +92,7 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveNonExitedId);
                 Interop.libproc.rusage_info_v3 info = Interop.libproc.proc_pid_rusage(_processId);
-                return new TimeSpan(Convert.ToInt64(info.ri_user_time / NanoSecondsTo100NanosecondsFactor));
+                return new TimeSpan(Convert.ToInt64(info.ri_user_time / NanosecondsTo100NanosecondsFactor));
             }
         }
 


### PR DESCRIPTION
As discussed with @danmosemsft [here](https://github.com/dotnet/corefx/pull/37637#discussion_r284052545) -  changing `NanoSecond` to `Nanosecond` (which should be the correct spelling). 