### PR TITLE
Fix IPv6Address parsing

### DIFF
--- a/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
+++ b/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System
 {
     internal static partial class IPv6AddressHelper

--- a/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
+++ b/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
@@ -107,6 +107,17 @@ namespace System
             {
                 start++;
                 needsClosingBracket = true;
+
+                // IsValidStrict() is only called if there is a ':' in the name string, i.e. 
+                // it is a possible IPv6 address. So, if the string starts with a '[' and
+                // the pointer is advanced here there are still more characters to parse.
+                Debug.Assert(start < end);
+            }
+
+            // Starting with a colon character is only valid if another colon follows.
+            if (name[start] == ':' && (start + 1 >= end || name[start + 1] != ':'))
+            {
+                return false;
             }
 
             int i;
@@ -278,7 +289,7 @@ namespace System
         //  Nothing
         //
 
-        internal static unsafe void Parse(ReadOnlySpan<char> address, ushort* numbers, int start, ref string scopeId)
+        internal static void Parse(ReadOnlySpan<char> address, Span<ushort> numbers, int start, ref string scopeId)
         {
             int number = 0;
             int index = 0;

--- a/src/System.Net.Primitives/src/System/Net/IPAddress.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddress.cs
@@ -146,10 +146,10 @@ namespace System.Net
             PrivateScopeId = (uint)scopeid;
         }
 
-        internal unsafe IPAddress(ushort* numbers, int numbersLength, uint scopeid)
+        internal IPAddress(ReadOnlySpan<ushort> numbers, uint scopeid)
         {
             Debug.Assert(numbers != null);
-            Debug.Assert(numbersLength == NumberOfLabels);
+            Debug.Assert(numbers.Length == NumberOfLabels);
 
             var arr = new ushort[NumberOfLabels];
             for (int i = 0; i < arr.Length; i++)

--- a/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
@@ -14,17 +14,17 @@ namespace System.Net
     {
         private const int MaxIPv4StringLength = 15; // 4 numbers separated by 3 periods, with up to 3 digits per number
 
-        internal static unsafe IPAddress Parse(ReadOnlySpan<char> ipSpan, bool tryParse)
+        iinternal static IPAddress Parse(ReadOnlySpan<char> ipSpan, bool tryParse)
         {
             if (ipSpan.Contains(':'))
             {
                 // The address is parsed as IPv6 if and only if it contains a colon. This is valid because
                 // we don't support/parse a port specification at the end of an IPv4 address.
-                ushort* numbers = stackalloc ushort[IPAddressParserStatics.IPv6AddressShorts];
-                new Span<ushort>(numbers, IPAddressParserStatics.IPv6AddressShorts).Clear();
+                Span<ushort> numbers = stackalloc ushort[IPAddressParserStatics.IPv6AddressShorts];
+                numbers.Clear();
                 if (Ipv6StringToAddress(ipSpan, numbers, IPAddressParserStatics.IPv6AddressShorts, out uint scope))
                 {
-                    return new IPAddress(numbers, IPAddressParserStatics.IPv6AddressShorts, scope);
+                    return new IPAddress(numbers, scope);
                 }
             }
             else if (Ipv4StringToAddress(ipSpan, out long address))
@@ -193,7 +193,7 @@ namespace System.Net
             }
         }
 
-        public static unsafe bool Ipv6StringToAddress(ReadOnlySpan<char> ipSpan, ushort* numbers, int numbersLength, out uint scope)
+        public static unsafe bool Ipv6StringToAddress(ReadOnlySpan<char> ipSpan, Span<ushort> numbers, int numbersLength, out uint scope)
         {
             Debug.Assert(numbers != null);
             Debug.Assert(numbersLength >= IPAddressParserStatics.IPv6AddressShorts);

--- a/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
+++ b/src/System.Net.Primitives/src/System/Net/IPAddressParser.cs
@@ -14,7 +14,7 @@ namespace System.Net
     {
         private const int MaxIPv4StringLength = 15; // 4 numbers separated by 3 periods, with up to 3 digits per number
 
-        iinternal static IPAddress Parse(ReadOnlySpan<char> ipSpan, bool tryParse)
+        internal static IPAddress Parse(ReadOnlySpan<char> ipSpan, bool tryParse)
         {
             if (ipSpan.Contains(':'))
             {

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -346,9 +346,6 @@ namespace System.Net.Primitives.Functional.Tests
 
         public static IEnumerable<object[]> InvalidIpv6Addresses()
         {
-            yield return new object[] { "" }; // malformed
-            yield return new object[] { "[" }; // malformed
-            yield return new object[] { "[]" }; // malformed
             yield return new object[] { "[:]" }; // malformed
             yield return new object[] { ":::4df" };
             yield return new object[] { "4df:::" };
@@ -442,6 +439,9 @@ namespace System.Net.Primitives.Functional.Tests
             new object[] { "%12" }, // just scope
             new object[] { "[192.168.0.1]" }, // raw v4
             new object[] { "[1]" }, // incomplete
+            new object[] { "" }; // malformed
+            new object[] { "[" }; // malformed
+            new object[] { "[]" }; // malformed
         };
 
         [Theory]

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -439,9 +439,9 @@ namespace System.Net.Primitives.Functional.Tests
             new object[] { "%12" }, // just scope
             new object[] { "[192.168.0.1]" }, // raw v4
             new object[] { "[1]" }, // incomplete
-            new object[] { "" }; // malformed
-            new object[] { "[" }; // malformed
-            new object[] { "[]" }; // malformed
+            new object[] { "" }, // malformed
+            new object[] { "[" }, // malformed
+            new object[] { "[]" }, // malformed
         };
 
         [Theory]

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -346,6 +346,10 @@ namespace System.Net.Primitives.Functional.Tests
 
         public static IEnumerable<object[]> InvalidIpv6Addresses()
         {
+            yield return new object[] { "" }; // malformed
+            yield return new object[] { "[" }; // malformed
+            yield return new object[] { "[]" }; // malformed
+            yield return new object[] { "[:]" }; // malformed
             yield return new object[] { ":::4df" };
             yield return new object[] { "4df:::" };
             yield return new object[] { "0:::4df" };
@@ -368,6 +372,24 @@ namespace System.Net.Primitives.Functional.Tests
             yield return new object[] { "Fe08::1]]" }; // two trailing brackets
             yield return new object[] { "[Fe08::1]]" }; // one leading and two trailing brackets
             yield return new object[] { ":1" }; // leading single colon
+            yield return new object[] { ":1:2" }; // leading single colon
+            yield return new object[] { ":1:2:3" }; // leading single colon
+            yield return new object[] { ":1:2:3:4" }; // leading single colon
+            yield return new object[] { ":1:2:3:4:5" }; // leading single colon
+            yield return new object[] { ":1:2:3:4:5:6" }; // leading single colon
+            yield return new object[] { ":1:2:3:4:5:6:7" }; // leading single colon
+            yield return new object[] { ":1:2:3:4:5:6:7:8" }; // leading single colon
+            yield return new object[] { ":1:2:3:4:5:6:7:8:9" }; // leading single colon
+            yield return new object[] { "::1:2:3:4:5:6:7:8" }; // compressor with too many number groups
+            yield return new object[] { "1::2:3:4:5:6:7:8" }; // compressor with too many number groups
+            yield return new object[] { "1:2::3:4:5:6:7:8" }; // compressor with too many number groups
+            yield return new object[] { "1:2:3::4:5:6:7:8" }; // compressor with too many number groups
+            yield return new object[] { "1:2:3:4::5:6:7:8" }; // compressor with too many number groups
+            yield return new object[] { "1:2:3:4:5::6:7:8" }; // compressor with too many number groups
+            yield return new object[] { "1:2:3:4:5:6::7:8" }; // compressor with too many number groups
+            yield return new object[] { "1:2:3:4:5:6:7::8" }; // compressor with too many number groups
+            yield return new object[] { "1:2:3:4:5:6:7:8::" }; // compressor with too many number groups
+            yield return new object[] { "::1:2:3:4:5:6:7:8:9" }; // compressor with too many number groups
             yield return new object[] { "1:" }; // trailing single colon
             yield return new object[] { " ::1" }; // leading whitespace
             yield return new object[] { "::1 " }; // trailing whitespace

--- a/src/System.Net.Primitives/tests/UnitTests/Fakes/IPv6AddressHelper.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/Fakes/IPv6AddressHelper.cs
@@ -10,7 +10,7 @@ namespace System
     {
         internal unsafe static (int longestSequenceStart, int longestSequenceLength) FindCompressionRange(
             ReadOnlySpan<ushort> numbers) => (-1, -1);
-        internal unsafe static bool ShouldHaveIpv4Embedded(ushort[] numbers) => false;
+        internal unsafe static bool ShouldHaveIpv4Embedded(ReadOnlySpan<ushort> numbers) => false;
         internal unsafe static bool IsValidStrict(char* name, int start, ref int end) => false;
         internal static unsafe bool Parse(ReadOnlySpan<char> ipSpan, Span<ushort> numbers, int start, ref string scopeId) => false;
     }

--- a/src/System.Net.Primitives/tests/UnitTests/Fakes/IPv6AddressHelper.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/Fakes/IPv6AddressHelper.cs
@@ -12,6 +12,6 @@ namespace System
             ReadOnlySpan<ushort> numbers) => (-1, -1);
         internal unsafe static bool ShouldHaveIpv4Embedded(ushort[] numbers) => false;
         internal unsafe static bool IsValidStrict(char* name, int start, ref int end) => false;
-        internal static unsafe bool Parse(ReadOnlySpan<char> ipSpan, ushort* numbers, int start, ref string scopeId) => false;
+        internal static unsafe bool Parse(ReadOnlySpan<char> ipSpan, Span<ushort> numbers, int start, ref string scopeId) => false;
     }
 }

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -17,6 +17,7 @@ namespace System
         {
             Span<ushort> numbers = stackalloc ushort[NumberOfLabels];
             numbers.Clear();
+            Parse(str, numbersPtr, start, ref scopeId);
             isLoopback = IsLoopback(numbers);
 
             // RFC 5952 Sections 4 & 5 - Compressed, lower case, with possible embedded IPv4 addresses.

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -17,7 +17,7 @@ namespace System
         {
             Span<ushort> numbers = stackalloc ushort[NumberOfLabels];
             numbers.Clear();
-            Parse(str, numbersPtr, start, ref scopeId);
+            Parse(str, numbers, start, ref scopeId);
             isLoopback = IsLoopback(numbers);
 
             // RFC 5952 Sections 4 & 5 - Compressed, lower case, with possible embedded IPv4 addresses.

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -114,33 +114,6 @@ namespace System
                                        || (numbers[5] == 0xFFFF))));
         }
 
-        // Returns true if the IPv6 address should be formated with an embedded IPv4 address:
-        // ::192.168.1.1
-        private static bool ShouldHaveIpv4Embedded(ReadOnlySpan<ushort> numbers)
-        {
-            // 0:0 : 0:0 : x:x : x.x.x.x
-            if (numbers[0] == 0 && numbers[1] == 0 && numbers[2] == 0 && numbers[3] == 0 && numbers[6] != 0)
-            {
-                // RFC 5952 Section 5 - 0:0 : 0:0 : 0:[0 | FFFF] : x.x.x.x
-                if (numbers[4] == 0 && (numbers[5] == 0 || numbers[5] == 0xFFFF))
-                {
-                    return true;
-                }
-                // SIIT - 0:0 : 0:0 : FFFF:0 : x.x.x.x
-                else if (numbers[4] == 0xFFFF && numbers[5] == 0)
-                {
-                    return true;
-                }
-            }
-            // ISATAP
-            if (numbers[4] == 0 && numbers[5] == 0x5EFE)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
         //
         // InternalIsValid
         //

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -321,7 +321,6 @@ namespace System.PrivateUri.Tests
         [InlineData(":1:2:3:4:5")] // leading single colon
         [InlineData(":1:2:3:4:5:6")] // leading single colon
         [InlineData(":1:2:3:4:5:6:7")] // leading single colon
-        [InlineData(":1:2:3:4:5:6:7:8")] // leading single colon
         [InlineData(":1:2:3:4:5:6:7:8:9")] // leading single colon
         [InlineData("::1:2:3:4:5:6:7:8")] // compressor with too many number groups
         [InlineData("1::2:3:4:5:6:7:8")] // compressor with too many number groups
@@ -351,6 +350,15 @@ namespace System.PrivateUri.Tests
         {
             ParseBadIPv6Address(address);
         }
+
+        [Theory]
+        [InlineData(":1:2:3:4:5:6:7:8")] // leading single colon
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework machines are not yet patched with the fix for this")]
+        public void UriIPv6Host_BadAddress_SkipOnFramework(string address)
+        {
+            ParseBadIPv6Address(address);
+        }
+
 
         #region Helpers
 

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -313,7 +313,26 @@ namespace System.PrivateUri.Tests
         [InlineData("")]
         [InlineData(" ")]
         [InlineData("1")]
-        [InlineData(":1")]
+        [InlineData(":")] // leading single colon
+        [InlineData(":1")] // leading single colon
+        [InlineData(":1:2")] // leading single colon
+        [InlineData(":1:2:3")] // leading single colon
+        [InlineData(":1:2:3:4")] // leading single colon
+        [InlineData(":1:2:3:4:5")] // leading single colon
+        [InlineData(":1:2:3:4:5:6")] // leading single colon
+        [InlineData(":1:2:3:4:5:6:7")] // leading single colon
+        [InlineData(":1:2:3:4:5:6:7:8")] // leading single colon
+        [InlineData(":1:2:3:4:5:6:7:8:9")] // leading single colon
+        [InlineData("::1:2:3:4:5:6:7:8")] // compressor with too many number groups
+        [InlineData("1::2:3:4:5:6:7:8")] // compressor with too many number groups
+        [InlineData("1:2::3:4:5:6:7:8")] // compressor with too many number groups
+        [InlineData("1:2:3::4:5:6:7:8")] // compressor with too many number groups
+        [InlineData("1:2:3:4::5:6:7:8")] // compressor with too many number groups
+        [InlineData("1:2:3:4:5::6:7:8")] // compressor with too many number groups
+        [InlineData("1:2:3:4:5:6::7:8")] // compressor with too many number groups
+        [InlineData("1:2:3:4:5:6:7::8")] // compressor with too many number groups
+        [InlineData("1:2:3:4:5:6:7:8::")] // compressor with too many number groups
+        [InlineData("::1:2:3:4:5:6:7:8:9")] // compressor with too many number groups
         [InlineData("1:")]
         [InlineData("::1 ")]
         [InlineData(" ::1")]


### PR DESCRIPTION
Ports 4006e521ac364a330f1c8b418ab651845f32367d & https://github.com/dotnet/corefx/commit/6fdf8be2b60145d65819395ad020c162246f983f. 

@karelz @davidsh @wfurt PTAL, especially at the changes to src/System.Private.Uri/src/System/IPv6AddressHelper.cs