### PR TITLE
Add missing PlatformSpecific attribute to ProcessStart_OnLinux_UsesSpecifiedProgram test

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -301,6 +301,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Linux)]
         public void ProcessStart_OnLinux_UsesSpecifiedProgram()
         {
             const string Program = "sleep";


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38227
cc: @tmds, @ViktorHofer 