### PR TITLE
Add tests for double-encoded URLs to both UrlDecode() methods

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -155,6 +155,9 @@ namespace System.Net.Tests
             yield return Tuple.Create("%1g", "%1g");
             yield return Tuple.Create("%G1", "%G1");
             yield return Tuple.Create("%1G", "%1G");
+
+            // The "Baz" portion of "http://example.net/Baz" has been double-encoded - one iteration of UrlDecode() should produce a once-encoded string.
+            yield return Tuple.Create("http://example.net/%2542%2561%257A", "http://example.net/%42%61%7A");
         }
 
         public static IEnumerable<Tuple<string, string>> UrlEncode_SharedTestData()

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -158,6 +158,8 @@ namespace System.Net.Tests
 
             // The "Baz" portion of "http://example.net/Baz" has been double-encoded - one iteration of UrlDecode() should produce a once-encoded string.
             yield return Tuple.Create("http://example.net/%2542%2561%257A", "http://example.net/%42%61%7A");
+            // The second iteration should return the original string
+            yield return Tuple.Create("http://example.net/%42%61%7A", "http://example.net/Baz");
         }
 
         public static IEnumerable<Tuple<string, string>> UrlEncode_SharedTestData()

--- a/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -462,7 +462,9 @@ namespace System.Web.Tests
                 new object[] { "http://example.net/\uFFFD", "http://example.net/\uD800" },
                 new object[] { "http://example.net/\uFFFDa", "http://example.net/\uD800a" },
                 new object[] { "http://example.net/\uFFFD", "http://example.net/\uDC00" },
-                new object[] { "http://example.net/\uFFFDa", "http://example.net/\uDC00a" }
+                new object[] { "http://example.net/\uFFFDa", "http://example.net/\uDC00a" },
+                // The "Baz" portion of "http://example.net/Baz" has been double-encoded - one iteration of UrlDecode() should produce a once-encoded string.
+                new object[] { "http://example.net/%42%61%7A", "http://example.net/%2542%2561%257A"}
             };
 
         public static IEnumerable<object[]> UrlDecodeDataToBytes =>

--- a/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -464,7 +464,9 @@ namespace System.Web.Tests
                 new object[] { "http://example.net/\uFFFD", "http://example.net/\uDC00" },
                 new object[] { "http://example.net/\uFFFDa", "http://example.net/\uDC00a" },
                 // The "Baz" portion of "http://example.net/Baz" has been double-encoded - one iteration of UrlDecode() should produce a once-encoded string.
-                new object[] { "http://example.net/%42%61%7A", "http://example.net/%2542%2561%257A"}
+                new object[] { "http://example.net/%42%61%7A", "http://example.net/%2542%2561%257A"},
+                // The second iteration should return the original string
+                new object[] { "http://example.net/Baz", "http://example.net/%42%61%7A"}
             };
 
         public static IEnumerable<object[]> UrlDecodeDataToBytes =>


### PR DESCRIPTION
Just a rough pass at testing the behavior described in https://github.com/dotnet/corefx/issues/36532.

CC @scalablecory @daohunliwei