### PR TITLE
Providing support for duplicate keys in dictionary

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -198,14 +198,7 @@ namespace System.Text.Json
 
                 string key = state.Current.KeyName;
                 Debug.Assert(!string.IsNullOrEmpty(key));
-                if (!dictionary.Contains(key))
-                {
-                    dictionary.Add(key, value);
-                }
-                else
-                {
-                    ThrowHelper.ThrowJsonException_DeserializeDuplicateKey(key, reader, state.JsonPath);
-                }
+                dictionary[key] = value;
             }
             else if (state.Current.IsIDictionaryConstructible ||
                 (state.Current.IsIDictionaryConstructibleProperty && !setPropertyDirectly) ||
@@ -217,14 +210,7 @@ namespace System.Text.Json
 
                 string key = state.Current.KeyName;
                 Debug.Assert(!string.IsNullOrEmpty(key));
-                if (!dictionary.Contains(key))
-                {
-                    dictionary.Add(key, value);
-                }
-                else
-                {
-                    ThrowHelper.ThrowJsonException_DeserializeDuplicateKey(key, reader, state.JsonPath);
-                }
+                dictionary[key] = value;
             }
             else
             {
@@ -280,14 +266,7 @@ namespace System.Text.Json
 
                 string key = state.Current.KeyName;
                 Debug.Assert(!string.IsNullOrEmpty(key));
-                if (!dictionary.ContainsKey(key)) // The IDictionary.TryAdd extension method is not available in netstandard.
-                {
-                    dictionary.Add(key, value);
-                }
-                else
-                {
-                    ThrowHelper.ThrowJsonException_DeserializeDuplicateKey(key, reader, state.JsonPath);
-                }
+                dictionary[key] = value;
             }
             else if (state.Current.IsProcessingIDictionaryConstructibleOrKeyValuePair)
             {
@@ -296,14 +275,7 @@ namespace System.Text.Json
 
                 string key = state.Current.KeyName;
                 Debug.Assert(!string.IsNullOrEmpty(key));
-                if (!dictionary.ContainsKey(key)) // The IDictionary.TryAdd extension method is not available in netstandard.
-                {
-                    dictionary.Add(key, value);
-                }
-                else
-                {
-                    ThrowHelper.ThrowJsonException_DeserializeDuplicateKey(key, reader, state.JsonPath);
-                }
+                dictionary[key] = value;
             }
             else
             {

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -140,22 +140,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void DuplicateKeysFail()
-        {
-            // Non-generic IDictionary case.
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<IDictionary>(
-                @"{""Hello"":""World"", ""Hello"":""World""}"));
-
-            // Strongly-typed IDictionary<,> case.
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<Dictionary<string, string>>(
-                @"{""Hello"":""World"", ""Hello"":""World""}"));
-
-            // Weakly-typed IDictionary case.
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<Dictionary<string, object>>(
-                @"{""Hello"":null, ""Hello"":null}"));
-        }
-
-        [Fact]
         public static void DictionaryOfObject()
         {
             {

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -790,6 +790,21 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void DeserializeDictionaryWithDuplicateKeys()
+        {
+            // Strongly-typed IDictionary<,> case.
+            Dictionary<string, string> deserialize = JsonSerializer.Parse<Dictionary<string, string>>(@"{""Hello"":""World"", ""Hello"":""NewValue""}");
+            Assert.Equal("NewValue", deserialize["Hello"]);
+
+            deserialize = JsonSerializer.Parse<Dictionary<string, string>>(@"{""Hello"":""World"", ""myKey"" : ""myValue"", ""Hello"":""NewValue""}");
+            Assert.Equal("NewValue", deserialize["Hello"]);
+
+            // Weakly-typed IDictionary case.
+            Dictionary<string, object> deserializeObject = JsonSerializer.Parse<Dictionary<string, object>>(@"{""Hello"":""World"", ""Hello"": null}");
+            Assert.Null(deserializeObject["Hello"]);
+        }
+
+        [Fact]
         public static void ClassWithNoSetter()
         {
             string json = @"{""MyDictionary"":{""Key"":""Value""}}";

--- a/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
@@ -35,7 +35,7 @@ namespace System.Text.Json.Serialization.Tests
             try
             {
                 JsonSerializer.Parse<IDictionary<string, string>>(@"{""Key"":1, ""Key"":2}");
-                Assert.True(false, "Expected JsonException was not thrown.");
+                Assert.True(false, "We follow 'Last value wins' approach for duplicate keys.");
             }
             catch (JsonException e)
             {

--- a/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
@@ -34,14 +34,14 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<IDictionary<string, int>>(@"{""Key"":1, ""Key"":2}");
+                JsonSerializer.Parse<IDictionary<string, string>>(@"{""Key"":1, ""Key"":2}");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
             {
                 Assert.Equal(0, e.LineNumber);
-                Assert.Equal(17, e.BytePositionInLine);
-                Assert.Contains("LineNumber: 0 | BytePositionInLine: 17.", e.Message);
+                Assert.Equal(8, e.BytePositionInLine);
+                Assert.Contains("LineNumber: 0 | BytePositionInLine: 8.", e.Message);
                 Assert.Contains("$.Key", e.Path);
 
                 // Verify Path is not repeated.


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/37694

``` ini
Before and After the change

```
|                         Method |  Mean(A) |  Mean(B)  |     Error |    StdDev |
|------------------------------- |---------:|----------:|----------:|----------:|
|       DeserializeDuplicateKeys | 7.052 us | 7.531 us  | 0.0194 us | 0.0172 us |
