### PR TITLE
Revert "Enable test for MemoryBarrierProcessWide on ARM64."

### DIFF
--- a/src/System.Threading/tests/InterlockedTests.netcoreapp.cs
+++ b/src/System.Threading/tests/InterlockedTests.netcoreapp.cs
@@ -98,7 +98,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // issue: https://github.com/dotnet/coreclr/issues/20215
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue(38400)]
         public void MemoryBarrierProcessWide()
         {
             // Stress MemoryBarrierProcessWide correctness using a simple AsymmetricLock

--- a/src/System.Threading/tests/InterlockedTests.netcoreapp.cs
+++ b/src/System.Threading/tests/InterlockedTests.netcoreapp.cs
@@ -98,7 +98,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // issue: https://github.com/dotnet/coreclr/issues/20215
         public void MemoryBarrierProcessWide()
         {
             // Stress MemoryBarrierProcessWide correctness using a simple AsymmetricLock


### PR DESCRIPTION
Reverts dotnet/corefx#38386

This test has failed times since it was enabled 16 hours ago.
cc: @vsadov