### PR TITLE
Improve default handling in ReadOnlySequence.Slice

### DIFF
--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
@@ -459,21 +459,6 @@ namespace System.Buffers
         private static int GetIndex(int Integer) => Integer & ReadOnlySequence.IndexBitMask;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private ReadOnlySequence<T> SliceImpl(in object? startObject, in int startIndex, in object? endObject, in int endIndex)
-        {
-            // In this method we reset high order bits from indices
-            // of positions that were passed in
-            // and apply type bits specific for current ReadOnlySequence type
-
-            return new ReadOnlySequence<T>(
-                startObject,
-                startIndex | (_startInteger & ReadOnlySequence.FlagBitMask),
-                endObject,
-                endIndex | (_endInteger & ReadOnlySequence.FlagBitMask)
-            );
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ReadOnlySequence<T> SliceImpl(in SequencePosition start, in SequencePosition end)
         {
             return new ReadOnlySequence<T>(

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
@@ -474,10 +474,30 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private ReadOnlySequence<T> SliceImpl(in SequencePosition start, in SequencePosition end) => SliceImpl(start.GetObject(), GetIndex(start), end.GetObject(), GetIndex(end));
+        private ReadOnlySequence<T> SliceImpl(in SequencePosition start, in SequencePosition end)
+        {
+            return new ReadOnlySequence<T>(
+                start.GetObject(),
+                GetIndex(start) | (_startInteger & ReadOnlySequence.FlagBitMask),
+                end.GetObject(),
+                GetIndex(end) | (_endInteger & ReadOnlySequence.FlagBitMask)
+                );
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private ReadOnlySequence<T> SliceImpl(in SequencePosition start) => SliceImpl(start.GetObject(), GetIndex(start), _endObject, _endInteger);
+        private ReadOnlySequence<T> SliceImpl(in SequencePosition start)
+        {
+            // In this method we reset high order bits from indices
+            // of positions that were passed in
+            // and apply type bits specific for current ReadOnlySequence type
+
+            return new ReadOnlySequence<T>(
+                start.GetObject(),
+                GetIndex(start) | (_startInteger & ReadOnlySequence.FlagBitMask),
+                _endObject,
+                _endInteger
+            );
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private long GetLength()

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
@@ -331,7 +331,7 @@ namespace System.Buffers
             return new SequencePosition(currentSegment, (int)offset);
         }
 
-        private void BoundsCheck(in SequencePosition position)
+        private void BoundsCheck(in SequencePosition position, bool positionIsNotNull)
         {
             uint sliceStartIndex = (uint)GetIndex(position);
 
@@ -354,7 +354,12 @@ namespace System.Buffers
                 // Multi-Segment Sequence
                 // Storing this in a local since it is used twice within InRange()
                 ulong startRange = (ulong)(((ReadOnlySequenceSegment<T>)startObject!).RunningIndex + startIndex);
-                long runningIndex = ((ReadOnlySequenceSegment<T>?)position.GetObject())?.RunningIndex ?? 0;
+                long runningIndex = 0;
+                if (positionIsNotNull)
+                {
+                    Debug.Assert(position.GetObject() != null);
+                    runningIndex = ((ReadOnlySequenceSegment<T>)position.GetObject()!).RunningIndex;
+                }
                 if (!InRange(
                     (ulong)(runningIndex + sliceStartIndex),
                     startRange,

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
@@ -481,7 +481,7 @@ namespace System.Buffers
                 GetIndex(start) | (_startInteger & ReadOnlySequence.FlagBitMask),
                 end.GetObject(),
                 GetIndex(end) | (_endInteger & ReadOnlySequence.FlagBitMask)
-                );
+            );
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
@@ -360,6 +360,7 @@ namespace System.Buffers
                     Debug.Assert(position.GetObject() != null);
                     runningIndex = ((ReadOnlySequenceSegment<T>)position.GetObject()!).RunningIndex;
                 }
+
                 if (!InRange(
                     (ulong)(runningIndex + sliceStartIndex),
                     startRange,

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.Helpers.cs
@@ -402,12 +402,12 @@ namespace System.Buffers
 
                 if (sliceStartObject != null)
                 {
-                    sliceStartRange += (ulong)((ReadOnlySequenceSegment<T>?)sliceStartObject!).RunningIndex;
+                    sliceStartRange += (ulong)((ReadOnlySequenceSegment<T>)sliceStartObject).RunningIndex;
                 }
 
                 if (sliceEndObject != null)
                 {
-                    sliceEndRange += (ulong)((ReadOnlySequenceSegment<T>?)sliceEndObject!).RunningIndex;
+                    sliceEndRange += (ulong)((ReadOnlySequenceSegment<T>)sliceEndObject).RunningIndex;
                 }
 
                 if (sliceStartRange > sliceEndRange)

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -271,7 +271,7 @@ namespace System.Buffers
                 ThrowHelper.ThrowStartOrEndArgumentValidationException(start);
 
             uint sliceEndIndex = (uint)GetIndex(end);
-            object? sliceEndObject = end.GetObject();
+            object? sliceEndObject = end.GetObject() ?? _startObject;
 
             uint startIndex = (uint)GetIndex(_startInteger);
             object? startObject = _startObject;
@@ -329,7 +329,7 @@ namespace System.Buffers
         FoundInFirstSegment:
             // startIndex + start <= int.MaxValue
             Debug.Assert(start <= int.MaxValue - startIndex);
-            return SliceImpl(new SequencePosition(startObject, (int)startIndex + (int)start), end);
+            return SliceImpl(startObject, (int)startIndex + (int)start, sliceEndObject, (int)sliceEndIndex);
         }
 
         /// <summary>
@@ -342,7 +342,7 @@ namespace System.Buffers
         {
             // Check start before length
             uint sliceStartIndex = (uint)GetIndex(start);
-            object? sliceStartObject = start.GetObject();
+            object? sliceStartObject = start.GetObject() ?? _startObject;
 
             uint startIndex = (uint)GetIndex(_startInteger);
             object? startObject = _startObject;
@@ -406,7 +406,7 @@ namespace System.Buffers
         FoundInFirstSegment:
             // sliceStartIndex + length <= int.MaxValue
             Debug.Assert(length <= int.MaxValue - sliceStartIndex);
-            return SliceImpl(start, new SequencePosition(sliceStartObject, (int)sliceStartIndex + (int)length));
+            return SliceImpl(sliceStartObject, (int)sliceStartIndex, sliceStartObject, (int)sliceStartIndex + (int)length);
         }
 
         /// <summary>
@@ -455,7 +455,7 @@ namespace System.Buffers
         public ReadOnlySequence<T> Slice(SequencePosition start)
         {
             BoundsCheck(start);
-            return SliceImpl(start);
+            return SliceImpl(start.GetObject() == null ? Start : start);
         }
 
         /// <summary>

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -454,7 +454,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySequence<T> Slice(SequencePosition start)
         {
-            BoundsCheck(start);
+            BoundsCheck(start, positionIsNotNull: start.GetObject() != null);
             return SliceImpl(start.GetObject() == null ? Start : start);
         }
 

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -329,7 +329,7 @@ namespace System.Buffers
         FoundInFirstSegment:
             // startIndex + start <= int.MaxValue
             Debug.Assert(start <= int.MaxValue - startIndex);
-            return SliceImpl(startObject, (int)startIndex + (int)start, sliceEndObject, (int)sliceEndIndex);
+            return SliceImpl(new SequencePosition(startObject, (int)startIndex + (int)start), new SequencePosition(sliceEndObject, (int)sliceEndIndex));
         }
 
         /// <summary>
@@ -406,7 +406,7 @@ namespace System.Buffers
         FoundInFirstSegment:
             // sliceStartIndex + length <= int.MaxValue
             Debug.Assert(length <= int.MaxValue - sliceStartIndex);
-            return SliceImpl(sliceStartObject, (int)sliceStartIndex, sliceStartObject, (int)sliceStartIndex + (int)length);
+            return SliceImpl(new SequencePosition(sliceStartObject, (int)sliceStartIndex), new SequencePosition(sliceStartObject, (int)sliceStartIndex + (int)length));
         }
 
         /// <summary>
@@ -454,8 +454,9 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySequence<T> Slice(SequencePosition start)
         {
-            BoundsCheck(start, positionIsNotNull: start.GetObject() != null);
-            return SliceImpl(start.GetObject() == null ? Start : start);
+            bool positionIsNotNull = start.GetObject() != null;
+            BoundsCheck(start, positionIsNotNull: positionIsNotNull);
+            return SliceImpl(positionIsNotNull ? start : Start);
         }
 
         /// <summary>

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -490,7 +490,7 @@ namespace System.Buffers
 
                 if (Length < int.MaxValue)
                 {
-                    return string.Create((int)Length, charSequence, (span, sequence) => sequence.CopyTo(span)); 
+                    return string.Create((int)Length, charSequence, (span, sequence) => sequence.CopyTo(span));
                 }
             }
 

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -270,15 +270,21 @@ namespace System.Buffers
             if (start < 0)
                 ThrowHelper.ThrowStartOrEndArgumentValidationException(start);
 
-            uint sliceEndIndex = (uint)GetIndex(end);
-            object? sliceEndObject = end.GetObject() ?? _startObject;
-
             uint startIndex = (uint)GetIndex(_startInteger);
             object? startObject = _startObject;
 
             uint endIndex = (uint)GetIndex(_endInteger);
             object? endObject = _endObject;
 
+            uint sliceEndIndex = (uint)GetIndex(end);
+            object? sliceEndObject = end.GetObject();
+
+            if (sliceEndObject == null)
+            {
+                sliceEndObject = _startObject;
+                sliceEndIndex = startIndex;
+            }
+            
             // Single-Segment Sequence
             if (startObject == endObject)
             {
@@ -340,15 +346,21 @@ namespace System.Buffers
         /// <returns>A slice that consists of <paramref name="length" /> elements from the current instance starting at sequence position <paramref name="start" />.</returns>
         public ReadOnlySequence<T> Slice(SequencePosition start, long length)
         {
-            // Check start before length
-            uint sliceStartIndex = (uint)GetIndex(start);
-            object? sliceStartObject = start.GetObject() ?? _startObject;
-
             uint startIndex = (uint)GetIndex(_startInteger);
             object? startObject = _startObject;
 
             uint endIndex = (uint)GetIndex(_endInteger);
             object? endObject = _endObject;
+
+            // Check start before length
+            uint sliceStartIndex = (uint)GetIndex(start);
+            object? sliceStartObject = start.GetObject();
+
+            if (sliceStartObject == null)
+            {
+                sliceStartIndex = startIndex;
+                sliceStartObject = _startObject;
+            }
 
             // Single-Segment Sequence
             if (startObject == endObject)

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -455,7 +455,7 @@ namespace System.Buffers
         public ReadOnlySequence<T> Slice(SequencePosition start)
         {
             bool positionIsNotNull = start.GetObject() != null;
-            BoundsCheck(start, positionIsNotNull: positionIsNotNull);
+            BoundsCheck(start, positionIsNotNull);
             return SliceImpl(positionIsNotNull ? start : Start);
         }
 

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Default.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Default.cs
@@ -122,6 +122,39 @@ namespace System.Memory.Tests
             Assert.Throws<ArgumentOutOfRangeException>("length", () => buffer.Slice(buffer.Start, -1L));
         }
 
+        [Fact]
+        public void Slice_DefaultSequencePosition()
+        {
+            var firstSegment = new BufferSegment<byte>(new byte[1]);
+            BufferSegment<byte> secondSegment = firstSegment.Append(new byte[1]);
+
+            var sequence = new ReadOnlySequence<byte>(firstSegment, 0, secondSegment, 1);
+            var slicedSequence = sequence.Slice(default(SequencePosition));
+            Assert.Equal(sequence, slicedSequence);
+
+            // Slice(default, default) should return an empty sequence
+            slicedSequence = sequence.Slice(default(SequencePosition), default(SequencePosition));
+            Assert.Equal(0, slicedSequence.Length);
+
+            // Slice(x, default) returns empty is x = 0. Otherwise throws
+            slicedSequence = sequence.Slice(0, default(SequencePosition));
+            Assert.Equal(0, slicedSequence.Length);
+
+            try
+            {
+                slicedSequence = sequence.Slice(1, default(SequencePosition));
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                Assert.Equal(0, slicedSequence.Length);
+            }
+
+            // Slice(default, x) returns sequence from the beginning to x
+            slicedSequence = sequence.Slice(default(SequencePosition), 1);
+            Assert.Equal(1, slicedSequence.Length);
+            Assert.Equal(sequence.Start, slicedSequence.Start);
+        }
+
         #endregion
 
         #region Enumerator

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Default.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Default.cs
@@ -129,7 +129,7 @@ namespace System.Memory.Tests
             BufferSegment<byte> secondSegment = firstSegment.Append(new byte[1]);
 
             var sequence = new ReadOnlySequence<byte>(firstSegment, 0, secondSegment, 1);
-            var slicedSequence = sequence.Slice(default(SequencePosition));
+            ReadOnlySequence<byte> slicedSequence = sequence.Slice(default(SequencePosition));
             Assert.Equal(sequence, slicedSequence);
 
             // Slice(default, default) should return an empty sequence
@@ -140,14 +140,7 @@ namespace System.Memory.Tests
             slicedSequence = sequence.Slice(0, default(SequencePosition));
             Assert.Equal(0, slicedSequence.Length);
 
-            try
-            {
-                slicedSequence = sequence.Slice(1, default(SequencePosition));
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                Assert.Equal(0, slicedSequence.Length);
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => sequence.Slice(1, default(SequencePosition)));
 
             // Slice(default, x) returns sequence from the beginning to x
             slicedSequence = sequence.Slice(default(SequencePosition), 1);

--- a/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Default.cs
+++ b/src/System.Memory/tests/ReadOnlyBuffer/ReadOnlySequenceTests.Default.cs
@@ -125,10 +125,10 @@ namespace System.Memory.Tests
         [Fact]
         public void Slice_DefaultSequencePosition()
         {
-            var firstSegment = new BufferSegment<byte>(new byte[1]);
-            BufferSegment<byte> secondSegment = firstSegment.Append(new byte[1]);
+            var firstSegment = new BufferSegment<byte>(new byte[4]);
+            BufferSegment<byte> secondSegment = firstSegment.Append(new byte[4]);
 
-            var sequence = new ReadOnlySequence<byte>(firstSegment, 0, secondSegment, 1);
+            var sequence = new ReadOnlySequence<byte>(firstSegment, 0, secondSegment, firstSegment.Memory.Length);
             ReadOnlySequence<byte> slicedSequence = sequence.Slice(default(SequencePosition));
             Assert.Equal(sequence, slicedSequence);
 
@@ -136,7 +136,8 @@ namespace System.Memory.Tests
             slicedSequence = sequence.Slice(default(SequencePosition), default(SequencePosition));
             Assert.Equal(0, slicedSequence.Length);
 
-            // Slice(x, default) returns empty is x = 0. Otherwise throws
+            // Slice(x, default) returns empty if x = 0. Otherwise throws
+            sequence = sequence.Slice(2);
             slicedSequence = sequence.Slice(0, default(SequencePosition));
             Assert.Equal(0, slicedSequence.Length);
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/35254

The null dereference was because we now allow nullable objects in SequencePosition. Once I fixed that, there's still the issue of what `default(SequencePosition)._object` should be. If the expectation is that the default start position is 0, it makes sense that `default(SequencePosition)._object = Start`?

Also, this is my first patch in corefx, so I'd appreciate comments on the new test and its location. Also, this seems like a small change, but how do folks generally measure the performance impacts of new changes? 