### PR TITLE
Spanify Cryptography.Base64Transform

### DIFF
--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -23,6 +23,9 @@
     <Compile Include="$(CommonPath)\Internal\Cryptography\Helpers.cs">
       <Link>Internal\Cryptography\Helpers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
+      <Link>System\Security\Cryptography\CryptoPool.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true'">
     <Compile Include="Internal\Cryptography\AsnFormatter.Windows.cs" />

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{AA81E343-5E54-40B0-9381-C459419BE780}</ProjectGuid>
     <AssemblyName>System.Security.Cryptography.Encoding</AssemblyName>
@@ -100,9 +100,6 @@
   <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
     <Compile Include="$(CommonPath)\System\Memory\PointerMemoryManager.cs">
       <Link>Common\System\Memory\PointerMemoryManager.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Security\Cryptography\CryptoPool.cs">
-      <Link>Common\System\Security\Cryptography\CryptoPool.cs</Link>
     </Compile>
     <AsnXml Include="$(CommonPath)\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml">
       <Link>Common\System\Security\Cryptography\Asn1\DirectoryStringAsn.xml</Link>

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -195,7 +195,7 @@ namespace System.Security.Cryptography
             tmpBuffer = GetTempBuffer(inputBuffer.AsSpan(inputOffset, inputCount), tmpBuffer);
             int bytesToTransform = _inputIndex + tmpBuffer.Length;
 
-            // To little data to decode
+            // Too little data to decode
             if (bytesToTransform < Base64InputBlockSize)
             {
                 // reinitialize the transform
@@ -259,7 +259,6 @@ namespace System.Security.Cryptography
             // FORM FEED    12
             // CR           13
 
-            // RyuJIT produces better code with the ternary. This JIT-bug is tracked in https://github.com/dotnet/coreclr/issues/914
             return value == 32 || ((uint)value - 9 <= (13 - 9));
         }
 
