### PR TITLE
Fix digest authentication on SocketsHttpHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
@@ -47,8 +47,8 @@ namespace System.Net.Http
             // It is mandatory for servers to implement sha-256 per RFC 7616
             // Keep MD5 for backward compatibility.
             string algorithm;
-            bool isAlgorithmSpecified;
-            if ((isAlgorithmSpecified = digestResponse.Parameters.TryGetValue(Algorithm, out algorithm)))
+            bool isAlgorithmSpecified = digestResponse.Parameters.TryGetValue(Algorithm, out algorithm);
+            if (isAlgorithmSpecified)
             {
                 if (!algorithm.Equals(Sha256, StringComparison.OrdinalIgnoreCase) &&
                     !algorithm.Equals(Md5, StringComparison.OrdinalIgnoreCase) &&
@@ -115,8 +115,8 @@ namespace System.Net.Http
 
             // Set qop, default is auth
             string qop = Auth;
-            bool isQopSpecified;
-            if ((isQopSpecified = digestResponse.Parameters.ContainsKey(Qop)))
+            bool isQopSpecified = digestResponse.Parameters.ContainsKey(Qop);
+            if (isQopSpecified)
             {
                 // Check if auth-int present in qop string
                 int index1 = digestResponse.Parameters[Qop].IndexOf(AuthInt, StringComparison.Ordinal);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
@@ -47,7 +47,8 @@ namespace System.Net.Http
             // It is mandatory for servers to implement sha-256 per RFC 7616
             // Keep MD5 for backward compatibility.
             string algorithm;
-            if (digestResponse.Parameters.TryGetValue(Algorithm, out algorithm))
+            bool isAlgorithmSpecified;
+            if ((isAlgorithmSpecified = digestResponse.Parameters.TryGetValue(Algorithm, out algorithm)))
             {
                 if (!algorithm.Equals(Sha256, StringComparison.OrdinalIgnoreCase) &&
                     !algorithm.Equals(Md5, StringComparison.OrdinalIgnoreCase) &&
@@ -114,7 +115,8 @@ namespace System.Net.Http
 
             // Set qop, default is auth
             string qop = Auth;
-            if (digestResponse.Parameters.ContainsKey(Qop))
+            bool isQopSpecified;
+            if ((isQopSpecified = digestResponse.Parameters.ContainsKey(Qop)))
             {
                 // Check if auth-int present in qop string
                 int index1 = digestResponse.Parameters[Qop].IndexOf(AuthInt, StringComparison.Ordinal);
@@ -153,33 +155,49 @@ namespace System.Net.Http
                 a2 = a2 + ":" + ComputeHash(content, algorithm);
             }
 
-            string response = ComputeHash(ComputeHash(a1, algorithm) + ":" +
-                                        nonce + ":" +
-                                        DigestResponse.NonceCount + ":" +
-                                        cnonce + ":" +
-                                        qop + ":" +
-                                        ComputeHash(a2, algorithm), algorithm);
+            string response;
+            if (isQopSpecified)
+            { 
+                response = ComputeHash(ComputeHash(a1, algorithm) + ":" +
+                                            nonce + ":" +
+                                            DigestResponse.NonceCount + ":" +
+                                            cnonce + ":" +
+                                            qop + ":" +
+                                            ComputeHash(a2, algorithm), algorithm);
+            }
+            else
+            {
+                response = ComputeHash(ComputeHash(a1, algorithm) + ":" +
+                            nonce + ":" +
+                            ComputeHash(a2, algorithm), algorithm);
+            }
 
             // Add response
-            sb.AppendKeyValue(Response, response);
-
-            // Add algorithm
-            sb.AppendKeyValue(Algorithm, algorithm, includeQuotes: false);
+            sb.AppendKeyValue(Response, response, includeComma: opaque != null || isAlgorithmSpecified || isQopSpecified);
 
             // Add opaque
             if (opaque != null)
             {
-                sb.AppendKeyValue(Opaque, opaque);
+                sb.AppendKeyValue(Opaque, opaque, includeComma: isAlgorithmSpecified || isQopSpecified);
             }
 
-            // Add qop
-            sb.AppendKeyValue(Qop, qop, includeQuotes: false);
+            if (isAlgorithmSpecified)
+            {
+                // Add algorithm
+                sb.AppendKeyValue(Algorithm, algorithm, includeQuotes: false, includeComma: isQopSpecified);
+            }
 
-            // Add nc
-            sb.AppendKeyValue(NC, DigestResponse.NonceCount, includeQuotes: false);
+            if (isQopSpecified)
+            {
+                // Add qop
+                sb.AppendKeyValue(Qop, qop, includeQuotes: false);
 
-            // Add cnonce
-            sb.AppendKeyValue(CNonce, cnonce, includeComma: false);
+                // Add nc
+                sb.AppendKeyValue(NC, DigestResponse.NonceCount, includeQuotes: false);
+
+                // Add cnonce
+                sb.AppendKeyValue(CNonce, cnonce, includeComma: false);
+            }
 
             return StringBuilderCache.GetStringAndRelease(sb);
         }

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1206,9 +1206,9 @@ namespace System.Net.Http.Functional.Tests
 
             // These tests check that the algorithm parameter is treated in case insensitive way.
             // WinHTTP only supports plain MD5, so other algorithms are included here.
-            yield return new object[] { $"Digest realm=\"testrealm\", algorithm=md5-Sess, nonce=\"testnonce\"", true };
+            yield return new object[] { $"Digest realm=\"testrealm\", algorithm=md5-Sess, nonce=\"testnonce\", qop=\"auth\"", true };
             yield return new object[] { $"Digest realm=\"testrealm\", algorithm=sha-256, nonce=\"testnonce\"", true };
-            yield return new object[] { $"Digest realm=\"testrealm\", algorithm=sha-256-SESS, nonce=\"testnonce\"", true };
+            yield return new object[] { $"Digest realm=\"testrealm\", algorithm=sha-256-SESS, nonce=\"testnonce\", qop=\"auth\"", true };
         }
     }
 

--- a/src/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http.Tests
             yield return new object[] { "    key1 = value1, key2 =    value2,", s_keyListWithCountTwo, s_valueListWithCountTwo };
             yield return new object[] { "item1 === item1,key2=, value2", s_listWithCountOne, s_listWithCountOne };
             yield return new object[] { "item1,==item1,,,    key2=\"value2\", key3 m", new List<string> { "item1," }, s_listWithCountOne };
-            yield return new object[] { "key1= \"value1   \",key2  =  \"v alu#e2\"   ,", s_keyListWithCountTwo, new List<string> { "value1   ", "v alu#e2"} };
+            yield return new object[] { "key1= \"value1   \",key2  =  \"v alu#e2\"   ,", s_keyListWithCountTwo, new List<string> { "value1   ", "v alu#e2" } };
             yield return new object[] { "key1   ", s_emptyStringList, s_emptyStringList };
             yield return new object[] { "=====", s_emptyStringList, s_emptyStringList };
             yield return new object[] { ",,", s_emptyStringList, s_emptyStringList };
@@ -49,7 +49,7 @@ namespace System.Net.Http.Tests
         [InlineData("realm=\"NetCore\", qop=\"auth\", stale=false", false)]
         public async void DigestResponse_AuthToken_Handling(string response, bool expectedResult)
         {
-            NetworkCredential credential = new NetworkCredential("foo","bar");
+            NetworkCredential credential = new NetworkCredential("foo", "bar");
             AuthenticationHelper.DigestResponse digestResponse = new AuthenticationHelper.DigestResponse(response);
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://microsoft.com/");
             string parameter = await AuthenticationHelper.GetDigestTokenForCredential(credential, request, digestResponse).ConfigureAwait(false);
@@ -70,6 +70,36 @@ namespace System.Net.Http.Tests
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://microsoft.com/");
             string parameter = await AuthenticationHelper.GetDigestTokenForCredential(credential, request, digestResponse).ConfigureAwait(false);
             Assert.StartsWith(encodedUserName, parameter);
+        }
+
+        public static IEnumerable<object[]> DigestResponse_ShouldSendQop_TestData()
+        {
+            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", qop=\"auth\", stale=false", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)", "(opaque=|algorithm=)", 8 };
+            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", stale=false", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)", "(qop=|cnonce=|opaque=|algorithm=)", 5 };
+            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", stale=false, algorithm=MD5", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*algorithm=)", null, 6 };
+            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", qop=\"auth\", stale=false, opaque=\"qMRqWgAAAAAA\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)", "(algorithm=)", 9 };
+            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", stale=false, opaque=\"qMRqWgAAAAAA\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*opaque=)", "(algorithm=)", 6 };
+            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", stale=false, algorithm=MD5-sess, qop=\"auth\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)", null, 9 };
+        }
+
+        [Theory]
+        [MemberData(nameof(DigestResponse_ShouldSendQop_TestData))]
+        public async void DigestResponse_ShouldSendQop(string response, string match, string doesNotMatch, int fieldCount)
+        {
+            NetworkCredential credential = new NetworkCredential("foo", "bar");
+            AuthenticationHelper.DigestResponse digestResponse = new AuthenticationHelper.DigestResponse(response);
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://microsoft.com/");
+            string parameter = await AuthenticationHelper.GetDigestTokenForCredential(credential, request, digestResponse).ConfigureAwait(false);
+            if (match != null)
+            { 
+                Assert.Matches(match, parameter);
+            }
+            if (doesNotMatch != null)
+            { 
+                Assert.DoesNotMatch(doesNotMatch, parameter);
+            }
+            Assert.Equal(fieldCount, parameter.Split(',').Length);
+            Assert.False(parameter.Trim().EndsWith(","));
         }
     }
 }

