### PR TITLE
Improve performance Enumerable.Min()

### DIFF
--- a/src/System.Linq/src/System/Linq/Min.cs
+++ b/src/System.Linq/src/System/Linq/Min.cs
@@ -166,6 +166,11 @@ namespace System.Linq
                 }
 
                 value = e.Current;
+                if (float.IsNaN(value))
+                {
+                    return value;
+                }
+
                 while (e.MoveNext())
                 {
                     float x = e.Current;
@@ -214,6 +219,11 @@ namespace System.Linq
                 while (!value.HasValue);
 
                 float valueVal = value.GetValueOrDefault();
+                if (float.IsNaN(valueVal))
+                {
+                    return valueVal;
+                }
+
                 while (e.MoveNext())
                 {
                     float? cur = e.Current;
@@ -252,6 +262,11 @@ namespace System.Linq
                 }
 
                 value = e.Current;
+                if (double.IsNaN(value))
+                {
+                    return value;
+                }
+
                 while (e.MoveNext())
                 {
                     double x = e.Current;
@@ -291,6 +306,11 @@ namespace System.Linq
                 while (!value.HasValue);
 
                 double valueVal = value.GetValueOrDefault();
+                if (double.IsNaN(valueVal))
+                {
+                    return valueVal;
+                }
+
                 while (e.MoveNext())
                 {
                     double? cur = e.Current;
@@ -620,6 +640,11 @@ namespace System.Linq
                 }
 
                 value = selector(e.Current);
+                if (float.IsNaN(value))
+                {
+                    return value;
+                }
+
                 while (e.MoveNext())
                 {
                     float x = selector(e.Current);
@@ -673,6 +698,11 @@ namespace System.Linq
                 while (!value.HasValue);
 
                 float valueVal = value.GetValueOrDefault();
+                if (float.IsNaN(valueVal))
+                {
+                    return valueVal;
+                }
+
                 while (e.MoveNext())
                 {
                     float? cur = selector(e.Current);
@@ -716,6 +746,11 @@ namespace System.Linq
                 }
 
                 value = selector(e.Current);
+                if (double.IsNaN(value))
+                {
+                    return value;
+                }
+
                 while (e.MoveNext())
                 {
                     double x = selector(e.Current);
@@ -760,6 +795,11 @@ namespace System.Linq
                 while (!value.HasValue);
 
                 double valueVal = value.GetValueOrDefault();
+                if (double.IsNaN(valueVal))
+                {
+                    return valueVal;
+                }
+
                 while (e.MoveNext())
                 {
                     double? cur = selector(e.Current);

--- a/src/System.Linq/src/System/Linq/Min.cs
+++ b/src/System.Linq/src/System/Linq/Min.cs
@@ -221,7 +221,7 @@ namespace System.Linq
                 float valueVal = value.GetValueOrDefault();
                 if (float.IsNaN(valueVal))
                 {
-                    return valueVal;
+                    return value;
                 }
 
                 while (e.MoveNext())
@@ -308,7 +308,7 @@ namespace System.Linq
                 double valueVal = value.GetValueOrDefault();
                 if (double.IsNaN(valueVal))
                 {
-                    return valueVal;
+                    return value;
                 }
 
                 while (e.MoveNext())
@@ -700,7 +700,7 @@ namespace System.Linq
                 float valueVal = value.GetValueOrDefault();
                 if (float.IsNaN(valueVal))
                 {
-                    return valueVal;
+                    return value;
                 }
 
                 while (e.MoveNext())
@@ -797,7 +797,7 @@ namespace System.Linq
                 double valueVal = value.GetValueOrDefault();
                 if (double.IsNaN(valueVal))
                 {
-                    return valueVal;
+                    return value;
                 }
 
                 while (e.MoveNext())

--- a/src/System.Linq/tests/ShortCircuitingTests.cs
+++ b/src/System.Linq/tests/ShortCircuitingTests.cs
@@ -43,10 +43,10 @@ namespace System.Linq.Tests
                 get
                 {
                     return x =>
-                        {
-                            ++Calls;
-                            return _baseFunc(x);
-                        };
+                    {
+                        ++Calls;
+                        return _baseFunc(x);
+                    };
                 }
             }
         }
@@ -115,7 +115,7 @@ namespace System.Linq.Tests
         public void MinDoubleDoesntCheckAllStartLeadingWithNaN()
         {
             var tracker = new TrackingEnumerable(10);
-            var source = tracker.Select(i => i == 1 ? double.NaN : (double)i);
+            IEnumerable<double> source = tracker.Select(i => i == 1 ? double.NaN : (double)i);
 
             Assert.True(double.IsNaN(source.Min()));
             Assert.Equal(1, tracker.Moves);
@@ -125,7 +125,7 @@ namespace System.Linq.Tests
         public void MinNullableDoubleDoesntCheckAllLeadingWithNaN()
         {
             var tracker = new TrackingEnumerable(10);
-            var source = tracker.Select(i => (double?)(i == 1 ? double.NaN : (double)i));
+            IEnumerable<double?> source = tracker.Select(i => (double?)(i == 1 ? double.NaN : (double)i));
 
             Assert.True(double.IsNaN(source.Min().GetValueOrDefault()));
             Assert.Equal(1, tracker.Moves);
@@ -135,7 +135,7 @@ namespace System.Linq.Tests
         public void MinSingleDoesntCheckAllLeadingWithNaN()
         {
             var tracker = new TrackingEnumerable(10);
-            var source = tracker.Select(i => i == 1 ? float.NaN : (float)i);
+            IEnumerable<float> source = tracker.Select(i => i == 1 ? float.NaN : (float)i);
 
             Assert.True(float.IsNaN(source.Min()));
             Assert.Equal(1, tracker.Moves);
@@ -145,7 +145,7 @@ namespace System.Linq.Tests
         public void MinNullableSingleDoesntCheckAllLeadingWithNaN()
         {
             var tracker = new TrackingEnumerable(10);
-            var source = tracker.Select(i => (float?)(i == 1 ? float.NaN : (float)i));
+            IEnumerable<float?> source = tracker.Select(i => (float?)(i == 1 ? float.NaN : (float)i));
 
             Assert.True(float.IsNaN(source.Min().GetValueOrDefault()));
             Assert.Equal(1, tracker.Moves);
@@ -155,7 +155,7 @@ namespace System.Linq.Tests
         public void MinDoubleSelectorDoesntCheckAllStartLeadingWithNaN()
         {
             var tracker = new TrackingEnumerable(10);
-            var source = tracker.Select(i => i == 1 ? double.NaN : (double)i);
+            IEnumerable<double> source = tracker.Select(i => i == 1 ? double.NaN : (double)i);
 
             Assert.True(double.IsNaN(source.Min(x => x + 1d)));
             Assert.Equal(1, tracker.Moves);
@@ -165,7 +165,7 @@ namespace System.Linq.Tests
         public void MinNullableDoubleSelectorDoesntCheckAllLeadingWithNaN()
         {
             var tracker = new TrackingEnumerable(10);
-            var source = tracker.Select(i => (double?)(i == 1 ? double.NaN : (double)i));
+            IEnumerable<double?> source = tracker.Select(i => (double?)(i == 1 ? double.NaN : (double)i));
 
             Assert.True(double.IsNaN(source.Min(x => x + 1d).GetValueOrDefault()));
             Assert.Equal(1, tracker.Moves);
@@ -175,7 +175,7 @@ namespace System.Linq.Tests
         public void MinSingleSelectorDoesntCheckAllLeadingWithNaN()
         {
             var tracker = new TrackingEnumerable(10);
-            var source = tracker.Select(i => i == 1 ? float.NaN : (float)i);
+            IEnumerable<float> source = tracker.Select(i => i == 1 ? float.NaN : (float)i);
 
             Assert.True(float.IsNaN(source.Min(x => x + 1f)));
             Assert.Equal(1, tracker.Moves);
@@ -185,7 +185,7 @@ namespace System.Linq.Tests
         public void MinNullableSingleSelectorDoesntCheckAllLeadingWithNaN()
         {
             var tracker = new TrackingEnumerable(10);
-            var source = tracker.Select(i => (float?)(i == 1 ? float.NaN : (float)i));
+            IEnumerable<float?> source = tracker.Select(i => (float?)(i == 1 ? float.NaN : (float)i));
 
             Assert.True(float.IsNaN(source.Min(x => x + 1f).GetValueOrDefault()));
             Assert.Equal(1, tracker.Moves);

--- a/src/System.Linq/tests/ShortCircuitingTests.cs
+++ b/src/System.Linq/tests/ShortCircuitingTests.cs
@@ -112,6 +112,94 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void MinDoubleDoesntCheckAllStartLeadingWithNaN()
+        {
+            var tracker = new TrackingEnumerable(10);
+            var source = tracker.Select(i => i == 1 ? double.NaN : (double)i);
+            Assert.True(double.IsNaN(source.Min()));
+
+            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.Equal(1, tracker.Moves);
+        }
+
+        [Fact]
+        public void MinNullableDoubleDoesntCheckAllLeadingWithNaN()
+        {
+            var tracker = new TrackingEnumerable(10);
+            var source = tracker.Select(i => (double?)(i == 1 ? double.NaN : (double)i));
+            Assert.True(double.IsNaN(source.Min().GetValueOrDefault()));
+
+            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.Equal(1, tracker.Moves);
+        }
+
+        [Fact]
+        public void MinSingleDoesntCheckAllLeadingWithNaN()
+        {
+            var tracker = new TrackingEnumerable(10);
+            var source = tracker.Select(i => i == 1 ? float.NaN : (float)i);
+            Assert.True(float.IsNaN(source.Min()));
+
+            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.Equal(1, tracker.Moves);
+        }
+
+        [Fact]
+        public void MinNullableSingleDoesntCheckAllLeadingWithNaN()
+        {
+            var tracker = new TrackingEnumerable(10);
+            var source = tracker.Select(i => (float?)(i == 1 ? float.NaN : (float)i));
+            Assert.True(float.IsNaN(source.Min().GetValueOrDefault()));
+
+            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.Equal(1, tracker.Moves);
+        }
+
+        [Fact]
+        public void MinDoubleSelectorDoesntCheckAllStartLeadingWithNaN()
+        {
+            var tracker = new TrackingEnumerable(10);
+            var source = tracker.Select(i => i == 1 ? double.NaN : (double)i);
+            Assert.True(double.IsNaN(source.Min(x => x + 1d)));
+
+            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.Equal(1, tracker.Moves);
+        }
+
+        [Fact]
+        public void MinNullableDoubleSelectorDoesntCheckAllLeadingWithNaN()
+        {
+            var tracker = new TrackingEnumerable(10);
+            var source = tracker.Select(i => (double?)(i == 1 ? double.NaN : (double)i));
+            Assert.True(double.IsNaN(source.Min(x => x + 1d).GetValueOrDefault()));
+
+            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.Equal(1, tracker.Moves);
+        }
+
+        [Fact]
+        public void MinSingleSelectorDoesntCheckAllLeadingWithNaN()
+        {
+            var tracker = new TrackingEnumerable(10);
+            var source = tracker.Select(i => i == 1 ? float.NaN : (float)i);
+            Assert.True(float.IsNaN(source.Min(x => x + 1f)));
+
+            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.Equal(1, tracker.Moves);
+        }
+
+        [Fact]
+        public void MinNullableSingleSelectorDoesntCheckAllLeadingWithNaN()
+        {
+            var tracker = new TrackingEnumerable(10);
+            var source = tracker.Select(i => (float?)(i == 1 ? float.NaN : (float)i));
+            Assert.True(float.IsNaN(source.Min(x => x + 1f).GetValueOrDefault()));
+
+            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.Equal(1, tracker.Moves);
+        }
+
+        [Fact]
         public void SingleWithPredicateDoesntCheckAll()
         {
             var tracker = new TrackingEnumerable(10);

--- a/src/System.Linq/tests/ShortCircuitingTests.cs
+++ b/src/System.Linq/tests/ShortCircuitingTests.cs
@@ -116,9 +116,8 @@ namespace System.Linq.Tests
         {
             var tracker = new TrackingEnumerable(10);
             var source = tracker.Select(i => i == 1 ? double.NaN : (double)i);
-            Assert.True(double.IsNaN(source.Min()));
 
-            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.True(double.IsNaN(source.Min()));
             Assert.Equal(1, tracker.Moves);
         }
 
@@ -127,9 +126,8 @@ namespace System.Linq.Tests
         {
             var tracker = new TrackingEnumerable(10);
             var source = tracker.Select(i => (double?)(i == 1 ? double.NaN : (double)i));
-            Assert.True(double.IsNaN(source.Min().GetValueOrDefault()));
 
-            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.True(double.IsNaN(source.Min().GetValueOrDefault()));
             Assert.Equal(1, tracker.Moves);
         }
 
@@ -138,9 +136,8 @@ namespace System.Linq.Tests
         {
             var tracker = new TrackingEnumerable(10);
             var source = tracker.Select(i => i == 1 ? float.NaN : (float)i);
-            Assert.True(float.IsNaN(source.Min()));
 
-            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.True(float.IsNaN(source.Min()));
             Assert.Equal(1, tracker.Moves);
         }
 
@@ -149,9 +146,8 @@ namespace System.Linq.Tests
         {
             var tracker = new TrackingEnumerable(10);
             var source = tracker.Select(i => (float?)(i == 1 ? float.NaN : (float)i));
-            Assert.True(float.IsNaN(source.Min().GetValueOrDefault()));
 
-            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.True(float.IsNaN(source.Min().GetValueOrDefault()));
             Assert.Equal(1, tracker.Moves);
         }
 
@@ -160,9 +156,8 @@ namespace System.Linq.Tests
         {
             var tracker = new TrackingEnumerable(10);
             var source = tracker.Select(i => i == 1 ? double.NaN : (double)i);
-            Assert.True(double.IsNaN(source.Min(x => x + 1d)));
 
-            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.True(double.IsNaN(source.Min(x => x + 1d)));
             Assert.Equal(1, tracker.Moves);
         }
 
@@ -171,9 +166,8 @@ namespace System.Linq.Tests
         {
             var tracker = new TrackingEnumerable(10);
             var source = tracker.Select(i => (double?)(i == 1 ? double.NaN : (double)i));
-            Assert.True(double.IsNaN(source.Min(x => x + 1d).GetValueOrDefault()));
 
-            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.True(double.IsNaN(source.Min(x => x + 1d).GetValueOrDefault()));
             Assert.Equal(1, tracker.Moves);
         }
 
@@ -182,9 +176,8 @@ namespace System.Linq.Tests
         {
             var tracker = new TrackingEnumerable(10);
             var source = tracker.Select(i => i == 1 ? float.NaN : (float)i);
-            Assert.True(float.IsNaN(source.Min(x => x + 1f)));
 
-            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.True(float.IsNaN(source.Min(x => x + 1f)));
             Assert.Equal(1, tracker.Moves);
         }
 
@@ -193,9 +186,8 @@ namespace System.Linq.Tests
         {
             var tracker = new TrackingEnumerable(10);
             var source = tracker.Select(i => (float?)(i == 1 ? float.NaN : (float)i));
-            Assert.True(float.IsNaN(source.Min(x => x + 1f).GetValueOrDefault()));
 
-            //see https://github.com/dotnet/corefx/issues/38392.
+            Assert.True(float.IsNaN(source.Min(x => x + 1f).GetValueOrDefault()));
             Assert.Equal(1, tracker.Moves);
         }
 


### PR DESCRIPTION
#38392 

If first nonull element is NaN, return it.

Here is the benchmark code, MinPerf() method is the code after optimized.
```
    public class MinTest
    {
        private float?[] data;

        [Params(2, 10, 100, 1000)]
        public int Length;

        [GlobalSetup]
        public void Setup()
        {
            Random random = new Random();
            this.data = new float?[this.Length];
            this.data[0] = null;
            this.data[1] = float.NaN;
            for (int i = 2; i < this.data.Length; i++)
                this.data[i] = random.Next();
        }

        [Benchmark(Baseline = true)]
        public float? Min()
        {
            return this.data.Min();
        }

        [Benchmark]
        public float? MinPerf()
        {
            return this.data.MinPerf();
        }
    }
```

And results blow
``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17134.765 (1803/April2018Update/Redstone4)
Intel Core i7-7500U CPU 2.70GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
Frequency=2835941 Hz, Resolution=352.6166 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3416.0
  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3416.0


```
|  Method | Length |          Mean |        Error |       StdDev |        Median | Ratio | RatioSD |
|-------- |------- |--------------:|-------------:|-------------:|--------------:|------:|--------:|
|     **Min** |      **2** |      **51.16 ns** |     **1.314 ns** |     **3.875 ns** |      **51.87 ns** |  **1.00** |    **0.00** |
| MinPerf |      2 |      43.92 ns |     1.996 ns |     5.885 ns |      46.76 ns |  0.87 |    0.15 |
|         |        |               |              |              |               |       |         |
|     **Min** |     **10** |   **1,232.71 ns** |    **16.672 ns** |    **15.595 ns** |   **1,234.14 ns** |  **1.00** |    **0.00** |
| MinPerf |     10 |      45.16 ns |     1.758 ns |     5.183 ns |      47.03 ns |  0.04 |    0.00 |
|         |        |               |              |              |               |       |         |
|     **Min** |    **100** |  **13,926.08 ns** |   **276.106 ns** |   **518.594 ns** |  **14,087.45 ns** | **1.000** |    **0.00** |
| MinPerf |    100 |      47.98 ns |     1.695 ns |     4.998 ns |      48.71 ns | 0.003 |    0.00 |
|         |        |               |              |              |               |       |         |
|     **Min** |   **1000** | **148,046.00 ns** | **2,903.423 ns** | **2,981.601 ns** | **148,040.84 ns** | **1.000** |    **0.00** |
| MinPerf |   1000 |      48.51 ns |     1.174 ns |     3.462 ns |      48.95 ns | 0.000 |    0.00 |
