### PR TITLE
Add Microsoft.Private.CoreFx.OOB package

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.builds
+++ b/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.builds
@@ -1,0 +1,10 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <!-- only build during the AllConfigurations leg because it depends on other nupkgs from this leg -->
+  <ItemGroup Condition="'$(BuildAllConfigurations)' == 'true'">
+    <Project Include="$(MSBuildProjectName).pkgproj" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(dir.traversal.targets))" />
+</Project>

--- a/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.pkgproj
@@ -1,4 +1,4 @@
-﻿<Project DefaultTargets="Build">
+﻿<Project DefaultTargets="Build" InitialTargets="FindNetCoreAppPackages">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <PropertyGroup>
     <!-- We use the PackageVersion property defined in Packaging.props for the Prerelease packages which are using it to be built -->
@@ -6,13 +6,9 @@
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>
   </PropertyGroup>
-  <ItemDefinitionGroup>
-    <PrereleaseLibraryPackage>
-      <Version>$(_PreReleasePackageVersion)</Version>
-    </PrereleaseLibraryPackage>
-  </ItemDefinitionGroup>
 
-  <Target Name="FindNetCoreAppPackages" BeforeTargets="GetPackageDependencies">
+  <Target Name="FindNetCoreAppPackages">
+
     <ItemGroup>
       <PkgProjGlobPath Include="$(SourceDir)/**/*.pkgproj" />
     </ItemGroup>

--- a/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.pkgproj
@@ -1,0 +1,20 @@
+﻿<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
+  <PropertyGroup>
+    <!-- We use the PackageVersion property defined in Packaging.props for the Prerelease packages which are using it to be built -->
+    <_PreReleasePackageVersion>$(PackageVersion)</_PreReleasePackageVersion>
+    <!-- We don't need to harvest the stable packages to build this -->
+    <HarvestStablePackage>false</HarvestStablePackage>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <PrereleaseLibraryPackage>
+      <Version>$(_PreReleasePackageVersion)</Version>
+    </PrereleaseLibraryPackage>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <PkgProjGlobPath Include="$(SourceDir)/**/*.pkgproj" />
+    <PrereleaseLibraryPackage Include="@(PrereleaseLibraryPackage -> %(Filename))" />
+    <Dependency Include="@(PrereleaseLibraryPackage)" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
+</Project>

--- a/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.pkgproj
@@ -12,7 +12,7 @@
     </PrereleaseLibraryPackage>
   </ItemDefinitionGroup>
 
-  <Target Name="FindNetCoreAppPackages" BeforeTargets="ApplyBaselineToStaticDependencies">
+  <Target Name="FindNetCoreAppPackages" BeforeTargets="GetPackageDependencies">
     <ItemGroup>
       <PkgProjGlobPath Include="$(SourceDir)/**/*.pkgproj" />
     </ItemGroup>

--- a/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.pkgproj
@@ -11,10 +11,24 @@
       <Version>$(_PreReleasePackageVersion)</Version>
     </PrereleaseLibraryPackage>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <PkgProjGlobPath Include="$(SourceDir)/**/*.pkgproj" />
-    <PrereleaseLibraryPackage Include="@(PrereleaseLibraryPackage -> %(Filename))" />
-    <Dependency Include="@(PrereleaseLibraryPackage)" />
-  </ItemGroup>
+
+  <Target Name="FindNetCoreAppPackages" BeforeTargets="ApplyBaselineToStaticDependencies">
+    <ItemGroup>
+      <PkgProjGlobPath Include="$(SourceDir)/**/*.pkgproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(PkgProjGlobPath)"
+             Targets="IsNotNetCoreAppProject"
+             BuildInParallel="true">
+      <Output TaskParameter="TargetOutputs" ItemName="PrereleaseLibraryPackage" />
+    </MSBuild>
+
+    <ItemGroup>
+      <Dependency Include="@(PrereleaseLibraryPackage)"
+                  Condition="!$([System.String]::new('%(Identity)').Contains('Private')) and !$([System.String]::new('%(Identity)').EndsWith('Experimental')) and !$([System.String]::new('%(Identity)').StartsWith('runtime.'))" />
+    </ItemGroup>
+    
+  </Target>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -201,6 +201,9 @@
     "Microsoft.Private.CoreFx.NETCoreApp": {
       "InboxOn": {}
     },
+    "Microsoft.Private.CoreFx.OOB": {
+      "InboxOn": {}
+    },
     "Microsoft.Private.PackageBaseline": {
       "InboxOn": {}
     },

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -156,6 +156,11 @@
     "CommonTypes": []
   },
   {
+    "Name": "Microsoft.Private.CoreFX.OOB",
+    "Description": "Package used to represent out-of-band packages that are not included in NetCoreApp.",
+    "CommonTypes": []
+  },
+  {
     "Name": "Microsoft.Private.CoreFx.UAP",
     "Description": "Package used to represent the portions of UAP that come from CoreFx.",
     "CommonTypes": []

--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -156,7 +156,7 @@
     "CommonTypes": []
   },
   {
-    "Name": "Microsoft.Private.CoreFX.OOB",
+    "Name": "Microsoft.Private.CoreFx.OOB",
     "Description": "Package used to represent out-of-band packages that are not included in NetCoreApp.",
     "CommonTypes": []
   },

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -16,6 +16,13 @@
     </ItemGroup>
   </Target>
 
+  <!-- Used for packaging -->
+  <Target Name="IsNotNetCoreAppProject" Returns="$(IsNotNetCoreAppProjectResult)">
+    <PropertyGroup>
+      <IsNotNetCoreAppProjectResult Condition="'$(IsNetCoreApp)' != 'true'">$(MSBuildProjectName)</IsNotNetCoreAppProjectResult>
+    </PropertyGroup>
+  </Target>
+
   <!-- Routing dotnet test to a test project's BuildAndTest target. -->
   <Target Name="VSTest"
           Condition="'$(IsTestProject)' == 'true' and '$(IsTestSupportProject)' != 'true'"

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -17,10 +17,10 @@
   </Target>
 
   <!-- Used for packaging -->
-  <Target Name="IsNotNetCoreAppProject" Returns="$(IsNotNetCoreAppProjectResult)">
-    <PropertyGroup>
-      <IsNotNetCoreAppProjectResult Condition="'$(IsNetCoreApp)' != 'true'">$(MSBuildProjectName)</IsNotNetCoreAppProjectResult>
-    </PropertyGroup>
+  <Target Name="IsNotNetCoreAppProject" Returns="@(IsNotNetCoreAppProjectResult)">
+    <ItemGroup>
+      <IsNotNetCoreAppProjectResult Condition="'$(IsNetCoreApp)' != 'true'" Include="$(MSBuildProjectName)" Version="$(PackageVersion)" />
+    </ItemGroup>
   </Target>
 
   <!-- Routing dotnet test to a test project's BuildAndTest target. -->


### PR DESCRIPTION
Package used to represent out-of-band packages that are not included in NetCoreApp. Used in Mono/CoreClr/Performance repo.