@@ -289,6 +288,7 @@ namespace System.Security.Cryptography
         private void ConvertFromBase64(Span<byte> tmpBuffer, Span<byte> outputBuffer, out int consumed, out int written)
         {
             int bytesToTransform = _inputIndex + tmpBuffer.Length;
+            Debug.Assert(bytesToTransform >= 4);
 
             // Common case for bytesToTransform = 4
             byte[] transformBufferArray = null;

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -122,6 +122,8 @@ namespace System.Security.Cryptography
 
         // Converting from Base64 generates 3 bytes output from each 4 bytes input block
         private const int Base64InputBlockSize = 4;
+        // A buffer with size 32 is stack allocated, to cover common cases and benefit from JIT's optimizations.
+        private const int StackAllocSize = 32;
         public int InputBlockSize => 1;
         public int OutputBlockSize => 3;
         public bool CanTransformMultipleBlocks => false;
@@ -140,8 +142,8 @@ namespace System.Security.Cryptography
 
             // The common case is inputCount = InputBlockSize
             byte[] tmpBufferArray = null;
-            Span<byte> tmpBuffer = stackalloc byte[InputBlockSize];
-            if (inputCount > InputBlockSize)
+            Span<byte> tmpBuffer = stackalloc byte[StackAllocSize];
+            if (inputCount > StackAllocSize)
             {
                 tmpBuffer = tmpBufferArray = CryptoPool.Rent(inputCount);
             }
@@ -185,8 +187,8 @@ namespace System.Security.Cryptography
 
             // The common case is inputCount <= Base64InputBlockSize
             byte[] tmpBufferArray = null;
-            Span<byte> tmpBuffer = stackalloc byte[Base64InputBlockSize];
-            if (inputCount > Base64InputBlockSize)
+            Span<byte> tmpBuffer = stackalloc byte[StackAllocSize];
+            if (inputCount > StackAllocSize)
             {
                 tmpBuffer = tmpBufferArray = CryptoPool.Rent(inputCount);
             }
@@ -288,10 +290,9 @@ namespace System.Security.Cryptography
             int bytesToTransform = _inputIndex + tmpBuffer.Length;
             Debug.Assert(bytesToTransform >= 4);
 
-            // Common case for bytesToTransform = 4
             byte[] transformBufferArray = null;
-            Span<byte> transformBuffer = stackalloc byte[4];
-            if (bytesToTransform > 4)
+            Span<byte> transformBuffer = stackalloc byte[StackAllocSize];
+            if (bytesToTransform > StackAllocSize)
             {
                 transformBuffer = transformBufferArray = CryptoPool.Rent(bytesToTransform);
             }

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -8,7 +8,6 @@
 using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
-using System.Text;
 
 namespace System.Security.Cryptography
 {

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -229,19 +229,36 @@ namespace System.Security.Cryptography
             return DiscardWhiteSpaces(inputBuffer, tmpBuffer);
         }
 
-        private Span<byte> DiscardWhiteSpaces(Span<byte> inputBuffer, Span<byte> tmpBuffer)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Span<byte> DiscardWhiteSpaces(Span<byte> inputBuffer, Span<byte> tmpBuffer)
         {
             int count = 0;
 
             for (int i = 0; i < inputBuffer.Length; i++)
             {
-                if (!char.IsWhiteSpace((char)inputBuffer[i]))
+                if (!IsWhitespace(inputBuffer[i]))
                 {
                     tmpBuffer[count++] = inputBuffer[i];
                 }
             }
 
             return tmpBuffer.Slice(0, count);
+        }
+
+        private static bool IsWhitespace(byte value)
+        {
+            // We assume ASCII encoded data. If there is any non-ASCII char, so it is invalid
+            // Base64 and will be caught during decoding.
+
+            // SPACE        32
+            // TAB           9
+            // LF           10
+            // VTAB         11
+            // FORM FEED    12
+            // CR           13
+
+            // https://github.com/dotnet/coreclr/issues/914
+            return value == 32 || ((uint)value - 9 <= (13 - 9)) ? true : false;
         }
 
         private void ConvertFromBase64(Span<byte> tmpBuffer, Span<byte> outputBuffer, out int consumed, out int written)

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography
 
         public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
         {
-            ThrowHelper.ValidateTransformBlock(inputBuffer, inputOffset, inputCount);
+            ThrowHelper.ValidateTransformBlock(inputBuffer, inputOffset, inputCount, InputBlockSize);
             if (outputBuffer == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.outputBuffer);
 
             // For now, only convert 3 bytes to 4
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography
             }
             else if (inputCount > InputBlockSize)
             {
-                ThrowHelper.ThrowInvalidOffLen();
+                ThrowHelper.ThrowArgumentInvalidValue();
             }
 
             // Again, for now only a block at a time
@@ -117,7 +117,7 @@ namespace System.Security.Cryptography
 
         public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
         {
-            ThrowHelper.ValidateTransformBlock(inputBuffer, inputOffset, inputCount);
+            ThrowHelper.ValidateTransformBlock(inputBuffer, inputOffset, inputCount, InputBlockSize);
             if (outputBuffer == null) ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.outputBuffer);
 
             if (_inputBuffer == null)
@@ -322,6 +322,12 @@ namespace System.Security.Cryptography
             if (inputOffset < 0) ThrowArgumentOutOfRangeNeedNonNegNum(ExceptionArgument.inputOffset);
             if ((uint)inputCount > inputBuffer.Length) ThrowArgumentInvalidValue();
             if ((inputBuffer.Length - inputCount) < inputOffset) ThrowInvalidOffLen();
+        }
+
+        public static void ValidateTransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, int inputBlockSize)
+        {
+            ValidateTransformBlock(inputBuffer, inputOffset, inputCount);
+            if (inputCount != inputBlockSize) ThrowArgumentInvalidValue();
         }
 
         public static void ThrowArgumentNull(ExceptionArgument argument) => throw new ArgumentNullException(argument.ToString());

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -121,7 +121,8 @@ namespace System.Security.Cryptography
         }
 
         // Converting from Base64 generates 3 bytes output from each 4 bytes input block
-        public int InputBlockSize => 4;
+        private const int Base64InputBlockSize = 4;
+        public int InputBlockSize => 1;
         public int OutputBlockSize => 3;
         public bool CanTransformMultipleBlocks => false;
         public virtual bool CanReuseTransform => true;
