### PR TITLE
HttpClient.SendAsync() should not attempt to read response body on a HEAD or PUT request.

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -481,13 +481,7 @@ namespace System.Net.Http
                 throw;
             }
 
-            // Response never has a body.
-            if (HttpMethod.Normalize(request.Method).NoResponseBody)
-            {
-                return FinishSendAsyncUnbuffered(sendTask, request, cts, disposeCts);
-            }
-
-            return completionOption == HttpCompletionOption.ResponseContentRead ?
+            return completionOption == HttpCompletionOption.ResponseContentRead && !HttpMethod.Normalize(request.Method).NoResponseBody ?
                 FinishSendAsyncBuffered(sendTask, request, cts, disposeCts) :
                 FinishSendAsyncUnbuffered(sendTask, request, cts, disposeCts);
         }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -481,7 +481,7 @@ namespace System.Net.Http
                 throw;
             }
 
-            return completionOption == HttpCompletionOption.ResponseContentRead && !HttpMethod.Normalize(request.Method).NoResponseBody ?
+            return completionOption == HttpCompletionOption.ResponseContentRead && !string.Equals(request.Method.Method, "HEAD", StringComparison.OrdinalIgnoreCase) ?
                 FinishSendAsyncBuffered(sendTask, request, cts, disposeCts) :
                 FinishSendAsyncUnbuffered(sendTask, request, cts, disposeCts);
         }

--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -481,6 +481,12 @@ namespace System.Net.Http
                 throw;
             }
 
+            // Response never has a body.
+            if (HttpMethod.Normalize(request.Method).NoResponseBody)
+            {
+                return FinishSendAsyncUnbuffered(sendTask, request, cts, disposeCts);
+            }
+
             return completionOption == HttpCompletionOption.ResponseContentRead ?
                 FinishSendAsyncBuffered(sendTask, request, cts, disposeCts) :
                 FinishSendAsyncUnbuffered(sendTask, request, cts, disposeCts);

--- a/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
@@ -186,7 +186,7 @@ namespace System.Net.Http
                 // Normalize before calling this
                 Debug.Assert(ReferenceEquals(this, Normalize(this)));
 
-                return ReferenceEquals(this, HttpMethod.Head) || ReferenceEquals(this, HttpMethod.Put);
+                return ReferenceEquals(this, HttpMethod.Head);
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
@@ -178,16 +178,5 @@ namespace System.Net.Http
                        !ReferenceEquals(this, HttpMethod.Options) && !ReferenceEquals(this, HttpMethod.Delete);
             }
         }
-
-        internal bool NoResponseBody
-        {
-            get
-            {
-                // Normalize before calling this
-                Debug.Assert(ReferenceEquals(this, Normalize(this)));
-
-                return ReferenceEquals(this, HttpMethod.Head);
-            }
-        }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpMethod.cs
@@ -178,5 +178,16 @@ namespace System.Net.Http
                        !ReferenceEquals(this, HttpMethod.Options) && !ReferenceEquals(this, HttpMethod.Delete);
             }
         }
+
+        internal bool NoResponseBody
+        {
+            get
+            {
+                // Normalize before calling this
+                Debug.Assert(ReferenceEquals(this, Normalize(this)));
+
+                return ReferenceEquals(this, HttpMethod.Head) || ReferenceEquals(this, HttpMethod.Put);
+            }
+        }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
@@ -254,12 +254,6 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task HttpRequest_BodylessMethod_LargeContentLength()
         {
-            if (IsWinHttpHandler || IsNetfxHandler || IsUapHandler)
-            {
-                // Some platform handlers differ but we don't take it as failure.
-                return;
-            }
-
             using (HttpClient client = CreateHttpClient())
             {
                 await LoopbackServer.CreateServerAsync(async (server, uri) =>
@@ -276,6 +270,11 @@ namespace System.Net.Http.Functional.Tests
 
                         await requestTask;
                     });
+
+                    var result = requestTask.Result;
+                    Assert.NotNull(result);
+                    Assert.NotNull(result.Content);
+                    Assert.Equal(2167849215, result.Content.Headers.ContentLength);
                 });
             }
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
@@ -261,20 +261,23 @@ namespace System.Net.Http.Functional.Tests
                     var request = new HttpRequestMessage(HttpMethod.Head, uri);
 
                     Task<HttpResponseMessage> requestTask = client.SendAsync(request);
+                    
                     await server.AcceptConnectionAsync(async connection =>
                     {
                         // Content-Length greater than 2GB.
-                        var response = LoopbackServer.GetConnectionCloseResponse(
+                        string response = LoopbackServer.GetConnectionCloseResponse(
                             HttpStatusCode.OK, "Content-Length: 2167849215\r\n\r\n");
                         await connection.SendResponseAsync(response);
 
                         await requestTask;
                     });
 
-                    var result = requestTask.Result;
-                    Assert.NotNull(result);
-                    Assert.NotNull(result.Content);
-                    Assert.Equal(2167849215, result.Content.Headers.ContentLength);
+                    using (HttpResponseMessage result = requestTask.Result)
+                    {
+                        Assert.NotNull(result);
+                        Assert.NotNull(result.Content);
+                        Assert.Equal(2167849215, result.Content.Headers.ContentLength);
+                    }
                 });
             }
         }


### PR DESCRIPTION
When using `HttpClient.SendAsync()` to issue a `HEAD` request, we shouldn't attempt to allocate a buffer for the return content regardless of the `HttpCompletionOption` (because `ResponseContentRead` is the default).

The problem is that even though the server won't send any response, the `Content-Length` could be quite large, so we would unnecessarily allocate a huge buffer.  Furthermore, you even get an exception if the length is above 2 GB (`HttpContent.MaxBufferSize` is `int.MaxValue`).

We have a regression in Mono about this: https://github.com/mono/mono/issues/14214.

I have investigated this and what's happening is that when using `FinishSendAsyncBuffered()`, the `response.Content` is an instance of `HttpConnection.HttpConnectionResponseContent`, so `response.Content.LoadIntoBufferAsync()` is called.

The then calls `CreateMemoryStream(maxBufferSize, out error)`, the `Headers.ContentLength` is (in our example 2167849215) larger than `int.MaxValue` and it throws.  But even it it were smaller, we'd still allocate a potentially huge buffer for no reason.