### PR TITLE
Fix several comparison issues in ConcurrentBag

### DIFF
--- a/src/System.Collections.Concurrent/tests/ConcurrentBagTests.netcoreapp.cs
+++ b/src/System.Collections.Concurrent/tests/ConcurrentBagTests.netcoreapp.cs
@@ -70,7 +70,7 @@ namespace System.Collections.Concurrent.Tests
         public static void Clear_ConcurrentUsage_NoExceptions(int threadsCount, int itemsPerThread)
         {
             var bag = new ConcurrentBag<int>();
-            Task.WaitAll((from i in Enumerable.Range(0, threadsCount) select Task.Run(() =>
+            Task.WaitAll((from i in Enumerable.Range(0, threadsCount) select Task.Factory.StartNew(() =>
             {
                 var random = new Random();
                 for (int j = 0; j < itemsPerThread; j++)
@@ -85,7 +85,7 @@ namespace System.Collections.Concurrent.Tests
                         case 4: bag.ToArray(); break;
                     }
                 }
-            })).ToArray());
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)).ToArray());
         }
     }
 }


### PR DESCRIPTION
A failed assert now and again in CI highlighted that we weren't properly accounting for overflows in ConcurrentBag.  In a variety of cases we compare the head position to the tail position, e.g. `head < tail` to determine if there are items in the queue, but in some situations when a position is temporarily updated, head can temporarily progress beyond tail, and if it does and wraps around due to overflow, we can end up in a situation where the condition passes even though it shouldn't.  This fixes all of the comparisons to do the subtraction and compare to 0, to avoid the overflow issue.

Separately, TrySteal had an inverted condition that was checking whether the queue contained at least 2 elements rather than checking whether it contained <= 2.  Also fixed that by inverting the check, along with doing the comparison appropriately per the above.

Fixes https://github.com/dotnet/corefx/issues/33500
cc: @kouvel, @tarekgh 