### PR TITLE
#8895 fix the rest of the handle leaks so the pull request in coreclr…

### DIFF
--- a/src/Native/Unix/Common/pal_config.h.in
+++ b/src/Native/Unix/Common/pal_config.h.in
@@ -11,6 +11,7 @@
 #cmakedefine01 HAVE_GETIFADDRS
 #cmakedefine01 HAVE_UTSNAME_DOMAINNAME
 #cmakedefine01 HAVE_STAT64
+#cmakedefine01 HAVE_STD_ATOMIC
 #cmakedefine01 HAVE_VFORK
 #cmakedefine01 HAVE_PIPE2
 #cmakedefine01 HAVE_STAT_BIRTHTIME

--- a/src/Native/Unix/System.Native/pal_process.h
+++ b/src/Native/Unix/System.Native/pal_process.h
@@ -273,3 +273,15 @@ DLLEXPORT int32_t SystemNative_SchedSetAffinity(int32_t pid, intptr_t* mask);
  */
 DLLEXPORT int32_t SystemNative_SchedGetAffinity(int32_t pid, intptr_t* mask);
 #endif
+
+enum HandleForkLockOwner {
+    NoHolder = 0,
+    LockedByHandle,
+    LockedByFork,
+    LockedByPOpen
+};
+
+// Not exported: acquires close or fork lock
+void AcquireHandleForkLock(enum HandleForkLockOwner acquirer, int *threadcancelstate);
+// Not exported: releases close or fork lock
+void ReleaseHandleForkLock(int *threadcancelstate);

--- a/src/Native/Unix/configure.cmake
+++ b/src/Native/Unix/configure.cmake
@@ -119,6 +119,11 @@ check_symbol_exists(
     HAVE_STAT64)
 
 check_symbol_exists(
+    atomic_fetch_add
+    stdatomic.h
+    HAVE_STD_ATOMIC)
+
+check_symbol_exists(
     vfork
     unistd.h
     HAVE_VFORK)


### PR DESCRIPTION
… actually works as it it should.

I really wish there was a cleaner way to go about this, but writable file handles leaking into fork() children cause problems for IO error detection. I can't restrict this to readonly handles only because `SafeHandle(IntPtr)` can't handle that, and it would be its own horrible level mixing anyway.