### PR TITLE
[System.Text.Json]Improve error output for unsupported scenarios in System.Text.Json.Serialization

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -369,9 +369,9 @@
     <value>Comments cannot be stored when deserializing objects, only the Skip and Disallow comment handling modes are supported.</value>
   </data>
   <data name="DeserializeMissingParameterlessConstructor" xml:space="preserve">
-    <value>Deserialization of reference types without parameterless constructor is not supported. Type {0}</value>
+    <value>Deserialization of reference types without parameterless constructor is not supported. Type '{0}'</value>
   </data>
   <data name="DeserializePolymorphicInterface" xml:space="preserve">
-    <value>Deserialization of interface types is not supported. Type {0}</value>
+    <value>Deserialization of interface types is not supported. Type '{0}'</value>
   </data>
 </root>

--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -368,4 +368,7 @@
   <data name="JsonSerializerDoesNotSupportComments" xml:space="preserve">
     <value>Comments cannot be stored when deserializing objects, only the Skip and Disallow comment handling modes are supported.</value>
   </data>
+  <data name="DeserializeMissingParameterlessConstructor" xml:space="preserve">
+    <value>Deserialization of reference types without parameterless constructor is not supported. Type {0}</value>
+  </data>
 </root>

--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -371,4 +371,7 @@
   <data name="DeserializeMissingParameterlessConstructor" xml:space="preserve">
     <value>Deserialization of reference types without parameterless constructor is not supported. Type {0}</value>
   </data>
+  <data name="DeserializePolymorphicInterface" xml:space="preserve">
+    <value>Deserialization of interface types is not supported. Type {0}</value>
+  </data>
 </root>

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -29,9 +29,16 @@ namespace System.Text.Json.Serialization
 
             JsonClassInfo classInfo = state.Current.JsonClassInfo;
 
-            if (classInfo.ClassType == ClassType.Object && classInfo.CreateObject is null)
+            if (classInfo.CreateObject is null && classInfo.ClassType == ClassType.Object)
             {
-                ThrowHelper.ThrowInvalidOperationException_DeserializeMissingParameterlessConstructor(classInfo.Type);
+                if (classInfo.Type.IsInterface)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_DeserializePolymorphicInterface(classInfo.Type);
+                }
+                else
+                {
+                    ThrowHelper.ThrowInvalidOperationException_DeserializeMissingParameterlessConstructor(classInfo.Type);
+                }
             }
 
             state.Current.ReturnValue = classInfo.CreateObject();

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -28,6 +28,12 @@ namespace System.Text.Json.Serialization
             }
 
             JsonClassInfo classInfo = state.Current.JsonClassInfo;
+
+            if (classInfo.ClassType == ClassType.Object && classInfo.CreateObject is null)
+            {
+                ThrowHelper.ThrowInvalidOperationException_DeserializeMissingParameterlessConstructor(classInfo.Type);
+            }
+
             state.Current.ReturnValue = classInfo.CreateObject();
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReflectionMaterializer.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReflectionMaterializer.cs
@@ -12,6 +12,14 @@ namespace System.Text.Json.Serialization
     {
         public override JsonClassInfo.ConstructorDelegate CreateConstructor(Type type)
         {
+            Debug.Assert(type != null);
+            ConstructorInfo realMethod = type.GetConstructor(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, binder: null, Type.EmptyTypes, modifiers: null);
+
+            if (realMethod == null && !type.IsValueType)
+            {
+                return null;
+            }
+
             return () => Activator.CreateInstance(type);
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -122,5 +122,11 @@ namespace System.Text.Json
         {
             throw new InvalidOperationException(SR.Format(SR.SerializationDataExtensionPropertyInvalidElement, jsonClassInfo.Type, jsonClassInfo.DataExtensionProperty.PropertyInfo.Name, invalidType));
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_DeserializeMissingParameterlessConstructor(Type invalidType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.DeserializeMissingParameterlessConstructor, invalidType));
+        }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -128,5 +128,11 @@ namespace System.Text.Json
         {
             throw new InvalidOperationException(SR.Format(SR.DeserializeMissingParameterlessConstructor, invalidType));
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_DeserializePolymorphicInterface(Type invalidType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.DeserializePolymorphicInterface, invalidType));
+        }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -126,13 +126,13 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_DeserializeMissingParameterlessConstructor(Type invalidType)
         {
-            throw new InvalidOperationException(SR.Format(SR.DeserializeMissingParameterlessConstructor, invalidType));
+            throw new NotSupportedException(SR.Format(SR.DeserializeMissingParameterlessConstructor, invalidType));
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_DeserializePolymorphicInterface(Type invalidType)
         {
-            throw new InvalidOperationException(SR.Format(SR.DeserializePolymorphicInterface, invalidType));
+            throw new NotSupportedException(SR.Format(SR.DeserializePolymorphicInterface, invalidType));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -161,6 +161,25 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ReadObjectFail_ReferenceTypeMissingParameterlessConstructor()
+        {
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<PublicParameterizedConstructorTestClass>(@"{""Name"":""Name!""}"));
+        }
+
+        class PublicParameterizedConstructorTestClass
+        {
+            private readonly string _name;
+            public PublicParameterizedConstructorTestClass(string name)
+            {
+                _name = name;
+            }
+            public string Name
+            {
+                get { return _name; }
+            }
+        }
+
+        [Fact]
         public static void ParseUntyped()
         {
             // Not supported until we are able to deserialize into JsonElement.

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -163,7 +163,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadObjectFail_ReferenceTypeMissingParameterlessConstructor()
         {
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<PublicParameterizedConstructorTestClass>(@"{""Name"":""Name!""}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Parse<PublicParameterizedConstructorTestClass>(@"{""Name"":""Name!""}"));
         }
 
         class PublicParameterizedConstructorTestClass

--- a/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
@@ -391,7 +391,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void PolymorphicInterface_NotSupported()
         {
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<MyClass>(@"{ ""Value"": ""A value"", ""Thing"": { ""Number"": 123 } }"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Parse<MyClass>(@"{ ""Value"": ""A value"", ""Thing"": { ""Number"": 123 } }"));
         }
 
         class MyClass

--- a/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
@@ -386,6 +386,28 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(typeof(UsaCustomer), deserializedCustomer.GetType());
             Assert.Equal(typeof(Address), deserializedCustomer.Address.GetType());
             ((Customer)deserializedCustomer).VerifyNonVirtual();
-       }
+        }
+
+        [Fact]
+        public static void PolymorphicInterface_NotSupported()
+        {
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<MyClass>(@"{ ""Value"": ""A value"", ""Thing"": { ""Number"": 123 } }"));
+        }
+
+        class MyClass
+        {
+            public string Value { get; set; }
+            public IThing Thing { get; set; }
+        }
+
+        interface IThing
+        {
+            int Number { get; set; }
+        }
+
+        class MyThing : IThing
+        {
+            public int Number { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Contrib to https://github.com/dotnet/corefx/issues/37545

fixes https://github.com/dotnet/corefx/issues/37885 polymorphic interface
fixes https://github.com/dotnet/corefx/issues/37537 parameterless ctor

Exception samples 
`System.InvalidOperationException : Deserialization of reference type without parameterless constructor is not supported. Type System.Text.Json.Serialization.Tests.ObjectTests+PublicParameterizedConstructorTestClass`  

`System.InvalidOperationException : Deserialization of interface types is not supported. Type System.Text.Json.Serialization.Tests.PolymorphicTests+IThing`

cc: @ahsonkhan @steveharter 