@@ -137,10 +138,10 @@ namespace System.Security.Cryptography
             if (outputBuffer == null)
                 ThrowHelper.ThrowArgumentNull(ThrowHelper.ExceptionArgument.outputBuffer);
 
-            // The common case is inputCount = 4
+            // The common case is inputCount = InputBlockSize
             byte[] tmpBufferArray = null;
-            Span<byte> tmpBuffer = stackalloc byte[4];
-            if (inputCount > 4)
+            Span<byte> tmpBuffer = stackalloc byte[InputBlockSize];
+            if (inputCount > InputBlockSize)
             {
                 tmpBuffer = tmpBufferArray = CryptoPool.Rent(inputCount);
             }
@@ -149,7 +150,7 @@ namespace System.Security.Cryptography
             int bytesToTransform = _inputIndex + tmpBuffer.Length;
 
             // To little data to decode: save data to _inputBuffer, so it can be transformed later
-            if (bytesToTransform < InputBlockSize)
+            if (bytesToTransform < Base64InputBlockSize)
             {
                 tmpBuffer.CopyTo(_inputBuffer.AsSpan(_inputIndex));
 
@@ -181,10 +182,10 @@ namespace System.Security.Cryptography
                 return Array.Empty<byte>();
             }
 
-            // The common case is inputCount <= 4
+            // The common case is inputCount <= Base64InputBlockSize
             byte[] tmpBufferArray = null;
-            Span<byte> tmpBuffer = stackalloc byte[4];
-            if (inputCount > 4)
+            Span<byte> tmpBuffer = stackalloc byte[Base64InputBlockSize];
+            if (inputCount > Base64InputBlockSize)
             {
                 tmpBuffer = tmpBufferArray = CryptoPool.Rent(inputCount);
             }
@@ -193,7 +194,7 @@ namespace System.Security.Cryptography
             int bytesToTransform = _inputIndex + tmpBuffer.Length;
 
             // To little data to decode
-            if (bytesToTransform < InputBlockSize)
+            if (bytesToTransform < Base64InputBlockSize)
             {
                 // reinitialize the transform
                 Reset();

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -187,6 +187,7 @@ namespace System.Security.Cryptography
 
                 if (resultBufferArray != null)
                 {
+                    resultBuffer.Clear();
                     ArrayPool<byte>.Shared.Return(resultBufferArray);
                 }
 
@@ -258,7 +259,8 @@ namespace System.Security.Cryptography
 
             if (transformBufferArray != null)
             {
-                ArrayPool<byte>.Shared.Return(transformBufferArray, clearArray: true);
+                transformBuffer.Clear();
+                ArrayPool<byte>.Shared.Return(transformBufferArray);
             }
         }
 

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -164,9 +164,8 @@ namespace System.Security.Cryptography
                 return Array.Empty<byte>();
             }
 
-            byte[] tmpBufferArray = null;
-
             // The common case is <= 4
+            byte[] tmpBufferArray = null;
             Span<byte> tmpBuffer = inputCount <= 4
                 ? stackalloc byte[4]
                 : inputCount <= 256
