### PR TITLE
Address #37794 by removing "UTF-16" when not needed in System.Text.Json docs

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
@@ -34,7 +34,7 @@ namespace System.Text.Json
         /// <summary>
         /// Encodes the string text value as a JSON string.
         /// </summary>
-        /// <param name="value">The UTF-16 encoded value to be transformed as JSON encoded text.</param>
+        /// <param name="value">The value to be transformed as JSON encoded text.</param>
         /// <exception cref="ArgumentNullException">
         /// Thrown if value is null.
         /// </exception>
@@ -50,9 +50,9 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Encodes the UTF-16 text value as a JSON string.
+        /// Encodes the text value as a JSON string.
         /// </summary>
-        /// <param name="value">The UTF-16 encoded value to be transformed as JSON encoded text.</param>
+        /// <param name="value">The value to be transformed as JSON encoded text.</param>
         /// <exception cref="ArgumentException">
         /// Thrown when the specified value is too large or if it contains invalid UTF-16 characters.
         /// </exception>

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -304,10 +304,10 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Compares the UTF-16 encoded text to the unescaped JSON token value in the source and returns true if they match.
+        /// Compares the text to the unescaped JSON token value in the source and returns true if they match.
         /// </summary>
-        /// <param name="otherText">The UTF-16 encoded text to compare against.</param>
-        /// <returns>True if the JSON token value in the source matches the UTF-16 encoded look up text.</returns>
+        /// <param name="otherText">The text to compare against.</param>
+        /// <returns>True if the JSON token value in the source matches the look up text.</returns>
         /// <exception cref="InvalidOperationException">
         /// Thrown if trying to find a text match on a JSON token that is not a string
         /// (i.e. other than <see cref="JsonTokenType.String"/> or <see cref="JsonTokenType.PropertyName"/>).

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -20,7 +20,7 @@ namespace System.Text.Json.Serialization
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
-        /// <remarks>Using a UTF-16 <see cref="System.String"/> is not as efficient as using the
+        /// <remarks>Using a <see cref="System.String"/> is not as efficient as using the
         /// UTF-8 methods since the implementation natively uses UTF-8.
         /// </remarks>
         public static TValue Parse<TValue>(string json, JsonSerializerOptions options = null)
@@ -46,7 +46,7 @@ namespace System.Text.Json.Serialization
         /// the <paramref name="returnType"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
-        /// <remarks>Using a UTF-16 <see cref="System.String"/> is not as efficient as using the
+        /// <remarks>Using a <see cref="System.String"/> is not as efficient as using the
         /// UTF-8 methods since the implementation natively uses UTF-8.
         /// </remarks>
         public static object Parse(string json, Type returnType, JsonSerializerOptions options = null)

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
@@ -40,7 +40,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="DateTime"/> value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -60,7 +60,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="DateTime"/> value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -40,7 +40,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="DateTimeOffset"/> value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -60,7 +60,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="DateTimeOffset"/> value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Decimal.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Decimal.cs
@@ -40,7 +40,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="decimal"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -60,7 +60,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="decimal"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
@@ -42,7 +42,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="double"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -62,7 +62,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="double"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
@@ -42,7 +42,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="float"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -62,7 +62,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="float"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.FormattedNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.FormattedNumber.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="utf8FormattedNumber">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
@@ -40,7 +40,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="Guid"/> value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -60,7 +60,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="Guid"/> value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Literal.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Literal.cs
@@ -37,7 +37,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and the JSON literal "null" as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <remarks>
         /// The property name is escaped before writing.
         /// </remarks>
@@ -53,7 +53,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and the JSON literal "null" as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <remarks>
         /// The property name is escaped before writing.
         /// </remarks>
@@ -128,7 +128,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="bool"/> value (as a JSON literal "true" or "false") as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON literal "true" or "false" as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -145,7 +145,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="bool"/> value (as a JSON literal "true" or "false") as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON literal "true" or "false" as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
@@ -40,7 +40,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="long"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -60,7 +60,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="long"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -131,7 +131,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="int"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -151,7 +151,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="int"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
@@ -36,7 +36,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and pre-encoded value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The JSON encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The value should already be escaped when the instance of <see cref="JsonEncodedText"/> was created. The property name is escaped before writing.
@@ -53,8 +53,8 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and string text value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name and value is escaped before writing.
         /// </remarks>
@@ -68,10 +68,10 @@ namespace System.Text.Json
             => WriteString(propertyName.AsSpan(), value.AsSpan());
 
         /// <summary>
-        /// Writes the UTF-16 property name and UTF-16 text value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// Writes the property name and text value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name and value is escaped before writing.
         /// </remarks>
@@ -119,7 +119,7 @@ namespace System.Text.Json
         /// Writes the pre-encoded property name and string text value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
         /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created. The value is escaped before writing.
         /// </remarks>
@@ -133,10 +133,10 @@ namespace System.Text.Json
             => WriteString(propertyName, value.AsSpan());
 
         /// <summary>
-        /// Writes the pre-encoded property name and UTF-16 text value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// Writes the pre-encoded property name and text value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
         /// <param name="propertyName">The JSON encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created. The value is escaped before writing.
         /// </remarks>
@@ -173,10 +173,10 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Writes the property name and UTF-16 text value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// Writes the property name and text value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name and value is escaped before writing.
         /// </remarks>
@@ -190,10 +190,10 @@ namespace System.Text.Json
             => WriteString(propertyName.AsSpan(), value);
 
         /// <summary>
