### PR TITLE
There have been CI failures for the core json serializer write test. …

### DIFF
--- a/src/System.Text.Json/tests/Serialization/Object.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.WriteTests.cs
@@ -15,7 +15,6 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<ArgumentException>(() => JsonSerializer.ToString(1, typeof(string)));
         }
 
-        [ActiveIssue(38092)]
         [Theory]
         [MemberData(nameof(WriteSuccessCases))]
         public static void Write(ITestClass testObj)

--- a/src/System.Text.Json/tests/Serialization/TestData.cs
+++ b/src/System.Text.Json/tests/Serialization/TestData.cs
@@ -73,7 +73,13 @@ namespace System.Text.Json.Serialization.Tests
                 yield return new object[] { new TestClassWithStringToPrimitiveDictionary() };
                 yield return new object[] { new TestClassWithObjectIEnumerableConstructibleTypes() };
                 yield return new object[] { new TestClassWithObjectImmutableTypes() };
-                yield return new object[] { new JsonElementTests.JsonElementClass() };
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                {
+                    // [ActiveIssue(38092)]
+                    // https://github.com/dotnet/corefx/issues/38092
+                    // This appears to only be failing on Unix, still trying to get a repro.
+                    yield return new object[] { new JsonElementTests.JsonElementClass() };
+                }
                 yield return new object[] { new JsonElementTests.JsonElementArrayClass() };
                 yield return new object[] { new ClassWithComplexObjects() };
             }


### PR DESCRIPTION
…Narrowing down the exclusion until we figure out what is happening for the reported failures as a blanket exclusion significantly cuts our coverage.