@@ -265,9 +264,8 @@ namespace System.Security.Cryptography
         {
             int bytesToTransform = _inputIndex + tmpBuffer.Length;
 
-            byte[] transformBufferArray = null;
-
             // Common case for bytesToTransform = 4
+            byte[] transformBufferArray = null;
             Span<byte> transformBuffer = bytesToTransform <= 4
                 ? stackalloc byte[4]
                 : bytesToTransform <= 256

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -8,6 +8,7 @@
 using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace System.Security.Cryptography
 {
@@ -325,14 +326,16 @@ namespace System.Security.Cryptography
 
     internal class ThrowHelper
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ValidateTransformBlock(byte[] inputBuffer, int inputOffset, int inputCount)
         {
             if (inputBuffer == null) ThrowArgumentNull(ExceptionArgument.inputBuffer);
-            if (inputOffset < 0) ThrowArgumentOutOfRangeNeedNonNegNum(ExceptionArgument.inputOffset);
             if ((uint)inputCount > inputBuffer.Length) ThrowArgumentInvalidValue(ExceptionArgument.inputCount);
+            if (inputOffset < 0) ThrowArgumentOutOfRangeNeedNonNegNum(ExceptionArgument.inputOffset);
             if ((inputBuffer.Length - inputCount) < inputOffset) ThrowInvalidOffLen();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ValidateTransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, int inputBlockSize)
         {
             ValidateTransformBlock(inputBuffer, inputOffset, inputCount);

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -166,11 +166,11 @@ namespace System.Security.Cryptography
 
             // The common case is <= 4
             byte[] tmpBufferArray = null;
-            Span<byte> tmpBuffer = inputCount <= 4
-                ? stackalloc byte[4]
-                : inputCount <= 256
-                    ? stackalloc byte[256]
-                    : tmpBufferArray = ArrayPool<byte>.Shared.Rent(inputCount);
+            Span<byte> tmpBuffer = stackalloc byte[4];
+            if (inputCount > 4)
+            {
+                tmpBuffer = tmpBufferArray = ArrayPool<byte>.Shared.Rent(inputCount);
+            }
 
             tmpBuffer = GetTempBuffer(inputBuffer.AsSpan(inputOffset, inputCount), tmpBuffer);
             int bytesToTransform = _inputIndex + tmpBuffer.Length;
@@ -266,11 +266,11 @@ namespace System.Security.Cryptography
 
             // Common case for bytesToTransform = 4
             byte[] transformBufferArray = null;
-            Span<byte> transformBuffer = bytesToTransform <= 4
-                ? stackalloc byte[4]
-                : bytesToTransform <= 256
-                    ? stackalloc byte[256]
-                    : transformBufferArray = ArrayPool<byte>.Shared.Rent(bytesToTransform);
+            Span<byte> transformBuffer = stackalloc byte[4];
+            if (bytesToTransform > 4)
+            {
+                transformBuffer = transformBufferArray = ArrayPool<byte>.Shared.Rent(bytesToTransform);
+            }
 
             transformBuffer = transformBuffer.Slice(0, bytesToTransform);
 

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -149,7 +149,7 @@ namespace System.Security.Cryptography
             tmpBuffer = GetTempBuffer(inputBuffer.AsSpan(inputOffset, inputCount), tmpBuffer);
             int bytesToTransform = _inputIndex + tmpBuffer.Length;
 
-            // To little data to decode: save data to _inputBuffer, so it can be transformed later
+            // Too little data to decode: save data to _inputBuffer, so it can be transformed later
             if (bytesToTransform < Base64InputBlockSize)
             {
                 tmpBuffer.CopyTo(_inputBuffer.AsSpan(_inputIndex));
@@ -175,7 +175,9 @@ namespace System.Security.Cryptography
             ThrowHelper.ValidateTransformBlock(inputBuffer, inputOffset, inputCount);
 
             if (_inputBuffer == null)
+            {
                 ThrowHelper.ThrowObjectDisposed();
+            }
 
             if (inputCount == 0)
             {
@@ -247,7 +249,7 @@ namespace System.Security.Cryptography
 
         private static bool IsWhitespace(byte value)
         {
-            // We assume ASCII encoded data. If there is any non-ASCII char, so it is invalid
+            // We assume ASCII encoded data. If there is any non-ASCII char, it is invalid
             // Base64 and will be caught during decoding.
 
             // SPACE        32
@@ -258,7 +260,7 @@ namespace System.Security.Cryptography
             // CR           13
 
             // RyuJIT produces better code with the ternary. This JIT-bug is tracked in https://github.com/dotnet/coreclr/issues/914
-            return value == 32 || ((uint)value - 9 <= (13 - 9)) ? true : false;
+            return value == 32 || ((uint)value - 9 <= (13 - 9));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -385,7 +387,6 @@ namespace System.Security.Cryptography
                 ThrowInvalidOffLen();
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ValidateTransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, int inputBlockSize)
         {
             ValidateTransformBlock(inputBuffer, inputOffset, inputCount);
@@ -399,7 +400,7 @@ namespace System.Security.Cryptography
         public static void ThrowInvalidOffLen() => throw new ArgumentException(SR.Argument_InvalidOffLen);
         public static void ThrowObjectDisposed() => throw new ObjectDisposedException(null, SR.ObjectDisposed_Generic);
         public static void ThrowCryptographicException() => throw new CryptographicException(SR.Cryptography_SSE_InvalidDataSize);
-        internal static void ThrowBase64FormatException() => throw new FormatException();
+        public static void ThrowBase64FormatException() => throw new FormatException();
 
         public enum ExceptionArgument
         {

--- a/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
@@ -60,7 +60,7 @@ namespace System.Security.Cryptography.Encoding.Tests
                 InvalidInput_Base64Transform(transform);
 
                 // These exceptions only thrown in ToBase
-                AssertExtensions.Throws<ArgumentException>(null, () => transform.TransformFinalBlock(data_5bytes, 0, 5));
+                AssertExtensions.Throws<ArgumentException>("inputCount", () => transform.TransformFinalBlock(data_5bytes, 0, 5));
             }
         }
 
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography.Encoding.Tests
 
             // These exceptions only thrown in FromBase
             transform.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => transform.TransformBlock(data_4bytes, 0, 4, Array.Empty<byte>(), 0));
+            Assert.Throws<ObjectDisposedException>(() => transform.TransformBlock(data_4bytes, 0, transform.InputBlockSize, Array.Empty<byte>(), 0));
             Assert.Throws<ObjectDisposedException>(() => transform.TransformFinalBlock(Array.Empty<byte>(), 0, 0));
         }
 
@@ -84,8 +84,9 @@ namespace System.Security.Cryptography.Encoding.Tests
 
             AssertExtensions.Throws<ArgumentNullException>("inputBuffer", () => transform.TransformBlock(null, 0, 0, null, 0));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("inputOffset", () => transform.TransformBlock(Array.Empty<byte>(), -1, 0, null, 0));
-            AssertExtensions.Throws<ArgumentNullException>("outputBuffer", () => transform.TransformBlock(data_4bytes, 0, 4, null, 0));
-            AssertExtensions.Throws<ArgumentException>(null, () => transform.TransformBlock(Array.Empty<byte>(), 0, 1, null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("outputBuffer", () => transform.TransformBlock(data_4bytes, 0, transform.InputBlockSize, null, 0));
+            AssertExtensions.Throws<ArgumentException>("inputCount", () => transform.TransformBlock(data_4bytes, 0, transform.InputBlockSize + 1, null, 0));
+            AssertExtensions.Throws<ArgumentException>("inputCount", () => transform.TransformBlock(Array.Empty<byte>(), 0, 1, null, 0));
             AssertExtensions.Throws<ArgumentException>(null, () => transform.TransformBlock(Array.Empty<byte>(), 1, 0, null, 0));
 
             AssertExtensions.Throws<ArgumentNullException>("inputBuffer", () => transform.TransformFinalBlock(null, 0, 0));
@@ -146,7 +147,7 @@ namespace System.Security.Cryptography.Encoding.Tests
                 Assert.True(inputBytes.Length > 4);
 
                 // Test passing blocks > 4 characters to TransformFinalBlock (not supported)
-                AssertExtensions.Throws<ArgumentException>(null, () => transform.TransformFinalBlock(inputBytes, 0, inputBytes.Length));
+                AssertExtensions.Throws<ArgumentException>("inputCount", () => transform.TransformFinalBlock(inputBytes, 0, inputBytes.Length));
             }
         }
 
@@ -207,7 +208,7 @@ namespace System.Security.Cryptography.Encoding.Tests
             byte[] outputBytes = new byte[100];
 
             // Verify default of FromBase64TransformMode.IgnoreWhiteSpaces
-            using (var base64Transform = new FromBase64Transform()) 
+            using (var base64Transform = new FromBase64Transform())
             using (var ms = new MemoryStream(inputBytes))
             using (var cs = new CryptoStream(ms, base64Transform, CryptoStreamMode.Read))
             {

--- a/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using Test.Cryptography;
 using Xunit;
 
 namespace System.Security.Cryptography.Encoding.Tests
@@ -61,7 +60,7 @@ namespace System.Security.Cryptography.Encoding.Tests
                 InvalidInput_Base64Transform(transform);
 
                 // These exceptions only thrown in ToBase
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("offsetOut", () => transform.TransformFinalBlock(data_5bytes, 0, 5));
+                AssertExtensions.Throws<ArgumentException>(null, () => transform.TransformFinalBlock(data_5bytes, 0, 5));
             }
         }
 
@@ -75,7 +74,7 @@ namespace System.Security.Cryptography.Encoding.Tests
 
             // These exceptions only thrown in FromBase
             transform.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => transform.TransformBlock(data_4bytes, 0, 4, null, 0));
+            Assert.Throws<ObjectDisposedException>(() => transform.TransformBlock(data_4bytes, 0, 4, Array.Empty<byte>(), 0));
             Assert.Throws<ObjectDisposedException>(() => transform.TransformFinalBlock(Array.Empty<byte>(), 0, 0));
         }
 
