### PR TITLE
[release/2.1] Disable tests on netfx for loop in URI & IPv6AddressHelper

### DIFF
--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -346,9 +346,6 @@ namespace System.Net.Primitives.Functional.Tests
 
         public static IEnumerable<object[]> InvalidIpv6Addresses()
         {
-            yield return new object[] { "" }; // malformed
-            yield return new object[] { "[" }; // malformed
-            yield return new object[] { "[]" }; // malformed
             yield return new object[] { "[:]" }; // malformed
             yield return new object[] { ":::4df" };
             yield return new object[] { "4df:::" };
@@ -442,6 +439,9 @@ namespace System.Net.Primitives.Functional.Tests
             new object[] { "%12" }, // just scope
             new object[] { "[192.168.0.1]" }, // raw v4
             new object[] { "[1]" }, // incomplete
+            new object[] { "" }, // malformed
+            new object[] { "[" }, // malformed
+            new object[] { "[]" }, // malformed
         };
 
         [Theory]

--- a/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/IriTest.cs
@@ -647,6 +647,7 @@ namespace System.PrivateUri.Tests
 
         [Theory]
         [MemberData(nameof(Iri_ExpandingContents_TooLong))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Disable until the .NET FX CI machines get the latest patches.")]
         public static void Iri_ExpandingContents_ThrowsIfTooLong(string input)
         {
             Assert.Throws<System.UriFormatException>(() => { Uri itemUri = new Uri(input); });

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -321,7 +321,6 @@ namespace System.PrivateUri.Tests
         [InlineData(":1:2:3:4:5")] // leading single colon
         [InlineData(":1:2:3:4:5:6")] // leading single colon
         [InlineData(":1:2:3:4:5:6:7")] // leading single colon
-        [InlineData(":1:2:3:4:5:6:7:8")] // leading single colon
         [InlineData(":1:2:3:4:5:6:7:8:9")] // leading single colon
         [InlineData("::1:2:3:4:5:6:7:8")] // compressor with too many number groups
         [InlineData("1::2:3:4:5:6:7:8")] // compressor with too many number groups
@@ -348,6 +347,14 @@ namespace System.PrivateUri.Tests
         // TODO # 8330 Discrepency: IPAddress doesn't accept bad scopes, Uri does.
         //[InlineData("::%1a")] // Alpha numeric Scope
         public void UriIPv6Host_BadAddress(string address)
+        {
+            ParseBadIPv6Address(address);
+        }
+
+        [Theory]
+        [InlineData(":1:2:3:4:5:6:7:8")] // leading single colon
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework machines are not yet patched with the fix for this")]
+        public void UriIPv6Host_BadAddress_SkipOnFramework(string address)
         {
             ParseBadIPv6Address(address);
         }


### PR DESCRIPTION
CC @davidsh @karelz @danmosemsft 

#### Description 

Back-ports test fixes from https://github.com/dotnet/corefx/pull/37734 and https://github.com/dotnet/corefx/pull/38076 to 2.1. Some of these test cases should be disabled on netfx until our test machines have the latest patches, otherwise they will fail.  

#### Customer Impact 

Customers running our test suite on desktop won't see unexpected/surprising test failures

#### Regression? 

 Just a test fix, so should not cause any

#### Risk 

We may forget to circle back and re-enable these on netfx once an appropriate amount of time has passed.