### PR TITLE
Disable warning suppressions related to missing XML comments within S.T.Json.

### DIFF
--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -9,6 +9,10 @@
     <!-- BUILDING_INBOX_LIBRARY is only false when building for netstandard to validate that the sources are netstandard compatible. -->
     <!-- This is meant to help with producing a source package and not to ship a netstandard compatible binary. -->
     <DefineConstants Condition="'$(TargetsNETStandard)' != 'true'">$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants>
+    <!-- Workaround for overriding the XML comments related warnings that are being supressed repo wide (within arcade): -->
+    <!-- https://github.com/dotnet/arcade/blob/ea6addfdc65e5df1b2c036f11614a5f922e36267/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props#L90 -->
+    <!-- For this project, we want warnings if there are public APIs/types without properly formatted XML comments (particularly CS1591). -->
+    <NoWarn/>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Text\Json\BitStack.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/JsonException.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonException.cs
@@ -48,6 +48,14 @@ namespace System.Text.Json
             Path = path;
         }
 
+        /// <summary>
+        /// Creates a new exception object with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="info"/> is <see langword="null" />.
+        /// </exception>
         protected JsonException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             LineNumber = (long?)info.GetValue("LineNumber", typeof(long?));

--- a/src/System.Text.Json/src/System/Text/Json/JsonTokenType.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonTokenType.cs
@@ -15,17 +15,68 @@ namespace System.Text.Json
     {
         // Do not re-order.
         // We rely on the ordering to quickly check things like IsTokenTypePrimitive
+
+        /// <summary>
+        ///   Indicates that there is no value (as distinct from <see cref="Null"/>).
+        /// </summary>
+        /// <remarks>
+        ///   This is the default token type if no data has been read by the <see cref="Utf8JsonReader"/>.
+        /// </remarks>
         None,
+
+        /// <summary>
+        ///   Indicates that the token type is the start of a JSON object.
+        /// </summary>
         StartObject,
+
+        /// <summary>
+        ///   Indicates that the token type is the end of a JSON object.
+        /// </summary>
         EndObject,
+
+        /// <summary>
+        ///   Indicates that the token type is the start of a JSON array.
+        /// </summary>
         StartArray,
+
+        /// <summary>
+        ///   Indicates that the token type is the end of a JSON array.
+        /// </summary>
         EndArray,
+
+        /// <summary>
+        ///   Indicates that the token type is a JSON property name.
+        /// </summary>
         PropertyName,
+
+        /// <summary>
+        ///   Indicates that the token type is a JSON string.
+        /// </summary>
         String,
+
+        /// <summary>
+        ///   Indicates that the token type is a JSON number.
+        /// </summary>
         Number,
+
+        /// <summary>
+        ///   Indicates that the token type is the JSON literal <c>true</c>.
+        /// </summary>
         True,
+
+        /// <summary>
+        ///   Indicates that the token type is the JSON literal <c>false</c>.
+        /// </summary>
         False,
+
+        /// <summary>
+        ///   Indicates that the token type is the JSON literal <c>null</c>.
+        /// </summary>
         Null,
+
+        /// <summary>
+        ///   Indicates that the token type is the comment string.
+        /// </summary>
         Comment,
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonIgnoreAttribute.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonIgnoreAttribute.cs
@@ -10,6 +10,9 @@ namespace System.Text.Json.Serialization
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
     public sealed class JsonIgnoreAttribute : JsonAttribute
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="JsonIgnoreAttribute"/>.
+        /// </summary>
         public JsonIgnoreAttribute() { }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonNamingPolicy.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonNamingPolicy.cs
@@ -9,6 +9,9 @@ namespace System.Text.Json.Serialization
     /// </summary>
     public abstract class JsonNamingPolicy
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="JsonNamingPolicy"/>.
+        /// </summary>
         protected JsonNamingPolicy() { }
 
         /// <summary>


### PR DESCRIPTION
cc @steveharter, @stephentoub, @carlossanlop, @safern, @danmosemsft, @mairaw, @terrajobst 

We probably want to do the same thing for other recent/new projects going forward.