@@ -85,7 +84,7 @@ namespace System.Security.Cryptography.Encoding.Tests
 
             AssertExtensions.Throws<ArgumentNullException>("inputBuffer", () => transform.TransformBlock(null, 0, 0, null, 0));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("inputOffset", () => transform.TransformBlock(Array.Empty<byte>(), -1, 0, null, 0));
-            AssertExtensions.Throws<ArgumentNullException>("dst", () => transform.TransformBlock(data_4bytes, 0, 4, null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("outputBuffer", () => transform.TransformBlock(data_4bytes, 0, 4, null, 0));
             AssertExtensions.Throws<ArgumentException>(null, () => transform.TransformBlock(Array.Empty<byte>(), 0, 1, null, 0));
             AssertExtensions.Throws<ArgumentException>(null, () => transform.TransformBlock(Array.Empty<byte>(), 1, 0, null, 0));
 
@@ -147,7 +146,7 @@ namespace System.Security.Cryptography.Encoding.Tests
                 Assert.True(inputBytes.Length > 4);
 
                 // Test passing blocks > 4 characters to TransformFinalBlock (not supported)
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("offsetOut", () => transform.TransformFinalBlock(inputBytes, 0, inputBytes.Length));
+                AssertExtensions.Throws<ArgumentException>(null, () => transform.TransformFinalBlock(inputBytes, 0, inputBytes.Length));
             }
         }
 

