### PR TITLE
Correcting some invalid array json inputs

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
@@ -58,6 +58,12 @@ namespace System.Text.Json
                 return;
             }
 
+            if (state.Current.IsProcessingEnumerable && state.Current.TempEnumerableValues == null && state.Current.ReturnValue == null)
+            {
+                ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
+                return;
+            }
+
             if (ValueConverter == null || !ValueConverter.TryRead(RuntimePropertyType, ref reader, out TRuntimeProperty value))
             {
                 ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoNotNullable.cs
@@ -52,12 +52,14 @@ namespace System.Text.Json
         {
             Debug.Assert(ShouldDeserialize);
 
+            // We need a property in order to a apply a value in a dictionary.
             if (state.Current.KeyName == null && (state.Current.IsProcessingDictionary || state.Current.IsProcessingImmutableDictionary))
             {
                 ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);
                 return;
             }
 
+            // We need an initialized array in order to store the values.
             if (state.Current.IsProcessingEnumerable && state.Current.TempEnumerableValues == null && state.Current.ReturnValue == null)
             {
                 ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(RuntimePropertyType, reader, state.JsonPath);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -162,12 +162,12 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    if (state.Current.ReturnValue == null)
+                    if (!(state.Current.ReturnValue is IList list))
                     {
                         ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(value.GetType(), reader, state.JsonPath);
                         return;
                     }
-                    ((IList)state.Current.ReturnValue).Add(value);
+                    list.Add(value);
                 }
             }
             else if (!setPropertyDirectly && state.Current.IsEnumerableProperty)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -162,6 +162,11 @@ namespace System.Text.Json
                 }
                 else
                 {
+                    if (state.Current.ReturnValue == null)
+                    {
+                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(value.GetType(), reader, state.JsonPath);
+                        return;
+                    }
                     ((IList)state.Current.ReturnValue).Add(value);
                 }
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -46,6 +46,11 @@ namespace System.Text.Json
                 }
                 else
                 {
+                    if (classInfo.CreateObject == null)
+                    {
+                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(classInfo.Type, reader, state.JsonPath);
+                        return;
+                    }
                     state.Current.ReturnValue = classInfo.CreateObject();
                 }
                 return;

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -158,7 +158,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(dict.key["c"], "d");
         }
 
-        class PocoDictionary
+        public class PocoDictionary
         {
             public Dictionary<string, string> key { get; set; }
         }
@@ -181,7 +181,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(@"{""Id"":10}", element.ToString());
         }
 
-        class Poco
+        public class Poco
         {
             public int Id { get; set; }
         }

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -131,7 +131,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(int[]), @"{}")]
         [InlineData(typeof(int[]), @"[""test""")]
         [InlineData(typeof(int[]), @"[true]")]
-        // [InlineData(typeof(int[]), @"[{}]")] TODO #38323: Uncomment when fixed
+        // [InlineData(typeof(int[]), @"[{}]")] TODO #38485: Uncomment when fixed
         [InlineData(typeof(int[]), @"[[]]")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": {}}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": ""test""}")]
@@ -139,7 +139,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": true}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [""test""]}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [[]]}")]
-        // [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")] TODO #38323: Uncomment when fixed
+        // [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")] TODO #38485: Uncomment when fixed
         public static void InvalidJsonForArrayShouldFail(Type type, string json)
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Parse(json, type));

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -124,12 +124,33 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Parse(json, type));
         }
 
+        [InlineData(typeof(int[]), @"""test""")]
+        [InlineData(typeof(int[]), @"1")]
+        [InlineData(typeof(int[]), @"false")]
+        [InlineData(typeof(int[]), @"{}")]
+        [InlineData(typeof(int[]), @"[""test""")]
+        [InlineData(typeof(int[]), @"[true]")]
+        // [InlineData(typeof(int[]), @"[{}]")] Fix is in progress
+        [InlineData(typeof(int[]), @"[[]]")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": {}}")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": ""test""}")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": 1}")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": true}")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [""test""]}")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [[]]}")]
+        // [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")]  Fix is in progress
+        public static void InvalidJsonForArrayShouldFail(Type type, string json)
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse(json, type));
+        }
+
         [Fact]
         public static void InvalidEmptyDictionaryInput()
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<string>("{}"));
         }
 
+        [Fact]
         public static void PocoWithDictionaryObject()
         {
             PocoDictionary dict = JsonSerializer.Parse<PocoDictionary>("{\n\t\"key\" : {\"a\" : \"b\", \"c\" : \"d\"}}");

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -124,13 +124,14 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Parse(json, type));
         }
 
+        [Theory]
         [InlineData(typeof(int[]), @"""test""")]
         [InlineData(typeof(int[]), @"1")]
         [InlineData(typeof(int[]), @"false")]
         [InlineData(typeof(int[]), @"{}")]
         [InlineData(typeof(int[]), @"[""test""")]
         [InlineData(typeof(int[]), @"[true]")]
-        // [InlineData(typeof(int[]), @"[{}]")] Fix is in progress
+        // [InlineData(typeof(int[]), @"[{}]")] TODO #38323: Uncomment when fixed
         [InlineData(typeof(int[]), @"[[]]")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": {}}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": ""test""}")]
@@ -138,7 +139,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": true}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [""test""]}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [[]]}")]
-        // [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")]  Fix is in progress
+        // [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")] TODO #38323: Uncomment when fixed
         public static void InvalidJsonForArrayShouldFail(Type type, string json)
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Parse(json, type));


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/37188

corrects exceptions for 

```csharp
[Theory]
[InlineData(typeof(int[]), @"1")]
[InlineData(typeof(int[]), @"{}")]
[InlineData(typeof(Dictionary<string, int[]>), @"{""test"": {}}")]
[InlineData(typeof(Dictionary<string, int[]>), @"{""test"": 1}")]
public static void InvalidJsonForArrayShouldFail(Type type, string json)
{
       Assert.Throws<JsonException>(() => JsonSerializer.Parse(json, type));
}
```

The remaing two will be fixed by steve harter TypeConverterChange
