### PR TITLE
Check regex timeout in loops and repetitions

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -73,6 +73,7 @@ namespace System.Text.RegularExpressions
         private LocalBuilder _temp2V;
         private LocalBuilder _temp3V;
         private LocalBuilder _cultureV;      // current culture is cached in local variable to prevent many thread local storage accesses for CultureInfo.CurrentCulture
+        private LocalBuilder _loopV;         // counter for setrep and setloop
 
         protected RegexCode _code;              // the RegexCode object (used for debugging only)
         protected int[] _codes;             // the RegexCodes being translated
@@ -111,6 +112,7 @@ namespace System.Text.RegularExpressions
         private const int Lazybranchcountback2 = 8;    // back2 part of lazybranchcount
         private const int Forejumpback = 9;    // back part of forejump
         private const int Uniquecount = 10;
+        private const int LoopTimeoutCheckCount = 2000; // A conservative value to guarantee the correct timeout handling.
 
         static RegexCompiler()
         {
@@ -366,6 +368,22 @@ namespace System.Text.RegularExpressions
         private void Ret()
         {
             _ilg.Emit(OpCodes.Ret);
+        }
+
+        /*
+         * A macro for _ilg.Emit(OpCodes.Rem)
+         */
+        private void Rem()
+        {
+            _ilg.Emit(OpCodes.Rem);
+        }
+
+        /*
+         * A macro for _ilg.Emit(OpCodes.Ceq)
+         */
+        private void Ceq()
+        {
+            _ilg.Emit(OpCodes.Ceq);
         }
 
         /*
@@ -1602,6 +1620,7 @@ namespace System.Text.RegularExpressions
             _tempV = DeclareInt();
             _temp2V = DeclareInt();
             _temp3V = DeclareInt();
+            _loopV = DeclareInt();
             _textbegV = DeclareInt();
             _textendV = DeclareInt();
             _textstartV = DeclareInt();
@@ -2787,6 +2806,7 @@ namespace System.Text.RegularExpressions
 
                         if (Code() == RegexCode.Setrep)
                         {
+                            EmitTimeoutCheck();
                             Ldstr(_strings[Operand(0)]);
                             Call(s_charInSetM);
 
@@ -2896,6 +2916,7 @@ namespace System.Text.RegularExpressions
 
                         if (Code() == RegexCode.Setloop)
                         {
+                            EmitTimeoutCheck();
                             Ldstr(_strings[Operand(0)]);
                             Call(s_charInSetM);
 
@@ -3104,6 +3125,29 @@ namespace System.Text.RegularExpressions
                 default:
                     throw new NotImplementedException(SR.UnimplementedState);
             }
+        }
+
+        private void EmitTimeoutCheck()
+        {
+            Label label = DefineLabel();
+
+            // Increment counter for each loop iteration.
+            Ldloc(_loopV);
+            Ldc(1);
+            Add();
+            Stloc(_loopV);
+
+            // Emit code to check the timeout every 2000th-iteration.
+            Ldloc(_loopV);
+            Ldc(LoopTimeoutCheckCount);
+            Rem();
+            Ldc(0);
+            Ceq();
+            Brfalse(label);
+            Ldthis();
+            Callvirt(s_checkTimeoutM);
+
+            MarkLabel(label);
         }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -112,7 +112,7 @@ namespace System.Text.RegularExpressions
         private const int Lazybranchcountback2 = 8;    // back2 part of lazybranchcount
         private const int Forejumpback = 9;    // back part of forejump
         private const int Uniquecount = 10;
-        private const int LoopTimeoutCheckCount = 2000; // A conservative value to guarantee the correct timeout handling.
+        private const int LoopTimeoutCheckCount = 2048; // A conservative value to guarantee the correct timeout handling.
 
         static RegexCompiler()
         {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -18,6 +18,7 @@ namespace System.Text.RegularExpressions
         private int _codepos;
         private bool _rightToLeft;
         private bool _caseInsensitive;
+        private const int LoopTimeoutCheckCount = 2000; // A conservative value to guarantee the correct timeout handling.
 
         public RegexInterpreter(RegexCode code, CultureInfo culture)
         {
@@ -964,8 +965,18 @@ namespace System.Text.RegularExpressions
                             string set = _code.Strings[Operand(0)];
 
                             while (c-- > 0)
+                            {
+                                // Check the timeout every 2000th iteration. The aditional if check
+                                // in every iteration can be neglected as the cost of the CharInClass
+                                // check is many times higher.
+                                if (c % LoopTimeoutCheckCount == 0)
+                                {
+                                    CheckTimeout();
+                                }
+
                                 if (!RegexCharClass.CharInClass(Forwardcharnext(), set))
                                     goto BreakBackward;
+                            }
 
                             advance = 2;
                             continue;
@@ -1035,6 +1046,14 @@ namespace System.Text.RegularExpressions
 
                             for (i = c; i > 0; i--)
                             {
+                                // Check the timeout every 2000th iteration. The aditional if check
+                                // in every iteration can be neglected as the cost of the CharInClass
+                                // check is many times higher.
+                                if (i % LoopTimeoutCheckCount == 0)
+                                {
+                                    CheckTimeout();
+                                }
+
                                 if (!RegexCharClass.CharInClass(Forwardcharnext(), set))
                                 {
                                     Backwardnext();

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -18,7 +18,7 @@ namespace System.Text.RegularExpressions
         private int _codepos;
         private bool _rightToLeft;
         private bool _caseInsensitive;
-        private const int LoopTimeoutCheckCount = 2000; // A conservative value to guarantee the correct timeout handling.
+        private const int LoopTimeoutCheckCount = 2048; // A conservative value to guarantee the correct timeout handling.
 
         public RegexInterpreter(RegexCode code, CultureInfo culture)
         {
@@ -966,10 +966,10 @@ namespace System.Text.RegularExpressions
 
                             while (c-- > 0)
                             {
-                                // Check the timeout every 2000th iteration. The aditional if check
+                                // Check the timeout every 2000th iteration. The additional if check
                                 // in every iteration can be neglected as the cost of the CharInClass
                                 // check is many times higher.
-                                if (c % LoopTimeoutCheckCount == 0)
+                                if ((uint)c % LoopTimeoutCheckCount == 0)
                                 {
                                     CheckTimeout();
                                 }
@@ -1046,10 +1046,10 @@ namespace System.Text.RegularExpressions
 
                             for (i = c; i > 0; i--)
                             {
-                                // Check the timeout every 2000th iteration. The aditional if check
+                                // Check the timeout every 2000th iteration. The additional if check
                                 // in every iteration can be neglected as the cost of the CharInClass
                                 // check is many times higher.
-                                if (i % LoopTimeoutCheckCount == 0)
+                                if ((uint)i % LoopTimeoutCheckCount == 0)
                                 {
                                     CheckTimeout();
                                 }

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -380,6 +380,29 @@ namespace System.Text.RegularExpressions.Tests
             }).Dispose();
         }
 
+        [Theory]
+        [InlineData(RegexOptions.Compiled)]
+        [InlineData(RegexOptions.None)]
+        public void Match_Timeout_Loop_Throws(RegexOptions options)
+        {
+            var regex = new Regex(@"a\s+", options, TimeSpan.FromSeconds(1));
+            string input = @"a" + new string(' ', 800_000_000) + @"b";
+
+            Assert.Throws<RegexMatchTimeoutException>(() => regex.Match(input));
+        }
+
+        [Theory]
+        [InlineData(RegexOptions.Compiled)]
+        [InlineData(RegexOptions.None)]
+        public void Match_Timeout_Repetition_Throws(RegexOptions options)
+        {
+            int repetitionCount = 800_000_000;
+            var regex = new Regex(@"a\s{" + repetitionCount+ "}", options, TimeSpan.FromSeconds(1));
+            string input = @"a" + new string(' ', repetitionCount) + @"b";
+
+            Assert.Throws<RegexMatchTimeoutException>(() => regex.Match(input));
+        }
+
         public static IEnumerable<object[]> Match_Advanced_TestData()
         {
             // \B special character escape: ".*\\B(SUCCESS)\\B.*"

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -380,7 +380,8 @@ namespace System.Text.RegularExpressions.Tests
             }).Dispose();
         }
 
-        [Theory]
+        // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
+        [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
         [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexOptions.None)]
         public void Match_Timeout_Loop_Throws(RegexOptions options)
@@ -391,7 +392,8 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Throws<RegexMatchTimeoutException>(() => regex.Match(input));
         }
 
-        [Theory]
+        // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
+        [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
         [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexOptions.None)]
         public void Match_Timeout_Repetition_Throws(RegexOptions options)


### PR DESCRIPTION
This is a cherry pick of the commit from .NET Core 2.2, resolving the issue disclosed in CVE-2019-0820.

Check the regex timeout in SetLoop and SetRepetition opcodes to avoid
the timeout not being handled.

@wtgodbe this needs to be in before branching of, the change was reviewed and approved in the servicing branches already, this is a simple cherry-pick. Therefore I'm merging this and if you notice any issues I'm happy to revert the change.

cc @danmosemsft