### PR TITLE
Check uncompressed size before decompressing a zip file. Fixes 33058

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
@@ -27,27 +27,27 @@ namespace System.IO.Compression
         private bool _wroteBytes;
 
         // A specific constructor to allow decompression of Deflate64
-        internal DeflateManagedStream(Stream stream, ZipArchiveEntry.CompressionMethodValues method)
+        internal DeflateManagedStream(Stream stream, ZipArchiveEntry.CompressionMethodValues method, long uncompressedSize)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
             if (!stream.CanRead)
                 throw new ArgumentException(SR.NotSupported_UnreadableStream, nameof(stream));
 
-            InitializeInflater(stream, false, null, method);
+            InitializeInflater(stream, false, null, method, uncompressedSize);
         }
 
         /// <summary>
         /// Sets up this DeflateManagedStream to be used for Inflation/Decompression
         /// </summary>
-        internal void InitializeInflater(Stream stream, bool leaveOpen, IFileFormatReader reader = null, ZipArchiveEntry.CompressionMethodValues method = ZipArchiveEntry.CompressionMethodValues.Deflate)
+        internal void InitializeInflater(Stream stream, bool leaveOpen, IFileFormatReader reader = null, ZipArchiveEntry.CompressionMethodValues method = ZipArchiveEntry.CompressionMethodValues.Deflate, long uncompressedSize = -1)
         {
             Debug.Assert(stream != null);
             Debug.Assert(method == ZipArchiveEntry.CompressionMethodValues.Deflate || method == ZipArchiveEntry.CompressionMethodValues.Deflate64);
             if (!stream.CanRead)
                 throw new ArgumentException(SR.NotSupported_UnreadableStream, nameof(stream));
 
-            _inflater = new InflaterManaged(reader, method == ZipArchiveEntry.CompressionMethodValues.Deflate64 ? true : false);
+            _inflater = new InflaterManaged(reader, method == ZipArchiveEntry.CompressionMethodValues.Deflate64 ? true : false, uncompressedSize);
 
             _stream = stream;
             _mode = CompressionMode.Decompress;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -108,7 +108,7 @@ namespace System.IO.Compression
             int count = 0;
             do
             {
-                int copied;
+                int copied = 0;
                 if (_uncompressedSize == -1)
                 {
                     copied = _output.CopyTo(bytes, offset, length);
@@ -117,15 +117,14 @@ namespace System.IO.Compression
                 {
                     if (_uncompressedSize > _currentInflatedCount)
                     {
+                        length = Math.Min(length, (int)(_uncompressedSize - _currentInflatedCount));
                         copied = _output.CopyTo(bytes, offset, length);
-                        copied = Math.Min(copied, (int)(_uncompressedSize - _currentInflatedCount));
                         _currentInflatedCount += copied;
                     }
                     else
                     {
-                        copied = 0;
                         _state = InflaterState.Done;
-                        _output._bytesUsed = 0;
+                        _output.ClearBytesUsed();
                     }
                 }
                 if (copied > 0)

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -137,14 +137,13 @@ namespace System.IO.Compression
                     _formatReader.Validate();
                 }
             }
-            count = RestrictStreamWithUnCompressedSize(count);
-
-            return count;
+            
+            return RestrictStreamWithUnCompressedSize(count);
         }
 
         private int RestrictStreamWithUnCompressedSize(int bytesRead)
         {
-            if (_uncompressedSize > 0 && _uncompressedSize - _currentInflatedCount < bytesRead)
+            if (_uncompressedSize > -1 && _uncompressedSize - _currentInflatedCount < bytesRead)
             {
                 bytesRead = (int)(_uncompressedSize - _currentInflatedCount);
                 _state = InflaterState.Done;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -137,21 +137,18 @@ namespace System.IO.Compression
                     _formatReader.Validate();
                 }
             }
-            count = RestrictStreamWithUnCompressedSize(count, out bool wasOverLimit);
-
-            if (wasOverLimit)
-                throw new InvalidDataException(SR.GenericInvalidData);
+            count = RestrictStreamWithUnCompressedSize(count);
 
             return count;
         }
 
