### PR TITLE
Avoid .ToArray() in JsonSerializer .NET Standard implementation

### DIFF
--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -106,7 +106,7 @@
     <Compile Include="System\Text\Json\Serialization\JsonSerializerOptions.cs" />
     <Compile Include="System\Text\Json\Serialization\MemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\Policies\JsonValueConverter.cs" />
-    <Compile Include="System\Text\Json\Serialization\PooledBufferWriter.cs" />
+    <Compile Include="System\Text\Json\Serialization\PooledByteBufferWriter.cs" />
     <Compile Include="System\Text\Json\Serialization\PropertyRef.cs" />
     <Compile Include="System\Text\Json\Serialization\ReadStack.cs" />
     <Compile Include="System\Text\Json\Serialization\ReadStackFrame.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -63,7 +63,7 @@ namespace System.Text.Json.Serialization
 
             byte[] result;
 
-            using (var output = new PooledBufferWriter<byte>(options.DefaultBufferSize))
+            using (var output = new PooledByteBufferWriter(options.DefaultBufferSize))
             {
                 WriteCore(output, value, type, options);
                 result = output.WrittenMemory.ToArray();
@@ -81,7 +81,7 @@ namespace System.Text.Json.Serialization
 
             string result;
 
-            using (var output = new PooledBufferWriter<byte>(options.DefaultBufferSize))
+            using (var output = new PooledByteBufferWriter(options.DefaultBufferSize))
             {
                 WriteCore(output, value, type, options);
                 result = JsonReaderHelper.TranscodeHelper(output.WrittenMemory.Span);
@@ -90,7 +90,7 @@ namespace System.Text.Json.Serialization
             return result;
         }
 
-        private static void WriteCore(PooledBufferWriter<byte> output, object value, Type type, JsonSerializerOptions options)
+        private static void WriteCore(PooledByteBufferWriter output, object value, Type type, JsonSerializerOptions options)
         {
             Debug.Assert(type != null || value == null);
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -60,7 +59,7 @@ namespace System.Text.Json.Serialization
                     writer.WriteNullValue();
                     writer.Flush();
 
-                    await bufferWriter.WriteToAsync(utf8Json, cancellationToken).ConfigureAwait(false);
+                    await bufferWriter.WriteToStreamAsync(utf8Json, cancellationToken).ConfigureAwait(false);
 
                     return;
                 }
@@ -84,7 +83,7 @@ namespace System.Text.Json.Serialization
                     isFinalBlock = Write(writer, flushThreshold, options, ref state);
                     writer.Flush();
 
-                    await bufferWriter.WriteToAsync(utf8Json, cancellationToken).ConfigureAwait(false);
+                    await bufferWriter.WriteToStreamAsync(utf8Json, cancellationToken).ConfigureAwait(false);
 
                     bufferWriter.Clear();
                 } while (!isFinalBlock);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -60,12 +60,8 @@ namespace System.Text.Json.Serialization
                     writer.WriteNullValue();
                     writer.Flush();
 
-#if BUILDING_INBOX_LIBRARY
-                    await utf8Json.WriteAsync(bufferWriter.WrittenMemory, cancellationToken).ConfigureAwait(false);
-#else
-                    // todo: stackalloc or pool here?
-                    await utf8Json.WriteAsync(bufferWriter.WrittenMemory.ToArray(), 0, bufferWriter.WrittenMemory.Length, cancellationToken).ConfigureAwait(false);
-#endif
+                    await bufferWriter.WriteToAsync(utf8Json, cancellationToken).ConfigureAwait(false);
+
                     return;
                 }
 
@@ -88,12 +84,8 @@ namespace System.Text.Json.Serialization
                     isFinalBlock = Write(writer, flushThreshold, options, ref state);
                     writer.Flush();
 
-#if BUILDING_INBOX_LIBRARY
-                    await utf8Json.WriteAsync(bufferWriter.WrittenMemory, cancellationToken).ConfigureAwait(false);
-#else
-                    // todo: use pool here to avod extra alloc?
-                    await utf8Json.WriteAsync(bufferWriter.WrittenMemory.ToArray(), 0, bufferWriter.WrittenMemory.Length, cancellationToken).ConfigureAwait(false);
-#endif
+                    await bufferWriter.WriteToAsync(utf8Json, cancellationToken).ConfigureAwait(false);
+
                     bufferWriter.Clear();
                 } while (!isFinalBlock);
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -52,7 +52,7 @@ namespace System.Text.Json.Serialization
 
             JsonWriterOptions writerOptions = options.GetWriterOptions();
 
