### PR TITLE
Utf8JsonReader: Do not allow non-standard line endings in single-line comments

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -378,7 +378,7 @@
     <value>There is not enough data to read through the entire JSON array or object.</value>
   </data>
   <data name="UnexpectedEndOfLineSeparator" xml:space="preserve">
-    <value>Unexpected end of line separator while reading a comment.</value>
+    <value>Found invalid line or paragraph separator character while reading a comment.</value>
   </data>
   <data name="JsonSerializerDoesNotSupportComments" xml:space="preserve">
     <value>Comments cannot be stored when deserializing objects, only the Skip and Disallow comment handling modes are supported.</value>

--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -377,6 +377,9 @@
   <data name="NotEnoughData" xml:space="preserve">
     <value>There is not enough data to read through the entire JSON array or object.</value>
   </data>
+  <data name="UnexpectedEndOfLineSeparator" xml:space="preserve">
+    <value>Unexpected end of line separator while reading a comment.</value>
+  </data>
   <data name="JsonSerializerDoesNotSupportComments" xml:space="preserve">
     <value>Comments cannot be stored when deserializing objects, only the Skip and Disallow comment handling modes are supported.</value>
   </data>

--- a/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json
 
         // \u2028 and \u2029 are considered respectively line and paragraph separators
         // UTF-8 representation for them is E2, 80, A8/A9
-        public const byte MaybeDangerousLineSeparator = 0xE2;
+        public const byte StartingByteOfNonStandardLineSeparator = 0xE2;
 
         public static ReadOnlySpan<byte> Utf8Bom => new byte[] { 0xEF, 0xBB, 0xBF };
         public static ReadOnlySpan<byte> TrueValue => new byte[] { (byte)'t', (byte)'r', (byte)'u', (byte)'e' };

--- a/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -29,6 +29,10 @@ namespace System.Text.Json
         public const byte UtcOffsetToken = (byte)'Z';
         public const byte TimePrefix = (byte)'T';
 
+        // \u2028 and \u2029 are considered respectively line and paragraph separators
+        // UTF-8 representation for them is E2, 80, A8/A9
+        public const byte MaybeDangerousLineSeparator = 0xE2;
+
         public static ReadOnlySpan<byte> Utf8Bom => new byte[] { 0xEF, 0xBB, 0xBF };
         public static ReadOnlySpan<byte> TrueValue => new byte[] { (byte)'t', (byte)'r', (byte)'u', (byte)'e' };
         public static ReadOnlySpan<byte> FalseValue => new byte[] { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };

--- a/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json
 
         // \u2028 and \u2029 are considered respectively line and paragraph separators
         // UTF-8 representation for them is E2, 80, A8/A9
-        public const byte StartingByteOfNonStandardLineSeparator = 0xE2;
+        public const byte StartingByteOfNonStandardSeparator = 0xE2;
 
         public static ReadOnlySpan<byte> Utf8Bom => new byte[] { 0xEF, 0xBB, 0xBF };
         public static ReadOnlySpan<byte> TrueValue => new byte[] { (byte)'t', (byte)'r', (byte)'u', (byte)'e' };

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -2510,31 +2510,30 @@ namespace System.Text.Json
                     ignoreNextLfForLineTracking = false;
                 }
 