-        private int RestrictStreamWithUnCompressedSize(int bytesRead, out bool wasOverLimit)
+        private int RestrictStreamWithUnCompressedSize(int bytesRead)
         {
-            wasOverLimit = false;
             if (_uncompressedSize > 0 && _uncompressedSize - _currentInflatedCount < bytesRead)
             {
-                wasOverLimit = true;
                 bytesRead = (int)(_uncompressedSize - _currentInflatedCount);
+                _state = InflaterState.Done;
+                _output._bytesUsed = 0;
             }
             _currentInflatedCount += bytesRead;
             return bytesRead;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -65,7 +65,7 @@ namespace System.IO.Compression
         private readonly bool _deflate64;
         private HuffmanTree _codeLengthTree;
         private long _uncompressedSize = -1;
-        private long _currentInflatedCount = 0;
+        private long _currentInflatedCount;
 
         private IFileFormatReader _formatReader; // class to decode header and footer (e.g. gzip)
 
@@ -109,6 +109,8 @@ namespace System.IO.Compression
             do
             {
                 int copied = _output.CopyTo(bytes, offset, length);
+                copied = RestrictStreamWithUnCompressedSize(copied);
+
                 if (copied > 0)
                 {
                     if (_hasFormatReader)
@@ -138,7 +140,7 @@ namespace System.IO.Compression
                 }
             }
             
-            return RestrictStreamWithUnCompressedSize(count);
+            return count;
         }
 
         private int RestrictStreamWithUnCompressedSize(int bytesRead)

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -65,7 +65,7 @@ namespace System.IO.Compression
         private readonly bool _deflate64;
         private HuffmanTree _codeLengthTree;
         private long _uncompressedSize = -1;
-        private long _currenInflatedCount = 0;
+        private long _currentInflatedCount = 0;
 
         private IFileFormatReader _formatReader; // class to decode header and footer (e.g. gzip)
 
@@ -148,12 +148,12 @@ namespace System.IO.Compression
         private int RestrictStreamWithUnCompressedSize(int bytesRead, out bool wasOverLimit)
         {
             wasOverLimit = false;
-            if (_uncompressedSize > 0 && _uncompressedSize - _currenInflatedCount < bytesRead)
+            if (_uncompressedSize > 0 && _uncompressedSize - _currentInflatedCount < bytesRead)
             {
                 wasOverLimit = true;
-                bytesRead = (int)(_uncompressedSize - _currenInflatedCount);
+                bytesRead = (int)(_uncompressedSize - _currentInflatedCount);
             }
-            _currenInflatedCount += bytesRead;
+            _currentInflatedCount += bytesRead;
             return bytesRead;
         }
 

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -64,7 +64,7 @@ namespace System.IO.Compression
         private readonly byte[] _codeLengthTreeCodeLength;
         private readonly bool _deflate64;
         private HuffmanTree _codeLengthTree;
-        private long _uncompressedSize = -1;
+        private readonly long _uncompressedSize;
         private long _currentInflatedCount;
 
         private IFileFormatReader _formatReader; // class to decode header and footer (e.g. gzip)

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -156,7 +156,7 @@ namespace System.IO.Compression
                     _formatReader.Validate();
                 }
             }
-            
+
             return count;
         }
 

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InputBuffer.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InputBuffer.cs
@@ -176,11 +176,13 @@ namespace System.IO.Compression
             Debug.Assert(offset >= 0);
             Debug.Assert(length >= 0);
             Debug.Assert(offset <= buffer.Length - length);
-            Debug.Assert(_start == _end);
 
-            _buffer = buffer;
-            _start = offset;
-            _end = offset + length;
+            if (_start == _end)
+            {
+                _buffer = buffer;
+                _start = offset;
+                _end = offset + length;
+            }
         }
 
         /// <summary>Skip n bits in the buffer.</summary>

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputWindow.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputWindow.cs
@@ -23,7 +23,7 @@ namespace System.IO.Compression
 
         private readonly byte[] _window = new byte[WindowSize]; // The window is 2^18 bytes
         private int _end;       // this is the position to where we should write next byte
-        private int _bytesUsed; // The number of bytes in the output window which is not consumed.
+        internal int _bytesUsed; // The number of bytes in the output window which is not consumed.
 
         /// <summary>Add a byte to output window.</summary>
         public void Write(byte b)

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputWindow.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/OutputWindow.cs
@@ -23,8 +23,13 @@ namespace System.IO.Compression
 
         private readonly byte[] _window = new byte[WindowSize]; // The window is 2^18 bytes
         private int _end;       // this is the position to where we should write next byte
-        internal int _bytesUsed; // The number of bytes in the output window which is not consumed.
+        private int _bytesUsed; // The number of bytes in the output window which is not consumed.
 
