### PR TITLE
Fixes outerloop test failures on OLEDB

### DIFF
--- a/src/Common/tests/CoreFx.Private.TestUtilities/System/AssertExtensions.cs
+++ b/src/Common/tests/CoreFx.Private.TestUtilities/System/AssertExtensions.cs
@@ -15,10 +15,10 @@ namespace System
     {
         private static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
 
-        public static void Throws<T>(Action action, string message)
+        public static void Throws<T>(Action action, string expectedMessage)
             where T : Exception
         {
-            Assert.Equal(Assert.Throws<T>(action).Message, message);
+            Assert.Equal(expectedMessage, Assert.Throws<T>(action).Message);
         }
 
         public static void Throws<T>(string netCoreParamName, string netFxParamName, Action action)
@@ -57,12 +57,12 @@ namespace System
             Assert.Equal(expectedParamName, exception.ParamName);
         }
 
-        public static T Throws<T>(string paramName, Action action)
+        public static T Throws<T>(string expectedParamName, Action action)
             where T : ArgumentException
         {
             T exception = Assert.Throws<T>(action);
 
-            Assert.Equal(paramName, exception.ParamName);
+            Assert.Equal(expectedParamName, exception.ParamName);
 
             return exception;
         }
@@ -75,27 +75,27 @@ namespace System
             return exception;
         }
 
-        public static T Throws<T>(string paramName, Func<object> testCode)
+        public static T Throws<T>(string expectedParamName, Func<object> testCode)
             where T : ArgumentException
         {
             T exception = Assert.Throws<T>(testCode);
 
-            Assert.Equal(paramName, exception.ParamName);
+            Assert.Equal(expectedParamName, exception.ParamName);
 
             return exception;
         }
 
-        public static async Task<T> ThrowsAsync<T>(string paramName, Func<Task> testCode)
+        public static async Task<T> ThrowsAsync<T>(string expectedParamName, Func<Task> testCode)
             where T : ArgumentException
         {
             T exception = await Assert.ThrowsAsync<T>(testCode);
 
-            Assert.Equal(paramName, exception.ParamName);
+            Assert.Equal(expectedParamName, exception.ParamName);
 
             return exception;
         }
 
-        public static void Throws<TNetCoreExceptionType, TNetFxExceptionType>(string paramName, Action action)
+        public static void Throws<TNetCoreExceptionType, TNetFxExceptionType>(string expectedParamName, Action action)
             where TNetCoreExceptionType : ArgumentException
             where TNetFxExceptionType : Exception
         {
@@ -106,7 +106,7 @@ namespace System
                 if (typeof(ArgumentException).IsAssignableFrom(typeof(TNetFxExceptionType)))
                 {
                     Exception exception = Assert.Throws(typeof(TNetFxExceptionType), action);
-                    Assert.Equal(paramName, ((ArgumentException)exception).ParamName);
+                    Assert.Equal(expectedParamName, ((ArgumentException)exception).ParamName);
                 }
                 else
                 {
@@ -115,7 +115,7 @@ namespace System
             }
             else
             {
-                AssertExtensions.Throws<TNetCoreExceptionType>(paramName, action);
+                AssertExtensions.Throws<TNetCoreExceptionType>(expectedParamName, action);
             }
         }
 

--- a/src/System.Data.OleDb/tests/Helpers.cs
+++ b/src/System.Data.OleDb/tests/Helpers.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace System.Data.OleDb.Tests
 {
@@ -34,6 +35,10 @@ namespace System.Data.OleDb.Tests
                 }
                 // skip if x86 or if the expected driver not available 
                 IsAvailable = !PlatformDetection.Is32BitProcess && providerNames.Contains(ExpectedProviderName);
+                if (!CultureInfo.CurrentCulture.Name.Equals("en-US", StringComparison.OrdinalIgnoreCase))
+                {
+                    IsAvailable = false; // ActiveIssue: https://github.com/dotnet/corefx/issues/38737
+                }
                 ProviderName = IsAvailable ? ExpectedProviderName : null;
             }
         }