-        /// Writes the UTF-8 property name and UTF-16 text value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// Writes the UTF-8 property name and text value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
         /// <param name="utf8PropertyName">The UTF-8 encoded property name of the JSON object to be written.</param>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name and value is escaped before writing.
         /// </remarks>
@@ -256,7 +256,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and UTF-8 text value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="utf8Value">The UTF-8 encoded value to be written as a JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name and value is escaped before writing.
@@ -271,9 +271,9 @@ namespace System.Text.Json
             => WriteString(propertyName.AsSpan(), utf8Value);
 
         /// <summary>
-        /// Writes the UTF-16 property name and UTF-8 text value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// Writes the property name and UTF-8 text value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="utf8Value">The UTF-8 encoded value to be written as a JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name and value is escaped before writing.
@@ -295,9 +295,9 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Writes the UTF-16 property name and pre-encoded value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// Writes the property name and pre-encoded value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The JSON encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The value should already be escaped when the instance of <see cref="JsonEncodedText"/> was created. The property name is escaped before writing.
@@ -335,10 +335,10 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        /// Writes the UTF-16 property name and string text value (as a JSON string) as part of a name/value pair of a JSON object.
+        /// Writes the property name and string text value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name and value is escaped before writing.
         /// </remarks>
@@ -395,7 +395,7 @@ namespace System.Text.Json
         /// Writes the UTF-8 property name and string text value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
         /// <param name="utf8PropertyName">The UTF-8 encoded property name of the JSON object to be written.</param>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON string as part of the name/value pair.</param>
         /// <remarks>
         /// The property name and value is escaped before writing.
         /// </remarks>

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.UnsignedNumber.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.UnsignedNumber.cs
@@ -41,7 +41,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="ulong"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -62,7 +62,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="ulong"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -136,7 +136,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="uint"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.
@@ -157,7 +157,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the property name and <see cref="uint"/> value (as a JSON number) as part of a name/value pair of a JSON object.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <param name="value">The value to be written as a JSON number as part of the name/value pair.</param>
         /// <remarks>
         /// The property name is escaped before writing.

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Comment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Comment.cs
@@ -16,7 +16,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the string text value (as a JSON comment).
         /// </summary>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON comment within /*..*/.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON comment within /*..*/.</param>
         /// <remarks>
         /// The comment value is not escaped before writing.
         /// </remarks>
@@ -27,14 +27,14 @@ namespace System.Text.Json
             => WriteCommentValue(value.AsSpan());
 
         /// <summary>
-        /// Writes the UTF-16 text value (as a JSON comment).
+        /// Writes the text value (as a JSON comment).
         /// </summary>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON comment within /*..*/.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON comment within /*..*/.</param>
         /// <remarks>
         /// The comment value is not escaped before writing.
         /// </remarks>
         /// <exception cref="ArgumentException">
-        /// Thrown when the specified value is too large OR if the given UTF-16 text value contains a comment delimiter (i.e. */).
+        /// Thrown when the specified value is too large OR if the given text value contains a comment delimiter (i.e. */).
         /// </exception>
         public void WriteCommentValue(ReadOnlySpan<char> value)
         {

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
@@ -35,7 +35,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the string text value (as a JSON string) as an element of a JSON array.
         /// </summary>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string element of a JSON array.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON string element of a JSON array.</param>
         /// <remarks>
         /// The value is escaped before writing.
         /// </remarks>
@@ -49,9 +49,9 @@ namespace System.Text.Json
            => WriteStringValue(value.AsSpan());
 
         /// <summary>
-        /// Writes the UTF-16 text value (as a JSON string) as an element of a JSON array.
+        /// Writes the text value (as a JSON string) as an element of a JSON array.
         /// </summary>
-        /// <param name="value">The UTF-16 encoded value to be written as a UTF-8 transcoded JSON string element of a JSON array.</param>
+        /// <param name="value">The value to be written as a UTF-8 transcoded JSON string element of a JSON array.</param>
         /// <remarks>
         /// The value is escaped before writing.
         /// </remarks>

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -703,7 +703,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the beginning of a JSON array with a property name as the key.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON array to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON array to be transcoded and written as UTF-8.</param>
         /// <remarks>
         /// The property name is escaped before writing.
         /// </remarks>
@@ -720,7 +720,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the beginning of a JSON object with a property name as the key.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <remarks>
         /// The property name is escaped before writing.
         /// </remarks>
@@ -737,7 +737,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the beginning of a JSON array with a property name as the key.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON array to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON array to be transcoded and written as UTF-8.</param>
         /// <remarks>
         /// The property name is escaped before writing.
         /// </remarks>
@@ -763,7 +763,7 @@ namespace System.Text.Json
         /// <summary>
         /// Writes the beginning of a JSON object with a property name as the key.
         /// </summary>
-        /// <param name="propertyName">The UTF-16 encoded property name of the JSON object to be transcoded and written as UTF-8.</param>
+        /// <param name="propertyName">The property name of the JSON object to be transcoded and written as UTF-8.</param>
         /// <remarks>
         /// The property name is escaped before writing.
         /// </remarks>


### PR DESCRIPTION
This addresses #37794 by removing "UTF-16" when not needed in the various System.Text.Json documentation comments. All overloads on `Utf8JsonWriter` and `JsonEncodedText` which took `string` or `ReadOnlySpan<char>` have been updated.