+        internal void ClearBytesUsed()
+        {
+            _bytesUsed = 0;
+        }
+        
         /// <summary>Add a byte to output window.</summary>
         public void Write(byte b)
         {

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -23,6 +23,10 @@ namespace System.IO.Compression
         private int _activeAsyncOperation; // 1 == true, 0 == false
         private bool _wroteBytes;
 
+        internal DeflateStream(Stream stream, CompressionMode mode, long uncompressedSize) : this(stream, mode, leaveOpen: false, ZLibNative.Deflate_DefaultWindowBits, uncompressedSize)
+        {
+        }
+
         public DeflateStream(Stream stream, CompressionMode mode) : this(stream, mode, leaveOpen: false)
         {
         }
@@ -45,7 +49,7 @@ namespace System.IO.Compression
         /// Internal constructor to check stream validity and call the correct initialization function depending on
         /// the value of the CompressionMode given.
         /// </summary>
-        internal DeflateStream(Stream stream, CompressionMode mode, bool leaveOpen, int windowBits)
+        internal DeflateStream(Stream stream, CompressionMode mode, bool leaveOpen, int windowBits, long uncompressedSize = -1)
         {
             if (stream == null)
                 throw new ArgumentNullException(nameof(stream));
@@ -53,7 +57,7 @@ namespace System.IO.Compression
             switch (mode)
             {
                 case CompressionMode.Decompress:
-                    InitializeInflater(stream, leaveOpen, windowBits);
+                    InitializeInflater(stream, leaveOpen, windowBits, uncompressedSize);
                     break;
 
                 case CompressionMode.Compress:
@@ -79,13 +83,13 @@ namespace System.IO.Compression
         /// <summary>
         /// Sets up this DeflateStream to be used for Zlib Inflation/Decompression
         /// </summary>
-        internal void InitializeInflater(Stream stream, bool leaveOpen, int windowBits)
+        internal void InitializeInflater(Stream stream, bool leaveOpen, int windowBits, long uncompressedSize)
         {
             Debug.Assert(stream != null);
             if (!stream.CanRead)
                 throw new ArgumentException(SR.NotSupported_UnreadableStream, nameof(stream));
 
-            _inflater = new Inflater(windowBits);
+            _inflater = new Inflater(windowBits, uncompressedSize);
 
             _stream = stream;
             _mode = CompressionMode.Decompress;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -1017,7 +1017,7 @@ namespace System.IO.Compression
                 }
 
                 // Feed the data from base stream into the decompression engine.
-                    _deflateStream._inflater.SetInput(buffer, offset, count);
+                _deflateStream._inflater.SetInput(buffer, offset, count);
 
                 // While there's more decompressed data available, forward it to the buffer stream.
                 while (true)

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -992,6 +992,10 @@ namespace System.IO.Compression
                     {
                         break;
                     }
+                    if (_deflateStream._inflater.Finished())
+                    {
+                        break;
+                    }
                 }
             }
 
@@ -1013,7 +1017,7 @@ namespace System.IO.Compression
                 }
 
                 // Feed the data from base stream into the decompression engine.
-                _deflateStream._inflater.SetInput(buffer, offset, count);
+                    _deflateStream._inflater.SetInput(buffer, offset, count);
 
                 // While there's more decompressed data available, forward it to the buffer stream.
                 while (true)
@@ -1024,6 +1028,10 @@ namespace System.IO.Compression
                         _destination.Write(_arrayPoolBuffer, 0, bytesRead);
                     }
                     else
+                    {
+                        break;
+                    }
+                    if (_deflateStream._inflater.Finished())
                     {
                         break;
                     }

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -21,7 +21,7 @@ namespace System.IO.Compression
         private int _windowBits;                            // The WindowBits parameter passed to Inflater construction
         private ZLibNative.ZLibStreamHandle _zlibStream;    // The handle to the primary underlying zlib stream
         private GCHandle _inputBufferHandle;                // The handle to the buffer that provides input to _zlibStream
-        private long _uncompressedSize = -1;
+        private readonly long _uncompressedSize;
         private long _currentInflatedCount;
 
         private object SyncLock => this;                    // Used to make writing to unmanaged structures atomic

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -98,13 +98,7 @@ namespace System.IO.Compression
                         _finished = true;
                     }
                 }
