### PR TITLE
Enable code path in TypeDescriptor.GetAssociation(...) to use IDesignerHost

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -599,10 +599,8 @@ namespace System.ComponentModel
                     }
                 }
 
-#if FEATURE_IDESIGNERHOST
                 // Not in our table. We have a default association with a designer 
                 // if that designer is a component.
-                //
                 if (associatedObject == primary)
                 {
                     IComponent component = primary as IComponent;
@@ -621,7 +619,6 @@ namespace System.ComponentModel
                                 // got here, we're probably hosed because the user just passed in
                                 // an object that this PropertyDescriptor can't munch on, but it's
                                 // clearer to use that object instance instead of it's designer.
-                                //
                                 if (designer != null && type.IsInstanceOfType(designer))
                                 {
                                     associatedObject = designer;
@@ -630,7 +627,6 @@ namespace System.ComponentModel
                         }
                     }
                 }
-#endif
             }
 
             return associatedObject;

--- a/src/System.ComponentModel.TypeConverter/tests/DescriptorTestComponent.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DescriptorTestComponent.cs
@@ -2,10 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+
 namespace System.ComponentModel.Tests
 {
     internal class DescriptorTestComponent : IComponent, ISite
     {
+        private Dictionary<Type, object> _services;
+
         [DefaultValue(null)]
         public event Action ActionEvent;
         public bool DesignMode { get; set; } = true;
@@ -23,13 +27,33 @@ namespace System.ComponentModel.Tests
             StringProperty = stringPropertyValue;
         }
 
+        public void AddService(Type serviceType, object service)
+        {
+            if (_services == null)
+            {
+                _services = new Dictionary<Type, object>();
+            }
+
+            _services.Add(serviceType, service);
+        }
+
         public void RaiseEvent() => ActionEvent();
 
         public event EventHandler Disposed;
 
         public void Dispose() => Disposed(new object(), new EventArgs());
 
-        public object GetService(Type serviceType) => null;
+        public object GetService(Type serviceType)
+        {
+            if (_services == null)
+            {
+                return null;
+            }
+
+            return _services.TryGetValue(serviceType, out var service)
+                ? service
+                : null;
+        }
 
         public IComponent Component => this;
 

--- a/src/System.ComponentModel.TypeConverter/tests/Mocks/MockDesigner.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Mocks/MockDesigner.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel.Design;
+
+namespace System.ComponentModel.Tests
+{
+    internal class MockDesigner : IDesigner
+    {
+        public IComponent Component => throw new NotImplementedException();
+
+        public DesignerVerbCollection Verbs => throw new NotImplementedException();
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void DoDefaultAction()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Initialize(IComponent component)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/tests/Mocks/MockDesignerHost.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Mocks/MockDesignerHost.cs
@@ -1,0 +1,160 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+
+namespace System.ComponentModel.Tests
+{
+    internal class MockDesignerHost : IDesignerHost
+    {
+        private Dictionary<IComponent, IDesigner> _designers;
+
+        public void AddDesigner(IComponent component, IDesigner designer)
+        {
+            if (_designers == null)
+            {
+                _designers = new Dictionary<IComponent, IDesigner>();
+            }
+
+            _designers.Add(component, designer);
+        }
+
+        public IContainer Container => throw new NotImplementedException();
+
+        public bool InTransaction => throw new NotImplementedException();
+
+        public bool Loading => throw new NotImplementedException();
+
+        public IComponent RootComponent => throw new NotImplementedException();
+
+        public string RootComponentClassName => throw new NotImplementedException();
+
+        public string TransactionDescription => throw new NotImplementedException();
+
+        public event EventHandler Activated
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event EventHandler Deactivated
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event EventHandler LoadComplete
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event DesignerTransactionCloseEventHandler TransactionClosed
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event DesignerTransactionCloseEventHandler TransactionClosing
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event EventHandler TransactionOpened
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public event EventHandler TransactionOpening
+        {
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
+        }
+
+        public void Activate()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddService(Type serviceType, ServiceCreatorCallback callback)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddService(Type serviceType, ServiceCreatorCallback callback, bool promote)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddService(Type serviceType, object serviceInstance)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddService(Type serviceType, object serviceInstance, bool promote)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IComponent CreateComponent(Type componentClass)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IComponent CreateComponent(Type componentClass, string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public DesignerTransaction CreateTransaction()
+        {
+            throw new NotImplementedException();
+        }
+
+        public DesignerTransaction CreateTransaction(string description)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void DestroyComponent(IComponent component)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDesigner GetDesigner(IComponent component)
+        {
+            if (_designers == null)
+            {
+                return null;
+            }
+
+            return _designers.TryGetValue(component, out var designer)
+                ? designer
+                : null;
+        }
+
+        public object GetService(Type serviceType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Type GetType(string typeName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveService(Type serviceType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveService(Type serviceType, bool promote)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{3F0326A1-9E19-4A6C-95CE-63E65C9D2030}</ProjectGuid>
     <DefineConstants>$(DefineConstants);FUNCTIONAL_TESTS</DefineConstants>
@@ -17,6 +17,8 @@
   <ItemGroup>
     <Compile Include="Design\Serialization\ComponentSerializationServiceTests.cs" />
     <Compile Include="Design\StandardCommandsTests.cs" />
+    <Compile Include="Mocks\MockDesigner.cs" />
+    <Compile Include="Mocks\MockDesignerHost.cs" />
     <Compile Include="NestedContainerTests.cs" />
     <Compile Include="PasswordPropertyTextAttributeTests.cs" />
     <Compile Include="MarshalByValueComponentTests.cs" />

--- a/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
@@ -77,10 +77,10 @@ namespace System.ComponentModel.Tests
             designerHost.AddDesigner(component, designer);
             component.AddService(typeof(IDesignerHost), designerHost);
 
-            var associatedObject = TypeDescriptor.GetAssociation(designer.GetType(), component);
+            object associatedObject = TypeDescriptor.GetAssociation(designer.GetType(), component);
 
-            Assert.IsType(designer.GetType(), associatedObject);
-            Assert.Equal(designer, associatedObject);
+            Assert.IsType<MockDesigner>(associatedObject);
+            Assert.Same(designer, associatedObject);
         }
 
         [Theory]

--- a/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.ComponentModel.Design;
 using System.Globalization;
 using Xunit;
 
@@ -64,6 +65,22 @@ namespace System.ComponentModel.Tests
 
             Assert.IsType(secondaryObject.GetType(), associatedObject);
             Assert.Equal(secondaryObject, associatedObject);
+        }
+
+        [Fact]
+        public void GetAssociationReturnsDesigner()
+        {
+            var designer = new MockDesigner();
+            var designerHost = new MockDesignerHost();
+            var component = new DescriptorTestComponent();
+
+            designerHost.AddDesigner(component, designer);
+            component.AddService(typeof(IDesignerHost), designerHost);
+
+            var associatedObject = TypeDescriptor.GetAssociation(designer.GetType(), component);
+
+            Assert.IsType(designer.GetType(), associatedObject);
+            Assert.Equal(designer, associatedObject);
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #38241

`TypeDescriptor.GetAssociation(...)` is supposed to have a fallback in the case that the primary object passed to it is a sited IComponent in design-mode. In that case, it tries to acquire an IDesignerHost from the component site and calls IDesignerHost.GetDesigner(...). Unfortunately, this code path has been disabled since TypeDescriptor was introduced in the corefx code base 3 years ago.

This change enables that code path and adds a test for the scenario.

This is currently blocking WinForms Designer work.