### PR TITLE
Ensure JSON TryGetXXX sets values to default if returning false #37119

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -305,7 +305,7 @@ namespace System.Text.Json
                 return true;
             }
 
-            value = default;
+            value = 0;
             return false;
         }
 
@@ -330,7 +330,7 @@ namespace System.Text.Json
                 return true;
             }
 
-            value = default;
+            value = 0;
             return false;
         }
 
@@ -355,7 +355,7 @@ namespace System.Text.Json
                 return true;
             }
 
-            value = default;
+            value = 0;
             return false;
         }
 
@@ -380,7 +380,7 @@ namespace System.Text.Json
                 return true;
             }
 
-            value = default;
+            value = 0;
             return false;
         }
 
@@ -407,7 +407,7 @@ namespace System.Text.Json
                 return true;
             }
 
-            value = default;
+            value = 0;
             return false;
         }
 
@@ -434,7 +434,7 @@ namespace System.Text.Json
                 return true;
             }
 
-            value = default;
+            value = 0;
             return false;
         }
 
@@ -461,7 +461,7 @@ namespace System.Text.Json
                 return true;
             }
 
-            value = default;
+            value = 0;
             return false;
         }
 
@@ -493,15 +493,16 @@ namespace System.Text.Json
 
             Debug.Assert(segment.IndexOf(JsonConstants.BackSlash) == -1);
 
-            if (segment.Length > JsonConstants.MaximumDateTimeOffsetParseLength
-                || !JsonHelpers.TryParseAsISO(segment, out value, out int bytesConsumed)
-                || segment.Length != bytesConsumed)
+            if (segment.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
+                && JsonHelpers.TryParseAsISO(segment, out DateTime tmp, out int bytesConsumed)
+                && segment.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = default;
+            return false;
         }
 
         /// <summary>
@@ -532,15 +533,16 @@ namespace System.Text.Json
 
             Debug.Assert(segment.IndexOf(JsonConstants.BackSlash) == -1);
 
-            if (segment.Length > JsonConstants.MaximumDateTimeOffsetParseLength
-                || !JsonHelpers.TryParseAsISO(segment, out value, out int bytesConsumed)
-                || segment.Length != bytesConsumed)
+            if (segment.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
+                && JsonHelpers.TryParseAsISO(segment, out DateTimeOffset tmp, out int bytesConsumed)
+                && segment.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = default;
+            return false;
         }
 
         /// <summary>
@@ -571,14 +573,15 @@ namespace System.Text.Json
 
             Debug.Assert(segment.IndexOf(JsonConstants.BackSlash) == -1);
 
-            if (segment.Length != JsonConstants.MaximumFormatGuidLength
-                || !Utf8Parser.TryParse(segment, out value, out _, 'D'))
+            if (segment.Length == JsonConstants.MaximumFormatGuidLength
+                && Utf8Parser.TryParse(segment, out Guid tmp, out _, 'D'))
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = default;
+            return false;
         }
 
         /// <summary>

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -493,10 +493,15 @@ namespace System.Text.Json
 
             Debug.Assert(segment.IndexOf(JsonConstants.BackSlash) == -1);
 
