### PR TITLE
Retarget RefContext and CompRegistration to NS2.1

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -90,7 +90,10 @@
 
     <!-- binplace targeting packs which may be different from BuildConfiguration -->
     <BinPlaceConfiguration Include="netstandard">
-      <RefPath>$(RefRootPath)netstandard/</RefPath>
+      <RefPath>$(NetStandardRefPath)</RefPath>
+    </BinPlaceConfiguration>
+    <BinPlaceConfiguration Include="netstandard2.1">
+      <RefPath>$(NetStandard21RefPath)</RefPath>
     </BinPlaceConfiguration>
     <!-- some libraries that produce packages will remain targeting netcoreapp2.0 -->
     <BinPlaceConfiguration Condition="'$(BuildingNETCoreAppVertical)' == 'true'" Include="netcoreapp2.0">

--- a/src/System.ComponentModel.Composition.Registration/pkg/System.ComponentModel.Composition.Registration.pkgproj
+++ b/src/System.ComponentModel.Composition.Registration/pkg/System.ComponentModel.Composition.Registration.pkgproj
@@ -2,9 +2,10 @@
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
     <ItemGroup>
     <ProjectReference Include="..\ref\System.ComponentModel.Composition.Registration.csproj">
-      <SupportedFramework>netcoreapp3.0;net45</SupportedFramework>
+      <SupportedFramework>netcoreapp3.0;net45;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.Composition.Registration.csproj" />
+    <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
     <InboxOnTargetFramework Include="net45">
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>

--- a/src/System.ComponentModel.Composition.Registration/pkg/System.ComponentModel.Composition.Registration.pkgproj
+++ b/src/System.ComponentModel.Composition.Registration/pkg/System.ComponentModel.Composition.Registration.pkgproj
@@ -2,7 +2,7 @@
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
     <ItemGroup>
     <ProjectReference Include="..\ref\System.ComponentModel.Composition.Registration.csproj">
-      <SupportedFramework>netcoreapp3.0;net45;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>netcoreapp3.0;net45</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.Composition.Registration.csproj" />
     <InboxOnTargetFramework Include="net45">

--- a/src/System.ComponentModel.Composition.Registration/pkg/System.ComponentModel.Composition.Registration.pkgproj
+++ b/src/System.ComponentModel.Composition.Registration/pkg/System.ComponentModel.Composition.Registration.pkgproj
@@ -2,10 +2,9 @@
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
     <ItemGroup>
     <ProjectReference Include="..\ref\System.ComponentModel.Composition.Registration.csproj">
-      <SupportedFramework>netcoreapp3.0;net45;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>netcoreapp3.0;net45</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.Composition.Registration.csproj" />
-    <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
     <InboxOnTargetFramework Include="net45">
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>

--- a/src/System.ComponentModel.Composition.Registration/pkg/System.ComponentModel.Composition.Registration.pkgproj
+++ b/src/System.ComponentModel.Composition.Registration/pkg/System.ComponentModel.Composition.Registration.pkgproj
@@ -2,7 +2,7 @@
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
     <ItemGroup>
     <ProjectReference Include="..\ref\System.ComponentModel.Composition.Registration.csproj">
-      <SupportedFramework>uap10.0.16299;netcoreapp2.0;net45;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>netcoreapp3.0;net45;$(AllXamarinFrameworks)</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.ComponentModel.Composition.Registration.csproj" />
     <InboxOnTargetFramework Include="net45">

--- a/src/System.ComponentModel.Composition.Registration/ref/Configurations.props
+++ b/src/System.ComponentModel.Composition.Registration/ref/Configurations.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup>
     <BuildConfigurations>
-      netstandard;
-      _netfx;
+      netstandard2.1;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel.Composition.Registration/ref/System.ComponentModel.Composition.Registration.csproj
+++ b/src/System.ComponentModel.Composition.Registration/ref/System.ComponentModel.Composition.Registration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{6E0C5F44-0160-4082-A25C-2DB8EA7ED30D}</ProjectGuid>
-    <Configurations>netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard2.1-Debug;netstandard2.1-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.ComponentModel.Composition.Registration.cs" />

