### PR TITLE
Re-generate System.Threading.Overlapped ref assembly against implementation

### DIFF
--- a/src/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
+++ b/src/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
@@ -49,6 +49,7 @@ namespace System.Threading
         [System.CLSCompliantAttribute(false)]
         public PreAllocatedOverlapped(System.Threading.IOCompletionCallback callback, object state, object pinData) { }
         public void Dispose() { }
+        ~PreAllocatedOverlapped() { }
     }
     public sealed partial class ThreadPoolBoundHandle : System.IDisposable
     {


### PR DESCRIPTION
cc: @stephentoub @ahsonkhan @danmosemsft @jkotas 