### PR TITLE
System.Text.Json Support for DateTime with Slash

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -80,7 +80,7 @@ namespace System.Text.Json
                 year = (int)(digit1 * 1000 + digit2 * 100 + digit3 * 10 + digit4);
             }
 
-            if (source[4] != JsonConstants.Hyphen)
+            if (source[4] != JsonConstants.Hyphen && source[4] != JsonConstants.Slash)
             {
                 goto ReturnFalse;
             }
@@ -91,7 +91,7 @@ namespace System.Text.Json
                 goto ReturnFalse;
             }
 
-            if (source[7] != JsonConstants.Hyphen)
+            if (source[7] != JsonConstants.Hyphen && source[4] != JsonConstants.Slash)
             {
                 goto ReturnFalse;
             }

--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.Date.cs
@@ -57,6 +57,9 @@ namespace System.Text.Json
         // YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45-0100)
         // YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01)
         // YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45-01)
+        // ---------------------------------
+        // The - and / values may be used interchangeably as input here eg:
+        // YYYY/MM/DD (eg 1997/07/16)
         private static bool TryParseDateTimeOffset(ReadOnlySpan<byte> source, out DateTimeOffset value, out int bytesConsumed, out DateTimeKind kind)
         {
             // Source does not have enough characters for YYYY-MM-DD

--- a/src/System.Text.Json/tests/JsonDateTimeTestData.cs
+++ b/src/System.Text.Json/tests/JsonDateTimeTestData.cs
@@ -19,6 +19,10 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-16T19:20:30.45\"", "1997-07-16T19:20:30.45" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555\"", "1997-07-16T19:20:30.4555555" };
 
+            // Explicitly test that the forward slash is supported
+            yield return new object[] { "\"0997/07/16\"", "0997/07/16" };
+            yield return new object[] { "\"1997/07/16\"", "1997/07/16" };
+
             // Skip test T24:00 till #35830 is fixed.
             // yield return new object[] { "\"1997-07-16T24:00\"", "1997-07-16T24:00" };
 

--- a/src/System.Text.Json/tests/JsonDateTimeTestData.cs
+++ b/src/System.Text.Json/tests/JsonDateTimeTestData.cs
@@ -143,6 +143,10 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"0997-07-166\"" };
             yield return new object[] { "\"1997-07-1sdsad\"" };
             yield return new object[] { "\"1997-07-16T19200\"" };
+            
+            // Explicitly test that the back slash is not supported
+            yield return new object[] { "\"0997\\\\07\\\\16\"" };
+            yield return new object[] { "\"1997\\\\07\\\\16\"" };
 
             // Invalid YYYY-MM-DDThh:mm
             yield return new object[] { "\"1997-07-16T1\"" };


### PR DESCRIPTION
Currently, parsing `DateTime` and `DateTimeOffset` values require the format to start with `YYYY-MM-DD`. If the date format is instead `YYYY/MM/DD`, the parse fails. The `DateTime.Parse` function accepts dates using `/` _and_ `-` so I've updated the parser to also support this.