### PR TITLE
Exclude non netcoreapp packages from OOB package

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.OOB/Microsoft.Private.CoreFx.OOB.pkgproj
@@ -20,7 +20,11 @@
     </MSBuild>
 
     <ItemGroup>
+      <NonNetCoreAppPackage Include="Microsoft.Diagnostics.Tracing.EventSource.Redist" />
+      <NonNetCoreAppPackage Include="Microsoft.IO.Redist" />
+
       <Dependency Include="@(PrereleaseLibraryPackage)"
+                  Exclude="@(NonNetCoreAppPackage)"
                   Condition="!$([System.String]::new('%(Identity)').Contains('Private')) and !$([System.String]::new('%(Identity)').EndsWith('Experimental')) and !$([System.String]::new('%(Identity)').StartsWith('runtime.'))" />
     </ItemGroup>
     


### PR DESCRIPTION
Went through the whole list, these are the only two packages that are netfx specific.