### PR TITLE
[3.0 Bug fix]JsonSerializer.Parse throws for UInt64 backed enum with value -1

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -9,16 +9,17 @@ namespace System.Text.Json.Serialization.Converters
     internal sealed class JsonValueConverterEnum<TValue> : JsonValueConverter<TValue>
         where TValue : struct, Enum
     {
-        private static readonly bool s_isUint64 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ulong);
+        private static readonly bool s_isUInt64 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ulong);
         private static readonly bool s_isInt64 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(long);
 
-        private static readonly bool s_isUint32 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(uint);
+        private static readonly bool s_isUInt32 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(uint);
         private static readonly bool s_isInt32 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(int);
 
-        private static readonly bool s_isUshort = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ushort);
-        private static readonly bool s_isshort = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ushort);
+        private static readonly bool s_isUInt16 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ushort);
+        private static readonly bool s_isInt16 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ushort);
 
         private static readonly bool s_isByte = Enum.GetUnderlyingType(typeof(TValue)) == typeof(byte);
+        private static readonly bool s_isSByte = Enum.GetUnderlyingType(typeof(TValue)) == typeof(sbyte);
 
         public bool TreatAsString { get; private set; }
 
@@ -48,113 +49,65 @@ namespace System.Text.Json.Serialization.Converters
                 return false;
             }
 
-            if (s_isUint64)
+            if (s_isUInt64 && reader.TryGetUInt64(out ulong uint64))
             {
-                if (reader.TryGetUInt64(out ulong ulongValue))
-                {
-                    value = (TValue)Enum.ToObject(valueType, ulongValue);
-                    return true;
-                }
-                else if (reader.TryGetInt64(out long fallback) && fallback == -1)
-                {
-                    value = (TValue)Enum.ToObject(valueType, fallback);
-                    return true;
-                }
-
-                value = default;
-                return false;
+                value = (TValue)Enum.ToObject(valueType, uint64);
+                return true;
             }
 
-            if (s_isInt64)
+            if (s_isInt64 && reader.TryGetInt64(out long int64))
             {
-                if (reader.TryGetInt64(out long ulongValue))
-                {
-                    value = (TValue)Enum.ToObject(valueType, ulongValue);
-                    return true;
-                }
-
-                value = default;
-                return false;
+                value = (TValue)Enum.ToObject(valueType, int64);
+                return true;
             }
 
-            if (s_isUint32)
+            if (s_isUInt32 && reader.TryGetUInt32(out uint uint32))
             {
-                if (reader.TryGetUInt32(out uint uintValue))
-                {
-                    value = (TValue)Enum.ToObject(valueType, uintValue);
-                    return true;
-                } 
-                else if (reader.TryGetInt64(out long fallback) && fallback == -1)
-                {
-                    value = (TValue)Enum.ToObject(valueType, fallback);
-                    return true;
-                }
-
-                value = default;
-                return false;
+                value = (TValue)Enum.ToObject(valueType, uint32);
+                return true;
             }
 
-            if (s_isInt32)
+            if (s_isInt32 && reader.TryGetInt32(out int int32))
             {
-                if (reader.TryGetInt32(out int intValue))
-                {
-                    value = (TValue)Enum.ToObject(valueType, intValue);
-                    return true;
-                } 
-
-                value = default;
-                return false;
+                value = (TValue)Enum.ToObject(valueType, int32);
+                return true;
             }
 
-            if (s_isUshort)
-            {
-                if (reader.TryGetUInt32(out uint uintValue) && uintValue >= ushort.MinValue && uintValue <= ushort.MaxValue)
-                {
-                    value = (TValue)Enum.ToObject(valueType, uintValue);
-                    return true;
-                }
-                else if (reader.TryGetInt64(out long fallback) && fallback == -1)
-                {
-                    value = (TValue)Enum.ToObject(valueType, fallback);
-                    return true;
-                }
+            // When utf8reader/writer will support all primitive types we should remove custom bound checks
+            // https://github.com/dotnet/corefx/issues/36125
 
-                value = default;
-                return false;
+            if (s_isUInt16 && reader.TryGetUInt32(out uint uint16) && uint16 >= ushort.MinValue && uint16 <= ushort.MaxValue)
+            {
+                value = (TValue)Enum.ToObject(valueType, uint16);
+                return true;
             }
 
-            if (s_isshort)
+            if (s_isInt16 && reader.TryGetInt32(out int int16) && int16 >= short.MinValue && int16 <= short.MaxValue)
             {
-                if (reader.TryGetInt32(out int intValue) && intValue >= short.MinValue && intValue <= short.MaxValue)
-                {
-                    value = (TValue)Enum.ToObject(valueType, intValue);
-                    return true;
-                }
-                else if (reader.TryGetInt64(out long fallback) && fallback == -1)
-                {
-                    value = (TValue)Enum.ToObject(valueType, fallback);
-                    return true;
-                }
-
-                value = default;
-                return false;
+                value = (TValue)Enum.ToObject(valueType, int16);
+                return true;
             }
 
-            if (s_isByte)
+            if (s_isByte && reader.TryGetUInt32(out uint ubyte8) && ubyte8 >= byte.MinValue && ubyte8 <= byte.MaxValue)
             {
-                if (reader.TryGetInt32(out int intValue) && intValue >= byte.MinValue && intValue <= byte.MinValue)
-                {
-                    value = (TValue)Enum.ToObject(valueType, intValue);
-                    return true;
-                }
-                else if (reader.TryGetInt64(out long fallback) && fallback == -1)
-                {
-                    value = (TValue)Enum.ToObject(valueType, fallback);
-                    return true;
-                }
+                value = (TValue)Enum.ToObject(valueType, ubyte8);
+                return true;
+            }
 
-                value = default;
-                return false;
+            if (s_isSByte && reader.TryGetInt32(out int byte8) && byte8 >= sbyte.MinValue && byte8 <= sbyte.MaxValue)
+            {
+                value = (TValue)Enum.ToObject(valueType, byte8);
+                return true;
+            }
+
+            // We try to parse with widest signed number type to handle -1 = MaxValue cases for unsigned numbers
+            if (s_isUInt64 || s_isUInt32 || s_isUInt16 || s_isByte)
+            {
+                if (reader.TryGetInt64(out long isMinusOne) && isMinusOne == -1)
+                {
+                    value = (TValue)Enum.ToObject(valueType, isMinusOne);
+                    return true;
+                }
             }
 
             value = default;
@@ -167,7 +120,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 writer.WriteStringValue(value.ToString());
             }
-            else if (s_isUint64)
+            else if (s_isUInt64)
             {
                 // Use the ulong converter to prevent conversion into a signed\long value.
                 ulong ulongValue = Convert.ToUInt64(value);
@@ -187,7 +140,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 writer.WriteString(propertyName, value.ToString());
             }
