### PR TITLE
Use Assembly.Load() instead of LoadFile() when loading pre-generated serializer

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -168,24 +168,9 @@ namespace System.Xml.Serialization
                 name.CodeBase = null;
                 name.CultureInfo = CultureInfo.InvariantCulture;
 
-                string serializerPath = null;
-
                 try
                 {
-                    if (!string.IsNullOrEmpty(type.Assembly.Location))
-                    {
-                        serializerPath = Path.Combine(Path.GetDirectoryName(type.Assembly.Location), serializerName + ".dll");
-                    }
-
-                    if ((string.IsNullOrEmpty(serializerPath) || !File.Exists(serializerPath)) && !string.IsNullOrEmpty(Assembly.GetEntryAssembly().Location))
-                    {
-                        serializerPath = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), serializerName + ".dll");
-                    }
-
-                    if (!string.IsNullOrEmpty(serializerPath))
-                    {
-                        serializer = Assembly.LoadFile(serializerPath);
-                    }
+                    serializer = Assembly.Load(name);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Fixes #26687
