### PR TITLE
Disable Socket_SendReceiveAsync_PropagateToStream_Success test on Windows

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.netcoreapp.cs
@@ -179,6 +179,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [ActiveIssue(29742, TestPlatforms.Windows)]
         [ConditionalTheory(nameof(PlatformSupportsUnixDomainSockets))]
         [InlineData(5000, 1, 1)]
         [InlineData(500, 18, 21)]


### PR DESCRIPTION
It's hanging sporadically in CI.
https://github.com/dotnet/corefx/issues/29742