### PR TITLE
Adds JsonElement.ValueEquals / JsonProperty.NameEquals APIs,

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -73,6 +73,9 @@ namespace System.Text.Json
         public bool TryGetUInt32(out uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public bool TryGetUInt64(out ulong value) { throw null; }
+        public bool ValueEquals(System.ReadOnlySpan<byte> utf8Text) { throw null; }
+        public bool ValueEquals(System.ReadOnlySpan<char> text) { throw null; }
+        public bool ValueEquals(string text) { throw null; }
         public void WriteAsProperty(System.ReadOnlySpan<byte> utf8PropertyName, System.Text.Json.Utf8JsonWriter writer) { }
         public void WriteAsProperty(System.ReadOnlySpan<char> propertyName, System.Text.Json.Utf8JsonWriter writer) { }
         public void WriteAsProperty(string propertyName, System.Text.Json.Utf8JsonWriter writer) { }
@@ -131,6 +134,9 @@ namespace System.Text.Json
         private readonly object _dummy;
         public string Name { get { throw null; } }
         public System.Text.Json.JsonElement Value { get { throw null; } }
+        public bool NameEquals(System.ReadOnlySpan<byte> utf8Text) { throw null; }
+        public bool NameEquals(System.ReadOnlySpan<char> text) { throw null; }
+        public bool NameEquals(string text) { throw null; }
         public override string ToString() { throw null; }
     }
     public partial struct JsonReaderOptions
@@ -215,8 +221,6 @@ namespace System.Text.Json
         public ulong GetUInt64() { throw null; }
         public bool Read() { throw null; }
         public void Skip() { }
-        public bool TextEquals(System.ReadOnlySpan<byte> otherUtf8Text) { throw null; }
-        public bool TextEquals(System.ReadOnlySpan<char> otherText) { throw null; }
         public bool TryGetBytesFromBase64(out byte[] value) { throw null; }
         public bool TryGetDateTime(out System.DateTime value) { throw null; }
         public bool TryGetDateTimeOffset(out System.DateTimeOffset value) { throw null; }
@@ -231,6 +235,9 @@ namespace System.Text.Json
         [System.CLSCompliantAttribute(false)]
         public bool TryGetUInt64(out ulong value) { throw null; }
         public bool TrySkip() { throw null; }