-                int idx = localBuffer.IndexOfAny(JsonConstants.LineFeed, JsonConstants.CarriageReturn, JsonConstants.Asterisk);
+                int idx = localBuffer.IndexOfAny(JsonConstants.Asterisk, JsonConstants.LineFeed, JsonConstants.CarriageReturn);
 
                 if (idx != -1)
                 {
-                    byte marker = localBuffer[idx];
-
                     int nextIdx = idx + 1;
-                    _consumed += nextIdx;
-                    _bytePositionInLine += nextIdx;
-
+                    byte marker = localBuffer[idx];
                     localBuffer = localBuffer.Slice(nextIdx);
+
+                    _consumed += nextIdx;
 
                     switch (marker)
                     {
                         case JsonConstants.Asterisk:
                             expectSlash = true;
+                            _bytePositionInLine += nextIdx;
                             break;
-                        case JsonConstants.CarriageReturn:
+                        case JsonConstants.LineFeed:
+                            _bytePositionInLine = 0;
+                            _lineNumber++;
+                            break;
+                        default: // JsonConstants.CarriageReturn:
                             _bytePositionInLine = 0;
                             _lineNumber++;
                             ignoreNextLfForLineTracking = true;
-                            break;
-                        default: // JsonConstants.LineFeed
-                            _bytePositionInLine = 0;
-                            _lineNumber++;
                             break;
                     }
                 }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -431,7 +431,7 @@ namespace System.Text.Json
                             if (marker == JsonConstants.Slash)
                             {
                                 SequencePosition copy = _currentPosition;
-                                if (SkipCommentMultiSegment())
+                                if (SkipCommentMultiSegment(out _))
                                 {
                                     if (_consumed >= (uint)_buffer.Length)
                                     {
@@ -1931,7 +1931,7 @@ namespace System.Text.Json
         {
             while (marker == JsonConstants.Slash)
             {
-                if (SkipCommentMultiSegment())
+                if (SkipCommentMultiSegment(out _))
                 {
                     if (!HasMoreDataMultiSegment())
                     {
@@ -1966,7 +1966,7 @@ namespace System.Text.Json
         {
             while (marker == JsonConstants.Slash)
             {
-                if (SkipCommentMultiSegment())
+                if (SkipCommentMultiSegment(out _))
                 {
                     // The next character must be a start of a property name or value.
                     if (!HasMoreDataMultiSegment(resource))
@@ -2165,195 +2165,53 @@ namespace System.Text.Json
             return ConsumeTokenResult.NotEnoughDataRollBackState;
         }
 
-        private bool SkipCommentMultiSegment()
-        {
-            // Create local copy to avoid bounds checks.
-            ReadOnlySpan<byte> localBuffer = _buffer.Slice(_consumed + 1);
-            int leftOver = 2;
-
-            if (localBuffer.Length == 0)
-            {
-                if (IsLastSpan)
-                {
-                    ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfValueNotFound, JsonConstants.Slash);
-                }
-
-                if (!GetNextSpan())
-                {
-                    if (IsLastSpan)
-                    {
-                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfValueNotFound, JsonConstants.Slash);
-                    }
-                    return false;
-                }
-
-                _totalConsumed++;
-                _bytePositionInLine++;
-                localBuffer = _buffer;
-                leftOver = 1;
-            }
-
-            byte marker = localBuffer[0];
-
-            if (marker == JsonConstants.Slash)
-            {
-                return SkipSingleLineCommentMultiSegment(localBuffer.Slice(1), leftOver);
-            }
-
-            if (marker != JsonConstants.Asterisk)
-            {
-                ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfValueNotFound, JsonConstants.Slash);
-            }
-
-            return SkipMultiLineCommentMultiSegment(localBuffer.Slice(1), leftOver);
-        }
-
-        private bool SkipSingleLineCommentMultiSegment(ReadOnlySpan<byte> localBuffer, int leftOver)
-        {
-            long prevTotalConsumed = _totalConsumed;
-            int idx = -1;
-            bool expectLF = false;
-            do
-            {
-                if (expectLF)
-                {
-                    if (localBuffer[0] == JsonConstants.LineFeed)
-                    {
-                        idx++;
-                    }
-                    break;
-                }
-                idx = localBuffer.IndexOfAny(JsonConstants.LineFeed, JsonConstants.CarriageReturn);
-                if (idx != -1)
-                {
-                    if (localBuffer[idx] == JsonConstants.LineFeed)
-                    {
-                        break;
-                    }
-
-                    // If we are here, we have definintely found a \r. So now to check if \n follows.
-                    Debug.Assert(localBuffer[idx] == JsonConstants.CarriageReturn);
-
-                    if (idx < localBuffer.Length - 1)
-                    {
-                        if (localBuffer[idx + 1] == JsonConstants.LineFeed)
-                        {
-                            idx++;
-                        }
-                        break;
-                    }
-                    expectLF = true;
-                }
-                if (IsLastSpan)
-                {
-                    idx = localBuffer.Length;
-                    // Assume everything on this line is a comment and there is no more data.
-                    _bytePositionInLine += 2 + localBuffer.Length;
-                    goto Done;
-                }
-
-                if (!GetNextSpan())
-                {
-                    _totalConsumed = prevTotalConsumed;
-                    return false;
-                }
-                _totalConsumed += localBuffer.Length + leftOver;
-                leftOver = 0;
-                localBuffer = _buffer;
-                idx = -1;
-            } while (true);
-
-            idx++;
-            _bytePositionInLine = 0;
-            _lineNumber++;
-        Done:
-            _consumed += leftOver + idx;
-            return true;
-        }
-
-        private bool SkipMultiLineCommentMultiSegment(ReadOnlySpan<byte> localBuffer, int leftOver)
-        {
-            long prevTotalConsumed = _totalConsumed;
-            int i;
-            bool lastAsterisk = false;
-            while (true)
-            {
-                i = 0;
-                for (; i < localBuffer.Length; i++)
-                {
-                    byte nextByte = localBuffer[i];
-
-                    if (nextByte == JsonConstants.Slash && lastAsterisk)
-                    {
-                        goto Done;
-                    }
-
-                    if (nextByte == JsonConstants.Asterisk)
-                    {
-                        i++;
-                        lastAsterisk = true;
-                        if (i < localBuffer.Length)
-                        {
-                            if (localBuffer[i] == JsonConstants.Slash)
-                            {
-                                goto Done;
-                            }
-                        }
-                        else
-                        {
-                            if (!GetNextSpan())
-                            {
-                                _totalConsumed = prevTotalConsumed;
-                                return false;
-                            }
-                            _totalConsumed += localBuffer.Length + leftOver;
-                            _bytePositionInLine += localBuffer.Length + leftOver;
-                            leftOver = 0;
-                            localBuffer = _buffer;
-                            i = 0;
-                            if (localBuffer[i] == JsonConstants.Slash)
-                            {
-                                goto Done;
-                            }
-                            break;
-                        }
-                    }
-                    else if (nextByte == JsonConstants.LineFeed)
-                    {
-                        _bytePositionInLine = 0;
-                        _lineNumber++;
-                        lastAsterisk = false;
-                    }
-                    else
-                    {
-                        lastAsterisk = false;
-                    }
-                }
-                if (i == localBuffer.Length)
-                {
-                    if (!GetNextSpan())
-                    {
-                        _totalConsumed = prevTotalConsumed;
-                        return false;
-                    }
-                    _totalConsumed += localBuffer.Length + leftOver;
-                    _bytePositionInLine += localBuffer.Length + leftOver;
-                    leftOver = 0;
-                    localBuffer = _buffer;
-                }
-            }
-
-        Done:
-            _consumed += i + 1 + leftOver;
-            _bytePositionInLine += i + 1 + leftOver;
-            return true;
-        }
-
         private bool ConsumeCommentMultiSegment()
         {
+            long prevTotalConsumed = BytesConsumed;
+            SequencePosition start = new SequencePosition(_currentPosition.GetObject(), _currentPosition.GetInteger() + _consumed);
+            bool ret = SkipCommentMultiSegment(out int tailBytesToIgnore);
+
+            if (ret)
+            {
+                SequencePosition end = new SequencePosition(_currentPosition.GetObject(), _currentPosition.GetInteger() + _consumed);
+
+                ReadOnlySequence<byte> commentSequence = _sequence.Slice(start, end);
+                commentSequence = commentSequence.Slice(2, commentSequence.Length - 2 - tailBytesToIgnore);
+                HasValueSequence = !commentSequence.IsSingleSegment;
+
+                if (HasValueSequence)
+                {
+                    ValueSequence = commentSequence;
+                }
+                else
+                {
+                    ValueSpan = commentSequence.First.Span;
+                }
+
+                if (_tokenType != JsonTokenType.Comment)
+                {
+                    _previousTokenType = _tokenType;
+                }
+
+                _tokenType = JsonTokenType.Comment;
+            }
+            else
+            {
+                _totalConsumed = prevTotalConsumed;
+                // consumed might not be correct now but it won't be used anymore after we return false
+                // if we don't wrong number of bytes might get reported (if consuming called GetNextSpan)
+                _consumed = 0;
+            }
+
+            return ret;
+        }
+
+        private bool SkipCommentMultiSegment(out int tailBytesToIgnore)
+        {
+            _consumed++;
+            _bytePositionInLine++;
             // Create local copy to avoid bounds checks.
-            ReadOnlySpan<byte> localBuffer = _buffer.Slice(_consumed + 1);
-            int leftOver = 2;
+            ReadOnlySpan<byte> localBuffer = _buffer.Slice(_consumed);
 
             if (localBuffer.Length == 0)
             {
@@ -2368,13 +2226,12 @@ namespace System.Text.Json
                     {
                         ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.UnexpectedEndOfDataWhileReadingComment);
                     }
+
+                    tailBytesToIgnore = 0;
                     return false;
                 }
 
-                _totalConsumed++;
-                _bytePositionInLine++;
                 localBuffer = _buffer;
-                leftOver = 1;
             }
 
             byte marker = localBuffer[0];
@@ -2383,81 +2240,85 @@ namespace System.Text.Json
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.InvalidCharacterAtStartOfComment, marker);
             }
 
-            bool allowEmptyComment = marker == JsonConstants.Slash;
+            bool multiLine = marker == JsonConstants.Asterisk;
 
+            _consumed++;
+            _bytePositionInLine++;
             localBuffer = localBuffer.Slice(1);
+
             if (localBuffer.Length == 0)
             {
-                if (IsLastSpan || !GetNextSpan())
+                if (IsLastSpan)
                 {
+                    tailBytesToIgnore = 0;
+
+                    if (multiLine)
+                    {
+                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.UnexpectedEndOfDataWhileReadingComment);
+                    }
+
+                    return true;
+                }
+
+                if (!GetNextSpan())
+                {
+                    tailBytesToIgnore = 0;
+
                     if (IsLastSpan)
                     {
-                        if (allowEmptyComment)
-                        {
-                            if (_tokenType != JsonTokenType.Comment)
-                            {
-                                _previousTokenType = _tokenType;
-                            }
-
-                            _totalConsumed++;
-                            _bytePositionInLine++;
-                            _tokenType = JsonTokenType.Comment;
-                            _consumed += 2;
-                            return true;
-                        }
-                        else
+                        if (multiLine)
                         {
                             ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.UnexpectedEndOfDataWhileReadingComment);
                         }
+
+                        return true;
                     }
 
                     return false;
                 }
 
-                _totalConsumed++;
-                _bytePositionInLine++;
                 localBuffer = _buffer;
-                leftOver = 0;
             }
 
-            SequencePosition start = new SequencePosition(_currentPosition.GetObject(), _currentPosition.GetInteger() + _consumed + leftOver);
-            if (marker == JsonConstants.Slash)
+            if (multiLine)
             {
-                return ConsumeSingleLineCommentMultiSegment(localBuffer, leftOver, start, _consumed);
+                tailBytesToIgnore = 2;
+                return SkipMultiLineCommentMultiSegment(localBuffer);
             }
-
-            return ConsumeMultiLineCommentMultiSegment(localBuffer, leftOver, start, _consumed);
+            else
+            {
+                return SkipSingleLineCommentMultiSegment(localBuffer, out tailBytesToIgnore);
+            }
         }
 
