### PR TITLE
make sure we close OS handle if socket is finalized without disposing 

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -4461,16 +4461,11 @@ namespace System.Net.Sockets
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposing)
-            {
-                return;
-            }
-
             if (NetEventSource.IsEnabled)
             {
                 try
                 {
-                    NetEventSource.Info(this, $"disposing:true CleanedUp:{CleanedUp}");
+                    NetEventSource.Info(this, $"disposing:{disposing} CleanedUp:{CleanedUp}");
                     NetEventSource.Enter(this);
                 }
                 catch (Exception exception) when (!ExceptionCheck.IsFatal(exception)) { }
@@ -4490,11 +4485,11 @@ namespace System.Net.Sockets
             try
             {
                 int timeout = _closeTimeout;
-                if (timeout == 0)
+                if (timeout == 0 || !disposing)
                 {
                     // Abortive.
                     if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling _handle.Dispose()");
-                    _handle.Dispose();
+                    _handle?.Dispose();
                 }
                 else
                 {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -331,6 +331,7 @@ namespace System.Net.Sockets
                             if (context != null)
                             {
                                 context.HandleEvents(_buffer[i].Events);
+                                context = null;
                             }
                         }
                     }

--- a/src/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.netcoreapp.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.netcoreapp.cs
@@ -18,15 +18,12 @@ namespace System.Net.Sockets.Tests
         public async Task NonDisposedSocket_SafeHandlesCollected(bool clientAsync)
         {
             List<WeakReference> handles = await CreateHandlesAsync(clientAsync);
-            int count = -1;
-
-            for (int i = 0; i < 10 && count != 0; i++)
+            RetryHelper.Execute(() =>
             {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                count = handles.Count(h => h.IsAlive);
-            }
-            Assert.Equal(0, count);
+                Assert.Equal(0, handles.Count(h => h.IsAlive));
+            });
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -66,8 +63,6 @@ namespace System.Net.Sockets.Tests
                             Assert.Equal(1, client.Receive(new byte[1]));
                         }
                     }
-
-                    client = null;
                 }
             }
 


### PR DESCRIPTION
If socket is finalized without disposing we currently leak OS socket as Dispose(false) does nothing. 

With this change, socket finalizer should nuke OS fd.
I originally forked CloseAsIs() but it seems like disposing _handle is sufficient.

The test @stephentoub wrote give me some grief.
It seems like EventLoop() can hold reference to SocketAsyncContext until new event kicks in.
I decided to explicitly drop that so we are more likely to release handle if finalize socket but there is no other activity for a while. 

fixes dotnet/runtime#29327
 