### PR TITLE
Enable test for MemoryBarrierProcessWide on ARM64.

### DIFF
--- a/src/System.Threading/tests/InterlockedTests.netcoreapp.cs
+++ b/src/System.Threading/tests/InterlockedTests.netcoreapp.cs
@@ -98,6 +98,7 @@ namespace System.Threading.Tests
             }
         }
 
+        [Fact]
         public void MemoryBarrierProcessWide()
         {
             // Stress MemoryBarrierProcessWide correctness using a simple AsymmetricLock

--- a/src/System.Threading/tests/InterlockedTests.netcoreapp.cs
+++ b/src/System.Threading/tests/InterlockedTests.netcoreapp.cs
@@ -98,7 +98,6 @@ namespace System.Threading.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // issue: https://github.com/dotnet/coreclr/issues/20215
         public void MemoryBarrierProcessWide()
         {
             // Stress MemoryBarrierProcessWide correctness using a simple AsymmetricLock


### PR DESCRIPTION
The corresponding bug is closed as fixed.

Re:https://github.com/dotnet/coreclr/issues/20215