### PR TITLE
Don't swallow OCE unconditionally

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
@@ -241,12 +241,16 @@ namespace System.IO.Pipelines
                 {
                     ClearCancellationToken();
 
-                    if (cancellationToken.IsCancellationRequested)
+                    if (tokenSource.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                    {
+                        // Catch cancellation and translate it into setting isCanceled = true
+                        isCanceled = true;
+                    }
+                    else
                     {
                         throw;
                     }
 
-                    isCanceled = true;
                 }
 
                 return new ReadResult(GetCurrentReadOnlySequence(), isCanceled, _isStreamCompleted);

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -306,13 +306,13 @@ namespace System.IO.Pipelines
                         _internalTokenSource = null;
                     }
 
-                    if (cancellationToken.IsCancellationRequested)
+                    if (localToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                     {
-                        throw;
+                        // Catch cancellation and translate it into setting isCanceled = true
+                        return new FlushResult(isCanceled: true, isCompleted: false);
                     }
 
-                    // Catch any cancellation and translate it into setting isCanceled = true
-                    return new FlushResult(isCanceled: true, isCompleted: false);
+                    throw;
                 }
             }
         }


### PR DESCRIPTION
- Today we swallow OperationCanceledExceptions to avoid throwing if CancelPendingRead/CancelPendingFlush, this unintentionally swallows all exceptions that derive from OperationCancelled that were triggered by the ReadAsync call itself. This change rethrows the error unless we're in that specific case of having called one of those Cancel* methods.
- Added tests and did some other small test cleanup.