### PR TITLE
LoopbackProxyServer cleanup

### DIFF
--- a/src/Common/tests/System/Net/EventSourceTestLogging.cs
+++ b/src/Common/tests/System/Net/EventSourceTestLogging.cs
@@ -32,6 +32,12 @@ namespace System.Net.Test.Common
             WriteEvent(2, message);
         }
 
+        [Event(3, Keywords = Keywords.Debug, Level = EventLevel.Error)]
+        public void TestAncillaryError(Exception ex)
+        {
+            WriteEvent(3, ex.ToString());
+        }
+
         public static class Keywords
         {
             public const EventKeywords Default = (EventKeywords)0x0001;

--- a/src/Common/tests/System/Net/Http/LoopbackProxyServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackProxyServer.cs
@@ -268,20 +268,18 @@ namespace System.Net.Test.Common
             {
                 SocketError sockErr = (ex.InnerException as SocketException)?.SocketErrorCode ?? SocketError.Success;
 
-                // if aborted, the other task failed and is asking this task to end.
-
+                // If aborted, the other task failed and is asking this task to end.
                 if (sockErr == SocketError.OperationAborted)
                 {
                     return;
                 }
 
-                // ask the other task to end by disposing, causing OperationAborted.
-
+                // Ask the other task to end by disposing, causing OperationAborted.
                 try
                 {
                     clientSocket.Close();
                 }
-                catch(ObjectDisposedException)
+                catch (ObjectDisposedException)
                 {
                 }
 
@@ -293,8 +291,7 @@ namespace System.Net.Test.Common
                 {
                 }
 
-                // eat reset/abort.
-
+                // Eat reset/abort.
                 if (sockErr != SocketError.ConnectionReset && sockErr != SocketError.ConnectionAborted)
                 {
                     ExceptionDispatchInfo.Throw(ex);

--- a/src/Common/tests/System/Net/Http/LoopbackProxyServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackProxyServer.cs
@@ -294,7 +294,7 @@ namespace System.Net.Test.Common
                 // Eat reset/abort.
                 if (sockErr != SocketError.ConnectionReset && sockErr != SocketError.ConnectionAborted)
                 {
-                    ExceptionDispatchInfo.Throw(ex);
+                    ExceptionDispatchInfo.Capture(ex).Throw();
                 }
             }
         }

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{7C395A91-D955-444C-98BF-D3F809A56CE1}</ProjectGuid>
     <StringResourcesPath>../src/Resources/Strings.resx</StringResourcesPath>
@@ -27,6 +27,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Configuration.WebSockets.cs">
       <Link>Common\System\Net\Configuration.WebSockets.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\EventSourceTestLogging.cs">
+      <Link>Common\System\Net\EventSourceTestLogging.cs</Link>
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Http\LoopbackProxyServer.cs">
       <Link>Common\System\Net\Http\LoopbackProxyServer.cs</Link>


### PR DESCRIPTION
This makes `LoopbackProxyServer` behave more properly as a server should.

- Ensure all connections are finished prior to `LoopbackProxyServer.Dispose()` returning.
- `Shutdown()` CONNECT sessions properly, and don't leave tasks hanging.
- `Dispose()` sockets rather than relying on finalizers.
- Eat fewer errors automatically, and expose uneaten errors via event to assist with troubleshooting.

Resolves #32808. Thanks @davidsh reminding me `~Socket()` without shutdown will not flush buffers and instead RST immediately -- confirmed with Wireshark. Above fixes resolve this.