### PR TITLE
Fix typo in JsonSerializer api documentation.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json.Serialization
         /// </summary>
         /// <returns>A UTF-8 representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
-        /// <param name="options">Options to control the convertion behavior.</param>
+        /// <param name="options">Options to control the conversion behavior.</param>
         public static byte[] ToBytes<TValue>(TValue value, JsonSerializerOptions options = null)
         {
             return WriteCoreBytes(value, typeof(TValue), options);
@@ -23,7 +23,7 @@ namespace System.Text.Json.Serialization
         /// <returns>A UTF-8 representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
         /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
-        /// <param name="options">Options to control the convertion behavior.</param>
+        /// <param name="options">Options to control the conversion behavior.</param>
         public static byte[] ToBytes(object value, Type type, JsonSerializerOptions options = null)
         {
             VerifyValueAndType(value, type);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json.Serialization
         /// <returns>A task that represents the asynchronous write operation.</returns>
         /// <param name="value">The value to convert.</param>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
-        /// <param name="options">Options to control the convertion behavior.</param>
+        /// <param name="options">Options to control the conversion behavior.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
         public static Task WriteAsync<TValue>(TValue value, Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
@@ -31,7 +31,7 @@ namespace System.Text.Json.Serialization
         /// <param name="value">The value to convert.</param>
         /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
-        /// <param name="options">Options to control the convertion behavior.</param>
+        /// <param name="options">Options to control the conversion behavior.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
         public static Task WriteAsync(object value, Type type, Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json.Serialization
         /// </summary>
         /// <returns>A <see cref="System.String"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
-        /// <param name="options">Options to control the convertion behavior.</param>
+        /// <param name="options">Options to control the conversion behavior.</param>
         /// <remarks>Using a <see cref="System.String"/> is not as efficient as using UTF-8
         /// encoding since the implementation internally uses UTF-8. See also <see cref="ToBytes"/>
         /// and <see cref="WriteAsync"/>.
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization
         /// <returns>A <see cref="System.String"/> representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
         /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
-        /// <param name="options">Options to control the convertion behavior.</param>
+        /// <param name="options">Options to control the conversion behavior.</param>
         /// <remarks>Using a <see cref="System.String"/> is not as efficient as using UTF-8
         /// encoding since the implementation internally uses UTF-8. See also <see cref="ToBytes"/>
         /// and <see cref="WriteAsync"/>.


### PR DESCRIPTION
Noticed typo when reviewing https://github.com/dotnet/corefx/pull/37912.