### PR TITLE
Use the High Sierra macOS pool

### DIFF
--- a/eng/pipelines/macos.yml
+++ b/eng/pipelines/macos.yml
@@ -39,7 +39,7 @@ jobs:
               _publishTests: true
 
       pool:
-        name: Hosted macOS
+        name: Hosted macOS High Sierra
 
       preBuildSteps:
         - script: |


### PR DESCRIPTION
We need to build with the lowest supported macOS version because of the native shims.