### PR TITLE
Ensure JsonException is thrown parsing invalid DateTime, DateTimeOffset, and Guid #37807

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTime.cs
@@ -10,6 +10,12 @@ namespace System.Text.Json.Serialization.Converters
     {
         public override bool TryRead(Type valueType, ref Utf8JsonReader reader, out DateTime value)
         {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                value = default;
+                return false;
+            }
+
             return reader.TryGetDateTime(out value);
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTimeOffset.cs
@@ -10,6 +10,12 @@ namespace System.Text.Json.Serialization.Converters
     {
         public override bool TryRead(Type valueType, ref Utf8JsonReader reader, out DateTimeOffset value)
         {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                value = default;
+                return false;
+            }
+
             return reader.TryGetDateTimeOffset(out value);
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterGuid.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterGuid.cs
@@ -10,6 +10,12 @@ namespace System.Text.Json.Serialization.Converters
     {
         public override bool TryRead(Type valueType, ref Utf8JsonReader reader, out Guid value)
         {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                value = default;
+                return false;
+            }
+
             return reader.TryGetGuid(out value);
         }
 

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -74,6 +74,32 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<int>(@""""""));
         }
 
+        [Theory]
+        [InlineData(typeof(bool))]
+        [InlineData(typeof(byte))]
+        [InlineData(typeof(char))]
+        [InlineData(typeof(DateTime))]
+        [InlineData(typeof(DateTimeOffset))]
+        [InlineData(typeof(decimal))]
+        [InlineData(typeof(double))]
+        [InlineData(typeof(JsonTokenType))]
+        [InlineData(typeof(Guid))]
+        [InlineData(typeof(short))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(long))]
+        [InlineData(typeof(sbyte))]
+        [InlineData(typeof(float))]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(ushort))]
+        [InlineData(typeof(uint))]
+        [InlineData(typeof(ulong))]
+        public static void PrimitivesShouldFailWithArrayOrObjectAssignment(Type primitiveType)
+        {
+            // This test lines up with the built in JsonValueConverters
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse(@"[]", primitiveType));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse(@"{}", primitiveType));
+        }
+
         [Fact]
         public static void ReadPrimitiveArray()
         {


### PR DESCRIPTION
While investigating #36901 with additional tests, I found that DateTime, DateTimeOffset, and Guid all unexpectedly throw InvalidOperationException when parsing `"[]"` or `"{}"`, instead of JsonException. This adds tests to ensure the correct behavior, and updates their implementations of JsonValueConverter to return false in those cases.

This also adds tests for every primitive with a JsonValueConverter to cover regressions down that path, covering #36901.