-        private bool ConsumeSingleLineCommentMultiSegment(ReadOnlySpan<byte> localBuffer, int leftOver, SequencePosition start, int previousConsumed)
+        private bool SkipSingleLineCommentMultiSegment(ReadOnlySpan<byte> localBuffer, out int tailBytesToSkip)
         {
-            SequencePosition end = start;
-
-            long prevTotalConsumed = _totalConsumed;
-            int idx = -1;
             bool expectLF = false;
-            int toConsume = idx;
             int dangerousLineSeparatorBytesConsumed = 0;
+            tailBytesToSkip = 0;
 
-            do
+            while (true)
             {
                 if (expectLF)
                 {
                     if (localBuffer[0] == JsonConstants.LineFeed)
                     {
-                        idx++;
+                        tailBytesToSkip++;
+                        _consumed++;
                     }
-                    HasValueSequence = true;
+
                     break;
                 }
 
-                idx = FindLineSeparatorMultiSegment(localBuffer, ref dangerousLineSeparatorBytesConsumed);
+                int idx = FindLineSeparatorMultiSegment(localBuffer, ref dangerousLineSeparatorBytesConsumed);
                 Debug.Assert(dangerousLineSeparatorBytesConsumed >= 0 && dangerousLineSeparatorBytesConsumed <= 2);
 
                 if (idx != -1)
                 {
-                    toConsume = idx;
-                    end = new SequencePosition(_currentPosition.GetObject(), _currentPosition.GetInteger() + previousConsumed + leftOver + idx);
+                    tailBytesToSkip++;
+                    _consumed += idx + 1;
+                    _bytePositionInLine += idx + 1;
+
                     if (localBuffer[idx] == JsonConstants.LineFeed)
                     {
                         break;
@@ -2470,8 +2331,11 @@ namespace System.Text.Json
                     {
                         if (localBuffer[idx + 1] == JsonConstants.LineFeed)
                         {
-                            idx++;
+                            tailBytesToSkip++;
+                            _consumed++;
+                            _bytePositionInLine++;
                         }
+
                         break;
                     }
 
@@ -2479,86 +2343,43 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    end = new SequencePosition(_currentPosition.GetObject(), _currentPosition.GetInteger() + previousConsumed + leftOver + localBuffer.Length);
+                    _consumed += localBuffer.Length;
+                    _bytePositionInLine += localBuffer.Length;
                 }
 
                 if (IsLastSpan)
                 {
-                    idx = localBuffer.Length;
-
                     if (expectLF)
                     {
-                        idx--;
+                        break;
                     }
 
-                    toConsume = idx;
-                    // Assume everything on this line is a comment and there is no more data.
-                    _bytePositionInLine += 2 + localBuffer.Length;
-                    goto Done;
+                    return true;
                 }
 
                 if (!GetNextSpan())
                 {
                     if (IsLastSpan)
                     {
-                        idx = localBuffer.Length;
-
                         if (expectLF)
                         {
-                            idx--;
+                            break;
                         }
 
-                        toConsume = idx;
-                        // Assume everything on this line is a comment and there is no more data.
-                        _bytePositionInLine += 2 + localBuffer.Length;
-                        goto Done;
+                        return true;
                     }
                     else
                     {
-                        _totalConsumed = prevTotalConsumed;
                         return false;
                     }
                 }
 
-                HasValueSequence = true;
-                _totalConsumed += localBuffer.Length + leftOver;
-                previousConsumed = 0;
-                leftOver = 0;
                 localBuffer = _buffer;
-                idx = -1;
-            } while (true);
+            }
 
-            idx++;
             _bytePositionInLine = 0;
             _lineNumber++;
 
-        Done:
-            if (HasValueSequence)
-            {
-                ReadOnlySequence<byte> commentSequence = _sequence.Slice(start, end);
-                if (commentSequence.IsSingleSegment)
-                {
-                    ValueSpan = commentSequence.First.Span;
-                    HasValueSequence = false;
-                }
-                else
-                {
-                    ValueSequence = commentSequence;
-                }
-            }
-            else
-            {
-                // Exclude start-of-comment chars //, if not already skipped and
-                // take characters until the first line separator character
-                ValueSpan = _buffer.Slice(previousConsumed + leftOver, toConsume);
-            }
-
-            if (_tokenType != JsonTokenType.Comment)
-            {
-                _previousTokenType = _tokenType;
-            }
-            _tokenType = JsonTokenType.Comment;
-            _consumed += leftOver + idx;
             return true;
         }
 
