### PR TITLE
Using double to avoid overflow 

### DIFF
--- a/src/Native/Unix/System.Native/pal_time.c
+++ b/src/Native/Unix/System.Native/pal_time.c
@@ -169,7 +169,7 @@ int32_t SystemNative_GetCpuUtilization(ProcessCpuInformation* previousCpuInfo)
     uint64_t resolution = SystemNative_GetTimestampResolution();
     uint64_t timestamp = SystemNative_GetTimestamp();
 
-    uint64_t currentTime = timestamp * SecondsToNanoSeconds / resolution;
+    uint64_t currentTime = (uint64_t)(timestamp * ((double)SecondsToNanoSeconds / resolution));
 
     uint64_t lastRecordedCurrentTime = previousCpuInfo->lastRecordedCurrentTime;
     uint64_t lastRecordedKernelTime = previousCpuInfo->lastRecordedKernelTime;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38001
Before
```
timestamp  762054685492600
currentTime  1241063584
```
After
```
timestamp 773175066373300.000000
currenttime 773175066373300.000000
```