--- a/src/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
@@ -77,9 +77,9 @@ namespace System.Net.Http.Tests
             yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", qop=\"auth\", stale=false", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)", "(opaque=|algorithm=)", 8 };
             yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", stale=false", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)", "(qop=|cnonce=|opaque=|algorithm=)", 5 };
             yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", stale=false, algorithm=MD5", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*algorithm=)", null, 6 };
-            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", qop=\"auth\", stale=false, opaque=\"qMRqWgAAAAAA\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)", "(algorithm=)", 9 };
+            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", qop=\"auth\", stale=false, opaque=\"qMRqWgAAAAAA\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)(?=.*opaque=)", "(algorithm=)", 9 };
             yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", stale=false, opaque=\"qMRqWgAAAAAA\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*opaque=)", "(algorithm=)", 6 };
-            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", stale=false, algorithm=MD5-sess, qop=\"auth\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)", null, 9 };
+            yield return new object[] { "realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", stale=false, algorithm=MD5-sess, qop=\"auth\"", "(?=.*username=)(?=.*realm=)(?=.*nonce=)(?=.*uri=)(?=.*response=)(?=.*qop=)(?=.*nc=)(?=.*cnonce=)(?=.*algorithm=)", null, 9 };
         }
 
         [Theory]


### PR DESCRIPTION
fixes https://github.com/dotnet/corefx/issues/37729

