### PR TITLE
Allow OperationCanceledExceptions to propagate out of ClientWebSocket.ConnectAsync

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.Managed.cs
@@ -223,10 +223,12 @@ namespace System.Net.WebSockets
                 Abort();
                 response?.Dispose();
 
-                if (exc is WebSocketException)
+                if (exc is WebSocketException ||
+                    (exc is OperationCanceledException && cancellationToken.IsCancellationRequested))
                 {
                     throw;
                 }
+
                 throw new WebSocketException(WebSocketError.Faulted, SR.net_webstatus_ConnectFailure, exc);
             }
             finally

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.WinRT.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WebSocketHandle.WinRT.cs
@@ -48,7 +48,7 @@ namespace System.Net.WebSockets
             {
                 await _webSocket.ConnectAsync(uri, cancellationToken, options).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
             {
                 WebErrorStatus status = RTWebSocketError.GetStatus(ex.HResult);
                 var inner = new Exception(status.ToString(), ex);


### PR DESCRIPTION
They're currently being wrapped in WebSocketExceptions, but they should be allowed to escape unwrapped.

Fixes https://github.com/dotnet/corefx/issues/38199
cc: @davidsh, @matthid