--- a/src/System.ComponentModel.Composition.Registration/src/Configurations.props
+++ b/src/System.ComponentModel.Composition.Registration/src/Configurations.props
@@ -1,12 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <PackageConfigurations>
-      netstandard;
-    </PackageConfigurations>
     <BuildConfigurations>
-      $(PackageConfigurations);
-      netcoreapp;
-      uap;
+      netstandard2.1;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel.Composition.Registration/src/System.ComponentModel.Composition.Registration.csproj
+++ b/src/System.ComponentModel.Composition.Registration/src/System.ComponentModel.Composition.Registration.csproj
@@ -2,10 +2,9 @@
   <PropertyGroup>
     <ProjectGuid>{E3663E26-6819-4997-B372-94454DB4D60E}</ProjectGuid>
     <AssemblyName>System.ComponentModel.Composition.Registration</AssemblyName>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard'">SR.PlatformNotSupported_ComponentModel_Composition_Registration</GeneratePlatformNotSupportedAssemblyMessage>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>netstandard2.1-Debug;netstandard2.1-Release</Configurations>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
+  <ItemGroup>
     <Compile Include="System\ComponentModel\Composition\Registration\ExportBuilder.cs" />
     <Compile Include="System\ComponentModel\Composition\Registration\ImportBuilder.cs" />
     <Compile Include="System\ComponentModel\Composition\Registration\ParameterImportBuilder.cs" />
@@ -34,14 +33,5 @@
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Reflection.Context" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
-    <Reference Include="System.Collections" />
-    <Reference Include="System.Diagnostics.Debug" />
-    <Reference Include="System.Linq" />
-    <Reference Include="System.Linq.Expressions" />
-    <Reference Include="System.Resources.ResourceManager" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Threading" />
   </ItemGroup>
 </Project>

--- a/src/System.ComponentModel.Composition.Registration/tests/Configurations.props
+++ b/src/System.ComponentModel.Composition.Registration/tests/Configurations.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
-      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel.Composition.Registration/tests/Configurations.props
+++ b/src/System.ComponentModel.Composition.Registration/tests/Configurations.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.ComponentModel.Composition.Registration/tests/System.ComponentModel.Composition.Registration.Tests.csproj
+++ b/src/System.ComponentModel.Composition.Registration/tests/System.ComponentModel.Composition.Registration.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <!-- TODO: Add netfx configuration after OOB package bug is fixed: https://github.com/dotnet/corefx/issues/23889 -->
   <PropertyGroup>
     <ProjectGuid>{0F8CFFA3-6E16-4642-82C1-289D95338D7C}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InternalCalls.cs" />

--- a/src/System.ComponentModel.Composition.Registration/tests/System.ComponentModel.Composition.Registration.Tests.csproj
+++ b/src/System.ComponentModel.Composition.Registration/tests/System.ComponentModel.Composition.Registration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{0F8CFFA3-6E16-4642-82C1-289D95338D7C}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InternalCalls.cs" />

--- a/src/System.Reflection.Context/pkg/System.Reflection.Context.pkgproj
+++ b/src/System.Reflection.Context/pkg/System.Reflection.Context.pkgproj
@@ -2,13 +2,12 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <ItemGroup>
     <ProjectReference Include="..\ref\System.Reflection.Context.csproj">
-      <SupportedFramework>uap10.0.16299;netcoreapp2.0;net45;$(AllXamarinFrameworks)</SupportedFramework>
+      <SupportedFramework>uap10.0.16299;netcoreapp2.0;net45</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Reflection.Context.csproj" />
     <InboxOnTargetFramework Include="net45">
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>
-    <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
     <!-- Since UAP are package based we still want to enable
          OOBing libraries that happen to overlap with their framework package.
          This avoids us having to lock the API in our NuGet packages just

