### PR TITLE
Don't throw in the On* callbacks

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
@@ -186,8 +186,6 @@ namespace System.IO.Pipelines
         /// <inheritdoc />
         public override void OnWriterCompleted(Action<Exception, object> callback, object state)
         {
-            // REVIEW: Do we fire this when the stream has ended?
-            throw new NotSupportedException("OnWriterCompleted is not supported");
         }
 
         /// <inheritdoc />

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -232,7 +232,6 @@ namespace System.IO.Pipelines
         /// <inheritdoc />
         public override void OnReaderCompleted(Action<Exception, object> callback, object state)
         {
-            throw new NotSupportedException("OnReaderCompleted is not supported.");
         }
 
         /// <inheritdoc />

--- a/src/System.IO.Pipelines/tests/StreamPipeReaderTests.cs
+++ b/src/System.IO.Pipelines/tests/StreamPipeReaderTests.cs
@@ -484,10 +484,11 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public void OnWriterCompletedThrowsNotSupportedException()
         {
+            bool fired = false;
             PipeReader reader = PipeReader.Create(Stream.Null);
-
-            Assert.Throws<NotSupportedException>(() => reader.OnWriterCompleted((_, __) => { }, null));
+            reader.OnWriterCompleted((_, __) => { fired = true; }, null);
             reader.Complete();
+            Assert.False(fired);
         }
 
         [Fact]

--- a/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
+++ b/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
@@ -453,9 +453,11 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public void OnReaderCompletedThrowsNotSupported()
         {
+            bool fired = false;
             PipeWriter writer = PipeWriter.Create(Stream.Null);
-            Assert.Throws<NotSupportedException>(() => writer.OnReaderCompleted((_, __) => { }, null));
+            writer.OnReaderCompleted((_, __) => { fired = true; }, null);
             writer.Complete();
+            Assert.False(fired);
         }
 
         private class FlushAsyncAwareStream : WriteOnlyStream


### PR DESCRIPTION
- We can't throw NotSupportedException in the OnWriterCompleted and OnReaderCompleted callbacks since consumers of the API won't know if it's safe to do so. We could add a SupportsOn* boolean but nooping is a much simpler solution without breaking existing callers. We can also add a boolean in the future so callers will know when they can register callbacks or not.