-
-                bytesRead = RestrictStreamWithUnCompressedSize(bytesRead);
-
-             //   if (wasOverLimit)
-               //     throw new InvalidDataException(SR.GenericInvalidData);
-
-                return bytesRead;
+                return RestrictStreamWithUnCompressedSize(bytesRead);
             }
             finally
             {
@@ -118,10 +112,8 @@ namespace System.IO.Compression
 
         private int RestrictStreamWithUnCompressedSize(int bytesRead)
         {
-          //  wasOverLimit = false;
-            if (_uncompressedSize > 0 && _uncompressedSize - _currentInflatedCount < bytesRead)
+            if (_uncompressedSize > -1 && _uncompressedSize - _currentInflatedCount < bytesRead)
             {
-        //        wasOverLimit = true;
                 bytesRead = (int)(_uncompressedSize - _currentInflatedCount);
                 _finished = true;
                 _zlibStream.AvailIn = 0;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -86,7 +86,7 @@ namespace System.IO.Compression
             // State is valid; attempt inflation
             try
             {
-                int bytesRead;
+                int bytesRead = 0;
                 if (_uncompressedSize == -1)
                 {
                     ReadOutput(bufPtr, length, out bytesRead);
@@ -95,13 +95,12 @@ namespace System.IO.Compression
                 {
                     if (_uncompressedSize > _currentInflatedCount)
                     {
+                        length = Math.Min(length, (int)(_uncompressedSize - _currentInflatedCount));
                         ReadOutput(bufPtr, length, out bytesRead);
-                        bytesRead = Math.Min(bytesRead, (int)(_uncompressedSize - _currentInflatedCount));
                         _currentInflatedCount += bytesRead;
                     }
                     else
                     {
-                        bytesRead = 0;
                         _finished = true;
                         _zlibStream.AvailIn = 0;
                     }

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -21,8 +21,8 @@ namespace System.IO.Compression
         private int _windowBits;                            // The WindowBits parameter passed to Inflater construction
         private ZLibNative.ZLibStreamHandle _zlibStream;    // The handle to the primary underlying zlib stream
         private GCHandle _inputBufferHandle;                // The handle to the buffer that provides input to _zlibStream
-        private long _uncompressedSize;
-        private long _currentInflatedCount = 0;
+        private long _uncompressedSize = -1;
+        private long _currentInflatedCount;
 
         private object SyncLock => this;                    // Used to make writing to unmanaged structures atomic
 

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -99,10 +99,10 @@ namespace System.IO.Compression
                     }
                 }
 
-                bytesRead = RestrictStreamWithUnCompressedSize(bytesRead, out bool wasOverLimit);
+                bytesRead = RestrictStreamWithUnCompressedSize(bytesRead);
 
-                if (wasOverLimit)
-                    throw new InvalidDataException(SR.GenericInvalidData);
+             //   if (wasOverLimit)
+               //     throw new InvalidDataException(SR.GenericInvalidData);
 
                 return bytesRead;
             }
@@ -116,13 +116,15 @@ namespace System.IO.Compression
             }
         }
 
-        private int RestrictStreamWithUnCompressedSize(int bytesRead, out bool wasOverLimit)
+        private int RestrictStreamWithUnCompressedSize(int bytesRead)
         {
-            wasOverLimit = false;
+          //  wasOverLimit = false;
             if (_uncompressedSize > 0 && _uncompressedSize - _currentInflatedCount < bytesRead)
             {
-                wasOverLimit = true;
+        //        wasOverLimit = true;
                 bytesRead = (int)(_uncompressedSize - _currentInflatedCount);
+                _finished = true;
+                _zlibStream.AvailIn = 0;
             }
             _currentInflatedCount += bytesRead;
             return bytesRead;

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -22,7 +22,7 @@ namespace System.IO.Compression
         private ZLibNative.ZLibStreamHandle _zlibStream;    // The handle to the primary underlying zlib stream
         private GCHandle _inputBufferHandle;                // The handle to the buffer that provides input to _zlibStream
         private long _uncompressedSize;
-        private long _currenInflatedCount = 0;
+        private long _currentInflatedCount = 0;
 
         private object SyncLock => this;                    // Used to make writing to unmanaged structures atomic
 
@@ -119,12 +119,12 @@ namespace System.IO.Compression
         private int RestrictStreamWithUnCompressedSize(int bytesRead, out bool wasOverLimit)
         {
             wasOverLimit = false;
-            if (_uncompressedSize > 0 && _uncompressedSize - _currenInflatedCount < bytesRead)
+            if (_uncompressedSize > 0 && _uncompressedSize - _currentInflatedCount < bytesRead)
             {
                 wasOverLimit = true;
-                bytesRead = (int)(_uncompressedSize - _currenInflatedCount);
+                bytesRead = (int)(_uncompressedSize - _currentInflatedCount);
             }
-            _currenInflatedCount += bytesRead;
+            _currentInflatedCount += bytesRead;
             return bytesRead;
         }
 

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -105,8 +105,7 @@ namespace System.IO.Compression
                         _finished = true;
                         _zlibStream.AvailIn = 0;
                     }
-                }             
-
+                }
                 return bytesRead;
             }
             finally

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -751,7 +751,7 @@ namespace System.IO.Compression
                     return false;
                 }
                 _archive.ArchiveStream.Seek(_offsetOfLocalHeader, SeekOrigin.Begin);
