### PR TITLE
Expose two missing known folder flags

### DIFF
--- a/src/Common/src/CoreLib/System/Environment.SpecialFolderOption.cs
+++ b/src/Common/src/CoreLib/System/Environment.SpecialFolderOption.cs
@@ -14,6 +14,8 @@ namespace System
             None = 0,
             Create = SpecialFolderOptionValues.CSIDL_FLAG_CREATE,
             DoNotVerify = SpecialFolderOptionValues.CSIDL_FLAG_DONT_VERIFY,
+            DefaultPath = SpecialFolderOptionValues.CSIDL_FLAG_DEFAULT_PATH,
+            NotParentRelative = SpecialFolderOptionValues.CSIDL_FLAG_NOT_PARENT_RELATIVE,
         }
 
         // These values are specific to Windows and are known to SHGetFolderPath, however they are
@@ -31,6 +33,17 @@ namespace System
             /// Return an unverified folder path. Equivalent of KF_FLAG_DONT_VERIFY (0x00004000).
             /// </summary>
             internal const int CSIDL_FLAG_DONT_VERIFY = 0x4000;
+
+            /// <summary>
+            /// Return the default path for a known folder. Equivalent of KF_FLAG_DEFAULT_PATH (0x00000400).
+            /// </summary>
+            internal const int CSIDL_FLAG_DEFAULT_PATH = 0x400;
+
+            /// <summary>
+            /// Return the default path independent of the current location of its parent. CSIDL_FLAG_DEFAULT_PATH must also be set.
+            /// Equivalent of KF_FLAG_NOT_PARENT_RELATIVE (0x00000200).
+            /// </summary>
+            internal const int CSIDL_FLAG_NOT_PARENT_RELATIVE = 0x200;
         }
     }
 }


### PR DESCRIPTION
On Windows, the locations of special folders [can be changed by the user](https://docs.microsoft.com/es-es/windows/desktop/api/shlobj_core/nf-shlobj_core-shsetknownfolderpath).
Currently, there's no way to retrieve the default path to these folders after they have been changed, other than calling the native functions directly. This is really not ideal for portability.
This PR exposes two new `SpecialFolderOptions` fields, which facilitate access to that information:
DefaultPath, which is equivalent to KF_FLAG_DEFAULT_PATH, and NotParentRelative, which is equivalent to KF_FLAG_NOT_PARENT_RELATIVE.
The Unix code path remains unaffected as there is currently no way for the special folders to change in that platform, meaning that these new flags are simply ignored.