### PR TITLE
 Enable C# mode command line diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,7 +17,7 @@
 #
 # Merging from the command prompt will add diff markers to the files if there
 # are conflicts (Merging from VS is not affected by the settings below, in VS
-# the diff markers are never inserted). Diff markers may cause the following 
+# the diff markers are never inserted). Diff markers may cause the following
 # file extensions to fail to load in VS. An alternative would be to treat
 # these files as binary and thus will always conflict and require user
 # intervention with every merge. To do so, just uncomment the entries below
@@ -46,9 +46,9 @@
 
 ###############################################################################
 # diff behavior for common document formats
-# 
+#
 # Convert binary document formats to text before diffing them. This feature
-# is only available from the command line. Turn it on by uncommenting the 
+# is only available from the command line. Turn it on by uncommenting the
 # entries below.
 ###############################################################################
 #*.doc   diff=astextplain

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,7 @@
 # default for csharp files.
 # Note: This is only used by command line
 ###############################################################################
-#*.cs     diff=csharp
+*.cs     diff=csharp
 
 ###############################################################################
 # Set the merge driver for project and solution files


### PR DESCRIPTION
*Taken from https://github.com/dotnet/standard/pull/1196*

When diffing on the command line, enabling this ensures that hunk headers will use the containing construct (i.e. method, type, or namespace).

For example, instead of this (pay attention to the `@@` line):

```diff
diff --git a/src/netstandard/ref/System.Security.Cryptography.cs b/src/netstandard/ref/System.Security.Cryptography.cs
index 9f68653..19d239a 100644
--- a/src/netstandard/ref/System.Security.Cryptography.cs
+++ b/src/netstandard/ref/System.Security.Cryptography.cs
@@ -101,8 +101,20 @@ namespace System.Security.Cryptography
         public virtual byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
         public virtual byte[] ExportPkcs8PrivateKey() { throw null; }
+        public virtual byte[] ExportSubjectPublicKeyInfo() { throw null; }
         public virtual void FromXmlString(string xmlString) { }
     }
     public abstract partial class AsymmetricKeyExchangeDeformatter
     {
```

You'll see this:

```diff
diff --git a/src/netstandard/ref/System.Security.Cryptography.cs b/src/netstandard/ref/System.Security.Cryptography.cs
index 9f68653..19d239a 100644
--- a/src/netstandard/ref/System.Security.Cryptography.cs
+++ b/src/netstandard/ref/System.Security.Cryptography.cs
@@ -101,8 +101,20 @@ public abstract partial class AsymmetricAlgorithm : System.IDisposable
         public virtual byte[] ExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters) { throw null; }
         public virtual byte[] ExportPkcs8PrivateKey() { throw null; }
+        public virtual byte[] ExportSubjectPublicKeyInfo() { throw null; }
         public virtual void FromXmlString(string xmlString) { }
     }
     public abstract partial class AsymmetricKeyExchangeDeformatter
     {
```