### PR TITLE
System.Text.Json is not inbox on netfx

### DIFF
--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{5F553243-042C-45C0-8E49-C739131E11C3}</ProjectGuid>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
-    <DefineConstants>$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'!='netfx'">$(DefineConstants);BUILDING_INBOX_LIBRARY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\IO\WrappedMemoryStream.cs">


### PR DESCRIPTION
Fixes test build break introduced by https://github.com/dotnet/corefx/commit/1743e47216aa698ffe91148f4db2078accf6030a

> Serialization\Value.ReadTests.cs(225,58): error CS0117: 'BitConverter' does not contain a definition for 'SingleToInt32Bits' [D:\a\1\s\src\System.Text.Json\tests\System.Text.Json.Tests.csproj]

https://github.com/dotnet/corefx/blob/30ca4113ed07fc78060a0c9d3f95eee4fe8f8ee3/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs#L224-L227

These tests were failing on netfx, since System.Text.Json isn't inbox on that platform, but the ifdef wasn't catching that after we added `netfx` to the test configurations: https://github.com/dotnet/corefx/blame/master/src/System.Text.Json/tests/Configurations.props

CC @safern @ViktorHofer @ahsonkhan 