### PR TITLE
Fix RegexCultureTests by moving it out-of-proc

### DIFF
--- a/src/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
@@ -18,27 +16,30 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void TurkishI_Is_Differently_LowerUpperCased_In_Turkish_Culture()
         {
-            var turkish = new CultureInfo("tr-TR");
-            string input = "Iıİi";
+            RemoteExecutor.Invoke(() =>
+            {
+                var turkish = new CultureInfo("tr-TR");
+                string input = "Iıİi";
 
-            Regex[] cultInvariantRegex = Create(input, CultureInfo.InvariantCulture, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-            Regex[] turkishRegex =       Create(input, turkish,                      RegexOptions.IgnoreCase);
+                Regex[] cultInvariantRegex = Create(input, CultureInfo.InvariantCulture, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                Regex[] turkishRegex = Create(input, turkish, RegexOptions.IgnoreCase);
 
-            // same input and regex does match so far so good
-            Assert.All(cultInvariantRegex, rex => Assert.Equal(true, rex.IsMatch(input)) );
+                // same input and regex does match so far so good
+                Assert.All(cultInvariantRegex, rex => Assert.Equal(true, rex.IsMatch(input)));
 
-            // when the Regex was created with a turkish locale the lower cased turkish version will
-            // no longer match the input string which contains upper and lower case iiiis hence even the input string 
-            // will no longer match
-            Assert.All(turkishRegex,       rex => Assert.Equal(false, rex.IsMatch(input)));
+                // when the Regex was created with a turkish locale the lower cased turkish version will
+                // no longer match the input string which contains upper and lower case iiiis hence even the input string 
+                // will no longer match
+                Assert.All(turkishRegex, rex => Assert.Equal(false, rex.IsMatch(input)));
 
-            // Now comes the tricky part depending on the use locale in ToUpper the results differ
-            // Hence the regular expression will not match if different locales were used
-            Assert.All(cultInvariantRegex, rex => Assert.Equal(true, rex.IsMatch(input.ToLowerInvariant())));
-            Assert.All(cultInvariantRegex, rex => Assert.Equal(false, rex.IsMatch(input.ToLower(turkish))));
+                // Now comes the tricky part depending on the use locale in ToUpper the results differ
+                // Hence the regular expression will not match if different locales were used
+                Assert.All(cultInvariantRegex, rex => Assert.Equal(true, rex.IsMatch(input.ToLowerInvariant())));
+                Assert.All(cultInvariantRegex, rex => Assert.Equal(false, rex.IsMatch(input.ToLower(turkish))));
 
-            Assert.All(turkishRegex, rex => Assert.Equal(false, rex.IsMatch(input.ToLowerInvariant())));
-            Assert.All(turkishRegex, rex => Assert.Equal(true, rex.IsMatch(input.ToLower(turkish))));
+                Assert.All(turkishRegex, rex => Assert.Equal(false, rex.IsMatch(input.ToLowerInvariant())));
+                Assert.All(turkishRegex, rex => Assert.Equal(true, rex.IsMatch(input.ToLower(turkish))));
+            }).Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
All of our tests that manipulate current culture currently need to be run out-of-proc.

Fixes https://github.com/dotnet/corefx/issues/38165
cc: @ViktorHofer 