--- a/src/System.Reflection.Context/pkg/System.Reflection.Context.pkgproj
+++ b/src/System.Reflection.Context/pkg/System.Reflection.Context.pkgproj
@@ -8,6 +8,7 @@
     <InboxOnTargetFramework Include="net45">
       <AsFrameworkReference>true</AsFrameworkReference>
     </InboxOnTargetFramework>
+    <InboxOnTargetFramework Include="$(AllXamarinFrameworks)" />
     <!-- Since UAP are package based we still want to enable
          OOBing libraries that happen to overlap with their framework package.
          This avoids us having to lock the API in our NuGet packages just

--- a/src/System.Reflection.Context/src/Configurations.props
+++ b/src/System.Reflection.Context/src/Configurations.props
@@ -1,11 +1,9 @@
 ﻿<Project>
   <PropertyGroup>
     <BuildConfigurations>
-      netcoreapp;
       netstandard;
       netstandard1.1;
-      uap;
-      _netfx;
+      netstandard2.1;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Context/src/System.Reflection.Context.csproj
+++ b/src/System.Reflection.Context/src/System.Reflection.Context.csproj
@@ -2,12 +2,10 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <ProjectGuid>{404DB891-B5AF-41E6-B89D-29E3F4573C4F}</ProjectGuid>
-    <!-- Only supported on .NET Framework, .NET Core and UAP -->
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard1.1' OR '$(TargetGroup)' == 'netstandard'">SR.PlatformNotSupported_ReflectionContext</GeneratePlatformNotSupportedAssemblyMessage>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release;uap-Debug;uap-Release</Configurations>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetFramework)' == 'netstandard1.1' OR '$(TargetFramework)' == 'netstandard2.0'">SR.PlatformNotSupported_ReflectionContext</GeneratePlatformNotSupportedAssemblyMessage>
+    <Configurations>netstandard2.1-Debug;netstandard2.1-Release;netstandard-Debug;netstandard-Release;netstandard1.1-Debug;netstandard1.1-Release</Configurations>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the options -->
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <Compile Include="System\Reflection\Context\CollectionServices.cs" />
     <Compile Include="System\Reflection\Context\CustomReflectionContext.cs" />
     <Compile Include="System\Reflection\Context\CustomReflectionContext.Projector.cs" />
@@ -64,13 +62,9 @@
     <Compile Include="System\Reflection\Context\Virtual\VirtualPropertyInfo.PropertySetter.cs" />
     <Compile Include="System\Reflection\Context\Virtual\VirtualReturnParameter.cs" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Reflection" />
     <Reference Include="System.Resources.ResourceManager" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' OR '$(TargetGroup)' == 'uap'">
-    <Reference Include="System.Collections" />
-    <Reference Include="System.Diagnostics.Debug" />
   </ItemGroup>
 </Project>

--- a/src/System.Reflection.Context/tests/Configurations.props
+++ b/src/System.Reflection.Context/tests/Configurations.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
-      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Context/tests/Configurations.props
+++ b/src/System.Reflection.Context/tests/Configurations.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp;
+      uap;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Context/tests/System.Reflection.Context.Tests.csproj
+++ b/src/System.Reflection.Context/tests/System.Reflection.Context.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{6183784D-CF12-476F-BA5F-CFAFF1EF1BE3}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CustomAssemblyAttributes.cs" />

--- a/src/System.Reflection.Context/tests/System.Reflection.Context.Tests.csproj
+++ b/src/System.Reflection.Context/tests/System.Reflection.Context.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{6183784D-CF12-476F-BA5F-CFAFF1EF1BE3}</ProjectGuid>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CustomAssemblyAttributes.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/30812
Fixes https://github.com/dotnet/corefx/issues/30820

- Adding a non-throwing `netstandard2.1` configuration for System.Reflection.Context
- Retarget System.ComponentModel.Composition.Registration to target `netstandard2.1` only.

cc @maryamariyan 
