### PR TITLE
Await for responseHeadersTask to observe exception if any

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1399,6 +1399,8 @@ namespace System.Net.Http
                     }
                     else
                     {
+                        await responseHeadersTask;
+
                         // We received the response headers but the request body hasn't yet finished.
                         // If the connection is aborted or if we get RST or GOAWAY from server, exception will be
                         // stored in stream._abortException and propagated to up to caller if possible while processing response.


### PR DESCRIPTION
There is race condition when we get RST from server. In this case the RST git during processing body but because we did not finish handing out HttpResponseMessage  we faulted the receiving task. Since we fail to throw, we were hitting NRE in some unrelated code while trying to dereference response we never processed. 

Since this depends on race in task processing I did not add new test. 

fixes #38293
 