### PR TITLE
Make JsonPropertyNameAttribute.Name property readonly

### DIFF
--- a/src/System.Text.Json/docs/SerializerProgrammingModel.md
+++ b/src/System.Text.Json/docs/SerializerProgrammingModel.md
@@ -128,8 +128,8 @@ namespace System.Text.Json.Serialization
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false)]
     public sealed class JsonPropertyNameAttribute : System.Text.Json.Serialization.JsonAttribute
     {
-        public JsonPropertyNameAttribute(string propertyName) { }
-        public string Name { get; set; }
+        public JsonPropertyNameAttribute(string name) { }
+        public string Name { get; }
     }
 
     public abstract partial class JsonNamingPolicy

--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -364,8 +364,8 @@ namespace System.Text.Json.Serialization
     [System.AttributeUsageAttribute(System.AttributeTargets.Property, AllowMultiple=false)]
     public sealed partial class JsonPropertyNameAttribute : System.Text.Json.Serialization.JsonAttribute
     {
-        public JsonPropertyNameAttribute(string propertyName) { }
-        public string Name { get { throw null; } set { } }
+        public JsonPropertyNameAttribute(string name) { }
+        public string Name { get { throw null; } }
     }
     public static partial class JsonSerializer
     {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyNameAttribute.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyNameAttribute.cs
@@ -14,15 +14,15 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// Initializes a new instance of <see cref="JsonPropertyNameAttribute"/> with the specified property name.
         /// </summary>
-        /// <param name="propertyName">The name of the property.</param>
-        public JsonPropertyNameAttribute(string propertyName)
+        /// <param name="name">The name of the property.</param>
+        public JsonPropertyNameAttribute(string name)
         {
-            Name = propertyName;
+            Name = name;
         }
 
         /// <summary>
         /// The name of the property.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; }
     }
 }


### PR DESCRIPTION
@ahsonkhan the test coverage for this class is already at 100%

- [x] Pending API approval.

Fixes https://github.com/dotnet/corefx/issues/37552