-            else if (s_isUint64)
+            else if (s_isUInt64)
             {
                 // Use the ulong converter to prevent conversion into a signed\long value.
                 ulong ulongValue = Convert.ToUInt64(value);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -10,6 +10,15 @@ namespace System.Text.Json.Serialization.Converters
         where TValue : struct, Enum
     {
         private static readonly bool s_isUint64 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ulong);
+        private static readonly bool s_isInt64 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(long);
+
+        private static readonly bool s_isUint32 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(uint);
+        private static readonly bool s_isInt32 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(int);
+
+        private static readonly bool s_isUshort = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ushort);
+        private static readonly bool s_isshort = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ushort);
+
+        private static readonly bool s_isByte = Enum.GetUnderlyingType(typeof(TValue)) == typeof(byte);
 
         public bool TreatAsString { get; private set; }
 
@@ -46,12 +55,106 @@ namespace System.Text.Json.Serialization.Converters
                     value = (TValue)Enum.ToObject(valueType, ulongValue);
                     return true;
                 }
+                else if (reader.TryGetInt64(out long fallback) && fallback == -1)
+                {
+                    value = (TValue)Enum.ToObject(valueType, fallback);
+                    return true;
+                }
+
+                value = default;
+                return false;
             }
 
-            if (reader.TryGetInt64(out long longValue))
+            if (s_isInt64)
             {
-                value = (TValue)Enum.ToObject(valueType, longValue);
-                return true;
+                if (reader.TryGetInt64(out long ulongValue))
+                {
+                    value = (TValue)Enum.ToObject(valueType, ulongValue);
+                    return true;
+                }
+
+                value = default;
+                return false;
+            }
+
+            if (s_isUint32)
+            {
+                if (reader.TryGetUInt32(out uint uintValue))
+                {
+                    value = (TValue)Enum.ToObject(valueType, uintValue);
+                    return true;
+                } 
+                else if (reader.TryGetInt64(out long fallback) && fallback == -1)
+                {
+                    value = (TValue)Enum.ToObject(valueType, fallback);
+                    return true;
+                }
+
+                value = default;
+                return false;
+            }
+
+            if (s_isInt32)
+            {
+                if (reader.TryGetInt32(out int intValue))
+                {
+                    value = (TValue)Enum.ToObject(valueType, intValue);
+                    return true;
+                } 
+
+                value = default;
+                return false;
+            }
+
+            if (s_isUshort)
+            {
+                if (reader.TryGetUInt32(out uint uintValue) && uintValue >= ushort.MinValue && uintValue <= ushort.MaxValue)
+                {
+                    value = (TValue)Enum.ToObject(valueType, uintValue);
+                    return true;
+                }
+                else if (reader.TryGetInt64(out long fallback) && fallback == -1)
+                {
+                    value = (TValue)Enum.ToObject(valueType, fallback);
+                    return true;
+                }
+
+                value = default;
+                return false;
+            }
+
+            if (s_isshort)
+            {
+                if (reader.TryGetInt32(out int intValue) && intValue >= short.MinValue && intValue <= short.MaxValue)
+                {
+                    value = (TValue)Enum.ToObject(valueType, intValue);
+                    return true;
+                }
+                else if (reader.TryGetInt64(out long fallback) && fallback == -1)
+                {
+                    value = (TValue)Enum.ToObject(valueType, fallback);
+                    return true;
+                }
+
+                value = default;
+                return false;
+            }
+
+            if (s_isByte)
+            {
+                if (reader.TryGetInt32(out int intValue) && intValue >= byte.MinValue && intValue <= byte.MinValue)
+                {
+                    value = (TValue)Enum.ToObject(valueType, intValue);
+                    return true;
+                }
+                else if (reader.TryGetInt64(out long fallback) && fallback == -1)
+                {
+                    value = (TValue)Enum.ToObject(valueType, fallback);
+                    return true;
+                }
+
+                value = default;
+                return false;
             }
 
             value = default;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -47,7 +47,8 @@ namespace System.Text.Json.Serialization.Converters
                     return true;
                 }
             }
-            else if (reader.TryGetInt64(out long longValue))
+
+            if (reader.TryGetInt64(out long longValue))
             {
                 value = (TValue)Enum.ToObject(valueType, longValue);
                 return true;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -100,16 +100,6 @@ namespace System.Text.Json.Serialization.Converters
                 return true;
             }
 