-            value = default;
-            return (segment.Length <= JsonConstants.MaximumDateTimeOffsetParseLength)
-                && JsonHelpers.TryParseAsISO(segment, out value, out int bytesConsumed)
-                && segment.Length == bytesConsumed;
+            if (segment.Length > JsonConstants.MaximumDateTimeOffsetParseLength
+                || !JsonHelpers.TryParseAsISO(segment, out value, out int bytesConsumed)
+                || segment.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -527,10 +532,15 @@ namespace System.Text.Json
 
             Debug.Assert(segment.IndexOf(JsonConstants.BackSlash) == -1);
 
-            value = default;
-            return (segment.Length <= JsonConstants.MaximumDateTimeOffsetParseLength)
-                && JsonHelpers.TryParseAsISO(segment, out value, out int bytesConsumed)
-                && segment.Length == bytesConsumed;
+            if (segment.Length > JsonConstants.MaximumDateTimeOffsetParseLength
+                || !JsonHelpers.TryParseAsISO(segment, out value, out int bytesConsumed)
+                || segment.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -561,8 +571,14 @@ namespace System.Text.Json
 
             Debug.Assert(segment.IndexOf(JsonConstants.BackSlash) == -1);
 
-            value = default;
-            return (segment.Length == JsonConstants.MaximumFormatGuidLength) && Utf8Parser.TryParse(segment, out value, out _, 'D');
+            if (segment.Length != JsonConstants.MaximumFormatGuidLength
+                || !Utf8Parser.TryParse(segment, out value, out _, 'D'))
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
@@ -275,10 +275,15 @@ namespace System.Text.Json
             sourceUnescaped = sourceUnescaped.Slice(0, written);
             Debug.Assert(!sourceUnescaped.IsEmpty);
 
-            value = default;
-            return (sourceUnescaped.Length <= JsonConstants.MaximumDateTimeOffsetParseLength)
-                && JsonHelpers.TryParseAsISO(sourceUnescaped, out value, out int bytesConsumed)
-                && sourceUnescaped.Length == bytesConsumed;
+            if (sourceUnescaped.Length > JsonConstants.MaximumDateTimeOffsetParseLength
+                || !JsonHelpers.TryParseAsISO(sourceUnescaped, out value, out int bytesConsumed)
+                || sourceUnescaped.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         public static bool TryGetEscapedDateTimeOffset(ReadOnlySpan<byte> source, out DateTimeOffset value)
@@ -295,10 +300,15 @@ namespace System.Text.Json
             sourceUnescaped = sourceUnescaped.Slice(0, written);
             Debug.Assert(!sourceUnescaped.IsEmpty);
 
-            value = default;
-            return (sourceUnescaped.Length <= JsonConstants.MaximumDateTimeOffsetParseLength)
-                && JsonHelpers.TryParseAsISO(sourceUnescaped, out value, out int bytesConsumed)
-                && sourceUnescaped.Length == bytesConsumed;
+            if (sourceUnescaped.Length > JsonConstants.MaximumDateTimeOffsetParseLength
+                || !JsonHelpers.TryParseAsISO(sourceUnescaped, out value, out int bytesConsumed)
+                || sourceUnescaped.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         public static bool TryGetEscapedGuid(ReadOnlySpan<byte> source, out Guid value)
@@ -316,8 +326,14 @@ namespace System.Text.Json
             utf8Unescaped = utf8Unescaped.Slice(0, written);
             Debug.Assert(!utf8Unescaped.IsEmpty);
 
-            value = default;
-            return (utf8Unescaped.Length == JsonConstants.MaximumFormatGuidLength) && Utf8Parser.TryParse(utf8Unescaped, out value, out _, 'D');
+            if (utf8Unescaped.Length != JsonConstants.MaximumFormatGuidLength 
+                || !Utf8Parser.TryParse(utf8Unescaped, out value, out _, 'D'))
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
@@ -275,15 +275,16 @@ namespace System.Text.Json
             sourceUnescaped = sourceUnescaped.Slice(0, written);
             Debug.Assert(!sourceUnescaped.IsEmpty);
 
-            if (sourceUnescaped.Length > JsonConstants.MaximumDateTimeOffsetParseLength
-                || !JsonHelpers.TryParseAsISO(sourceUnescaped, out value, out int bytesConsumed)
-                || sourceUnescaped.Length != bytesConsumed)
+            if (sourceUnescaped.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
+                && JsonHelpers.TryParseAsISO(sourceUnescaped, out DateTime tmp, out int bytesConsumed)
+                && sourceUnescaped.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = default;
+            return false;
         }
 
         public static bool TryGetEscapedDateTimeOffset(ReadOnlySpan<byte> source, out DateTimeOffset value)
@@ -300,15 +301,16 @@ namespace System.Text.Json
             sourceUnescaped = sourceUnescaped.Slice(0, written);
             Debug.Assert(!sourceUnescaped.IsEmpty);
 
-            if (sourceUnescaped.Length > JsonConstants.MaximumDateTimeOffsetParseLength
-                || !JsonHelpers.TryParseAsISO(sourceUnescaped, out value, out int bytesConsumed)
-                || sourceUnescaped.Length != bytesConsumed)
+            if (sourceUnescaped.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
+                && JsonHelpers.TryParseAsISO(sourceUnescaped, out DateTimeOffset tmp, out int bytesConsumed)
+                && sourceUnescaped.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = default;
+            return false;
         }
 
         public static bool TryGetEscapedGuid(ReadOnlySpan<byte> source, out Guid value)
@@ -326,14 +328,15 @@ namespace System.Text.Json
             utf8Unescaped = utf8Unescaped.Slice(0, written);
             Debug.Assert(!utf8Unescaped.IsEmpty);
 
-            if (utf8Unescaped.Length != JsonConstants.MaximumFormatGuidLength 
-                || !Utf8Parser.TryParse(utf8Unescaped, out value, out _, 'D'))
+            if (utf8Unescaped.Length == JsonConstants.MaximumFormatGuidLength 
+                && Utf8Parser.TryParse(utf8Unescaped, out Guid tmp, out _, 'D'))
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = default;
+            return false;
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -338,7 +338,14 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            return Utf8Parser.TryParse(span, out value, out int bytesConsumed) && span.Length == bytesConsumed;
+            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed)
+                || span.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -359,7 +366,14 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            return Utf8Parser.TryParse(span, out value, out int bytesConsumed) && span.Length == bytesConsumed;
+            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed) 
+                || span.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -381,7 +395,14 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            return Utf8Parser.TryParse(span, out value, out int bytesConsumed) && span.Length == bytesConsumed;
+            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed)
+                || span.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -403,7 +424,14 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            return Utf8Parser.TryParse(span, out value, out int bytesConsumed) && span.Length == bytesConsumed;
+            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed) 
+                || span.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -424,7 +452,14 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            return Utf8Parser.TryParse(span, out value, out int bytesConsumed, _numberFormat) && span.Length == bytesConsumed;
+            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed, _numberFormat) 
+                || span.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -445,7 +480,14 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            return Utf8Parser.TryParse(span, out value, out int bytesConsumed, _numberFormat) && span.Length == bytesConsumed;
+            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed, _numberFormat)
+                || span.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+            
+            return true;
         }
 
         /// <summary>
