### PR TITLE
Add (de)serialization support for Base64 string as Byte array

### DIFF
--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -22,6 +22,7 @@
     <Compile Include="System\Text\Json\JsonHelpers.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Date.cs" />
     <Compile Include="System\Text\Json\JsonTokenType.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterByteArray.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.Serialization.cs" />
     <Compile Include="System\Text\Json\Document\JsonDocument.cs" />

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -22,7 +22,6 @@
     <Compile Include="System\Text\Json\JsonHelpers.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Date.cs" />
     <Compile Include="System\Text\Json\JsonTokenType.cs" />
-    <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterByteArray.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.Serialization.cs" />
     <Compile Include="System\Text\Json\Document\JsonDocument.cs" />
@@ -57,6 +56,7 @@
     <Compile Include="System\Text\Json\Serialization\Converters\DefaultImmutableConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterBoolean.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterByte.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterByteArray.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterChar.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterDateTime.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\JsonValueConverterDateTimeOffset.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultConverters.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/DefaultConverters.cs
@@ -11,9 +11,10 @@ namespace System.Text.Json.Serialization.Converters
     {
         private static readonly Dictionary<Type, object> s_valueConverters = new Dictionary<Type, object>()
         {
+            { typeof(byte[]), new JsonValueConverterByteArray() },
             { typeof(DateTimeOffset), new JsonValueConverterDateTimeOffset() },
             { typeof(Guid), new JsonValueConverterGuid() },
-            { typeof(JsonElement), new JsonValueConverterJsonElement() }
+            { typeof(JsonElement), new JsonValueConverterJsonElement() },
         };
 
         internal static bool IsValueConvertable(Type type)
@@ -32,6 +33,7 @@ namespace System.Text.Json.Serialization.Converters
                     new object[] { false },
                     culture: null);
             }
+
             TypeCode typeCode = Type.GetTypeCode(type);
             switch (typeCode)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterByteArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterByteArray.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization.Policies;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class JsonValueConverterByteArray : JsonValueConverter<byte[]>
+    {
+        public override bool TryRead(Type valueType, ref Utf8JsonReader reader, out byte[] value)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                value = default;
+                return false;
+            }
+
+            return reader.TryGetBytesFromBase64(out value);
+        }
+
+        public override void Write(byte[] value, Utf8JsonWriter writer)
+        {
+            writer.WriteBase64StringValue(value);
+        }
+
+        public override void Write(JsonEncodedText propertyName, byte[] value, Utf8JsonWriter writer)
+        {
+            writer.WriteBase64String(propertyName, value);
+        }
+    }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -50,7 +50,6 @@ namespace System.Text.Json.Serialization
                 IsPropertyPolicy = true;
                 HasGetter = true;
                 HasSetter = true;
