### PR TITLE
Enable MaxConnectionsPerServer_WaitingConnectionsAreCancelable again

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -292,7 +292,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(32000)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "WinRT stack can't set MaxConnectionsPerServer < 2")]
         [Fact]
         public async Task MaxConnectionsPerServer_WaitingConnectionsAreCancelable()

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -9,6 +9,9 @@ using System.IO;
 using System.Net.Test.Common;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.DotNet.XUnitExtensions;
+
 using Xunit;
 using Xunit.Abstractions;
 
@@ -293,14 +296,15 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "WinRT stack can't set MaxConnectionsPerServer < 2")]
-        [Fact]
+        [ConditionalFact]
         public async Task MaxConnectionsPerServer_WaitingConnectionsAreCancelable()
         {
-            if (IsNetfxHandler)
+            if (IsNetfxHandler || IsCurlHandler)
             {
                 // Throws HttpRequestException wrapping a WebException for the canceled request
                 // instead of throwing an OperationCanceledException or a canceled WebException directly.
-                return;
+                // With CurlHandler, this test sometimes hangs.
+                throw new SkipTestException("Skipping on unstable platform handler");
             }
 
             using (HttpClientHandler handler = CreateHttpClientHandler())


### PR DESCRIPTION
enable MaxConnectionsPerServer_WaitingConnectionsAreCancelable again. It had issues with curl, but I think we don't care much at this point.  This should work on SocketHttpHandler. (and if not, we should fix that)