### PR TITLE
Add nowarns for reference assemblies to be annotated with nullable warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -309,8 +309,8 @@
     <CLSCompliant Condition="'$(CLSCompliant)'==''">true</CLSCompliant>
     <GenFacadesIgnoreBuildAndRevisionMismatch>true</GenFacadesIgnoreBuildAndRevisionMismatch>
 
-    <!-- Warnings -->
-    <NoWarn>$(NoWarn);CS8609</NoWarn> <!-- TODO: Remove CS8609 once https://github.com/dotnet/roslyn/issues/23268 is consumed. -->
+    <!-- TODO-NULLABLE: remove CS8609, CS8610 once we consume roslyn that allows nullable covariant overrides -->
+    <NoWarn>$(NoWarn);CS8609;CS8610</NoWarn>
   </PropertyGroup>
 
   <!-- Set up some common paths -->

--- a/eng/ReferenceAssemblies.props
+++ b/eng/ReferenceAssemblies.props
@@ -11,7 +11,13 @@
     <IntermediateOutputPath>$(ArtifactsObjDir)ref/$(MSBuildProjectName)/$(Configuration)</IntermediateOutputPath>
 
     <!-- disable warnings about unused fields -->
-    <NoWarn>$(NoWarn);0169;0649</NoWarn>
+    <NoWarn>$(NoWarn);CS0169;CS0649;CS8618</NoWarn>
+
+    <!-- disable CS8597 because we throw null on reference assemblies. -->
+    <NoWarn>$(NoWarn);CS8597</NoWarn>
+
+    <!-- We base calls from constructors with null literals. -->
+    <NoWarn>$(NoWarn);CS8625</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsReferenceAssembly)'=='true'">


### PR DESCRIPTION
Since I'm starting to add nullable annotations to multiple ref assemblies at a time, I'd like to add this nowarns in a separate PR so that I don't have to wait for 1 of them to be approved, merged and then rebase on top of master. This also avoids duplication on the diffs.

cc: @stephentoub @danmosemsft 