-                if (needToUncompress && !needToLoadIntoMemory && _archive.Mode != ZipArchiveMode.Create)
+                if (needToUncompress && !needToLoadIntoMemory)
                 {
                     if (!ZipLocalFileHeader.TryValidateBlock(_archive.ArchiveReader, this))
                     {

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -646,10 +646,10 @@ namespace System.IO.Compression
             switch (CompressionMethod)
             {
                 case CompressionMethodValues.Deflate:
-                    uncompressedStream = new DeflateStream(compressedStreamToRead, CompressionMode.Decompress);
+                    uncompressedStream = new DeflateStream(compressedStreamToRead, CompressionMode.Decompress, _uncompressedSize);
                     break;
                 case CompressionMethodValues.Deflate64:
-                    uncompressedStream = new DeflateManagedStream(compressedStreamToRead, CompressionMethodValues.Deflate64);
+                    uncompressedStream = new DeflateManagedStream(compressedStreamToRead, CompressionMethodValues.Deflate64, _uncompressedSize);
                     break;
                 case CompressionMethodValues.Stored:
                 default:
@@ -751,10 +751,21 @@ namespace System.IO.Compression
                     return false;
                 }
                 _archive.ArchiveStream.Seek(_offsetOfLocalHeader, SeekOrigin.Begin);
-                if (!ZipLocalFileHeader.TrySkipBlock(_archive.ArchiveReader))
+                if (needToUncompress && !needToLoadIntoMemory && _archive.Mode != ZipArchiveMode.Create)
                 {
-                    message = SR.LocalFileHeaderCorrupt;
-                    return false;
+                    if (!ZipLocalFileHeader.TryValidateBlock(_archive.ArchiveReader, this))
+                    {
+                        message = SR.LocalFileHeaderCorrupt;
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (!ZipLocalFileHeader.TrySkipBlock(_archive.ArchiveReader))
+                    {
+                        message = SR.LocalFileHeaderCorrupt;
+                        return false;
+                    }
                 }
                 // when this property gets called, some duplicated work
                 if (OffsetOfCompressedData + _compressedSize > _archive.ArchiveStream.Length)
@@ -1231,7 +1242,6 @@ namespace System.IO.Compression
                         // go back and finish writing
                         if (_entry._archive.ArchiveStream.CanSeek)
                             // finish writing local header if we have seek capabilities
-
                             _entry.WriteCrcAndSizesInLocalHeader(_usedZip64inLH);
                         else
                             // write out data descriptor if we don't have seek capabilities
@@ -1246,7 +1256,7 @@ namespace System.IO.Compression
         }
 
         [Flags]
-        private enum BitFlagValues : ushort { DataDescriptor = 0x8, UnicodeFileName = 0x800 }
+        internal enum BitFlagValues : ushort { DataDescriptor = 0x8, UnicodeFileName = 0x800 }
 
         internal enum CompressionMethodValues : ushort { Stored = 0x0, Deflate = 0x8, Deflate64 = 0x9, BZip2 = 0xC, LZMA = 0xE }
     }

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -429,6 +429,95 @@ namespace System.IO.Compression
 
             return true;
         }