@@ -2582,13 +2403,13 @@ namespace System.Text.Json
             int totalIdx = 0;
             while (true)
             {
-                int idx = localBuffer.IndexOfAny(JsonConstants.LineFeed, JsonConstants.CarriageReturn, JsonConstants.MaybeDangerousLineSeparator);
+                int idx = localBuffer.IndexOfAny(JsonConstants.LineFeed, JsonConstants.CarriageReturn, JsonConstants.StartingByteOfNonStandardLineSeparator);
                 dangerousLineSeparatorBytesConsumed = 0;
 
                 if (idx == -1)
                     return -1;
 
-                if (localBuffer[idx] != JsonConstants.MaybeDangerousLineSeparator)
+                if (localBuffer[idx] != JsonConstants.StartingByteOfNonStandardLineSeparator)
                     return totalIdx + idx;
 
                 int p = idx + 1;
@@ -2608,7 +2429,7 @@ namespace System.Text.Json
             }
         }
 
-        // assumes first byte (JsonConstants.MaybeDangerousLineSeparator) is already read
+        // assumes first byte (JsonConstants.UnexpectedEndOfLineSeparator) is already read
         private void ThrowOnDangerousLineSeparatorMultiSegment(ReadOnlySpan<byte> localBuffer, ref int dangerousLineSeparatorBytesConsumed)
         {
             Debug.Assert(dangerousLineSeparatorBytesConsumed == 1 || dangerousLineSeparatorBytesConsumed == 2);
@@ -2617,178 +2438,136 @@ namespace System.Text.Json
             // UTF-8 representation for them is E2, 80, A8/A9
             // we have already read E2 and maybe 80 we need to check for remaining 1 or 2 bytes
 
-            while (true)
+            if (localBuffer.IsEmpty)
             {
-                if (localBuffer.IsEmpty)
-                {
-                    return;
-                }
-
-                if (dangerousLineSeparatorBytesConsumed == 1)
-                {
-                    if (localBuffer[0] == 0x80)
-                    {
-                        localBuffer = localBuffer.Slice(1);
-                        dangerousLineSeparatorBytesConsumed++;
-                    }
-                    else
-                    {
-                        // no match
-                        dangerousLineSeparatorBytesConsumed = 0;
-                        return;
-                    }
-                }
-                else // dangerousLineSeparatorBytesConsumed == 2
-                {
-                    if (localBuffer[0] == 0xA8 || localBuffer[0] == 0xA9)
-                    {
-                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.UnexpectedEndOfLineSeparator);
-                    }
-                    else
-                    {
-                        // no match
-                        dangerousLineSeparatorBytesConsumed = 0;
-                        return;
-                    }
-                }
-            }   
-        }
-
-        private bool ConsumeMultiLineCommentMultiSegment(ReadOnlySpan<byte> localBuffer, int leftOver, SequencePosition start, int previousConsumed)
-        {
-            SequencePosition end = start;
-            long prevTotalConsumed = _totalConsumed;
-            int i;
-            int lastLineFeedIndex;
-            bool lastAsterisk = false;
-            while (true)
-            {
-                i = 0;
-                lastLineFeedIndex = -1;
-                for (; i < localBuffer.Length; i++)
-                {
-                    byte nextByte = localBuffer[i];
-
-                    if (nextByte == JsonConstants.Slash && lastAsterisk)
-                    {
-                        goto Done;
-                    }
-
-                    if (nextByte == JsonConstants.Asterisk)
-                    {
-                        end = new SequencePosition(_currentPosition.GetObject(), _currentPosition.GetInteger() + previousConsumed + leftOver + i);
-                        i++;
-                        lastAsterisk = true;
-                        if (i < localBuffer.Length)
-                        {
-                            if (localBuffer[i] == JsonConstants.Slash)
-                            {
-                                goto Done;
-                            }
-                        }
-                        else
-                        {
-                            if (!GetNextSpan())
-                            {
-                                _totalConsumed = prevTotalConsumed;
-                                return false;
-                            }
-                            HasValueSequence = true;
-                            _totalConsumed += localBuffer.Length + leftOver;
-
-                            if (lastLineFeedIndex == -1)
-                            {
-                                _bytePositionInLine += localBuffer.Length + leftOver;
-                            }
-                            else
-                            {
-                                _bytePositionInLine += i - lastLineFeedIndex - 1;
-                            }
-                            lastLineFeedIndex = -1;
-                            leftOver = 0;
-                            previousConsumed = 0;
-                            localBuffer = _buffer;
-                            i = 0;
-                            if (localBuffer[i] == JsonConstants.Slash)
-                            {
-                                goto Done;
-                            }
-                            break;
-                        }
-                    }
-                    else if (nextByte == JsonConstants.LineFeed)
-                    {
-                        lastLineFeedIndex = i;
-                        _bytePositionInLine = 0;
-                        _lineNumber++;
-                        lastAsterisk = false;
-                    }
-                    else
-                    {
-                        lastAsterisk = false;
-                    }
-                }
-                if (i == localBuffer.Length)
-                {
-                    if (!GetNextSpan())
-                    {
-                        _totalConsumed = prevTotalConsumed;
-                        return false;
-                    }
-                    HasValueSequence = true;
-                    _totalConsumed += localBuffer.Length + leftOver;
-
-                    if (lastLineFeedIndex == -1)
-                    {
-                        _bytePositionInLine += localBuffer.Length + leftOver;
-                    }
-                    else
-                    {
-                        _bytePositionInLine += i - lastLineFeedIndex - 1;
-                    }
-                    lastLineFeedIndex = -1;
-                    leftOver = 0;
-                    previousConsumed = 0;
-                    localBuffer = _buffer;
-                }
+                return;
             }
 
-        Done:
-            if (HasValueSequence)
+            if (dangerousLineSeparatorBytesConsumed == 1)
             {
-                ReadOnlySequence<byte> commentSequence = _sequence.Slice(start, end);
-                if (commentSequence.IsSingleSegment)
+                if (localBuffer[0] == 0x80)
                 {
-                    ValueSpan = commentSequence.First.Span;
-                    HasValueSequence = false;
+                    localBuffer = localBuffer.Slice(1);
+                    dangerousLineSeparatorBytesConsumed++;
+
+                    if (localBuffer.IsEmpty)
+                    {
+                        return;
+                    }
                 }
                 else
                 {
-                    ValueSequence = commentSequence;
+                    // no match
+                    dangerousLineSeparatorBytesConsumed = 0;
+                    return;
                 }
             }
-            else
-            {
-                // Exclude the start-of-comment characters /*, if not already skipped
-                // and end-of-comment characters */
-                ValueSpan = _buffer.Slice(previousConsumed + leftOver, i - 1);
-            }
 
-            if (_tokenType != JsonTokenType.Comment)
+            if (dangerousLineSeparatorBytesConsumed == 2)
             {
-                _previousTokenType = _tokenType;
+                if (localBuffer[0] == 0xA8 || localBuffer[0] == 0xA9)
+                {
+                    ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.UnexpectedEndOfLineSeparator);
+                }
+                else
+                {
+                    // no match
+                    dangerousLineSeparatorBytesConsumed = 0;
+                    return;
+                }
             }
