### PR TITLE
[3.0 DRAFT Bug fix]JsonSerializer.Parse throws for UInt64 backed enum with value -1

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -47,7 +47,8 @@ namespace System.Text.Json.Serialization.Converters
                     return true;
                 }
             }
-            else if (reader.TryGetInt64(out long longValue))
+
+            if (reader.TryGetInt64(out long longValue))
             {
                 value = (TValue)Enum.ToObject(valueType, longValue);
                 return true;

--- a/src/System.Text.Json/tests/Serialization/EnumTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumTests.cs
@@ -33,6 +33,99 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyUInt64Enum"" : " + ulong.MaxValue +
                 @"}";
 
+        private static readonly string s_jsonByteEnum =
+                @"{" +
+                @"""MyByteEnum"" : " + byte.MaxValue +
+                @"}";
+
+        private const string UlongMaxPlus1 = "18446744073709551616"; // ulong.MaxValue + 1;
+
+        [Fact]
+        public static void Parse_UlongMaxPlus1_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {UlongMaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {UlongMaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {UlongMaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {UlongMaxPlus1} }}"));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{UlongMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{UlongMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{UlongMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{UlongMaxPlus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_MaxValues_QuotedVsNotQuoted_QuotedThrows()
+        {
+            string json = $"{{ \"MyByteEnum\" : {byte.MaxValue}, \"MyUInt32Enum\" : {UInt32.MaxValue}, \"MyUInt64Enum\" : {ulong.MaxValue} }}";
+            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
+            Assert.Equal((SampleByteEnum)byte.MaxValue, result.MyByteEnum);
+            Assert.Equal((SampleUInt32Enum)UInt32.MaxValue, result.MyUInt32Enum);
+            Assert.Equal((SampleUInt64Enum)ulong.MaxValue, result.MyUInt64Enum);
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {ulong.MaxValue} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {ulong.MaxValue} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {ulong.MaxValue} }}"));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{ulong.MaxValue}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{ulong.MaxValue}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{ulong.MaxValue}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_MaxValuePlus1_QuotedVsNotQuoted_QuotedThrows()
+        {
+            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(
+                $"{{ \"MyByteEnum\" : {(ulong)byte.MaxValue + 1}, \"MyUInt32Enum\" : {(ulong)UInt32.MaxValue + 1} }}");
+            Assert.Equal((SampleByteEnum)0, result.MyByteEnum);
+            Assert.Equal((SampleUInt32Enum)0, result.MyUInt32Enum);
+
+            // Quoted throws
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{(ulong)byte.MaxValue + 1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{(ulong)UInt32.MaxValue + 1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_Negative1_QuotedVsUnquoted_QuotedThrows()
+        {
+            string json = "{ \"MyByteEnum\" : -1, \"MyUInt32Enum\" : -1 }";
+            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
+            Assert.Equal((SampleByteEnum)byte.MaxValue, result.MyByteEnum);
+            Assert.Equal((SampleUInt32Enum)UInt32.MaxValue, result.MyUInt32Enum);
+
+            // Quoted throws
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>("{ \"MyByteEnum\" : \"-1\" }"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>("{ \"MyUInt32Enum\" : \"-1\" }"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>("{ \"MyUInt64Enum\" : \"-1\" }"));
+        }
+
+        [Theory]
+        [InlineData("{ \"MyUInt64Enum\" : -1 }")]
+        [InlineData("{ \"MyUInt64Enum\" : -1, \"MyUInt32Enum\" : -1 }")]
+        [InlineData("{ \"MyUInt64Enum\" : -1, \"MyUInt32Enum\" : -1, \"MyByteEnum\" : -1 }")]
+        [ActiveIssue(38363)]
+        public static void Parse_Negative1ForUInt64Enum_ShouldNotThrow(string json)
+        {
+            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
+            Assert.Equal((SampleUInt64Enum)UInt64.MaxValue, result.MyUInt64Enum);
+        }
+
+        [Theory]
+        [InlineData((ulong)byte.MaxValue + 1, (ulong)UInt32.MaxValue + 1, (SampleByteEnum)0, (SampleUInt32Enum)0)]
+        [InlineData((ulong)byte.MaxValue + 2, (ulong)UInt32.MaxValue + 2, (SampleByteEnum)1, (SampleUInt32Enum)1)]
+        [InlineData((ulong)byte.MaxValue + 13, (ulong)UInt32.MaxValue + 13, (SampleByteEnum)12, (SampleUInt32Enum)12)]
+        [InlineData((ulong)byte.MaxValue * 2, (ulong)UInt32.MaxValue * 2, (SampleByteEnum)byte.MaxValue - 1, (SampleUInt32Enum)UInt32.MaxValue - 1)]
+        public static void Parse_Ulong_JsonWithAcceptableInvalidNumber_Success(ulong i, ulong j, SampleByteEnum e1, SampleUInt32Enum e2)
+        {
+            string json = $"{{ \"MyByteEnum\" : {i}, \"MyUInt32Enum\" : {j} }}";
+            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
+            Assert.Equal(e1, result.MyByteEnum);
+            Assert.Equal(e2, result.MyUInt32Enum);
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{i}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{j}\" }}"));
+        }
+
         [Fact]
         public static void EnumAsStringFail()
         {
@@ -68,12 +161,9 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void Tmp_Test()
+        public static void EnumAsByteMax()
         {
-            string json = "{ \"MyByteEnum\" : -1, \"MyUInt32Enum\" : -1, \"MyUInt64Enum\" : -1 }";
-            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(json);
-            Assert.Equal(SampleUInt64Enum.Max, obj.MyUInt64Enum);
-            Assert.Equal(SampleUInt32Enum.Max, obj.MyUInt32Enum);
+            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(s_jsonByteEnum);
             Assert.Equal(SampleByteEnum.Max, obj.MyByteEnum);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/EnumTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumTests.cs
@@ -66,5 +66,15 @@ namespace System.Text.Json.Serialization.Tests
             SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(s_jsonUInt64EnumMax);
             Assert.Equal(SampleUInt64Enum.Max, obj.MyUInt64Enum);
         }
+
+        [Fact]
+        public static void Tmp_Test()
+        {
+            string json = "{ \"MyByteEnum\" : -1, \"MyUInt32Enum\" : -1, \"MyUInt64Enum\" : -1 }";
+            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(json);
+            Assert.Equal(SampleUInt64Enum.Max, obj.MyUInt64Enum);
+            Assert.Equal(SampleUInt32Enum.Max, obj.MyUInt32Enum);
+            Assert.Equal(SampleByteEnum.Max, obj.MyByteEnum);
+        }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
@@ -9,24 +9,8 @@ using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
 {
-    public enum SampleByteEnum : byte
-    {
-        One = 0,
-        Two = 1,
-        Max = byte.MaxValue
-    }
-
-    public enum SampleUInt32Enum : UInt32
-    {
-        One = 0,
-        Two = 1,
-        Max = UInt32.MaxValue
-    }
-
     public class SimpleTestClass : ITestClass
     {
-        public SampleByteEnum MyByteEnum { get; set; }
-        public SampleUInt32Enum MyUInt32Enum { get; set; }
         public short MyInt16 { get; set; }
         public int MyInt32 { get; set; }
         public long MyInt64 { get; set; }
@@ -44,8 +28,10 @@ namespace System.Text.Json.Serialization.Tests
         public double MyDouble { get; set; }
         public DateTime MyDateTime { get; set; }
         public DateTimeOffset MyDateTimeOffset { get; set; }
+        public SampleByteEnum MyByteEnum { get; set; }
         public SampleEnum MyEnum { get; set; }
         public SampleInt64Enum MyInt64Enum { get; set; }
+        public SampleUInt32Enum MyUInt32Enum { get; set; }
         public SampleUInt64Enum MyUInt64Enum { get; set; }
         public short[] MyInt16Array { get; set; }
         public int[] MyInt32Array { get; set; }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
@@ -9,8 +9,24 @@ using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
 {
+    public enum SampleByteEnum : byte
+    {
+        One = 0,
+        Two = 1,
+        Max = byte.MaxValue
+    }
+
+    public enum SampleUInt32Enum : UInt32
+    {
+        One = 0,
+        Two = 1,
+        Max = UInt32.MaxValue
+    }
+
     public class SimpleTestClass : ITestClass
     {
+        public SampleByteEnum MyByteEnum { get; set; }
+        public SampleUInt32Enum MyUInt32Enum { get; set; }
         public short MyInt16 { get; set; }
         public int MyInt32 { get; set; }
         public long MyInt64 { get; set; }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38363

If we fail to parse with uint64 enum we don't return any valid enum value.
For negative values unsigned return always false, so the idea is to try with uint64 and in case fallback to int64 that will parse -1 as `Max` value.
We'll overflow for other values.

I copied tests from @maryamariyan PR so I don't know if this could be "integrated" or handled separated after merge of https://github.com/dotnet/corefx/pull/37895.

cc: @steveharter @ahsonkhan 

