### PR TITLE
Increase timeout on Linux, change macOS pool and move arm64 legs around

### DIFF
--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -23,54 +23,16 @@ jobs:
       displayName: Linux
       strategy:
         matrix:
-          x64_Release:
-            _BuildConfig: Release
-            _architecture: x64
-            _framework: netcoreapp
-            _helixQueues: $(linuxDefaultQueues)
-            _dockerContainer: rhel7_container
-            _buildScriptPrefix: ''
-            _buildExtraArguments: ''
-            _publishTests: true
-
-          arm64_Release:
-            _BuildConfig: Release
-            _architecture: arm64
-            _framework: netcoreapp
-            _helixQueues: $(linuxArm64Queues)
-            _dockerContainer: ubuntu_1604_arm64_cross_container
-            _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
-            _buildExtraArguments: -warnAsError false
-            _publishTests: true
-
-          musl_x64_Release:
-             _BuildConfig: Release
-             _architecture: x64
-             _framework: netcoreapp
-             _helixQueues: $(alpineQueues)
-             _dockerContainer: alpine_36_container
-             _buildScriptPrefix: ''
-             _buildExtraArguments: /p:RuntimeOS=linux-musl
-             _publishTests: true
-
-          ${{ if or(eq(parameters.testScope, 'outerloop'), eq(parameters.testScope, 'all')) }}:
-            x64_Debug:
-              _BuildConfig: Debug
+          ${{ if eq(parameters.fullMatrix, 'false') }}:
+            x64_Release:
+              _BuildConfig: Release
               _architecture: x64
               _framework: netcoreapp
               _helixQueues: $(linuxDefaultQueues)
               _dockerContainer: rhel7_container
               _buildScriptPrefix: ''
               _buildExtraArguments: ''
-
-            arm64_Debug:
-              _BuildConfig: Debug
-              _architecture: arm64
-              _framework: netcoreapp
-              _helixQueues: $(linuxArm64Queues)
-              _dockerContainer: ubuntu_1604_arm64_cross_container
-              _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
-              _buildExtraArguments: --warnAsError false
+              _publishTests: true
 
             musl_x64_Debug:
               _BuildConfig: Debug
@@ -82,6 +44,25 @@ jobs:
               _buildExtraArguments: /p:RuntimeOS=linux-musl
 
           ${{ if eq(parameters.fullMatrix, 'true') }}:
+            x64_Debug:
+              _BuildConfig: Debug
+              _architecture: x64
+              _framework: netcoreapp
+              _helixQueues: $(linuxDefaultQueues)
+              _dockerContainer: rhel7_container
+              _buildScriptPrefix: ''
+              _buildExtraArguments: ''
+
+            musl_x64_Release:
+              _BuildConfig: Release
+              _architecture: x64
+              _framework: netcoreapp
+              _helixQueues: $(alpineQueues)
+              _dockerContainer: alpine_36_container
+              _buildScriptPrefix: ''
+              _buildExtraArguments: /p:RuntimeOS=linux-musl
+              _publishTests: true
+
             arm_Release:
               _BuildConfig: Release
               _architecture: arm
@@ -100,6 +81,16 @@ jobs:
               _dockerContainer: alpine_37_arm64_container
               _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
               _buildExtraArguments: -warnAsError false /p:BuildNativeCompiler=--clang5.0 /p:RuntimeOS=linux-musl
+              _publishTests: true
+
+            arm64_Release:
+              _BuildConfig: Release
+              _architecture: arm64
+              _framework: netcoreapp
+              _helixQueues: $(linuxArm64Queues)
+              _dockerContainer: ubuntu_1604_arm64_cross_container
+              _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
+              _buildExtraArguments: -warnAsError false
               _publishTests: true
 
       pool:
@@ -132,21 +123,29 @@ jobs:
         displayName: Linux
         strategy:
           matrix:
-            arm_Release:
-              _BuildConfig: Release
+            arm_Debug:
+              _BuildConfig: Debug
               _architecture: arm
               _framework: netcoreapp
               _buildExtraArguments: /p:RuntimeOS=ubuntu.16.04 -warnAsError false
               _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm '
               _dockerContainer: ubuntu_1604_arm_cross_container
 
-            musl_arm64_Release:
-              _BuildConfig: Release
+            musl_arm64_Debug:
+              _BuildConfig: Debug
               _architecture: arm64
               _framework: netcoreapp
               _dockerContainer: alpine_37_arm64_container
               _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
               _buildExtraArguments: -warnAsError false /p:BuildNativeCompiler=--clang5.0 /p:RuntimeOS=linux-musl
+
+            arm64_Debug:
+              _BuildConfig: Debug
+              _architecture: arm64
+              _framework: netcoreapp
+              _dockerContainer: ubuntu_1604_arm64_cross_container
+              _buildScriptPrefix: 'ROOTFS_DIR=/crossrootfs/arm64 '
+              _buildExtraArguments: --warnAsError false
 
         pool:
           name: Hosted Ubuntu 1604

