### PR TITLE
SqlClient fix managed MARS timeout cancellation

### DIFF
--- a/src/System.Data.SqlClient/System.Data.SqlClient.sln
+++ b/src/System.Data.SqlClient/System.Data.SqlClient.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28922.388
+# Visual Studio 15
+VisualStudioVersion = 15.0.27213.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Data.SqlClient.Tests", "tests\FunctionalTests\System.Data.SqlClient.Tests.csproj", "{F3E72F35-0351-4D67-9388-725BCAD807BA}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -114,10 +114,10 @@ Global
 		{AF78BA88-6428-47EA-8682-442DAF8E9656}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{AF78BA88-6428-47EA-8682-442DAF8E9656}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
 		{AF78BA88-6428-47EA-8682-442DAF8E9656}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
-		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.ActiveCfg = netcoreapp-Unix-Debug|Any CPU
-		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.Build.0 = netcoreapp-Unix-Debug|Any CPU
-		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.ActiveCfg = netfx-Windows_NT-Release|Any CPU
-		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.Build.0 = netfx-Windows_NT-Release|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
 		{518A4E22-0144-4699-80AE-757B744E8E38}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{518A4E22-0144-4699-80AE-757B744E8E38}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{518A4E22-0144-4699-80AE-757B744E8E38}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU

--- a/src/System.Data.SqlClient/System.Data.SqlClient.sln
+++ b/src/System.Data.SqlClient/System.Data.SqlClient.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27213.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28922.388
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Data.SqlClient.Tests", "tests\FunctionalTests\System.Data.SqlClient.Tests.csproj", "{F3E72F35-0351-4D67-9388-725BCAD807BA}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -114,10 +114,10 @@ Global
 		{AF78BA88-6428-47EA-8682-442DAF8E9656}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{AF78BA88-6428-47EA-8682-442DAF8E9656}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
 		{AF78BA88-6428-47EA-8682-442DAF8E9656}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
-		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
-		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
-		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU
-		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.Build.0 = netstandard-Windows_NT-Release|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.ActiveCfg = netcoreapp-Unix-Debug|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Debug|Any CPU.Build.0 = netcoreapp-Unix-Debug|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.ActiveCfg = netfx-Windows_NT-Release|Any CPU
+		{B94B8E6D-3E41-4046-B758-4A2E281F74EE}.Release|Any CPU.Build.0 = netfx-Windows_NT-Release|Any CPU
 		{518A4E22-0144-4699-80AE-757B744E8E38}.Debug|Any CPU.ActiveCfg = netstandard-Windows_NT-Debug|Any CPU
 		{518A4E22-0144-4699-80AE-757B744E8E38}.Debug|Any CPU.Build.0 = netstandard-Windows_NT-Debug|Any CPU
 		{518A4E22-0144-4699-80AE-757B744E8E38}.Release|Any CPU.ActiveCfg = netstandard-Windows_NT-Release|Any CPU

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -136,7 +136,10 @@ namespace System.Data.SqlClient.SNI
             Debug.Assert(Monitor.IsEntered(this), "HandleReceiveError was called without being locked.");
             foreach (SNIMarsHandle handle in _sessions.Values)
             {
-                handle.HandleReceiveError(packet);
+                if (packet.HasCompletionCallback)
+                {
+                    handle.HandleReceiveError(packet);
+                }
             }
             packet?.Release();
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -45,10 +45,8 @@ namespace System.Data.SqlClient.SNI
         /// <summary>
         /// Packet data
         /// </summary>
-        public void Dispose()
-        {
-            Release();
-        }
+        public void Dispose() => Release();
+
         public int ReservedHeaderSize => _headerLength;
 
         /// <summary>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -40,6 +40,15 @@ namespace System.Data.SqlClient.SNI
         /// </summary>
         public bool IsInvalid => _data is null;
 
+        public bool HasCompletionCallback => !(_completionCallback is null);
+
+        /// <summary>
+        /// Packet data
+        /// </summary>
+        public void Dispose()
+        {
+            Release();
+        }
         public int ReservedHeaderSize => _headerLength;
 
         /// <summary>

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -15,13 +15,13 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private static readonly string _tcpMarsConnStr = (new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr) { MultipleActiveResultSets = true, Pooling = true }).ConnectionString;
 
 
-        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup), /* [ActiveIssue(33930)]: */ nameof(DataTestUtility.IsUsingNativeSNI))]
+        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup))]
         public static void ConnectionPool_NonMars()
         {
             RunDataTestForSingleConnString(_tcpConnStr);
         }
 
