### PR TITLE
Remove socket cancellation workarounds on Unix from System.IO.Pipes

### DIFF
--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -175,54 +175,13 @@ namespace System.IO.Pipes
             }
         }
 
-        private async Task<int> ReadAsyncCore(Memory<byte> destination, CancellationToken cancellationToken)
+        private async ValueTask<int> ReadAsyncCore(Memory<byte> destination, CancellationToken cancellationToken)
         {
             Debug.Assert(this is NamedPipeClientStream || this is NamedPipeServerStream, $"Expected a named pipe, got a {GetType()}");
 
-            Socket socket = InternalHandle.NamedPipeSocket;
-
             try
             {
-                // TODO #22608:
-                // Remove all of this cancellation workaround once Socket.ReceiveAsync
-                // that accepts a CancellationToken is available.
-
-                // If a cancelable token is used and there's no data, issue a zero-length read so that
-                // we're asynchronously notified when data is available, and concurrently monitor the
-                // supplied cancellation token.  If cancellation is requested, we will end up "leaking"
-                // the zero-length read until data becomes available, at which point it'll be satisfied.
-                // But it's very rare to reuse a stream after an operation has been canceled, so even if
-                // we do incur such a situation, it's likely to be very short lived.
-                if (cancellationToken.CanBeCanceled)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    if (socket.Available == 0)
-                    {
-                        Task<int> t = socket.ReceiveAsync(Array.Empty<byte>(), SocketFlags.None);
-                        if (!t.IsCompletedSuccessfully)
-                        {
-                            var cancelTcs = new TaskCompletionSource<bool>();
-                            using (cancellationToken.UnsafeRegister(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), cancelTcs))
-                            {
-                                if (t == await Task.WhenAny(t, cancelTcs.Task).ConfigureAwait(false))
-                                {
-                                    t.GetAwaiter().GetResult(); // propagate any failure
-                                }
-                                cancellationToken.ThrowIfCancellationRequested();
-
-                                // At this point there was data available.  In the rare case where multiple concurrent
-                                // ReadAsyncs are issued against the PipeStream, worst case is the reads that lose
-                                // the race condition for the data will end up in a non-cancelable state as part of
-                                // the actual async receive operation.
-                            }
-                        }
-                    }
-                }
-
-                // Issue the asynchronous read.
-                return await (MemoryMarshal.TryGetArray(destination, out ArraySegment<byte> buffer) ?
-                    socket.ReceiveAsync(buffer, SocketFlags.None) :
-                    socket.ReceiveAsync(destination.ToArray(), SocketFlags.None)).ConfigureAwait(false);
+                return await InternalHandle.NamedPipeSocket.ReceiveAsync(destination, SocketFlags.None, cancellationToken).ConfigureAwait(false);
             }
             catch (SocketException e)
             {
@@ -233,38 +192,14 @@ namespace System.IO.Pipes
         private async Task WriteAsyncCore(ReadOnlyMemory<byte> source, CancellationToken cancellationToken)
         {
             Debug.Assert(this is NamedPipeClientStream || this is NamedPipeServerStream, $"Expected a named pipe, got a {GetType()}");
+
             try
             {
-                // TODO #22608: Remove this terribly inefficient special-case once Socket.SendAsync
-                // accepts a Memory<T> in the near future.
-                byte[] buffer;
-                int offset, count;
-                if (MemoryMarshal.TryGetArray(source, out ArraySegment<byte> segment))
+                while (source.Length > 0)
                 {
-                    buffer = segment.Array;
-                    offset = segment.Offset;
-                    count = segment.Count;
-                }
-                else
-                {
-                    buffer = source.ToArray();
-                    offset = 0;
-                    count = buffer.Length;
-                }
-
-                while (count > 0)
-                {
-                    // cancellationToken is (mostly) ignored.  We could institute a polling loop like we do for reads if 
-                    // cancellationToken.CanBeCanceled, but that adds costs regardless of whether the operation will be canceled, and 
-                    // most writes will complete immediately as they simply store data into the socket's buffer.  The only time we end 
-                    // up using it in a meaningful way is if a write completes partially, we'll check it on each individual write operation.
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    int bytesWritten = await _handle.NamedPipeSocket.SendAsync(new ArraySegment<byte>(buffer, offset, count), SocketFlags.None).ConfigureAwait(false);
-                    Debug.Assert(bytesWritten <= count);
-
-                    count -= bytesWritten;
-                    offset += bytesWritten;
+                    int bytesWritten = await _handle.NamedPipeSocket.SendAsync(source, SocketFlags.None, cancellationToken).ConfigureAwait(false);
+                    Debug.Assert(bytesWritten > 0 && bytesWritten <= source.Length);
+                    source = source.Slice(bytesWritten);
                 }
             }
             catch (SocketException e)

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Windows.cs
@@ -81,7 +81,7 @@ namespace System.IO.Pipes
             return r;
         }
 
-        private Task<int> ReadAsyncCore(Memory<byte> buffer, CancellationToken cancellationToken)
+        private ValueTask<int> ReadAsyncCore(Memory<byte> buffer, CancellationToken cancellationToken)
         {
             var completionSource = new ReadWriteCompletionSource(this, buffer, isWrite: false);
 
@@ -121,7 +121,7 @@ namespace System.IO.Pipes
 
                         completionSource.ReleaseResources();
                         UpdateMessageCompletion(true);
-                        return s_zeroTask;
+                        return new ValueTask<int>(0);
 
                     case Interop.Errors.ERROR_IO_PENDING:
                         break;
@@ -132,7 +132,7 @@ namespace System.IO.Pipes
             }
 
             completionSource.RegisterForCancellation(cancellationToken);
-            return completionSource.Task;
+            return new ValueTask<int>(completionSource.Task);
         }
 
         private unsafe void WriteCore(ReadOnlySpan<byte> buffer)

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -168,7 +168,7 @@ namespace System.IO.Pipes
                 return s_zeroTask;
             }
 
-            return ReadAsyncCore(new Memory<byte>(buffer, offset, count), cancellationToken);
+            return ReadAsyncCore(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
         }
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))
@@ -196,7 +196,7 @@ namespace System.IO.Pipes
                 return new ValueTask<int>(0);
             }
 
-            return new ValueTask<int>(ReadAsyncCore(buffer, cancellationToken));
+            return ReadAsyncCore(buffer, cancellationToken);
         }
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)


### PR DESCRIPTION
Named pipes on Unix are implemented in terms of System.Net.Sockets.Socket.  We didn't previously support cancellation of Socket operations, but we do now, so we can remove the workarounds that were in place.  Apparently we also previously neglected to remove the workarounds for the lack of Memory-based overloads in Sockets, so this fixes that, too.

cc: @JeremyKuhne, @carlossanlop, @ViktorHofer 

I'm hopeful this fixes https://github.com/dotnet/corefx/issues/37842 as well.