Problem I found:


1) Updated code to follow https://tools.ietf.org/html/rfc2617#section-3.2.2

```
qop
     Indicates what "quality of protection" the client has applied to
     the message. If present, its value MUST be one of the alternatives
     the server indicated it supports in the WWW-Authenticate header.
     These values affect the computation of the request-digest. Note
     that this is a single token, not a quoted list of alternatives as
     in WWW- Authenticate.  This directive is optional in order to
     preserve backward compatibility with a minimal implementation of
     RFC 2069 [6], but SHOULD be used if the server indicated that qop
     is supported by providing a qop directive in the WWW-Authenticate
     header field.
```
At the moment `qop` is always included and not follow `but SHOULD be used if the server indicated that qop is supported by providing a qop directive in the WWW-Authenticate header field`

2) Updated code to follow: https://tools.ietf.org/html/rfc2617#section-3.2.2

```
The values of the opaque and algorithm fields must be those supplied
   in the WWW-Authenticate response header for the entity being
   requested.
```
To be compatible with .NET full and WinHttpHandler we'll send `algorithm` only if specified in `WWW-Authenticate` header, otherwise we "silently" use default.

3) Fixed `-sess` tests, passing `qop` otherwise now that we follow 1) server side validation fails because we don't pass nouces anymore. 
    But it's not correct avoid to pass `qop`, `-sess` is present only in rfc2617 where `qop` `it SHOULD be used by all implementations compliant with this version of the Digest scheme.`
    rfc2069 does not mention this kind of algorithm.