--- a/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
@@ -60,7 +60,7 @@ namespace System.Security.Cryptography.Encoding.Tests
                 InvalidInput_Base64Transform(transform);
 
                 // These exceptions only thrown in ToBase
-                AssertExtensions.Throws<ArgumentException>("inputCount", () => transform.TransformFinalBlock(data_5bytes, 0, 5));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("inputCount", () => transform.TransformFinalBlock(data_5bytes, 0, 5));
             }
         }
 
@@ -85,8 +85,8 @@ namespace System.Security.Cryptography.Encoding.Tests
             AssertExtensions.Throws<ArgumentNullException>("inputBuffer", () => transform.TransformBlock(null, 0, 0, null, 0));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("inputOffset", () => transform.TransformBlock(Array.Empty<byte>(), -1, 0, null, 0));
             AssertExtensions.Throws<ArgumentNullException>("outputBuffer", () => transform.TransformBlock(data_4bytes, 0, transform.InputBlockSize, null, 0));
-            AssertExtensions.Throws<ArgumentException>("inputCount", () => transform.TransformBlock(data_4bytes, 0, transform.InputBlockSize + 1, null, 0));
-            AssertExtensions.Throws<ArgumentException>("inputCount", () => transform.TransformBlock(Array.Empty<byte>(), 0, 1, null, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("inputCount", () => transform.TransformBlock(data_4bytes, 0, transform.InputBlockSize + 1, null, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("inputCount", () => transform.TransformBlock(Array.Empty<byte>(), 0, 1, null, 0));
             AssertExtensions.Throws<ArgumentException>(null, () => transform.TransformBlock(Array.Empty<byte>(), 1, 0, null, 0));
 
             AssertExtensions.Throws<ArgumentNullException>("inputBuffer", () => transform.TransformFinalBlock(null, 0, 0));
@@ -147,7 +147,7 @@ namespace System.Security.Cryptography.Encoding.Tests
                 Assert.True(inputBytes.Length > 4);
 
                 // Test passing blocks > 4 characters to TransformFinalBlock (not supported)
-                AssertExtensions.Throws<ArgumentException>("inputCount", () => transform.TransformFinalBlock(inputBytes, 0, inputBytes.Length));
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("inputCount", () => transform.TransformFinalBlock(inputBytes, 0, inputBytes.Length));
             }
         }
 

--- a/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography.Encoding.Tests
 
             // These exceptions only thrown in FromBase
             transform.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => transform.TransformBlock(data_4bytes, 0, transform.InputBlockSize, Array.Empty<byte>(), 0));
+            Assert.Throws<ObjectDisposedException>(() => transform.TransformBlock(data_4bytes, 0, 4, null, 0));
             Assert.Throws<ObjectDisposedException>(() => transform.TransformFinalBlock(Array.Empty<byte>(), 0, 0));
         }
 
