### PR TITLE
Disable some Calendars when using GlobalizationMode.Invariant.

### DIFF
--- a/src/Common/src/CoreLib/System/Globalization/DateTimeFormat.cs
+++ b/src/Common/src/CoreLib/System/Globalization/DateTimeFormat.cs
@@ -458,8 +458,8 @@ namespace System
             }
 
             // This is a flag to indicate if we are format the dates using Hebrew calendar.
-            bool isHebrewCalendar = (cal.ID == CalendarId.HEBREW);
-            bool isJapaneseCalendar = (cal.ID == CalendarId.JAPAN);
+            bool isHebrewCalendar = !GlobalizationMode.Invariant && ((CalendarId)cal.ID == CalendarId.HEBREW);
+            bool isJapaneseCalendar = !GlobalizationMode.Invariant && ((CalendarId)cal.ID == CalendarId.JAPAN);
             // This is a flag to indicate if we are formating hour/minute/second only.
             bool bTimeOnly = true;
 
@@ -666,7 +666,7 @@ namespace System
                         {
                             FormatDigits(result, year, tokenLen <= 2 ? tokenLen : 2);
                         }
-                        else if (cal.ID == CalendarId.HEBREW)
+                        else if (isHebrewCalendar)
                         {
                             HebrewFormatDigits(result, year);
                         }

--- a/src/Common/src/CoreLib/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/Common/src/CoreLib/System/Globalization/DateTimeFormatInfo.cs
@@ -2226,46 +2226,14 @@ namespace System.Globalization
                 InsertHash(temp, AMDesignator, TokenType.SEP_Am | TokenType.Am, 0);
                 InsertHash(temp, PMDesignator, TokenType.SEP_Pm | TokenType.Pm, 1);
 
-                // TODO: This ignores similar custom cultures
-                if (!GlobalizationMode.Invariant && LanguageName.Equals("sq"))
-                {
-                    // Albanian allows time formats like "12:00.PD"
-                    InsertHash(temp, IgnorablePeriod + AMDesignator, TokenType.SEP_Am | TokenType.Am, 0);
-                    InsertHash(temp, IgnorablePeriod + PMDesignator, TokenType.SEP_Pm | TokenType.Pm, 1);
-                }
+                // For some cultures, the date separator works more like a comma, being allowed before or after any date part.
+                // In these cultures, we do not use normal date separator since we disallow date separator after a date terminal state.
+                // This is determined in DateTimeFormatInfoScanner.  Use this flag to determine if we should treat date separator as ignorable symbol.
+                bool useDateSepAsIgnorableSymbol = false;
 
                 if (!GlobalizationMode.Invariant)
                 {
-                    // CJK suffix
-                    InsertHash(temp, CJKYearSuff, TokenType.SEP_YearSuff, 0);
-                    InsertHash(temp, KoreanYearSuff, TokenType.SEP_YearSuff, 0);
-                    InsertHash(temp, CJKMonthSuff, TokenType.SEP_MonthSuff, 0);
-                    InsertHash(temp, KoreanMonthSuff, TokenType.SEP_MonthSuff, 0);
-                    InsertHash(temp, CJKDaySuff, TokenType.SEP_DaySuff, 0);
-                    InsertHash(temp, KoreanDaySuff, TokenType.SEP_DaySuff, 0);
-
-                    InsertHash(temp, CJKHourSuff, TokenType.SEP_HourSuff, 0);
-                    InsertHash(temp, ChineseHourSuff, TokenType.SEP_HourSuff, 0);
-                    InsertHash(temp, CJKMinuteSuff, TokenType.SEP_MinuteSuff, 0);
-                    InsertHash(temp, CJKSecondSuff, TokenType.SEP_SecondSuff, 0);
-
-                    if (!AppContextSwitches.EnforceLegacyJapaneseDateParsing && Calendar.ID == (int)CalendarId.JAPAN)
-                    {
-                        // We need to support parsing the dates has the start of era symbol which means it is year 1 in the era.
-                        // The start of era symbol has to be followed by the year symbol suffix, otherwise it would be invalid date.
-                        InsertHash(temp, JapaneseEraStart, TokenType.YearNumberToken, 1);
-                        InsertHash(temp, "(", TokenType.IgnorableSymbol, 0);
-                        InsertHash(temp, ")", TokenType.IgnorableSymbol, 0);
-                    }
-
-                    // TODO: This ignores other custom cultures that might want to do something similar
-                    if (koreanLanguage)
-                    {
-                        // Korean suffix
-                        InsertHash(temp, KoreanHourSuff, TokenType.SEP_HourSuff, 0);
-                        InsertHash(temp, KoreanMinuteSuff, TokenType.SEP_MinuteSuff, 0);
-                        InsertHash(temp, KoreanSecondSuff, TokenType.SEP_SecondSuff, 0);
-                    }
+                    PopulateSpecialTokenHashTable(temp, ref useDateSepAsIgnorableSymbol);
                 }
 
                 if (!GlobalizationMode.Invariant && LanguageName.Equals("ky"))