-            _tokenType = JsonTokenType.Comment;
-            _consumed += i + 1 + leftOver;
-            if (lastLineFeedIndex == -1)
+        }
+
+        private bool SkipMultiLineCommentMultiSegment(ReadOnlySpan<byte> localBuffer)
+        {
+            bool expectSlash = false;
+            bool ignoreNextLfForLineTracking = false;
+
+            while (true)
             {
-                _bytePositionInLine += i + 1 + leftOver;
+                Debug.Assert(localBuffer.Length > 0);
+
+                if (expectSlash)
+                {
+                    if (localBuffer[0] == JsonConstants.Slash)
+                    {
+                        _consumed++;
+                        _bytePositionInLine++;
+                        return true;
+                    }
+
+                    expectSlash = false;
+                }
+
+                if (ignoreNextLfForLineTracking)
+                {
+                    if (localBuffer[0] == JsonConstants.LineFeed)
+                    {
+                        _consumed++;
+                        localBuffer = localBuffer.Slice(1);
+                    }
+
+                    ignoreNextLfForLineTracking = false;
+                }
+
+                int idx = localBuffer.IndexOfAny(JsonConstants.LineFeed, JsonConstants.CarriageReturn, JsonConstants.Asterisk);
+
+                if (idx != -1)
+                {
+                    byte marker = localBuffer[idx];
+
+                    int p = idx + 1;
+                    _consumed += p;
+                    _bytePositionInLine += p;
+
+                    localBuffer = localBuffer.Slice(p);
+
+                    switch (marker)
+                    {
+                        case JsonConstants.Asterisk:
+                            expectSlash = true;
+                            break;
+                        case JsonConstants.CarriageReturn:
+                            _bytePositionInLine = 0;
+                            _lineNumber++;
+                            ignoreNextLfForLineTracking = true;
+                            break;
+                        default: // JsonConstants.LineFeed
+                            _bytePositionInLine = 0;
+                            _lineNumber++;
+                            break;
+                    }
+                }
+                else
+                {
+                    _consumed += localBuffer.Length;
+                    _bytePositionInLine += localBuffer.Length;
+                    localBuffer = ReadOnlySpan<byte>.Empty;
+                }
+
+                if (localBuffer.IsEmpty)
+                {
+                    if (IsLastSpan)
+                    {
+                        ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.UnexpectedEndOfDataWhileReadingComment);
+                    }
+
+                    if (!GetNextSpan())
+                    {
+                        if (IsLastSpan)
+                        {
+                            ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.UnexpectedEndOfDataWhileReadingComment);
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+
+                    localBuffer = _buffer;
+                    Debug.Assert(!localBuffer.IsEmpty);
+                }
             }
-            else
-            {
-                _bytePositionInLine += i - lastLineFeedIndex;
-            }
-            return true;
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -2403,13 +2403,13 @@ namespace System.Text.Json
             int totalIdx = 0;
             while (true)
             {
-                int idx = localBuffer.IndexOfAny(JsonConstants.LineFeed, JsonConstants.CarriageReturn, JsonConstants.StartingByteOfNonStandardLineSeparator);
+                int idx = localBuffer.IndexOfAny(JsonConstants.LineFeed, JsonConstants.CarriageReturn, JsonConstants.StartingByteOfNonStandardSeparator);
                 dangerousLineSeparatorBytesConsumed = 0;
 
                 if (idx == -1)
                     return -1;
 
-                if (localBuffer[idx] != JsonConstants.StartingByteOfNonStandardLineSeparator)
+                if (localBuffer[idx] != JsonConstants.StartingByteOfNonStandardSeparator)
                     return totalIdx + idx;
 
                 int p = idx + 1;
@@ -2422,7 +2422,7 @@ namespace System.Text.Json
 
                 if (dangerousLineSeparatorBytesConsumed != 0)
                 {
-                    // this can only happen in the end of stream
+                    // this can only happen in the end of the local buffer
                     Debug.Assert(localBuffer.Length < 2);
                     return -1;
                 }
@@ -2516,11 +2516,11 @@ namespace System.Text.Json
                 {
                     byte marker = localBuffer[idx];
 
-                    int p = idx + 1;
-                    _consumed += p;
-                    _bytePositionInLine += p;
+                    int nextIdx = idx + 1;
+                    _consumed += nextIdx;
+                    _bytePositionInLine += nextIdx;
 
-                    localBuffer = localBuffer.Slice(p);
+                    localBuffer = localBuffer.Slice(nextIdx);
 
                     switch (marker)
                     {

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -2370,7 +2370,7 @@ namespace System.Text.Json
             }
         }
 
-        // assumes first byte (JsonConstants.MaybeDangerousLineSeparator) is already read
+        // assumes first byte (JsonConstants.StartingByteOfNonStandardSeparator) is already read
         private void ThrowOnDangerousLineSeparator(ReadOnlySpan<byte> localBuffer)
         {
             // \u2028 and \u2029 are considered respectively line and paragraph separators
@@ -2384,7 +2384,9 @@ namespace System.Text.Json
 
             byte next = localBuffer[1];
             if (localBuffer[0] == 0x80 && (next == 0xA8 || next == 0xA9))
+            {
                 ThrowHelper.ThrowJsonReaderException(ref this, ExceptionResource.UnexpectedEndOfLineSeparator);
+            }
         }
 
         private bool SkipMultiLineComment(ReadOnlySpan<byte> localBuffer, out int idx)

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -29,6 +29,8 @@ namespace System.Text.Json
 
         private long _lineNumber;
         private long _bytePositionInLine;
+
+        // bytes consumed in the current segment (not token)
         private int _consumed;
         private bool _inObject;
         private bool _isNotPrimitive;
@@ -2349,12 +2351,12 @@ namespace System.Text.Json
             int totalIdx = 0;
             while (true)
             {
-                int idx = localBuffer.IndexOfAny(JsonConstants.LineFeed, JsonConstants.CarriageReturn, JsonConstants.MaybeDangerousLineSeparator);
+                int idx = localBuffer.IndexOfAny(JsonConstants.LineFeed, JsonConstants.CarriageReturn, JsonConstants.StartingByteOfNonStandardLineSeparator);
 
                 if (idx == -1)
                     return -1;
 
-                if (localBuffer[idx] != JsonConstants.MaybeDangerousLineSeparator)
+                if (localBuffer[idx] != JsonConstants.StartingByteOfNonStandardLineSeparator)
                     return totalIdx + idx;
 
                 int p = idx + 1;

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -630,7 +630,7 @@ namespace System.Text.Json
         TrailingCommaNotAllowedBeforeObjectEnd,
         InvalidCharacterAtStartOfComment,
         UnexpectedEndOfDataWhileReadingComment,
-		UnexpectedEndOfLineSeparator,
+        UnexpectedEndOfLineSeparator,
         ExpectedOneCompleteToken,
         NotEnoughData,
     }

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -377,6 +377,9 @@ namespace System.Text.Json
                 case ExceptionResource.UnexpectedEndOfDataWhileReadingComment:
                     message = SR.Format(SR.UnexpectedEndOfDataWhileReadingComment);
                     break;
+                case ExceptionResource.UnexpectedEndOfLineSeparator:
+                    message = SR.Format(SR.UnexpectedEndOfLineSeparator);
+                    break;
                 default:
                     Debug.Fail($"The ExceptionResource enum value: {resource} is not part of the switch. Add the appropriate case and exception message.");
                     break;
@@ -627,8 +630,9 @@ namespace System.Text.Json
         TrailingCommaNotAllowedBeforeObjectEnd,
         InvalidCharacterAtStartOfComment,
         UnexpectedEndOfDataWhileReadingComment,
+		UnexpectedEndOfLineSeparator,
         ExpectedOneCompleteToken,
-        NotEnoughData
+        NotEnoughData,
     }
 
     internal enum NumericType

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -906,36 +906,72 @@ namespace System.Text.Json.Tests
         public static void JsonWithSingleLineCommentEndingWithNonStandardLineEndingMultiSegment(string jsonString, int segmentSize)
         {
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
-            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
             ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, segmentSize);
 
-            foreach (bool isFinalBlock in new bool[] { false, true })
+            foreach (JsonCommentHandling jsonCommentHandling in typeof(JsonCommentHandling).GetEnumValues())
             {
-                var json = new Utf8JsonReader(sequence, isFinalBlock, state);
+                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = jsonCommentHandling });
 
