### PR TITLE
fix #36798 by updating PipeReader doc comment

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -71,7 +71,7 @@ namespace System.IO.Pipelines
         public abstract void Complete(Exception exception = null);
 
         /// <summary>
-        /// Cancel the pending <see cref="ReadAsync"/> operation. If there is none, cancels next <see cref="ReadAsync"/> operation, without completing the <see cref="PipeWriter"/>.
+        /// Registers a callback that gets executed when the <see cref="PipeWriter"/> side of the pipe is completed
         /// </summary>
         public abstract void OnWriterCompleted(Action<Exception, object> callback, object state);
 


### PR DESCRIPTION
Fixes #36798

Corrects an inaccurate doc comment in System.IO.Pipelines.PipeReader.

Based this on the existing comment for `PipeWriter.OnReaderCompleted`:

https://github.com/dotnet/corefx/blob/af562e84b8b5a4a335ceb5006886a6c42c1c023e/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriter.cs#L29-L32

cc @AArnott 