### PR TITLE
Fix binary bitwise operators with resized BitArray

### DIFF
--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -261,12 +261,10 @@ namespace System.Collections
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
-
-            int count = Length; // length in bits
-            if (count != value.Length)
+            if (Length != value.Length)
                 throw new ArgumentException(SR.Arg_ArrayLengthsDiffer);
 
-            count = GetInt32ArrayLengthFromBitLength(count); // now length in bytes
+            int count = GetInt32ArrayLengthFromBitLength(Length);
 
             switch (count)
             {
@@ -309,12 +307,10 @@ namespace System.Collections
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
-
-            int count = Length; // length in bits
-            if (count != value.Length)
+            if (Length != value.Length)
                 throw new ArgumentException(SR.Arg_ArrayLengthsDiffer);
 
-            count = GetInt32ArrayLengthFromBitLength(count); // now length in bytes
+            int count = GetInt32ArrayLengthFromBitLength(Length);
 
             switch (count)
             {
@@ -357,12 +353,10 @@ namespace System.Collections
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
-
-            int count = Length; // length in bits
-            if (count != value.Length)
+            if (Length != value.Length)
                 throw new ArgumentException(SR.Arg_ArrayLengthsDiffer);
 
-            count = GetInt32ArrayLengthFromBitLength(count); // now length in bytes
+            int count = GetInt32ArrayLengthFromBitLength(Length);
 
             switch (count)
             {

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -261,10 +261,12 @@ namespace System.Collections
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
-            if (Length != value.Length)
+
+            int count = Length; // length in bits
+            if (count != value.Length)
                 throw new ArgumentException(SR.Arg_ArrayLengthsDiffer);
 
-            int count = m_array.Length;
+            count = GetInt32ArrayLengthFromBitLength(count); // now length in bytes
 
             switch (count)
             {
@@ -307,10 +309,12 @@ namespace System.Collections
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
-            if (Length != value.Length)
+
+            int count = Length; // length in bits
+            if (count != value.Length)
                 throw new ArgumentException(SR.Arg_ArrayLengthsDiffer);
 
-            int count = m_array.Length;
+            count = GetInt32ArrayLengthFromBitLength(count); // now length in bytes
 
             switch (count)
             {
@@ -353,10 +357,12 @@ namespace System.Collections
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
-            if (Length != value.Length)
+
+            int count = Length; // length in bits
+            if (count != value.Length)
                 throw new ArgumentException(SR.Arg_ArrayLengthsDiffer);
 
-            int count = m_array.Length;
+            count = GetInt32ArrayLengthFromBitLength(count); // now length in bytes
 
             switch (count)
             {

--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -187,6 +187,60 @@ namespace System.Collections.Tests
 
             AssertExtensions.Throws<ArgumentNullException>("value", () => bitArray1.Xor(null));
         }
+
+        public static IEnumerable<object[]> Resize_TestData()
+        {
+            yield return new object[] { new BitArray(32), new BitArray(64), 32, 32 };
+            yield return new object[] { new BitArray(32), new BitArray(64), 64, 64 };
+            yield return new object[] { new BitArray(64), new BitArray(32), 32, 32 };
+            yield return new object[] { new BitArray(64), new BitArray(32), 64, 64 };
+            yield return new object[] { new BitArray(288), new BitArray(32), 288, 288 };
+            yield return new object[] { new BitArray(288), new BitArray(32), 32, 32 };
+            yield return new object[] { new BitArray(32), new BitArray(288), 288, 288 };
+            yield return new object[] { new BitArray(32), new BitArray(288), 32, 32 };
+            yield return new object[] { new BitArray(1), new BitArray(9), 9, 9 };
+            yield return new object[] { new BitArray(1), new BitArray(9), 1, 1 };
+            yield return new object[] { new BitArray(9), new BitArray(1), 9, 9 };
+            yield return new object[] { new BitArray(9), new BitArray(1), 1, 1 };
+            yield return new object[] { new BitArray(287), new BitArray(32), 32, 32 };
+            yield return new object[] { new BitArray(287), new BitArray(32), 287, 287 };
+            yield return new object[] { new BitArray(32), new BitArray(287), 32, 32 };
+            yield return new object[] { new BitArray(32), new BitArray(287), 287, 287 };
+            yield return new object[] { new BitArray(289), new BitArray(32), 289, 289 };
+            yield return new object[] { new BitArray(289), new BitArray(32), 32, 32 };
+            yield return new object[] { new BitArray(32), new BitArray(289), 289, 289 };
+            yield return new object[] { new BitArray(32), new BitArray(289), 32, 32 };
+        }
+
+        [Theory]
+        [MemberData(nameof(Resize_TestData))]
+        public static void And_With_Resize(BitArray left, BitArray right, int newLeftLength, int newRightLength)
+        {
+            left.Length = newLeftLength;
+            right.Length = newRightLength;
+
+            left.And(right);
+        }
+
+        [Theory]
+        [MemberData(nameof(Resize_TestData))]
+        public static void Or_With_Resize(BitArray left, BitArray right, int newLeftLength, int newRightLength)
+        {
+            left.Length = newLeftLength;
+            right.Length = newRightLength;
+
+            left.Or(right);
+        }
+
+        [Theory]
+        [MemberData(nameof(Resize_TestData))]
+        public static void Xor_With_Resize(BitArray left, BitArray right, int newLeftLength, int newRightLength)
+        {
+            left.Length = newLeftLength;
+            right.Length = newRightLength;
+
+            left.Xor(right);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #37849.

* Use `Length` property instead of `m_array.Length` to avoid operating on unused area / IndexOutOfRangeException when the array is resized
* Add tests for binary bitwise operators using resized `BitArray`s (to ensure they do not throw)