+
+        public static bool TryValidateBlock(BinaryReader reader, ZipArchiveEntry entry)
+        {
+            const int OffsetToFilename = 26; // from the point after the signature
+
+            if (reader.ReadUInt32() != SignatureConstant)
+                return false;
+
+            if (reader.BaseStream.Length < reader.BaseStream.Position + OffsetToFilename)
+                return false;
+
+            uint minimumVersion = reader.ReadUInt16();
+            uint dataDescriptorBit = reader.ReadUInt16() & (uint)ZipArchiveEntry.BitFlagValues.DataDescriptor;
+            reader.BaseStream.Seek(10, SeekOrigin.Current); // skipping bytes used for Compression method (2 bytes), File last modification time and date (4 bytes) and CRC (4 bytes)
+            long compressedSize = reader.ReadUInt32();
+            long uncompressedSize = reader.ReadUInt32();
+            int filenameLength = reader.ReadUInt16();
+            uint extraFieldLength = reader.ReadUInt16();
+
+            if (reader.BaseStream.Length < reader.BaseStream.Position + filenameLength + extraFieldLength)
+                return false;
+
+            reader.BaseStream.Seek(filenameLength, SeekOrigin.Current);  // skipping Filename
+            long endExtraFields = reader.BaseStream.Position + extraFieldLength;
+            
+            if (dataDescriptorBit == 0)
+            {
+                bool isUncompressedSizeInZip64 = uncompressedSize == ZipHelper.Mask32Bit;
+                bool isCompressedSizeInZip64 = compressedSize == ZipHelper.Mask32Bit;
+                Zip64ExtraField zip64;
+
+                // Ideally we should also check if the minimunVersion is 64 bit or above, but there could zip files for which this version is not set correctly
+                if (isUncompressedSizeInZip64 || isCompressedSizeInZip64)
+                {
+                    zip64 = Zip64ExtraField.GetJustZip64Block(new SubReadStream(reader.BaseStream, reader.BaseStream.Position, extraFieldLength), isUncompressedSizeInZip64, isCompressedSizeInZip64, false, false);
+
+                    if (zip64.UncompressedSize != null)
+                        uncompressedSize = zip64.UncompressedSize.Value;
+                    if (zip64.CompressedSize != null)
+                        compressedSize = zip64.CompressedSize.Value;
+                }
+
+                reader.BaseStream.AdvanceToPosition(endExtraFields);
+            }
+            else
+            {            
+                if (reader.BaseStream.Length < reader.BaseStream.Position + extraFieldLength + entry.CompressedLength + 4)
+                    return false;
+
+                reader.BaseStream.Seek(extraFieldLength + entry.CompressedLength, SeekOrigin.Current); // seek to end of compressed file from which Data descriptor starts             
+                uint dataDescriptorSignature = reader.ReadUInt32();
+                bool wasDataDescriptorSignatureRead = false;
+                int seekSize = 0;
+                if (dataDescriptorSignature == DataDescriptorSignature)
+                {
+                    wasDataDescriptorSignatureRead = true;
+                    seekSize = 4;
+                }
+
+                bool is64bit = minimumVersion > (uint)ZipVersionNeededValues.Zip64;
+                seekSize += (is64bit ? 8 : 4) * 2;   // if Zip64 read by 8 bytes else 4 bytes 2 times (compressed and uncompressed size)
+
+                if (reader.BaseStream.Length < reader.BaseStream.Position + seekSize)
+                    return false;
+
+                // dataDescriptorSignature is optional, if it was the DataDescriptorSignature we need to skip CRC 4 bytes else we can assume CRC is alreadyskipped
+                if (wasDataDescriptorSignatureRead)
+                    reader.BaseStream.Seek(4, SeekOrigin.Current);
+
+                if (is64bit)
+                {
+                    compressedSize = reader.ReadInt64();
+                    uncompressedSize = reader.ReadInt64();
+                }
+                else
+                {
+                    compressedSize = reader.ReadInt32();
+                    uncompressedSize = reader.ReadInt32();
+                }
+                reader.BaseStream.Seek( -seekSize - entry.CompressedLength - 4,  SeekOrigin.Current); // Seek back to the beginning of compressed stream
+            }
+            if (entry.CompressedLength != compressedSize)
+                return false;
+
+            if (entry.Length != uncompressedSize)
+                return false;
+
+            return true;
+        }
     }
 
     internal struct ZipCentralDirectoryFileHeader

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -466,17 +466,24 @@ namespace System.IO.Compression
                     zip64 = Zip64ExtraField.GetJustZip64Block(new SubReadStream(reader.BaseStream, reader.BaseStream.Position, extraFieldLength), isUncompressedSizeInZip64, isCompressedSizeInZip64, false, false);
 
                     if (zip64.UncompressedSize != null)
+                    {
                         uncompressedSize = zip64.UncompressedSize.Value;
+                    }
+
                     if (zip64.CompressedSize != null)
+                    {
                         compressedSize = zip64.CompressedSize.Value;
+                    }
                 }
 
                 reader.BaseStream.AdvanceToPosition(endExtraFields);
             }
             else
-            {            
+            {
                 if (reader.BaseStream.Length < reader.BaseStream.Position + extraFieldLength + entry.CompressedLength + 4)
+                {
                     return false;
+                }
 
                 reader.BaseStream.Seek(extraFieldLength + entry.CompressedLength, SeekOrigin.Current); // seek to end of compressed file from which Data descriptor starts             
                 uint dataDescriptorSignature = reader.ReadUInt32();
@@ -492,7 +499,9 @@ namespace System.IO.Compression
                 seekSize += (is64bit ? 8 : 4) * 2;   // if Zip64 read by 8 bytes else 4 bytes 2 times (compressed and uncompressed size)
 
                 if (reader.BaseStream.Length < reader.BaseStream.Position + seekSize)
+                {
                     return false;
+                }
 
                 // dataDescriptorSignature is optional, if it was the DataDescriptorSignature we need to skip CRC 4 bytes else we can assume CRC is alreadyskipped
                 if (wasDataDescriptorSignatureRead)
@@ -510,11 +519,16 @@ namespace System.IO.Compression
                 }
                 reader.BaseStream.Seek( -seekSize - entry.CompressedLength - 4,  SeekOrigin.Current); // Seek back to the beginning of compressed stream
             }
