### PR TITLE
Reenable BuildInvalidSignatureTwice with better diagnostics

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -856,7 +856,6 @@ tHP28fj0LUop/QFojSZPsaPAW6JvoQ0t4hd6WoyX6z7FsA==
             }
         }
 
-        [ActiveIssue(36124, TestPlatforms.Windows)]
         [Fact]
         public static void BuildInvalidSignatureTwice()
         {
@@ -896,9 +895,9 @@ tHP28fj0LUop/QFojSZPsaPAW6JvoQ0t4hd6WoyX6z7FsA==
                     }
                     else
                     {
-                        Assert.False(valid, $"Chain is valid on execution {iter}");
-
-                        Assert.Equal(3, chain.ChainElements.Count);
+                        // These asserts are "most informative first".
+                        // (There was an interval where valid was reporting as true in CI, but
+                        // that is the least informative failure)
 
                         // Clear UntrustedRoot, if it happened.
                         allFlags &= ~X509ChainStatusFlags.UntrustedRoot;
@@ -906,6 +905,10 @@ tHP28fj0LUop/QFojSZPsaPAW6JvoQ0t4hd6WoyX6z7FsA==
                         Assert.Equal(
                             X509ChainStatusFlags.NotSignatureValid,
                             allFlags);
+
+                        Assert.Equal(3, chain.ChainElements.Count);
+
+                        Assert.False(valid, $"Chain is valid on execution {iter}");
                     }
 
                     chainHolder.DisposeChainElements();


### PR DESCRIPTION
Fixes #36124.

The asserts have been reversed so that the most informative one comes first.  If there's something weird about our CI state then it becomes more actionable.  Similarly, if it was caused by a bad OS update that has since been cleared, we'll be in a better position of knowing what that bad update did.

(The test is succeeding in my local development environment, so just re-enabling it and seeing if CI agrees.)