### PR TITLE
Update Reflection.Emit and String tests after changes due to nullable review

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,16 +1,16 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview7.19302.1">
+    <Dependency Name="Microsoft.NETCore.Runtime.CoreCLR" Version="3.0.0-preview7.19305.2">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>6d783b29087b5f260c9a64f347867bf6f6391bfe</Sha>
+      <Sha>10df20ed3ff0208b3f16f79d5062662a8827f579</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview7.19302.1">
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="3.0.0-preview7.19305.2">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>6d783b29087b5f260c9a64f347867bf6f6391bfe</Sha>
+      <Sha>10df20ed3ff0208b3f16f79d5062662a8827f579</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview7.19302.1">
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="3.0.0-preview7.19305.2">
       <Uri>https://github.com/dotnet/coreclr</Uri>
-      <Sha>6d783b29087b5f260c9a64f347867bf6f6391bfe</Sha>
+      <Sha>10df20ed3ff0208b3f16f79d5062662a8827f579</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,8 +40,8 @@
     <MicrosoftNETCoreDotNetHostPackageVersion>3.0.0-preview7-27803-11</MicrosoftNETCoreDotNetHostPackageVersion>
     <MicrosoftNETCoreDotNetHostPolicyPackageVersion>3.0.0-preview7-27803-11</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
     <!-- Coreclr dependencies -->
-    <MicrosoftNETCoreILAsmPackageVersion>3.0.0-preview7.19302.1</MicrosoftNETCoreILAsmPackageVersion>
-    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview7.19302.1</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
+    <MicrosoftNETCoreILAsmPackageVersion>3.0.0-preview7.19305.2</MicrosoftNETCoreILAsmPackageVersion>
+    <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview7.19305.2</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <!-- Corefx dependencies -->
     <MicrosoftNETCorePlatformsPackageVersion>3.0.0-preview7.19303.11</MicrosoftNETCorePlatformsPackageVersion>
     <runtimenativeSystemIOPortsPackageVersion>4.6.0-preview7.19303.11</runtimenativeSystemIOPortsPackageVersion>

--- a/global.json
+++ b/global.json
@@ -6,6 +6,6 @@
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19304.1",
     "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19304.1",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
-    "Microsoft.NET.Sdk.IL": "3.0.0-preview7.19302.1"
+    "Microsoft.NET.Sdk.IL": "3.0.0-preview7.19305.2"
   }
 }

--- a/src/System.Reflection.Emit.Lightweight/tests/Utilities.cs
+++ b/src/System.Reflection.Emit.Lightweight/tests/Utilities.cs
@@ -20,7 +20,6 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal(callingConvention, method.CallingConvention);
 
             Assert.Equal(returnType ?? typeof(void), method.ReturnType);
-            Assert.Null(method.ReturnParameter);
 
             ParameterInfo[] parameters = method.GetParameters();
             if (parameterTypes == null)

--- a/src/System.Reflection.Emit.Lightweight/tests/Utilities.cs
+++ b/src/System.Reflection.Emit.Lightweight/tests/Utilities.cs
@@ -20,6 +20,7 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal(callingConvention, method.CallingConvention);
 
             Assert.Equal(returnType ?? typeof(void), method.ReturnType);
+            Assert.NotNull(method.ReturnParameter);
 
             ParameterInfo[] parameters = method.GetParameters();
             if (parameterTypes == null)

--- a/src/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderGetGenericArguments.cs
+++ b/src/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderGetGenericArguments.cs
@@ -10,11 +10,11 @@ namespace System.Reflection.Emit.Tests
     public class MethodBuilderGetGenericArguments
     {
         [Fact]
-        public void GetGenericArguments_NonGenericMethod_ReturnsNull()
+        public void GetGenericArguments_NonGenericMethod_ReturnsEmptyArray()
         {
             TypeBuilder type = Helpers.DynamicType(TypeAttributes.Abstract);
             MethodBuilder method = type.DefineMethod("Name", MethodAttributes.Public);
-            Assert.Null(method.GetGenericArguments());
+            Assert.Equal(Array.Empty<Type>(), method.GetGenericArguments());
         }
 
         [Fact]

--- a/src/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderSetReturnType.cs
+++ b/src/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderSetReturnType.cs
@@ -140,7 +140,7 @@ namespace System.Reflection.Emit.Tests
 
             method.SetReturnType(null);
             type.CreateTypeInfo().AsType();
-            VerifyReturnType(method, null);
+            VerifyReturnType(method, typeof(void));
         }
 
         private void VerifyReturnType(MethodBuilder method, Type expected)

--- a/src/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderSetSignature.cs
+++ b/src/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderSetSignature.cs
@@ -198,7 +198,7 @@ namespace System.Reflection.Emit.Tests
             MethodBuilder method = type.DefineMethod("TestMethod", MethodAttributes.Public | MethodAttributes.Abstract | MethodAttributes.Virtual);
 
             method.SetSignature(null, null, null, null, null, null);
-            VerifyMethodSignature(type, method, null);
+            VerifyMethodSignature(type, method, typeof(void));
         }
 
         [Fact]
@@ -211,7 +211,7 @@ namespace System.Reflection.Emit.Tests
             GenericTypeParameterBuilder desiredReturnType = typeParameters[0];
 
             method.SetSignature(null, null, null, null, null, null);
-            VerifyMethodSignature(type, method, null);
+            VerifyMethodSignature(type, method, typeof(void));
         }
 
         [Fact]
@@ -260,17 +260,10 @@ namespace System.Reflection.Emit.Tests
             Type ret = type.CreateTypeInfo().AsType();
             MethodInfo methodInfo = method.GetBaseDefinition();
             Type actualReturnType = methodInfo.ReturnType;
-
-            if (desiredReturnType == null)
-            {
-                Assert.Null(actualReturnType);
-            }
-            else
-            {
-                Assert.NotNull(actualReturnType);
-                Assert.Equal(desiredReturnType.Name, actualReturnType.Name);
-                Assert.True(actualReturnType.Equals(desiredReturnType));
-            }
+            
+            Assert.NotNull(actualReturnType);
+            Assert.Equal(desiredReturnType.Name, actualReturnType.Name);
+            Assert.Equal(desiredReturnType, actualReturnType);
         }
     }
 }

--- a/src/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderDefineMethod.cs
+++ b/src/System.Reflection.Emit/tests/TypeBuilder/TypeBuilderDefineMethod.cs
@@ -118,7 +118,7 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal(name, method.Name);
             Assert.Equal(attributes, method.Attributes);
             Assert.Equal(expectedCallingConvention, method.CallingConvention);
-            Assert.Equal(returnType, method.ReturnType);
+            Assert.Equal(returnType ?? typeof(void), method.ReturnType);
         }
     }
 }


### PR DESCRIPTION
Depends on: https://github.com/dotnet/coreclr/pull/24937

After some API Reviews we decided to fix/change some nullable annotations impacting the behavior in some reflection emit APIs (found incomplete implementation) and some string comparison and manipulation APIs when passing down a null CultureInfo to instead of throwing an `ArgumentNullException` to default to `CurrentCulture`. 

Still need to apply the string changes to MemoryExtensions, but since we haven't gotten to that ref assembly I rather not make my PR in coreclr larger and will do it in another round of fixing feedback.

cc: @stephentoub @jkotas @danmosemsft 