### PR TITLE
Dont escape the property names twice

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterBoolean.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterBoolean.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Span<byte> escapedPropertyName, bool value, Utf8JsonWriter writer)
         {
-            writer.WriteBoolean(escapedPropertyName, value);
+            writer.WriteBooleanEscapeValueOnly(escapedPropertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterString.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterString.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Span<byte> escapedPropertyName, string value, Utf8JsonWriter writer)
         {
-            writer.WriteString(escapedPropertyName, value);
+            writer.WriteStringEscapeValueOnly(escapedPropertyName, value);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Literal.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Literal.cs
@@ -194,6 +194,20 @@ namespace System.Text.Json
             _tokenType = value ? JsonTokenType.True : JsonTokenType.False;
         }
 
+        internal void WriteBooleanEscapeValueOnly(ReadOnlySpan<byte> escapedUtf8PropertyName, bool value)
+        {
+            Debug.Assert(JsonWriterHelper.NeedsEscaping(escapedUtf8PropertyName) == -1);
+
+            JsonWriterHelper.ValidateProperty(escapedUtf8PropertyName);
+
+            ReadOnlySpan<byte> span = value ? JsonConstants.TrueValue : JsonConstants.FalseValue;
+
+            WriteLiteralByOptions(escapedUtf8PropertyName, span);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = value ? JsonTokenType.True : JsonTokenType.False;
+        }
+
         private void WriteLiteralEscape(ReadOnlySpan<char> propertyName, ReadOnlySpan<byte> value)
         {
             int propertyIdx = JsonWriterHelper.NeedsEscaping(propertyName);

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
@@ -213,6 +213,18 @@ namespace System.Text.Json
             _tokenType = JsonTokenType.String;
         }
 
+        internal void WriteStringEscapeValueOnly(ReadOnlySpan<byte> escapedUtf8PropertyName, string value)
+        {
+            ReadOnlySpan<char> asSpan = value.AsSpan();
+
+            JsonWriterHelper.ValidatePropertyAndValue(escapedUtf8PropertyName, asSpan);
+
+            WriteStringEscapeValueOnly(escapedUtf8PropertyName, asSpan);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.String;
+        }
+
         /// <summary>
         /// Writes the pre-encoded property name and UTF-8 text value (as a JSON string) as part of a name/value pair of a JSON object.
         /// </summary>
@@ -573,6 +585,23 @@ namespace System.Text.Json
             else
             {
                 WriteStringByOptions(utf8PropertyName, value);
+            }
+        }
+
+        private void WriteStringEscapeValueOnly(ReadOnlySpan<byte> escapedUtf8PropertyName, ReadOnlySpan<char> value)
+        {
+            Debug.Assert(JsonWriterHelper.NeedsEscaping(escapedUtf8PropertyName) == -1);
+
+            int valueIdx = JsonWriterHelper.NeedsEscaping(value);
+            Debug.Assert(valueIdx >= -1 && valueIdx < value.Length && valueIdx < int.MaxValue / 2);
+
+            if (valueIdx != -1)
+            {
+                WriteStringEscapePropertyOrValue(escapedUtf8PropertyName, value, -1, valueIdx);
+            }
+            else
+            {
+                WriteStringByOptions(escapedUtf8PropertyName, value);
             }
         }
 


### PR DESCRIPTION
One of the hottest methods in the profiles is `NeedsEscaping`.  The method is called for both property names and values. The contract of the internal type called `JsonValueConverter` expects that the property name is already escaped. So to improve the performance, we don't need to check if the property names need escaping in such case.

```cs
internal abstract class JsonValueConverter<TValue>
{
    public abstract void Write(Span<byte> escapedPropertyName, TValue value, Utf8JsonWriter writer);
}
```

The gain for microbenchmarks if from 2% to 11%:

```cmd
dotnet run -c Release -f netcoreapp3.0 --coreRun C:\Projects\corefx\artifacts\bin\runtime\before\CoreRun.exe C:\Projects\corefx\artifacts\bin\runtime\after\CoreRun.exe --filter *WriteJson* --join --launchCount 3
```

