### PR TITLE
 Checking if the eventlog registry key is actually an eventlog

### DIFF
--- a/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
+++ b/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
@@ -655,14 +656,20 @@ namespace System.Diagnostics
                 eventkey?.Close();
             }
             // now create EventLog objects that point to those logs
-            EventLog[] logs = new EventLog[logNames.Length];
+            List<EventLog> logs = new List<EventLog>();
             for (int i = 0; i < logNames.Length; i++)
             {
-                EventLog log = new EventLog(logNames[i], machineName);
-                logs[i] = log;
+                SafeEventLogReadHandle handle = Interop.Advapi32.OpenEventLog(machineName, logNames[i]);
+
+                if (!handle.IsInvalid)
+                {
+                    handle.Close();
+                    EventLog log = new EventLog(logNames[i], machineName);
+                    logs.Add(log);
+                }
             }
 
-            return logs;
+            return logs.ToArray();
         }
 
         internal static RegistryKey GetEventLogRegKey(string machine, bool writable)

--- a/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
+++ b/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
@@ -656,15 +656,15 @@ namespace System.Diagnostics
                 eventkey?.Close();
             }
             // now create EventLog objects that point to those logs
-            List<EventLog> logs = new List<EventLog>();
+            List<EventLog> logs = new List<EventLog>(logNames.Length);
             for (int i = 0; i < logNames.Length; i++)
             {
+                EventLog log = new EventLog(logNames[i], machineName);
                 SafeEventLogReadHandle handle = Interop.Advapi32.OpenEventLog(machineName, logNames[i]);
 
                 if (!handle.IsInvalid)
                 {
                     handle.Close();
-                    EventLog log = new EventLog(logNames[i], machineName);
                     logs.Add(log);
                 }
             }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -349,5 +349,15 @@ namespace System.Diagnostics.Tests
                 Assert.Contains("", eventlog.Entries.LastOrDefault()?.Message ?? "");
             }
         }
+
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
+        public void GetEventLogEntriesTest()
+        {
+            foreach (var eventLog in EventLog.GetEventLogs())
+            {
+                // Accessing eventlog properties should not throw.
+                int _ = eventLog.Entries.Count;
+            }
+        }
     }
 }

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -351,6 +351,7 @@ namespace System.Diagnostics.Tests
         }
 
         [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void GetEventLogEntriesTest()
         {
             foreach (var eventLog in EventLog.GetEventLogs())

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -356,7 +356,7 @@ namespace System.Diagnostics.Tests
             foreach (var eventLog in EventLog.GetEventLogs())
             {
                 // Accessing eventlog properties should not throw.
-                int _ = eventLog.Entries.Count;
+                Assert.True(eventLog.Entries.Count >= 0);
             }
         }
     }


### PR DESCRIPTION
.Net considers that the subkeys under the event log registry key is a "eventlog" which is not the case anymore. So we are just filtering out the eventlog entries if we cnt open it.


@tarekgh i verified that the release handle is being called by close handle. 