-                ValueConverter = DefaultConverters<TRuntimeProperty>.s_converter;
             }
 
             GetPolicies();

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -26,6 +26,71 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ReadNullByteArray()
+        {
+            string json = @"null";
+            byte[] arr = JsonSerializer.Parse<byte[]>(json);
+            Assert.Null(arr);
+        }
+
+        [Fact]
+        public static void ReadEmptyByteArray()
+        {
+            string json = @"""""";
+            byte[] arr = JsonSerializer.Parse<byte[]>(json);
+            Assert.Equal(0, arr.Length);
+        }
+
+        [Fact]
+        public static void ReadByteArray()
+        {
+            string json = $"\"{Convert.ToBase64String(new byte[] { 1, 2 })}\"";
+            byte[] arr = JsonSerializer.Parse<byte[]>(json);
+
+            Assert.Equal(2, arr.Length);
+            Assert.Equal(1, arr[0]);
+            Assert.Equal(2, arr[1]);
+        }
+
+        [Fact]
+        public static void Read2dByteArray()
+        {
+            // Baseline for comparison.
+            Assert.Equal("AQI=", Convert.ToBase64String(new byte[] { 1, 2 }));
+
+            string json = "[\"AQI=\",\"AQI=\"]";
+            byte[][] arr = JsonSerializer.Parse<byte[][]>(json);
+            Assert.Equal(2, arr.Length);
+
+            Assert.Equal(2, arr[0].Length);
+            Assert.Equal(1, arr[0][0]);
+            Assert.Equal(2, arr[0][1]);
+
+            Assert.Equal(2, arr[1].Length);
+            Assert.Equal(1, arr[1][0]);
+            Assert.Equal(2, arr[1][1]);
+        }
+
+        [Fact]
+        public static void ReadByteArrayAsJsonArrayFail()
+        {
+            string json = $"[1, 2]";
+            // Currently no support deserializing JSON arrays as byte[] - only Base64 string.
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte[]>(json));
+        }
+
+        [Fact]
+        public static void ReadByteListAsJsonArray()
+        {
+            string json = $"[1, 2]";
+            List<byte> list = JsonSerializer.Parse<List<byte>>(json);
+
+            Assert.Equal(2, list.Count);
+            Assert.Equal(1, list[0]);
+            Assert.Equal(2, list[1]);
+        }
+
+        [Fact]
         public static void DeserializeObjectArray_36167()
         {
             // https://github.com/dotnet/corefx/issues/36167

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -72,6 +72,13 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ReadByteArrayFail()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte[]>(@"""1"""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte[]>(@"""A==="""));
+        }
+
+        [Fact]
         public static void ReadByteArrayAsJsonArrayFail()
         {
             string json = $"[1, 2]";

--- a/src/System.Text.Json/tests/Serialization/Array.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.WriteTests.cs
@@ -26,6 +26,39 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void WriteNullByteArray()
+        {
+            byte[] input = null;
+            string json = JsonSerializer.ToString(input);
+            Assert.Equal($"null", json);
+        }
+
+        [Fact]
+        public static void WriteEmptyByteArray()
+        {
+            var input = new byte[] {};
+            string json = JsonSerializer.ToString(input);
+            Assert.Equal(@"""""", json);
+        }
+
+        [Fact]
+        public static void WriteByteArray()
+        {
+            var input = new byte[] { 1, 2 };
+            string json = JsonSerializer.ToString(input);
+            Assert.Equal($"\"{Convert.ToBase64String(input)}\"", json);
+        }
+
+        [Fact]
+        public static void WriteTwo2dByteArray()
+        {
+            var inner = new byte[] { 1, 2 };
+            var outer = new byte[2][] { inner, inner };
+            string json = JsonSerializer.ToString(outer);
+            Assert.Equal($"[\"{Convert.ToBase64String(inner)}\",\"{Convert.ToBase64String(inner)}\"]", json);
+        }
+
+        [Fact]
         public static void WriteObjectArray()
         {
             string json;

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
@@ -111,7 +111,7 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyUInt16Array"" : [4]," +
                 @"""MyUInt32Array"" : [5]," +
                 @"""MyUInt64Array"" : [6]," +
-                @"""MyByteArray"" : [7]," +
+                @"""MyByteArray"" : ""Bw==""," + // Base64 encoded value of 7
                 @"""MySByteArray"" : [8]," +
                 @"""MyCharArray"" : [""a""]," +
                 @"""MyStringArray"" : [""Hello""]," +

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestStruct.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestStruct.cs
@@ -83,7 +83,7 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyUInt16Array"" : [4]," +
                 @"""MyUInt32Array"" : [5]," +
                 @"""MyUInt64Array"" : [6]," +
-                @"""MyByteArray"" : [7]," +
+                @"""MyByteArray"" : ""Bw==""," + // Base64 encoded value of 7
                 @"""MySByteArray"" : [8]," +
                 @"""MyCharArray"" : [""a""]," +
                 @"""MyStringArray"" : [""Hello""]," +


### PR DESCRIPTION
Uptake the recent Base64 reader\writer work to the serializer.

Addresses serialization work for #36974 and follow up for [reader\writer\doc PR](https://github.com/dotnet/corefx/pull/38088).
