### PR TITLE
Handle Byte Order Mark in Utf8JsonReader.Read

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -89,10 +89,12 @@ namespace System.Text.Json
             var readerState = new JsonReaderState(options.GetReaderOptions());
 
             // todo: switch to ArrayBuffer implementation to handle and simplify the allocs?
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(options.DefaultBufferSize);
+            int utf8BomLength = JsonConstants.Utf8Bom.Length;
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(Math.Max(options.DefaultBufferSize, utf8BomLength));
             int bytesInBuffer = 0;
             long totalBytesRead = 0;
             int clearMax = 0;
+            bool firstIteration = true;
 
             try
             {
@@ -132,11 +134,24 @@ namespace System.Text.Json
                         clearMax = bytesInBuffer;
                     }
 
+                    int start = 0;
+                    if (firstIteration)
+                    {
+                        firstIteration = false;
+                        // Handle the UTF-8 BOM if present
+                        Debug.Assert(buffer.Length >= JsonConstants.Utf8Bom.Length);
+                        if (buffer.AsSpan().StartsWith(JsonConstants.Utf8Bom))
+                        {
+                            start += utf8BomLength;
+                            bytesInBuffer -= utf8BomLength;
+                        }
+                    }
+
                     // Process the data available
                     ReadCore(
                         ref readerState,
                         isFinalBlock,
-                        new Span<byte>(buffer, 0, bytesInBuffer),
+                        new ReadOnlySpan<byte>(buffer, start, bytesInBuffer),
                         options,
                         ref readStack);
 
@@ -155,9 +170,10 @@ namespace System.Text.Json
                     {
                         // We have less than half the buffer available, double the buffer size.
                         byte[] dest = ArrayPool<byte>.Shared.Rent((buffer.Length < (int.MaxValue / 2)) ? buffer.Length * 2 : int.MaxValue);
-                        
+
                         // Copy the unprocessed data to the new buffer while shifting the processed bytes.
-                        Buffer.BlockCopy(buffer, bytesConsumed, dest, 0, bytesInBuffer);
+                        Debug.Assert(start > 0);
+                        Buffer.BlockCopy(buffer, bytesConsumed + start, dest, 0, bytesInBuffer);
 
                         new Span<byte>(buffer, 0, clearMax).Clear();
                         ArrayPool<byte>.Shared.Return(buffer);
@@ -190,7 +206,7 @@ namespace System.Text.Json
         private static void ReadCore(
             ref JsonReaderState readerState,
             bool isFinalBlock,
-            Span<byte> buffer,
+            ReadOnlySpan<byte> buffer,
             JsonSerializerOptions options,
             ref ReadStack readStack)
         {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -172,7 +172,6 @@ namespace System.Text.Json
                         byte[] dest = ArrayPool<byte>.Shared.Rent((buffer.Length < (int.MaxValue / 2)) ? buffer.Length * 2 : int.MaxValue);
 
                         // Copy the unprocessed data to the new buffer while shifting the processed bytes.
-                        Debug.Assert(start > 0);
                         Buffer.BlockCopy(buffer, bytesConsumed + start, dest, 0, bytesInBuffer);
 
                         new Span<byte>(buffer, 0, clearMax).Clear();

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -440,6 +440,20 @@ namespace System.Text.Json.Tests
             }
         }
 
+        [Theory]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false)]
+        public static void TestBOMWithSingleJsonValue(byte[] utf8BomAndValue, bool isFinalBlock)
+        {
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                var json = new Utf8JsonReader(utf8BomAndValue, isFinalBlock: isFinalBlock, state: default);
+                json.Read();
+            });
+        }
+
         [Fact]
         public static void TestSingleStringsMultiSegmentByOne()
         {

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -1797,20 +1797,6 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true)]
-        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false)]
-        public static void TestBOMWithSingleJsonValue(byte[] utf8BomAndValue, bool isFinalBlock)
-        {
-            Assert.ThrowsAny<JsonException>(() =>
-            {
-                var json = new Utf8JsonReader(utf8BomAndValue, isFinalBlock: isFinalBlock, state: default);
-                json.Read();
-            });
-        }
-
-        [Theory]
         [MemberData(nameof(SingleValueJson))]
         public static void SingleJsonValue(string jsonString, string expectedString)
         {

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -1797,6 +1797,20 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false)]
+        public static void TestBOMWithSingleJsonValue(byte[] utf8BomAndValue, bool isFinalBlock)
+        {
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                var json = new Utf8JsonReader(utf8BomAndValue, isFinalBlock: isFinalBlock, state: default);
+                json.Read();
+            });
+        }
+
+        [Theory]
         [MemberData(nameof(SingleValueJson))]
         public static void SingleJsonValue(string jsonString, string expectedString)
         {
@@ -3817,6 +3831,29 @@ namespace System.Text.Json.Tests
                     new object[] {"[1,/*comment*/]"},
                 };
             }
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true, 1)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true, 2)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, true, 3)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false, 1)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false, 2)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, (byte)'1' }, false, 3)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true, 1)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true, 2)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, true, 3)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false, 1)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false, 2)]
+        [InlineData(new byte[] { 0xEF, 0xBB, 0xBF }, false, 3)]
+        public static void TestBOMWithSingleJsonValueMultiSegment(byte[] utf8BomAndValue, bool isFinalBlock, int segmentSize)
+        {
+            Assert.ThrowsAny<JsonException>(() =>
+            {
+                ReadOnlySequence<byte> sequence = JsonTestHelper.GetSequence(utf8BomAndValue, segmentSize);
+                var json = new Utf8JsonReader(sequence, isFinalBlock: isFinalBlock, state: default);
+                json.Read();
+            });
         }
 
         public static IEnumerable<object[]> JsonWithInvalidTrailingCommas


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38418