### PR TITLE
Fix catch blocks for cancellation in ConnectHelper.ConnectAsync

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -79,7 +79,7 @@ namespace System.Net.Http
                 socket.NoDelay = true;
                 return new ExposedSocketNetworkStream(socket, ownsSocket: true);
             }
-            catch (Exception error)
+            catch (Exception error) when (!(error is OperationCanceledException))
             {
                 throw CancellationHelper.ShouldWrapInOperationCanceledException(error, cancellationToken) ?
                     CancellationHelper.CreateOperationCanceledException(error, cancellationToken) :
@@ -165,6 +165,11 @@ namespace System.Net.Http
             catch (Exception e)
             {
                 sslStream.Dispose();
+
+                if (e is OperationCanceledException)
+                {
+                    throw;
+                }
 
                 if (CancellationHelper.ShouldWrapInOperationCanceledException(e, cancellationToken))
                 {

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1045,7 +1045,6 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop]
         [Fact]
-        [ActiveIssue(30032)]
         public async Task ConnectTimeout_TimesOutSSLAuth_Throws()
         {
             var releaseServer = new TaskCompletionSource<bool>();
@@ -1057,7 +1056,7 @@ namespace System.Net.Http.Functional.Tests
                     handler.ConnectTimeout = TimeSpan.FromSeconds(1);
 
                     var sw = Stopwatch.StartNew();
-                    await Assert.ThrowsAsync<TaskCanceledException>(() =>
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
                         invoker.SendAsync(new HttpRequestMessage(HttpMethod.Get,
                             new UriBuilder(uri) { Scheme = "https" }.ToString()) { Version = VersionFromUseHttp2 }, default));
                     sw.Stop();


### PR DESCRIPTION
There are logic errors in ConnectHelper's catch blocks regarding cancellation.  It's catching all exceptions and then trying to decide whether it should wrap the exception in an OperationCanceledException (based on whether cancellation was requested), but it's ignoring the possibility that the exception already is an OperationCanceledException.

Fixes https://github.com/dotnet/corefx/issues/30032
cc: @krwq, @davidsh, @wfurt