|                               Type |               Method |           Toolchain |         Mean | Ratio |
|----------------------------------- |--------------------- |-------------------- |-------------:|------:|
|          WriteJson&lt;IndexViewModel&gt; |    SerializeToString | \before\CoreRun.exe |  35,367.9 ns |  1.00 |
|          WriteJson&lt;IndexViewModel&gt; |    SerializeToString |  \after\CoreRun.exe |  32,964.8 ns |  0.93 |
|                                    |                      |                     |              |       |
|                WriteJson&lt;Location&gt; |    SerializeToString | \before\CoreRun.exe |   1,216.6 ns |  1.00 |
|                WriteJson&lt;Location&gt; |    SerializeToString |  \after\CoreRun.exe |   1,121.1 ns |  0.92 |
|                                    |                      |                     |              |       |
|          WriteJson&lt;LoginViewModel&gt; |    SerializeToString | \before\CoreRun.exe |     517.7 ns |  1.00 |
|          WriteJson&lt;LoginViewModel&gt; |    SerializeToString |  \after\CoreRun.exe |     509.4 ns |  0.98 |
|                                    |                      |                     |              |       |
| WriteJson&lt;MyEventsListerViewModel&gt; |    SerializeToString | \before\CoreRun.exe | 657,079.9 ns |  1.00 |
| WriteJson&lt;MyEventsListerViewModel&gt; |    SerializeToString |  \after\CoreRun.exe | 642,131.1 ns |  0.98 |
|                                    |                      |                     |              |       |
|          WriteJson&lt;IndexViewModel&gt; | SerializeToUtf8Bytes | \before\CoreRun.exe |  32,234.8 ns |  1.00 |
|          WriteJson&lt;IndexViewModel&gt; | SerializeToUtf8Bytes |  \after\CoreRun.exe |  30,931.8 ns |  0.96 |
|                                    |                      |                     |              |       |
|                WriteJson&lt;Location&gt; | SerializeToUtf8Bytes | \before\CoreRun.exe |   1,164.5 ns |  1.00 |
|                WriteJson&lt;Location&gt; | SerializeToUtf8Bytes |  \after\CoreRun.exe |   1,074.5 ns |  0.92 |
|                                    |                      |                     |              |       |
|          WriteJson&lt;LoginViewModel&gt; | SerializeToUtf8Bytes | \before\CoreRun.exe |     484.0 ns |  1.00 |
|          WriteJson&lt;LoginViewModel&gt; | SerializeToUtf8Bytes |  \after\CoreRun.exe |     443.5 ns |  0.92 |
|                                    |                      |                     |              |       |
| WriteJson&lt;MyEventsListerViewModel&gt; | SerializeToUtf8Bytes | \before\CoreRun.exe | 611,713.4 ns |  1.00 |
| WriteJson&lt;MyEventsListerViewModel&gt; | SerializeToUtf8Bytes |  \after\CoreRun.exe | 591,267.5 ns |  0.97 |
|                                    |                      |                     |              |       |
|          WriteJson&lt;IndexViewModel&gt; |    SerializeToStream | \before\CoreRun.exe |  31,295.3 ns |  1.00 |
|          WriteJson&lt;IndexViewModel&gt; |    SerializeToStream |  \after\CoreRun.exe |  29,500.1 ns |  0.94 |
|                                    |                      |                     |              |       |
|                WriteJson&lt;Location&gt; |    SerializeToStream | \before\CoreRun.exe |   1,288.5 ns |  1.00 |
|                WriteJson&lt;Location&gt; |    SerializeToStream |  \after\CoreRun.exe |   1,211.7 ns |  0.94 |
|                                    |                      |                     |              |       |
|          WriteJson&lt;LoginViewModel&gt; |    SerializeToStream | \before\CoreRun.exe |     629.7 ns |  1.00 |
|          WriteJson&lt;LoginViewModel&gt; |    SerializeToStream |  \after\CoreRun.exe |     561.1 ns |  0.89 |
|                                    |                      |                     |              |       |
| WriteJson&lt;MyEventsListerViewModel&gt; |    SerializeToStream | \before\CoreRun.exe | 597,486.9 ns |  1.00 |
| WriteJson&lt;MyEventsListerViewModel&gt; |    SerializeToStream |  \after\CoreRun.exe | 573,776.9 ns |  0.96 |