### PR TITLE
Update JsonSerializer and JsonElement APIs - drop "As" and parameter re-ordering

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -76,10 +76,10 @@ namespace System.Text.Json
         public bool ValueEquals(System.ReadOnlySpan<byte> utf8Text) { throw null; }
         public bool ValueEquals(System.ReadOnlySpan<char> text) { throw null; }
         public bool ValueEquals(string text) { throw null; }
-        public void WriteAsProperty(System.ReadOnlySpan<byte> utf8PropertyName, System.Text.Json.Utf8JsonWriter writer) { }
-        public void WriteAsProperty(System.ReadOnlySpan<char> propertyName, System.Text.Json.Utf8JsonWriter writer) { }
-        public void WriteAsProperty(string propertyName, System.Text.Json.Utf8JsonWriter writer) { }
-        public void WriteAsValue(System.Text.Json.Utf8JsonWriter writer) { }
+        public void WriteProperty(System.ReadOnlySpan<byte> utf8PropertyName, System.Text.Json.Utf8JsonWriter writer) { }
+        public void WriteProperty(System.ReadOnlySpan<char> propertyName, System.Text.Json.Utf8JsonWriter writer) { }
+        public void WriteProperty(string propertyName, System.Text.Json.Utf8JsonWriter writer) { }
+        public void WriteValue(System.Text.Json.Utf8JsonWriter writer) { }
         public partial struct ArrayEnumerator : System.Collections.Generic.IEnumerable<System.Text.Json.JsonElement>, System.Collections.Generic.IEnumerator<System.Text.Json.JsonElement>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
         {
             private object _dummy;
@@ -175,8 +175,8 @@ namespace System.Text.Json
         public static string ToString<TValue>(TValue value, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
         public static byte[] ToUtf8Bytes(object value, System.Type type, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
         public static byte[] ToUtf8Bytes<TValue>(TValue value, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static System.Threading.Tasks.Task WriteAsync(object value, System.Type type, System.IO.Stream utf8Json, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static System.Threading.Tasks.Task WriteAsync<TValue>(TValue value, System.IO.Stream utf8Json, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task WriteAsync(System.IO.Stream utf8Json, object value, System.Type type, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task WriteAsync<TValue>(System.IO.Stream utf8Json, TValue value, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public sealed partial class JsonSerializerOptions
     {

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1074,7 +1074,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        ///   Write the element into the provided writer as a named object property.
+        ///   Write the element into the provided writer as a named JSON object property.
         /// </summary>
         /// <param name="propertyName">The name for this value within the JSON object.</param>
         /// <param name="writer">The writer.</param>
@@ -1084,11 +1084,11 @@ namespace System.Text.Json
         /// <exception cref="ObjectDisposedException">
         ///   The parent <see cref="JsonDocument"/> has been disposed.
         /// </exception>
-        public void WriteAsProperty(string propertyName, Utf8JsonWriter writer)
-            => WriteAsProperty(propertyName.AsSpan(), writer);
+        public void WriteProperty(string propertyName, Utf8JsonWriter writer)
+            => WriteProperty(propertyName.AsSpan(), writer);
 
         /// <summary>
-        ///   Write the element into the provided writer as a named object property.
+        ///   Write the element into the provided writer as a named JSON object property.
         /// </summary>
         /// <param name="propertyName">The name for this value within the JSON object.</param>
         /// <param name="writer">The writer.</param>
@@ -1098,7 +1098,7 @@ namespace System.Text.Json
         /// <exception cref="ObjectDisposedException">
         ///   The parent <see cref="JsonDocument"/> has been disposed.
         /// </exception>
-        public void WriteAsProperty(ReadOnlySpan<char> propertyName, Utf8JsonWriter writer)
+        public void WriteProperty(ReadOnlySpan<char> propertyName, Utf8JsonWriter writer)
         {
             CheckValidInstance();
 
@@ -1106,7 +1106,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        ///   Write the element into the provided writer as a named object property.
+        ///   Write the element into the provided writer as a named JSON object property.
         /// </summary>
         /// <param name="utf8PropertyName">
         ///   The name for this value within the JSON object, as UTF-8 text.
@@ -1118,7 +1118,7 @@ namespace System.Text.Json
         /// <exception cref="ObjectDisposedException">
         ///   The parent <see cref="JsonDocument"/> has been disposed.
         /// </exception>
-        public void WriteAsProperty(ReadOnlySpan<byte> utf8PropertyName, Utf8JsonWriter writer)
+        public void WriteProperty(ReadOnlySpan<byte> utf8PropertyName, Utf8JsonWriter writer)
         {
             CheckValidInstance();
 
@@ -1126,7 +1126,7 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        ///   Write the element into the provided writer as a value.
+        ///   Write the element into the provided writer as a JSON value.
         /// </summary>
         /// <param name="writer">The writer.</param>
         /// <exception cref="InvalidOperationException">
@@ -1135,7 +1135,7 @@ namespace System.Text.Json
         /// <exception cref="ObjectDisposedException">
         ///   The parent <see cref="JsonDocument"/> has been disposed.
         /// </exception>
-        public void WriteAsValue(Utf8JsonWriter writer)
+        public void WriteValue(Utf8JsonWriter writer)
         {
             CheckValidInstance();
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterJsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterJsonElement.cs
@@ -25,12 +25,12 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(JsonElement value, Utf8JsonWriter writer)
         {
-            value.WriteAsValue(writer);
+            value.WriteValue(writer);
         }
 
         public override void Write(JsonEncodedText propertyName, JsonElement value, Utf8JsonWriter writer)
         {
-            value.WriteAsProperty(propertyName.ToString(), writer);
+            value.WriteProperty(propertyName.ToString(), writer);
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -143,7 +143,7 @@ namespace System.Text.Json
                 Debug.Assert(entry.Key is string);
 
                 string propertyName = (string)entry.Key;
-                element.WriteAsProperty(propertyName, writer);
+                element.WriteProperty(propertyName, writer);
             }
             else
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -14,35 +14,35 @@ namespace System.Text.Json
         /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        /// <param name="value">The value to convert.</param>
         /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
+        /// <param name="value">The value to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
-        public static Task WriteAsync<TValue>(TValue value, Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
+        public static Task WriteAsync<TValue>(Stream utf8Json, TValue value, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
-            return WriteAsyncCore(value, typeof(TValue), utf8Json, options, cancellationToken);
+            return WriteAsyncCore(utf8Json, value, typeof(TValue), options, cancellationToken);
         }
 
         /// <summary>
         /// Convert the provided value to UTF-8 encoded JSON text and write it to the <see cref="System.IO.Stream"/>.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
+        /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
         /// <param name="value">The value to convert.</param>
         /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
-        /// <param name="utf8Json">The UTF-8 <see cref="System.IO.Stream"/> to write to.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
-        public static Task WriteAsync(object value, Type type, Stream utf8Json, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
+        public static Task WriteAsync(Stream utf8Json, object value, Type type, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
             if (utf8Json == null)
                 throw new ArgumentNullException(nameof(utf8Json));
 
             VerifyValueAndType(value, type);
 
-            return WriteAsyncCore(value, type, utf8Json, options, cancellationToken);
+            return WriteAsyncCore(utf8Json, value, type, options, cancellationToken);
         }
 
-        private static async Task WriteAsyncCore(object value, Type type, Stream utf8Json, JsonSerializerOptions options, CancellationToken cancellationToken)
+        private static async Task WriteAsyncCore(Stream utf8Json, object value, Type type, JsonSerializerOptions options, CancellationToken cancellationToken)
         {
             if (options == null)
             {

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -1420,19 +1420,19 @@ namespace System.Text.Json.Tests
                 Assert.Throws<ObjectDisposedException>(() =>
                 {
                     Utf8JsonWriter writer = default;
-                    root.WriteAsValue(writer);
+                    root.WriteValue(writer);
                 });
 
                 Assert.Throws<ObjectDisposedException>(() =>
                 {
                     Utf8JsonWriter writer = default;
-                    root.WriteAsProperty(ReadOnlySpan<char>.Empty, writer);
+                    root.WriteProperty(ReadOnlySpan<char>.Empty, writer);
                 });
 
                 Assert.Throws<ObjectDisposedException>(() =>
                 {
                     Utf8JsonWriter writer = default;
-                    root.WriteAsProperty(ReadOnlySpan<byte>.Empty, writer);
+                    root.WriteProperty(ReadOnlySpan<byte>.Empty, writer);
                 });
             }
         }
@@ -1471,19 +1471,19 @@ namespace System.Text.Json.Tests
             Assert.Throws<InvalidOperationException>(() =>
             {
                 Utf8JsonWriter writer = default;
-                root.WriteAsValue(writer);
+                root.WriteValue(writer);
             });
 
             Assert.Throws<InvalidOperationException>(() =>
             {
                 Utf8JsonWriter writer = default;
-                root.WriteAsProperty(ReadOnlySpan<char>.Empty, writer);
+                root.WriteProperty(ReadOnlySpan<char>.Empty, writer);
             });
 
             Assert.Throws<InvalidOperationException>(() =>
             {
                 Utf8JsonWriter writer = default;
-                root.WriteAsProperty(ReadOnlySpan<byte>.Empty, writer);
+                root.WriteProperty(ReadOnlySpan<byte>.Empty, writer);
             });
         }
 

--- a/src/System.Text.Json/tests/JsonElementWriteTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWriteTests.cs
@@ -846,7 +846,7 @@ null,
             using (JsonDocument doc = JsonDocument.Parse(jsonIn, optionsCopy))
             {
                 var writer = new Utf8JsonWriter(buffer);
-                doc.RootElement.WriteAsValue(writer);
+                doc.RootElement.WriteValue(writer);
                 writer.Flush();
 
                 ReadOnlySpan<byte> formatted = buffer.WrittenSpan;
@@ -879,9 +879,9 @@ null,
                 {
                     foreach (JsonElement val in root.EnumerateArray())
                     {
-                        val.WriteAsProperty(CharLabel, writer);
-                        val.WriteAsProperty(CharLabel.AsSpan(), writer);
-                        val.WriteAsProperty(byteUtf8, writer);
+                        val.WriteProperty(CharLabel, writer);
+                        val.WriteProperty(CharLabel.AsSpan(), writer);
+                        val.WriteProperty(byteUtf8, writer);
                     }
 
                     writer.Flush();
@@ -902,15 +902,15 @@ null,
                     {
                         JsonTestHelper.AssertThrows<InvalidOperationException>(
                             ref writer,
-                            (ref Utf8JsonWriter w) => val.WriteAsProperty(CharLabel, w));
+                            (ref Utf8JsonWriter w) => val.WriteProperty(CharLabel, w));
 
                         JsonTestHelper.AssertThrows<InvalidOperationException>(
                             ref writer,
-                            (ref Utf8JsonWriter w) => val.WriteAsProperty(CharLabel.AsSpan(), w));
+                            (ref Utf8JsonWriter w) => val.WriteProperty(CharLabel.AsSpan(), w));
 
                         JsonTestHelper.AssertThrows<InvalidOperationException>(
                             ref writer,
-                            (ref Utf8JsonWriter w) => val.WriteAsProperty(byteUtf8, w));
+                            (ref Utf8JsonWriter w) => val.WriteProperty(byteUtf8, w));
                     }
 
                     writer.Flush();
@@ -941,7 +941,7 @@ null,
                 {
                     foreach (JsonElement val in root.EnumerateArray())
                     {
-                        val.WriteAsValue(writer);
+                        val.WriteValue(writer);
                     }
 
                     writer.WriteEndObject();
@@ -957,7 +957,7 @@ null,
                     {
                         JsonTestHelper.AssertThrows<InvalidOperationException>(
                             ref writer,
-                            (ref Utf8JsonWriter w) => val.WriteAsValue(w));
+                            (ref Utf8JsonWriter w) => val.WriteValue(w));
                     }
 
                     writer.WriteEndObject();
@@ -982,7 +982,7 @@ null,
 
                 var writer = new Utf8JsonWriter(buffer, options);
 
-                target.WriteAsValue(writer);
+                target.WriteValue(writer);
                 writer.Flush();
 
                 AssertContents(jsonOut ?? jsonIn, buffer);
@@ -1007,7 +1007,7 @@ null,
 
                 var writer = new Utf8JsonWriter(buffer, options);
 
-                target.WriteAsValue(writer);
+                target.WriteValue(writer);
                 writer.Flush();
 
                 if (indented && s_replaceNewlines)
@@ -1071,7 +1071,7 @@ null,
                 var writer = new Utf8JsonWriter(buffer, options);
 
                 writer.WriteStartObject();
-                target.WriteAsProperty(propertyName, writer);
+                target.WriteProperty(propertyName, writer);
                 writer.WriteEndObject();
                 writer.Flush();
 
@@ -1106,7 +1106,7 @@ null,
                 var writer = new Utf8JsonWriter(buffer, options);
 
                 writer.WriteStartObject();
-                target.WriteAsProperty(propertyName, writer);
+                target.WriteProperty(propertyName, writer);
                 writer.WriteEndObject();
                 writer.Flush();
 
@@ -1141,7 +1141,7 @@ null,
                 var writer = new Utf8JsonWriter(buffer, options);
 
                 writer.WriteStartObject();
-                target.WriteAsProperty(propertyName, writer);
+                target.WriteProperty(propertyName, writer);
                 writer.WriteEndObject();
                 writer.Flush();
 

--- a/src/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
@@ -15,7 +15,7 @@ namespace System.Text.Json.Serialization.Tests
         public async static Task VerifyValueFail()
         {
             MemoryStream stream = new MemoryStream();
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.WriteAsync(stream, "", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.WriteAsync(stream, "", (Type)null));
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
@@ -15,21 +15,21 @@ namespace System.Text.Json.Serialization.Tests
         public async static Task VerifyValueFail()
         {
             MemoryStream stream = new MemoryStream();
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.WriteAsync("", null, stream));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.WriteAsync(stream, "", null));
         }
 
         [Fact]
         public async static Task VerifyTypeFail()
         {
             MemoryStream stream = new MemoryStream();
-            await Assert.ThrowsAsync<ArgumentException>(async () => await JsonSerializer.WriteAsync(1, typeof(string), stream));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await JsonSerializer.WriteAsync(stream, 1, typeof(string)));
         }
 
         [Fact]
         public static async Task NullObjectValue()
         {
             MemoryStream stream = new MemoryStream();
-            await JsonSerializer.WriteAsync((object)null, stream);
+            await JsonSerializer.WriteAsync(stream, (object)null);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -73,7 +73,7 @@ namespace System.Text.Json.Serialization.Tests
                 obj.Initialize();
                 obj.Verify();
 
-                await JsonSerializer.WriteAsync(obj, stream, options: options);
+                await JsonSerializer.WriteAsync(stream, obj, options: options);
             }
 
             // Must be changed if the test classes change:


### PR DESCRIPTION
Update the existing APIs according to latest review: https://github.com/dotnet/corefx/issues/36714#issuecomment-497417558

cc @bartonjs, @steveharter, @rynowak, @BrennanConroy, @pranavkm, @KrzysztofCwalina, @wli3, @adamsitnik, @billwert 