+        public bool ValueTextEquals(System.ReadOnlySpan<byte> utf8Text) { throw null; }
+        public bool ValueTextEquals(System.ReadOnlySpan<char> text) { throw null; }
+        public bool ValueTextEquals(string text) { throw null; }
     }
     public sealed partial class Utf8JsonWriter : System.IDisposable
     {

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -280,13 +280,10 @@ namespace System.Text.Json
 
             ReadOnlySpan<byte> utf16Text = MemoryMarshal.AsBytes(otherText);
             OperationStatus status = JsonWriterHelper.ToUtf8(utf16Text, otherUtf8Text, out int consumed, out int written);
-            // Debug.Assert(status != OperationStatus.DestinationTooSmall);
             if (status > OperationStatus.DestinationTooSmall)   // Equivalent to: (status == NeedMoreData || status == InvalidData)
             {
                 return false;
             }
-            // Debug.Assert(status == OperationStatus.Done);
-            // Debug.Assert(consumed == utf16Text.Length);
 
             bool result = TextEquals(index, otherUtf8Text.Slice(0, written), isPropertyName);
 

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -280,13 +280,13 @@ namespace System.Text.Json
 
             ReadOnlySpan<byte> utf16Text = MemoryMarshal.AsBytes(otherText);
             OperationStatus status = JsonWriterHelper.ToUtf8(utf16Text, otherUtf8Text, out int consumed, out int written);
-            Debug.Assert(status != OperationStatus.DestinationTooSmall);
+            // Debug.Assert(status != OperationStatus.DestinationTooSmall);
             if (status > OperationStatus.DestinationTooSmall)   // Equivalent to: (status == NeedMoreData || status == InvalidData)
             {
                 return false;
             }
-            Debug.Assert(status == OperationStatus.Done);
-            Debug.Assert(consumed == utf16Text.Length);
+            // Debug.Assert(status == OperationStatus.Done);
+            // Debug.Assert(consumed == utf16Text.Length);
 
             bool result = TextEquals(index, otherUtf8Text.Slice(0, written), isPropertyName);
 

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -280,10 +280,13 @@ namespace System.Text.Json
 
             ReadOnlySpan<byte> utf16Text = MemoryMarshal.AsBytes(otherText);
             OperationStatus status = JsonWriterHelper.ToUtf8(utf16Text, otherUtf8Text, out int consumed, out int written);
+            Debug.Assert(status != OperationStatus.DestinationTooSmall);
             if (status > OperationStatus.DestinationTooSmall)   // Equivalent to: (status == NeedMoreData || status == InvalidData)
             {
                 return false;
             }
+            Debug.Assert(status == OperationStatus.Done);
+            Debug.Assert(consumed == utf16Text.Length);
 
             bool result = TextEquals(index, otherUtf8Text.Slice(0, written), isPropertyName);
 

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Buffers;
 using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace System.Text.Json
 {
@@ -970,6 +973,103 @@ namespace System.Text.Json
             CheckValidInstance();
 
             return _parent.GetPropertyRawValueAsString(_idx);
+        }
+
+        /// <summary>
+        ///   Compares <paramref name="text" /> to the string value of this element.
+        /// </summary>
+        /// <param name="text">The text to compare against.</param>
+        /// <returns>
+        ///   <see langword="true" /> if the string value of this element matches <paramref name="text"/>,
+        ///   <see langword="false" /> otherwise.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="Type"/> is not <see cref="JsonValueType.String"/> or <see cref="JsonTokenType.PropertyName"/>.
+        /// </exception>
+        /// <remarks>
+        ///   This method is functionally equal to doing an ordinal comparision of <paramref name="text" /> and
+        ///   the result of calling <see cref="GetString" />, but avoids creating the string instance.
+        /// </remarks>
+        public bool ValueEquals(string text)
+        {
+            // CheckValidInstance is done in the helper
+
+            if (TokenType == JsonTokenType.Null)
+            {
+                return text == null;
+            }
+
+            return TextEqualsHelper(text.AsSpan(), isPropertyName: false);
+        }
+
+        /// <summary>
+        ///   Compares the text represented by <paramref name="utf8Text" /> to the string value of this element.
+        /// </summary>
+        /// <param name="utf8Text">The UTF-8 encoded text to compare against.</param>
+        /// <returns>
+        ///   <see langword="true" /> if the string value of this element has the same UTF-8 encoding as
+        ///   <paramref name="utf8Text" />, <see langword="false" /> otherwise.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="Type"/> is not <see cref="JsonValueType.String"/> or <see cref="JsonTokenType.PropertyName"/>.
+        /// </exception>
+        /// <remarks>
+        ///   This method is functionally equal to doing an ordinal comparision of the string produced by UTF-8 decoding
+        ///   <paramref name="utf8Text" /> with the result of calling <see cref="GetString" />, but avoids creating the
+        ///   string instances.
+        /// </remarks>
+        public bool ValueEquals(ReadOnlySpan<byte> utf8Text)
+        {
+            // CheckValidInstance is done in the helper
+
+            if (TokenType == JsonTokenType.Null)
+            {
+                return utf8Text == default;
+            }
+
+            return TextEqualsHelper(utf8Text, isPropertyName: false);
+        }
+
+        /// <summary>
+        ///   Compares <paramref name="text" /> to the string value of this element.
+        /// </summary>
+        /// <param name="text">The text to compare against.</param>
+        /// <returns>
+        ///   <see langword="true" /> if the string value of this element matches <paramref name="text"/>,
+        ///   <see langword="false" /> otherwise.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="Type"/> is not <see cref="JsonValueType.String"/> or <see cref="JsonTokenType.PropertyName"/>.
+        /// </exception>
+        /// <remarks>
+        ///   This method is functionally equal to doing an ordinal comparision of <paramref name="text" /> and
+        ///   the result of calling <see cref="GetString" />, but avoids creating the string instance.
+        /// </remarks>
+        public bool ValueEquals(ReadOnlySpan<char> text)
+        {
+            // CheckValidInstance is done in the helper
+
+            if (TokenType == JsonTokenType.Null)
+            {
+                // This is different than Length == 0, in that it tests true for null, but false for ""
+                return text == default;
+            }
+
+            return TextEqualsHelper(text, isPropertyName: false);
+        }
+
+        internal bool TextEqualsHelper(ReadOnlySpan<byte> utf8Text, bool isPropertyName)
+        {
+            CheckValidInstance();
+
+            return _parent.TextEquals(_idx, utf8Text, isPropertyName);
+        }
+
+        internal bool TextEqualsHelper(ReadOnlySpan<char> text, bool isPropertyName)
+        {
+            CheckValidInstance();
+
+            return _parent.TextEquals(_idx, text, isPropertyName);
         }
 
         /// <summary>

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -984,10 +984,10 @@ namespace System.Text.Json
         ///   <see langword="false" /> otherwise.
         /// </returns>
         /// <exception cref="InvalidOperationException">
-        ///   This value's <see cref="Type"/> is not <see cref="JsonValueType.String"/> or <see cref="JsonTokenType.PropertyName"/>.
+        ///   This value's <see cref="Type"/> is not <see cref="JsonValueType.String"/>.
         /// </exception>
         /// <remarks>
-        ///   This method is functionally equal to doing an ordinal comparision of <paramref name="text" /> and
+        ///   This method is functionally equal to doing an ordinal comparison of <paramref name="text" /> and
         ///   the result of calling <see cref="GetString" />, but avoids creating the string instance.
         /// </remarks>
         public bool ValueEquals(string text)
@@ -1011,10 +1011,10 @@ namespace System.Text.Json
         ///   <paramref name="utf8Text" />, <see langword="false" /> otherwise.
         /// </returns>
         /// <exception cref="InvalidOperationException">
-        ///   This value's <see cref="Type"/> is not <see cref="JsonValueType.String"/> or <see cref="JsonTokenType.PropertyName"/>.
+        ///   This value's <see cref="Type"/> is not <see cref="JsonValueType.String"/>.
         /// </exception>
         /// <remarks>
-        ///   This method is functionally equal to doing an ordinal comparision of the string produced by UTF-8 decoding
+        ///   This method is functionally equal to doing an ordinal comparison of the string produced by UTF-8 decoding
         ///   <paramref name="utf8Text" /> with the result of calling <see cref="GetString" />, but avoids creating the
         ///   string instances.
         /// </remarks>
@@ -1024,6 +1024,7 @@ namespace System.Text.Json
 
             if (TokenType == JsonTokenType.Null)
             {
+                // This is different than Length == 0, in that it tests true for null, but false for ""
                 return utf8Text == default;
             }
 
@@ -1039,10 +1040,10 @@ namespace System.Text.Json
         ///   <see langword="false" /> otherwise.
         /// </returns>
         /// <exception cref="InvalidOperationException">
-        ///   This value's <see cref="Type"/> is not <see cref="JsonValueType.String"/> or <see cref="JsonTokenType.PropertyName"/>.
+        ///   This value's <see cref="Type"/> is not <see cref="JsonValueType.String"/>.
         /// </exception>
         /// <remarks>
-        ///   This method is functionally equal to doing an ordinal comparision of <paramref name="text" /> and
+        ///   This method is functionally equal to doing an ordinal comparison of <paramref name="text" /> and
         ///   the result of calling <see cref="GetString" />, but avoids creating the string instance.
         /// </remarks>
         public bool ValueEquals(ReadOnlySpan<char> text)

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace System.Text.Json
 {
     /// <summary>
@@ -23,6 +25,54 @@ namespace System.Text.Json
         ///   The name of this property.
         /// </summary>
         public string Name => Value.GetPropertyName();
+
+        /// <summary>
+        ///   Compares <paramref name="text" /> to the property name.
+        /// </summary>
+        /// <param name="text">The text to compare against.</param>
+        /// <returns>
+        ///   <see langword="true" /> if the property name matches <paramref name="text"/>,
+        ///   <see langword="false" /> otherwise.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="Type"/> is not <see cref="JsonTokenType.PropertyName"/>.
+        /// </exception>
+        public bool NameEquals(string text)
+        {
+            return NameEquals(text.AsSpan());
+        }
+
+        /// <summary>
+        ///   Compares the text represented by <paramref name="utf8Text" /> to the property name.
+        /// </summary>
+        /// <param name="utf8Text">The UTF-8 encoded text to compare against.</param>
+        /// <returns>
+        ///   <see langword="true" /> if the property name has the same UTF-8 encoding as
+        ///   <paramref name="utf8Text" />, <see langword="false" /> otherwise.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="Type"/> is not <see cref="JsonTokenType.PropertyName"/>.
+        /// </exception>
+        public bool NameEquals(ReadOnlySpan<byte> utf8Text)
+        {
+            return Value.TextEqualsHelper(utf8Text, isPropertyName: true);
+        }
+
+        /// <summary>
+        ///   Compares <paramref name="text" /> to the property name.
+        /// </summary>
+        /// <param name="text">The text to compare against.</param>
+        /// <returns>
+        ///   <see langword="true" /> if the property name matches <paramref name="text"/>,
+        ///   <see langword="false" /> otherwise.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   This value's <see cref="Type"/> is not <see cref="JsonTokenType.PropertyName"/>.
+        /// </exception>
+        public bool NameEquals(ReadOnlySpan<char> text)
+        {
+            return Value.TextEqualsHelper(text, isPropertyName: true);
+        }
 
         /// <summary>
         ///   Provides a <see cref="string"/> representation of the property for

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
@@ -27,48 +27,60 @@ namespace System.Text.Json
         public string Name => Value.GetPropertyName();
 
         /// <summary>
-        ///   Compares <paramref name="text" /> to the property name.
+        ///   Compares <paramref name="text" /> to the name of this property.
         /// </summary>
         /// <param name="text">The text to compare against.</param>
         /// <returns>
-        ///   <see langword="true" /> if the property name matches <paramref name="text"/>,
+        ///   <see langword="true" /> if the name of this property matches <paramref name="text"/>,
         ///   <see langword="false" /> otherwise.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         ///   This value's <see cref="Type"/> is not <see cref="JsonTokenType.PropertyName"/>.
         /// </exception>
+        /// <remarks>
+        ///   This method is functionally equal to doing an ordinal comparison of <paramref name="text" /> and
+        ///   <see cref="Name" />, but can avoid creating the string instance.
+        /// </remarks>
         public bool NameEquals(string text)
         {
             return NameEquals(text.AsSpan());
         }
 
         /// <summary>
-        ///   Compares the text represented by <paramref name="utf8Text" /> to the property name.
+        ///   Compares the text represented by <paramref name="utf8Text" /> to the name of this property.
         /// </summary>
         /// <param name="utf8Text">The UTF-8 encoded text to compare against.</param>
         /// <returns>
-        ///   <see langword="true" /> if the property name has the same UTF-8 encoding as
+        ///   <see langword="true" /> if the name of this property has the same UTF-8 encoding as
         ///   <paramref name="utf8Text" />, <see langword="false" /> otherwise.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         ///   This value's <see cref="Type"/> is not <see cref="JsonTokenType.PropertyName"/>.
         /// </exception>
+        /// <remarks>
+        ///   This method is functionally equal to doing an ordinal comparison of <paramref name="utf8Text" /> and
+        ///   <see cref="Name" />, but can avoid creating the string instance.
+        /// </remarks>
         public bool NameEquals(ReadOnlySpan<byte> utf8Text)
         {
             return Value.TextEqualsHelper(utf8Text, isPropertyName: true);
         }
 
         /// <summary>
-        ///   Compares <paramref name="text" /> to the property name.
+        ///   Compares <paramref name="text" /> to the name of this property.
         /// </summary>
         /// <param name="text">The text to compare against.</param>
         /// <returns>
-        ///   <see langword="true" /> if the property name matches <paramref name="text"/>,
+        ///   <see langword="true" /> if the name of this property matches <paramref name="text"/>,
         ///   <see langword="false" /> otherwise.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         ///   This value's <see cref="Type"/> is not <see cref="JsonTokenType.PropertyName"/>.
         /// </exception>
+        /// <remarks>
+        ///   This method is functionally equal to doing an ordinal comparison of <paramref name="text" /> and
+        ///   <see cref="Name" />, but can avoid creating the string instance.
+        /// </remarks>
         public bool NameEquals(ReadOnlySpan<char> text)
         {
             return Value.TextEqualsHelper(text, isPropertyName: true);

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -508,10 +508,13 @@ namespace System.Text.Json
 
             ReadOnlySpan<byte> utf16Text = MemoryMarshal.AsBytes(text);
             OperationStatus status = JsonWriterHelper.ToUtf8(utf16Text, otherUtf8Text, out int consumed, out int written);
+            Debug.Assert(status != OperationStatus.DestinationTooSmall);
             if (status > OperationStatus.DestinationTooSmall)   // Equivalent to: (status == NeedMoreData || status == InvalidData)
             {
                 return false;
             }
+            Debug.Assert(status == OperationStatus.Done);
+            Debug.Assert(consumed == utf16Text.Length);
 
             bool result = TextEqualsHelper(otherUtf8Text.Slice(0, written));
 

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -508,13 +508,13 @@ namespace System.Text.Json
 
             ReadOnlySpan<byte> utf16Text = MemoryMarshal.AsBytes(text);
             OperationStatus status = JsonWriterHelper.ToUtf8(utf16Text, otherUtf8Text, out int consumed, out int written);
-            Debug.Assert(status != OperationStatus.DestinationTooSmall);
+            // Debug.Assert(status != OperationStatus.DestinationTooSmall);
             if (status > OperationStatus.DestinationTooSmall)   // Equivalent to: (status == NeedMoreData || status == InvalidData)
             {
                 return false;
             }
-            Debug.Assert(status == OperationStatus.Done);
-            Debug.Assert(consumed == utf16Text.Length);
+            // Debug.Assert(status == OperationStatus.Done);
+            // Debug.Assert(consumed == utf16Text.Length);
 
             bool result = TextEqualsHelper(otherUtf8Text.Slice(0, written));
 

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -508,13 +508,10 @@ namespace System.Text.Json
 
             ReadOnlySpan<byte> utf16Text = MemoryMarshal.AsBytes(text);
             OperationStatus status = JsonWriterHelper.ToUtf8(utf16Text, otherUtf8Text, out int consumed, out int written);
-            // Debug.Assert(status != OperationStatus.DestinationTooSmall);
             if (status > OperationStatus.DestinationTooSmall)   // Equivalent to: (status == NeedMoreData || status == InvalidData)
             {
                 return false;
             }
-            // Debug.Assert(status == OperationStatus.Done);
-            // Debug.Assert(consumed == utf16Text.Length);
 
             bool result = TextEqualsHelper(otherUtf8Text.Slice(0, written));
 

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -3157,6 +3157,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
+        [ActiveIssue(38178)]
         [InlineData("\"hello\"", new char[1] { (char)0xDC01 })]    // low surrogate - invalid
         [InlineData("\"hello\"", new char[1] { (char)0xD801 })]    // high surrogate - missing pair
         public static void InvalidUTF16Search(string jsonString, char[] lookup)

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -3156,7 +3156,7 @@ namespace System.Text.Json.Tests
             }
         }
 
-        [Theory]
+        // [Theory]
         [InlineData("\"hello\"", new char[1] { (char)0xDC01 })]    // low surrogate - invalid
         [InlineData("\"hello\"", new char[1] { (char)0xD801 })]    // high surrogate - missing pair
         public static void InvalidUTF16Search(string jsonString, char[] lookup)

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -700,6 +700,10 @@ namespace System.Text.Json.Tests
                 Assert.Throws<InvalidOperationException>(() => address.GetProperty("zip").GetString());
                 Assert.Throws<InvalidOperationException>(() => person.GetProperty("phoneNumbers").GetString());
                 Assert.Throws<InvalidOperationException>(() => person.GetString());
+                const string throwsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => person.ValueEquals(throwsAnyway));
+                Assert.Throws<InvalidOperationException>(() => person.ValueEquals(throwsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => person.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
             }
         }
 