--- a/eng/pipelines/linux.yml
+++ b/eng/pipelines/linux.yml
@@ -109,6 +109,8 @@ jobs:
       buildScriptPrefix: $(_buildScriptPrefix)
       buildExtraArguments: $(_buildExtraArguments)
       submitToHelix: true
+      # Temporary till we reduced workloads on ARM64
+      timeoutInMinutes: 180
 
       variables:
         - linuxArm64Queues: \(Ubuntu.1604.Arm64.Open\)Ubuntu.1604.Arm64.Docker.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-helix-arm64v8-b049512-20190321153539

--- a/eng/pipelines/macos.yml
+++ b/eng/pipelines/macos.yml
@@ -39,7 +39,7 @@ jobs:
               _publishTests: true
 
       pool:
-        name: Hosted Mac Internal Sierra
+        name: Hosted macOS
 
       preBuildSteps:
         - script: |

--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -50,15 +50,6 @@ jobs:
               _architecture: x64
               _framework: uap
               _helixQueues: $(uapNetfxQueues)
-
-          # Run arm on the matrix or in Outerloop
-          ${{ if or(eq(parameters.fullMatrix, 'true'), or(eq(parameters.testScope, 'outerloop'), eq(parameters.testScope, 'all'))) }}:
-            arm64_Release:
-              _BuildConfig: Release
-              _architecture: arm64
-              _framework: netcoreapp
-              _helixQueues: $(windowsArmQueue)
-              _publishTests: true
           
           # Full test matrix
           ${{ if eq(parameters.fullMatrix, 'true') }}:
@@ -102,6 +93,13 @@ jobs:
               _framework: uap
               _helixQueues: $(uapNetfxQueues)
 
+            arm64_Release:
+              _BuildConfig: Release
+              _architecture: arm64
+              _framework: netcoreapp
+              _helixQueues: $(windowsArmQueue)
+              _publishTests: true
+
       pool:
         name: Hosted VS2017
 
@@ -126,7 +124,6 @@ jobs:
         displayName: Packaging All Configurations
         strategy:
           matrix:
-            # PR Validation Matrix
             ${{ if eq(parameters.fullMatrix, 'false') }}:
               x64_Debug:
                 _BuildConfig: Debug
@@ -134,7 +131,6 @@ jobs:
                 _framework: allConfigurations
                 _helixQueues: $(allConfigurationsQueues)
 
-            # Official Build Matrix
             ${{ if eq(parameters.fullMatrix, 'true') }}:
               x64_Release:
                 _BuildConfig: Release
@@ -166,23 +162,23 @@ jobs:
             displayName: Build Packages and Tests
 
       # Legs without HELIX testing
-    - ${{ if eq(parameters.fullMatrix, 'true') }}:
-      - job: WindowsNoTest
-        displayName: Windows
-        strategy:
-          matrix:
-            arm_Release:
-              _BuildConfig: Release
-              _architecture: arm
-              _framework: netcoreapp
+      - ${{ if eq(parameters.fullMatrix, 'true') }}:
+        - job: WindowsNoTest
+          displayName: Windows
+          strategy:
+            matrix:
+              arm_Release:
+                _BuildConfig: Release
+                _architecture: arm
+                _framework: netcoreapp
 
-            UAP_arm_Release:
-              _BuildConfig: Release
-              _architecture: arm
-              _framework: uap
+              UAP_arm_Release:
+                _BuildConfig: Release
+                _architecture: arm
+                _framework: uap
 
-        pool:
-          name: Hosted VS2017
+          pool:
+            name: Hosted VS2017
 
-        submitToHelix: false
-        buildExtraArguments: /p:RuntimeOS=win10
+          submitToHelix: false
+          buildExtraArguments: /p:RuntimeOS=win10

--- a/eng/sendtohelix.proj
+++ b/eng/sendtohelix.proj
@@ -9,6 +9,8 @@
     <HelixBuild Condition="'$(HelixBuild)' == ''">$(BUILD_BUILDNUMBER)</HelixBuild>
     <HelixBuild Condition="'$(HelixBuild)' == ''">default</HelixBuild>
 
+    <!-- For arm64 we set a 30min timeout temporarily until we split up slow test assemblies. -->
+    <TimeoutInSeconds Condition="'$(Platform)' == 'arm64'">1800</TimeoutInSeconds>
     <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">900</TimeoutInSeconds>
     <_timeoutSpan>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</_timeoutSpan>
     


### PR DESCRIPTION
This increases the timeout for all Linux jobs as the condition in corefx-base.yml is currently based on the job. As this change is temporary until we figured out what is causing the long test executions I'm ok with enabling it for all Linux legs.

Other changes:
- Moving to the `Hosted macOS` which runs with macOS 10.14 latest.
- Correctly condition no-test legs that shouldn't run on Outerloop
- Move arm64 legs out of PR to save cycles
- Moving legs around that were conditioned on Outerloop

cc @stephentoub