### PR TITLE
Add string-based WriteAsProperty overload to JsonElement.

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -73,6 +73,7 @@ namespace System.Text.Json
         public bool TryGetUInt64(out ulong value) { throw null; }
         public void WriteAsProperty(System.ReadOnlySpan<byte> utf8PropertyName, System.Text.Json.Utf8JsonWriter writer) { }
         public void WriteAsProperty(System.ReadOnlySpan<char> propertyName, System.Text.Json.Utf8JsonWriter writer) { }
+        public void WriteAsProperty(string propertyName, System.Text.Json.Utf8JsonWriter writer) { }
         public void WriteAsValue(System.Text.Json.Utf8JsonWriter writer) { }
         public partial struct ArrayEnumerator : System.Collections.Generic.IEnumerable<System.Text.Json.JsonElement>, System.Collections.Generic.IEnumerator<System.Text.Json.JsonElement>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
         {

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -946,7 +946,7 @@ namespace System.Text.Json
         /// <summary>
         ///   Write the element into the provided writer as a named object property.
         /// </summary>
-        /// <param name="propertyName">The name for this value within the JSON object, as UTF-16 text.</param>
+        /// <param name="propertyName">The name for this value within the JSON object.</param>
         /// <param name="writer">The writer.</param>
         /// <exception cref="InvalidOperationException">
         ///   This value's <see cref="Type"/> is <see cref="JsonValueType.Undefined"/>.

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -940,6 +940,20 @@ namespace System.Text.Json
         /// <exception cref="ObjectDisposedException">
         ///   The parent <see cref="JsonDocument"/> has been disposed.
         /// </exception>
+        public void WriteAsProperty(string propertyName, Utf8JsonWriter writer)
+            => WriteAsProperty(propertyName.AsSpan(), writer);
+
+        /// <summary>
+        ///   Write the element into the provided writer as a named object property.
+        /// </summary>
+        /// <param name="propertyName">The name for this value within the JSON object, as UTF-16 text.</param>
+        /// <param name="writer">The writer.</param>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="Type"/> is <see cref="JsonValueType.Undefined"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The parent <see cref="JsonDocument"/> has been disposed.
+        /// </exception>
         public void WriteAsProperty(ReadOnlySpan<char> propertyName, Utf8JsonWriter writer)
         {
             CheckValidInstance();

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -166,7 +166,7 @@ namespace System.Text.Json.Serialization
                 Debug.Assert(entry.Key is string);
 
                 string propertyName = (string)entry.Key;
-                element.WriteAsProperty(propertyName.AsSpan(), writer);
+                element.WriteAsProperty(propertyName, writer);
             }
             else
             {


### PR DESCRIPTION
This API is useful internally within JsonSerializer as well. See https://github.com/dotnet/corefx/pull/37690#discussion_r284512718