### PR TITLE
HttpClient: Try decode Location header using UTF-8

### DIFF
--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -122,6 +122,20 @@ namespace System.Net.Test.Common
         {
             List<string> lines = null;
 
+            // Note, we assume there's no request body.
+            // We'll close the connection after reading the request header and sending the response.
+            await AcceptConnectionAsync(async connection =>
+            {
+                lines = await connection.ReadRequestHeaderAndSendCustomResponseAsync(response).ConfigureAwait(false);
+            });
+
+            return lines;
+        }
+
+        public async Task<List<string>> AcceptConnectionSendCustomResponseAndCloseAsync(byte[] response)
+        {
+            List<string> lines = null;
+
             // Note, we assume there's no request body.  
             // We'll close the connection after reading the request header and sending the response.
             await AcceptConnectionAsync(async connection =>
@@ -588,6 +602,13 @@ namespace System.Net.Test.Common
             {
                 List<string> lines = await ReadRequestHeaderAsync().ConfigureAwait(false);
                 await _writer.WriteAsync(response).ConfigureAwait(false);
+                return lines;
+            }
+
+            public async Task<List<string>> ReadRequestHeaderAndSendCustomResponseAsync(byte[] response)
+            {
+                List<string> lines = await ReadRequestHeaderAsync().ConfigureAwait(false);
+                await _stream.WriteAsync(response).ConfigureAwait(false);
                 return lines;
             }
 

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -608,7 +608,7 @@ namespace System.Net.Test.Common
             public async Task<List<string>> ReadRequestHeaderAndSendCustomResponseAsync(byte[] response)
             {
                 List<string> lines = await ReadRequestHeaderAsync().ConfigureAwait(false);
-                await _stream.WriteAsync(response).ConfigureAwait(false);
+                await _stream.WriteAsync(response, 0, response.Length).ConfigureAwait(false);
                 return lines;
             }
 

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2167,6 +2167,60 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
+    public sealed class SocketsHttpHandlerTest_LocationHeader
+    {
+        private static readonly byte[] s_redirectResponseBefore = Encoding.ASCII.GetBytes(
+            "HTTP/1.1 301 Moved Permanently\r\n" +
+            "Connection: close\r\n" +
+            "Transfer-Encoding: chunked\r\n" +
+            "Location: ");
+
+        private static readonly byte[] s_redirectResponseAfter = Encoding.ASCII.GetBytes(
+            "\r\n" +
+            "Server: Loopback\r\n" +
+            "\r\n" +
+            "0\r\n\r\n");
+
+        [Theory]
+        // US-ASCII only
+        [InlineData("http://a/", new byte[] { (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/', (byte)'a', (byte)'/' })]
+        [InlineData("http://a/asdasd", new byte[] { (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/', (byte)'a', (byte)'/', (byte)'a', (byte)'s', (byte)'d', (byte)'a', (byte)'s', (byte)'d' })]
+        // 2, 3, 4 byte UTF-8 characters
+        [InlineData("http://a/\u00A2", new byte[] { (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/', (byte)'a', (byte)'/', 0xC2, 0xA2 })]
+        [InlineData("http://a/\u20AC", new byte[] { (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/', (byte)'a', (byte)'/', 0xE2, 0x82, 0xAC })]
+        [InlineData("http://a/\uD800\uDF48", new byte[] { (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/', (byte)'a', (byte)'/', 0xF0, 0x90, 0x8D, 0x88 })]
+        // 3 Polish letters
+        [InlineData("http://a/\u0105\u015B\u0107", new byte[] { (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/', (byte)'a', (byte)'/', 0xC4, 0x85, 0xC5, 0x9B, 0xC4, 0x87 })]
+        // Negative cases - should be interpreted as ISO-8859-1
+        // Invalid utf-8 sequence (continuation without start)
+        [InlineData("http://a/%C2%80", new byte[] { (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/', (byte)'a', (byte)'/', 0b10000000 })]
+        // Invalid utf-8 sequence (not allowed character)
+        [InlineData("http://a/\u00C3\u0028", new byte[] { (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/', (byte)'a', (byte)'/', 0xC3, 0x28 })]
+        // Incomplete utf-8 sequence
+        [InlineData("http://a/\u00C2", new byte[] { (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/', (byte)'a', (byte)'/', 0xC2 })]
+        public async void LocationHeader_DecodesUtf8_Success(string expected, byte[] location)
+        {
+            await LoopbackServer.CreateClientAndServerAsync(async url =>
+            {
+                using (HttpClientHandler handler = new HttpClientHandler())
+                {
+                    handler.AllowAutoRedirect = false;
+
+                    using (HttpClient client = new HttpClient(handler))
+                    {
+                        HttpResponseMessage response = await client.GetAsync(url);
+                        Assert.Equal(expected, response.Headers.Location.ToString());
+                    }
+                }
+            }, server => server.AcceptConnectionSendCustomResponseAndCloseAsync(PreperateResponseWithRedirect(location)));
+        }
+
+        private static byte[] PreperateResponseWithRedirect(byte[] location)
+        {
+            return s_redirectResponseBefore.Concat(location).Concat(s_redirectResponseAfter).ToArray();
+        }
+    }
+
     public sealed class SocketsHttpHandlerTest_Http2 : HttpClientHandlerTest_Http2
     {
         public SocketsHttpHandlerTest_Http2(ITestOutputHelper output) : base(output) { }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/35103

Some websites such as i.e. https://www.ilna.ir/fa/tiny/news-724227 (link from repro)
when asking for redirect put utf-8 characters in the Location header - currently all browsers and desktop implementation of HttpClient can handle such case.

This change is moving the desktop logic which is checking if Location contains any characters higher than 127 and if it does it tries to decode using UTF-8 (if that fails it falls back to the old behavior which is ISO-8859-1)

Desktop code:
https://referencesource.microsoft.com/#System/net/System/Net/WebHeaderCollection.cs,1126

You can note that there is only one usage for Location header (every other header uses ISO-8859-1)
https://referencesource.microsoft.com/#System/net/System/Net/WebHeaderCollection.cs,175