### PR TITLE
Add read ahead logic for streams.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -195,6 +195,11 @@ namespace System.Text.Json.Serialization
         {
             var reader = new Utf8JsonReader(buffer, isFinalBlock, readerState);
 
+            // If we haven't read in all the data we need to read ahead when reading a json object
+            // or array into a single .NET object so the JsonDocument has all of the needed data
+            // to parse.
+            options.ReadAhead = !isFinalBlock;
+
             ReadCore(
                 options,
                 ref reader,

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -196,9 +196,10 @@ namespace System.Text.Json.Serialization
         {
             var reader = new Utf8JsonReader(buffer, isFinalBlock, readerState);
 
-            // If we haven't read in all the data we need to read ahead when reading a json object
-            // or array into a single .NET object so the JsonDocument has all of the needed data
-            // to parse.
+            // If we haven't read in the entire stream's payload we'll need signify that we want
+            // to enable read ahead behaviors to ensure we have complete json objects and arrays
+            // ({}, []) when needed. (Notably to successfully parse JsonElement via JsonDocument
+            // to assign to object and JsonElement properties in the constructed .NET object.)
             options.ReadAhead = !isFinalBlock;
             readStack.BytesConsumed = 0;
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -83,8 +83,8 @@ namespace System.Text.Json.Serialization
                 options = JsonSerializerOptions.s_defaultOptions;
             }
 
-            ReadStack state = default;
-            state.Current.Initialize(returnType, options);
+            ReadStack readStack = default;
+            readStack.Current.Initialize(returnType, options);
 
             var readerState = new JsonReaderState(options.GetReaderOptions());
 
@@ -138,10 +138,11 @@ namespace System.Text.Json.Serialization
                         isFinalBlock,
                         new Span<byte>(buffer, 0, bytesInBuffer),
                         options,
-                        ref state);
+                        ref readStack);
 
-                    Debug.Assert(readerState.BytesConsumed <= bytesInBuffer);
-                    int bytesConsumed = (int)readerState.BytesConsumed;
+                    Debug.Assert(readStack.BytesConsumed <= bytesInBuffer);
+                    int bytesConsumed = checked((int)readStack.BytesConsumed);
+
                     bytesInBuffer -= bytesConsumed;
 
                     if (isFinalBlock)
@@ -183,7 +184,7 @@ namespace System.Text.Json.Serialization
                 ThrowHelper.ThrowJsonException_DeserializeDataRemaining(totalBytesRead, bytesInBuffer);
             }
 
-            return (TValue)state.Current.ReturnValue;
+            return (TValue)readStack.Current.ReturnValue;
         }
 
         private static void ReadCore(
@@ -191,7 +192,7 @@ namespace System.Text.Json.Serialization
             bool isFinalBlock,
             Span<byte> buffer,
             JsonSerializerOptions options,
-            ref ReadStack state)
+            ref ReadStack readStack)
         {
             var reader = new Utf8JsonReader(buffer, isFinalBlock, readerState);
 
@@ -199,11 +200,12 @@ namespace System.Text.Json.Serialization
             // or array into a single .NET object so the JsonDocument has all of the needed data
             // to parse.
             options.ReadAhead = !isFinalBlock;
+            readStack.BytesConsumed = 0;
 
             ReadCore(
                 options,
                 ref reader,
-                ref state);
+                ref readStack);
 
             readerState = reader.CurrentState;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -196,7 +196,7 @@ namespace System.Text.Json.Serialization
         {
             var reader = new Utf8JsonReader(buffer, isFinalBlock, readerState);
 
-            // If we haven't read in the entire stream's payload we'll need signify that we want
+            // If we haven't read in the entire stream's payload we'll need to signify that we want
             // to enable read ahead behaviors to ensure we have complete json objects and arrays
             // ({}, []) when needed. (Notably to successfully parse JsonElement via JsonDocument
             // to assign to object and JsonElement properties in the constructed .NET object.)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -314,5 +314,10 @@ namespace System.Text.Json.Serialization
                 ThrowHelper.ThrowInvalidOperationException_SerializerOptionsImmutable();
             }
         }
+
+        /// <summary>
+        /// Internal flag to let us know that we need to read ahead in the inner read loop.
+        /// </summary>
+        internal bool ReadAhead { get; set; }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -145,5 +145,10 @@ namespace System.Text.Json.Serialization
 
             return propertyName;
         }
+
+        /// <summary>
+        /// Bytes consumed in the current loop
+        /// </summary>
+        public long BytesConsumed;
     }
 }

