### PR TITLE
Delete FromMilliseconds_Desktop test

### DIFF
--- a/src/System.Runtime/tests/System/TimeSpanTests.cs
+++ b/src/System.Runtime/tests/System/TimeSpanTests.cs
@@ -445,25 +445,6 @@ namespace System.Tests
             Assert.Equal(expected, TimeSpan.FromMilliseconds(value));
         }
 
-        public static IEnumerable<object[]> FromMilliseconds_TestData_Desktop()
-        {
-            yield return new object[] { 1500.5, new TimeSpan(15010000) };
-            yield return new object[] { 2.5, new TimeSpan(30000) };
-            yield return new object[] { 1.0, new TimeSpan(10000) };
-            yield return new object[] { 0.0, new TimeSpan(0) };
-            yield return new object[] { -1.0, new TimeSpan(-10000) };
-            yield return new object[] { -2.5, new TimeSpan(-30000) };
-            yield return new object[] { -1500.5, new TimeSpan(-15010000) };
-        }
-
-        [Theory]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
-        [MemberData(nameof(FromMilliseconds_TestData_Desktop))]
-        public static void FromMilliseconds_Desktop(double value, TimeSpan expected)
-        {
-            Assert.Equal(expected, TimeSpan.FromMilliseconds(value));
-        }
-
         [Fact]
         public static void FromMilliseconds_Invalid()
         {


### PR DESCRIPTION
This test is validating netfx behavior prior to fixes in .NET Core, and it's failed in CI 120 times in the last week.  Since we decided we don't care about such netfx-specific tests in corefx, I'm deleting it.

cc: @tannergooding, @bartonjs, @joperezr