### PR TITLE
Fixing issue where assemblies would build againsta lower version of a contract than what their package depends on.

### DIFF
--- a/external/binplacePackages/binplacePackages.depproj
+++ b/external/binplacePackages/binplacePackages.depproj
@@ -29,7 +29,7 @@
     <!-- runtime dependency: System.Data.SqlClient uap10.0.16299 -->
     <!-- runtime dependency: System.Diagnostics.PerformanceCounters netcoreapp2.0,net461 -->
     <PackageReference Include="System.Memory" Condition="'$(TargetGroup)' == 'netcoreapp2.0' OR '$(TargetGroup)' == 'uap10.0.16299' OR '$(TargetsNetfx)' == 'true' OR ('$(TargetsNetStandard)' == 'true' AND '$(NETStandardVersion)' &gt;= 1.1)">
-      <Version>4.5.1</Version>
+      <Version>4.5.3</Version>
     </PackageReference>
 
     <PackageReference Include="System.Numerics.Vectors" Condition="'$(DotNetBuildFromSource)' != 'true' AND '$(TargetsNetStandard)' == 'true' AND '$(NETStandardVersion)' &lt; 2.1">
@@ -37,7 +37,7 @@
     </PackageReference>
 
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition="'$(TargetGroup)' == 'netcoreapp2.0' OR '$(TargetsNetfx)' == 'true' OR '$(TargetsNetStandard)' == 'true'">
-      <Version>4.5.1</Version>
+      <Version>4.5.2</Version>
     </PackageReference>
 
     <!-- Only include the assets from the direct packages we reference in the output -->


### PR DESCRIPTION
Fixes #37943

When re-baselining all package versions for .NET Core 3.0, I forgot to also make sure I bumped the versions of the binplacePackages.depproj dependencies. This project helps building the some targetting packs that our assemblies will build against, so we need to make sure that we build against the same version of the packages that the actual package will depend on after baselining the versions.

cc: @ericstj @vatsan-madhavan