### PR TITLE
Added CopyToAsync(PipeWriter)

### DIFF
--- a/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
+++ b/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
@@ -47,6 +47,7 @@ namespace System.IO.Pipelines
         public virtual System.IO.Stream AsStream() { throw null; }
         public abstract void CancelPendingRead();
         public abstract void Complete(System.Exception exception = null);
+        public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Pipelines.PipeWriter destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.IO.Pipelines.PipeReader Create(System.IO.Stream stream, System.IO.Pipelines.StreamPipeReaderOptions readerOptions = null) { throw null; }
         public abstract void OnWriterCompleted(System.Action<System.Exception, object> callback, object state);

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -89,7 +89,38 @@ namespace System.IO.Pipelines
         /// <summary>
         /// Asynchronously reads the bytes from the <see cref="PipeReader"/> and writes them to the specified stream, using a specified buffer size and cancellation token.
         /// </summary>
-        /// <param name="destination">The stream to which the contents of the current stream will be copied.</param>
+        /// <param name="destination">The <see cref="PipeWriter"/> to which the contents of the current stream will be copied.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
+        /// <returns>A task that represents the asynchronous copy operation.</returns>
+        public virtual Task CopyToAsync(PipeWriter destination, CancellationToken cancellationToken = default)
+        {
+            if (destination == null)
+            {
+                throw new ArgumentNullException(nameof(destination));
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled(cancellationToken);
+            }
+
+            static async ValueTask WriteAsync(PipeWriter destination, ReadOnlyMemory<byte> memory, CancellationToken cancellationToken)
+            {
+                FlushResult result = await destination.WriteAsync(memory, cancellationToken).ConfigureAwait(false);
+
+                if (result.IsCanceled)
+                {
+                    ThrowHelper.ThrowOperationCanceledException_FlushCanceled();
+                }
+            }
+
+            return CopyToAsyncCore(destination, WriteAsync, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the bytes from the <see cref="PipeReader"/> and writes them to the specified stream, using a specified buffer size and cancellation token.
+        /// </summary>
+        /// <param name="destination">The <see cref="Stream"/> to which the contents of the current stream will be copied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns>A task that represents the asynchronous copy operation.</returns>
         public virtual Task CopyToAsync(Stream destination, CancellationToken cancellationToken = default)
@@ -104,10 +135,15 @@ namespace System.IO.Pipelines
                 return Task.FromCanceled(cancellationToken);
             }
 
-            return CopyToAsyncCore(destination, cancellationToken);
+            static ValueTask WriteAsync(Stream destination, ReadOnlyMemory<byte> memory, CancellationToken cancellationToken)
+            {
+                return destination.WriteAsync(memory, cancellationToken);
+            }
+
+            return CopyToAsyncCore(destination, WriteAsync, cancellationToken);
         }
 
-        private async Task CopyToAsyncCore(Stream destination, CancellationToken cancellationToken)
+        private async Task CopyToAsyncCore<TStream>(TStream destination, Func<TStream, ReadOnlyMemory<byte>, CancellationToken, ValueTask> writeAsync, CancellationToken cancellationToken)
         {
             while (true)
             {
@@ -126,7 +162,7 @@ namespace System.IO.Pipelines
 
                     while (buffer.TryGet(ref position, out ReadOnlyMemory<byte> memory))
                     {
-                        await destination.WriteAsync(memory, cancellationToken).ConfigureAwait(false);
+                        await writeAsync(destination, memory, cancellationToken).ConfigureAwait(false);
 
                         consumed = position;
                     }

--- a/src/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
@@ -22,8 +22,8 @@ namespace System.IO.Pipelines.Tests
         public async Task CopyToAsyncThrowsArgumentNullExceptionForNullDestination()
         {
             var pipe = new Pipe(s_testOptions);
-            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => pipe.Reader.CopyToAsync((Stream)null));
-            Assert.Equal("destination", ex.ParamName);
+            await AssertExtensions.ThrowsAsync<ArgumentNullException>("destination", () => pipe.Reader.CopyToAsync((Stream)null));
+            await AssertExtensions.ThrowsAsync<ArgumentNullException>("destination", () => pipe.Reader.CopyToAsync((PipeWriter)null));
         }
 
         [Fact]

--- a/src/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
+++ b/src/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO.Pipelines.Tests.Infrastructure;
 using System.Linq;
@@ -21,7 +22,7 @@ namespace System.IO.Pipelines.Tests
         public async Task CopyToAsyncThrowsArgumentNullExceptionForNullDestination()
         {
             var pipe = new Pipe(s_testOptions);
-            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => pipe.Reader.CopyToAsync(null));
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => pipe.Reader.CopyToAsync((Stream)null));
             Assert.Equal("destination", ex.ParamName);
         }
 