@@ -466,7 +508,14 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            return Utf8Parser.TryParse(span, out value, out int bytesConsumed, _numberFormat) && span.Length == bytesConsumed;
+            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed, _numberFormat)
+                || span.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -522,10 +571,15 @@ namespace System.Text.Json
 
             Debug.Assert(span.IndexOf(JsonConstants.BackSlash) == -1);
 
-            value = default;
-            return (span.Length <= JsonConstants.MaximumDateTimeOffsetParseLength)
-                && JsonHelpers.TryParseAsISO(span, out value, out int bytesConsumed)
-                && span.Length == bytesConsumed;
+            if (span.Length > JsonConstants.MaximumDateTimeOffsetParseLength
+                || !JsonHelpers.TryParseAsISO(span, out value, out int bytesConsumed)
+                || span.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -581,10 +635,15 @@ namespace System.Text.Json
 
             Debug.Assert(span.IndexOf(JsonConstants.BackSlash) == -1);
 
-            value = default;
-            return (span.Length <= JsonConstants.MaximumDateTimeOffsetParseLength)
-                && JsonHelpers.TryParseAsISO(span, out value, out int bytesConsumed)
-                && span.Length == bytesConsumed;
+            if (span.Length > JsonConstants.MaximumDateTimeOffsetParseLength
+                || !JsonHelpers.TryParseAsISO(span, out value, out int bytesConsumed)
+                || span.Length != bytesConsumed)
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -640,8 +699,14 @@ namespace System.Text.Json
 
             Debug.Assert(span.IndexOf(JsonConstants.BackSlash) == -1);
 
-            value = default;
-            return (span.Length == JsonConstants.MaximumFormatGuidLength) && Utf8Parser.TryParse(span, out value, out _, 'D');
+            if (span.Length != JsonConstants.MaximumFormatGuidLength
+                || !Utf8Parser.TryParse(span, out value, out _, 'D'))
+            {
+                value = default;
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -338,14 +338,15 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed)
-                || span.Length != bytesConsumed)
+            if (Utf8Parser.TryParse(span, out int tmp, out int bytesConsumed)
+                && span.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = 0;
+            return false;
         }
 
         /// <summary>
@@ -366,14 +367,15 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed) 
-                || span.Length != bytesConsumed)
+            if (Utf8Parser.TryParse(span, out long tmp, out int bytesConsumed) 
+                && span.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = 0;
+            return false;
         }
 
         /// <summary>
@@ -395,14 +397,15 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed)
-                || span.Length != bytesConsumed)
+            if (Utf8Parser.TryParse(span, out uint tmp, out int bytesConsumed)
+                && span.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = 0;
+            return false;
         }
 
         /// <summary>