@@ -2276,62 +2244,6 @@ namespace System.Globalization
                 else
                 {
                     InsertHash(temp, dateSeparatorOrTimeZoneOffset, TokenType.SEP_DateOrOffset, 0);
-                }
-
-                String[] dateWords = null;
-                DateTimeFormatInfoScanner scanner = null;
-
-                if (!GlobalizationMode.Invariant)
-                {
-                    // We need to rescan the date words since we're always synthetic
-                    scanner = new DateTimeFormatInfoScanner();
-                    dateWords = scanner.GetDateWordsOfDTFI(this);
-                }
-
-                // Ensure the formatflags is initialized.
-                DateTimeFormatFlags flag = FormatFlags;
-
-                // For some cultures, the date separator works more like a comma, being allowed before or after any date part.
-                // In these cultures, we do not use normal date separator since we disallow date separator after a date terminal state.
-                // This is determined in DateTimeFormatInfoScanner.  Use this flag to determine if we should treat date separator as ignorable symbol.
-                bool useDateSepAsIgnorableSymbol = false;
-
-                String monthPostfix = null;
-                if (!GlobalizationMode.Invariant && dateWords != null)
-                {
-                    // There are DateWords.  It could be a real date word (such as "de"), or a monthPostfix.
-                    // The monthPostfix starts with '\xfffe' (MonthPostfixChar), followed by the real monthPostfix.
-                    for (int i = 0; i < dateWords.Length; i++)
-                    {
-                        switch (dateWords[i][0])
-                        {
-                            // This is a month postfix
-                            case DateTimeFormatInfoScanner.MonthPostfixChar:
-                                // Get the real month postfix.
-                                ReadOnlySpan<char> monthPostfix = dateWords[i].AsSpan(1);
-                                // Add the month name + postfix into the token.
-                                AddMonthNames(temp, monthPostfix);
-                                break;
-                            case DateTimeFormatInfoScanner.IgnorableSymbolChar:
-                                string symbol = dateWords[i].Substring(1);
-                                InsertHash(temp, symbol, TokenType.IgnorableSymbol, 0);
-                                if (DateSeparator.Trim(null).Equals(symbol))
-                                {
-                                    // The date separator is the same as the ignorable symbol.
-                                    useDateSepAsIgnorableSymbol = true;
-                                }
-                                break;
-                            default:
-                                InsertHash(temp, dateWords[i], TokenType.DateWordToken, 0);
-                                // TODO: This ignores similar custom cultures
-                                if (LanguageName.Equals("eu"))
-                                {
-                                    // Basque has date words with leading dots
-                                    InsertHash(temp, IgnorablePeriod + dateWords[i], TokenType.DateWordToken, 0);
-                                }
-                                break;
-                        }
-                    }
                 }
 
                 if (!useDateSepAsIgnorableSymbol)
@@ -2387,42 +2299,6 @@ namespace System.Globalization
                     InsertHash(temp, GetAbbreviatedEraName(i), TokenType.EraToken, i);
                 }
 