--- a/src/System.Data.OleDb/tests/Helpers.cs
+++ b/src/System.Data.OleDb/tests/Helpers.cs
@@ -24,21 +24,16 @@ namespace System.Data.OleDb.Tests
             private Nested() { }
             static Nested()
             {
-                bool jetDriverInstalled = false;
                 // Get the sources rowset for the SQLOLEDB enumerator
                 DataTable table = (new OleDbEnumerator()).GetElements();
                 DataColumn providersRegistered = table.Columns["SOURCES_NAME"];
                 List<object> providerNames = new List<object>();
                 foreach (DataRow row in table.Rows)
                 {
-                    var curProvider = (string)row[providersRegistered];
-                    if (curProvider.Contains("JET"))
-                        jetDriverInstalled = true;
-                    providerNames.Add(curProvider);
+                    providerNames.Add((string)row[providersRegistered]);
                 }
-                // skip if x86 or if both drivers available 
-                IsAvailable = !PlatformDetection.Is32BitProcess &&
-                        !(jetDriverInstalled && providerNames.Contains(ExpectedProviderName));
+                // skip if x86 or if the expected driver not available 
+                IsAvailable = !PlatformDetection.Is32BitProcess && providerNames.Contains(ExpectedProviderName);
                 ProviderName = IsAvailable ? ExpectedProviderName : null;
             }
         }

--- a/src/System.Data.OleDb/tests/Helpers.cs
+++ b/src/System.Data.OleDb/tests/Helpers.cs
@@ -24,7 +24,7 @@ namespace System.Data.OleDb.Tests
             private Nested() { }
             static Nested()
             {
-                bool shouldSkip = false; 
+                bool jetDriverInstalled = false;
                 // Get the sources rowset for the SQLOLEDB enumerator
                 DataTable table = (new OleDbEnumerator()).GetElements();
                 DataColumn providersRegistered = table.Columns["SOURCES_NAME"];
@@ -33,12 +33,12 @@ namespace System.Data.OleDb.Tests
                 {
                     var curProvider = (string)row[providersRegistered];
                     if (curProvider.Contains("JET"))
-                        shouldSkip = true; // JET driver installed 
+                        jetDriverInstalled = true;
                     providerNames.Add(curProvider);
                 }
                 // skip if x86 or if both drivers available 
-                shouldSkip |= PlatformDetection.Is32BitProcess;
-                IsAvailable = !shouldSkip && providerNames.Contains(s_expectedProviderName);
+                IsAvailable = !PlatformDetection.Is32BitProcess &&
+                        !(jetDriverInstalled && providerNames.Contains(s_expectedProviderName));
                 ProviderName = IsAvailable ? s_expectedProviderName : null;
             }
         }

--- a/src/System.Data.OleDb/tests/Helpers.cs
+++ b/src/System.Data.OleDb/tests/Helpers.cs
@@ -20,7 +20,7 @@ namespace System.Data.OleDb.Tests
             public static readonly string ProviderName;
             public static Nested Instance => s_instance;
             private static readonly Nested s_instance = new Nested();
-            private static readonly string s_expectedProviderName = @"Microsoft.ACE.OLEDB.12.0";
+            private const string ExpectedProviderName = @"Microsoft.ACE.OLEDB.12.0";
             private Nested() { }
             static Nested()
             {
@@ -38,8 +38,8 @@ namespace System.Data.OleDb.Tests
                 }
                 // skip if x86 or if both drivers available 
                 IsAvailable = !PlatformDetection.Is32BitProcess &&
-                        !(jetDriverInstalled && providerNames.Contains(s_expectedProviderName));
-                ProviderName = IsAvailable ? s_expectedProviderName : null;
+                        !(jetDriverInstalled && providerNames.Contains(ExpectedProviderName));
+                ProviderName = IsAvailable ? ExpectedProviderName : null;
             }
         }
     }

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Data.OleDb.Tests
@@ -154,7 +155,18 @@ namespace System.Data.OleDb.Tests
                     Firstname NVARCHAR(5),
                     Lastname NVARCHAR(40), 
                     Nickname NVARCHAR(30))";