@@ -834,6 +838,10 @@ namespace System.Text.Json.Tests
                 }
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
+                const string throwsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.TryGetBytesFromBase64(out byte[] bytes));
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
@@ -922,6 +930,10 @@ namespace System.Text.Json.Tests
                 }
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
+                const string throwsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTimeOffset());
@@ -979,6 +991,10 @@ namespace System.Text.Json.Tests
                 Assert.Equal(value, root.GetUInt64());
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
+                const string throwsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTimeOffset());
@@ -1036,6 +1052,10 @@ namespace System.Text.Json.Tests
                 Assert.Throws<FormatException>(() => root.GetUInt64());
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
+                const string throwsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTimeOffset());
@@ -1225,6 +1245,10 @@ namespace System.Text.Json.Tests
                 Assert.Throws<FormatException>(() => root.GetUInt64());
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
+                const string throwsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTimeOffset());
@@ -1293,6 +1317,10 @@ namespace System.Text.Json.Tests
                 Assert.Throws<FormatException>(() => root.GetUInt64());
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
+                const string throwsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTimeOffset());
@@ -1345,6 +1373,10 @@ namespace System.Text.Json.Tests
                 Assert.Throws<InvalidOperationException>(() => root.GetUInt64());
                 Assert.Throws<InvalidOperationException>(() => root.TryGetUInt64(out ulong _));
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
+                const string throwsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.TryGetBytesFromBase64(out byte[] _));
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
@@ -1376,6 +1408,10 @@ namespace System.Text.Json.Tests
                 Assert.Throws<ObjectDisposedException>(() => root.GetUInt64());
                 Assert.Throws<ObjectDisposedException>(() => root.TryGetUInt64(out ulong _));
                 Assert.Throws<ObjectDisposedException>(() => root.GetString());
+                const string throwsAnyway = "throws-anyway";
+                Assert.Throws<ObjectDisposedException>(() => root.ValueEquals(throwsAnyway));
+                Assert.Throws<ObjectDisposedException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
+                Assert.Throws<ObjectDisposedException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
                 Assert.Throws<ObjectDisposedException>(() => root.GetBytesFromBase64());
                 Assert.Throws<ObjectDisposedException>(() => root.TryGetBytesFromBase64(out byte[] _));
                 Assert.Throws<ObjectDisposedException>(() => root.GetBoolean());
@@ -1420,6 +1456,10 @@ namespace System.Text.Json.Tests
             Assert.Throws<InvalidOperationException>(() => root.GetUInt64());
             Assert.Throws<InvalidOperationException>(() => root.TryGetUInt64(out ulong _));
             Assert.Throws<InvalidOperationException>(() => root.GetString());
+                const string throwsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
             Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
             Assert.Throws<InvalidOperationException>(() => root.TryGetBytesFromBase64(out byte[] _));
             Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
@@ -1475,7 +1515,8 @@ namespace System.Text.Json.Tests
                 JsonElement root = doc.RootElement;
 
                 Assert.Equal(JsonValueType.String, root.Type);
