### PR TITLE
Open pdb files with FileShare.Read and FileShare.Delete (#38214)

### DIFF
--- a/src/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.CoreCLR.cs
+++ b/src/System.Diagnostics.StackTrace/src/System/Diagnostics/StackTraceSymbols.CoreCLR.cs
@@ -214,7 +214,8 @@ namespace System.Diagnostics
 
             try
             {
-                return File.OpenRead(path);
+                // Open the file with read and delete FileShare flags. This matches what dll loading does
+                return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
             }
             catch
             {

--- a/src/System.Diagnostics.StackTrace/tests/StackTraceSymbolsTests.cs
+++ b/src/System.Diagnostics.StackTrace/tests/StackTraceSymbolsTests.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace System.Diagnostics.SymbolStore.Tests
+{
+    public class StackTraceSymbolsTests
+    {
+        [Fact]
+        public void StackTraceSymbolsDoNotLockFile()
+        {
+            var asmPath = typeof(StackTraceSymbolsTests).Assembly.Location;
+            var pdbPath = Path.ChangeExtension(asmPath, ".pdb");
+
+            Assert.True(File.Exists(pdbPath));
+            new StackTrace(true).GetFrames();
+            File.Move(pdbPath, pdbPath);
+        }
+    }
+}

--- a/src/System.Diagnostics.StackTrace/tests/System.Diagnostics.StackTrace.Tests.csproj
+++ b/src/System.Diagnostics.StackTrace/tests/System.Diagnostics.StackTrace.Tests.csproj
@@ -20,5 +20,8 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <ReferenceFromRuntime Include="System.Runtime.InteropServices.RuntimeInformation" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Compile Include="StackTraceSymbolsTests.cs" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
#### Description
We've been getting reports of locked pdb files (aspnet/AspNetCore#3269) when deploying ASP.NET Core applications (but not locked dlls) and we assumed that it was application insights locking the pdb. Turns out, the runtime opens pdb files (once somebody accesses something like Exception.StackTrace) it can't be renamed/deleted until the process ends. This interrupts the deployment process on azure app service. It turns out we need to pass the right FileShare permissions when opening the file pdb file.
		
#### Customer Impact

Customers that experience any exception today cannot easily re-deploy their site without going to the azure portal and restarting the site. The same goes for a server on premises (the admin needs to go restart the IIS application pool to upgrade the site).

#### Regression?
No.

#### Risk
Very small, it's a very small tweak to the code that opens the file.

cc: @tmat @danmosemsft @stephentoub @DamianEdwards 