+            try
+            { 
             command.ExecuteNonQuery();
+            }
+            catch (SEHException sehEx)
+            {
+                Console.WriteLine($"Code: {sehEx.ErrorCode}");
+                Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().HResult}");
+                Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().ToString()}");
+                Console.WriteLine($"Base Inner Exception: {sehEx.InnerException}");
+                throw;
+            }
             Assert.True(File.Exists(Path.Combine(TestDirectory, tableName)));
 
             command.CommandText =

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -162,8 +162,12 @@ namespace System.Data.OleDb.Tests
             catch (SEHException sehEx)
             {
                 Console.WriteLine($"Code: {sehEx.ErrorCode}");
-                Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().HResult}");
-                Console.WriteLine($"Base Exception message : {sehEx.GetBaseException()?.ToString()}");
+                Exception baseException = sehEx.GetBaseException();
+                if (baseException != null)
+                {
+                    Console.WriteLine($"Base Exception error code : {baseException.HResult}");
+                    Console.WriteLine($"Base Exception message : {baseException.ToString()}");
+                }
                 Console.WriteLine($"Base Inner Exception: {sehEx.InnerException}");
                 
                 // This exception is not expected. So rethrow to indicate test failure.

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -163,11 +164,9 @@ namespace System.Data.OleDb.Tests
             {
                 Console.WriteLine($"Code: {sehEx.ErrorCode}");
                 Exception baseException = sehEx.GetBaseException();
-                if (baseException != null)
-                {
-                    Console.WriteLine($"Base Exception error code : {baseException.HResult}");
-                    Console.WriteLine($"Base Exception message : {baseException.ToString()}");
-                }
+                Debug.Assert(baseException != null);
+                Console.WriteLine($"Base Exception error code : {baseException.HResult}");
+                Console.WriteLine($"Base Exception message : {baseException}");
                 Console.WriteLine($"Base Inner Exception: {sehEx.InnerException}");
                 
                 // This exception is not expected. So rethrow to indicate test failure.

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -165,6 +165,8 @@ namespace System.Data.OleDb.Tests
                 Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().HResult}");
                 Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().ToString()}");
                 Console.WriteLine($"Base Inner Exception: {sehEx.InnerException}");
+                
+                // This exception is not expected. So rethrow to indicate test failure.
                 throw;
             }
             Assert.True(File.Exists(Path.Combine(TestDirectory, tableName)));

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -163,7 +163,7 @@ namespace System.Data.OleDb.Tests
             {
                 Console.WriteLine($"Code: {sehEx.ErrorCode}");
                 Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().HResult}");
-                Console.WriteLine($"Base Exception message : {sehEx.GetBaseException().ToString()}");
+                Console.WriteLine($"Base Exception message : {sehEx.GetBaseException()?.ToString()}");
                 Console.WriteLine($"Base Inner Exception: {sehEx.InnerException}");
                 
                 // This exception is not expected. So rethrow to indicate test failure.

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -163,7 +163,7 @@ namespace System.Data.OleDb.Tests
             {
                 Console.WriteLine($"Code: {sehEx.ErrorCode}");
                 Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().HResult}");
-                Console.WriteLine($"Base Exception error code : {sehEx.GetBaseException().ToString()}");
+                Console.WriteLine($"Base Exception message : {sehEx.GetBaseException().ToString()}");
                 Console.WriteLine($"Base Inner Exception: {sehEx.InnerException}");
                 
                 // This exception is not expected. So rethrow to indicate test failure.

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -157,7 +157,7 @@ namespace System.Data.OleDb.Tests
                     Nickname NVARCHAR(30))";
             try
             { 
-            command.ExecuteNonQuery();
+                command.ExecuteNonQuery();
             }
             catch (SEHException sehEx)
             {

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -92,13 +92,26 @@ namespace System.Data.OleDb.Tests
                 command.CommandText = @"SELECT * FROM " + tableName;
                 using (var builder = (OleDbCommandBuilder)OleDbFactory.Instance.CreateCommandBuilder())
                 {
-                    AssertExtensions.Throws<ArgumentNullException>(
-                        () => builder.QuoteIdentifier(null, command.Connection), 
-                        $"Value cannot be null. (Parameter \'unquotedIdentifier\')");
+                    if (PlatformDetection.IsFullFramework)
+                    {
+                        AssertExtensions.Throws<ArgumentNullException>(
+                            () => builder.QuoteIdentifier(null, command.Connection), 
+                            $"Value cannot be null.\r\nParameter name: unquotedIdentifier");
 
-                    AssertExtensions.Throws<ArgumentNullException>(
-                        () => builder.UnquoteIdentifier(null, command.Connection), 
-                        $"Value cannot be null. (Parameter \'quotedIdentifier\')");
+                        AssertExtensions.Throws<ArgumentNullException>(
+                            () => builder.UnquoteIdentifier(null, command.Connection), 
+                            $"Value cannot be null.\r\nParameter name: quotedIdentifier");
+                    }
+                    else
+                    {
+                        AssertExtensions.Throws<ArgumentNullException>(
+                            () => builder.QuoteIdentifier(null, command.Connection), 
+                            $"Value cannot be null. (Parameter \'unquotedIdentifier\')");
+
+                        AssertExtensions.Throws<ArgumentNullException>(
+                            () => builder.UnquoteIdentifier(null, command.Connection), 
+                            $"Value cannot be null. (Parameter \'quotedIdentifier\')");
+                    }
                 }
                 command.CommandType = CommandType.Text;
             });