4) Implemented missing part https://tools.ietf.org/html/rfc2617#section-3.2.2.1 (some tests fail without)
```
If the "qop" directive is not present (this construction is for
   compatibility with RFC 2069):

      request-digest  =
                 <"> < KD ( H(A1), unq(nonce-value) ":" H(A2) ) >
   <">
```

I added tests where I validate the presence of fields using regex.

I did issue's test on fiddler, log:
```
GET https://jigsaw.w3.org/HTTP/Digest/ HTTP/1.1
Host: jigsaw.w3.org

HTTP/1.1 401 Unauthorized
Date: Tue, 04 Jun 2019 20:11:58 GMT
Content-Length: 261
Content-Type: text/html;charset=ISO-8859-1
Server: Jigsaw/2.3.0-beta2
WWW-Authenticate: Digest realm="test", domain="/HTTP/Digest", nonce="b9aa1067c188f78cdbedd405741231c2"
Strict-Transport-Security: max-age=15552015; includeSubDomains; preload
Public-Key-Pins: pin-sha256="cN0QSpPIkuwpT6iP2YjEo1bEwGpH/yiUn6yhdy+HNto="; pin-sha256="WGJkyYjx1QMdMe0UqlyOKXtydPDVrk7sl2fV+nNm1r4="; pin-sha256="LrKdTxZLRTvyHM4/atX2nquX9BeHRZMCxg3cf4rhc2I="; max-age=864000
X-Frame-Options: deny
X-XSS-Protection: 1; mode=block

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
               "http://www.w3.org/TR/html4/loose.dtd">
<html>
<head>
 <title>Unauthorized</title>
</head>
<body>
<h1>Unauthorized access</h1><p>You are denied access to this resource.</body>
</html>
```
```
GET https://jigsaw.w3.org/HTTP/Digest/ HTTP/1.1
Host: jigsaw.w3.org
Authorization: Digest username="guest", realm="test", nonce="b9aa1067c188f78cdbedd405741231c2", uri="/HTTP/Digest/", response="5641fcab8f7b107e90eab9fc059008fd"

HTTP/1.1 200 OK
Date: Tue, 04 Jun 2019 20:11:58 GMT
Content-Length: 459
Content-Location: https://jigsaw.w3.org/HTTP/Digest/ok.html
Content-Type: text/html
Etag: "6km9jn:qogunjao"
Last-Modified: Thu, 01 Jun 2000 22:07:10 GMT
Server: Jigsaw/2.3.0-beta2
Strict-Transport-Security: max-age=15552015; includeSubDomains; preload
Public-Key-Pins: pin-sha256="cN0QSpPIkuwpT6iP2YjEo1bEwGpH/yiUn6yhdy+HNto="; pin-sha256="WGJkyYjx1QMdMe0UqlyOKXtydPDVrk7sl2fV+nNm1r4="; pin-sha256="LrKdTxZLRTvyHM4/atX2nquX9BeHRZMCxg3cf4rhc2I="; max-age=864000
X-Frame-Options: deny
X-XSS-Protection: 1; mode=block

<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
<html>
  <head>
    <title>Digest Authentication test page</title>
<!-- Changed by: Yves Lafon, 22-Feb-1999 -->
  </head>

<BODY BGCOLOR="white">
<P>
      <A HREF=".."><IMG SRC="/icons/jigsaw" ALT="Jigsaw" BORDER="0" WIDTH="212"
	  HEIGHT="49"></A><IMG SRC="/icons/jigpower.gif" WIDTH="94" HEIGHT="52" ALT="Jigsaw Powered !"
	BORDER="0" ALIGN="Right">
      
<P>
<HR>
<P>Your browser made it!
  </body>
</html>
```

cc area owners: @geoffkizer, @wfurt, @davidsh, @karelz