### PR TITLE
[3.0 System.Text.Json]JsonExtensionData should allow non-JsonElement types during serialization

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -356,9 +356,6 @@
   <data name="SerializationNotSupportedCollectionType" xml:space="preserve">
     <value>The collection type '{0}' is not supported.</value>
   </data>
-  <data name="SerializationDataExtensionPropertyInvalidElement" xml:space="preserve">
-    <value>The data extension property '{0}.{1}' cannot contain dictionary values of type '{2}'. Dictionary values must be of type JsonElement.</value>
-  </data>
   <data name="SerializationNotSupportedCollection" xml:space="preserve">
     <value>The collection type '{0}' on '{1}' is not supported.</value>
   </data>

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -40,33 +40,29 @@ namespace System.Text.Json
                 // Handle DataExtension.
                 if (ReferenceEquals(jsonPropertyInfo, state.Current.JsonClassInfo.DataExtensionProperty))
                 {
-                    WriteExtensionData(writer, ref state.Current);
-                }
-                else
-                {
-                    // Check for polymorphism.
-                    if (elementClassInfo.ClassType == ClassType.Unknown)
-                    {
-                        object currentValue = ((IDictionaryEnumerator)state.Current.Enumerator).Entry.Value;
-                        GetRuntimeClassInfo(currentValue, ref elementClassInfo, options);
-                    }
+                    DictionaryEntry entry = ((IDictionaryEnumerator)state.Current.Enumerator).Entry;
 
-                    if (elementClassInfo.ClassType == ClassType.Value)
+                    // for JsonElement values we emit a json property
+                    if (entry.Value is JsonElement element)
                     {
-                        elementClassInfo.GetPolicyProperty().WriteDictionary(ref state.Current, writer);
+                        Debug.Assert(entry.Key is string);
+
+                        string propertyName = (string)entry.Key;
+                        element.WriteProperty(propertyName, writer);
                     }
-                    else if (state.Current.Enumerator.Current == null)
+                    // for object values we emit a dictionary
+                    else if (entry.Value is object)
                     {
-                        writer.WriteNull(jsonPropertyInfo.Name);
+                        WriteDictionary(jsonPropertyInfo, elementClassInfo, options, writer, ref state);
                     }
                     else
                     {
-                        // An object or another enumerator requires a new stack frame.
-                        var enumerator = (IDictionaryEnumerator)state.Current.Enumerator;
-                        object value = enumerator.Value;
-                        state.Push(elementClassInfo, value);
-                        state.Current.KeyName = (string)enumerator.Key;
+                        ThrowHelper.ThrowInvalidOperationException_SerializationDataExtensionPropertyInvalid(state.Current.JsonClassInfo, entry.Value.GetType());
                     }
+                }
+                else
+                {
+                    WriteDictionary(jsonPropertyInfo, elementClassInfo, options, writer, ref state);
                 }
 
                 return false;
@@ -85,6 +81,33 @@ namespace System.Text.Json
             }
 
             return true;
+        }
+
+        private static void WriteDictionary(JsonPropertyInfo jsonPropertyInfo, JsonClassInfo elementClassInfo, JsonSerializerOptions options, Utf8JsonWriter writer, ref WriteStack state)
+        {
+            // Check for polymorphism.
+            if (elementClassInfo.ClassType == ClassType.Unknown)
+            {
+                object currentValue = ((IDictionaryEnumerator)state.Current.Enumerator).Entry.Value;
+                GetRuntimeClassInfo(currentValue, ref elementClassInfo, options);
+            }
+
+            if (elementClassInfo.ClassType == ClassType.Value)
+            {
+                elementClassInfo.GetPolicyProperty().WriteDictionary(ref state.Current, writer);
+            }
+            else if (state.Current.Enumerator.Current == null)
+            {
+                writer.WriteNull(jsonPropertyInfo.Name);
+            }
+            else
+            {
+                // An object or another enumerator requires a new stack frame.
+                var enumerator = (IDictionaryEnumerator)state.Current.Enumerator;
+                object value = enumerator.Value;
+                state.Push(elementClassInfo, value);
+                state.Current.KeyName = (string)enumerator.Key;
+            }
         }
 
         internal static void WriteDictionary<TProperty>(
@@ -132,22 +155,6 @@ namespace System.Text.Json
             {
                 JsonEncodedText escapedKey = JsonEncodedText.Encode(key);
                 converter.Write(escapedKey, value, writer);
-            }
-        }
-
-        private static void WriteExtensionData(Utf8JsonWriter writer, ref WriteStackFrame frame)
-        {
-            DictionaryEntry entry = ((IDictionaryEnumerator)frame.Enumerator).Entry;
-            if (entry.Value is JsonElement element)
-            {
-                Debug.Assert(entry.Key is string);
-
-                string propertyName = (string)entry.Key;
-                element.WriteProperty(propertyName, writer);
-            }
-            else
-            {
-                ThrowHelper.ThrowInvalidOperationException_SerializationDataExtensionPropertyInvalid(frame.JsonClassInfo, entry.Value.GetType());
             }
         }
     }

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -118,12 +118,6 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowInvalidOperationException_SerializationDataExtensionPropertyInvalid(JsonClassInfo jsonClassInfo, Type invalidType)
-        {
-            throw new InvalidOperationException(SR.Format(SR.SerializationDataExtensionPropertyInvalidElement, jsonClassInfo.Type, jsonClassInfo.DataExtensionProperty.PropertyInfo.Name, invalidType));
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_DeserializeMissingParameterlessConstructor(Type invalidType)
         {
             throw new NotSupportedException(SR.Format(SR.DeserializeMissingParameterlessConstructor, invalidType));

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -197,12 +197,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void ExtensionPropertyObjectValue_Issue_38238()
-        {
-            Assert.Equal(@"{""Name"":""Test"",""Extensions"":{""foo"":1}}", JsonSerializer.ToString(new TestModel_Issue_38238()));
-        }
-
-        [Fact]
         public static void ExtensionPropertyObjectValue_RoundTrip()
         {
             // Baseline
@@ -339,17 +333,6 @@ namespace System.Text.Json.Serialization.Tests
             public Dictionary<string, JsonElement> MyOverflow { get; set; }
 
             public ClassWithExtensionProperty MyReference { get; set; }
-        }
-
-        // Match model in issue https://github.com/dotnet/corefx/issues/38238
-        public class TestModel_Issue_38238
-        {
-            public string Name { get; set; } = "Test";
-
-            public Dictionary<string, object> Extensions { get; set; } = new Dictionary<string, object>()
-            {
-                ["foo"] = 1,
-            };
         }
     }
 }


### PR DESCRIPTION
fixes https://github.com/dotnet/corefx/issues/38238

~~If we have `Dictionary<string,JsonElement>` we'll emit json properties~~ it's my understanding that isn't needed, I thought that we wanted to have `JsonElement` as property.
~~If we have `Dictionary<string,object>` we'll emit standard dictionary~~
We serialize all like normal dictionary.
Deserialization produce always `Dictionary<string,JsonElement>`

cc: @steveharter @ahsonkhan @pakrym 