@@ -424,14 +427,15 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed) 
-                || span.Length != bytesConsumed)
+            if (Utf8Parser.TryParse(span, out ulong tmp, out int bytesConsumed) 
+                && span.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = 0;
+            return false;
         }
 
         /// <summary>
@@ -452,14 +456,15 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed, _numberFormat) 
-                || span.Length != bytesConsumed)
+            if (Utf8Parser.TryParse(span, out float tmp, out int bytesConsumed, _numberFormat) 
+                && span.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = 0;
+            return false;
         }
 
         /// <summary>
@@ -480,14 +485,15 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed, _numberFormat)
-                || span.Length != bytesConsumed)
+            if (Utf8Parser.TryParse(span, out double tmp, out int bytesConsumed, _numberFormat)
+                && span.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
-            
-            return true;
+
+            value = 0;
+            return false;
         }
 
         /// <summary>
@@ -508,14 +514,15 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            if (!Utf8Parser.TryParse(span, out value, out int bytesConsumed, _numberFormat)
-                || span.Length != bytesConsumed)
+            if (Utf8Parser.TryParse(span, out decimal tmp, out int bytesConsumed, _numberFormat)
+                && span.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = 0;
+            return false;
         }
 
         /// <summary>
@@ -571,15 +578,16 @@ namespace System.Text.Json
 
             Debug.Assert(span.IndexOf(JsonConstants.BackSlash) == -1);
 
-            if (span.Length > JsonConstants.MaximumDateTimeOffsetParseLength
-                || !JsonHelpers.TryParseAsISO(span, out value, out int bytesConsumed)
-                || span.Length != bytesConsumed)
+            if (span.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
+                && JsonHelpers.TryParseAsISO(span, out DateTime tmp, out int bytesConsumed)
+                && span.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = default;
+            return false;
         }
 
         /// <summary>
@@ -635,15 +643,16 @@ namespace System.Text.Json
 
             Debug.Assert(span.IndexOf(JsonConstants.BackSlash) == -1);
 
-            if (span.Length > JsonConstants.MaximumDateTimeOffsetParseLength
-                || !JsonHelpers.TryParseAsISO(span, out value, out int bytesConsumed)
-                || span.Length != bytesConsumed)
+            if (span.Length <= JsonConstants.MaximumDateTimeOffsetParseLength
+                && JsonHelpers.TryParseAsISO(span, out DateTimeOffset tmp, out int bytesConsumed)
+                && span.Length == bytesConsumed)
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = default;
+            return false;
         }
 
         /// <summary>
@@ -699,14 +708,15 @@ namespace System.Text.Json
 
             Debug.Assert(span.IndexOf(JsonConstants.BackSlash) == -1);
 
-            if (span.Length != JsonConstants.MaximumFormatGuidLength
-                || !Utf8Parser.TryParse(span, out value, out _, 'D'))
+            if (span.Length == JsonConstants.MaximumFormatGuidLength
+                && Utf8Parser.TryParse(span, out Guid tmp, out _, 'D'))
             {
-                value = default;
-                return false;
+                value = tmp;
+                return true;
             }
 
-            return true;
+            value = default;
+            return false;
         }
     }
 }

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -1116,7 +1116,9 @@ namespace System.Text.Json.Tests
                 Assert.Equal(JsonValueType.String, root.Type);
 
                 Assert.False(root.TryGetDateTime(out DateTime DateTimeVal));
+                Assert.Equal(default, DateTimeVal);
                 Assert.False(root.TryGetDateTimeOffset(out DateTimeOffset DateTimeOffsetVal));
+                Assert.Equal(default, DateTimeOffsetVal);
 
                 Assert.Throws<FormatException>(() => root.GetDateTime());
                 Assert.Throws<FormatException>(() => root.GetDateTimeOffset());
@@ -1167,6 +1169,7 @@ namespace System.Text.Json.Tests
                 Assert.Equal(JsonValueType.String, root.Type);
 
                 Assert.False(root.TryGetGuid(out Guid GuidVal));
+                Assert.Equal(default, GuidVal);
 
                 Assert.Throws<FormatException>(() => root.GetGuid());
             }
@@ -1480,10 +1483,15 @@ namespace System.Text.Json.Tests
                 const string NotPresent = "Not Present";
                 byte[] notPresentUtf8 = Encoding.UTF8.GetBytes(NotPresent);
 