@@ -84,8 +84,7 @@ namespace System.Security.Cryptography.Encoding.Tests
 
             AssertExtensions.Throws<ArgumentNullException>("inputBuffer", () => transform.TransformBlock(null, 0, 0, null, 0));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("inputOffset", () => transform.TransformBlock(Array.Empty<byte>(), -1, 0, null, 0));
-            AssertExtensions.Throws<ArgumentNullException>("outputBuffer", () => transform.TransformBlock(data_4bytes, 0, transform.InputBlockSize, null, 0));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("inputCount", () => transform.TransformBlock(data_4bytes, 0, transform.InputBlockSize + 1, null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("outputBuffer", () => transform.TransformBlock(data_4bytes, 0, 4, null, 0));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("inputCount", () => transform.TransformBlock(Array.Empty<byte>(), 0, 1, null, 0));
             AssertExtensions.Throws<ArgumentException>(null, () => transform.TransformBlock(Array.Empty<byte>(), 1, 0, null, 0));
 


### PR DESCRIPTION
## Description

`Convert.{To|From}Base64CharArray` was used, so this involved temporary buffer allocations and copying between them. With https://github.com/dotnet/corefx/blob/adc16f3d53b18467d5ed92fd1b988b0c21901ab9/src/System.Memory/ref/System.Memory.cs#L397 we have a nice API that does the same, but based on spans. So the code got rewritten to use the span-based conversion, thus saving allocation and unnecessary copying.

## Benchmarks

[Source](https://github.com/gfoidl/Benchmarks/tree/f0ed5a11f9a14b04f90f0a643d34ef8f39bc63c6/corefx/System/Security/Cryptography/Base64TransformsBenchmarks/Base64TransformsBenchmarks/Benchmarks)

### ToBase64Transform

#### TransformBlock

```
|   Method |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |---------:|----------:|----------:|------:|-------:|------:|------:|----------:|
| Original | 85.65 ns | 0.4726 ns | 0.4189 ns |  1.00 | 0.0101 |     - |     - |      64 B |
|       PR | 30.24 ns | 0.3475 ns | 0.3080 ns |  0.35 |      - |     - |     - |         - |
```

#### TransformFinalBlock

```
|   Method |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |---------:|----------:|----------:|------:|-------:|------:|------:|----------:|
| Original | 74.00 ns | 0.7205 ns | 0.6387 ns |  1.00 | 0.0101 |     - |     - |      64 B |
|       PR | 43.51 ns | 0.4889 ns | 0.4334 ns |  0.59 | 0.0051 |     - |     - |      32 B |
```

### FromBase64Transform

#### TransformBlock

```
|   Method |      Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |----------:|----------:|----------:|------:|-------:|------:|------:|----------:|
| Original | 199.08 ns | 1.0918 ns | 1.0212 ns |  1.00 | 0.0203 |     - |     - |     128 B |
|       PR |  83.15 ns | 0.7017 ns | 0.6564 ns |  0.42 |      - |     - |     - |         - |

```

#### TransformFinalBlock

```
|   Method |      Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |----------:|----------:|----------:|------:|-------:|------:|------:|----------:|
| Original | 207.60 ns | 2.1021 ns | 1.8635 ns |  1.00 | 0.0203 |     - |     - |     128 B |
|       PR |  97.46 ns | 0.6792 ns | 0.6353 ns |  0.47 | 0.0050 |     - |     - |      32 B |

```