### PR TITLE
Fix wrong Activity.Id serialization - flags are not inherited from parent

### DIFF
--- a/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -281,7 +281,7 @@ namespace System.Diagnostics
                 _traceIdSet = true;
                 _parentSpanId = spanId;
                 _parentSpanIdSet = true;
-                _w3CIdFlags = (byte) activityTraceFlags;
+                _w3CIdFlags = (byte)activityTraceFlags;
                 _w3CIdFlagsSet = true;
             }
             return this;
@@ -525,17 +525,9 @@ namespace System.Diagnostics
             {
                 if (!_w3CIdFlagsSet)
                 {
-                    if (Parent != null)
-                    {
-                        ActivityTraceFlags = Parent.ActivityTraceFlags;
-                    }
-                    else if (_parentId != null && IsW3CId(_parentId))
-                    {
-                        _w3CIdFlags = ActivityTraceId.HexByteFromChars(_parentId[53], _parentId[54]);
-                        _w3CIdFlagsSet = true;
-                    }
+                    _w3CIdFlagsSet = TrySetTraceFlagsFromParent();
                 }
-                return (ActivityTraceFlags) _w3CIdFlags;
+                return (ActivityTraceFlags)_w3CIdFlags;
             }
             set
             {
@@ -646,6 +638,12 @@ namespace System.Diagnostics
                     _traceIdSet = true;
                 }
             }
+
+            if (!_w3CIdFlagsSet)
+            {
+                _w3CIdFlagsSet = TrySetTraceFlagsFromParent();
+            }
+
             // Create a new SpanID. 
             _spanId = ActivitySpanId.CreateRandom();
             _spanIdSet = true;
@@ -792,6 +790,30 @@ namespace System.Diagnostics
 
             return _traceIdSet;
         }
+
+#if ALLOW_PARTIALLY_TRUSTED_CALLERS
+        [System.Security.SecuritySafeCriticalAttribute]
+#endif
+        private bool TrySetTraceFlagsFromParent()
+        {
+            Debug.Assert(!_w3CIdFlagsSet);
+
+            if (!_w3CIdFlagsSet)
+            {
+                if (Parent != null)
+                {
+                    ActivityTraceFlags = Parent.ActivityTraceFlags;
+                }
+                else if (_parentId != null && IsW3CId(_parentId))
+                {
+                    _w3CIdFlags = ActivityTraceId.HexByteFromChars(_parentId[53], _parentId[54]);
+                    _w3CIdFlagsSet = true;
+                }
+            }
+
+            return _w3CIdFlagsSet;
+        }
+
 
         private string _rootId;
         private int _currentChildId;  // A unique number for all children of this activity.  

--- a/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -687,6 +687,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal("0123456789abcdef0123456789abcdef", activity.TraceId.ToHexString());
             Assert.Equal("0123456789abcdef", activity.ParentSpanId.ToHexString());
             Assert.True(IdIsW3CFormat(activity.Id));
+            Assert.Equal($"00-0123456789abcdef0123456789abcdef-{activity.SpanId.ToHexString()}-01", activity.Id);
             Assert.Equal(ActivityTraceFlags.Recorded, activity.ActivityTraceFlags);
             Assert.True(activity.Recorded);
             activity.Stop();
@@ -699,6 +700,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal(ActivityIdFormat.W3C, activity.IdFormat);
             Assert.Equal(activityTraceId.ToHexString(), activity.TraceId.ToHexString());
             Assert.True(IdIsW3CFormat(activity.Id));
+            Assert.Equal($"00-{activity.TraceId.ToHexString()}-{activity.SpanId.ToHexString()}-01", activity.Id);
             Assert.Equal(ActivityTraceFlags.Recorded, activity.ActivityTraceFlags);
             Assert.True(activity.Recorded);
             activity.Stop();
@@ -712,6 +714,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal("0123456789abcdef0123456789abcdef", activity.TraceId.ToHexString());
             Assert.Equal("0123456789abcdef", activity.ParentSpanId.ToHexString());
             Assert.True(IdIsW3CFormat(activity.Id));
+            Assert.Equal($"00-{activity.TraceId.ToHexString()}-{activity.SpanId.ToHexString()}-00", activity.Id);
             Assert.Equal(ActivityTraceFlags.None, activity.ActivityTraceFlags);
             Assert.False(activity.Recorded);
 
@@ -730,6 +733,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal("0123456789abcdef0123456789abcdef", activity.TraceId.ToHexString());
             Assert.Equal("0123456789abcdef", activity.ParentSpanId.ToHexString());
             Assert.True(IdIsW3CFormat(activity.Id));
+            Assert.Equal($"00-{activity.TraceId.ToHexString()}-{activity.SpanId.ToHexString()}-01", activity.Id);
             Assert.Equal(ActivityTraceFlags.Recorded, activity.ActivityTraceFlags);
             Assert.True(activity.Recorded);
 
@@ -741,6 +745,7 @@ namespace System.Diagnostics.Tests
             Assert.Equal("0123456789abcdef0123456789abcdef", childActivity.TraceId.ToHexString());
             Assert.NotEqual(activity.SpanId.ToHexString(), childActivity.SpanId.ToHexString());
             Assert.True(IdIsW3CFormat(childActivity.Id));
+            Assert.Equal($"00-{childActivity.TraceId.ToHexString()}-{childActivity.SpanId.ToHexString()}-01", childActivity.Id);
             Assert.Equal(ActivityTraceFlags.Recorded, childActivity.ActivityTraceFlags);
             Assert.True(childActivity.Recorded);
 


### PR DESCRIPTION
Trace flags provided in W3C trace-context are not respected because of lazy initialization of the flags. E.g.

```csharp
            var activity = new Activity("foo");
            activity.SetParentId("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
            activity.Start();
```
 ActivityId here was 00-0123456789abcdef0123456789abcdef-new_span_id-00, but supposed to get flags (last byte) from parent. 

This change forces initialization of trace flags from parentId when Activity starts. 
