### PR TITLE
Make it so GenAPI is only used during online source build

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -125,6 +125,7 @@
 
   <Import Project="$(RepositoryEngineeringDir)referenceFromRuntime.targets" />
   <Import Project="$(RepositoryEngineeringDir)illink.targets" />
+  <Import Project="$(RepositoryEngineeringDir)notSupported.SourceBuild.targets" Condition="'$(DotNetBuildFromSource)' == 'true'" />
 
   <Target Name="ReportConfigurationErrorMessage"
           BeforeTargets="AssignProjectConfiguration"

--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -16,7 +16,6 @@
   <!-- source-built packages -->
   <ItemGroup>
     <!-- arcade -->
-    <PackageReference Include="Microsoft.DotNet.GenAPI" Version="$(MicrosoftDotNetGenApiPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Configuration" Version="$(MicrosoftDotNetBuildTasksConfigurationPackageVersion)" />
@@ -24,6 +23,12 @@
 
     <!-- roslyn -->
     <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="$(MicrosoftNetCompilersToolsetVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <!-- excluded from offline portion of source build -->
+  <ItemGroup Condition="'$(OfflineBuild)' != 'true'">
+    <!-- arcade -->
+    <PackageReference Include="Microsoft.DotNet.GenAPI" Version="$(MicrosoftDotNetGenApiPackageVersion)" />
   </ItemGroup>
 
   <!-- excluded from source build -->

--- a/eng/notSupported.SourceBuild.targets
+++ b/eng/notSupported.SourceBuild.targets
@@ -1,0 +1,25 @@
+<Project InitialTargets="_RedefineNotSupportedSourceFile">
+
+  <Target Name="_RedefineNotSupportedSourceFile"
+          Condition="'$(DotNetBuildFromSource)' == 'true' and
+                     ('$(GeneratePlatformNotSupportedAssembly)' == 'true' or '$(GeneratePlatformNotSupportedAssemblyMessage)' != '')">
+                     
+    <Error Condition="'$(DotNetSourceBuildIntermediatePath)' == ''" 
+           Text="'DotNetSourceBuildIntermediatePath' must be specified when 'DotNetBuildFromSource' is true" />
+           
+    <PropertyGroup>
+      <_notSupportedSourceDirectory>$([MSBuild]::NormalizeDirectory('$(DotNetSourceBuildIntermediatePath)', '$(MSBuildProjectName)', '$(TargetGroup)-$(OSGroup)'))</_notSupportedSourceDirectory>
+      <NotSupportedSourceFile>$(_notSupportedSourceDirectory)$(TargetName).notsupported.cs</NotSupportedSourceFile>
+    </PropertyGroup>
+    
+    <MakeDir Condition="'$(OfflineBuild)' != 'true'" Directories="$(_notSupportedSourceDirectory)" />
+    
+    <Error Condition="'$(OfflineBuild)' == 'true' AND !Exists('$(NotSupportedSourceFile)')"
+           Text="Error NotSupportedSourceFile '$(NotSupportedSourceFile)' did not exist under DotNetSourceBuildIntermediatePath." />
+    
+    <!-- OfflineBuild == true, don't use GenAPI and include source from DotNetSourceBuildIntermediatePath -->  
+    <ItemGroup Condition="'$(OfflineBuild)' == 'true'">
+      <Compile Include="$(NotSupportedSourceFile)" />
+    </ItemGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
Fixes #38035 

Tested by building CoreFx specifying DotNetBuildFromSource & DotNetSourceBuildIntermediatePath.

Deleted artifacts.

Built again specifying DotNetBuildFromSource & DotNetSourceBuildIntermediatePath & OfflineBuild.
