### PR TITLE
Add TrimEndingDirectorySeparator/EndsInDirectorySeparator tests

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.netcoreapp.cs
@@ -242,41 +242,5 @@ namespace System.IO.Tests
         {
             Assert.Throws<ArgumentException>(paramName, () => Path.GetFullPath(path, basePath));
         }
-        
-        [ActiveIssue(38066, TestPlatforms.AnyUnix)]
-        [Theory,
-            MemberData(nameof(TestData_TrimEndingDirectorySeparator))]
-        public void TrimEndingDirectorySeparator_String_CoreTests(string path, string expected)
-        {
-            string trimmed = Path.TrimEndingDirectorySeparator(path);
-            Assert.Equal(expected, trimmed);
-            Assert.Same(trimmed, Path.TrimEndingDirectorySeparator(trimmed));
-        }
-
-        [ActiveIssue(38066, TestPlatforms.AnyUnix)]
-        [Theory,
-            MemberData(nameof(TestData_TrimEndingDirectorySeparator))]
-        public void TrimEndingDirectorySeparator_ReadOnlySpan_CoreTests(string path, string expected)
-        {
-            ReadOnlySpan<char> trimmed = Path.TrimEndingDirectorySeparator(path.AsSpan());
-            PathAssert.Equal(expected, trimmed);
-            PathAssert.Equal(trimmed, Path.TrimEndingDirectorySeparator(trimmed));
-        }
-
-        [ActiveIssue(38066, TestPlatforms.AnyUnix)]
-        [Theory,
-            MemberData(nameof(TestData_EndsInDirectorySeparator))]
-        public void EndsInDirectorySeparator_String_CoreTests(string path, bool expected)
-        {
-            Assert.Equal(expected, Path.EndsInDirectorySeparator(path));
-        }
-
-        [ActiveIssue(38066, TestPlatforms.AnyUnix)]
-        [Theory,
-            MemberData(nameof(TestData_EndsInDirectorySeparator))]
-        public void EndsInDirectorySeparator_ReadOnlySpan_CoreTests(string path, bool expected)
-        {
-            Assert.Equal(expected, Path.EndsInDirectorySeparator(path.AsSpan()));
-        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTestsBase.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTestsBase.cs
@@ -205,49 +205,6 @@ namespace System.IO.Tests
             { @"C:\\foo2", @"C:\" },
         };
 
-        public static TheoryData<string,string> TestData_TrimEndingDirectorySeparator => new TheoryData<string, string>
-        {
-            { @"C:\folder\", @"C:\folder" },
-            { @"C:/folder/", @"C:/folder" },
-            { @"/folder/", @"/folder" },
-            { @"\folder\", @"\folder" },
-            { @"folder\", @"folder" },
-            { @"folder/", @"folder" },
-            { @"C:\", @"C:\" },
-            { @"C:/", @"C:/" },
-            { @"", @"" },
-            { @"/", @"/" },
-            { @"\", @"\" },
-            { @"\\server\share\", @"\\server\share" },
-            { @"\\server\share\folder\", @"\\server\share\folder" },
-            { @"\\?\C:\", @"\\?\C:\" },
-            { @"\\?\C:\folder\", @"\\?\C:\folder" },
-            { @"\\?\UNC\", @"\\?\UNC\" },
-            { @"\\?\UNC\a\", @"\\?\UNC\a\" },
-            { @"\\?\UNC\a\folder\", @"\\?\UNC\a\folder" },
-            { null, null }
-        };
-
-        public static TheoryData<string, bool> TestData_EndsInDirectorySeparator => new TheoryData<string, bool>
-        {
-            { @"\", true },
-            { @"/", true },
-            { @"C:\folder\", true },
-            { @"C:/folder/", true },
-            { @"C:\", true },
-            { @"C:/", true },
-            { @"\\", true },
-            { @"//", true },
-            { @"\\server\share\", true },
-            { @"\\?\UNC\a\", true },
-            { @"\\?\C:\", true },
-            { @"\\?\UNC\", true },
-            { @"folder\", true },
-            { @"folder", false },
-            { @"", false },
-            { null, false }
-        };
-
         protected static void GetTempPath_SetEnvVar(string envVar, string expected, string newTempPath)
         {
             string original = Path.GetTempPath();

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Unix.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Unix.cs
@@ -128,5 +128,57 @@ namespace System.IO.Tests
         {
             Assert.Throws<ArgumentException>(null, () => Path.GetFullPath("/gi\0t", "/foo/bar"));
         }
+
+        public static TheoryData<string, string> TestData_TrimEndingDirectorySeparator => new TheoryData<string, string>
+        {
+            { @"/folder/", @"/folder" },
+            { @"folder/", @"folder" },
+            { @"", @"" },
+            { @"/", @"/" },
+            { null, null }
+        };
+
+        public static TheoryData<string, bool> TestData_EndsInDirectorySeparator => new TheoryData<string, bool>
+        {
+            { @"/", true },
+            { @"/folder/", true },
+            { @"//", true },
+            { @"folder", false },
+            { @"folder/", true },
+            { @"", false },
+            { null, false }
+        };
+
+        [Theory,
+            MemberData(nameof(TestData_TrimEndingDirectorySeparator))]
+        public void TrimEndingDirectorySeparator_String(string path, string expected)
+        {
+            string trimmed = Path.TrimEndingDirectorySeparator(path);
+            Assert.Equal(expected, trimmed);
+            Assert.Same(trimmed, Path.TrimEndingDirectorySeparator(trimmed));
+        }
+
+        [Theory,
+            MemberData(nameof(TestData_TrimEndingDirectorySeparator))]
+        public void TrimEndingDirectorySeparator_ReadOnlySpan(string path, string expected)
+        {
+            ReadOnlySpan<char> trimmed = Path.TrimEndingDirectorySeparator(path.AsSpan());
+            PathAssert.Equal(expected, trimmed);
+            PathAssert.Equal(trimmed, Path.TrimEndingDirectorySeparator(trimmed));
+        }
+
+        [Theory,
+            MemberData(nameof(TestData_EndsInDirectorySeparator))]
+        public void EndsInDirectorySeparator_String(string path, bool expected)
+        {
+            Assert.Equal(expected, Path.EndsInDirectorySeparator(path));
+        }
+
+        [Theory,
+            MemberData(nameof(TestData_EndsInDirectorySeparator))]
+        public void EndsInDirectorySeparator_ReadOnlySpan(string path, bool expected)
+        {
+            Assert.Equal(expected, Path.EndsInDirectorySeparator(path.AsSpan()));
+        }
     }
 }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests_Windows.netcoreapp.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests_Windows.netcoreapp.cs
@@ -264,5 +264,80 @@ namespace System.IO.Tests
         {
             Assert.Throws<ArgumentException>(null, () => Path.GetFullPath("/gi\0t", @"C:\foo\bar"));
         }
+
+        public static TheoryData<string, string> TestData_TrimEndingDirectorySeparator => new TheoryData<string, string>
+        {
+            { @"C:\folder\", @"C:\folder" },
+            { @"C:/folder/", @"C:/folder" },
+            { @"/folder/", @"/folder" },
+            { @"\folder\", @"\folder" },
+            { @"folder\", @"folder" },
+            { @"folder/", @"folder" },
+            { @"C:\", @"C:\" },
+            { @"C:/", @"C:/" },
+            { @"", @"" },
+            { @"/", @"/" },
+            { @"\", @"\" },
+            { @"\\server\share\", @"\\server\share" },
+            { @"\\server\share\folder\", @"\\server\share\folder" },
+            { @"\\?\C:\", @"\\?\C:\" },
+            { @"\\?\C:\folder\", @"\\?\C:\folder" },
+            { @"\\?\UNC\", @"\\?\UNC\" },
+            { @"\\?\UNC\a\", @"\\?\UNC\a\" },
+            { @"\\?\UNC\a\folder\", @"\\?\UNC\a\folder" },
+            { null, null }
+        };
+
+        public static TheoryData<string, bool> TestData_EndsInDirectorySeparator => new TheoryData<string, bool>
+        {
+            { @"\", true },
+            { @"/", true },
+            { @"C:\folder\", true },
+            { @"C:/folder/", true },
+            { @"C:\", true },
+            { @"C:/", true },
+            { @"\\", true },
+            { @"//", true },
+            { @"\\server\share\", true },
+            { @"\\?\UNC\a\", true },
+            { @"\\?\C:\", true },
+            { @"\\?\UNC\", true },
+            { @"folder\", true },
+            { @"folder", false },
+            { @"", false },
+            { null, false }
+        };
+
+        [Theory,
+            MemberData(nameof(TestData_TrimEndingDirectorySeparator))]
+        public void TrimEndingDirectorySeparator_String(string path, string expected)
+        {
+            string trimmed = Path.TrimEndingDirectorySeparator(path);
+            Assert.Equal(expected, trimmed);
+            Assert.Same(trimmed, Path.TrimEndingDirectorySeparator(trimmed));
+        }
+
+        [Theory,
+            MemberData(nameof(TestData_TrimEndingDirectorySeparator))]
+        public void TrimEndingDirectorySeparator_ReadOnlySpan(string path, string expected)
+        {
+            ReadOnlySpan<char> trimmed = Path.TrimEndingDirectorySeparator(path.AsSpan());
+            PathAssert.Equal(expected, trimmed);
+            PathAssert.Equal(trimmed, Path.TrimEndingDirectorySeparator(trimmed));
+        }
+
+        [Theory,
+            MemberData(nameof(TestData_EndsInDirectorySeparator))]
+        public void EndsInDirectorySeparator_String(string path, bool expected)
+        {
+            Assert.Equal(expected, Path.EndsInDirectorySeparator(path));
+        }
+
+        [Theory,
+            MemberData(nameof(TestData_EndsInDirectorySeparator))]
+        public void EndsInDirectorySeparator_ReadOnlySpan(string path, bool expected)
+        {
+            Assert.Equal(expected, Path.EndsInDirectorySeparator(path.AsSpan()));
+        }
     }
 }


### PR DESCRIPTION
superseeds https://github.com/dotnet/corefx/pull/33244
closes https://github.com/dotnet/corefx/issues/31570

@stephentoub  I apologize for yesterday bore with build

I divided tests on unix/windows files...I think it's the best strategy here(instead of "run on unix" parameters on tests), there is a bit of replication.
@ViktorHofer I have to say that use WSL+VS Code Remote is very confortable...no more spin up vm.

cc: @JeremyKuhne @danmosemsft @Anipik