### PR TITLE
Use HTTP Host header for Kerberos auth SPN calculation

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -76,32 +76,50 @@ namespace System.Net.Http
                             needDrain = false;
                         }
 
-                        string challengeData = challenge.ChallengeData;
-
-                        // Need to use FQDN normalized host so that CNAME's are traversed.
-                        // Use DNS to do the forward lookup to an A (host) record.
-                        // But skip DNS lookup on IP literals. Otherwise, we would end up
-                        // doing an unintended reverse DNS lookup.
-                        string spn;
-                        UriHostNameType hnt = authUri.HostNameType;
-                        if (hnt == UriHostNameType.IPv6 || hnt == UriHostNameType.IPv4)
+                        if (NetEventSource.IsEnabled)
                         {
-                            spn = authUri.IdnHost;
+                            NetEventSource.Info(connection, $"Authentication: {challenge.AuthenticationType}, Uri: {authUri.AbsoluteUri.ToString()}");
+                        }
+
+                        // Calculate SPN (Service Principal Name) using the host name of the request.
+                        // Use the request's 'Host' header if available. Otherwise, use the request uri.
+                        string hostName;
+                        if (request.HasHeaders && request.Headers.Host != null)
+                        {
+                            // Use the host name without any normalization.
+                            hostName = request.Headers.Host;
+                            if (NetEventSource.IsEnabled)
+                            {
+                                NetEventSource.Info(connection, $"Authentication: {challenge.AuthenticationType}, Host: {hostName}");
+                            }
                         }
                         else
                         {
-                            IPHostEntry result = await Dns.GetHostEntryAsync(authUri.IdnHost).ConfigureAwait(false);
-                            spn = result.HostName;
+                            // Need to use FQDN normalized host so that CNAME's are traversed.
+                            // Use DNS to do the forward lookup to an A (host) record.
+                            // But skip DNS lookup on IP literals. Otherwise, we would end up
+                            // doing an unintended reverse DNS lookup.
+                            UriHostNameType hnt = authUri.HostNameType;
+                            if (hnt == UriHostNameType.IPv6 || hnt == UriHostNameType.IPv4)
+                            {
+                                hostName = authUri.IdnHost;
+                            }
+                            else
+                            {
+                                IPHostEntry result = await Dns.GetHostEntryAsync(authUri.IdnHost).ConfigureAwait(false);
+                                hostName = result.HostName;
+                            }
                         }
-                        spn = "HTTP/" + spn;
 
+                        string spn = "HTTP/" + hostName;
                         if (NetEventSource.IsEnabled)
                         {
-                            NetEventSource.Info(connection, $"Authentication: {challenge.AuthenticationType}, Host: {authUri.IdnHost}, SPN: {spn}");
+                            NetEventSource.Info(connection, $"Authentication: {challenge.AuthenticationType}, SPN: {spn}");
                         }
 
                         ChannelBinding channelBinding = connection.TransportContext?.GetChannelBinding(ChannelBindingKind.Endpoint);
                         NTAuthentication authContext = new NTAuthentication(isServer:false, challenge.SchemeName, challenge.Credential, spn, ContextFlagsPal.Connection, channelBinding);
+                        string challengeData = challenge.ChallengeData;
                         try
                         {
                             while (true)


### PR DESCRIPTION
Fixed SocketsHttpHandler so that it will use the request's Host header,
if present, as part of building the Service Principal Name (SPN) when
doing Kerberos authentication. This now matches .NET Framework behavior.

Contributes to #34697 and #27745