### PR TITLE
Implement MaxResponseHeadersLength for HTTP2

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -519,4 +519,10 @@
   <data name="net_http_hpack_late_dynamic_table_size_update" xml:space="preserve">
     <value>Dynamic table size update received after beginning of header block.</value>
   </data>
+  <data name="net_http_hpack_huffman_string_length_too_large" xml:space="preserve">
+    <value>Huffman-coded header of length {0} exceeds configured maximum of {1} specified by MaxResponseHeadersLength.</value>
+  </data>
+  <data name="net_http_hpack_string_length_too_large" xml:space="preserve">
+    <value>Header of length {0} exceeds configured maximum of {1} specified by MaxResponseHeadersLength.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -87,7 +87,7 @@ namespace System.Net.Http
             _outgoingBuffer = new ArrayBuffer(InitialConnectionBufferSize);
             _headerBuffer = new ArrayBuffer(InitialConnectionBufferSize);
 
-            _hpackDecoder = new HPackDecoder();
+            _hpackDecoder = new HPackDecoder(maxRequestHeaderFieldSize: pool.Settings._maxResponseHeadersLength * 1024);
 
             _httpStreams = new Dictionary<int, Http2Stream>();
 

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -145,7 +145,6 @@
     <Compile Include="HttpClientHandlerTest.Decompression.cs" />
     <Compile Include="HttpClientTest.netcoreapp.cs" />
     <Compile Include="HttpMethodTest.netcoreapp.cs" />
-    <Compile Include="HuffmanDecodingTests.cs" />
     <Compile Include="NtAuthTests.cs" />
     <Compile Include="ReadOnlyMemoryContentTest.cs" />
     <Compile Include="SocketsHttpHandlerTest.cs" />

--- a/src/System.Net.Http/tests/UnitTests/HPack/HuffmanDecodingTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HuffmanDecodingTests.cs
@@ -3,31 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Xunit;
+using System.Net.Http.HPack;
 
-namespace System.Net.Http.Functional.Tests
+namespace System.Net.Http.Unit.Tests.HPack
 {
     public class HuffmanDecodingTests
     {
-        delegate int DecodeDelegate(ReadOnlySpan<byte> src, ref byte[] dst);
-
-        private static readonly DecodeDelegate s_decodeDelegate = GetDecodeDelegate();
-
-        private static DecodeDelegate GetDecodeDelegate()
-        {
-            Assembly assembly = typeof(HttpClient).Assembly;
-            Type huffmanType = assembly.GetType("System.Net.Http.HPack.Huffman");
-            MethodInfo decodeMethod = huffmanType.GetMethod("Decode", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
-            return (DecodeDelegate)Delegate.CreateDelegate(typeof(DecodeDelegate), decodeMethod);
-        }
-
-        private static int Decode(ReadOnlySpan<byte> source, ref byte[] destination)
-        {
-            return s_decodeDelegate(source, ref destination);
-        }
-
         private static readonly (uint code, int bitLength)[] s_encodingTable = new (uint code, int bitLength)[]
         {
             (0b11111111_11000000_00000000_00000000, 13),
@@ -347,8 +332,9 @@ namespace System.Net.Http.Functional.Tests
             // Worst case decoding is an output byte per 5 input bits, so make the decoded buffer 2 times as big
             byte[] decoded = new byte[encoded.Length * 2];
 
-            int decodedByteCount = Decode(new ReadOnlySpan<byte>(encoded, 0, encodedByteCount), ref decoded);
+            bool success = Huffman.TryDecode(new ReadOnlySpan<byte>(encoded, 0, encodedByteCount), ref decoded, int.MaxValue, out int decodedByteCount);
 
+            Assert.True(success);
             Assert.Equal(input.Length, decodedByteCount);
             Assert.Equal(input, decoded.Take(decodedByteCount));
         }
@@ -362,7 +348,7 @@ namespace System.Net.Http.Functional.Tests
             // Worst case decoding is an output byte per 5 input bits, so make the decoded buffer 2 times as big
             byte[] decoded = new byte[encoded.Length * 2];
 
-            Assert.Throws(s_huffmanDecodingExceptionType, () => Decode(encoded, ref decoded));
+            Assert.Throws(s_huffmanDecodingExceptionType, () => Huffman.TryDecode(encoded, ref decoded, int.MaxValue, out int _));
         }
 
         // This input sequence will encode to 17 bits, thus offsetting the next character to encode

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -409,6 +409,7 @@
     <Compile Include="Headers\WarningHeaderValueTest.cs" />
     <Compile Include="HPack\HPackDecoderTest.cs" />
     <Compile Include="HPack\HPackIntegerTest.cs" />
+    <Compile Include="HPack\HuffmanDecodingTests.cs" />
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpRuleParserTest.cs" />
     <Compile Include="MockContent.cs" />


### PR DESCRIPTION
Resolves #35528.

Implement MaxResponseHeadersLength for HTTP2. This checks both pre- and post-Huffman decode.
Add a new test for huffman-coded MaxResponseHeadersLength, and port over two more from ASP.NET for the plaintext variant.
Move HuffmanDecodingTests from functional to unit tests to avoid reflection.

Reviewers note: two tests are brought over from ASP.NET (these are the final two, now we have them all) and are intentionally not scrubbed for styling to make future diffs easier -- see `DecodesStringLength_GreaterThanLimit_Error` and `DecodesStringLength_LimitConfigurable`.