### PR TITLE
Re-enable UseCallback_HaveNoCredsAndUseAuthenticatedCustomProxyAndPostToSecureServer_ProxyAuthenticationRequiredStatusCode

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ServerCertificates.cs
@@ -86,7 +86,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(37250)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP won't send requests through a custom proxy")]
         [OuterLoop("Uses external server")]
         [Fact]
@@ -135,7 +134,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(37250)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap, "UAP won't send requests through a custom proxy")]
         [OuterLoop("Uses external server")]
         [Fact]


### PR DESCRIPTION
Resolves #37250. Re-enable tests that #38038 resolved -- `LoopbackProxyServer` with CONNECT requests was closing (via GC) its socket without a `shutdown()`.