### PR TITLE
Allow ReflectPropertyDescriptor to reflect over non-public members

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs
@@ -298,12 +298,8 @@ namespace System.ComponentModel
                     {
                         if (_propInfo == null)
                         {
-#if VERIFY_REFLECTION_CHANGE
                             BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.GetProperty;
-                            _propInfo = _componentClass.GetProperty(Name, bindingFlags, null, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
-#else
-                            _propInfo = _componentClass.GetProperty(Name, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
-#endif
+                            _propInfo = _componentClass.GetProperty(Name, bindingFlags, binder: null, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
                         }
                         if (_propInfo != null)
                         {
@@ -386,11 +382,8 @@ namespace System.ComponentModel
                     {
                         for (Type t = ComponentType.BaseType; t != null && t != typeof(object); t = t.BaseType)
                         {
-#if VERIFY_REFLECTION_CHANGE
                             BindingFlags bindingFlags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
-                            PropertyInfo p = t.GetProperty(name, bindingFlags, null, PropertyType, Array.Empty<Type>(), null);
-#endif
-                            PropertyInfo p = t.GetProperty(name, PropertyType, Array.Empty<Type>(), null);
+                            PropertyInfo p = t.GetProperty(name, bindingFlags, binder: null, PropertyType, Array.Empty<Type>(), null);
                             if (p != null)
                             {
                                 _setMethod = p.GetSetMethod(nonPublic: false);
@@ -410,12 +403,8 @@ namespace System.ComponentModel
                     {
                         if (_propInfo == null)
                         {
-#if VERIFY_REFLECTION_CHANGE
                             BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.GetProperty;
-                            _propInfo = _componentClass.GetProperty(Name, bindingFlags, null, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
-#else
-                            _propInfo = _componentClass.GetProperty(Name, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
-#endif
+                            _propInfo = _componentClass.GetProperty(Name, bindingFlags, binder: null, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
                         }
                         if (_propInfo != null)
                         {
@@ -772,30 +761,18 @@ namespace System.ComponentModel
                 {
                     MemberInfo memberInfo = null;
 
-#if VERIFY_REFLECTION_CHANGE
                     BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly;
                     // Fill in our member info so we can get at the custom attributes.
                     if (IsExtender)
                     {
                         //receiverType is used to avoid ambitiousness when there are overloads for the get method.
-                        memberInfo = currentReflectType.GetMethod("Get" + Name, bindingFlags, null, new Type[] { _receiverType }, null);
+                        memberInfo = currentReflectType.GetMethod("Get" + Name, bindingFlags, binder: null, new Type[] { _receiverType }, modifiers: null);
                     }
                     else
                     {
-                        memberInfo = currentReflectType.GetProperty(Name, bindingFlags, null, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
+                        memberInfo = currentReflectType.GetProperty(Name, bindingFlags, binder: null, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
                     }
-#else
-                    // Fill in our member info so we can get at the custom attributes.
-                    if (IsExtender)
-                    {
-                        //receiverType is used to avoid ambitiousness when there are overloads for the get method.
-                        memberInfo = currentReflectType.GetMethod("Get" + Name, new Type[] { _receiverType }, null);
-                    }
-                    else
-                    {
-                        memberInfo = currentReflectType.GetProperty(Name, PropertyType, Array.Empty<Type>(), Array.Empty<ParameterModifier>());
-                    }
-#endif
+
                     // Get custom attributes for the member info.
                     if (memberInfo != null)
                     {

--- a/src/System.ComponentModel.TypeConverter/tests/DescriptorTestComponent.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DescriptorTestComponent.cs
@@ -22,6 +22,11 @@ namespace System.ComponentModel.Tests
 
         public string StringProperty { get; private set; }
 
+        public const string ProtectedStringPropertyName = nameof(ProtectedStringProperty);
+        protected string ProtectedStringProperty { get; private set; }
+
+        public string ProtectedStringPropertyValue => ProtectedStringProperty;
+
         public DescriptorTestComponent(string stringPropertyValue = "")
         {
             StringProperty = stringPropertyValue;

--- a/src/System.ComponentModel.TypeConverter/tests/Mocks/MockDesigner.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Mocks/MockDesigner.cs
@@ -8,6 +8,25 @@ namespace System.ComponentModel.Tests
 {
     internal class MockDesigner : IDesigner
     {
+        private string StringProperty { get; set; }
+
+        public bool StringPropertyHasBeenSet => StringProperty != null;
+
+        private bool ShouldSerializeStringProperty()
+        {
+            ShouldSerializeStringPropertyCalled = true;
+            return true;
+        }
+
+        public bool ShouldSerializeStringPropertyCalled { get; private set; }
+
+        private void ResetStringProperty()
+        {
+            ResetStringPropertyCalled = true;
+        }
+
+        public bool ResetStringPropertyCalled { get; private set; }
+
         public IComponent Component => throw new NotImplementedException();
 
         public DesignerVerbCollection Verbs => throw new NotImplementedException();

--- a/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
@@ -191,11 +191,11 @@ namespace System.ComponentModel.Tests
                 name: DescriptorTestComponent.ProtectedStringPropertyName,
                 type: typeof(string));
 
-            const string propertyValue = "Test";
+            const string PropertyValue = "Test";
 
-            property.SetValue(component, propertyValue);
-            Assert.Equal(propertyValue, property.GetValue(component));
-            Assert.Equal(propertyValue, component.ProtectedStringPropertyValue);
+            property.SetValue(component, PropertyValue);
+            Assert.Equal(PropertyValue, property.GetValue(component));
+            Assert.Equal(PropertyValue, component.ProtectedStringPropertyValue);
         }
 
         [Fact]
@@ -220,12 +220,12 @@ namespace System.ComponentModel.Tests
                 attributes: new[] { ReadOnlyAttribute.No });
 
             // The property descriptor should be redirected to reflect over the designer.
-            const string propertyValue = "Test";
+            const string PropertyValue = "Test";
 
             Assert.False(designer.StringPropertyHasBeenSet);
-            newStringProperty.SetValue(component, propertyValue);
+            newStringProperty.SetValue(component, PropertyValue);
             Assert.Empty(component.StringProperty);
-            Assert.Equal(propertyValue, newStringProperty.GetValue(component));
+            Assert.Equal(PropertyValue, newStringProperty.GetValue(component));
             Assert.True(designer.StringPropertyHasBeenSet);
 
             Assert.False(designer.ShouldSerializeStringPropertyCalled);

--- a/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/PropertyDescriptorTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel.Design;
 using System.Reflection;
 using Xunit;
 
@@ -177,6 +178,63 @@ namespace System.ComponentModel.Tests
             public bool BarReadOnly { get; private set; }
             public bool BarNotReadOnly { get; set; }
             public override bool BarReadOnlyBaseClass { get; }
+        }
+
+        [Fact]
+        public void PropertyDescriptorCanBeCreatedThatAccessesNonPublicProperty()
+        {
+            var component = new DescriptorTestComponent();
+
+            // Create a new property that "exposes" a protected property on our component.
+            PropertyDescriptor property = TypeDescriptor.CreateProperty(
+                componentType: typeof(DescriptorTestComponent),
+                name: DescriptorTestComponent.ProtectedStringPropertyName,
+                type: typeof(string));
+
+            const string propertyValue = "Test";
+
+            property.SetValue(component, propertyValue);
+            Assert.Equal(propertyValue, property.GetValue(component));
+            Assert.Equal(propertyValue, component.ProtectedStringPropertyValue);
+        }
+
+        [Fact]
+        public void PropertyDescriptorCanBeCreatedThatAccessesNonPublicPropertyOnAssociatedDesigner()
+        {
+            var designer = new MockDesigner();
+            var designerHost = new MockDesignerHost();
+            var component = new DescriptorTestComponent();
+
+            designerHost.AddDesigner(component, designer);
+            component.AddService(typeof(IDesignerHost), designerHost);
+
+            PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(component);
+            PropertyDescriptor stringProperty = properties[nameof(DescriptorTestComponent.StringProperty)];
+            Assert.NotNull(stringProperty);
+
+            // Create new property that "wraps" stringProperty and redirects to the designer.
+            // Note that a ReadOnlyAttribute is added to ensure that we can set it
+            PropertyDescriptor newStringProperty = TypeDescriptor.CreateProperty(
+                componentType: typeof(MockDesigner),
+                oldPropertyDescriptor: stringProperty,
+                attributes: new[] { ReadOnlyAttribute.No });
+
+            // The property descriptor should be redirected to reflect over the designer.
+            const string propertyValue = "Test";
+
+            Assert.False(designer.StringPropertyHasBeenSet);
+            newStringProperty.SetValue(component, propertyValue);
+            Assert.Empty(component.StringProperty);
+            Assert.Equal(propertyValue, newStringProperty.GetValue(component));
+            Assert.True(designer.StringPropertyHasBeenSet);
+
+            Assert.False(designer.ShouldSerializeStringPropertyCalled);
+            Assert.True(newStringProperty.ShouldSerializeValue(component));
+            Assert.True(designer.ShouldSerializeStringPropertyCalled);
+
+            Assert.False(designer.ResetStringPropertyCalled);
+            newStringProperty.ResetValue(component);
+            Assert.True(designer.ResetStringPropertyCalled);
         }
     }
 }


### PR DESCRIPTION
Fixes #38311

On .NET Framework, ReflectPropertyDescriptor can access non-public members, but has been disabled on .NET Core since ReflectPropertyDescriptor was ported. Most PropertyDescriptor runtime scenarios don't require this behavior, but design-time scenarios do. Component/Control designers can (and do) create new PropertyDescriptors that expose non-public properties from runtime components for design-time (e.g. for display in the Property Browser). In addition, designers often create "shadow" properties which are used at design-time in place of the actual properties on the runtime components. A shadowed property is normally declared as private, but ReflectPropertyDescriptor still needs to be able to find it.