### PR TITLE
[DRAFT]JsonExtensionData should allow non-JsonElement types during serialization

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -174,6 +174,7 @@ namespace System.Text.Json.Serialization
                             {
                                 if (!reader.TryGetDouble(out double d))
                                 {
+                                    // TODO FIX EXCEPTION
                                     throw new NotSupportedException();
                                 }
                                 extensionData.Add(keyName, d);
@@ -187,6 +188,7 @@ namespace System.Text.Json.Serialization
                         extensionData.Add(keyName, reader.GetBoolean());
                         break;
                     default:
+                        // TODO FIX EXCEPTION
                         throw new NotSupportedException();
                 }
             }

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -187,7 +187,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ExtensionPropertyDictionaryStringObject()
         {
-            ClassWithExtensionPropertyAsObject obj = JsonSerializer.Parse<ClassWithExtensionPropertyAsObject>(@"{}");
+            ClassWithExtensionPropertyAlreadyInstantiated obj = JsonSerializer.Parse<ClassWithExtensionPropertyAlreadyInstantiated>(@"{}");
             obj.MyOverflow.Add("test", new object());
             Assert.Equal(@"{""MyOverflow"":{""test"":{}}}", JsonSerializer.ToString(obj));
         }


### PR DESCRIPTION
working on https://github.com/dotnet/corefx/issues/38238

THIS IS A TMP DRAFT PR(INCOMPLETE) TO DISCUSS THE ISSUE, I'LL CLOSE.

Fix serialization it's not a great problem, the hard part is understand how to handle "deserialization" of numbers/object.
I tested Newtonsoft.Json and I would know if should be ok behave in the same way.
```cs
 public class TestModel
    {
        public string Name { get; set; } = "Test";

        [JsonExtensionDataAttribute]
        public Dictionary<string, object> Extensions { get; set; } = new Dictionary<string, object>()
        {
            // ["foo"] = 1.1
        };
    }

    class Program
    {
        static void Main(string[] args)
        {
            string s = @"{""Name"":""Test"",""foo"":1e-005}";
            var s1 = JsonConvert.DeserializeObject<TestModel>(s);
            Console.WriteLine(s1.Extensions["foo"].GetType());

            s = @"{""Name"":""Test"",""foo"":1.1}";
            s1 = JsonConvert.DeserializeObject<TestModel>(s);
            Console.WriteLine(s1.Extensions["foo"].GetType());

            s = @"{""Name"":""Test"",""foo"":1}";
            s1 = JsonConvert.DeserializeObject<TestModel>(s);
            Console.WriteLine(s1.Extensions["foo"].GetType());

            s = @"{""Name"":""Test"",""foo"":-1}";
            s1 = JsonConvert.DeserializeObject<TestModel>(s);
            Console.WriteLine(s1.Extensions["foo"].GetType());

            s = @"{""Name"":""Test"",""foo"":""text""}";
            s1 = JsonConvert.DeserializeObject<TestModel>(s);
            Console.WriteLine(s1.Extensions["foo"].GetType());

            s = @"{""Name"":""Test"",""foo"":{""prop"":""text""}}";
            s1 = JsonConvert.DeserializeObject<TestModel>(s);
            Console.WriteLine(s1.Extensions["foo"].GetType());

            s = @"{""Name"":""Test"",""foo"":true}";
            s1 = JsonConvert.DeserializeObject<TestModel>(s);
            Console.WriteLine(s1.Extensions["foo"].GetType());

            s = @"{""Name"":""Test"",""foo"":false}";
            s1 = JsonConvert.DeserializeObject<TestModel>(s);
            Console.WriteLine(s1.Extensions["foo"].GetType());
        }
    }
```
Result
```
System.Double
System.Double
System.Int64
System.Int64
System.String
Newtonsoft.Json.Linq.JObject <- we have JsonElement
System.Boolean
System.Boolean
```

@steveharter @ahsonkhan  before go on and prepare a complete PR I would like to know if I'm on right way or if there was another plan, thank's!

> Note that in the one use case that MVC uses this feature, it stores arbitrary content (strings or numbers) 

Or should we allow serialization and left deserialization to add only JsonElement on deserialization?

cc: @pranavkm 