### PR TITLE
Changed DisplayNameAttribute targets to all

### DIFF
--- a/src/System.ComponentModel.Primitives/src/System/ComponentModel/DisplayNameAttribute.cs
+++ b/src/System.ComponentModel.Primitives/src/System/ComponentModel/DisplayNameAttribute.cs
@@ -8,7 +8,7 @@ namespace System.ComponentModel
     /// Specifies the display name for a property or event.
     /// The default is the name of the property or event.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Event | AttributeTargets.Class | AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.All)]
     public class DisplayNameAttribute : Attribute
     {
         /// <summary>


### PR DESCRIPTION
I wanted to apply the DisplayNameAttribute to enum values, but currently it can't be used for that purpose because the targets are limited. I've discovered someone else who wanted to do the same thing, but [used the DescriptionAttribute](https://www.codingame.com/playgrounds/2487/c---how-to-display-friendly-names-for-enumerations).

While it is possible to use the DescriptionAttribute I feel it has a different meaning, and in the future I might want to use both the DisplayNameAttribute and the DescriptionAttribute.

In my commit I've changed the targets to AttributeTargets.All because that is what DescriptionAttribute is using. A more limited target could suffice but I don't know what the trade-offs might be in that case. For instance adding AttributeTargets.Struct seems sensible as well.