### PR TITLE
Fix testscope usage in yml and sh script

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -102,7 +102,7 @@ while [[ $# > 0 ]]; do
       ;;
      -testscope)
       arguments="$arguments /p:TestScope=$2"
-      shift 1
+      shift 2
       ;;
      -coverage)
       arguments="$arguments /p:Coverage=true"

--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -78,7 +78,7 @@ jobs:
         - _testScopeArg: ''
 
         - ${{ if ne(parameters.testScope, '') }}:
-          - _testScopeArg: -testScope ${{ parameters.testScope }}
+          - _testScopeArg: -testscope ${{ parameters.testScope }}
 
         - ${{ if ne(job._jobFramework, '')}}:
           - _finalFrameworkArg: ${{ job._jobFramework }}


### PR DESCRIPTION
In the build.sh bash script, `testscope` was set to a switch instead of an option which causes outerloop osx and linux build definitions to fail.