### PR TITLE
Adding debug logs for OleDb test failures

### DIFF
--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Data.OleDb.Tests
@@ -154,7 +155,18 @@ namespace System.Data.OleDb.Tests
                     Firstname NVARCHAR(5),
                     Lastname NVARCHAR(40), 
                     Nickname NVARCHAR(30))";
+            try
+            { 
             command.ExecuteNonQuery();
+            }
+            catch (SEHException sehEx)
+            {
+                Console.WriteLine($"Code: {sehEx.ErrorCode}");
+                Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().HResult}");
+                Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().ToString()}");
+                Console.WriteLine($"Base Inner Exception: {sehEx.InnerException}");
+                throw;
+            }
             Assert.True(File.Exists(Path.Combine(TestDirectory, tableName)));
 
             command.CommandText =

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -165,6 +165,8 @@ namespace System.Data.OleDb.Tests
                 Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().HResult}");
                 Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().ToString()}");
                 Console.WriteLine($"Base Inner Exception: {sehEx.InnerException}");
+                
+                // This exception is not expected. So rethrow to indicate test failure.
                 throw;
             }
             Assert.True(File.Exists(Path.Combine(TestDirectory, tableName)));

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -163,7 +163,7 @@ namespace System.Data.OleDb.Tests
             {
                 Console.WriteLine($"Code: {sehEx.ErrorCode}");
                 Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().HResult}");
-                Console.WriteLine($"Base Exception message : {sehEx.GetBaseException().ToString()}");
+                Console.WriteLine($"Base Exception message : {sehEx.GetBaseException()?.ToString()}");
                 Console.WriteLine($"Base Inner Exception: {sehEx.InnerException}");
                 
                 // This exception is not expected. So rethrow to indicate test failure.

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -163,7 +163,7 @@ namespace System.Data.OleDb.Tests
             {
                 Console.WriteLine($"Code: {sehEx.ErrorCode}");
                 Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().HResult}");
-                Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().ToString()}");
+                Console.WriteLine($"Base Exception message : {sehEx.GetBaseException().ToString()}");
                 Console.WriteLine($"Base Inner Exception: {sehEx.InnerException}");
                 
                 // This exception is not expected. So rethrow to indicate test failure.

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -157,7 +157,7 @@ namespace System.Data.OleDb.Tests
                     Nickname NVARCHAR(30))";
             try
             { 
-            command.ExecuteNonQuery();
+                command.ExecuteNonQuery();
             }
             catch (SEHException sehEx)
             {


### PR DESCRIPTION
Adding some diagnostics to get more information from the SEHException to debug OleDb Test failures in OuterLoop.
Related issue at https://github.com/dotnet/corefx/issues/37823