--- a/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandBuilderTests.cs
@@ -94,11 +94,11 @@ namespace System.Data.OleDb.Tests
                 {
                     AssertExtensions.Throws<ArgumentNullException>(
                         () => builder.QuoteIdentifier(null, command.Connection), 
-                        $"Value cannot be null.\r\nParameter name: unquotedIdentifier");
+                        $"Value cannot be null. (Parameter \'unquotedIdentifier\')");
 
                     AssertExtensions.Throws<ArgumentNullException>(
                         () => builder.UnquoteIdentifier(null, command.Connection), 
-                        $"Value cannot be null.\r\nParameter name: quotedIdentifier");
+                        $"Value cannot be null. (Parameter \'quotedIdentifier\')");
                 }
                 command.CommandType = CommandType.Text;
             });

--- a/src/System.Data.OleDb/tests/OleDbCommandTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandTests.cs
@@ -21,10 +21,20 @@ namespace System.Data.OleDb.Tests
                 Assert.Equal(UpdateRowSource.Both, cmd.UpdatedRowSource);
                 cmd.UpdatedRowSource = UpdateRowSource.FirstReturnedRecord;
                 Assert.Equal(UpdateRowSource.FirstReturnedRecord, cmd.UpdatedRowSource);
-                AssertExtensions.Throws<ArgumentOutOfRangeException>(
-                    () => cmd.UpdatedRowSource = (UpdateRowSource)InvalidValue, 
-                    $"The {nameof(UpdateRowSource)} enumeration value, {InvalidValue}, is invalid. (Parameter \'{nameof(UpdateRowSource)}\')"
-                );
+                if (PlatformDetection.IsFullFramework)
+                {
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                        () => cmd.UpdatedRowSource = (UpdateRowSource)InvalidValue, 
+                        $"The {nameof(UpdateRowSource)} enumeration value, {InvalidValue}, is invalid.\r\nParameter name: {nameof(UpdateRowSource)}"
+                    );
+                }
+                else
+                {
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                        () => cmd.UpdatedRowSource = (UpdateRowSource)InvalidValue, 
+                        $"The {nameof(UpdateRowSource)} enumeration value, {InvalidValue}, is invalid. (Parameter \'{nameof(UpdateRowSource)}\')"
+                    );
+                }
             }
         }
 
@@ -34,10 +44,20 @@ namespace System.Data.OleDb.Tests
             const int InvalidValue = -1;
             using (var cmd = new OleDbCommand(default, connection, transaction))
             {
-                AssertExtensions.Throws<ArgumentException>(
-                    () => cmd.CommandTimeout = InvalidValue, 
-                    $"Invalid CommandTimeout value {InvalidValue}; the value must be >= 0. (Parameter \'{nameof(cmd.CommandTimeout)}\')"
-                );
+                if (PlatformDetection.IsFullFramework)
+                {
+                    AssertExtensions.Throws<ArgumentException>(
+                        () => cmd.CommandTimeout = InvalidValue, 
+                        $"Invalid CommandTimeout value {InvalidValue}; the value must be >= 0.\r\nParameter name: {nameof(cmd.CommandTimeout)}"
+                    );
+                }
+                else
+                {
+                    AssertExtensions.Throws<ArgumentException>(
+                        () => cmd.CommandTimeout = InvalidValue, 
+                        $"Invalid CommandTimeout value {InvalidValue}; the value must be >= 0. (Parameter \'{nameof(cmd.CommandTimeout)}\')"
+                    );
+                }
             }
         }
 
@@ -61,10 +81,20 @@ namespace System.Data.OleDb.Tests
             const int InvalidValue = 0;
             using (var cmd = (OleDbCommand)OleDbFactory.Instance.CreateCommand())
             {
-                AssertExtensions.Throws<ArgumentOutOfRangeException>(
-                    () => cmd.CommandType = (CommandType)InvalidValue, 
-                    $"The CommandType enumeration value, {InvalidValue}, is invalid. (Parameter \'{nameof(cmd.CommandType)}\')"
-                );
+                if (PlatformDetection.IsFullFramework)
+                {
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                        () => cmd.CommandType = (CommandType)InvalidValue, 
+                        $"The CommandType enumeration value, {InvalidValue}, is invalid.\r\nParameter name: {nameof(cmd.CommandType)}"
+                    );
+                }
+                else
+                {
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                        () => cmd.CommandType = (CommandType)InvalidValue, 
+                        $"The CommandType enumeration value, {InvalidValue}, is invalid. (Parameter \'{nameof(cmd.CommandType)}\')"
+                    );
+                }
             }
         }
 
