### PR TITLE
fix CopyToAsyncCore - cancellation and infinite loop

### DIFF
--- a/src/Common/src/CoreLib/System/Resources/ManifestBasedResourceGroveler.cs
+++ b/src/Common/src/CoreLib/System/Resources/ManifestBasedResourceGroveler.cs
@@ -4,14 +4,14 @@
 
 /*============================================================
 **
-** 
-** 
+**
+**
 **
 **
 ** Purpose: Searches for resources in Assembly manifest, used
 ** for assembly-based resource lookup.
 **
-** 
+**
 ===========================================================*/
 
 namespace System.Resources
@@ -34,7 +34,7 @@ namespace System.Resources
     // Note: this type is integral to the construction of exception objects,
     // and sometimes this has to be done in low memory situtations (OOM) or
     // to create TypeInitializationExceptions due to failure of a static class
-    // constructor. This type needs to be extremely careful and assume that 
+    // constructor. This type needs to be extremely careful and assume that
     // any type it references may have previously failed to construct, so statics
     // belonging to that type may not be initialized. FrameworkEventSource.Log
     // is one such example.
@@ -93,7 +93,7 @@ namespace System.Resources
             {
                 // Handle case in here where someone added a callback for assembly load events.
                 // While no other threads have called into GetResourceSet, our own thread can!
-                // At that point, we could already have an RS in our hash table, and we don't 
+                // At that point, we could already have an RS in our hash table, and we don't
                 // want to add it twice.
                 lock (localResourceSets)
                 {
@@ -165,7 +165,7 @@ namespace System.Resources
             }
             catch (ArgumentException e)
             { // we should catch ArgumentException only.
-                // Note we could go into infinite loops if mscorlib's 
+                // Note we could go into infinite loops if mscorlib's
                 // NeutralResourcesLanguageAttribute is mangled.  If this assert
                 // fires, please fix the build process for the BCL directory.
                 if (a == typeof(object).Assembly)
@@ -333,7 +333,7 @@ namespace System.Resources
             return stream;
         }
 
-        // Looks up a .resources file in the assembly manifest using 
+        // Looks up a .resources file in the assembly manifest using
         // case-insensitive lookup rules.  Yes, this is slow.  The metadata
         // dev lead refuses to make all assembly manifest resource lookups case-insensitive,
         // even optionally case-insensitive.
@@ -416,7 +416,7 @@ namespace System.Resources
             if (_mediator.UserResourceSet != null)
                 return false;
 
-            // Ignore the actual version of the ResourceReader and 
+            // Ignore the actual version of the ResourceReader and
             // RuntimeResourceSet classes.  Let those classes deal with
             // versioning themselves.
 
@@ -463,6 +463,27 @@ namespace System.Resources
             throw new MissingSatelliteAssemblyException(SR.Format(SR.MissingSatelliteAssembly_Culture_Name, _mediator.NeutralResourcesCulture, satAssemName), missingCultureName);
         }
 
+        private static string GetManifestResourceNamesList(Assembly assembly)
+        {
+            try
+            {
+                string postfix = "\"";
+                string [] resourceSetNames = assembly.GetManifestResourceNames();
+
+                // If we have more than 10 resource sets, we just print the first 10 for the sake of the exception message readability.
+                if (resourceSetNames.Length > 10)
+                {
+                    resourceSetNames = resourceSetNames[..10];
+                    postfix = "\", ...";
+                }
+                return "\"" + String.Join("\", \"", resourceSetNames) + postfix;
+            }
+            catch
+            {
+                return "\"\"";
+            }
+        }
+
         private void HandleResourceStreamMissing(string fileName)
         {
             Debug.Assert(_mediator.BaseName != null);
@@ -483,7 +504,9 @@ namespace System.Resources
                 resName = _mediator.LocationInfo.Namespace + Type.Delimiter;
             resName += fileName;
             Debug.Assert(_mediator.MainAssembly != null);
-            throw new MissingManifestResourceException(SR.Format(SR.MissingManifestResource_NoNeutralAsm, resName, _mediator.MainAssembly.GetName().Name));
+            throw new MissingManifestResourceException(
+                            SR.Format(SR.MissingManifestResource_NoNeutralAsm,
+                            resName, _mediator.MainAssembly.GetName().Name, GetManifestResourceNamesList(_mediator.MainAssembly)));
         }
     }
 }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -130,12 +130,12 @@ namespace System.IO.Pipelines
 
                         consumed = position;
                     }
-                    
-                    if (consumed.Equals(default(SequencePosition)))
+
+                    if (consumed.Equals(default))
                     {
                         consumed = buffer.End;
                     }
-                        
+
                     if (result.IsCompleted)
                     {
                         break;

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -131,7 +131,7 @@ namespace System.IO.Pipelines
                         consumed = position;
                     }
                     