-        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup), /* [ActiveIssue(33930)] */ nameof(DataTestUtility.IsUsingNativeSNI))]
+        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup))]
         public static void ConnectionPool_Mars()
         {
             RunDataTestForSingleConnString(_tcpMarsConnStr);

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/PoolBlockPeriodTest.netcoreapp.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/PoolBlockPeriodTest.netcoreapp.cs
@@ -21,7 +21,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         private const int ConnectionTimeout = 15;
         private const int CompareMargin = 2;
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), /* [ActiveIssue(33930)] */ nameof(DataTestUtility.IsUsingNativeSNI))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [InlineData("Azure with Default Policy must Disable blocking (*.database.windows.net)", new object[] { AzureEndpointSample })]
         [InlineData("Azure with Default Policy must Disable blocking (*.database.chinacloudapi.cn)", new object[] { AzureChinaEnpointSample })]
         [InlineData("Azure with Default Policy must Disable blocking (*.database.usgovcloudapi.net)", new object[] { AzureUSGovernmentEndpointSample })]
@@ -45,7 +45,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             PoolBlockingPeriodAzureTest(connString, policy);
         }
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), /* [ActiveIssue(33930)] */ nameof(DataTestUtility.IsUsingNativeSNI))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [InlineData("NonAzure with Default Policy must Enable blocking", new object[] { NonExistentServer })]
         [InlineData("NonAzure with Auto Policy must Enable Blocking", new object[] { NonExistentServer, PoolBlockingPeriod.Auto })]
         [InlineData("NonAzure with Always Policy must Enable Blocking", new object[] { NonExistentServer, PoolBlockingPeriod.AlwaysBlock })]
@@ -66,7 +66,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             PoolBlockingPeriodNonAzureTest(connString, policy);
         }
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), /* [ActiveIssue(33930)] */ nameof(DataTestUtility.IsUsingNativeSNI))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [InlineData("Test policy with Auto (lowercase)", "auto")]
         [InlineData("Test policy with Auto (PascalCase)", "Auto")]
         [InlineData("Test policy with Always (lowercase)", "alwaysblock")]

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -64,10 +64,10 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             // These tests fail with named pipes, since they try to do DNS lookups on named pipe paths.
             if (!usingNamePipes)
             {
-                //if (DataTestUtility.IsUsingNativeSNI()) /* [ActiveIssue(33930)] */
-                //{
-                //    TimeoutDuringReadAsyncWithClosedReaderTest(connectionString);
-                //}
+                if (DataTestUtility.IsUsingNativeSNI())
+                {
+                    TimeoutDuringReadAsyncWithClosedReaderTest(connectionString);
+                }
                 NonFatalTimeoutDuringRead(connectionString);
             }
         }

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/MARSTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/MARSTest/MARSTest.cs
@@ -33,7 +33,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
         }
 
 #if DEBUG
-        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup), /* [ActiveIssue(33930)] */ nameof(DataTestUtility.IsUsingNativeSNI))]
+        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup))]
         public static void MARSAsyncTimeoutTest()
         {
             using (SqlConnection connection = new SqlConnection(_connStr))
@@ -73,7 +73,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup), /* [ActiveIssue(33930)] */ nameof(DataTestUtility.IsUsingNativeSNI))]
+        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup))]
         public static void MARSSyncTimeoutTest()
         {
             using (SqlConnection connection = new SqlConnection(_connStr))

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlCredentialTest/SqlCredentialTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlCredentialTest/SqlCredentialTest.cs
@@ -17,7 +17,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
     public static class SqlCredentialTest
     {
 
-        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup), /* [ActiveIssue(33930)] */ nameof(DataTestUtility.IsUsingNativeSNI))]
+        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup))]
         public static void CreateSqlConnectionWithCredential()
         {
             var user = "u" + Guid.NewGuid().ToString().Replace("-", "");
@@ -49,7 +49,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup), /* [ActiveIssue(33930)] */ nameof(DataTestUtility.IsUsingNativeSNI))]
+        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup))]
         public static void SqlConnectionChangePasswordPlaintext()
         {
             var user = "u" + Guid.NewGuid().ToString().Replace("-", "");
@@ -82,7 +82,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup), /* [ActiveIssue(33930)] */ nameof(DataTestUtility.IsUsingNativeSNI))]
+        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup))]
         public static void SqlConnectionChangePasswordSecureString()
         {
             var user = "u" + Guid.NewGuid().ToString().Replace("-", "");
@@ -122,7 +122,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), /* [ActiveIssue(33930)] */ nameof(DataTestUtility.IsUsingNativeSNI))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void OldCredentialsShouldFail()
         {
             String user = "u" + Guid.NewGuid().ToString().Replace("-", "");


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/108

When a disconnection event occurs using the managed sql network interface (unix and uwp) the error is incorrectly propagated to the receive completion callback which causes an assertion in debug mode and possible unknown bad things in release mode which may contribute to the observed instability of the unix version. This PR adds a check for a property on the packet which is only set when the connection is in a correct state for receiving packets.

Third attempt at this fix now with enhanced knowledge from the SQL team so hopefully this one is the last one. Manual and functional tests pass including those re-enabled in this PR.

/cc @afsanehr, @Gary-Zh , @david-engel and @saurabh500 (whose implementation and knowlege this is based on)