--- a/src/System.Text.Json/tests/Serialization/JsonElementTests.cs
+++ b/src/System.Text.Json/tests/Serialization/JsonElementTests.cs
@@ -152,7 +152,7 @@ namespace System.Text.Json.Serialization.Tests
             InlineData(10),
             InlineData(20),
             InlineData(1024)]
-        public static void ReadFromStream(int defaultBufferSize)
+        public void ReadJsonElementFromStream(int defaultBufferSize)
         {
             // Streams need to read ahead when they hit objects or arrays that are assigned to JsonElement or object.
 
@@ -163,6 +163,15 @@ namespace System.Text.Json.Serialization.Tests
             data = Encoding.UTF8.GetBytes(@"[1,true,{""City"":""MyCity""},null,""foo""]");
             stream = new MemoryStream(data);
             obj = JsonSerializer.ReadAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result;
+
+            // Ensure we fail with incomplete data
+            data = Encoding.UTF8.GetBytes(@"{""Data"":[1,true,{""City"":""MyCity""},null,""foo""]");
+            stream = new MemoryStream(data);
+            Assert.Throws<JsonException>(() => JsonSerializer.ReadAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result);
+
+            data = Encoding.UTF8.GetBytes(@"[1,true,{""City"":""MyCity""},null,""foo""");
+            stream = new MemoryStream(data);
+            Assert.Throws<JsonException>(() => JsonSerializer.ReadAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/JsonElementTests.cs
+++ b/src/System.Text.Json/tests/Serialization/JsonElementTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using System.Linq;
 using Xunit;
 
@@ -144,6 +145,24 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(JsonValueType.String, Array[3].Type);
                 Assert.Equal("Hello", Array[3].ToString());
             }
+        }
+
+        [Theory,
+            InlineData(5),
+            InlineData(10),
+            InlineData(20),
+            InlineData(1024)]
+        public static void ReadFromStream(int defaultBufferSize)
+        {
+            // Streams need to read ahead when they hit objects or arrays that are assigned to JsonElement or object.
+
+            byte[] data = Encoding.UTF8.GetBytes(@"{""Data"":[1,true,{""City"":""MyCity""},null,""foo""]}");
+            MemoryStream stream = new MemoryStream(data);
+            JsonElement obj = JsonSerializer.ReadAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result;
+
+            data = Encoding.UTF8.GetBytes(@"[1,true,{""City"":""MyCity""},null,""foo""]");
+            stream = new MemoryStream(data);
+            obj = JsonSerializer.ReadAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result;
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/SpanTests.cs
+++ b/src/System.Text.Json/tests/Serialization/SpanTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -20,6 +21,27 @@ namespace System.Text.Json.Serialization.Tests
         public static void Read(Type classType, byte[] data)
         {
             object obj = JsonSerializer.Parse(data, classType);
+            Assert.IsAssignableFrom(typeof(ITestClass), obj);
+            ((ITestClass)obj).Verify();
+        }
+
+        [Theory]
+        [MemberData(nameof(ReadSuccessCases))]
+        public static void ReadFromStream(Type classType, byte[] data)
+        {
+            MemoryStream stream = new MemoryStream(data);
+            object obj = JsonSerializer.ReadAsync(
+                stream,
+                classType).Result;
+            Assert.IsAssignableFrom(typeof(ITestClass), obj);
+            ((ITestClass)obj).Verify();
+
+            // Try again with a smaller initial buffer size to ensure we handle incomplete data
+            stream = new MemoryStream(data);
+            obj = JsonSerializer.ReadAsync(
+                stream,
+                classType,
+                new JsonSerializerOptions { DefaultBufferSize = 5 }).Result;
             Assert.IsAssignableFrom(typeof(ITestClass), obj);
             ((ITestClass)obj).Verify();
         }

--- a/src/System.Text.Json/tests/Serialization/SpanTests.cs
+++ b/src/System.Text.Json/tests/Serialization/SpanTests.cs
@@ -33,6 +33,7 @@ namespace System.Text.Json.Serialization.Tests
             object obj = JsonSerializer.ReadAsync(
                 stream,
                 classType).Result;
+
             Assert.IsAssignableFrom(typeof(ITestClass), obj);
             ((ITestClass)obj).Verify();
 
@@ -42,6 +43,7 @@ namespace System.Text.Json.Serialization.Tests
                 stream,
                 classType,
                 new JsonSerializerOptions { DefaultBufferSize = 5 }).Result;
+
             Assert.IsAssignableFrom(typeof(ITestClass), obj);
             ((ITestClass)obj).Verify();
         }


### PR DESCRIPTION
When reading a json object or array from a stream into an object we need to TrySkip to ensure that we have all the needed data for the JsonDocument to create a JsonElement. This is only necessary  if we haven't already drained the stream.