-                // TODO: This ignores other cultures that might want to do something similar
-                if (!GlobalizationMode.Invariant && LanguageName.Equals(JapaneseLangName))
-                {
-                    // Japanese allows day of week forms like: "(Tue)"
-                    for (int i = 0; i < 7; i++)
-                    {
-                        string specialDayOfWeek = "(" + GetAbbreviatedDayName((DayOfWeek)i) + ")";
-                        InsertHash(temp, specialDayOfWeek, TokenType.DayOfWeekToken, i);
-                    }
-                    if (Calendar.GetType() != typeof(JapaneseCalendar))
-                    {
-                        // Special case for Japanese.  If this is a Japanese DTFI, and the calendar is not Japanese calendar,
-                        // we will check Japanese Era name as well when the calendar is Gregorian.
-                        DateTimeFormatInfo jaDtfi = GetJapaneseCalendarDTFI();
-                        for (int i = 1; i <= jaDtfi.Calendar.Eras.Length; i++)
-                        {
-                            InsertHash(temp, jaDtfi.GetEraName(i), TokenType.JapaneseEraToken, i);
-                            InsertHash(temp, jaDtfi.GetAbbreviatedEraName(i), TokenType.JapaneseEraToken, i);
-                            // m_abbrevEnglishEraNames[0] contains the name for era 1, so the token value is i+1.
-                            InsertHash(temp, jaDtfi.AbbreviatedEnglishEraNames[i - 1], TokenType.JapaneseEraToken, i);
-                        }
-                    }
-                }
-                // TODO: This prohibits similar custom cultures, but we hard coded the name
-                else if (!GlobalizationMode.Invariant && CultureName.Equals("zh-TW"))
-                {
-                    DateTimeFormatInfo twDtfi = GetTaiwanCalendarDTFI();
-                    for (int i = 1; i <= twDtfi.Calendar.Eras.Length; i++)
-                    {
-                        if (twDtfi.GetEraName(i).Length > 0)
-                        {
-                            InsertHash(temp, twDtfi.GetEraName(i), TokenType.TEraToken, i);
-                        }
-                    }
-                }
-
                 InsertHash(temp, InvariantInfo.AMDesignator, TokenType.SEP_Am | TokenType.Am, 0);
                 InsertHash(temp, InvariantInfo.PMDesignator, TokenType.SEP_Pm | TokenType.Pm, 1);
 
@@ -2467,7 +2343,136 @@ namespace System.Globalization
             return (temp);
         }
 