-                Assert.Throws<InvalidOperationException>(() => root.GetString());
+                AssertExtensions.Throws<InvalidOperationException>(() => root.GetString(), "Cannot transcode invalid UTF-8 JSON text to UTF-16 string.");
+                // Assert.Throws<InvalidOperationException>(() => root.ValueEquals("throws-anyway")); // TODO: Fix error should throw but doesn't
                 Assert.Throws<InvalidOperationException>(() => root.GetRawText());
             }
         }
@@ -3032,6 +3073,153 @@ namespace System.Text.Json.Tests
                     Assert.Equal(i, int.Parse(root[i].GetString()));
                 }
             }
+        }
+
+        [Fact]
+        public static void ValueEquals_Null_FalseForEmptyArgsTrueForNullOrDefault()
+        {
+            using (JsonDocument doc = JsonDocument.Parse("   null   "))
+            {
+                JsonElement jElement = doc.RootElement;
+                Assert.True(jElement.ValueEquals((string)null));
+                Assert.True(jElement.ValueEquals(default(ReadOnlySpan<char>)));
+                Assert.True(jElement.ValueEquals((ReadOnlySpan<byte>)null));
+                Assert.True(jElement.ValueEquals(default(ReadOnlySpan<byte>)));
+                
+                Assert.False(jElement.ValueEquals(Array.Empty<byte>()));
+                Assert.False(jElement.ValueEquals(""));
+                Assert.False(jElement.ValueEquals("".AsSpan()));
+            }
+        }
+
+        [Fact]
+        public static void ValueEquals_EmptyJsonString_True()
+        {
+            using (JsonDocument doc = JsonDocument.Parse("\"\""))
+            {
+                JsonElement jElement = doc.RootElement;
+                Assert.True(jElement.ValueEquals(""));
+                Assert.True(jElement.ValueEquals("".AsSpan()));
+                Assert.True(jElement.ValueEquals(default(ReadOnlySpan<char>)));
+                Assert.True(jElement.ValueEquals(default(ReadOnlySpan<byte>)));
+                Assert.True(jElement.ValueEquals(Array.Empty<byte>()));
+            }
+        }
+
+        [Fact]
+        public static void ValueEquals_TestTextEqualsLargeMatch_True()
+        {
+            string lookup = new string('a', 320);
+            string jsonString = "\"" + lookup + "\"";
+            using (JsonDocument doc = JsonDocument.Parse(jsonString))
+            {
+                JsonElement jElement = doc.RootElement;
+                Assert.True(jElement.ValueEquals((string)lookup));
+                Assert.True(jElement.ValueEquals((ReadOnlySpan<char>)lookup.AsSpan()));
+            }
+        }
+
+        [Theory]
+        [InlineData("\"conne\\u0063tionId\"", "connectionId")]
+        [InlineData("\"connectionId\"", "connectionId")]
+        [InlineData("\"123\"", "123")]
+        [InlineData("\"My name is \\\"Ahson\\\"\"", "My name is \"Ahson\"")]
+        public static void ValueEquals_JsonTokenStringType_True(string jsonString, string expected)
+        {
+            using (JsonDocument doc = JsonDocument.Parse(jsonString))
+            {
+                JsonElement jElement = doc.RootElement;
+                Assert.True(jElement.ValueEquals(expected));
+                Assert.True(jElement.ValueEquals(expected.AsSpan()));
+                byte[] expectedGetBytes = Encoding.UTF8.GetBytes(expected);
+                Assert.True(jElement.ValueEquals(expectedGetBytes));
+            }
+        }
+
+        [Theory]
+        [InlineData("\"conne\\u0063tionId\"", "c")]
+        public static void ValueEquals_DestinationTooSmallComparesEscaping_False(string jsonString, string other)
+        {
+            using (JsonDocument doc = JsonDocument.Parse(jsonString))
+            {
+                JsonElement jElement = doc.RootElement;
+                Assert.False(jElement.ValueEquals(other));
+                Assert.False(jElement.ValueEquals(other.AsSpan()));
+                byte[] otherGetBytes = Encoding.UTF8.GetBytes(other);
+                Assert.False(jElement.ValueEquals(otherGetBytes));
+            }
+        }
+
+        [Theory]
+        [InlineData("\"hello\"", new char[1] { (char)0xDC01 })]    // low surrogate - invalid
+        [InlineData("\"hello\"", new char[1] { (char)0xD801 })]    // high surrogate - missing pair
+        public static void InvalidUTF16Search(string jsonString, char[] lookup)
+        {
+            using (JsonDocument doc = JsonDocument.Parse(jsonString))
+            {
+                JsonElement jElement = doc.RootElement;
+                Assert.False(jElement.ValueEquals(lookup));
+            }
+        }
+
+        [Theory]
+        [InlineData("\"connectionId\"", "\"conne\\u0063tionId\"")]
+        [InlineData("\"conne\\u0063tionId\"", "bonnecxionId")] // intentionally making mismatch after escaped character
+        [InlineData("\"conne\\u0063tionId\"", "bonnectionId")] // intentionally changing the expected starting character
+        public static void ValueEquals_JsonTokenStringType_False(string jsonString, string otherText)
+        {
+            using (JsonDocument doc = JsonDocument.Parse(jsonString))
+            {
+                JsonElement jElement = doc.RootElement;
+                Assert.False(jElement.ValueEquals(otherText));
+                Assert.False(jElement.ValueEquals(otherText.AsSpan()));
+                byte[] expectedGetBytes = Encoding.UTF8.GetBytes(otherText);
+                Assert.False(jElement.ValueEquals(expectedGetBytes));
+            }
+        }
+
+        [Theory]
+        [InlineData("{}")]
+        [InlineData("{\"\" : \"\"}")]
+        [InlineData("{\"sample\" : \"\"}")]
+        [InlineData("{\"sample\" : null}")]
+        [InlineData("{\"sample\" : \"sample-value\"}")]
+        [InlineData("{\"connectionId\" : \"123\"}")]
+        public static void ValueEquals_JsonTokenNotString_Success(string jsonString)
+        {
+            const string errorMessage = "The requested operation requires an element of type 'String', but the target element has type 'Object'.";
+            using (JsonDocument doc = JsonDocument.Parse(jsonString))
+            {
+                JsonElement jElement = doc.RootElement;
+                const string throwsAnyway = "throws-anyway";
+                AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(throwsAnyway), errorMessage);
+                AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(throwsAnyway.AsSpan()), errorMessage);
+                AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)), errorMessage);
+            }
+        }
+
+        [Fact]
+        public static void NameEquals_TakeJsonProperty_ReturnsPropertyName()
+        {
+            string jsonString = $"{{ \"aPropertyName\" : \"itsValue\" }}";
+            using (JsonDocument doc = JsonDocument.Parse(jsonString))
+            {
+                JsonElement jElement = doc.RootElement;
+                JsonProperty property = jElement.EnumerateObject().First();
+                Assert.True(property.NameEquals("aPropertyName"));
+                Assert.True(property.NameEquals("aPropertyName".AsSpan()));
+                byte[] expectedGetBytes = Encoding.UTF8.GetBytes("aPropertyName");
+                Assert.True(property.NameEquals(expectedGetBytes));
+            }
+        }
+
+        [Fact]
+        public static void NameEquals_InvalidInstance_Throws()
+        {
+            const string ErrorMessage = "Operation is not valid due to the current state of the object.";
+            JsonProperty prop = default;
+            AssertExtensions.Throws<InvalidOperationException>(() => prop.NameEquals("hello"), ErrorMessage);
+            AssertExtensions.Throws<InvalidOperationException>(() => prop.NameEquals((string)null), ErrorMessage);
         }
 
         private static void BuildSegmentedReader(

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -3156,7 +3156,7 @@ namespace System.Text.Json.Tests
             }
         }
 
-        // [Theory]
+        [Theory]
         [InlineData("\"hello\"", new char[1] { (char)0xDC01 })]    // low surrogate - invalid
         [InlineData("\"hello\"", new char[1] { (char)0xD801 })]    // high surrogate - missing pair
         public static void InvalidUTF16Search(string jsonString, char[] lookup)

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -681,6 +681,7 @@ namespace System.Text.Json.Tests
                 string street = address.GetProperty("street").GetString();
                 string city = address.GetProperty("city").GetString();
                 double zipCode = address.GetProperty("zip").GetDouble();
