### PR TITLE
Fix nested objects in object arrays

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1284,6 +1284,7 @@ namespace System.Text.Json
             }
         }
 
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private string DebuggerDisplay => $"Type = {Type} : \"{ToString()}\"";
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -2436,6 +2436,7 @@ namespace System.Text.Json
             return true;
         }
 
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private string DebuggerDisplay => $"TokenType = {DebugTokenType} (TokenStartIndex = {TokenStartIndex}) Consumed = {BytesConsumed}";
 
         // Using TokenType.ToString() (or {TokenType}) fails to render in the debug window. The

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -1088,6 +1088,7 @@ namespace System.Text.Json
             _currentDepth |= 1 << 31;
         }
 
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private string DebuggerDisplay => $"BytesCommitted = {BytesCommitted} BytesPending = {BytesPending} CurrentDepth = {CurrentDepth}";
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -89,6 +89,43 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ReadArrayInObjectArray()
+        {
+            object[] array = JsonSerializer.Parse<object[]>(@"[[]]");
+            Assert.Equal(1, array.Length);
+            Assert.IsType<JsonElement>(array[0]);
+            Assert.Equal(JsonValueType.Array, ((JsonElement)array[0]).Type);
+        }
+
+        [Fact]
+        public static void ReadObjectInObjectArray()
+        {
+            object[] array = JsonSerializer.Parse<object[]>(@"[{}]");
+            Assert.Equal(1, array.Length);
+            Assert.IsType<JsonElement>(array[0]);
+            Assert.Equal(JsonValueType.Object, ((JsonElement)array[0]).Type);
+
+            // Scenario described in https://github.com/dotnet/corefx/issues/36169
+            array = JsonSerializer.Parse<object[]>("[1, false]");
+            Assert.Equal(2, array.Length);
+            Assert.IsType<JsonElement>(array[0]);
+            Assert.Equal(JsonValueType.Number, ((JsonElement)array[0]).Type);
+            Assert.Equal(1, ((JsonElement)array[0]).GetInt32());
+            Assert.IsType<JsonElement>(array[1]);
+            Assert.Equal(JsonValueType.False, ((JsonElement)array[1]).Type);
+
+            array = JsonSerializer.Parse<object[]>(@"[1, false, { ""name"" : ""Person"" }]");
+            Assert.Equal(3, array.Length);
+            Assert.IsType<JsonElement>(array[0]);
+            Assert.Equal(JsonValueType.Number, ((JsonElement)array[0]).Type);
+            Assert.Equal(1, ((JsonElement)array[0]).GetInt32());
+            Assert.IsType<JsonElement>(array[1]);
+            Assert.Equal(JsonValueType.False, ((JsonElement)array[1]).Type);
+            Assert.IsType<JsonElement>(array[2]);
+            Assert.Equal(JsonValueType.Object, ((JsonElement)array[2]).Type);
+        }
+
+        [Fact]
         public static void ReadClassWithComplexObjects()
         {
             ClassWithComplexObjects obj = JsonSerializer.Parse<ClassWithComplexObjects>(ClassWithComplexObjects.s_json);


### PR DESCRIPTION
We weren't recognizing polymorphism for json objects nested in .NET object arrays.

This change also hides the debugger backing field for clarity.