### PR TITLE
Don't display any GUI during test run.

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -229,7 +229,9 @@ namespace System.Diagnostics.Tests
             }
 
             // Open a file that doesn't exist with an argument that xdg-open considers invalid.
-            using (var px = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = "/nosuchfile", Arguments = "invalid_arg" }))
+            var startInfo = new ProcessStartInfo { UseShellExecute = true, FileName = "/nosuchfile", Arguments = "invalid_arg" };
+            startInfo.Environment.Remove("DISPLAY"); // Get rid of DISPLAY environment variable as this causes spurious test failures.
+            using (var px = Process.Start(startInfo))
             {
                 Assert.NotNull(px);
                 px.WaitForExit();


### PR DESCRIPTION
This was displaying a message box on screen and causing a spurious test failure.

This test won't ever fail on the test runner but fails if ran with `./build.sh -test` from an xterm.