-        private void AddMonthNames(TokenHashValue[] temp, ReadOnlySpan<char> monthPostfix = default)
+        private void PopulateSpecialTokenHashTable(TokenHashValue[] temp, ref bool useDateSepAsIgnorableSymbol)
+        {
+            // TODO: This ignores similar custom cultures
+            if (LanguageName.Equals("sq"))
+            {
+                // Albanian allows time formats like "12:00.PD"
+                InsertHash(temp, IgnorablePeriod + this.AMDesignator, TokenType.SEP_Am | TokenType.Am, 0);
+                InsertHash(temp, IgnorablePeriod + this.PMDesignator, TokenType.SEP_Pm | TokenType.Pm, 1);
+            }
+
+            // CJK suffix
+            InsertHash(temp, CJKYearSuff, TokenType.SEP_YearSuff, 0);
+            InsertHash(temp, KoreanYearSuff, TokenType.SEP_YearSuff, 0);
+            InsertHash(temp, CJKMonthSuff, TokenType.SEP_MonthSuff, 0);
+            InsertHash(temp, KoreanMonthSuff, TokenType.SEP_MonthSuff, 0);
+            InsertHash(temp, CJKDaySuff, TokenType.SEP_DaySuff, 0);
+            InsertHash(temp, KoreanDaySuff, TokenType.SEP_DaySuff, 0);
+
+            InsertHash(temp, CJKHourSuff, TokenType.SEP_HourSuff, 0);
+            InsertHash(temp, ChineseHourSuff, TokenType.SEP_HourSuff, 0);
+            InsertHash(temp, CJKMinuteSuff, TokenType.SEP_MinuteSuff, 0);
+            InsertHash(temp, CJKSecondSuff, TokenType.SEP_SecondSuff, 0);
+
+            if (!AppContextSwitches.EnforceLegacyJapaneseDateParsing && Calendar.ID == (int)CalendarId.JAPAN)
+            {
+                // We need to support parsing the dates has the start of era symbol which means it is year 1 in the era.
+                // The start of era symbol has to be followed by the year symbol suffix, otherwise it would be invalid date.
+                InsertHash(temp, JapaneseEraStart, TokenType.YearNumberToken, 1);
+                InsertHash(temp, "(", TokenType.IgnorableSymbol, 0);
+                InsertHash(temp, ")", TokenType.IgnorableSymbol, 0);
+            }
+
+            // TODO: This ignores other custom cultures that might want to do something similar
+            if (LanguageName.Equals(KoreanLangName))
+            {
+                // Korean suffix
+                InsertHash(temp, KoreanHourSuff, TokenType.SEP_HourSuff, 0);
+                InsertHash(temp, KoreanMinuteSuff, TokenType.SEP_MinuteSuff, 0);
+                InsertHash(temp, KoreanSecondSuff, TokenType.SEP_SecondSuff, 0);
+            }
+
+            DateTimeFormatInfoScanner scanner = new DateTimeFormatInfoScanner();
+            String[] dateWords = scanner.GetDateWordsOfDTFI(this);
+
+            // Ensure the formatflags is initialized.
+            DateTimeFormatFlags flag = FormatFlags;
+
+            String monthPostfix = null;
+            if (dateWords != null)
+            {
+                // There are DateWords.  It could be a real date word (such as "de"), or a monthPostfix.
+                // The monthPostfix starts with '\xfffe' (MonthPostfixChar), followed by the real monthPostfix.
+                for (int i = 0; i < dateWords.Length; i++)
+                {
+                    switch (dateWords[i][0])
+                    {
+                        // This is a month postfix
+                        case DateTimeFormatInfoScanner.MonthPostfixChar:
+                            // Get the real month postfix.
+                            monthPostfix = dateWords[i].Substring(1);
+                            // Add the month name + postfix into the token.
+                            AddMonthNames(temp, monthPostfix);
+                            break;
+                        case DateTimeFormatInfoScanner.IgnorableSymbolChar:
+                            String symbol = dateWords[i].Substring(1);
+                            InsertHash(temp, symbol, TokenType.IgnorableSymbol, 0);
+                            if (this.DateSeparator.Trim(null).Equals(symbol))
+                            {
+                                // The date separator is the same as the ignorable symbol.
+                                useDateSepAsIgnorableSymbol = true;
+                            }
+                            break;
+                        default:
+                            InsertHash(temp, dateWords[i], TokenType.DateWordToken, 0);
+                            // TODO: This ignores similar custom cultures
+                            if (LanguageName.Equals("eu"))
+                            {
+                                // Basque has date words with leading dots
+                                InsertHash(temp, IgnorablePeriod + dateWords[i], TokenType.DateWordToken, 0);
+                            }
+                            break;
+                    }
+                }
+            }
+
+            // TODO: This ignores other cultures that might want to do something similar
+            if (LanguageName.Equals(JapaneseLangName))
+            {
+                // Japanese allows day of week forms like: "(Tue)"
+                for (int i = 0; i < 7; i++)
+                {
+                    String specialDayOfWeek = "(" + GetAbbreviatedDayName((DayOfWeek)i) + ")";
+                    InsertHash(temp, specialDayOfWeek, TokenType.DayOfWeekToken, i);
+                }
+                if (!IsJapaneseCalendar(this.Calendar))
+                {
+                    // Special case for Japanese.  If this is a Japanese DTFI, and the calendar is not Japanese calendar,
+                    // we will check Japanese Era name as well when the calendar is Gregorian.
+                    DateTimeFormatInfo jaDtfi = GetJapaneseCalendarDTFI();
+                    for (int i = 1; i <= jaDtfi.Calendar.Eras.Length; i++)
+                    {
+                        InsertHash(temp, jaDtfi.GetEraName(i), TokenType.JapaneseEraToken, i);
+                        InsertHash(temp, jaDtfi.GetAbbreviatedEraName(i), TokenType.JapaneseEraToken, i);
+                        // m_abbrevEnglishEraNames[0] contains the name for era 1, so the token value is i+1.
+                        InsertHash(temp, jaDtfi.AbbreviatedEnglishEraNames[i - 1], TokenType.JapaneseEraToken, i);
+                    }
+                }
+            }
+            // TODO: This prohibits similar custom cultures, but we hard coded the name
+            else if (CultureName.Equals("zh-TW"))
+            {
+                DateTimeFormatInfo twDtfi = GetTaiwanCalendarDTFI();
+                for (int i = 1; i <= twDtfi.Calendar.Eras.Length; i++)
+                {
+                    if (twDtfi.GetEraName(i).Length > 0)
+                    {
+                        InsertHash(temp, twDtfi.GetEraName(i), TokenType.TEraToken, i);
+                    }
+                }
+            }
+        }
+
+        private static bool IsJapaneseCalendar(Calendar calendar)
+        {
+            if (GlobalizationMode.Invariant)
+                throw new PlatformNotSupportedException();
+            return calendar.GetType() == typeof(JapaneseCalendar);
+        }
+
+        private void AddMonthNames(TokenHashValue[] temp, String monthPostfix)
         {
             for (int i = 1; i <= 13; i++)
             {

--- a/src/Common/src/CoreLib/System/Globalization/DateTimeParse.cs
+++ b/src/Common/src/CoreLib/System/Globalization/DateTimeParse.cs
@@ -1056,7 +1056,7 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
                     {
                         throw new PlatformNotSupportedException();
                     }
-                    result.calendar = JapaneseCalendar.GetDefaultInstance();
+                    result.calendar = GetJapaneseCalendarDefaultInstance();
                     dtfi = DateTimeFormatInfo.GetJapaneseCalendarDTFI();
                     if (result.era != -1)
                     {
@@ -1075,7 +1075,7 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
                     {
                         throw new PlatformNotSupportedException();
                     }
-                    result.calendar = TaiwanCalendar.GetDefaultInstance();
+                    result.calendar = GetTaiwanCalendarDefaultInstance();
                     dtfi = DateTimeFormatInfo.GetTaiwanCalendarDTFI();
                     if (result.era != -1)
                     {
@@ -1169,7 +1169,21 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
             return true;
         }
 
-        private static bool VerifyValidPunctuation(ref __DTString str)
+        private static Calendar GetJapaneseCalendarDefaultInstance()
+        {
+            if (GlobalizationMode.Invariant)
+                throw new PlatformNotSupportedException();
+            return JapaneseCalendar.GetDefaultInstance();
+        }
+
+        internal static Calendar GetTaiwanCalendarDefaultInstance()
+        {
+            if (GlobalizationMode.Invariant)
+                throw new PlatformNotSupportedException();
+            return TaiwanCalendar.GetDefaultInstance();
+        }
+
+        private static Boolean VerifyValidPunctuation(ref __DTString str)
         {
             // Compatability Behavior. Allow trailing nulls and surrounding hashes
             char ch = str.Value[str.Index];

--- a/src/Common/src/CoreLib/System/Globalization/DateTimeParse.cs
+++ b/src/Common/src/CoreLib/System/Globalization/DateTimeParse.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Text;
 
 namespace System
@@ -15,7 +16,7 @@ namespace System
 
         internal delegate bool MatchNumberDelegate(ref __DTString str, int digitLen, out int result);
 
-        internal static MatchNumberDelegate m_hebrewNumberParser = new MatchNumberDelegate(DateTimeParse.MatchHebrewDigits);
+        internal static MatchNumberDelegate m_hebrewNumberParser;
 
         internal static DateTime ParseExact(ReadOnlySpan<char> s, ReadOnlySpan<char> format, DateTimeFormatInfo dtfi, DateTimeStyles style)
         {
@@ -1051,6 +1052,10 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
                     break;
                 case TokenType.JapaneseEraToken:
                     // Special case for Japanese.  We allow Japanese era name to be used even if the calendar is not Japanese Calendar.
+                    if (GlobalizationMode.Invariant)
+                    {
+                        throw new PlatformNotSupportedException();
+                    }
                     result.calendar = JapaneseCalendar.GetDefaultInstance();
                     dtfi = DateTimeFormatInfo.GetJapaneseCalendarDTFI();
                     if (result.era != -1)
@@ -1066,6 +1071,10 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
                     }
                     break;
                 case TokenType.TEraToken:
+                    if (GlobalizationMode.Invariant)
+                    {
+                        throw new PlatformNotSupportedException();
+                    }
                     result.calendar = TaiwanCalendar.GetDefaultInstance();
                     dtfi = DateTimeFormatInfo.GetTaiwanCalendarDTFI();
                     if (result.era != -1)
@@ -2292,7 +2301,7 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
                         result.SetFailure(ParseFailureKind.FormatBadDateTimeCalendar, nameof(SR.Format_BadDateTimeCalendar));
                         return false;
                     }
-                    if (!GetHebrewDayOfNM(ref result, ref raw, dtfi))
+                    if (!GlobalizationMode.Invariant && !GetHebrewDayOfNM(ref result, ref raw, dtfi))
                     {
                         return false;
                     }
@@ -2634,7 +2643,7 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
                     {
                         if ((dtfi.FormatFlags & DateTimeFormatFlags.UseHebrewRule) != 0)
                         {
-                            if (!ProcessHebrewTerminalState(dps, ref str, ref result, ref styles, ref raw, dtfi))
+                            if (!GlobalizationMode.Invariant && !ProcessHebrewTerminalState(dps, ref str, ref result, ref styles, ref raw, dtfi))
                             {
                                 TPTraceExit("0050 (ProcessHebrewTerminalState)", dps);
                                 return false;
@@ -4511,8 +4520,9 @@ new DS[] { DS.ERROR, DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,  
             bool bTimeOnly = false;
             result.calendar = parseInfo.calendar;
 
-            if (parseInfo.calendar.ID == CalendarId.HEBREW)
+            if (!GlobalizationMode.Invariant && (CalendarId)parseInfo.calendar.ID == CalendarId.HEBREW)
             {
+                LazyInitializer.EnsureInitialized (ref m_hebrewNumberParser, () => new MatchNumberDelegate(DateTimeParse.MatchHebrewDigits));
                 parseInfo.parseNumberDelegate = m_hebrewNumberParser;
                 parseInfo.fCustomNumberParser = true;
             }

--- a/src/Common/tests/System/Globalization/GlobalizationMode.cs
+++ b/src/Common/tests/System/Globalization/GlobalizationMode.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Globalization
+{
+    internal sealed partial class GlobalizationMode
+    {
+        internal static bool Invariant { get; } = false;
+    }
+}

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -50,6 +50,9 @@
     <Compile Include="$(CommonTestPath)\System\Collections\IEnumerable.NonGeneric.Tests.cs">
       <Link>Common\System\Collections\IEnumerable.NonGeneric.Tests.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Globalization\GlobalizationMode.cs">
+      <Link>Common\System\Globalization\Globalizationmode.cs</Link>
+    </Compile>
     <Compile Include="Microsoft\Win32\SafeHandles\CriticalHandleZeroOrMinusOneIsInvalid.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\SafeHandleZeroOrMinusOneIsInvalid.cs" />
     <Compile Include="System\AccessViolationExceptionTests.cs" />

--- a/src/System.Runtime/tests/System/DateTimeOffsetTests.cs
+++ b/src/System.Runtime/tests/System/DateTimeOffsetTests.cs
@@ -1238,7 +1238,10 @@ namespace System.Tests
         [MemberData(nameof(ToString_WithCulture_MatchesExpected_MemberData))]
         public static void ToString_WithCulture_MatchesExpected(DateTimeOffset dateTimeOffset, string format, CultureInfo culture, string expected)
         {
-            Assert.Equal(expected, dateTimeOffset.ToString(format, culture));
+            if (!GlobalizationMode.Invariant)
+            {
+                Assert.Equal(expected, dateTimeOffset.ToString(format, culture));
+            }
         }
     }
 }

--- a/src/System.Runtime/tests/System/DateTimeTests.cs
+++ b/src/System.Runtime/tests/System/DateTimeTests.cs
@@ -1713,13 +1713,16 @@ namespace System.Tests
             yield return new object[] { "2 2 2Z", CultureInfo.InvariantCulture, TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2002, 2, 2, 0, 0, 0, DateTimeKind.Utc), TimeZoneInfo.Local) };
             yield return new object[] { "#10/10/2095#\0", CultureInfo.InvariantCulture, new DateTime(2095, 10, 10, 0, 0, 0) };
 
-            DateTime today = DateTime.Today;
-            var hebrewCulture = new CultureInfo("he-IL");
-            hebrewCulture.DateTimeFormat.Calendar = new HebrewCalendar();
-            yield return new object[] { today.ToString(hebrewCulture), hebrewCulture, today };
+            if (!GlobalizationMode.Invariant)
+            {
+                DateTime today = DateTime.Today;
+                var hebrewCulture = new CultureInfo("he-IL");
+                hebrewCulture.DateTimeFormat.Calendar = new HebrewCalendar();
+                yield return new object[] { today.ToString(hebrewCulture), hebrewCulture, today };
 
-            var mongolianCulture = new CultureInfo("mn-MN");
-            yield return new object[] { today.ToString(mongolianCulture), mongolianCulture, today };
+                var mongolianCulture = new CultureInfo("mn-MN");
+                yield return new object[] { today.ToString(mongolianCulture), mongolianCulture, today };
+            }
         }
 
         [Theory]
@@ -1833,6 +1836,11 @@ namespace System.Tests
             yield return new object[] { "9/8/2017 10 : 11 : 12 AM", "M/d/yyyy HH':'mm':'ss tt\'  \'", CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, new DateTime(2017, 9, 8, 10, 11, 12) };
             yield return new object[] { " 9 / 8 / 2017    10 : 11 : 12 AM", "M/d/yyyy HH':'mm':'ss tt\'  \'", CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, new DateTime(2017, 9, 8, 10, 11, 12) };
             yield return new object[] { "   9   /   8   /   2017    10  :   11  :   12  AM", "M/d/yyyy HH':'mm':'ss tt\'  \'", CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, new DateTime(2017, 9, 8, 10, 11, 12) };
+
+            if (GlobalizationMode.Invariant)
+            {
+                yield break;
+            }
 
             var hebrewCulture = new CultureInfo("he-IL");
             hebrewCulture.DateTimeFormat.Calendar = new HebrewCalendar();

--- a/src/System.Runtime/tests/System/TimeSpanTests.cs
+++ b/src/System.Runtime/tests/System/TimeSpanTests.cs
@@ -583,9 +583,12 @@ namespace System.Tests
             yield return new object[] { "23:00:00", null, new TimeSpan(23, 0, 0) };
             yield return new object[] { "24:00:00", null, new TimeSpan(24, 0, 0, 0) };
 
-            // Croatia uses ',' in place of '.'
-            CultureInfo croatianCulture = new CultureInfo("hr-HR");
-            yield return new object[] { "6:12:14:45,348", croatianCulture, new TimeSpan(6, 12, 14, 45, 348) };
+            if (!GlobalizationMode.Invariant)
+            {
+                // Croatia uses ',' in place of '.'
+                CultureInfo croatianCulture = new CultureInfo("hr-HR");
+                yield return new object[] { "6:12:14:45,348", croatianCulture, new TimeSpan(6, 12, 14, 45, 348) };
+            }
         }
 
         [Theory]
@@ -630,7 +633,11 @@ namespace System.Tests
             yield return new object[] { "00:00::00", null, typeof(FormatException) }; // duplicated separator
             yield return new object[] { "00:00:00:", null, typeof(FormatException) }; // extra separator at end
             yield return new object[] { "00:00:00:00:00:00:00:00", null, typeof(FormatException) }; // too many components
-            yield return new object[] { "6:12:14:45.3448", new CultureInfo("hr-HR"), typeof(FormatException) }; // culture that uses ',' rather than '.'
+
+            if (!GlobalizationMode.Invariant)
+            {
+                yield return new object[] { "6:12:14:45.3448", new CultureInfo("hr-HR"), typeof(FormatException) }; // culture that uses ',' rather than '.'
+            }
 
             // OverflowExceptions
             yield return new object[] { "1:1:1.99999999", null, typeof(OverflowException) }; // overflowing fraction


### PR DESCRIPTION
When using `GlobalizationMode.Invariant`, disable the Japanese, Taiwan and Hebrew calendars and make the code more linker friendly.

Since the linker does not currently support dead code elimination, it cannot break down any conditionals inside method bodies. One trick that we use to work around this is to move those conditional pieces into separate methods; then we can give the linker a list of those methods and tell it to replace their bodies with exceptions.