@@ -149,10 +179,20 @@ namespace System.Data.OleDb.Tests
         public void Parameters_AddNullParameter_Throws()
         {
             RunTest((command, tableName) => {
-                AssertExtensions.Throws<ArgumentNullException>(
-                    () => command.Parameters.Add(null), 
-                    $"The {nameof(OleDbParameterCollection)} only accepts non-null {nameof(OleDbParameter)} type objects. (Parameter \'value\')"
-                );
+                if (PlatformDetection.IsFullFramework)
+                {
+                    AssertExtensions.Throws<ArgumentNullException>(
+                        () => command.Parameters.Add(null), 
+                        $"The {nameof(OleDbParameterCollection)} only accepts non-null {nameof(OleDbParameter)} type objects.\r\nParameter name: value"
+                    );
+                }
+                else
+                {
+                    AssertExtensions.Throws<ArgumentNullException>(
+                        () => command.Parameters.Add(null), 
+                        $"The {nameof(OleDbParameterCollection)} only accepts non-null {nameof(OleDbParameter)} type objects. (Parameter \'value\')"
+                    );
+                }
                 command.CommandText = "SELECT * FROM " + tableName + " WHERE NumPlants = ?";
                 command.Parameters.Add(new OleDbParameter("@p1", 7));
                 using (OleDbDataReader reader = command.ExecuteReader())

--- a/src/System.Data.OleDb/tests/OleDbCommandTests.cs
+++ b/src/System.Data.OleDb/tests/OleDbCommandTests.cs
@@ -23,7 +23,7 @@ namespace System.Data.OleDb.Tests
                 Assert.Equal(UpdateRowSource.FirstReturnedRecord, cmd.UpdatedRowSource);
                 AssertExtensions.Throws<ArgumentOutOfRangeException>(
                     () => cmd.UpdatedRowSource = (UpdateRowSource)InvalidValue, 
-                    $"The {nameof(UpdateRowSource)} enumeration value, {InvalidValue}, is invalid.\r\nParameter name: {nameof(UpdateRowSource)}"
+                    $"The {nameof(UpdateRowSource)} enumeration value, {InvalidValue}, is invalid. (Parameter \'{nameof(UpdateRowSource)}\')"
                 );
             }
         }
@@ -36,7 +36,7 @@ namespace System.Data.OleDb.Tests
             {
                 AssertExtensions.Throws<ArgumentException>(
                     () => cmd.CommandTimeout = InvalidValue, 
-                    $"Invalid CommandTimeout value {InvalidValue}; the value must be >= 0.\r\nParameter name: {nameof(cmd.CommandTimeout)}"
+                    $"Invalid CommandTimeout value {InvalidValue}; the value must be >= 0. (Parameter \'{nameof(cmd.CommandTimeout)}\')"
                 );
             }
         }
@@ -63,7 +63,7 @@ namespace System.Data.OleDb.Tests
             {
                 AssertExtensions.Throws<ArgumentOutOfRangeException>(
                     () => cmd.CommandType = (CommandType)InvalidValue, 
-                    $"The CommandType enumeration value, {InvalidValue}, is invalid.\r\nParameter name: {nameof(cmd.CommandType)}"
+                    $"The CommandType enumeration value, {InvalidValue}, is invalid. (Parameter \'{nameof(cmd.CommandType)}\')"
                 );
             }
         }
@@ -151,7 +151,7 @@ namespace System.Data.OleDb.Tests
             RunTest((command, tableName) => {
                 AssertExtensions.Throws<ArgumentNullException>(
                     () => command.Parameters.Add(null), 
-                    $"The {nameof(OleDbParameterCollection)} only accepts non-null {nameof(OleDbParameter)} type objects.\r\nParameter name: value"
+                    $"The {nameof(OleDbParameterCollection)} only accepts non-null {nameof(OleDbParameter)} type objects. (Parameter \'value\')"
                 );
                 command.CommandText = "SELECT * FROM " + tableName + " WHERE NumPlants = ?";
                 command.Parameters.Add(new OleDbParameter("@p1", 7));

--- a/src/System.Security.Cryptography.Pkcs/tests/SignedCms/CmsSignerTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/SignedCms/CmsSignerTests.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             CmsSigner signer = new CmsSigner();
 
             AssertExtensions.Throws<ArgumentException>(
-                paramName: null,
+                expectedParamName: null,
                 () => signer.SignerIdentifierType = invalidType);
         }
     }


### PR DESCRIPTION
- [x] Wait for CI setup to complete that gets rid of JET driver from the CI. (Ensures that the SEH doesn't occur on x64 platforms)
- [x] Disable tests on x86 platform
- [x] Include extra Console.WriteLine logging and rethrow in case of SEH failure

cc: @saurabh500 @MattGal @stephentoub 
Fixes: (#37823)