### PR TITLE
Disable sporadically failing GetGCMemoryInfo test

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
@@ -26,6 +26,7 @@ namespace System.Tests
             Assert.True((end - start) < 5 * size, $"Allocated too much: start: {start} end: {end} size: {size}");
         }
 
+        [ActiveIssue(37378)]
         [Fact]
         public static void GetGCMemoryInfo()
         {


### PR DESCRIPTION
cc: @luhenry, @ViktorHofer 
https://github.com/dotnet/corefx/issues/37378