### PR TITLE
move tests with external servers to outerloop

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
@@ -47,7 +47,6 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(2)]
         [InlineData(int.MaxValue)]
         [InlineData(int.MaxValue - 1)]
-        [OuterLoop("Uses external servers")]
         public void Set_ValidValues_Success(int validValue)
         {
             using (HttpClientHandler handler = CreateHttpClientHandler())

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxConnectionsPerServer.cs
@@ -47,19 +47,12 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(2)]
         [InlineData(int.MaxValue)]
         [InlineData(int.MaxValue - 1)]
+        [OuterLoop("Uses external servers")]
         public void Set_ValidValues_Success(int validValue)
         {
             using (HttpClientHandler handler = CreateHttpClientHandler())
             {
-                try
-                {
-                    handler.MaxConnectionsPerServer = validValue;
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    // Some older libcurls used in some of our Linux CI systems don't support this
-                    Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
-                }
+                handler.MaxConnectionsPerServer = validValue;
             }
         }
 
@@ -71,6 +64,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(3, 2, false)]
         [InlineData(3, 2, true)]
         [InlineData(3, 5, false)]
+        [OuterLoop("Uses external servers")]
         public async Task GetAsync_MaxLimited_ConcurrentCallsStillSucceed(int maxConnections, int numRequests, bool secure)
         {
             using (HttpClientHandler handler = CreateHttpClientHandler())


### PR DESCRIPTION
Update concurency tests to:
- move GetAsync_MaxLimited_ConcurrentCallsStillSucceed to outerloop as it uses external Azure serverts
- remove unnecesary craft from Set_ValidValues_Success. It seems like the comment about curl is no longer true.