-                    if (consumed.Equals(default(SequencePosition)) 
+                    if (consumed.Equals(default(SequencePosition)))
                     {
                         consumed = buffer.End;
                     }

--- a/src/System.IO.Pipelines/tests/Infrastructure/WriteCheckStream.cs
+++ b/src/System.IO.Pipelines/tests/Infrastructure/WriteCheckStream.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO.Pipelines.Tests.Infrastructure
+{
+    public class WriteCheckMemoryStream : Stream
+    {
+        private readonly MemoryStream _ms = new MemoryStream();
+        private int _writeCnt = 0;
+        private int _waitCnt = 0;
+        private TaskCompletionSource<object> _waitSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        public CancellationTokenSource MidWriteCancellation { get; set; }
+        private readonly object _lock = new object();
+
+        public override bool CanRead => _ms.CanRead;
+
+        public override bool CanSeek => _ms.CanSeek;
+
+        public override bool CanWrite => _ms.CanWrite;
+
+        public override long Length => _ms.Length;
+
+        public override long Position { get => _ms.Position; set => _ms.Position = value; }
+
+        public override void Flush() => _ms.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => _ms.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => _ms.Seek(offset, origin);
+        public override void SetLength(long value) => _ms.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            lock (_lock)
+            {
+                _ms.Write(buffer, offset, count);
+                MidWriteCancellation?.Cancel();
+                _writeCnt += count;
+                if (_waitCnt > 0 && _writeCnt >= _waitCnt)
+                {
+                    _writeCnt = 0;
+                    _waitCnt = 0;
+                    _waitSource.TrySetResult(null);
+                }
+            }
+        }
+
+        public byte[] ToArray() => _ms.ToArray();
+
+        public Task WaitForBytesWrittenAsync(int cnt)
+        {
+            if (cnt <= 0)
+                throw new ArgumentException($"{nameof(cnt)} must be greater than 0");
+            lock (_lock)
+            {
+                _waitCnt = cnt;
+                _waitSource.TrySetCanceled();
+                _waitSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                return _waitSource.Task;
+            }
+        }
+
+        public override string ToString() => Encoding.ASCII.GetString(_ms.ToArray());
+    }
+}

--- a/src/System.IO.Pipelines/tests/Infrastructure/WriteCheckStream.cs
+++ b/src/System.IO.Pipelines/tests/Infrastructure/WriteCheckStream.cs
@@ -37,12 +37,7 @@ namespace System.IO.Pipelines.Tests.Infrastructure
                 _ms.Write(buffer, offset, count);
                 MidWriteCancellation?.Cancel();
                 _writeCnt += count;
-                if (_waitCnt > 0 && _writeCnt >= _waitCnt)
-                {
-                    _writeCnt = 0;
-                    _waitCnt = 0;
-                    _waitSource.TrySetResult(null);
-                }
+                CheckWaitCount();
             }
         }
 
@@ -57,7 +52,18 @@ namespace System.IO.Pipelines.Tests.Infrastructure
                 _waitCnt = cnt;
                 _waitSource.TrySetCanceled();
                 _waitSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+                CheckWaitCount();
                 return _waitSource.Task;
+            }
+        }
+        
+        private void CheckWaitCount() 
+        {
+            if (_waitCnt > 0 && _writeCnt >= _waitCnt)
+            {
+                _writeCnt = 0;
+                _waitCnt = 0;
+                _waitSource.TrySetResult(null);
             }
         }
 

--- a/src/System.IO.Pipelines/tests/System.IO.Pipelines.Tests.csproj
+++ b/src/System.IO.Pipelines/tests/System.IO.Pipelines.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="Infrastructure\HeapBufferPool.cs" />
     <Compile Include="Infrastructure\DisposeTrackingBufferPool.cs" />
     <Compile Include="Infrastructure\ReadOnlyStream.cs" />
+    <Compile Include="Infrastructure\WriteCheckStream.cs" />
     <Compile Include="Infrastructure\WriteOnlyStream.cs" />
     <Compile Include="Infrastructure\CancelledWritesStream.cs" />
     <Compile Include="Infrastructure\CancelledReadsStream.cs" />


### PR DESCRIPTION
#37802 
ReadResult result = await ReadAsync(cancellationToken).ConfigureAwait(false); should be before the try/finally block because if you cancel the read operation the finally clause will try to advance reader that is not in reading state and instead of OperationCancelledException you will end up with InvalidOperationException.

There is a bug either in PipeReader.CopyToAsyncCore() or ReadOnlySequence.TryGet():

When ReadOnlySequence.TryGet() reaches final segment it will return true and this final memory but it will also set position as default(SequencePosition) - I don't know if this is by design but CopyToAsyncCore() method does not take it in consideration and it will copy the memory but not advance the reader - this will cause it to repeat this data indefinitely.