### PR TITLE
Use RepoTools instead of global tools

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -348,8 +348,6 @@
     <NetStandardRefPath>$(RefRootPath)netstandard/</NetStandardRefPath>
     <NetStandard21RefPath>$(RefRootPath)netstandard2.1/</NetStandard21RefPath>
     <NetFxRefPath>$(RefRootPath)netfx/</NetFxRefPath>
-    <!-- Keep in sync with property in eng\Tools.props. -->
-    <GlobalToolsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', '.tools', 'globaltools'))</GlobalToolsDir>
     <IbcOptimizationDataDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'ibc'))</IbcOptimizationDataDir>
     <ILAsmToolPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsToolsetDir)', 'ilasm'))</ILAsmToolPath>
     <ILLinkDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsToolsetDir)', 'ILLink'))</ILLinkDir>

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -47,72 +47,7 @@
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
     <PackageReference Include="System.Runtime.InteropServices.Analyzers" Version="1.1.0" />
     <PackageReference Include="System.Security.Cryptography.Hashing.Algorithms.Analyzers" Version="1.1.0" />
-
-    <!-- repo tools -->
-    <RepoTool Include="coverlet.console" Version="$(CoverletConsolePackageVersion)" />
-    <RepoTool Include="dotnet-reportgenerator-globaltool" Version="$(DotNetReportGeneratorGlobalToolPackageVersion)" />
   </ItemGroup>
-
-  <!-- Opt-in target to restore internal tools with interactive authentication. -->
-  <Target Name="InitOptionalTools"
-          Condition="'$(RestoreInternalTools)' == 'true'"
-          AfterTargets="Restore">
-
-    <PropertyGroup>
-      <ToolsDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', '.tools', 'CredentialsProvider'))</ToolsDir>
-      <CredentialsProviderScriptUrl Condition="'$(OS)' == 'Windows_NT'">https://raw.githubusercontent.com/Microsoft/artifacts-credprovider/master/helpers/installcredprovider.ps1</CredentialsProviderScriptUrl>
-      <CredentialsProviderScriptUrl Condition="'$(OS)' != 'Windows_NT'">https://raw.githubusercontent.com/Microsoft/artifacts-credprovider/master/helpers/installcredprovider.sh</CredentialsProviderScriptUrl>
-    </PropertyGroup>
-
-    <DownloadFile SourceUrl="$(CredentialsProviderScriptUrl)" DestinationFolder="$(ToolsDir)">
-      <Output TaskParameter="DownloadedFile" ItemName="CredentialsProviderScriptPath" />
-    </DownloadFile>
-
-    <Exec Condition="'$(OS)' == 'Windows_NT'" Command="powershell -ExecutionPolicy ByPass -NoProfile -File &quot;%(CredentialsProviderScriptPath.Identity)&quot;" />
-    <Exec Condition="'$(OS)' != 'Windows_NT'" Command="chmod +x &quot;%(CredentialsProviderScriptPath.Identity)&quot; %26%26 &quot;%(CredentialsProviderScriptPath.Identity)&quot;" />
-
-    <PropertyGroup>
-      <OptionalToolDir>$([MSBuild]::NormalizeDirectory('$(RepositoryEngineeringDir)', 'common', 'internal'))</OptionalToolDir>
-      <OptionalToolProjectPath>$(OptionalToolDir)Tools.csproj</OptionalToolProjectPath>
-    </PropertyGroup>
-
-    <Exec Command="&quot;$(DotNetTool)&quot; restore &quot;$(OptionalToolProjectPath)&quot; --interactive --ignore-failed-sources /p:TargetGroup=$(TargetGroup)"
-          WorkingDirectory="$(RepoRoot)" />
-
-  </Target>
-
-  <Target Name="InitGlobalTools" Condition="'@(RepoTool)' != ''" AfterTargets="Restore">
-
-    <PropertyGroup>
-      <!-- Keep in sync with property in RepoRoot\Directory.Build.props. -->
-      <GlobalToolsDir>$([MSBuild]::NormalizePath('$(RepoRoot)', '.tools', 'globaltools'))</GlobalToolsDir>
-    </PropertyGroup>
-
-    <!-- List all global tools and save the output. -->
-    <Exec Condition="Exists('$(GlobalToolsDir)')"
-          Command="&quot;$(DotNetTool)&quot; tool list --tool-path &quot;$(GlobalToolsDir)&quot;"
-          WorkingDirectory="$(RepoRoot)"
-          ConsoleToMsBuild="true"
-          ContinueOnError="WarnAndContinue">
-      <Output TaskParameter="ConsoleOutput" PropertyName="DotNetListToolsOutput" />
-    </Exec>
-
-    <!-- Uninstall the global tool if it exists with a different version. -->
-    <Exec Condition="Exists('$(GlobalToolsDir)') AND $(DotNetListToolsOutput.Contains('%(RepoTool.Identity)')) AND !$([System.Text.RegularExpressions.Regex]::IsMatch('$(DotNetListToolsOutput)', '$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Identity)'))\s+$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Version)'))'))"
-          Command="&quot;$(DotNetTool)&quot; tool uninstall --tool-path &quot;$(GlobalToolsDir)&quot; %(RepoTool.Identity)"
-          WorkingDirectory="$(RepoRoot)"
-          ContinueOnError="WarnAndContinue" />
-
-    <!--
-      Installs the global tool if it doesn't exist with the right version.
-      Creates the global tools folder automatically if it doesn't exist.
-    -->
-    <Exec Condition="!Exists('$(GlobalToolsDir)') OR !$([System.Text.RegularExpressions.Regex]::IsMatch('$(DotNetListToolsOutput)', '$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Identity)'))\s+$([System.Text.RegularExpressions.Regex]::Escape('%(RepoTool.Version)'))'))"
-          Command="&quot;$(DotNetTool)&quot; tool install --tool-path &quot;$(GlobalToolsDir)&quot; %(RepoTool.Identity) --version %(RepoTool.Version) --add-source https:%2F%2Fapi.nuget.org/v3/index.json"
-          WorkingDirectory="$(RepoRoot)"
-          ContinueOnError="WarnAndContinue" />
-
-  </Target>
 
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SaveItems" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
 