@@ -33,7 +34,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public async Task CopyToAsyncWorks()
+        public async Task CopyToAsyncStreamWorks()
         {
             var messages = new List<byte[]>()
             {
@@ -55,6 +56,35 @@ namespace System.IO.Pipelines.Tests
             await task;
             
             Assert.Equal(messages.SelectMany(msg => msg).ToArray(), stream.ToArray());
+        }
+
+        [Fact]
+        public async Task CopyToAsyncPipeWriterWorks()
+        {
+            var messages = new List<byte[]>()
+            {
+                Encoding.UTF8.GetBytes("Hello World1"),
+                Encoding.UTF8.GetBytes("Hello World2"),
+                Encoding.UTF8.GetBytes("Hello World3"),
+            };
+
+            var pipe = new Pipe(s_testOptions);
+            var targetPipe = new Pipe(s_testOptions);
+
+            Task task = pipe.Reader.CopyToAsync(targetPipe.Writer);
+            foreach (var msg in messages)
+            {
+                await pipe.Writer.WriteAsync(msg);
+            }
+            pipe.Writer.Complete();
+            await task;
+
+            ReadResult readResult = await targetPipe.Reader.ReadAsync();
+            Assert.Equal(messages.SelectMany(msg => msg).ToArray(), readResult.Buffer.ToArray());
+
+            targetPipe.Reader.AdvanceTo(readResult.Buffer.End);
+            targetPipe.Reader.Complete();
+            targetPipe.Writer.Complete();
         }
 
         [Fact]
@@ -160,6 +190,35 @@ namespace System.IO.Pipelines.Tests
             Task task = pipe.Reader.CopyToAsync(stream, cts.Token);
 
             cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => task);
+        }
+
+        [Fact]
+        public async Task CancelingPipeWriterViaCancellationTokenThrowsOperationCancelledException()
+        {
+            var pipe = new Pipe(s_testOptions);
+            // This should make the write call pause
+            var targetPipe = new Pipe(new PipeOptions(pauseWriterThreshold: 1, resumeWriterThreshold: 1));
+            var cts = new CancellationTokenSource();
+            await pipe.Writer.WriteAsync(Encoding.ASCII.GetBytes("Gello World"));
+            Task task = pipe.Reader.CopyToAsync(targetPipe.Writer, cts.Token);
+
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() => task);
+        }
+
+        [Fact]
+        public async Task CancelingPipeWriterViaPendingFlushThrowsOperationCancelledException()
+        {
+            var pipe = new Pipe(s_testOptions);
+            // This should make the write call pause
+            var targetPipe = new Pipe(new PipeOptions(pauseWriterThreshold: 1, resumeWriterThreshold: 1));
+            await pipe.Writer.WriteAsync(Encoding.ASCII.GetBytes("Gello World"));
+            Task task = pipe.Reader.CopyToAsync(targetPipe.Writer);
+
+            targetPipe.Writer.CancelPendingFlush();
 
             await Assert.ThrowsAsync<OperationCanceledException>(() => task);
         }


### PR DESCRIPTION
- Reuse existing CopyToAsync routine to implement the PipeWriter overload.
- Added tests for PipeWriter overload

Fixes #35513