### PR TITLE
Remove flaky asserts in Marshal.R/WInt16 tests.

### DIFF
--- a/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
+++ b/src/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
@@ -85,7 +85,6 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal("ABC", ((StructWithReferenceTypes)structure).stringValue);
             Assert.Equal(new short[10] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 100 }, ((StructWithReferenceTypes)structure).byValueArray);
             Assert.Equal(200, Marshal.ReadInt16(structure, pointerOffset));
-            Assert.NotEqual(0, Marshal.ReadInt16(structure, stringOffset));
             Assert.Equal(100, Marshal.ReadInt16(structure, arrayOffset + sizeof(short) * 9));
         }
 
@@ -120,20 +119,6 @@ namespace System.Runtime.InteropServices.Tests
             };
 
             Assert.Equal(100, Marshal.ReadInt16(structure, pointerOffset));
-
-            // The ReadInt16() for object types does an explicit marshal which requires
-            // an allocation on each read. It can occur that the allocation is aligned
-            // on a 16-bit boundary which would yield a value of 0. To mitigate the chance,
-            // marshal several times, choosing 20 as an arbitrary value. If this test
-            // fails, we should reconsider whether it is worth the flakiness.
-            int readShorts = 0;
-            for (int i = 0; i < 20; ++i)
-            {
-                readShorts += Marshal.ReadInt16(structure, stringOffset);
-            }
-
-            Assert.NotEqual(0, readShorts);
-
             Assert.Equal(3, Marshal.ReadInt16(structure, arrayOffset + sizeof(short) * 2));
         }
 


### PR DESCRIPTION
These asserts aren't very useful for what they're testing and they're flaky. I believe we should remove them since we aren't getting much good extra code coverage from them.

Fixes #34422 
Fixes #38353 
