### PR TITLE
Avoid using X509Certificate2's IntPtr ctor in SecureChannel

### DIFF
--- a/src/Common/tests/System/Net/Configuration.Certificates.cs
+++ b/src/Common/tests/System/Net/Configuration.Certificates.cs
@@ -75,7 +75,7 @@ namespace System.Net.Test.Common
                     return new X509Certificate2(
                         File.ReadAllBytes(Path.Combine(TestDataFolder, certificateFileName)),
                         CertificatePassword,
-                        X509KeyStorageFlags.DefaultKeySet);
+                        X509KeyStorageFlags.DefaultKeySet | X509KeyStorageFlags.Exportable);
                 }
                 catch (Exception ex)
                 {

--- a/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -268,7 +268,7 @@ namespace System.Net.Security
             {
                 if (certificate.Handle != IntPtr.Zero)
                 {
-                    certificateEx = new X509Certificate2(certificate.Handle);
+                    certificateEx = new X509Certificate2(certificate);
                 }
             }
             catch (SecurityException) { }

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.netcoreapp.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.netcoreapp.cs
@@ -16,12 +16,13 @@ namespace System.Net.Security.Tests
 
     public sealed class SslStreamStreamToStreamTest_MemoryAsync : SslStreamStreamToStreamTest_CancelableReadWriteAsync
     {
-        protected override async Task DoHandshake(SslStream clientSslStream, SslStream serverSslStream, X509Certificate serverCertificate = null)
+        protected override async Task DoHandshake(SslStream clientSslStream, SslStream serverSslStream, X509Certificate serverCertificate = null, X509Certificate clientCertificate = null)
         {
-            await WithCertificate(serverCertificate, async(certificate, name) =>
+            X509CertificateCollection clientCerts = clientCertificate != null ? new X509CertificateCollection() { clientCertificate } : null;
+            await WithServerCertificate(serverCertificate, async(certificate, name) =>
             {
-                Task t1 = clientSslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions() { TargetHost = name }, CancellationToken.None);
-                Task t2 = serverSslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions() { ServerCertificate = certificate }, CancellationToken.None);
+                Task t1 = clientSslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions() { TargetHost = name, ClientCertificates = clientCerts }, CancellationToken.None);
+                Task t2 = serverSslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions() { ServerCertificate = certificate, ClientCertificateRequired = clientCertificate != null }, CancellationToken.None);
                 await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2);
             });
         }

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.netcoreapp.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.netcoreapp.cs
@@ -16,14 +16,14 @@ namespace System.Net.Security.Tests
 
     public sealed class SslStreamStreamToStreamTest_MemoryAsync : SslStreamStreamToStreamTest_CancelableReadWriteAsync
     {
-        protected override async Task DoHandshake(SslStream clientSslStream, SslStream serverSslStream)
+        protected override async Task DoHandshake(SslStream clientSslStream, SslStream serverSslStream, X509Certificate serverCertificate = null)
         {
-            using (X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate())
+            await WithCertificate(serverCertificate, async(certificate, name) =>
             {
-                Task t1 = clientSslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions() { TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false) }, CancellationToken.None);
+                Task t1 = clientSslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions() { TargetHost = name }, CancellationToken.None);
                 Task t2 = serverSslStream.AuthenticateAsServerAsync(new SslServerAuthenticationOptions() { ServerCertificate = certificate }, CancellationToken.None);
                 await TestConfiguration.WhenAllOrAnyFailedWithTimeout(t1, t2);
-            }
+            });
         }
 
         protected override Task<int> ReadAsync(Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/37516

cc: @bartonjs