+
             if (entry.CompressedLength != compressedSize)
+            {
                 return false;
+            }
 
             if (entry.Length != uncompressedSize)
+            {
                 return false;
+            }
 
             return true;
         }

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -442,7 +442,7 @@ namespace System.IO.Compression
 
             uint minimumVersion = reader.ReadUInt16();
             uint dataDescriptorBit = reader.ReadUInt16() & (uint)ZipArchiveEntry.BitFlagValues.DataDescriptor;
-            reader.BaseStream.Seek(10, SeekOrigin.Current); // skipping bytes used for Compression method (2 bytes), File last modification time and date (4 bytes) and CRC (4 bytes)
+            reader.BaseStream.Seek(10, SeekOrigin.Current); // skipping bytes used for Compression method (2 bytes), last modification time and date (4 bytes) and CRC (4 bytes)
             long compressedSize = reader.ReadUInt32();
             long uncompressedSize = reader.ReadUInt32();
             int filenameLength = reader.ReadUInt16();

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -460,7 +460,7 @@ namespace System.IO.Compression
                 bool isCompressedSizeInZip64 = compressedSize == ZipHelper.Mask32Bit;
                 Zip64ExtraField zip64;
 
-                // Ideally we should also check if the minimunVersion is 64 bit or above, but there could zip files for which this version is not set correctly
+                // Ideally we should also check if the minimumVersion is 64 bit or above, but there could zip files for which this version is not set correctly
                 if (isUncompressedSizeInZip64 || isCompressedSizeInZip64)
                 {
                     zip64 = Zip64ExtraField.GetJustZip64Block(new SubReadStream(reader.BaseStream, reader.BaseStream.Position, extraFieldLength), isUncompressedSizeInZip64, isCompressedSizeInZip64, false, false);

--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -190,7 +190,7 @@ namespace System.IO.Compression.Tests
                             ms.Write(buffer, 0, read);
                         }
                         Assert.True(e.Length == ms.Length);     // Only allow to decompress up to uncompressed size
