### PR TITLE
Re-activate test Transactions test.

### DIFF
--- a/src/System.Transactions.Local/tests/AsyncTransactionScopeTests.cs
+++ b/src/System.Transactions.Local/tests/AsyncTransactionScopeTests.cs
@@ -96,7 +96,6 @@ namespace System.Transactions.Tests
         [InlineData(52)]
         [InlineData(53)]
         [InlineData(54)]
-        [ActiveIssue(31913, TargetFrameworkMonikers.Uap)]
         public void AsyncTSTest(int variation)
         {
             RemoteExecutor.Invoke(variationString =>


### PR DESCRIPTION
* This test was disabled a long time ago with failures only occuring in CI.
* Re-enabling to see if the issue still exists.
* System.Transactions.Tests.AsyncTransactionScopeTests.AsyncTSTest