+                const string ThrowsAnyway = "throws-anyway";
 
                 Assert.Equal(30, age);
                 Assert.Equal("John", first);
@@ -700,10 +701,9 @@ namespace System.Text.Json.Tests
                 Assert.Throws<InvalidOperationException>(() => address.GetProperty("zip").GetString());
                 Assert.Throws<InvalidOperationException>(() => person.GetProperty("phoneNumbers").GetString());
                 Assert.Throws<InvalidOperationException>(() => person.GetString());
-                const string throwsAnyway = "throws-anyway";
-                Assert.Throws<InvalidOperationException>(() => person.ValueEquals(throwsAnyway));
-                Assert.Throws<InvalidOperationException>(() => person.ValueEquals(throwsAnyway.AsSpan()));
-                Assert.Throws<InvalidOperationException>(() => person.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
+                Assert.Throws<InvalidOperationException>(() => person.ValueEquals(ThrowsAnyway));
+                Assert.Throws<InvalidOperationException>(() => person.ValueEquals(ThrowsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => person.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)));
             }
         }
 
@@ -838,10 +838,10 @@ namespace System.Text.Json.Tests
                 }
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
-                const string throwsAnyway = "throws-anyway";
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
+                const string ThrowsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.TryGetBytesFromBase64(out byte[] bytes));
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
@@ -930,10 +930,10 @@ namespace System.Text.Json.Tests
                 }
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
-                const string throwsAnyway = "throws-anyway";
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
+                const string ThrowsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTimeOffset());
@@ -991,10 +991,10 @@ namespace System.Text.Json.Tests
                 Assert.Equal(value, root.GetUInt64());
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
-                const string throwsAnyway = "throws-anyway";
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
+                const string ThrowsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTimeOffset());
@@ -1052,10 +1052,10 @@ namespace System.Text.Json.Tests
                 Assert.Throws<FormatException>(() => root.GetUInt64());
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
-                const string throwsAnyway = "throws-anyway";
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
+                const string ThrowsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTimeOffset());
@@ -1245,10 +1245,10 @@ namespace System.Text.Json.Tests
                 Assert.Throws<FormatException>(() => root.GetUInt64());
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
-                const string throwsAnyway = "throws-anyway";
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
+                const string ThrowsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTimeOffset());
@@ -1317,10 +1317,10 @@ namespace System.Text.Json.Tests
                 Assert.Throws<FormatException>(() => root.GetUInt64());
 
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
-                const string throwsAnyway = "throws-anyway";
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
+                const string ThrowsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTimeOffset());
@@ -1373,10 +1373,10 @@ namespace System.Text.Json.Tests
                 Assert.Throws<InvalidOperationException>(() => root.GetUInt64());
                 Assert.Throws<InvalidOperationException>(() => root.TryGetUInt64(out ulong _));
                 Assert.Throws<InvalidOperationException>(() => root.GetString());
-                const string throwsAnyway = "throws-anyway";
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
+                const string ThrowsAnyway = "throws-anyway";
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway.AsSpan()));
+                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)));
                 Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
                 Assert.Throws<InvalidOperationException>(() => root.TryGetBytesFromBase64(out byte[] _));
                 Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
@@ -1408,10 +1408,10 @@ namespace System.Text.Json.Tests
                 Assert.Throws<ObjectDisposedException>(() => root.GetUInt64());
                 Assert.Throws<ObjectDisposedException>(() => root.TryGetUInt64(out ulong _));
                 Assert.Throws<ObjectDisposedException>(() => root.GetString());
-                const string throwsAnyway = "throws-anyway";
-                Assert.Throws<ObjectDisposedException>(() => root.ValueEquals(throwsAnyway));
-                Assert.Throws<ObjectDisposedException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
-                Assert.Throws<ObjectDisposedException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
+                const string ThrowsAnyway = "throws-anyway";
+                Assert.Throws<ObjectDisposedException>(() => root.ValueEquals(ThrowsAnyway));
+                Assert.Throws<ObjectDisposedException>(() => root.ValueEquals(ThrowsAnyway.AsSpan()));
+                Assert.Throws<ObjectDisposedException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)));
                 Assert.Throws<ObjectDisposedException>(() => root.GetBytesFromBase64());
                 Assert.Throws<ObjectDisposedException>(() => root.TryGetBytesFromBase64(out byte[] _));
                 Assert.Throws<ObjectDisposedException>(() => root.GetBoolean());
@@ -1456,10 +1456,10 @@ namespace System.Text.Json.Tests
             Assert.Throws<InvalidOperationException>(() => root.GetUInt64());
             Assert.Throws<InvalidOperationException>(() => root.TryGetUInt64(out ulong _));
             Assert.Throws<InvalidOperationException>(() => root.GetString());
-                const string throwsAnyway = "throws-anyway";
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(throwsAnyway.AsSpan()));
-                Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)));
+            const string ThrowsAnyway = "throws-anyway";
+            Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway));
+            Assert.Throws<InvalidOperationException>(() => root.ValueEquals(ThrowsAnyway.AsSpan()));
+            Assert.Throws<InvalidOperationException>(() => root.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)));
             Assert.Throws<InvalidOperationException>(() => root.GetBytesFromBase64());
             Assert.Throws<InvalidOperationException>(() => root.TryGetBytesFromBase64(out byte[] _));
             Assert.Throws<InvalidOperationException>(() => root.GetDateTime());
@@ -1510,14 +1510,20 @@ namespace System.Text.Json.Tests
         {
             // The Arabic ligature Lam-Alef (U+FEFB) (which happens to, as a standalone, mean "no" in English)
             // is UTF-8 EF BB BB.  So let's leave out a BB and put it in quotes.
-            using (JsonDocument doc = JsonDocument.Parse(new byte[] { 0x22, 0xEF, 0xBB, 0x22 }))
+            byte[] badUtf8 = new byte[] { 0x22, 0xEF, 0xBB, 0x22 };
+            using (JsonDocument doc = JsonDocument.Parse(badUtf8))
             {
                 JsonElement root = doc.RootElement;
 
+                const string ErrorMessage = "Cannot transcode invalid UTF-8 JSON text to UTF-16 string.";
                 Assert.Equal(JsonValueType.String, root.Type);
-                AssertExtensions.Throws<InvalidOperationException>(() => root.GetString(), "Cannot transcode invalid UTF-8 JSON text to UTF-16 string.");
-                // Assert.Throws<InvalidOperationException>(() => root.ValueEquals("throws-anyway")); // TODO: Fix error should throw but doesn't
+                AssertExtensions.Throws<InvalidOperationException>(() => root.GetString(), ErrorMessage);
                 Assert.Throws<InvalidOperationException>(() => root.GetRawText());
+                const string DummyString = "dummy-string";
+                Assert.False(root.ValueEquals(badUtf8));
+                Assert.False(root.ValueEquals(DummyString));
+                Assert.False(root.ValueEquals(DummyString.AsSpan()));
+                Assert.False(root.ValueEquals(Encoding.UTF8.GetBytes(DummyString)));
             }
         }
 
@@ -3076,7 +3082,7 @@ namespace System.Text.Json.Tests
         }
 
         [Fact]