-                try
+                foreach (bool isFinalBlock in new bool[] { false, true })
                 {
-                    json.Read();
-                    Assert.True(false, "Expected JsonException was not thrown.");
+                    var json = new Utf8JsonReader(sequence, isFinalBlock, state);
+
+                    try
+                    {
+                        json.Read();
+                        Assert.True(false, $"Expected JsonException was not thrown. CommentHandling = {jsonCommentHandling}");
+                    }
+                    catch (JsonException) { }
                 }
-                catch (JsonException) { }
             }
         }
 
         [Theory]
-        [InlineData("//", "", 1)]
-        [InlineData("//", "", 2)]
-        [InlineData("//", "", 3)]
-        [InlineData("//", "", 100)]
-        [InlineData("//a", "a", 1)]
-        [InlineData("//a", "a", 2)]
-        [InlineData("//a", "a", 3)]
-        [InlineData("//a", "a", 100)]
-        [InlineData("//abc", "abc", 1)]
-        [InlineData("//abc", "abc", 2)]
-        [InlineData("//abc", "abc", 3)]
-        [InlineData("//abc", "abc", 100)]
-        public static void JsonWithSingleLineCommentWithNoLineEndingsFinalBlockMultiSegment(string jsonString, string expectedComment, int segmentSize)
+        [InlineData("{ \"foo\" : \"bar\" //\u2028\n}", 1)]
+        [InlineData("{ \"foo\" : \"bar\" //\u2028\n}", 2)]
+        [InlineData("{ \"foo\" : \"bar\" //\u2028\n}", 3)]
+        [InlineData("{ \"foo\" : \"bar\" //\u2028\n}", 100)]
+        public static void JsonWithSingleLineCommentInTheMiddleOfThePayloadEndingWithNonStandardLineEndingMultiSegment(string jsonString, int segmentSize)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, segmentSize);
+
+            foreach (JsonCommentHandling jsonCommentHandling in typeof(JsonCommentHandling).GetEnumValues())
+            {
+                var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = jsonCommentHandling });
+
+
+                foreach (bool isFinalBlock in new bool[] { false, true })
+                {
+                    var json = new Utf8JsonReader(sequence, isFinalBlock, state);
+
+                    try
+                    {
+                        Assert.True(json.Read()); // {
+                        Assert.True(json.Read()); // "foo"
+                        Assert.True(json.Read()); // "bar"
+                        json.Read(); // bad comment
+                        Assert.True(false, $"Expected JsonException was not thrown. CommentHandling = {jsonCommentHandling}");
+                    }
+                    catch (JsonException) { }
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("//", "", 1, 2)]
+        [InlineData("//", "", 2, 2)]
+        [InlineData("//", "", 3, 2)]
+        [InlineData("//", "", 100, 2)]
+        [InlineData("//a", "a", 1, 3)]
+        [InlineData("//a", "a", 2, 3)]
+        [InlineData("//a", "a", 3, 3)]
+        [InlineData("//a", "a", 100, 3)]
+        [InlineData("//abc", "abc", 1, 5)]
+        [InlineData("//abc", "abc", 2, 5)]
+        [InlineData("//abc", "abc", 3, 5)]
+        [InlineData("//abc", "abc", 100, 5)]
+        public static void JsonWithSingleLineCommentWithNoLineEndingsFinalBlockMultiSegment(string jsonString, string expectedComment, int segmentSize, int expectedBytesConsumed)
         {
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
             var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
@@ -946,6 +982,93 @@ namespace System.Text.Json.Tests
             Assert.Equal(JsonTokenType.Comment, json.TokenType);
             Assert.Equal(expectedComment, json.GetComment());
             Assert.False(json.Read());
+            Assert.Equal(expectedBytesConsumed, json.BytesConsumed);
+        }
+
+        [Theory]
+        [InlineData("//", 1)]
+        [InlineData("//", 2)]
+        [InlineData("//", 3)]
+        [InlineData("//", 100)]
+        [InlineData("//a", 1)]
+        [InlineData("//a", 2)]
+        [InlineData("//a", 3)]
+        [InlineData("//a", 100)]
+        [InlineData("//abc", 1)]
+        [InlineData("//abc", 2)]
+        [InlineData("//abc", 3)]
+        [InlineData("//abc", 100)]
+        public static void JsonWithSingleLineCommentWithNoLineEndingsNonFinalBlockMultiSegment(string jsonString, int segmentSize)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, segmentSize);
+            var json = new Utf8JsonReader(sequence, isFinalBlock: false, state);
+
+            Assert.False(json.Read());
+            Assert.Equal(0, json.BytesConsumed);
+        }
+
+        [Theory]
+        [InlineData("/**/", "", 1, 4)]
+        [InlineData("/**/", "", 2, 4)]
+        [InlineData("/**/", "", 3, 4)]
+        [InlineData("/**/", "", 100, 4)]
+        [InlineData("/*a*/", "a", 1, 5)]
+        [InlineData("/*a*/", "a", 2, 5)]
+        [InlineData("/*a*/", "a", 3, 5)]
+        [InlineData("/*a*/", "a", 100, 5)]
+        [InlineData("/*abc*/", "abc", 1, 7)]
+        [InlineData("/*abc*/", "abc", 2, 7)]
+        [InlineData("/*abc*/", "abc", 3, 7)]
+        [InlineData("/*abc*/", "abc", 100, 7)]
+        [InlineData("/*\u2028*/", "\u2028", 1, 7)]
+        [InlineData("/*\u2028*/", "\u2028", 2, 7)]
+        [InlineData("/*\u2028*/", "\u2028", 3, 7)]
+        [InlineData("/*\u2028*/", "\u2028", 100, 7)]
+        [InlineData("/*\u2029*/", "\u2029", 1, 7)]
+        [InlineData("/*\u2029*/", "\u2029", 2, 7)]
+        [InlineData("/*\u2029*/", "\u2029", 3, 7)]
+        [InlineData("/*\u2029*/", "\u2029", 100, 7)]
+        public static void JsonWithMultiLineCommentWithNoLineEndingsFinalBlockMultiSegment(string jsonString, string expectedComment, int segmentSize, int expectedBytesConsumed)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, segmentSize);
+            var json = new Utf8JsonReader(sequence, isFinalBlock: true, state);
+
+            Assert.True(json.Read());
+            Assert.Equal(JsonTokenType.Comment, json.TokenType);
+            Assert.Equal(expectedComment, json.GetComment());
+            Assert.False(json.Read());
+            Assert.Equal(expectedBytesConsumed, json.BytesConsumed);
+        }
+
+        [Theory]
+        [InlineData("/*", 1)]
+        [InlineData("/*", 2)]
+        [InlineData("/*", 100)]
+        [InlineData("/*  ", 1)]
+        [InlineData("/*  ", 2)]
+        [InlineData("/*  ", 3)]
+        [InlineData("/*  ", 100)]
+        [InlineData("/**", 1)]
+        [InlineData("/**", 2)]
+        [InlineData("/**", 3)]
+        [InlineData("/**", 100)]
+        [InlineData("/*  *", 1)]
+        [InlineData("/*  *", 2)]
+        [InlineData("/*  *", 3)]
+        [InlineData("/*  *", 100)]
+        public static void JsonWithUnfinishedMultiLineCommentNonFinalBlockMultiSegment(string jsonString, int segmentSize)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, segmentSize);
+            var json = new Utf8JsonReader(sequence, isFinalBlock: false, state);
+
+            Assert.False(json.Read());
+            Assert.Equal(0, json.BytesConsumed);
         }
 
         [Theory]

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace System.Text.Json.Tests
@@ -874,6 +875,139 @@ namespace System.Text.Json.Tests
 
                 json = new Utf8JsonReader(sequence.Slice(json.BytesConsumed), isFinalBlock: true, json.CurrentState);
                 VerifyReadLoop(ref json, null);
