### PR TITLE
Opt-out of the new AzDO reporting behavior

### DIFF
--- a/eng/sendtohelix.proj
+++ b/eng/sendtohelix.proj
@@ -32,6 +32,9 @@
     <TestRunNamePrefix Condition="'$(IsPackageTesting)' == 'true'">PackageTests-$(ConfigurationGroup)-$(ArchGroup)</TestRunNamePrefix>
 
     <FailOnTestFailure Condition="'$(WaitForWorkItemCompletion)' != ''">$(WaitForWorkItemCompletion)</FailOnTestFailure>
+    
+    <!-- Disable until the flaky test support is fixed: https://github.com/dotnet/core-eng/issues/6663 -->
+    <DisableFlakyTestSupport>true</DisableFlakyTestSupport>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(HelixType)' == ''">


### PR DESCRIPTION
See https://github.com/dotnet/core-eng/issues/6663

The current behavior which was set to default is broken. We are opting out of it to get back to a sane reporting state.