-        public static void ValueEquals_Null_FalseForEmptyArgsTrueForNullOrDefault()
+        public static void ValueEquals_Null_TrueForNullFalseForEmpty()
         {
             using (JsonDocument doc = JsonDocument.Parse("   null   "))
             {
@@ -3164,7 +3170,7 @@ namespace System.Text.Json.Tests
 
         [Theory]
         [InlineData("\"connectionId\"", "\"conne\\u0063tionId\"")]
-        [InlineData("\"conne\\u0063tionId\"", "bonnecxionId")] // intentionally making mismatch after escaped character
+        [InlineData("\"conne\\u0063tionId\"", "connecxionId")] // intentionally making mismatch after escaped character
         [InlineData("\"conne\\u0063tionId\"", "bonnectionId")] // intentionally changing the expected starting character
         public static void ValueEquals_JsonTokenStringType_False(string jsonString, string otherText)
         {
@@ -3187,14 +3193,14 @@ namespace System.Text.Json.Tests
         [InlineData("{\"connectionId\" : \"123\"}")]
         public static void ValueEquals_JsonTokenNotString_Success(string jsonString)
         {
-            const string errorMessage = "The requested operation requires an element of type 'String', but the target element has type 'Object'.";
+            const string ErrorMessage = "The requested operation requires an element of type 'String', but the target element has type 'Object'.";
             using (JsonDocument doc = JsonDocument.Parse(jsonString))
             {
                 JsonElement jElement = doc.RootElement;
-                const string throwsAnyway = "throws-anyway";
-                AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(throwsAnyway), errorMessage);
-                AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(throwsAnyway.AsSpan()), errorMessage);
-                AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(Encoding.UTF8.GetBytes(throwsAnyway)), errorMessage);
+                const string ThrowsAnyway = "throws-anyway";
+                AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(ThrowsAnyway), ErrorMessage);
+                AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(ThrowsAnyway.AsSpan()), ErrorMessage);
+                AssertExtensions.Throws<InvalidOperationException>(() => jElement.ValueEquals(Encoding.UTF8.GetBytes(ThrowsAnyway)), ErrorMessage);
             }
         }
 

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -63,8 +63,8 @@
     <Compile Include="TestClasses.ClassWithComplexObjects.cs" />
     <Compile Include="Utf8JsonReaderTests.cs" />
     <Compile Include="Utf8JsonReaderTests.MultiSegment.cs" />
-    <Compile Include="Utf8JsonReaderTests.TextEquals.cs" />
     <Compile Include="Utf8JsonReaderTests.TryGet.cs" />
+    <Compile Include="Utf8JsonReaderTests.ValueTextEquals.cs" />
     <Compile Include="Utf8JsonWriterTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Text.Json/tests/TestClasses.ClassWithComplexObjects.cs
+++ b/src/System.Text.Json/tests/TestClasses.ClassWithComplexObjects.cs
@@ -53,6 +53,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(JsonValueType.Object, jsonObject.Type);
             JsonProperty property = jsonObject.EnumerateObject().First();
             Assert.Equal("NestedArray", property.Name);
+            Assert.True(property.NameEquals("NestedArray"));
             ValidateArray(property.Value);
 
             void ValidateArray(JsonElement element)

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
@@ -31,22 +31,22 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.PropertyName)
                 {
-                    if (json.TextEquals(connectionId) && json.TextEquals("connectionId".AsSpan()))
+                    if (json.ValueTextEquals(connectionId) && json.ValueTextEquals("connectionId".AsSpan()))
                     {
                         foundId = true;
                     }
-                    else if (json.TextEquals(availableTransports) && json.TextEquals("availableTransports".AsSpan()))
+                    else if (json.ValueTextEquals(availableTransports) && json.ValueTextEquals("availableTransports".AsSpan()))
                     {
                         foundTransports = true;
                     }
                 }
                 else if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(value123) && json.TextEquals("123".AsSpan()))
+                    if (json.ValueTextEquals(value123) && json.ValueTextEquals("123".AsSpan()))
                     {
                         foundValue = true;
                     }
-                    else if (json.TextEquals(embeddedQuotes) && json.TextEquals("My name is \"Ahson\"".AsSpan()))
+                    else if (json.ValueTextEquals(embeddedQuotes) && json.ValueTextEquals("My name is \"Ahson\"".AsSpan()))
                     {
                         foundArrayValue = true;
                     }
@@ -72,8 +72,8 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    Assert.Equal(expectedFound, json.TextEquals(default(ReadOnlySpan<byte>)));
-                    Assert.Equal(expectedFound, json.TextEquals(default(ReadOnlySpan<char>)));
+                    Assert.Equal(expectedFound, json.ValueTextEquals(default(ReadOnlySpan<byte>)));
+                    Assert.Equal(expectedFound, json.ValueTextEquals(default(ReadOnlySpan<char>)));
                     break;
                 }
             }
@@ -85,8 +85,8 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    Assert.Equal(expectedFound, json.TextEquals(default(ReadOnlySpan<byte>)));
-                    Assert.Equal(expectedFound, json.TextEquals(default(ReadOnlySpan<char>)));
+                    Assert.Equal(expectedFound, json.ValueTextEquals(default(ReadOnlySpan<byte>)));
+                    Assert.Equal(expectedFound, json.ValueTextEquals(default(ReadOnlySpan<char>)));
                     break;
                 }
             }