-                Assert.False(root.TryGetProperty(NotPresent, out _));
-                Assert.False(root.TryGetProperty(NotPresent.AsSpan(), out _));
-                Assert.False(root.TryGetProperty(notPresentUtf8, out _));
-                Assert.False(root.TryGetProperty(new string('z', 512), out _));
+                JsonElement element;
+                Assert.False(root.TryGetProperty(NotPresent, out element));
+                Assert.Equal(default, element);
+                Assert.False(root.TryGetProperty(NotPresent.AsSpan(), out element));
+                Assert.Equal(default, element);
+                Assert.False(root.TryGetProperty(notPresentUtf8, out element));
+                Assert.Equal(default, element);
+                Assert.False(root.TryGetProperty(new string('z', 512), out element));
+                Assert.Equal(default, element);
 
                 Assert.Throws<KeyNotFoundException>(() => root.GetProperty(NotPresent));
                 Assert.Throws<KeyNotFoundException>(() => root.GetProperty(NotPresent.AsSpan()));

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -252,6 +252,7 @@ namespace System.Text.Json.Tests
                 if (json.TokenType == JsonTokenType.Number)
                 {
                     Assert.False(json.TryGetInt32(out int value));
+                    Assert.Equal(default, value);
                     Assert.True(json.TryGetDouble(out double doubleValue));
                     Assert.Equal(expected, doubleValue);
 
@@ -290,6 +291,7 @@ namespace System.Text.Json.Tests
                 if (json.TokenType == JsonTokenType.Number)
                 {
                     Assert.False(json.TryGetInt64(out long value));
+                    Assert.Equal(default, value);
                     Assert.True(json.TryGetDouble(out double doubleValue));
                     Assert.Equal(expected, doubleValue);
 
@@ -329,6 +331,7 @@ namespace System.Text.Json.Tests
                 if (json.TokenType == JsonTokenType.Number)
                 {
                     Assert.False(json.TryGetUInt32(out uint value));
+                    Assert.Equal(default, value);
                     Assert.True(json.TryGetDouble(out double doubleValue));
                     Assert.Equal(expected, doubleValue);
 
@@ -367,6 +370,7 @@ namespace System.Text.Json.Tests
                 if (json.TokenType == JsonTokenType.Number)
                 {
                     Assert.False(json.TryGetUInt64(out ulong value));
+                    Assert.Equal(default, value);
                     Assert.True(json.TryGetDouble(out double doubleValue));
                     Assert.Equal(expected, doubleValue);
 
@@ -452,6 +456,7 @@ namespace System.Text.Json.Tests
                 if (json.TokenType == JsonTokenType.Number)
                 {
                     Assert.False(json.TryGetDecimal(out decimal value));
+                    Assert.Equal(default, value);
                     Assert.True(json.TryGetDouble(out double doubleValue));
                     Assert.Equal(expected, doubleValue);
 
@@ -966,6 +971,7 @@ namespace System.Text.Json.Tests
             while (json.Read())
             {
                 Assert.False(json.TryGetDateTime(out DateTime actualDateTime));
+                Assert.Equal(default, actualDateTime);
 
                 try
                 {
@@ -989,6 +995,7 @@ namespace System.Text.Json.Tests
                 if (json.TokenType == JsonTokenType.String)
                 {
                     Assert.False(json.TryGetDateTimeOffset(out DateTimeOffset actualDateTime));
+                    Assert.Equal(default, actualDateTime);
 
                     try
                     {
@@ -1033,7 +1040,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(JsonTokenType.String, json.TokenType);
 
             Assert.False(json.TryGetGuid(out Guid actual));
-            Assert.Equal(Guid.Empty, actual);
+            Assert.Equal(default, actual);
 
             JsonTestHelper.AssertThrows<FormatException>(json, (jsonReader) => jsonReader.GetGuid());
         }


### PR DESCRIPTION
This fixes #37119 by ensuring that `value` is assigned `default` whenever a TryGetXXX method would return `false`.

Test coverage notes:
I was unable to get coverage on TryGetSingle and TryGetDouble's false path. The simple take, an invalid number, causes an InvalidOperationException to be thrown instead of returning false. If the value is a number, it appears that Utf8Parser.TryParse will always return *some* value (be it NaN, +/-Inf) for the inputs we give it because of the preceding check that the value itself is a number.