### PR TITLE
Converting SystemColors into InstanceDescriptors using Color Convertor

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/Drawing/ColorConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/Drawing/ColorConverter.cs
@@ -112,7 +112,7 @@ namespace System.Drawing
                     }
                     else if (ColorTable.IsKnownNamedColor(c.Name))
                     {
-                        member = typeof(SystemColors).GetProperty(c.Name) ?? typeof(Color).GetProperty(c.Name);   
+                        member = typeof(Color).GetProperty(c.Name) ?? typeof(SystemColors).GetProperty(c.Name);   
                     }
                     else if (c.A != 255)
                     {

--- a/src/System.ComponentModel.TypeConverter/src/System/Drawing/ColorConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/Drawing/ColorConverter.cs
@@ -112,7 +112,7 @@ namespace System.Drawing
                     }
                     else if (ColorTable.IsKnownNamedColor(c.Name))
                     {
-                        member = typeof(Color).GetProperty(c.Name);
+                        member = typeof(SystemColors).GetProperty(c.Name) ?? typeof(Color).GetProperty(c.Name);   
                     }
                     else if (c.A != 255)
                     {

--- a/src/System.ComponentModel.TypeConverter/tests/Drawing/ColorConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Drawing/ColorConverterTests.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Design.Serialization;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace System.ComponentModel.TypeConverterTests
@@ -460,8 +461,11 @@ namespace System.ComponentModel.TypeConverterTests
         public void ConvertToInstanceDescriptorTests()
         {
             var conv = new ColorConverter();
-            Assert.NotNull(conv.ConvertTo(Color.Blue, typeof(InstanceDescriptor)));
-            Assert.NotNull(conv.ConvertTo(SystemColors.ActiveCaption, typeof(InstanceDescriptor)));
+            InstanceDescriptor descriptor = (InstanceDescriptor)conv.ConvertTo(Color.Blue, typeof(InstanceDescriptor));
+            Assert.Equal("Blue", descriptor.MemberInfo.Name);
+
+            descriptor = (InstanceDescriptor)conv.ConvertTo(SystemColors.ActiveCaption, typeof(InstanceDescriptor));
+            Assert.Equal("ActiveCaption", descriptor.MemberInfo.Name);
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/Drawing/ColorConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Drawing/ColorConverterTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.ComponentModel.Design.Serialization;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;
@@ -445,6 +446,22 @@ namespace System.ComponentModel.TypeConverterTests
         {
             var conv = new ColorConverter();
             Assert.False(conv.GetStandardValuesExclusive());
+        }
+
+        [Fact]
+        public void ConvertToStringTests()
+        {
+            var conv = new ColorConverter();
+            Assert.Equal("Blue", conv.ConvertTo(Color.Blue, typeof(string)));
+            Assert.Equal("ActiveCaption", conv.ConvertTo(SystemColors.ActiveCaption, typeof(string)));
+        }
+
+        [Fact]
+        public void ConvertToInstanceDescriptorTests()
+        {
+            var conv = new ColorConverter();
+            Assert.NotNull(conv.ConvertTo(Color.Blue, typeof(InstanceDescriptor)));
+            Assert.NotNull(conv.ConvertTo(SystemColors.ActiveCaption, typeof(InstanceDescriptor)));
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/34252

We combined the check of the known colors and system colors into one check in .net Core.
But this created a bug as ```typeof(Color).GetProperty(c.Name);``` on system colors donot give the required output.

 we can do almost a similar thing i.e first try as it was a system color, if it returns null try for colors.