### PR TITLE
Re-generate reference source against impl for System.Threading.Tasks

### DIFF
--- a/src/System.Threading.Tasks/ref/System.Threading.Tasks.cs
+++ b/src/System.Threading.Tasks/ref/System.Threading.Tasks.cs
@@ -68,17 +68,20 @@ namespace System.Runtime.CompilerServices
     public readonly partial struct ConfiguredAsyncDisposable
     {
         private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable DisposeAsync() { throw null; }
     }
     public readonly partial struct ConfiguredCancelableAsyncEnumerable<T>
     {
         private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait(bool continueOnCapturedContext) { throw null; }
         public System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T>.Enumerator GetAsyncEnumerator() { throw null; }
         public System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> WithCancellation(System.Threading.CancellationToken cancellationToken) { throw null; }
         public readonly partial struct Enumerator
         {
             private readonly object _dummy;
+            private readonly int _dummyPrimitive;
             public T Current { get { throw null; } }
             public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable DisposeAsync() { throw null; }
             public System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<bool> MoveNextAsync() { throw null; }
@@ -117,6 +120,12 @@ namespace System.Threading.Tasks
         public System.Threading.Tasks.TaskScheduler ExclusiveScheduler { get { throw null; } }
         public void Complete() { }
     }
+    public static partial class TaskAsyncEnumerableExtensions
+    {
+        public static System.Runtime.CompilerServices.ConfiguredAsyncDisposable ConfigureAwait(this System.IAsyncDisposable source, bool continueOnCapturedContext) { throw null; }
+        public static System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait<T>(this System.Collections.Generic.IAsyncEnumerable<T> source, bool continueOnCapturedContext) { throw null; }
+        public static System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> WithCancellation<T>(this System.Collections.Generic.IAsyncEnumerable<T> source, System.Threading.CancellationToken cancellationToken) { throw null; }
+    }
     public partial class TaskCanceledException : System.OperationCanceledException
     {
         public TaskCanceledException() { }
@@ -143,12 +152,6 @@ namespace System.Threading.Tasks
         public bool TrySetException(System.Collections.Generic.IEnumerable<System.Exception> exceptions) { throw null; }
         public bool TrySetException(System.Exception exception) { throw null; }
         public bool TrySetResult(TResult result) { throw null; }
-    }
-    public static partial class TaskAsyncEnumerableExtensions
-    {
-        public static System.Runtime.CompilerServices.ConfiguredAsyncDisposable ConfigureAwait(this System.IAsyncDisposable source, bool continueOnCapturedContext) { throw null; }
-        public static System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> ConfigureAwait<T>(this System.Collections.Generic.IAsyncEnumerable<T> source, bool continueOnCapturedContext) { throw null; }
-        public static System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable<T> WithCancellation<T>(this System.Collections.Generic.IAsyncEnumerable<T> source, System.Threading.CancellationToken cancellationToken) { throw null; }
     }
     public static partial class TaskExtensions
     {


### PR DESCRIPTION
In order to reduce noise when adding nullable annotations.

cc: @stephentoub @jkotas @danmosemsft @ahsonkhan 