-            // We try to parse with widest signed number type to handle -1 = MaxValue cases for unsigned numbers
-            if (s_isUInt64 || s_isUInt32 || s_isUInt16 || s_isByte)
-            {
-                if (reader.TryGetInt64(out long isMinusOne) && isMinusOne == -1)
-                {
-                    value = (TValue)Enum.ToObject(valueType, isMinusOne);
-                    return true;
-                }
-            }
-
             value = default;
             return false;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -45,22 +45,11 @@ namespace System.Text.Json.Serialization.Converters
 
             switch (s_enumTypeCode)
             {
-                case TypeCode.Empty:
-                case TypeCode.Object:
-                case TypeCode.DBNull:
-                case TypeCode.Boolean:
-                case TypeCode.Char:
-                case TypeCode.Decimal:
-                case TypeCode.Double:
-                case TypeCode.DateTime:
-                case TypeCode.String:
-                case TypeCode.Single:
-                    break;
                 case TypeCode.SByte:
                     {
                         if (reader.TryGetInt32(out int byte8) && JsonHelpers.IsInRangeInclusive(byte8, sbyte.MinValue, sbyte.MaxValue))
                         {
-                            value = (TValue)Enum.ToObject(valueType, byte8);
+                            value = Unsafe.As<int, TValue>(ref byte8);
                             return true;
                         }
                         break;
@@ -69,7 +58,7 @@ namespace System.Text.Json.Serialization.Converters
                     {
                         if (reader.TryGetUInt32(out uint ubyte8) && JsonHelpers.IsInRangeInclusive(ubyte8, byte.MinValue, byte.MaxValue))
                         {
-                            value = (TValue)Enum.ToObject(valueType, ubyte8);
+                            value = Unsafe.As<uint, TValue>(ref ubyte8);
                             return true;
                         }
                         break;
@@ -78,7 +67,7 @@ namespace System.Text.Json.Serialization.Converters
                     {
                         if (reader.TryGetInt32(out int int16) && JsonHelpers.IsInRangeInclusive(int16, short.MinValue, short.MaxValue))
                         {
-                            value = (TValue)Enum.ToObject(valueType, int16);
+                            value = Unsafe.As<int, TValue>(ref int16);
                             return true;
                         }
                         break;
@@ -87,7 +76,7 @@ namespace System.Text.Json.Serialization.Converters
                     {
                         if (reader.TryGetUInt32(out uint uint16) && JsonHelpers.IsInRangeInclusive(uint16, ushort.MinValue, ushort.MaxValue))
                         {
-                            value = (TValue)Enum.ToObject(valueType, uint16);
+                            value = Unsafe.As<uint, TValue>(ref uint16);
                             return true;
                         }
                         break;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -49,7 +49,8 @@ namespace System.Text.Json.Serialization.Converters
                     {
                         if (reader.TryGetInt32(out int byte8) && JsonHelpers.IsInRangeInclusive(byte8, sbyte.MinValue, sbyte.MaxValue))
                         {
-                            value = Unsafe.As<int, TValue>(ref byte8);
+                            sbyte byte8Value = (sbyte)byte8;
+                            value = Unsafe.As<sbyte, TValue>(ref byte8Value);
                             return true;
                         }
                         break;
@@ -58,7 +59,8 @@ namespace System.Text.Json.Serialization.Converters
                     {
                         if (reader.TryGetUInt32(out uint ubyte8) && JsonHelpers.IsInRangeInclusive(ubyte8, byte.MinValue, byte.MaxValue))
                         {
-                            value = Unsafe.As<uint, TValue>(ref ubyte8);
+                            byte ubyte8Value = (byte)ubyte8;
+                            value = Unsafe.As<byte, TValue>(ref ubyte8Value);
                             return true;
                         }
                         break;
@@ -67,7 +69,8 @@ namespace System.Text.Json.Serialization.Converters
                     {
                         if (reader.TryGetInt32(out int int16) && JsonHelpers.IsInRangeInclusive(int16, short.MinValue, short.MaxValue))
                         {
-                            value = Unsafe.As<int, TValue>(ref int16);
+                            short shortValue = (short)int16;
+                            value = Unsafe.As<short, TValue>(ref shortValue);
                             return true;
                         }
                         break;
@@ -76,7 +79,8 @@ namespace System.Text.Json.Serialization.Converters
                     {
                         if (reader.TryGetUInt32(out uint uint16) && JsonHelpers.IsInRangeInclusive(uint16, ushort.MinValue, ushort.MaxValue))
                         {
-                            value = Unsafe.As<uint, TValue>(ref uint16);
+                            ushort ushortValue = (ushort)uint16;
+                            value = Unsafe.As<ushort, TValue>(ref ushortValue);
                             return true;
                         }
                         break;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization.Policies;
 
 namespace System.Text.Json.Serialization.Converters
@@ -9,17 +10,7 @@ namespace System.Text.Json.Serialization.Converters
     internal sealed class JsonValueConverterEnum<TValue> : JsonValueConverter<TValue>
         where TValue : struct, Enum
     {
-        private static readonly bool s_isUInt64 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ulong);
-        private static readonly bool s_isInt64 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(long);
-
-        private static readonly bool s_isUInt32 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(uint);
-        private static readonly bool s_isInt32 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(int);
-
-        private static readonly bool s_isUInt16 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ushort);
-        private static readonly bool s_isInt16 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(short);
-
-        private static readonly bool s_isByte = Enum.GetUnderlyingType(typeof(TValue)) == typeof(byte);
-        private static readonly bool s_isSByte = Enum.GetUnderlyingType(typeof(TValue)) == typeof(sbyte);
+        private static readonly TypeCode s_enumTypeCode = Type.GetTypeCode(Enum.GetUnderlyingType(typeof(TValue)));
 
         public bool TreatAsString { get; private set; }
 
@@ -49,90 +40,96 @@ namespace System.Text.Json.Serialization.Converters
                 return false;
             }
 
-            if (s_isInt32)
-            {
-                if (reader.TryGetInt32(out int int32))
-                {
-                    value = (TValue)Enum.ToObject(valueType, int32);
-                    return true;
-                }
-                goto False;
-            }
-
-            if (s_isByte)
-            {
-                if (reader.TryGetUInt32(out uint ubyte8) && JsonHelpers.IsInRangeInclusive(ubyte8, byte.MinValue, byte.MaxValue))
-                {
-                    value = (TValue)Enum.ToObject(valueType, ubyte8);
-                    return true;
-                }
-                goto False;
-            }
-
-            if (s_isUInt64)
-            {
-                if (reader.TryGetUInt64(out ulong uint64))
-                {
-                    value = (TValue)Enum.ToObject(valueType, uint64);
-                    return true;
-                }
-                goto False;
-            }
-
-            if (s_isInt64)
-            {
-                if (reader.TryGetInt64(out long int64))
-                {
-                    value = (TValue)Enum.ToObject(valueType, int64);
-                    return true;
-                }
-                goto False;
-            }
-
-            if (s_isUInt32)
-            {
-                if (reader.TryGetUInt32(out uint uint32))
-                {
-                    value = (TValue)Enum.ToObject(valueType, uint32);
-                    return true;
-                }
-                goto False;
-            }
-
             // When utf8reader/writer will support all primitive types we should remove custom bound checks
             // https://github.com/dotnet/corefx/issues/36125
 
-            if (s_isUInt16)
+            switch (s_enumTypeCode)
             {
-                if (reader.TryGetUInt32(out uint uint16) && JsonHelpers.IsInRangeInclusive(uint16, ushort.MinValue, ushort.MaxValue))
-                {
-                    value = (TValue)Enum.ToObject(valueType, uint16);
-                    return true;
-                }
-                goto False;
+                case TypeCode.Empty:
+                case TypeCode.Object:
+                case TypeCode.DBNull:
+                case TypeCode.Boolean:
+                case TypeCode.Char:
+                case TypeCode.Decimal:
+                case TypeCode.Double:
+                case TypeCode.DateTime:
+                case TypeCode.String:
+                case TypeCode.Single:
+                    break;
+                case TypeCode.SByte:
+                    {
+                        if (reader.TryGetInt32(out int byte8) && JsonHelpers.IsInRangeInclusive(byte8, sbyte.MinValue, sbyte.MaxValue))
+                        {
+                            value = (TValue)Enum.ToObject(valueType, byte8);
+                            return true;
+                        }
+                        break;
+                    }
+                case TypeCode.Byte:
+                    {
+                        if (reader.TryGetUInt32(out uint ubyte8) && JsonHelpers.IsInRangeInclusive(ubyte8, byte.MinValue, byte.MaxValue))
+                        {
+                            value = (TValue)Enum.ToObject(valueType, ubyte8);
+                            return true;
+                        }
+                        break;
+                    }
+                case TypeCode.Int16:
+                    {
+                        if (reader.TryGetInt32(out int int16) && JsonHelpers.IsInRangeInclusive(int16, short.MinValue, short.MaxValue))
+                        {
+                            value = (TValue)Enum.ToObject(valueType, int16);
+                            return true;
+                        }
+                        break;
+                    }
+                case TypeCode.UInt16:
+                    {
+                        if (reader.TryGetUInt32(out uint uint16) && JsonHelpers.IsInRangeInclusive(uint16, ushort.MinValue, ushort.MaxValue))
+                        {
+                            value = (TValue)Enum.ToObject(valueType, uint16);
+                            return true;
+                        }
+                        break;
+                    }
+                case TypeCode.Int32:
+                    {
+                        if (reader.TryGetInt32(out int int32))
+                        {
+                            value = Unsafe.As<int, TValue>(ref int32);
+                            return true;
+                        }
+                        break;
+                    }
+                case TypeCode.UInt32:
+                    {
+                        if (reader.TryGetUInt32(out uint uint32))
+                        {
+                            value = Unsafe.As<uint, TValue>(ref uint32);
+                            return true;
+                        }
+                        break;
+                    }
+                case TypeCode.Int64:
+                    {
+                        if (reader.TryGetInt64(out long int64))
+                        {
+                            value = Unsafe.As<long, TValue>(ref int64);
+                            return true;
+                        }
+                        break;
+                    }
+                case TypeCode.UInt64:
+                    {
+                        if (reader.TryGetUInt64(out ulong uint64))
+                        {
+                            value = Unsafe.As<ulong, TValue>(ref uint64);
+                            return true;
+                        }
+                        break;
+                    }
             }
 
-            if (s_isInt16)
-            {
-                if (reader.TryGetInt32(out int int16) && JsonHelpers.IsInRangeInclusive(int16, short.MinValue, short.MaxValue))
-                {
-                    value = (TValue)Enum.ToObject(valueType, int16);
-                    return true;
-                }
-                goto False;
-            }
-
-            if (s_isSByte)
-            {
-                if (reader.TryGetInt32(out int byte8) && JsonHelpers.IsInRangeInclusive(byte8, sbyte.MinValue, sbyte.MaxValue))
-                {
-                    value = (TValue)Enum.ToObject(valueType, byte8);
-                    return true;
-                }
-                goto False;
-            }
-
-        False:
             value = default;
             return false;
         }
@@ -143,7 +140,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 writer.WriteStringValue(value.ToString());
             }
-            else if (s_isUInt64)
+            else if (s_enumTypeCode == TypeCode.UInt64)
             {
                 // Use the ulong converter to prevent conversion into a signed\long value.
                 ulong ulongValue = Convert.ToUInt64(value);
@@ -163,7 +160,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 writer.WriteString(propertyName, value.ToString());
             }
-            else if (s_isUInt64)
+            else if (s_enumTypeCode == TypeCode.UInt64)
             {
                 // Use the ulong converter to prevent conversion into a signed\long value.
                 ulong ulongValue = Convert.ToUInt64(value);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -49,57 +49,90 @@ namespace System.Text.Json.Serialization.Converters
                 return false;
             }
 
-            if (s_isUInt64 && reader.TryGetUInt64(out ulong uint64))
+            if (s_isInt32)
             {
-                value = (TValue)Enum.ToObject(valueType, uint64);
-                return true;
+                if (reader.TryGetInt32(out int int32))
+                {
+                    value = (TValue)Enum.ToObject(valueType, int32);
+                    return true;
+                }
+                goto False;
             }
 
-            if (s_isInt64 && reader.TryGetInt64(out long int64))
+            if (s_isByte)
             {
-                value = (TValue)Enum.ToObject(valueType, int64);
-                return true;
+                if (reader.TryGetUInt32(out uint ubyte8) && JsonHelpers.IsInRangeInclusive(ubyte8, byte.MinValue, byte.MaxValue))
+                {
+                    value = (TValue)Enum.ToObject(valueType, ubyte8);
+                    return true;
+                }
+                goto False;
             }
 
-            if (s_isUInt32 && reader.TryGetUInt32(out uint uint32))
+            if (s_isUInt64)
             {
-                value = (TValue)Enum.ToObject(valueType, uint32);
-                return true;
+                if (reader.TryGetUInt64(out ulong uint64))
+                {
+                    value = (TValue)Enum.ToObject(valueType, uint64);
+                    return true;
+                }
+                goto False;
             }
 
-            if (s_isInt32 && reader.TryGetInt32(out int int32))
+            if (s_isInt64)
             {
-                value = (TValue)Enum.ToObject(valueType, int32);
-                return true;
+                if (reader.TryGetInt64(out long int64))
+                {
+                    value = (TValue)Enum.ToObject(valueType, int64);
+                    return true;
+                }
+                goto False;
+            }
+
+            if (s_isUInt32)
+            {
+                if (reader.TryGetUInt32(out uint uint32))
+                {
+                    value = (TValue)Enum.ToObject(valueType, uint32);
+                    return true;
+                }
+                goto False;
             }
 
             // When utf8reader/writer will support all primitive types we should remove custom bound checks
             // https://github.com/dotnet/corefx/issues/36125
 
-            if (s_isUInt16 && reader.TryGetUInt32(out uint uint16) && uint16 >= ushort.MinValue && uint16 <= ushort.MaxValue)
+            if (s_isUInt16)
             {
-                value = (TValue)Enum.ToObject(valueType, uint16);
-                return true;
+                if (reader.TryGetUInt32(out uint uint16) && JsonHelpers.IsInRangeInclusive(uint16, ushort.MinValue, ushort.MaxValue))
+                {
+                    value = (TValue)Enum.ToObject(valueType, uint16);
+                    return true;
+                }
+                goto False;
             }
 
-            if (s_isInt16 && reader.TryGetInt32(out int int16) && int16 >= short.MinValue && int16 <= short.MaxValue)
+            if (s_isInt16)
             {
-                value = (TValue)Enum.ToObject(valueType, int16);
-                return true;
+                if (reader.TryGetInt32(out int int16) && JsonHelpers.IsInRangeInclusive(int16, short.MinValue, short.MaxValue))
+                {
+                    value = (TValue)Enum.ToObject(valueType, int16);
+                    return true;
+                }
+                goto False;
             }
 
-            if (s_isByte && reader.TryGetUInt32(out uint ubyte8) && ubyte8 >= byte.MinValue && ubyte8 <= byte.MaxValue)
+            if (s_isSByte)
             {
-                value = (TValue)Enum.ToObject(valueType, ubyte8);
-                return true;
+                if (reader.TryGetInt32(out int byte8) && JsonHelpers.IsInRangeInclusive(byte8, sbyte.MinValue, sbyte.MaxValue))
+                {
+                    value = (TValue)Enum.ToObject(valueType, byte8);
+                    return true;
+                }
+                goto False;
             }
 
-            if (s_isSByte && reader.TryGetInt32(out int byte8) && byte8 >= sbyte.MinValue && byte8 <= sbyte.MaxValue)
-            {
-                value = (TValue)Enum.ToObject(valueType, byte8);
-                return true;
-            }
-
+        False:
             value = default;
             return false;
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterEnum.cs
@@ -16,7 +16,7 @@ namespace System.Text.Json.Serialization.Converters
         private static readonly bool s_isInt32 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(int);
 
         private static readonly bool s_isUInt16 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ushort);
-        private static readonly bool s_isInt16 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(ushort);
+        private static readonly bool s_isInt16 = Enum.GetUnderlyingType(typeof(TValue)) == typeof(short);
 
         private static readonly bool s_isByte = Enum.GetUnderlyingType(typeof(TValue)) == typeof(byte);
         private static readonly bool s_isSByte = Enum.GetUnderlyingType(typeof(TValue)) == typeof(sbyte);

--- a/src/System.Text.Json/tests/Serialization/EnumTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumTests.cs
@@ -39,6 +39,83 @@ namespace System.Text.Json.Serialization.Tests
                 @"}";
 
         private const string UlongMaxPlus1 = "18446744073709551616"; // ulong.MaxValue + 1;
+        private const string MinusUlongMaxMinus1 = "-18446744073709551616"; // -ulong.MaxValue - 1
+
+        private const string LongMaxPlus1 = "9223372036854775808"; // long.MaxValue + 1;
+        private const string MinuslongMaxMinus1 = "-9223372036854775809"; // long.MinValue - 1
+
+        private const string UintMaxPlus1 = "4294967296"; // uint.MaxValue + 1;
+        private const string MinusUintMaxMinus1 = "-4294967296"; // -uint.MaxValue - 1
+
+        [Fact]
+        public static void Parse_MinusUintMaxMinus1_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {MinusUintMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {MinusUintMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {MinusUintMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {MinusUintMaxMinus1} }}"));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{MinuslongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{MinuslongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{MinuslongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{MinuslongMaxMinus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_UintMaxPlus1_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {UintMaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {UintMaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {UintMaxPlus1} }}"));
+            Assert.Equal(ulong.Parse(UintMaxPlus1), (ulong)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {UintMaxPlus1} }}").MyUInt64Enum);
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{UintMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{UintMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{UintMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{UintMaxPlus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_MinusLongMaxMinus1_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {MinuslongMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {MinuslongMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {MinuslongMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {MinuslongMaxMinus1} }}"));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{MinuslongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{MinuslongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{MinuslongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{MinuslongMaxMinus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_LongMaxPlus1_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {LongMaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {LongMaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {LongMaxPlus1} }}"));
+            Assert.Equal(ulong.Parse(LongMaxPlus1), (ulong)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {LongMaxPlus1} }}").MyUInt64Enum);
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{LongMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{LongMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{LongMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{LongMaxPlus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_MinusUlongMaxMinus1_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {MinusUlongMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {MinusUlongMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {MinusUlongMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {MinusUlongMaxMinus1} }}"));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{MinusUlongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{MinusUlongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{MinusUlongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{MinusUlongMaxMinus1}\" }}"));
+        }
 
         [Fact]
         public static void Parse_UlongMaxPlus1_Throws()
@@ -109,21 +186,21 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal((SampleUInt64Enum)UInt64.MaxValue, result.MyUInt64Enum);
         }
 
-        [Theory]
-        [InlineData((ulong)byte.MaxValue + 1, (ulong)UInt32.MaxValue + 1, (SampleByteEnum)0, (SampleUInt32Enum)0)]
-        [InlineData((ulong)byte.MaxValue + 2, (ulong)UInt32.MaxValue + 2, (SampleByteEnum)1, (SampleUInt32Enum)1)]
-        [InlineData((ulong)byte.MaxValue + 13, (ulong)UInt32.MaxValue + 13, (SampleByteEnum)12, (SampleUInt32Enum)12)]
-        [InlineData((ulong)byte.MaxValue * 2, (ulong)UInt32.MaxValue * 2, (SampleByteEnum)byte.MaxValue - 1, (SampleUInt32Enum)UInt32.MaxValue - 1)]
-        public static void Parse_Ulong_JsonWithAcceptableInvalidNumber_Success(ulong i, ulong j, SampleByteEnum e1, SampleUInt32Enum e2)
-        {
-            string json = $"{{ \"MyByteEnum\" : {i}, \"MyUInt32Enum\" : {j} }}";
-            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
-            Assert.Equal(e1, result.MyByteEnum);
-            Assert.Equal(e2, result.MyUInt32Enum);
+        //[Theory]
+        //[InlineData((ulong)byte.MaxValue + 1, (ulong)UInt32.MaxValue + 1, (SampleByteEnum)0, (SampleUInt32Enum)0)]
+        //[InlineData((ulong)byte.MaxValue + 2, (ulong)UInt32.MaxValue + 2, (SampleByteEnum)1, (SampleUInt32Enum)1)]
+        //[InlineData((ulong)byte.MaxValue + 13, (ulong)UInt32.MaxValue + 13, (SampleByteEnum)12, (SampleUInt32Enum)12)]
+        //[InlineData((ulong)byte.MaxValue * 2, (ulong)UInt32.MaxValue * 2, (SampleByteEnum)byte.MaxValue - 1, (SampleUInt32Enum)UInt32.MaxValue - 1)]
+        //public static void Parse_Ulong_JsonWithAcceptableInvalidNumber_Success(ulong i, ulong j, SampleByteEnum e1, SampleUInt32Enum e2)
+        //{
+        //    string json = $"{{ \"MyByteEnum\" : {i}, \"MyUInt32Enum\" : {j} }}";
+        //    SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
+        //    Assert.Equal(e1, result.MyByteEnum);
+        //    Assert.Equal(e2, result.MyUInt32Enum);
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{i}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{j}\" }}"));
-        }
+        //    Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{i}\" }}"));
+        //    Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{j}\" }}"));
+        //}
 
         [Fact]
         public static void EnumAsStringFail()

--- a/src/System.Text.Json/tests/Serialization/EnumTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumTests.cs
@@ -50,6 +50,99 @@ namespace System.Text.Json.Serialization.Tests
         private const string Int32MaxPlus1 = "2147483648"; // int.MaxValue + 1;
         private const string Int32MinMinus1 = "-2147483649"; // int.MinValue - 1
 
+        private const string UInt16MaxPlus1 = "65536"; // ushort.MaxValue + 1;
+        private const string MinusUInt16MaxMinus1 = "-65536"; // -ushort.MaxValue - 1
+
+        private const string Int16MaxPlus1 = "32768"; // int.MaxValue + 1;
+        private const string Int16MinMinus1 = "-32769"; // int.MinValue - 1
+
+        private const string ByteMaxPlus1 = "256"; // byte.MaxValue + 1;
+        private const string MinusByteMaxMinus1 = "-257"; // -byte.MaxValue - 1
+
+        [Fact]
+        public static void Parse_MinusByteMaxMinus1_Throws()
+        {
+            Assert.Equal(int.Parse(MinusByteMaxMinus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {MinusByteMaxMinus1} }}").MyEnum);
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {MinusByteMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {MinusByteMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {MinusByteMaxMinus1} }}"));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{MinusByteMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{MinusByteMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{MinusByteMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{MinusByteMaxMinus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_ByteMaxPlus1_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {ByteMaxPlus1} }}"));
+            Assert.Equal(int.Parse(ByteMaxPlus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {ByteMaxPlus1} }}").MyEnum);
+            Assert.Equal(int.Parse(ByteMaxPlus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {ByteMaxPlus1} }}").MyUInt32Enum);
+            Assert.Equal(int.Parse(ByteMaxPlus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {ByteMaxPlus1} }}").MyUInt64Enum);
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{ByteMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{ByteMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{ByteMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{ByteMaxPlus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_Int16MinMinus1_Throws()
+        {
+            Assert.Equal(int.Parse(Int16MinMinus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {Int16MinMinus1} }}").MyEnum);
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {Int16MinMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {Int16MinMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {Int16MinMinus1} }}"));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{Int16MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{Int16MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{Int16MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{Int16MinMinus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_Int16MaxPlus1_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {Int16MaxPlus1} }}"));
+            Assert.Equal(int.Parse(Int16MaxPlus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {Int16MaxPlus1} }}").MyEnum);
+            Assert.Equal(int.Parse(Int16MaxPlus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {Int16MaxPlus1} }}").MyUInt32Enum);
+            Assert.Equal(int.Parse(Int16MaxPlus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {Int16MaxPlus1} }}").MyUInt64Enum);
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{Int16MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{Int16MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{Int16MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{Int16MaxPlus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_MinusUInt16MaxMinus1_Throws()
+        {
+            Assert.Equal(int.Parse(MinusUInt16MaxMinus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {MinusUInt16MaxMinus1} }}").MyEnum);
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {MinusUInt16MaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {MinusUInt16MaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {MinusUInt16MaxMinus1} }}"));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{MinusUInt16MaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{MinusUInt16MaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{MinusUInt16MaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{MinusUInt16MaxMinus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_UInt16MaxPlus1_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {UInt16MaxPlus1} }}"));
+            Assert.Equal(int.Parse(UInt16MaxPlus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {UInt16MaxPlus1} }}").MyEnum);
+            Assert.Equal(int.Parse(UInt16MaxPlus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {UInt16MaxPlus1} }}").MyUInt32Enum);
+            Assert.Equal(int.Parse(UInt16MaxPlus1), (int)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {UInt16MaxPlus1} }}").MyUInt64Enum);
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{UInt16MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{UInt16MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{UInt16MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{UInt16MaxPlus1}\" }}"));
+        }
+
         [Fact]
         public static void Parse_Int32MinMinus1_Throws()
         {

--- a/src/System.Text.Json/tests/Serialization/EnumTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumTests.cs
@@ -287,10 +287,9 @@ namespace System.Text.Json.Serialization.Tests
         public static void Parse_Negative1_QuotedVsUnquoted_QuotedThrows()
         {
             string json = "{ \"MyByteEnum\" : -1, \"MyUInt32Enum\" : -1 }";
-            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
-            Assert.Equal((SampleByteEnum)byte.MaxValue, result.MyByteEnum);
-            Assert.Equal((SampleUInt32Enum)UInt32.MaxValue, result.MyUInt32Enum);
 
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
+            
             // Quoted throws
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>("{ \"MyByteEnum\" : \"-1\" }"));
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>("{ \"MyUInt32Enum\" : \"-1\" }"));
@@ -301,10 +300,9 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("{ \"MyUInt64Enum\" : -1 }")]
         [InlineData("{ \"MyUInt64Enum\" : -1, \"MyUInt32Enum\" : -1 }")]
         [InlineData("{ \"MyUInt64Enum\" : -1, \"MyUInt32Enum\" : -1, \"MyByteEnum\" : -1 }")]
-        public static void Parse_Negative1ForUInt64Enum_ShouldNotThrow(string json)
+        public static void Parse_Negative1ForUInt64Enum_Throw(string json)
         {
-            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
-            Assert.Equal((SampleUInt64Enum)UInt64.MaxValue, result.MyUInt64Enum);
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
         }
 
         [Theory]

--- a/src/System.Text.Json/tests/Serialization/EnumTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumTests.cs
@@ -18,6 +18,11 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyEnum"" : 2" +
                 @"}";
 
+        private static readonly string s_jsonInt16Enum =
+                @"{" +
+                @"""MyInt16Enum"" : 2" +
+                @"}";
+
         private static readonly string s_jsonInt64EnumMin =
                 @"{" +
                 @"""MyInt64Enum"" : " + long.MinValue +
@@ -33,10 +38,20 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyUInt64Enum"" : " + ulong.MaxValue +
                 @"}";
 
+        private static readonly string s_jsonUInt16EnumMax =
+                @"{" +
+                @"""MyUInt16Enum"" : " + ushort.MaxValue +
+                @"}";
+
         private static readonly string s_jsonByteEnum =
                 @"{" +
                 @"""MyByteEnum"" : " + byte.MaxValue +
                 @"}";
+
+        private static readonly string s_jsonSByteEnum =
+        @"{" +
+        @"""MySByteEnum"" : " + sbyte.MaxValue +
+        @"}";
 
         private const string UInt64MaxPlus1 = "18446744073709551616"; // ulong.MaxValue + 1;
         private const string MinusUInt64MaxMinus1 = "-18446744073709551616"; // -ulong.MaxValue - 1
@@ -332,6 +347,13 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void EnumAsInt16()
+        {
+            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(s_jsonInt16Enum);
+            Assert.Equal(SampleEnumInt16.Two, obj.MyInt16Enum);
+        }
+
+        [Fact]
         public static void EnumAsInt64Min()
         {
             SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(s_jsonInt64EnumMin);
@@ -353,10 +375,24 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void EnumAsUInt16Max()
+        {
+            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(s_jsonUInt16EnumMax);
+            Assert.Equal(SampleEnumUInt16.Max, obj.MyUInt16Enum);
+        }
+
+        [Fact]
         public static void EnumAsByteMax()
         {
             SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(s_jsonByteEnum);
             Assert.Equal(SampleByteEnum.Max, obj.MyByteEnum);
+        }
+
+        [Fact]
+        public static void EnumAsSByteMax()
+        {
+            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(s_jsonSByteEnum);
+            Assert.Equal(SampleSByteEnum.Max, obj.MySByteEnum);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/EnumTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumTests.cs
@@ -103,7 +103,6 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("{ \"MyUInt64Enum\" : -1 }")]
         [InlineData("{ \"MyUInt64Enum\" : -1, \"MyUInt32Enum\" : -1 }")]
         [InlineData("{ \"MyUInt64Enum\" : -1, \"MyUInt32Enum\" : -1, \"MyByteEnum\" : -1 }")]
-        [ActiveIssue(38363)]
         public static void Parse_Negative1ForUInt64Enum_ShouldNotThrow(string json)
         {
             SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);

--- a/src/System.Text.Json/tests/Serialization/EnumTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumTests.cs
@@ -38,97 +38,128 @@ namespace System.Text.Json.Serialization.Tests
                 @"""MyByteEnum"" : " + byte.MaxValue +
                 @"}";
 
-        private const string UlongMaxPlus1 = "18446744073709551616"; // ulong.MaxValue + 1;
-        private const string MinusUlongMaxMinus1 = "-18446744073709551616"; // -ulong.MaxValue - 1
+        private const string UInt64MaxPlus1 = "18446744073709551616"; // ulong.MaxValue + 1;
+        private const string MinusUInt64MaxMinus1 = "-18446744073709551616"; // -ulong.MaxValue - 1
 
-        private const string LongMaxPlus1 = "9223372036854775808"; // long.MaxValue + 1;
-        private const string MinuslongMaxMinus1 = "-9223372036854775809"; // long.MinValue - 1
+        private const string Int64MaxPlus1 = "9223372036854775808"; // long.MaxValue + 1;
+        private const string Int64MinMinus1 = "-9223372036854775809"; // long.MinValue - 1
 
-        private const string UintMaxPlus1 = "4294967296"; // uint.MaxValue + 1;
-        private const string MinusUintMaxMinus1 = "-4294967296"; // -uint.MaxValue - 1
+        private const string UInt32MaxPlus1 = "4294967296"; // uint.MaxValue + 1;
+        private const string MinusUInt32MaxMinus1 = "-4294967296"; // -uint.MaxValue - 1
+
+        private const string Int32MaxPlus1 = "2147483648"; // int.MaxValue + 1;
+        private const string Int32MinMinus1 = "-2147483649"; // int.MinValue - 1
 
         [Fact]
-        public static void Parse_MinusUintMaxMinus1_Throws()
+        public static void Parse_Int32MinMinus1_Throws()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {MinusUintMaxMinus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {MinusUintMaxMinus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {MinusUintMaxMinus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {MinusUintMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {Int32MinMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {Int32MinMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {Int32MinMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {Int32MinMinus1} }}"));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{MinuslongMaxMinus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{MinuslongMaxMinus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{MinuslongMaxMinus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{MinuslongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{Int32MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{Int32MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{Int32MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{Int32MinMinus1}\" }}"));
         }
 
         [Fact]
-        public static void Parse_UintMaxPlus1_Throws()
+        public static void Parse_Int32MaxPlus1_Throws()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {UintMaxPlus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {UintMaxPlus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {UintMaxPlus1} }}"));
-            Assert.Equal(ulong.Parse(UintMaxPlus1), (ulong)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {UintMaxPlus1} }}").MyUInt64Enum);
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {Int32MaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {Int32MaxPlus1} }}"));
+            Assert.Equal(ulong.Parse(Int32MaxPlus1), (ulong)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {Int32MaxPlus1} }}").MyUInt32Enum);
+            Assert.Equal(ulong.Parse(Int32MaxPlus1), (ulong)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {Int32MaxPlus1} }}").MyUInt64Enum);
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{UintMaxPlus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{UintMaxPlus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{UintMaxPlus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{UintMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{Int32MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{Int32MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{Int32MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{Int32MaxPlus1}\" }}"));
         }
 
         [Fact]
-        public static void Parse_MinusLongMaxMinus1_Throws()
+        public static void Parse_MinusUInt32MaxMinus1_Throws()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {MinuslongMaxMinus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {MinuslongMaxMinus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {MinuslongMaxMinus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {MinuslongMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {MinusUInt32MaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {MinusUInt32MaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {MinusUInt32MaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {MinusUInt32MaxMinus1} }}"));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{MinuslongMaxMinus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{MinuslongMaxMinus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{MinuslongMaxMinus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{MinuslongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{Int64MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{Int64MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{Int64MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{Int64MinMinus1}\" }}"));
         }
 
         [Fact]
-        public static void Parse_LongMaxPlus1_Throws()
+        public static void Parse_UInt32MaxPlus1_Throws()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {LongMaxPlus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {LongMaxPlus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {LongMaxPlus1} }}"));
-            Assert.Equal(ulong.Parse(LongMaxPlus1), (ulong)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {LongMaxPlus1} }}").MyUInt64Enum);
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {UInt32MaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {UInt32MaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {UInt32MaxPlus1} }}"));
+            Assert.Equal(ulong.Parse(UInt32MaxPlus1), (ulong)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {UInt32MaxPlus1} }}").MyUInt64Enum);
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{LongMaxPlus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{LongMaxPlus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{LongMaxPlus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{LongMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{UInt32MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{UInt32MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{UInt32MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{UInt32MaxPlus1}\" }}"));
         }
 
         [Fact]
-        public static void Parse_MinusUlongMaxMinus1_Throws()
+        public static void Parse_Int64MinMinus1_Throws()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {MinusUlongMaxMinus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {MinusUlongMaxMinus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {MinusUlongMaxMinus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {MinusUlongMaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {Int64MinMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {Int64MinMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {Int64MinMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {Int64MinMinus1} }}"));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{MinusUlongMaxMinus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{MinusUlongMaxMinus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{MinusUlongMaxMinus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{MinusUlongMaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{Int64MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{Int64MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{Int64MinMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{Int64MinMinus1}\" }}"));
         }
 
         [Fact]
-        public static void Parse_UlongMaxPlus1_Throws()
+        public static void Parse_Int64MaxPlus1_Throws()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {UlongMaxPlus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {UlongMaxPlus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {UlongMaxPlus1} }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {UlongMaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {Int64MaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {Int64MaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {Int64MaxPlus1} }}"));
+            Assert.Equal(ulong.Parse(Int64MaxPlus1), (ulong)JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {Int64MaxPlus1} }}").MyUInt64Enum);
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{UlongMaxPlus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{UlongMaxPlus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{UlongMaxPlus1}\" }}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{UlongMaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{Int64MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{Int64MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{Int64MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{Int64MaxPlus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_MinusUInt64MaxMinus1_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {MinusUInt64MaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {MinusUInt64MaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {MinusUInt64MaxMinus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {MinusUInt64MaxMinus1} }}"));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{MinusUInt64MaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{MinusUInt64MaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{MinusUInt64MaxMinus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{MinusUInt64MaxMinus1}\" }}"));
+        }
+
+        [Fact]
+        public static void Parse_UInt64MaxPlus1_Throws()
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : {UInt64MaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {UInt64MaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : {UInt64MaxPlus1} }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : {UInt64MaxPlus1} }}"));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{UInt64MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{UInt64MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt32Enum\" : \"{UInt64MaxPlus1}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyUInt64Enum\" : \"{UInt64MaxPlus1}\" }}"));
         }
 
         [Fact]
@@ -150,12 +181,9 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void Parse_MaxValuePlus1_QuotedVsNotQuoted_QuotedThrows()
+        public static void Parse_MaxValuePlus1_QuotedVsNotQuoted_Throws()
         {
-            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(
-                $"{{ \"MyByteEnum\" : {(ulong)byte.MaxValue + 1}, \"MyUInt32Enum\" : {(ulong)UInt32.MaxValue + 1} }}");
-            Assert.Equal((SampleByteEnum)0, result.MyByteEnum);
-            Assert.Equal((SampleUInt32Enum)0, result.MyUInt32Enum);
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : {(ulong)byte.MaxValue + 1}, \"MyUInt32Enum\" : {(ulong)UInt32.MaxValue + 1} }}"));
 
             // Quoted throws
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{(ulong)byte.MaxValue + 1}\" }}"));
@@ -186,21 +214,18 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal((SampleUInt64Enum)UInt64.MaxValue, result.MyUInt64Enum);
         }
 
-        //[Theory]
-        //[InlineData((ulong)byte.MaxValue + 1, (ulong)UInt32.MaxValue + 1, (SampleByteEnum)0, (SampleUInt32Enum)0)]
-        //[InlineData((ulong)byte.MaxValue + 2, (ulong)UInt32.MaxValue + 2, (SampleByteEnum)1, (SampleUInt32Enum)1)]
-        //[InlineData((ulong)byte.MaxValue + 13, (ulong)UInt32.MaxValue + 13, (SampleByteEnum)12, (SampleUInt32Enum)12)]
-        //[InlineData((ulong)byte.MaxValue * 2, (ulong)UInt32.MaxValue * 2, (SampleByteEnum)byte.MaxValue - 1, (SampleUInt32Enum)UInt32.MaxValue - 1)]
-        //public static void Parse_Ulong_JsonWithAcceptableInvalidNumber_Success(ulong i, ulong j, SampleByteEnum e1, SampleUInt32Enum e2)
-        //{
-        //    string json = $"{{ \"MyByteEnum\" : {i}, \"MyUInt32Enum\" : {j} }}";
-        //    SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
-        //    Assert.Equal(e1, result.MyByteEnum);
-        //    Assert.Equal(e2, result.MyUInt32Enum);
-
-        //    Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{i}\" }}"));
-        //    Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{j}\" }}"));
-        //}
+        [Theory]
+        [InlineData((ulong)byte.MaxValue + 1, (ulong)UInt32.MaxValue + 1, (SampleByteEnum)0, (SampleUInt32Enum)0)]
+        [InlineData((ulong)byte.MaxValue + 2, (ulong)UInt32.MaxValue + 2, (SampleByteEnum)1, (SampleUInt32Enum)1)]
+        [InlineData((ulong)byte.MaxValue + 13, (ulong)UInt32.MaxValue + 13, (SampleByteEnum)12, (SampleUInt32Enum)12)]
+        [InlineData((ulong)byte.MaxValue * 2, (ulong)UInt32.MaxValue * 2, (SampleByteEnum)byte.MaxValue - 1, (SampleUInt32Enum)UInt32.MaxValue - 1)]
+        public static void Parse_Ulong_InvalidNumber_Throw(ulong i, ulong j, SampleByteEnum e1, SampleUInt32Enum e2)
+        {
+            string json = $"{{ \"MyByteEnum\" : {i}, \"MyUInt32Enum\" : {j} }}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyEnum\" : \"{i}\" }}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>($"{{ \"MyByteEnum\" : \"{j}\" }}"));
+        }
 
         [Fact]
         public static void EnumAsStringFail()

--- a/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.SimpleTestClass.cs
@@ -28,10 +28,13 @@ namespace System.Text.Json.Serialization.Tests
         public double MyDouble { get; set; }
         public DateTime MyDateTime { get; set; }
         public DateTimeOffset MyDateTimeOffset { get; set; }
+        public SampleSByteEnum MySByteEnum { get; set; }
         public SampleByteEnum MyByteEnum { get; set; }
         public SampleEnum MyEnum { get; set; }
+        public SampleEnumInt16 MyInt16Enum { get; set; }
         public SampleInt64Enum MyInt64Enum { get; set; }
         public SampleUInt32Enum MyUInt32Enum { get; set; }
+        public SampleEnumUInt16 MyUInt16Enum { get; set; }
         public SampleUInt64Enum MyUInt64Enum { get; set; }
         public short[] MyInt16Array { get; set; }
         public int[] MyInt32Array { get; set; }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.cs
@@ -22,10 +22,31 @@ namespace System.Text.Json.Serialization.Tests
         Max = byte.MaxValue
     }
 
+    public enum SampleSByteEnum : sbyte
+    {
+        One = 0,
+        Two = 1,
+        Max = sbyte.MaxValue
+    }
+
     public enum SampleEnum
     {
         One = 1,
         Two = 2
+    }
+
+    public enum SampleEnumInt16 : short
+    {
+        One = 1,
+        Two = 2,
+        Max = short.MaxValue
+    }
+
+    public enum SampleEnumUInt16 : ushort
+    {
+        One = 1,
+        Two = 2,
+        Max = ushort.MaxValue
     }
 
     public enum SampleInt64Enum : long


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38363

If we fail to parse with uint64 enum we don't return any valid enum value.
For negative values unsigned return always false, so the idea is to try with uint64 and in case fallback to int64 that will parse -1 as `Max` value.
We'll overflow for other values.

cc: @steveharter @ahsonkhan @maryamariyan 

