### PR TITLE
Cache the escaped property names

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterBoolean.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterBoolean.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteBooleanValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, bool value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, bool value, Utf8JsonWriter writer)
         {
             writer.WriteBoolean(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterBoolean.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterBoolean.cs
@@ -25,9 +25,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteBooleanValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, bool value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, bool value, Utf8JsonWriter writer)
         {
-            writer.WriteBoolean(escapedPropertyName, value);
+            writer.WriteBoolean(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterByte.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterByte.cs
@@ -27,9 +27,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, byte value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, byte value, Utf8JsonWriter writer)
         {
-            writer.WriteNumber(escapedPropertyName, value);
+            writer.WriteNumber(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterByte.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterByte.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, byte value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, byte value, Utf8JsonWriter writer)
         {
             writer.WriteNumber(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterChar.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterChar.cs
@@ -32,7 +32,7 @@ namespace System.Text.Json.Serialization.Converters
                 );
         }
 
-        public override void Write(in JsonEncodedText propertyName, char value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, char value, Utf8JsonWriter writer)
         {
             writer.WriteString(propertyName,
 #if BUILDING_INBOX_LIBRARY

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterChar.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterChar.cs
@@ -32,9 +32,9 @@ namespace System.Text.Json.Serialization.Converters
                 );
         }
 
-        public override void Write(Span<byte> escapedPropertyName, char value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, char value, Utf8JsonWriter writer)
         {
-            writer.WriteString(escapedPropertyName,
+            writer.WriteString(propertyName,
 #if BUILDING_INBOX_LIBRARY
                 MemoryMarshal.CreateSpan(ref value, 1)
 #else

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTime.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, DateTime value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, DateTime value, Utf8JsonWriter writer)
         {
             writer.WriteString(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTime.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTime.cs
@@ -24,9 +24,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, DateTime value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, DateTime value, Utf8JsonWriter writer)
         {
-            writer.WriteString(escapedPropertyName, value);
+            writer.WriteString(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTimeOffset.cs
@@ -24,9 +24,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, DateTimeOffset value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, DateTimeOffset value, Utf8JsonWriter writer)
         {
-            writer.WriteString(escapedPropertyName, value);
+            writer.WriteString(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTimeOffset.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDateTimeOffset.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, DateTimeOffset value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, DateTimeOffset value, Utf8JsonWriter writer)
         {
             writer.WriteString(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDecimal.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDecimal.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, decimal value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, decimal value, Utf8JsonWriter writer)
         {
             writer.WriteNumber(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDecimal.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDecimal.cs
@@ -24,9 +24,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, decimal value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, decimal value, Utf8JsonWriter writer)
         {
-            writer.WriteNumber(escapedPropertyName, value);
+            writer.WriteNumber(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDouble.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDouble.cs
@@ -24,9 +24,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, double value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, double value, Utf8JsonWriter writer)
         {
-            writer.WriteNumber(escapedPropertyName, value);
+            writer.WriteNumber(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDouble.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterDouble.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, double value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, double value, Utf8JsonWriter writer)
         {
             writer.WriteNumber(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -77,7 +77,7 @@ namespace System.Text.Json.Serialization.Converters
             }
         }
 
-        public override void Write(in JsonEncodedText propertyName, TValue value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, TValue value, Utf8JsonWriter writer)
         {
             if (TreatAsString)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -77,23 +77,23 @@ namespace System.Text.Json.Serialization.Converters
             }
         }
 
-        public override void Write(Span<byte> escapedPropertyName, TValue value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, TValue value, Utf8JsonWriter writer)
         {
             if (TreatAsString)
             {
-                writer.WriteString(escapedPropertyName, value.ToString());
+                writer.WriteString(propertyName, value.ToString());
             }
             else if (s_isUint64)
             {
                 // Use the ulong converter to prevent conversion into a signed\long value.
                 ulong ulongValue = Convert.ToUInt64(value);
-                writer.WriteNumber(escapedPropertyName, ulongValue);
+                writer.WriteNumber(propertyName, ulongValue);
             }
             else
             {
                 // long can hold the signed\unsigned values of other integer types.
                 long longValue = Convert.ToInt64(value);
-                writer.WriteNumber(escapedPropertyName, longValue);
+                writer.WriteNumber(propertyName, longValue);
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterGuid.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterGuid.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, Guid value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, Guid value, Utf8JsonWriter writer)
         {
             writer.WriteString(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterGuid.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterGuid.cs
@@ -24,9 +24,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, Guid value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, Guid value, Utf8JsonWriter writer)
         {
-            writer.WriteString(escapedPropertyName, value);
+            writer.WriteString(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt16.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt16.cs
@@ -27,9 +27,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, short value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, short value, Utf8JsonWriter writer)
         {
-            writer.WriteNumber(escapedPropertyName, value);
+            writer.WriteNumber(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt16.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt16.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, short value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, short value, Utf8JsonWriter writer)
         {
             writer.WriteNumber(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt32.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt32.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, int value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, int value, Utf8JsonWriter writer)
         {
             writer.WriteNumber(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt32.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt32.cs
@@ -24,9 +24,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, int value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, int value, Utf8JsonWriter writer)
         {
-            writer.WriteNumber(escapedPropertyName, value);
+            writer.WriteNumber(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt64.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt64.cs
@@ -24,9 +24,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, long value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, long value, Utf8JsonWriter writer)
         {
-            writer.WriteNumber(escapedPropertyName, value);
+            writer.WriteNumber(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt64.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterInt64.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, long value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, long value, Utf8JsonWriter writer)
         {
             writer.WriteNumber(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterJsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterJsonElement.cs
@@ -28,7 +28,7 @@ namespace System.Text.Json.Serialization.Converters
             value.WriteAsValue(writer);
         }
 
-        public override void Write(in JsonEncodedText propertyName, JsonElement value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, JsonElement value, Utf8JsonWriter writer)
         {
             value.WriteAsProperty(propertyName.ToString(), writer);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterJsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterJsonElement.cs
@@ -28,9 +28,9 @@ namespace System.Text.Json.Serialization.Converters
             value.WriteAsValue(writer);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, JsonElement value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, JsonElement value, Utf8JsonWriter writer)
         {
-            value.WriteAsProperty(escapedPropertyName, writer);
+            value.WriteAsProperty(propertyName.ToString(), writer);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterObject.cs
@@ -28,7 +28,7 @@ namespace System.Text.Json.Serialization.Converters
             throw new InvalidOperationException();
         }
 
-        public override void Write(Span<byte> escapedPropertyName, object value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, object value, Utf8JsonWriter writer)
         {
             throw new InvalidOperationException();
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterObject.cs
@@ -28,7 +28,7 @@ namespace System.Text.Json.Serialization.Converters
             throw new InvalidOperationException();
         }
 
-        public override void Write(in JsonEncodedText propertyName, object value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, object value, Utf8JsonWriter writer)
         {
             throw new InvalidOperationException();
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterSByte.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterSByte.cs
@@ -27,9 +27,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, sbyte value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, sbyte value, Utf8JsonWriter writer)
         {
-            writer.WriteNumber(escapedPropertyName, value);
+            writer.WriteNumber(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterSByte.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterSByte.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, sbyte value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, sbyte value, Utf8JsonWriter writer)
         {
             writer.WriteNumber(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterSingle.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterSingle.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, float value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, float value, Utf8JsonWriter writer)
         {
             writer.WriteNumber(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterSingle.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterSingle.cs
@@ -27,9 +27,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, float value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, float value, Utf8JsonWriter writer)
         {
-            writer.WriteNumber(escapedPropertyName, value);
+            writer.WriteNumber(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterString.cs
@@ -25,7 +25,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, string value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, string value, Utf8JsonWriter writer)
         {
             writer.WriteString(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterString.cs
@@ -25,9 +25,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteStringValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, string value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, string value, Utf8JsonWriter writer)
         {
-            writer.WriteString(escapedPropertyName, value);
+            writer.WriteString(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt16.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt16.cs
@@ -27,9 +27,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, ushort value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, ushort value, Utf8JsonWriter writer)
         {
-            writer.WriteNumber(escapedPropertyName, value);
+            writer.WriteNumber(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt16.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt16.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, ushort value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, ushort value, Utf8JsonWriter writer)
         {
             writer.WriteNumber(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt32.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt32.cs
@@ -24,9 +24,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, uint value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, uint value, Utf8JsonWriter writer)
         {
-            writer.WriteNumber(escapedPropertyName, value);
+            writer.WriteNumber(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt32.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt32.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, uint value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, uint value, Utf8JsonWriter writer)
         {
             writer.WriteNumber(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt64.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt64.cs
@@ -24,9 +24,9 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(Span<byte> escapedPropertyName, ulong value, Utf8JsonWriter writer)
+        public override void Write(in JsonEncodedText propertyName, ulong value, Utf8JsonWriter writer)
         {
-            writer.WriteNumber(escapedPropertyName, value);
+            writer.WriteNumber(propertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt64.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUInt64.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
             writer.WriteNumberValue(value);
         }
 
-        public override void Write(in JsonEncodedText propertyName, ulong value, Utf8JsonWriter writer)
+        public override void Write(JsonEncodedText propertyName, ulong value, Utf8JsonWriter writer)
         {
             writer.WriteNumber(propertyName, value);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -38,7 +38,7 @@ namespace System.Text.Json.Serialization
         public string NameUsedToCompareAsString { get; private set; }
 
         // The escaped name passed to the writer.
-        public byte[] EscapedName { get; private set; }
+        public JsonEncodedText? EscapedName { get; private set; }
 
         public bool HasGetter { get; set; }
         public bool HasSetter { get; set; }
@@ -171,36 +171,7 @@ namespace System.Text.Json.Serialization
             }
 
             // Cache the escaped name.
-#if true
-            // temporary behavior until the writer can accept escaped string.
-            EscapedName = Name;
-#else
-            int valueIdx = JsonWriterHelper.NeedsEscaping(_name);
-            if (valueIdx == -1)
-            {
-                _escapedName = _name;
-            }
-            else
-            {
-                byte[] pooledName = null;
-                int length = JsonWriterHelper.GetMaxEscapedLength(_name.Length, valueIdx);
-
-                Span<byte> escapedName = length <= JsonConstants.StackallocThreshold ?
-                    stackalloc byte[length] :
-                    (pooledName = ArrayPool<byte>.Shared.Rent(length));
-
-                JsonWriterHelper.EscapeString(_name, escapedName, 0, out int written);
-
-                _escapedName = escapedName.Slice(0, written).ToArray();
-
-                if (pooledName != null)
-                {
-                    // We clear the array because it is "user data" (although a property name).
-                    new Span<byte>(pooledName, 0, written).Clear();
-                    ArrayPool<byte>.Shared.Return(pooledName);
-                }
-            }
-#endif
+            EscapedName = JsonEncodedText.Encode(Name);
         }
 
         private void DetermineSerializationCapabilities()

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
@@ -78,18 +78,18 @@ namespace System.Text.Json.Serialization
 
             if (value == null)
             {
-                Debug.Assert(EscapedName != null);
+                Debug.Assert(EscapedName.HasValue);
 
                 if (!IgnoreNullValues)
                 {
-                    writer.WriteNull(EscapedName);
+                    writer.WriteNull(EscapedName.Value);
                 }
             }
             else if (ValueConverter != null)
             {
-                if (EscapedName != null)
+                if (EscapedName.HasValue)
                 {
-                    ValueConverter.Write(EscapedName, value, writer);
+                    ValueConverter.Write(EscapedName.Value, value, writer);
                 }
                 else
                 {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNullable.cs
@@ -77,18 +77,18 @@ namespace System.Text.Json.Serialization
 
                 if (value == null)
                 {
-                    Debug.Assert(EscapedName != null);
+                    Debug.Assert(EscapedName.HasValue);
 
                     if (!IgnoreNullValues)
                     {
-                        writer.WriteNull(EscapedName);
+                        writer.WriteNull(EscapedName.Value);
                     }
                 }
                 else if (ValueConverter != null)
                 {
-                    if (EscapedName != null)
+                    if (EscapedName.HasValue)
                     {
-                        ValueConverter.Write(EscapedName, value.GetValueOrDefault(), writer);
+                        ValueConverter.Write(EscapedName.Value, value.GetValueOrDefault(), writer);
                     }
                     else
                     {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -124,37 +125,8 @@ namespace System.Text.Json.Serialization
             }
             else
             {
-                byte[] utf8Key = Encoding.UTF8.GetBytes(key);
-#if true
-                // temporary behavior until the writer can accept escaped string.
-                converter.Write(utf8Key, value, writer);
-#else
-                int valueIdx = JsonWriterHelper.NeedsEscaping(utf8Key);
-                if (valueIdx == -1)
-                {
-                    converter.Write(utf8Key, value, writer);
-                }
-                else
-                {
-                    byte[] pooledKey = null;
-                    int length = JsonWriterHelper.GetMaxEscapedLength(utf8Key.Length, valueIdx);
-
-                    Span<byte> escapedKey = length <= JsonConstants.StackallocThreshold ?
-                        stackalloc byte[length] :
-                        (pooledKey = ArrayPool<byte>.Shared.Rent(length));
-
-                    JsonWriterHelper.EscapeString(utf8Key, escapedKey, valueIdx, out int written);
-
-                    converter.Write(escapedKey.Slice(0, written), value, writer);
-
-                    if (pooledKey != null)
-                    {
-                        // We clear the array because it is "user data" (although a property name).
-                        new Span<byte>(pooledKey, 0, written).Clear();
-                        ArrayPool<byte>.Shared.Return(pooledKey);
-                    }
-                }
-#endif
+                JsonEncodedText escapedKey = JsonEncodedText.Encode(key);
+                converter.Write(escapedKey, value, writer);
             }
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleObject.cs
@@ -126,7 +126,7 @@ namespace System.Text.Json.Serialization
             {
                 if (!jsonPropertyInfo.IgnoreNullValues)
                 {
-                    writer.WriteNull(jsonPropertyInfo.EscapedName);
+                    writer.WriteNull(jsonPropertyInfo.EscapedName.Value);
                 }
 
                 state.Current.NextProperty();

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Policies/JsonValueConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Policies/JsonValueConverter.cs
@@ -8,6 +8,6 @@ namespace System.Text.Json.Serialization.Policies
     {
         public abstract bool TryRead(Type valueType, ref Utf8JsonReader reader, out TValue value);
         public abstract void Write(TValue value, Utf8JsonWriter writer);
-        public abstract void Write(in JsonEncodedText propertyName, TValue value, Utf8JsonWriter writer);
+        public abstract void Write(JsonEncodedText propertyName, TValue value, Utf8JsonWriter writer);
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Policies/JsonValueConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Policies/JsonValueConverter.cs
@@ -8,6 +8,6 @@ namespace System.Text.Json.Serialization.Policies
     {
         public abstract bool TryRead(Type valueType, ref Utf8JsonReader reader, out TValue value);
         public abstract void Write(TValue value, Utf8JsonWriter writer);
-        public abstract void Write(Span<byte> escapedPropertyName, TValue value, Utf8JsonWriter writer);
+        public abstract void Write(in JsonEncodedText propertyName, TValue value, Utf8JsonWriter writer);
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -46,29 +46,14 @@ namespace System.Text.Json.Serialization
 
         public void WriteObjectOrArrayStart(ClassType classType, Utf8JsonWriter writer, bool writeNull = false)
         {
-            if (JsonPropertyInfo?.EscapedName != null)
+            if (JsonPropertyInfo?.EscapedName.HasValue == true)
             {
-                WriteObjectOrArrayStart(classType, JsonPropertyInfo?.EscapedName, writer, writeNull);
+                WriteObjectOrArrayStart(classType, JsonPropertyInfo.EscapedName.Value, writer, writeNull);
             }
             else if (KeyName != null)
             {
-                byte[] pooledKey = null;
-                byte[] utf8Key = Encoding.UTF8.GetBytes(KeyName);
-                int length = JsonWriterHelper.GetMaxEscapedLength(utf8Key.Length, 0);
-
-                Span<byte> escapedKey = length <= JsonConstants.StackallocThreshold ?
-                    stackalloc byte[length] :
-                    (pooledKey = ArrayPool<byte>.Shared.Rent(length));
-
-                JsonWriterHelper.EscapeString(utf8Key, escapedKey, 0, out int written);
-                Span<byte> propertyName = escapedKey.Slice(0, written);
-
+                JsonEncodedText propertyName = JsonEncodedText.Encode(KeyName);
                 WriteObjectOrArrayStart(classType, propertyName, writer, writeNull);
-
-                if (pooledKey != null)
-                {
-                    ArrayPool<byte>.Shared.Return(pooledKey);
-                }
             }
             else
             {
@@ -88,7 +73,7 @@ namespace System.Text.Json.Serialization
             }
         }
 
-        private void WriteObjectOrArrayStart(ClassType classType, ReadOnlySpan<byte> propertyName, Utf8JsonWriter writer, bool writeNull)
+        private void WriteObjectOrArrayStart(ClassType classType, in JsonEncodedText propertyName, Utf8JsonWriter writer, bool writeNull)
         {
             if (writeNull)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -73,7 +73,7 @@ namespace System.Text.Json.Serialization
             }
         }
 
-        private void WriteObjectOrArrayStart(ClassType classType, in JsonEncodedText propertyName, Utf8JsonWriter writer, bool writeNull)
+        private void WriteObjectOrArrayStart(ClassType classType, JsonEncodedText propertyName, Utf8JsonWriter writer, bool writeNull)
         {
             if (writeNull)
             {


### PR DESCRIPTION
Some clean-up of ifdef'd code and small perf gain (within margin of error) due to not having to check if the property name needs escaping.

Most of the converter changes will likely be removed in the future when\if we can set the property name independently.

Before:
```
|               Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|    SerializeToString | 35.76 us | 0.8167 us | 0.9078 us | 35.64 us | 34.34 us | 37.96 us |      6.0069 |      0.4291 |           - |             25488 B |
| SerializeToUtf8Bytes | 33.20 us | 0.5414 us | 0.5065 us | 33.03 us | 32.34 us | 34.23 us |      3.0914 |           - |           - |             13016 B |
|    SerializeToStream | 32.17 us | 0.7758 us | 0.8301 us | 31.83 us | 31.40 us | 34.06 us |           - |           - |           - |               432 B |
```
After:
```
|               Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|--------------------- |---------:|----------:|----------:|---------:|---------:|---------:|------------:|------------:|------------:|--------------------:|
|    SerializeToString | 34.79 us | 0.6817 us | 0.6377 us | 34.62 us | 34.07 us | 36.45 us |      6.0573 |           - |           - |             25568 B |
| SerializeToUtf8Bytes | 33.11 us | 0.4332 us | 0.3382 us | 33.15 us | 32.27 us | 33.61 us |      3.0371 |           - |           - |             12976 B |
|    SerializeToStream | 31.27 us | 0.4164 us | 0.3477 us | 31.13 us | 30.88 us | 32.13 us |           - |           - |           - |               432 B |
```

