### PR TITLE
Allow unlimited json array dimensions during deserialization

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -26,10 +26,10 @@ namespace System.Text.Json.Serialization
             {
                 Debug.Assert(state.Current.IsDictionary);
 
-                JsonClassInfo classInfoTemp = state.Current.JsonClassInfo;
                 state.Push();
-                state.Current.JsonClassInfo = classInfoTemp.ElementClassInfo;
+                state.Current.JsonClassInfo = jsonPropertyInfo.ElementClassInfo;
                 state.Current.InitializeJsonPropertyInfo();
+                state.Current.PropertyInitialized = true;
 
                 ClassType classType = state.Current.JsonClassInfo.ClassType;
                 if (classType == ClassType.Value &&

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -60,6 +60,8 @@ namespace System.Text.Json.Serialization
             }
             else
             {
+                state.Current.ResetProperty();
+
                 ReadOnlySpan<byte> propertyName = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
                 if (reader._stringHasEscaping)
                 {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -102,6 +102,7 @@ namespace System.Text.Json.Serialization
             PropertyInitialized = false;
             JsonPropertyInfo = null;
             TempEnumerableValues = null;
+            KeyName = null;
         }
 
         public void EndObject()

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -3,14 +3,74 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Reflection;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
 {
     public static partial class ArrayTests
     {
+        [Fact]
+        public static void ReadObjectArray()
+        {
+            string data =
+                "[" +
+                SimpleTestClass.s_json +
+                "," +
+                SimpleTestClass.s_json +
+                "]";
+
+            SimpleTestClass[] i = JsonSerializer.Parse<SimpleTestClass[]>(Encoding.UTF8.GetBytes(data));
+
+            i[0].Verify();
+            i[1].Verify();
+        }
+
+        [Fact]
+        public static void ReadEmptyObjectArray()
+        {
+            SimpleTestClass[] data = JsonSerializer.Parse<SimpleTestClass[]>("[{}]");
+            Assert.Equal(1, data.Length);
+            Assert.NotNull(data[0]);
+        }
+
+        [Fact]
+        public static void ReadPrimitiveJagged2dArray()
+        {
+            int[][] i = JsonSerializer.Parse<int[][]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Assert.Equal(1, i[0][0]);
+            Assert.Equal(2, i[0][1]);
+            Assert.Equal(3, i[1][0]);
+            Assert.Equal(4, i[1][1]);
+        }
+
+        [Fact]
+        public static void ReadPrimitiveJagged3dArray()
+        {
+            int[][][] i = JsonSerializer.Parse<int[][][]>(Encoding.UTF8.GetBytes(@"[[[11,12],[13,14]], [[21,22],[23,24]]]"));
+            Assert.Equal(11, i[0][0][0]);
+            Assert.Equal(12, i[0][0][1]);
+            Assert.Equal(13, i[0][1][0]);
+            Assert.Equal(14, i[0][1][1]);
+
+            Assert.Equal(21, i[1][0][0]);
+            Assert.Equal(22, i[1][0][1]);
+            Assert.Equal(23, i[1][1][0]);
+            Assert.Equal(24, i[1][1][1]);
+        }
+
+        [Fact]
+        public static void ReadArrayWithInterleavedComments()
+        {
+            var options = new JsonSerializerOptions();
+            options.ReadCommentHandling = JsonCommentHandling.Skip;
+
+            int[][] i = JsonSerializer.Parse<int[][]>(Encoding.UTF8.GetBytes("[[1,2] // Inline [\n,[3, /* Multi\n]] Line*/4]]"), options);
+            Assert.Equal(1, i[0][0]);
+            Assert.Equal(2, i[0][1]);
+            Assert.Equal(3, i[1][0]);
+            Assert.Equal(4, i[1][1]);
+        }
+
         [Fact]
         public static void ReadEmpty()
         {
@@ -21,6 +81,37 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(0, list.Count);
         }
 
+        [Fact]
+        public static void ReadPrimitiveArray()
+        {
+            int[] i = JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            Assert.Equal(1, i[0]);
+            Assert.Equal(2, i[1]);
+
+            i = JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[]"));
+            Assert.Equal(0, i.Length);
+        }
+
+        [Fact]
+        public static void ReadArrayWithEnums()
+        {
+            SampleEnum[] i = JsonSerializer.Parse<SampleEnum[]>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            Assert.Equal(SampleEnum.One, i[0]);
+            Assert.Equal(SampleEnum.Two, i[1]);
+        }
+
+        [Fact]
+        public static void ReadPrimitiveArrayFail()
+        {
+            // Invalid data
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[1,""a""]")));
+
+            // Invalid data
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<List<int?>>(Encoding.UTF8.GetBytes(@"[1,""a""]")));
+
+            // Multidimensional arrays currently not supported
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[,]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]")));
+        }
 
         public static IEnumerable<object[]> ReadNullJson
         {

--- a/src/System.Text.Json/tests/Serialization/Array.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.WriteTests.cs
@@ -10,6 +10,66 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class ArrayTests
     {
         [Fact]
+        public static void WritePrimitiveArray()
+        {
+            var input = new int[] { 0, 1 };
+            string json = JsonSerializer.ToString(input);
+            Assert.Equal("[0,1]", json);
+        }
+
+        [Fact]
+        public static void WriteArrayWithEnums()
+        {
+            var input = new SampleEnum[] { SampleEnum.One, SampleEnum.Two };
+            string json = JsonSerializer.ToString(input);
+            Assert.Equal("[1,2]", json);
+        }
+
+        [Fact]
+        public static void WriteObjectArray()
+        {
+            string json;
+
+            {
+                SimpleTestClass[] input = new SimpleTestClass[] { new SimpleTestClass(), new SimpleTestClass() };
+                input[0].Initialize();
+                input[0].Verify();
+
+                input[1].Initialize();
+                input[1].Verify();
+
+                json = JsonSerializer.ToString(input);
+            }
+
+            {
+                SimpleTestClass[] output = JsonSerializer.Parse<SimpleTestClass[]>(json);
+                Assert.Equal(2, output.Length);
+                output[0].Verify();
+                output[1].Verify();
+            }
+        }
+
+        [Fact]
+        public static void WriteEmptyObjectArray()
+        {
+            object[] arr = new object[] { new object() };
+
+            string json = JsonSerializer.ToString(arr);
+            Assert.Equal("[{}]", json);
+        }
+
+        [Fact]
+        public static void WritePrimitiveJaggedArray()
+        {
+            var input = new int[2][];
+            input[0] = new int[] { 1, 2 };
+            input[1] = new int[] { 3, 4 };
+
+            string json = JsonSerializer.ToString(input);
+            Assert.Equal("[[1,2],[3,4]]", json);
+        }
+
+        [Fact]
         public static void WriteEmpty()
         {
             string json = JsonSerializer.ToString(new SimpleTestClass[] { });

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -208,6 +208,72 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void DictionaryOfDictionaryOfDictionary()
+        {
+            const string JsonString = @"{""Key1"":{""Key1"":{""Key1"":1,""Key2"":2},""Key2"":{""Key1"":3,""Key2"":4}},""Key2"":{""Key1"":{""Key1"":5,""Key2"":6},""Key2"":{""Key1"":7,""Key2"":8}}}";
+            Dictionary<string, Dictionary<string, Dictionary<string, int>>> obj = JsonSerializer.Parse<Dictionary<string, Dictionary<string, Dictionary<string, int>>>>(JsonString);
+
+            Assert.Equal(2, obj.Count);
+            Assert.Equal(2, obj["Key1"].Count);
+            Assert.Equal(2, obj["Key1"]["Key1"].Count);
+            Assert.Equal(2, obj["Key1"]["Key2"].Count);
+
+            Assert.Equal(1, obj["Key1"]["Key1"]["Key1"]);
+            Assert.Equal(2, obj["Key1"]["Key1"]["Key2"]);
+            Assert.Equal(3, obj["Key1"]["Key2"]["Key1"]);
+            Assert.Equal(4, obj["Key1"]["Key2"]["Key2"]);
+
+            Assert.Equal(2, obj["Key2"].Count);
+            Assert.Equal(2, obj["Key2"]["Key1"].Count);
+            Assert.Equal(2, obj["Key2"]["Key2"].Count);
+
+            Assert.Equal(5, obj["Key2"]["Key1"]["Key1"]);
+            Assert.Equal(6, obj["Key2"]["Key1"]["Key2"]);
+            Assert.Equal(7, obj["Key2"]["Key2"]["Key1"]);
+            Assert.Equal(8, obj["Key2"]["Key2"]["Key2"]);
+
+            string json = JsonSerializer.ToString(obj);
+            Assert.Equal(JsonString, json);
+
+            // Verify that typeof(object) doesn't interfere.
+            json = JsonSerializer.ToString<object>(obj);
+            Assert.Equal(JsonString, json);
+        }
+
+        [Fact]
+        public static void DictionaryOfArrayOfDictionary()
+        {
+            const string JsonString = @"{""Key1"":[{""Key1"":1,""Key2"":2},{""Key1"":3,""Key2"":4}],""Key2"":[{""Key1"":5,""Key2"":6},{""Key1"":7,""Key2"":8}]}";
+            Dictionary<string, Dictionary<string, int>[]> obj = JsonSerializer.Parse<Dictionary<string, Dictionary<string, int>[]>>(JsonString);
+
+            Assert.Equal(2, obj.Count);
+            Assert.Equal(2, obj["Key1"].Length);
+            Assert.Equal(2, obj["Key1"][0].Count);
+            Assert.Equal(2, obj["Key1"][1].Count);
+
+            Assert.Equal(1, obj["Key1"][0]["Key1"]);
+            Assert.Equal(2, obj["Key1"][0]["Key2"]);
+            Assert.Equal(3, obj["Key1"][1]["Key1"]);
+            Assert.Equal(4, obj["Key1"][1]["Key2"]);
+
+            Assert.Equal(2, obj["Key2"].Length);
+            Assert.Equal(2, obj["Key2"][0].Count);
+            Assert.Equal(2, obj["Key2"][1].Count);
+
+            Assert.Equal(5, obj["Key2"][0]["Key1"]);
+            Assert.Equal(6, obj["Key2"][0]["Key2"]);
+            Assert.Equal(7, obj["Key2"][1]["Key1"]);
+            Assert.Equal(8, obj["Key2"][1]["Key2"]);
+
+            string json = JsonSerializer.ToString(obj);
+            Assert.Equal(JsonString, json);
+
+            // Verify that typeof(object) doesn't interfere.
+            json = JsonSerializer.ToString<object>(obj);
+            Assert.Equal(JsonString, json);
+        }
+
+        [Fact]
         public static void DictionaryOfClasses()
         {
             Dictionary<string, SimpleTestClass> obj;

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -174,5 +174,42 @@ namespace System.Text.Json.Serialization.Tests
             TestClassWithStringToPrimitiveDictionary obj = JsonSerializer.Parse<TestClassWithStringToPrimitiveDictionary>(TestClassWithStringToPrimitiveDictionary.s_data);
             obj.Verify();
         }
+
+        public class TestClassWithBadData
+        {
+            public TestChildClassWithBadData[] Children { get; set; }
+        }
+
+        public class TestChildClassWithBadData
+        {
+            public int MyProperty { get; set; }
+        }
+
+        [Fact]
+        public static void ReadConversionFails()
+        {
+            byte[] data = Encoding.UTF8.GetBytes(
+                @"{" +
+                    @"""Children"":[" +
+                        @"{""MyProperty"":""StringButShouldBeInt""}" +
+                    @"]" +
+                @"}");
+
+            bool exceptionThrown = false;
+
+            try
+            {
+                JsonSerializer.Parse<TestClassWithBadData>(data);
+            }
+            catch (JsonException exception)
+            {
+                exceptionThrown = true;
+
+                // Exception should contain property path.
+                Assert.True(exception.ToString().Contains("[System.Text.Json.Serialization.Tests.ObjectTests+TestClassWithBadData].Children.MyProperty"));
+            }
+
+            Assert.True(exceptionThrown);
+        }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
@@ -49,6 +49,10 @@ namespace System.Text.Json.Serialization.Tests
         public DateTime[] MyDateTimeArray { get; set; }
         public DateTimeOffset[] MyDateTimeOffsetArray { get; set; }
         public SampleEnum[] MyEnumArray { get; set; }
+        public int[][] MyInt16TwoDimensionArray { get; set; }
+        public List<List<int>> MyInt16TwoDimensionList { get; set; }
+        public int[][][] MyInt16ThreeDimensionArray { get; set; }
+        public List<List<List<int>>> MyInt16ThreeDimensionList { get; set; }
         public List<string> MyStringList { get; set; }
         public IEnumerable<string> MyStringIEnumerableT { get; set; }
         public IList<string> MyStringIListT { get; set; }
@@ -119,6 +123,10 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyDateTimeArray"" : [""2019-01-30T12:01:02.0000000Z""]," +
                 @"""MyDateTimeOffsetArray"" : [""2019-01-30T12:01:02.0000000+01:00""]," +
                 @"""MyEnumArray"" : [2]," + // int by default
+                @"""MyInt16TwoDimensionArray"" : [[10, 11],[20, 21]]," +
+                @"""MyInt16TwoDimensionList"" : [[10, 11],[20, 21]]," +
+                @"""MyInt16ThreeDimensionArray"" : [[[11, 12],[13, 14]],[[21,22],[23,24]]]," +
+                @"""MyInt16ThreeDimensionList"" : [[[11, 12],[13, 14]],[[21,22],[23,24]]]," +
                 @"""MyStringList"" : [""Hello""]," +
                 @"""MyStringIEnumerableT"" : [""Hello""]," +
                 @"""MyStringIListT"" : [""Hello""]," +
@@ -182,6 +190,32 @@ namespace System.Text.Json.Serialization.Tests
             MyDateTimeArray = new DateTime[] { new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc) };
             MyDateTimeOffsetArray = new DateTimeOffset[] { new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)) };
             MyEnumArray = new SampleEnum[] { SampleEnum.Two };
+
+            MyInt16TwoDimensionArray = new int[2][];
+            MyInt16TwoDimensionArray[0] = new int[] { 10, 11 };
+            MyInt16TwoDimensionArray[1] = new int[] { 20, 21 };
+
+            MyInt16TwoDimensionList = new List<List<int>>();
+            MyInt16TwoDimensionList.Add(new List<int> { 10, 11 });
+            MyInt16TwoDimensionList.Add(new List<int> { 20, 21 });
+
+            MyInt16ThreeDimensionArray = new int[2][][];
+            MyInt16ThreeDimensionArray[0] = new int[2][];
+            MyInt16ThreeDimensionArray[1] = new int[2][];
+            MyInt16ThreeDimensionArray[0][0] = new int[] { 11, 12 };
+            MyInt16ThreeDimensionArray[0][1] = new int[] { 13, 14 };
+            MyInt16ThreeDimensionArray[1][0] = new int[] { 21, 22 };
+            MyInt16ThreeDimensionArray[1][1] = new int[] { 23, 24 };
+
+            MyInt16ThreeDimensionList = new List<List<List<int>>>();
+            var list1 = new List<List<int>>();
+            MyInt16ThreeDimensionList.Add(list1);
+            list1.Add(new List<int> { 11, 12 });
+            list1.Add(new List<int> { 13, 14 });
+            var list2 = new List<List<int>>();
+            MyInt16ThreeDimensionList.Add(list2);
+            list2.Add(new List<int> { 21, 22 });
+            list2.Add(new List<int> { 23, 24 });
 
             MyStringList = new List<string>() { "Hello" };
             MyStringIEnumerableT = new string[] { "Hello" };
@@ -252,6 +286,34 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(new DateTime(2019, 1, 30, 12, 1, 2, DateTimeKind.Utc), MyDateTimeArray[0]);
             Assert.Equal(new DateTimeOffset(2019, 1, 30, 12, 1, 2, new TimeSpan(1, 0, 0)), MyDateTimeOffsetArray[0]);
             Assert.Equal(SampleEnum.Two, MyEnumArray[0]);
+
+            Assert.Equal(10, MyInt16TwoDimensionArray[0][0]);
+            Assert.Equal(11, MyInt16TwoDimensionArray[0][1]);
+            Assert.Equal(20, MyInt16TwoDimensionArray[1][0]);
+            Assert.Equal(21, MyInt16TwoDimensionArray[1][1]);
+
+            Assert.Equal(10, MyInt16TwoDimensionList[0][0]);
+            Assert.Equal(11, MyInt16TwoDimensionList[0][1]);
+            Assert.Equal(20, MyInt16TwoDimensionList[1][0]);
+            Assert.Equal(21, MyInt16TwoDimensionList[1][1]);
+
+            Assert.Equal(11, MyInt16ThreeDimensionArray[0][0][0]);
+            Assert.Equal(12, MyInt16ThreeDimensionArray[0][0][1]);
+            Assert.Equal(13, MyInt16ThreeDimensionArray[0][1][0]);
+            Assert.Equal(14, MyInt16ThreeDimensionArray[0][1][1]);
+            Assert.Equal(21, MyInt16ThreeDimensionArray[1][0][0]);
+            Assert.Equal(22, MyInt16ThreeDimensionArray[1][0][1]);
+            Assert.Equal(23, MyInt16ThreeDimensionArray[1][1][0]);
+            Assert.Equal(24, MyInt16ThreeDimensionArray[1][1][1]);
+
+            Assert.Equal(11, MyInt16ThreeDimensionList[0][0][0]);
+            Assert.Equal(12, MyInt16ThreeDimensionList[0][0][1]);
+            Assert.Equal(13, MyInt16ThreeDimensionList[0][1][0]);
+            Assert.Equal(14, MyInt16ThreeDimensionList[0][1][1]);
+            Assert.Equal(21, MyInt16ThreeDimensionList[1][0][0]);
+            Assert.Equal(22, MyInt16ThreeDimensionList[1][0][1]);
+            Assert.Equal(23, MyInt16ThreeDimensionList[1][1][0]);
+            Assert.Equal(24, MyInt16ThreeDimensionList[1][1][1]);
 
             Assert.Equal("Hello", MyStringList[0]);
             Assert.Equal("Hello", MyStringIEnumerableT.First());

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -101,42 +100,10 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void ReadPrimitiveArray()
-        {
-            int[] i = JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[1,2]"));
-            Assert.Equal(1, i[0]);
-            Assert.Equal(2, i[1]);
-
-            i = JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[]"));
-            Assert.Equal(0, i.Length);
-        }
-
-        [Fact]
-        public static void ReadArrayWithEnums()
-        {
-            SampleEnum[] i = JsonSerializer.Parse<SampleEnum[]>(Encoding.UTF8.GetBytes(@"[1,2]"));
-            Assert.Equal(SampleEnum.One, i[0]);
-            Assert.Equal(SampleEnum.Two, i[1]);
-        }
-
-        [Fact]
         public static void EmptyStringInput()
         {
             string obj = JsonSerializer.Parse<string>(@"""""");
             Assert.Equal(string.Empty, obj);
-        }
-
-        [Fact]
-        public static void ReadPrimitiveArrayFail()
-        {
-            // Invalid data
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[1,""a""]")));
-
-            // Invalid data
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<List<int?>>(Encoding.UTF8.GetBytes(@"[1,""a""]")));
-
-            // Multidimensional arrays currently not supported
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[,]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]")));
         }
 
         [Fact]
@@ -300,90 +267,6 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<char?>("1"));
 
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<Enum>(unexpectedString));
-        }
-
-        [Fact]
-        public static void ReadObjectArray()
-        {
-            string data =
-                "[" +
-                SimpleTestClass.s_json +
-                "," +
-                SimpleTestClass.s_json +
-                "]";
-
-            SimpleTestClass[] i = JsonSerializer.Parse<SimpleTestClass[]>(Encoding.UTF8.GetBytes(data));
-
-            i[0].Verify();
-            i[1].Verify();
-        }
-
-        [Fact]
-        public static void ReadEmptyObjectArray()
-        {
-            SimpleTestClass[] data = JsonSerializer.Parse<SimpleTestClass[]>("[{}]");
-            Assert.Equal(1, data.Length);
-            Assert.NotNull(data[0]);
-        }
-
-        [Fact]
-        public static void ReadPrimitiveJaggedArray()
-        {
-            int[][] i = JsonSerializer.Parse<int[][]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
-            Assert.Equal(1, i[0][0]);
-            Assert.Equal(2, i[0][1]);
-            Assert.Equal(3, i[1][0]);
-            Assert.Equal(4, i[1][1]);
-        }
-
-        [Fact]
-        public static void ReadArrayWithInterleavedComments()
-        {
-            var options = new JsonSerializerOptions();
-            options.ReadCommentHandling = JsonCommentHandling.Skip;
-
-            int[][] i = JsonSerializer.Parse<int[][]>(Encoding.UTF8.GetBytes("[[1,2] // Inline [\n,[3, /* Multi\n]] Line*/4]]"), options);
-            Assert.Equal(1, i[0][0]);
-            Assert.Equal(2, i[0][1]);
-            Assert.Equal(3, i[1][0]);
-            Assert.Equal(4, i[1][1]);
-        }
-
-        public class TestClassWithBadData
-        {
-            public TestChildClassWithBadData[] Children { get; set; }
-        }
-
-        public class TestChildClassWithBadData
-        {
-            public int MyProperty { get; set; }
-        }
-
-        [Fact]
-        public static void ReadConversionFails()
-        {
-            byte[] data = Encoding.UTF8.GetBytes(
-                @"{" +
-                    @"""Children"":[" +
-                        @"{""MyProperty"":""StringButShouldBeInt""}" +
-                    @"]" +
-                @"}");
-
-            bool exceptionThrown = false;
-
-            try
-            {
-                JsonSerializer.Parse<TestClassWithBadData>(data);
-            }
-            catch (JsonException exception)
-            {
-                exceptionThrown = true;
-
-                // Exception should contain property path.
-                Assert.True(exception.ToString().Contains("[System.Text.Json.Serialization.Tests.ValueTests+TestClassWithBadData].Children.MyProperty"));
-            }
-
-            Assert.True(exceptionThrown);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -54,66 +52,6 @@ namespace System.Text.Json.Serialization.Tests
                 Span<byte> json = JsonSerializer.ToBytes("Hello");
                 Assert.Equal(Encoding.UTF8.GetBytes(@"""Hello"""), json.ToArray());
             }
-        }
-
-        [Fact]
-        public static void WritePrimitiveArray()
-        {
-            var input = new int[] { 0, 1 };
-            string json = JsonSerializer.ToString(input);
-            Assert.Equal("[0,1]", json);
-        }
-
-        [Fact]
-        public static void WriteArrayWithEnums()
-        {
-            var input = new SampleEnum[] { SampleEnum.One, SampleEnum.Two };
-            string json = JsonSerializer.ToString(input);
-            Assert.Equal("[1,2]", json);
-        }
-
-        [Fact]
-        public static void WriteObjectArray()
-        {
-            string json;
-
-            {
-                SimpleTestClass[] input = new SimpleTestClass[] { new SimpleTestClass(), new SimpleTestClass() };
-                input[0].Initialize();
-                input[0].Verify();
-
-                input[1].Initialize();
-                input[1].Verify();
-
-                json = JsonSerializer.ToString(input);
-            }
-
-            {
-                SimpleTestClass[] output = JsonSerializer.Parse<SimpleTestClass[]>(json);
-                Assert.Equal(2, output.Length);
-                output[0].Verify();
-                output[1].Verify();
-            }
-        }
-
-        [Fact]
-        public static void WriteEmptyObjectArray()
-        {
-            object[] arr = new object[]{new object()};
-
-            string json = JsonSerializer.ToString(arr);
-            Assert.Equal("[{}]", json);
-        }
-
-        [Fact]
-        public static void WritePrimitiveJaggedArray()
-        {
-            var input = new int[2][];
-            input[0] = new int[] { 1, 2 };
-            input[1] = new int[] { 3, 4 };
-
-            string json = JsonSerializer.ToString(input);
-            Assert.Equal("[[1,2],[3,4]]", json);
         }
     }
 }

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -29,9 +29,9 @@
     <Compile Include="Serialization\CyclicTests.cs" />
     <Compile Include="Serialization\DictionaryTests.cs" />
     <Compile Include="Serialization\EnumTests.cs" />
+    <Compile Include="Serialization\ExceptionTests.cs" />
     <Compile Include="Serialization\ExtensionDataTests.cs" />
     <Compile Include="Serialization\JsonElementTests.cs" />
-    <Compile Include="Serialization\ExceptionTests.cs" />
     <Compile Include="Serialization\Null.ReadTests.cs" />
     <Compile Include="Serialization\Null.WriteTests.cs" />
     <Compile Include="Serialization\Object.ReadTests.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/36889

Note some tests were moved from `Value.ReadTests` and `Value.WriteTests` to `Array.ReadTests`, `Array.WriteTests` and `Object.ReadTests`. There were no changes to these tests.
