### PR TITLE
ProcessNameMatchesScriptName: add missing Fact attribute

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -157,7 +157,7 @@ namespace System.Diagnostics.Tests
         }
 
         // Active issue https://github.com/dotnet/corefx/issues/37739
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotRedHatFamily6))]
         [PlatformSpecific(~TestPlatforms.OSX)] // On OSX, ProcessName returns the script interpreter.
         public void ProcessNameMatchesScriptName()
         {

--- a/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -157,6 +157,7 @@ namespace System.Diagnostics.Tests
         }
 
         // Active issue https://github.com/dotnet/corefx/issues/37739
+        [Fact]
         [PlatformSpecific(~TestPlatforms.OSX)] // On OSX, ProcessName returns the script interpreter.
         public void ProcessNameMatchesScriptName()
         {
@@ -172,7 +173,7 @@ namespace System.Diagnostics.Tests
                 try
                 {
                     string stat = File.ReadAllText($"/proc/{process.Id}/stat");
-                    Assert.Contains($"({scriptName})", stat);
+                    Assert.Contains($"({scriptName.Substring(0, 15)})", stat);
                     string cmdline = File.ReadAllText($"/proc/{process.Id}/cmdline");
                     Assert.Equal($"/bin/sh\0{filename}\0", cmdline);
 


### PR DESCRIPTION
The test is no longer running due to removing the `ConditionalFact` in https://github.com/dotnet/corefx/pull/38175.