--- a/eng/dotnet-tools.json
+++ b/eng/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "coverlet.console": {
+      "version": "1.5.1",
+      "commands": [
+        "coverlet"
+      ]
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "4.1.6",
+      "commands": [
+        "reportgenerator"
+      ]
+    }
+  }
+}

--- a/eng/sendtohelix.proj
+++ b/eng/sendtohelix.proj
@@ -50,37 +50,22 @@
     <HelixCommand>$(HelixCommand) /p:LocalPackagesPath="%HELIX_CORRELATION_PAYLOAD%\packages\</HelixCommand>
   </PropertyGroup>
 
-  <!-- Define which workloads require global tools. -->
-  <PropertyGroup Condition="'$(UseGlobalTools)' == ''">
-    <UseGlobalTools Condition="'$(Coverage)' == 'true'">true</UseGlobalTools>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(HelixCommand)' == '' and '$(TargetsWindows)' == 'true'">
+  <PropertyGroup Condition="'$(HelixCommand)' == ''">
     <!--
       For windows we need to use call, since the command is going to be called from a bat script created by Helix
       and we exit /b at the end of RunTests.cmd, Helix runs some other commands after ours within the bat script,
       if we don't use call, then we cause the parent script to exit, and anything after will not be executed.
     -->
-    <HelixCommand>call RunTests.cmd --runtime-path %HELIX_CORRELATION_PAYLOAD% --dotnet-root %HELIX_CORRELATION_PAYLOAD%</HelixCommand>
-    <HelixCommand Condition="'$(UseGlobalTools)' == 'true'">$(HelixCommand) --global-tools-dir "%HELIX_CORRELATION_PAYLOAD%\tools"</HelixCommand>
+    <HelixCommand Condition="'$(TargetsWindows)' == 'true'">call RunTests.cmd --runtime-path %HELIX_CORRELATION_PAYLOAD% --dotnet-root %HELIX_CORRELATION_PAYLOAD%</HelixCommand>
+    <HelixCommand Condition="'$(TargetsWindows)' != 'true'">./RunTests.sh --runtime-path "$HELIX_CORRELATION_PAYLOAD" --dotnet-root "$HELIX_CORRELATION_PAYLOAD"</HelixCommand>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(HelixCommand)' == '' and '$(TargetsWindows)' != 'true'">
-    <HelixCommand>./RunTests.sh --runtime-path "$HELIX_CORRELATION_PAYLOAD" --dotnet-root "$HELIX_CORRELATION_PAYLOAD"</HelixCommand>
-    <HelixCommand Condition="'$(UseGlobalTools)' == 'true'">$(HelixCommand) --global-tools-dir "$HELIX_CORRELATION_PAYLOAD/tools"</HelixCommand>
-  </PropertyGroup>
-
-  <!-- We need to include all dlls in the runtime path as inputs to make it really incremental
-  if we use the root folder, if a dll is updated, the folder's timestamp is not updated, therefore skipped. -->
+  <!--
+    We need to include all dlls in the runtime path as inputs to make it really incremental if we use the root folder,
+    if a dll is updated, the folder's timestamp is not updated, therefore skipped.
+  -->
   <ItemGroup>
     <_RuntimeInputs Include="$(TestHostRootPath)**/*.dll" />