@@ -115,7 +115,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.PropertyName)
                 {
-                    if (json.TextEquals(lookup) && json.TextEquals(lookUpString.AsSpan()))
+                    if (json.ValueTextEquals(lookup) && json.ValueTextEquals(lookUpString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -133,7 +133,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.PropertyName)
                 {
-                    if (json.TextEquals(lookup) && json.TextEquals(lookUpString.AsSpan()))
+                    if (json.ValueTextEquals(lookup) && json.ValueTextEquals(lookUpString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -167,7 +167,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(lookup) && json.TextEquals(lookUpString.AsSpan()))
+                    if (json.ValueTextEquals(lookup) && json.ValueTextEquals(lookUpString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -185,7 +185,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(lookup) && json.TextEquals(lookUpString.AsSpan()))
+                    if (json.ValueTextEquals(lookup) && json.ValueTextEquals(lookUpString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -226,7 +226,7 @@ namespace System.Text.Json.Tests
                 {
                     if (json.TokenType == JsonTokenType.String)
                     {
-                        if (json.TextEquals(lookupSpan) && json.TextEquals(lookupChars))
+                        if (json.ValueTextEquals(lookupSpan) && json.ValueTextEquals(lookupChars))
                         {
                             found = true;
                             break;
@@ -244,7 +244,7 @@ namespace System.Text.Json.Tests
                 {
                     if (json.TokenType == JsonTokenType.String)
                     {
-                        if (json.TextEquals(lookupSpan) && json.TextEquals(lookupChars))
+                        if (json.ValueTextEquals(lookupSpan) && json.ValueTextEquals(lookupChars))
                         {
                             found = true;
                             break;
@@ -308,7 +308,7 @@ namespace System.Text.Json.Tests
                     {
                         if (json.TokenType == JsonTokenType.String)
                         {
-                            if (json.TextEquals(lookup) || json.TextEquals(lookupChars))
+                            if (json.ValueTextEquals(lookup) || json.ValueTextEquals(lookupChars))
                             {
                                 found = true;
                                 break;
@@ -326,7 +326,7 @@ namespace System.Text.Json.Tests
                     {
                         if (json.TokenType == JsonTokenType.String)
                         {
-                            if (json.TextEquals(lookup) || json.TextEquals(lookupChars))
+                            if (json.ValueTextEquals(lookup) || json.ValueTextEquals(lookupChars))
                             {
                                 found = true;
                                 break;
@@ -353,7 +353,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(new byte[] { (byte)'a' }) || json.TextEquals(new char[] { 'a' }))
+                    if (json.ValueTextEquals(new byte[] { (byte)'a' }) || json.ValueTextEquals(new char[] { 'a' }))
                     {
                         found = true;
                         break;
@@ -371,7 +371,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(new byte[] { (byte)'a' }) || json.TextEquals(new char[] { 'a' }))
+                    if (json.ValueTextEquals(new byte[] { (byte)'a' }) || json.ValueTextEquals(new char[] { 'a' }))
                     {
                         found = true;
                         break;
@@ -398,7 +398,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.TextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -416,7 +416,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.TextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -441,7 +441,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.TextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -459,7 +459,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.TextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -484,7 +484,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.TextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -502,7 +502,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.TextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -530,7 +530,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(lookup) || json.TextEquals("Hello, \"Ahson\"".AsSpan()))
+                    if (json.ValueTextEquals(lookup) || json.ValueTextEquals("Hello, \"Ahson\"".AsSpan()))
                     {
                         found = true;
                         break;
@@ -554,7 +554,7 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.TextEquals(lookup))
+                    if (json.ValueTextEquals(lookup))
                     {
                         found = true;
                         break;
@@ -575,7 +575,7 @@ namespace System.Text.Json.Tests
             var json = new Utf8JsonReader(utf8Data, isFinalBlock: true, state: default);
             Assert.True(json.Read());
             Assert.Equal(JsonTokenType.String, json.TokenType);
-            Assert.False(json.TextEquals(lookup.AsSpan()));
+            Assert.False(json.ValueTextEquals(lookup.AsSpan()));
         }
 
         [Fact]
@@ -589,7 +589,7 @@ namespace System.Text.Json.Tests
             var json = new Utf8JsonReader(utf8Data, isFinalBlock: true, state: default);
             Assert.True(json.Read());
             Assert.Equal(JsonTokenType.String, json.TokenType);
-            Assert.False(json.TextEquals(lookup));
+            Assert.False(json.ValueTextEquals(lookup));
         }
 
         [ConditionalFact(nameof(IsX64))]
@@ -610,8 +610,8 @@ namespace System.Text.Json.Tests
 
             try
             {
-                json.TextEquals(jsonString.AsSpan(1, jsonString.Length - 2));
-                Assert.True(false, $"Expected OverflowException was not thrown when calling TextEquals with large lookup string");
+                json.ValueTextEquals(jsonString.AsSpan(1, jsonString.Length - 2));
+                Assert.True(false, $"Expected OverflowException was not thrown when calling ValueTextEquals with large lookup string");
             }
             catch (OverflowException)
             { }
@@ -628,16 +628,16 @@ namespace System.Text.Json.Tests
 
             try
             {
-                json.TextEquals(default(ReadOnlySpan<byte>));
-                Assert.True(false, $"Expected InvalidOperationException was not thrown when calling TextEquals with TokenType = {json.TokenType}");
+                json.ValueTextEquals(default(ReadOnlySpan<byte>));
+                Assert.True(false, $"Expected InvalidOperationException was not thrown when calling ValueTextEquals with TokenType = {json.TokenType}");
             }
             catch (InvalidOperationException)
             { }
 
             try
             {
-                json.TextEquals(default(ReadOnlySpan<char>));
-                Assert.True(false, $"Expected InvalidOperationException was not thrown when calling TextEquals(char) with TokenType = {json.TokenType}");
+                json.ValueTextEquals(default(ReadOnlySpan<char>));
+                Assert.True(false, $"Expected InvalidOperationException was not thrown when calling ValueTextEquals(char) with TokenType = {json.TokenType}");
             }
             catch (InvalidOperationException)
             { }
@@ -646,16 +646,16 @@ namespace System.Text.Json.Tests
             {
                 try
                 {
-                    json.TextEquals(default(ReadOnlySpan<byte>));
-                    Assert.True(false, $"Expected InvalidOperationException was not thrown when calling TextEquals with TokenType = {json.TokenType}");
+                    json.ValueTextEquals(default(ReadOnlySpan<byte>));
+                    Assert.True(false, $"Expected InvalidOperationException was not thrown when calling ValueTextEquals with TokenType = {json.TokenType}");
                 }
                 catch (InvalidOperationException)
                 { }
 
                 try
                 {
-                    json.TextEquals(default(ReadOnlySpan<char>));
-                    Assert.True(false, $"Expected InvalidOperationException was not thrown when calling TextEquals(char) with TokenType = {json.TokenType}");
+                    json.ValueTextEquals(default(ReadOnlySpan<char>));
+                    Assert.True(false, $"Expected InvalidOperationException was not thrown when calling ValueTextEquals(char) with TokenType = {json.TokenType}");
                 }
                 catch (InvalidOperationException)
                 { }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
@@ -74,6 +74,7 @@ namespace System.Text.Json.Tests
                 {
                     Assert.Equal(expectedFound, json.ValueTextEquals(default(ReadOnlySpan<byte>)));
                     Assert.Equal(expectedFound, json.ValueTextEquals(default(ReadOnlySpan<char>)));
+                    Assert.Equal(expectedFound, json.ValueTextEquals(default(string)));
                     break;
                 }
             }
@@ -87,6 +88,7 @@ namespace System.Text.Json.Tests
                 {
                     Assert.Equal(expectedFound, json.ValueTextEquals(default(ReadOnlySpan<byte>)));
                     Assert.Equal(expectedFound, json.ValueTextEquals(default(ReadOnlySpan<char>)));
+                    Assert.Equal(expectedFound, json.ValueTextEquals(default(string)));
                     break;
                 }
             }
@@ -115,7 +117,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.PropertyName)
                 {
-                    if (json.ValueTextEquals(lookup) && json.ValueTextEquals(lookUpString.AsSpan()))
+                    if (json.ValueTextEquals(lookup) &&
+                        json.ValueTextEquals(lookUpString) &&
+                        json.ValueTextEquals(lookUpString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -133,7 +137,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.PropertyName)
                 {
-                    if (json.ValueTextEquals(lookup) && json.ValueTextEquals(lookUpString.AsSpan()))
+                    if (json.ValueTextEquals(lookup) && 
+                        json.ValueTextEquals(lookUpString) && 
+                        json.ValueTextEquals(lookUpString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -167,7 +173,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.ValueTextEquals(lookup) && json.ValueTextEquals(lookUpString.AsSpan()))
+                    if (json.ValueTextEquals(lookup) &&
+                        json.ValueTextEquals(lookUpString) &&
+                        json.ValueTextEquals(lookUpString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -185,7 +193,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.ValueTextEquals(lookup) && json.ValueTextEquals(lookUpString.AsSpan()))
+                    if (json.ValueTextEquals(lookup) &&
+                        json.ValueTextEquals(lookUpString) &&
+                        json.ValueTextEquals(lookUpString.AsSpan()))
                     {
                         found = true;
                         break;
@@ -226,7 +236,9 @@ namespace System.Text.Json.Tests
                 {
                     if (json.TokenType == JsonTokenType.String)
                     {
-                        if (json.ValueTextEquals(lookupSpan) && json.ValueTextEquals(lookupChars))
+                        if (json.ValueTextEquals(lookupSpan) && 
+                            json.ValueTextEquals(lookupChars) && 
+                            json.ValueTextEquals(new string(lookupChars)))
                         {
                             found = true;
                             break;
@@ -244,7 +256,9 @@ namespace System.Text.Json.Tests
                 {
                     if (json.TokenType == JsonTokenType.String)
                     {
-                        if (json.ValueTextEquals(lookupSpan) && json.ValueTextEquals(lookupChars))
+                        if (json.ValueTextEquals(lookupSpan) && 
+                            json.ValueTextEquals(lookupChars) && 
+                            json.ValueTextEquals(new string(lookupChars)))
                         {
                             found = true;
                             break;
@@ -308,7 +322,9 @@ namespace System.Text.Json.Tests
                     {
                         if (json.TokenType == JsonTokenType.String)
                         {
-                            if (json.ValueTextEquals(lookup) || json.ValueTextEquals(lookupChars))
+                            if (json.ValueTextEquals(lookup) || 
+                                json.ValueTextEquals(lookupChars) || 
+                                json.ValueTextEquals(new string(lookupChars)))
                             {
                                 found = true;
                                 break;
@@ -326,7 +342,9 @@ namespace System.Text.Json.Tests
                     {
                         if (json.TokenType == JsonTokenType.String)
                         {
-                            if (json.ValueTextEquals(lookup) || json.ValueTextEquals(lookupChars))
+                            if (json.ValueTextEquals(lookup) || 
+                                json.ValueTextEquals(lookupChars) ||
+                                json.ValueTextEquals(new string(lookupChars)))
                             {
                                 found = true;
                                 break;
@@ -353,7 +371,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.ValueTextEquals(new byte[] { (byte)'a' }) || json.ValueTextEquals(new char[] { 'a' }))
+                    if (json.ValueTextEquals(new byte[] { (byte)'a' }) || 
+                        json.ValueTextEquals(new char[] { 'a' }) || 
+                        json.ValueTextEquals("a"))
                     {
                         found = true;
                         break;
@@ -371,7 +391,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.ValueTextEquals(new byte[] { (byte)'a' }) || json.ValueTextEquals(new char[] { 'a' }))
+                    if (json.ValueTextEquals(new byte[] { (byte)'a' }) || 
+                        json.ValueTextEquals(new char[] { 'a' }) || 
+                        json.ValueTextEquals("a"))
                     {
                         found = true;
                         break;
@@ -398,7 +420,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || 
+                        json.ValueTextEquals(lookupString.AsSpan()) || 
+                        json.ValueTextEquals(lookupString))
                     {
                         found = true;
                         break;
@@ -416,7 +440,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || 
+                        json.ValueTextEquals(lookupString.AsSpan()) || 
+                        json.ValueTextEquals(lookupString))
                     {
                         found = true;
                         break;
@@ -441,7 +467,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || 
+                        json.ValueTextEquals(lookupString.AsSpan()) || 
+                        json.ValueTextEquals(lookupString))
                     {
                         found = true;
                         break;
@@ -459,7 +487,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || 
+                        json.ValueTextEquals(lookupString.AsSpan()) || 
+                        json.ValueTextEquals(lookupString))
                     {
                         found = true;
                         break;
@@ -484,7 +514,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || 
+                        json.ValueTextEquals(lookupString.AsSpan()) || 
+                        json.ValueTextEquals(lookupString))
                     {
                         found = true;
                         break;
@@ -502,7 +534,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || json.ValueTextEquals(lookupString.AsSpan()))
+                    if (json.ValueTextEquals(Encoding.UTF8.GetBytes(lookupString)) || 
+                        json.ValueTextEquals(lookupString.AsSpan()) ||
+                        json.ValueTextEquals(lookupString))
                     {
                         found = true;
                         break;
@@ -530,7 +564,9 @@ namespace System.Text.Json.Tests
             {
                 if (json.TokenType == JsonTokenType.String)
                 {
-                    if (json.ValueTextEquals(lookup) || json.ValueTextEquals("Hello, \"Ahson\"".AsSpan()))
+                    if (json.ValueTextEquals(lookup) || 
+                        json.ValueTextEquals("Hello, \"Ahson\"".AsSpan()) || 
+                        json.ValueTextEquals("Hello, \"Ahson\""))
                     {
                         found = true;
                         break;
@@ -642,6 +678,14 @@ namespace System.Text.Json.Tests
             catch (InvalidOperationException)
             { }
 
+            try
+            {
+                json.ValueTextEquals(default(string));
+                Assert.True(false, $"Expected InvalidOperationException was not thrown when calling ValueTextEquals(char) with TokenType = {json.TokenType}");
+            }
+            catch (InvalidOperationException)
+            { }
+
             while (json.Read())
             {
                 try
@@ -655,6 +699,14 @@ namespace System.Text.Json.Tests
                 try
                 {
                     json.ValueTextEquals(default(ReadOnlySpan<char>));
+                    Assert.True(false, $"Expected InvalidOperationException was not thrown when calling ValueTextEquals(char) with TokenType = {json.TokenType}");
+                }
+                catch (InvalidOperationException)
+                { }
+
+                try
+                {
+                    json.ValueTextEquals(default(string));
                     Assert.True(false, $"Expected InvalidOperationException was not thrown when calling ValueTextEquals(char) with TokenType = {json.TokenType}");
                 }
                 catch (InvalidOperationException)

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
@@ -238,7 +238,7 @@ namespace System.Text.Json.Tests
                     {
                         if (json.ValueTextEquals(lookupSpan) && 
                             json.ValueTextEquals(lookupChars) && 
-                            json.ValueTextEquals(new string(lookupChars)))
+                            json.ValueTextEquals(new string(lookupChars.ToArray())))
                         {
                             found = true;
                             break;
@@ -258,7 +258,7 @@ namespace System.Text.Json.Tests
                     {
                         if (json.ValueTextEquals(lookupSpan) && 
                             json.ValueTextEquals(lookupChars) && 
-                            json.ValueTextEquals(new string(lookupChars)))
+                            json.ValueTextEquals(new string(lookupChars.ToArray())))
                         {
                             found = true;
                             break;
@@ -324,7 +324,7 @@ namespace System.Text.Json.Tests
                         {
                             if (json.ValueTextEquals(lookup) || 
                                 json.ValueTextEquals(lookupChars) || 
-                                json.ValueTextEquals(new string(lookupChars)))
+                                json.ValueTextEquals(new string(lookupChars.ToArray())))
                             {
                                 found = true;
                                 break;
@@ -344,7 +344,7 @@ namespace System.Text.Json.Tests
                         {
                             if (json.ValueTextEquals(lookup) || 
                                 json.ValueTextEquals(lookupChars) ||
-                                json.ValueTextEquals(new string(lookupChars)))
+                                json.ValueTextEquals(new string(lookupChars.ToArray())))
                             {
                                 found = true;
                                 break;

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
@@ -578,6 +578,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
+        [ActiveIssue(38178)]
         [InlineData("\"hello\"", new char[1] { (char)0xDC01 })]    // low surrogate - invalid
         [InlineData("\"hello\"", new char[1] { (char)0xD801 })]    // high surrogate - missing pair
         public static void InvalidUTF16Search(string jsonString, char[] lookup)

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
@@ -541,7 +541,7 @@ namespace System.Text.Json.Tests
             Assert.False(found);
         }
 
-        [Theory]
+        // [Theory]
         [InlineData("\"hello\"", new char[1] { (char)0xDC01 })]    // low surrogate - invalid
         [InlineData("\"hello\"", new char[1] { (char)0xD801 })]    // high surrogate - missing pair
         public static void InvalidUTF16Search(string jsonString, char[] lookup)

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
@@ -541,7 +541,7 @@ namespace System.Text.Json.Tests
             Assert.False(found);
         }
 
-        // [Theory]
+        [Theory]
         [InlineData("\"hello\"", new char[1] { (char)0xDC01 })]    // low surrogate - invalid
         [InlineData("\"hello\"", new char[1] { (char)0xD801 })]    // high surrogate - missing pair
         public static void InvalidUTF16Search(string jsonString, char[] lookup)

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -38,9 +38,10 @@ namespace System.Text.Json.Tests
             Assert.False(json.Read());
 
             json = default;
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TextEquals("".AsSpan()));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TextEquals(default(ReadOnlySpan<char>)));
-            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.TextEquals(default(ReadOnlySpan<byte>)));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.ValueTextEquals(""));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.ValueTextEquals("".AsSpan()));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.ValueTextEquals(default(ReadOnlySpan<char>)));
+            JsonTestHelper.AssertThrows<InvalidOperationException>(json, (jsonReader) => jsonReader.ValueTextEquals(default(ReadOnlySpan<byte>)));
 
             TestGetMethodsOnDefault();
         }


### PR DESCRIPTION
- [x] Rename Utf8JsonReader.TextEquals to Utf8JsonReader.ValueTextEquals
- [x] Implement JsonElement.ValueEquals and add code coverage
- [x] Reuse logic for JsonProperty and add code coverage
- [x] Address existing feedback
- [x]  improve header documentation
- [x]  cleanup tests

Fixes: https://github.com/dotnet/corefx/issues/37751