-                        Assert.Equal(0, source.Read(buffer, 0, buffer.Length)); // shouldn't be able read more     
+                        Assert.Equal(0, source.Read(buffer, 0, bufferSize)); // shouldn't be able read more 
                         ms.Seek(0, SeekOrigin.Begin);
                         while ((read = ms.Read(buffer, 0, buffer.Length)) != 0)
                         { // No need to do anything, just making sure all bytes readable from output stream
@@ -251,7 +251,7 @@ namespace System.IO.Compression.Tests
                 {
                     using (Stream source = e.Open())
                     {
-                        byte[] buffer = new byte[10000];
+                        byte[] buffer = new byte[bufferSize];
                         int read;
                         while ((read = source.Read(buffer, 0, buffer.Length)) != 0)
                         {

--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -149,7 +149,7 @@ namespace System.IO.Compression.Tests
                 {
                     using (Stream source = e.Open())
                     {
-                        await source.CopyToAsync(ms, bufferSize);
+                        source.CopyTo(ms);
                         Assert.True(e.Length == ms.Length);     // Only allow to decompress up to uncompressed size
                         byte[] buffer = new byte[bufferSize];
                         Assert.Equal(0, source.Read(buffer, 0, buffer.Length)); // shouldn't be able read more                        

--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -319,7 +319,6 @@ namespace System.IO.Compression.Tests
             using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Update, true))
             {
                 ZipArchiveEntry e = archive.GetEntry(tamperedFileName);
-                Console.WriteLine(e.CompressedLength+ ", "+e.Length);
                 Stream s = null;
                 Assert.Throws<InvalidDataException>(() => s = e.Open());
                 Assert.Null(s);

--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -14,6 +14,7 @@ namespace System.IO.Compression.Tests
 {
     public class zip_InvalidParametersAndStrangeFiles : ZipFileTestBase
     {
+        private static readonly int bufferSize = 4096;
         private static void ConstructorThrows<TException>(Func<ZipArchive> constructor, string Message) where TException : Exception
         {
             try
@@ -148,9 +149,9 @@ namespace System.IO.Compression.Tests
                 {
                     using (Stream source = e.Open())
                     {
-                        source.CopyTo(ms);
+                        await source.CopyToAsync(ms, bufferSize);
                         Assert.True(e.Length == ms.Length);     // Only allow to decompress up to uncompressed size
-                        byte[] buffer = new byte[4096];
+                        byte[] buffer = new byte[bufferSize];
                         Assert.Equal(0, source.Read(buffer, 0, buffer.Length)); // shouldn't be able read more                        
                         ms.Seek(0, SeekOrigin.Begin);
                         int read;
@@ -182,7 +183,7 @@ namespace System.IO.Compression.Tests
                 {
                     using (Stream source = e.Open())
                     {
-                        byte[] buffer = new byte[4096];
+                        byte[] buffer = new byte[bufferSize];
                         int read;
                         while ((read = source.Read(buffer, 0, buffer.Length)) != 0)
                         {
@@ -222,7 +223,7 @@ namespace System.IO.Compression.Tests
                         Assert.True(e.Length == ms.Length);     // Only allow to decompress up to uncompressed size
                         ms.Seek(0, SeekOrigin.Begin);
                         int read;
-                        byte[] buffer = new byte[1024];
+                        byte[] buffer = new byte[bufferSize];
                         while ((read = ms.Read(buffer, 0, buffer.Length)) != 0)
                         { // No need to do anything, just making sure all bytes readable
                         }
@@ -335,7 +336,7 @@ namespace System.IO.Compression.Tests
                 {
                     using (var ms = new MemoryStream())
                     {
-                        s.CopyTo(ms);
+                        await s.CopyToAsync(ms, bufferSize);
                         Assert.Equal(updatedUncompressedLength + data.Length, ms.Length);
                         ms.Seek(updatedUncompressedLength, SeekOrigin.Begin);
                         byte[] read = new byte[data.Length];
@@ -371,7 +372,7 @@ namespace System.IO.Compression.Tests
                     {
                         Assert.Equal(updatedUncompressedLength, es.Length);
                         es.SetLength(0);
-                        s.CopyTo(es);
+                        await s.CopyToAsync(es, bufferSize);
                         Assert.Equal(data.Length, es.Length);
                     }
                 }
@@ -384,7 +385,7 @@ namespace System.IO.Compression.Tests
                 {
                     using (var ms = new MemoryStream())
                     {
-                        s.CopyTo(ms);
+                        await s.CopyToAsync(ms, bufferSize);
                         Assert.Equal(data.Length, ms.Length);
                         Assert.Equal(overwrite, Encoding.ASCII.GetString(ms.GetBuffer(), 0, data.Length));
                     }
@@ -419,7 +420,7 @@ namespace System.IO.Compression.Tests
                 {
                     using (var ms = new MemoryStream())
                     {
-                        s.CopyTo(ms);
+                        await s.CopyToAsync(ms, bufferSize);
                         Assert.Equal(e.Length, ms.Length);  // tampered file should read up to uncompressed size
                     }
                 }

--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -204,19 +204,22 @@ namespace System.IO.Compression.Tests
             using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Read))
             {
                 ZipArchiveEntry e = archive.GetEntry(s_tamperedFileName);
-                using (MemoryStream ms = new MemoryStream())
                 using (Stream source = e.Open())
                 {
                     byte[] buffer = new byte[e.Length + 20];
+                    Array.Fill<byte>(buffer, 0xDE);
                     int read;
-                    while ((read = source.Read(buffer, 0, buffer.Length)) != 0)
+                    int offset = 0;
+                    int length = buffer.Length;
+
+                    while ((read = source.Read(buffer, offset, length)) != 0)
                     {
-                        ms.Write(buffer, 0, read);
+                        offset += read;
+                        length -= read;
                     }
-                    for (int i = (int)e.Length; i < buffer.Length; i++)
+                    for (int i = offset; i < buffer.Length; i++)
                     {
-                        //As buffer initialized to 0, all extra 20 bytes should still be equal to 0
-                        Assert.Equal(0, buffer[i]);
+                        Assert.Equal(0xDE, buffer[i]);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #33058
There is 2 things done in this PR to account uncompressed size for opening/reading zip file
1. Compare compressed uncompressed sizes written in local file header and central directory record. If they don't match throw `InvalidDataException`
- as we were just skipping local file header before added code for reading local file header as needed (account data descriptor in which case the sizes written at the end of compressed file stream)
- and then check data validity.
 2. Truncate inflated stream read up to uncompressed size, throw if it was over uncompressed size