-  </ItemGroup>
-
-  <!-- Add global tools to runtime -->
-  <ItemGroup Condition="'$(UseGlobalTools)' == 'true'">
-    <TestArchiveRuntimeDependency Include="$(DotNetRoot)shared\Microsoft.NETCore.App\**\*.*" DestinationDir="shared\Microsoft.NETCore.App" />
-    <TestArchiveRuntimeDependency Include="$(DotNetRoot)host\**\*.*" DestinationDir="host" />
-    <TestArchiveRuntimeDependency Include="$(GlobalToolsDir)**\*.*" DestinationDir="tools" />
   </ItemGroup>
 
   <Target Name="CompressRuntimeDirectory"
@@ -88,34 +73,17 @@
           Outputs="$(TestArchiveRuntimeFile)"
           Condition="'$(TargetGroup)' != 'AllConfigurations'">
 
-    <!-- Copy additional test dependencies. -->
-    <ItemGroup>
-      <_TestArchiveRuntimeDependency Include="@(TestArchiveRuntimeDependency)">
-        <DestinationDir>%(TestArchiveRuntimeDependency.DestinationDir)\%(RecursiveDir)</DestinationDir>
-      </_TestArchiveRuntimeDependency>
-    </ItemGroup>
-
-    <Copy SourceFiles="@(_TestArchiveRuntimeDependency)"
-          DestinationFiles="@(_TestArchiveRuntimeDependency -> '$([MSBuild]::NormalizePath('$(TestHostRootPath)', '%(DestinationDir)', '%(Filename)%(Extension)'))')"
-          SkipUnchangedFiles="true"
-          OverwriteReadOnlyFiles="true"
-          Retries="3"
-          RetryDelayMilliseconds="300">
-      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
-    </Copy>
-
     <MakeDir Directories="$(TestArchiveRuntimeRoot)" />
-    <ZipDirectory
-        SourceDirectory="$(TestHostRootPath)"
-        DestinationFile="$(TestArchiveRuntimeFile)"
-        Overwrite="true" />
+    <ZipDirectory SourceDirectory="$(TestHostRootPath)"
+                  DestinationFile="$(TestArchiveRuntimeFile)"
+                  Overwrite="true" />
 
   </Target>
 
   <Target Name="BuildHelixWorkItems"
           DependsOnTargets="CompressRuntimeDirectory">
-    <ItemGroup>
 
+    <ItemGroup>
       <HelixCorrelationPayload Include="$(HelixCorrelationPayload)" />
 
       <_WorkItem Include="$(WorkItemArchiveWildCard)" Exclude="$(HelixCorrelationPayload)" />
@@ -126,5 +94,6 @@
         <Timeout>$(_timeoutSpan)</Timeout>
       </HelixWorkItem>
     </ItemGroup>
+
   </Target>
 </Project>


### PR DESCRIPTION
Depends on https://github.com/dotnet/arcade/pull/2848

I added the restoring repo tools (out-of-proc) logic to arcade with an extension point to configure the path of the repo tools manifest. Also I removed the restoring optional tools logic as we don't have TestILC anymore in corefx. If we want that step back we can just look into the git history. There's currently no reason to have it.

Removing the global tools logic from sendtohelix.proj as it won't work with repo tools this way. When we actually need this we will probably go a different way (i.e. coverlet integration with dotnet test or restoring repo tools on helix).