-            using (var bufferWriter = new PooledBufferWriter<byte>(options.DefaultBufferSize))
+            using (var bufferWriter = new PooledByteBufferWriter(options.DefaultBufferSize))
             using (var writer = new Utf8JsonWriter(bufferWriter, writerOptions))
             {
                 if (value == null)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/PooledBufferWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/PooledBufferWriter.cs
@@ -4,6 +4,9 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Text.Json.Serialization
 {
@@ -109,6 +112,18 @@ namespace System.Text.Json.Serialization
             CheckAndResizeBuffer(sizeHint);
             return _rentedBuffer.AsSpan(_index);
         }
+
+#if BUILDING_INBOX_LIBRARY
+        internal ValueTask WriteToAsync(Stream destination, CancellationToken cancellationToken)
+        {
+            return destination.WriteAsync(WrittenMemory, cancellationToken);
+        }
+#else
+        internal Task WriteToAsync(Stream destination, CancellationToken cancellationToken)
+        {
+            return destination.WriteAsync(_rentedBuffer, 0, _index, cancellationToken);
+        }
+#endif
 
         private void CheckAndResizeBuffer(int sizeHint)
         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/PooledBufferWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/PooledBufferWriter.cs
@@ -10,22 +10,22 @@ namespace System.Text.Json.Serialization
     /// <summary>
     ///   This is an implementation detail and MUST NOT be called by source-package consumers.
     /// </summary>
-    internal sealed class PooledBufferWriter<T> : IBufferWriter<T>, IDisposable
+    internal sealed class PooledByteBufferWriter : IBufferWriter<byte>, IDisposable
     {
-        private T[] _rentedBuffer;
+        private byte[] _rentedBuffer;
         private int _index;
 
         private const int MinimumBufferSize = 256;
 
-        public PooledBufferWriter(int initialCapacity)
+        public PooledByteBufferWriter(int initialCapacity)
         {
             Debug.Assert(initialCapacity > 0);
 
-            _rentedBuffer = ArrayPool<T>.Shared.Rent(initialCapacity);
+            _rentedBuffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
             _index = 0;
         }
 
-        public ReadOnlyMemory<T> WrittenMemory
+        public ReadOnlyMemory<byte> WrittenMemory
         {
             get
             {
@@ -85,7 +85,7 @@ namespace System.Text.Json.Serialization
             }
 
             ClearHelper();
-            ArrayPool<T>.Shared.Return(_rentedBuffer);
+            ArrayPool<byte>.Shared.Return(_rentedBuffer);
             _rentedBuffer = null;
         }
 
@@ -98,13 +98,13 @@ namespace System.Text.Json.Serialization
             _index += count;
         }
 
-        public Memory<T> GetMemory(int sizeHint = 0)
+        public Memory<byte> GetMemory(int sizeHint = 0)
         {
             CheckAndResizeBuffer(sizeHint);
             return _rentedBuffer.AsMemory(_index);
         }
 
-        public Span<T> GetSpan(int sizeHint = 0)
+        public Span<byte> GetSpan(int sizeHint = 0)
         {
             CheckAndResizeBuffer(sizeHint);
             return _rentedBuffer.AsSpan(_index);
@@ -128,17 +128,17 @@ namespace System.Text.Json.Serialization
 
                 int newSize = checked(_rentedBuffer.Length + growBy);
 
-                T[] oldBuffer = _rentedBuffer;
+                byte[] oldBuffer = _rentedBuffer;
 
-                _rentedBuffer = ArrayPool<T>.Shared.Rent(newSize);
+                _rentedBuffer = ArrayPool<byte>.Shared.Rent(newSize);
 
                 Debug.Assert(oldBuffer.Length >= _index);
                 Debug.Assert(_rentedBuffer.Length >= _index);
 
-                Span<T> previousBuffer = oldBuffer.AsSpan(0, _index);
+                Span<byte> previousBuffer = oldBuffer.AsSpan(0, _index);
                 previousBuffer.CopyTo(_rentedBuffer);
                 previousBuffer.Clear();
-                ArrayPool<T>.Shared.Return(oldBuffer);
+                ArrayPool<byte>.Shared.Return(oldBuffer);
             }
 
             Debug.Assert(_rentedBuffer.Length - _index > 0);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/PooledByteBufferWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/PooledByteBufferWriter.cs
@@ -114,12 +114,12 @@ namespace System.Text.Json.Serialization
         }
 
 #if BUILDING_INBOX_LIBRARY
-        internal ValueTask WriteToAsync(Stream destination, CancellationToken cancellationToken)
+        internal ValueTask WriteToStreamAsync(Stream destination, CancellationToken cancellationToken)
         {
             return destination.WriteAsync(WrittenMemory, cancellationToken);
         }
 #else
-        internal Task WriteToAsync(Stream destination, CancellationToken cancellationToken)
+        internal Task WriteToStreamAsync(Stream destination, CancellationToken cancellationToken)
         {
             return destination.WriteAsync(_rentedBuffer, 0, _index, cancellationToken);
         }


### PR DESCRIPTION
I have been looking at the profiles and code and I found that we are using `.ToArray()` in the .NET Standard implementation of the JsonSerializer. I know that .NET Core is our priority, but this is a low hanging fruit so I decided to solve this issue.

```cs
await utf8Json.WriteAsync(bufferWriter.WrittenMemory.ToArray(), 0, bufferWriter.WrittenMemory.Length, cancellationToken)
```

Initially, I just added the following method to the `PooledBufferWriter<T>`:

```cs
internal ValueTask WriteToAsync(Stream destination, CancellationToken cancellationToken)
{
    return destination.WriteAsync(WrittenMemory, cancellationToken);
}
```

But then compiler reminded me that `stream.WriteAsync` accepts arrays/ROMs of `bytes` only.

I did not want to expose `private T[] _rentedBuffer;` as internal and introduce an extension method, but I realized that `PooledBufferWriter<T>` is always used as byte buffer. So I maded it a non-generic byte buffer. This type is internal so I hope it's not a problem.