+            }
+        }
+
+        [Theory]
+        [InlineData("//\u2028", 1)]
+        [InlineData("//\u2028", 2)]
+        [InlineData("//\u2028", 3)]
+        [InlineData("//\u2028", 100)]
+        [InlineData("//\u2029", 1)]
+        [InlineData("//\u2029", 2)]
+        [InlineData("//\u2029", 3)]
+        [InlineData("//\u2029", 100)]
+        [InlineData("// \u2028", 1)]
+        [InlineData("// \u2028", 2)]
+        [InlineData("// \u2028", 3)]
+        [InlineData("// \u2028", 100)]
+        [InlineData("//   \u2028", 1)]
+        [InlineData("//   \u2028", 2)]
+        [InlineData("//   \u2028", 3)]
+        [InlineData("//   \u2028", 100)]
+        [InlineData("//  \u2029 ", 1)]
+        [InlineData("//  \u2029 ", 2)]
+        [InlineData("//  \u2029 ", 3)]
+        [InlineData("//  \u2029 ", 100)]
+        [InlineData("//  \u2029  ", 1)]
+        [InlineData("//  \u2029  ", 2)]
+        [InlineData("//  \u2029  ", 3)]
+        [InlineData("//  \u2029  ", 100)]
+        public static void JsonWithSingleLineCommentEndingWithNonStandardLineEndingMultiSegment(string jsonString, int segmentSize)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, segmentSize);
+
+            foreach (bool isFinalBlock in new bool[] { false, true })
+            {
+                var json = new Utf8JsonReader(sequence, isFinalBlock, state);
+
+                try
+                {
+                    json.Read();
+                    Assert.True(false, "Expected JsonException was not thrown.");
+                }
+                catch (JsonException) { }
+            }
+        }
+
+        [Theory]
+        [InlineData("//", "", 1)]
+        [InlineData("//", "", 2)]
+        [InlineData("//", "", 3)]
+        [InlineData("//", "", 100)]
+        [InlineData("//a", "a", 1)]
+        [InlineData("//a", "a", 2)]
+        [InlineData("//a", "a", 3)]
+        [InlineData("//a", "a", 100)]
+        [InlineData("//abc", "abc", 1)]
+        [InlineData("//abc", "abc", 2)]
+        [InlineData("//abc", "abc", 3)]
+        [InlineData("//abc", "abc", 100)]
+        public static void JsonWithSingleLineCommentWithNoLineEndingsFinalBlockMultiSegment(string jsonString, string expectedComment, int segmentSize)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, segmentSize);
+            var json = new Utf8JsonReader(sequence, isFinalBlock: true, state);
+
+            Assert.True(json.Read());
+            Assert.Equal(JsonTokenType.Comment, json.TokenType);
+            Assert.Equal(expectedComment, json.GetComment());
+            Assert.False(json.Read());
+        }
+
+        [Theory]
+        [InlineData("//", "", 1)]
+        [InlineData("//", "", 2)]
+        [InlineData("//", "", 3)]
+        [InlineData("//", "", 100)]
+        [InlineData("//a", "a", 1)]
+        [InlineData("//a", "a", 2)]
+        [InlineData("//a", "a", 3)]
+        [InlineData("//a", "a", 100)]
+        [InlineData("//abc", "abc", 1)]
+        [InlineData("//abc", "abc", 2)]
+        [InlineData("//abc", "abc", 3)]
+        [InlineData("//abc", "abc", 100)]
+        public static void JsonWithSingleLineCommentWithNoLineEndingsNonFinalBlockMultiSegment(string jsonString, string expectedComment, int segmentSize)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
+            ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, segmentSize);
+            var json = new Utf8JsonReader(sequence, isFinalBlock: false, state);
+
+            Assert.False(json.Read());
+        }
+
+        [Theory]
+        [InlineData("//", "", 1)]
+        [InlineData("//", "", 2)]
+        [InlineData("//", "", 3)]
+        [InlineData("//", "", 100)]
+        [InlineData("//a", "a", 1)]
+        [InlineData("//a", "a", 2)]
+        [InlineData("//a", "a", 3)]
+        [InlineData("//a", "a", 100)]
+        [InlineData("//abc", "abc", 1)]
+        [InlineData("//abc", "abc", 2)]
+        [InlineData("//abc", "abc", 3)]
+        [InlineData("//abc", "abc", 100)]
+        public static void JsonWithSingleLineCommentWithRegularLineEndingMultiSegment(string jsonStringWithoutLineEnding, string expectedComment, int segmentSize)
+        {
+            foreach (string lineEnding in new string[] { "\r", "\r ", "\r\n", "\r\n ", "\n", "\n " })
+            {
+                foreach (bool isFinalBlock in new bool[] { false, true })
+                {
+                    if (!isFinalBlock && lineEnding == "\r")
+                    {
+                        // In this case parser would return false on the first Read (and check for \n on the next segment)
+                        // which is not the purpose of this test and is covered separately
+                        continue;
+                    }
+
+                    byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonStringWithoutLineEnding + lineEnding);
+                    var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
+                    ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(dataUtf8, segmentSize);
+
+                    var json = new Utf8JsonReader(sequence, isFinalBlock, state);
+
+                    Assert.True(json.Read(), $"Expected read to return true. IsFinalBlock = {isFinalBlock}; LineEnding = {string.Join("", lineEnding.Select((c) => ((byte)c).ToString("X2")))}");
+                    Assert.Equal(JsonTokenType.Comment, json.TokenType);
+                    Assert.Equal(expectedComment, json.GetComment());
+                    Assert.False(json.Read());
+                }
             }
         }
 

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -684,7 +684,7 @@ namespace System.Text.Json.Tests
         // For first line in each case:
         //     . represents contiguous characters in input.
         //     | represents end of a segment in the sequence. Character below | is last character of particular segment.
