### PR TITLE
SqlClient Fix managed command cancellation

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -40,6 +40,15 @@ namespace System.Data.SqlClient.SNI
         /// </summary>
         public bool IsInvalid => _data is null;
 
+        /// <summary>
+        /// Indicates that the packet should be sent out of band bypassing the normal send-recieve lock
+        /// </summary>
+        public bool IsOutOfBand { get; set; }
+
+        /// <summary>
+        /// Indicates the amonut of reserved header space available at the start of this packet.
+        /// Used with SMUX packet headers, see <see cref="GetHeaderBuffer"/> and <see cref="SetHeaderActive"/>
+        /// </summary>
         public int ReservedHeaderSize => _headerLength;
 
         /// <summary>
@@ -74,7 +83,7 @@ namespace System.Data.SqlClient.SNI
         }
 
         /// <summary>
-        /// Read packet data into a buffer without removing it from the packet
+        /// Get packet data
         /// </summary>
         /// <param name="buffer">Buffer</param>
         /// <param name="dataSize">Number of bytes read from the packet into the buffer</param>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -23,6 +23,7 @@ namespace System.Data.SqlClient.SNI
     {
         private readonly string _targetServer;
         private readonly object _callbackObject;
+        private readonly object _sendSync;
         private readonly Socket _socket;
         private NetworkStream _tcpStream;
 
@@ -100,6 +101,7 @@ namespace System.Data.SqlClient.SNI
         /// <param name="callbackObject">Callback object</param>
         public SNITCPHandle(string serverName, int port, long timerExpire, object callbackObject, bool parallel)
         {
+            _sendSync = new object();
             _callbackObject = callbackObject;
             _targetServer = serverName;
 
@@ -420,24 +422,52 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint Send(SNIPacket packet)
         {
-            lock (this)
+            bool releaseLock = false;
+            try
             {
-                try
+                // is the packet is marked out out-of-band (attention packets only) it must be
+                // sent immediately even if a send of recieve operation is already in progress
+                // because out of band packets are used to cancel ongoing operations
+                // so try to take the lock if possible but continue even if it can't be taken
+                if (packet.IsOutOfBand)
                 {
-                    packet.WriteToStream(_stream);
-                    return TdsEnums.SNI_SUCCESS;
+                    Monitor.TryEnter(this, ref releaseLock);
                 }
-                catch (ObjectDisposedException ode)
+                else
                 {
-                    return ReportTcpSNIError(ode);
+                    Monitor.Enter(this);
+                    releaseLock = true;
                 }
-                catch (SocketException se)
+
+                // this lock ensures that two packets are not being written to the transport at the same time
+                // so that sending a standard and an out-of-band packet are both written atomically no data is 
+                // interleaved
+                lock (_sendSync)
                 {
-                    return ReportTcpSNIError(se);
+                    try
+                    {
+                        packet.WriteToStream(_stream);
+                        return TdsEnums.SNI_SUCCESS;
+                    }
+                    catch (ObjectDisposedException ode)
+                    {
+                        return ReportTcpSNIError(ode);
+                    }
+                    catch (SocketException se)
+                    {
+                        return ReportTcpSNIError(se);
+                    }
+                    catch (IOException ioe)
+                    {
+                        return ReportTcpSNIError(ioe);
+                    }
                 }
-                catch (IOException ioe)
+            }
+            finally
+            {
+                if (releaseLock)
                 {
-                    return ReportTcpSNIError(ioe);
+                    Monitor.Exit(this);
                 }
             }
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -144,6 +144,7 @@ namespace System.Data.SqlClient.SNI
         {
             PacketHandle packetHandle = GetResetWritePacket(TdsEnums.HEADER_LEN);
             SetPacketData(packetHandle, SQL.AttentionHeader, TdsEnums.HEADER_LEN);
+            packetHandle.ManagedPacket.IsOutOfBand = true;
             return packetHandle;
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/CommandCancelTest/CommandCancelTest.cs
@@ -295,7 +295,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
                     .ContinueWith(t => cmd.Cancel());
 
                 DateTime started = DateTime.UtcNow;
-                DateTime ended = default;
+                DateTime ended = DateTime.MinValue;
                 Exception exception = null;
                 try
                 {


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/109

When using the managed implementation of the sql network interface (unix an uap) any attempt to cancel a request waits until the request completes naturally before the cancellation packet is sent and processed. This results in cancellation taking as long as the query lasts and then acting as if it has been correctly cancelled instead of being cancelled as soon as possible.

This PR modifies the locking used in Send and Receive functions so that packets marked as out-of-band (only attention packets) can bypass the normal lock and be sent immediately. The locking has been changed from a single lock serializing all Send and Receive operations to a pair of locks. Normal in-band packets follow the current behaviour. Out-of-band packets will attempt to take the send-receive lock if possible but continue if it is not. An inner send lock has been added which prevents multiple send operations sending interleaved data, each packet is sent completely.

All tests pass. New tests are added which check that cancellation doesn't just wait for the query to finish.
/cc @afsanehr, @Gary-Zh , @david-engel , reporter @roji and @saurabh500 from discussion in the issue