-        //     
+        //
         //     Note: \ for escape sequence has neither a . nor a |
         //
         // Second line in each case represents whether the resulting token after parsing has a value sequence or not.
@@ -939,7 +939,6 @@ namespace System.Text.Json.Tests
             foreach (JsonCommentHandling jsonCommentHandling in typeof(JsonCommentHandling).GetEnumValues())
             {
                 var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = jsonCommentHandling });
-
 
                 foreach (bool isFinalBlock in new bool[] { false, true })
                 {

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -1109,11 +1109,11 @@ namespace System.Text.Json.Tests
         [InlineData("//abc", "abc", 100)]
         public static void JsonWithSingleLineCommentWithRegularLineEndingMultiSegment(string jsonStringWithoutLineEnding, string expectedComment, int segmentSize)
         {
-            foreach (string lineEnding in new string[] { "\r", "\r ", "\r\n", "\r\n ", "\n", "\n " })
+            foreach (string lineEnding in new string[] { "\r", "\r ", "\r\n", "\r\n ", "\n", "\n ", "" })
             {
                 foreach (bool isFinalBlock in new bool[] { false, true })
                 {
-                    if (!isFinalBlock && lineEnding == "\r")
+                    if (!isFinalBlock && (lineEnding == "\r" || lineEnding == ""))
                     {
                         // In this case parser would return false on the first Read (and check for \n on the next segment)
                         // which is not the purpose of this test and is covered separately

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -2701,6 +2701,56 @@ namespace System.Text.Json.Tests
             }
         }
 
+        [Theory]
+        [InlineData("//\u2028")]
+        [InlineData("//\u2029")]
+        [InlineData("// \u2028")]
+        [InlineData("//   \u2028")]
+        [InlineData("//  \u2029 ")]
+        [InlineData("//  \u2029  ")]
+        public static void JsonWithSingleLineCommentEndingWithNonStandardLineEnding(string jsonString)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
+            var json = new Utf8JsonReader(dataUtf8, isFinalBlock: true, state);
+
+            try
+            {
+                json.Read();
+                Assert.True(false, "Expected JsonException was not thrown.");
+            }
+            catch (JsonException) { }
+        }
+
+        [Theory]
+        // Non-standard line-endings are: \u2028 \u2029 (E2, 80, A8/A9)
+        // last byte does not match (E2, 80, AA)
+        [InlineData("//\u2030\n", "\u2030")]
+        [InlineData("//\u2030 \r\n", "\u2030 ")]
+        [InlineData("// \u2030\r", " \u2030")]
+        [InlineData("//\u2030\u2031\n", "\u2030\u2031")]
+        [InlineData("//\u2030 \u2031\r\n", "\u2030 \u2031")]
+        [InlineData("// \u2030 \u2031\n", " \u2030 \u2031")]
+        [InlineData("// \u2030 \u2031 \r", " \u2030 \u2031 ")]
+        // second byte does not match (E2, 81, A8/A9)
+        [InlineData("//\u2069\r\n", "\u2069")]
+        [InlineData("// \u2069\r", " \u2069")]
+        [InlineData("//\u2069 \n", "\u2069 ")]
+        [InlineData("//\u2069\u2068\n", "\u2069\u2068")]
+        [InlineData("//\u2069 \u2068\n", "\u2069 \u2068")]
+        [InlineData("//\u2069 \u2068 \u2068\n", "\u2069 \u2068 \u2068")]
+        [InlineData("// \u2069 \u2068 \u2068 \n", " \u2069 \u2068 \u2068 ")]
+        public static void JsonWithSingleCorrectLineCommentWithPartialNonStandardLineEnding(string jsonString, string expectedComment)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            var state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Allow });
+            var json = new Utf8JsonReader(dataUtf8, isFinalBlock: true, state);
+
+            Assert.True(json.Read());
+            Assert.Equal(expectedComment, json.GetComment());
+            Assert.False(json.Read());
+        }
+
         [Fact]
         public static void EmptyJsonIsInvalid()
         {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/33321
Fixes: https://github.com/dotnet/corefx/issues/37931
(also some other fixes - see below)

Some Unicode characters (i.e. U+2028, U+2029) are considered line endings and are sometimes used in some attack vectors when coming over the wire.

This change causes that parser will throw an exception if such character is encountered in a comment.

Also fixes couple of issues w.r.t to single-line comment handling with both mult- and single segment case around EOF/final block which I haven't reported. I.e.:
- end of json on `\r`
- end of json on empty comment in the end (i.e. `{}//` would cause parser to throw)

Perf results are here: dotnet/performance#543