### PR TITLE
Implement MaxResponseHeadersLength for HTTP2

### DIFF
--- a/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -44,14 +44,14 @@ namespace System.Net.Test.Common
     {
         public string Name { get; }
         public string Value { get; }
-        public bool HuffmanCode { get; }
+        public bool HuffmanEncoded { get; }
         public byte[] Raw { get; }
 
-        public HttpHeaderData(string name, string value, bool huffmanCode = false, byte[] raw = null)
+        public HttpHeaderData(string name, string value, bool huffmanEncoded = false, byte[] raw = null)
         {
             Name = name;
             Value = value;
-            HuffmanCode = huffmanCode;
+            HuffmanEncoded = huffmanEncoded;
             Raw = raw;
         }
 

--- a/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -44,12 +44,14 @@ namespace System.Net.Test.Common
     {
         public string Name { get; }
         public string Value { get; }
+        public bool HuffmanCode { get; }
         public byte[] Raw { get; }
 
-        public HttpHeaderData(string name, string value, byte[] raw = null)
+        public HttpHeaderData(string name, string value, bool huffmanCode = false, byte[] raw = null)
         {
             Name = name;
             Value = value;
+            HuffmanCode = huffmanCode;
             Raw = raw;
         }
 

--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -324,13 +324,30 @@ namespace System.Net.Test.Common
             }
         }
 
-        private static int EncodeString(string value, Span<byte> headerBlock)
+        private static int EncodeString(string value, Span<byte> headerBlock, bool huffmanCode)
         {
-            int bytesGenerated = EncodeInteger(value.Length, 0, 0x80, headerBlock);
+            byte[] data = Encoding.ASCII.GetBytes(value);
+            byte prefix;
 
-            bytesGenerated += Encoding.ASCII.GetBytes(value.AsSpan(), headerBlock.Slice(bytesGenerated));
+            if (!huffmanCode)
+            {
+                prefix = 0;
+            }
+            else
+            {
+                int len = HuffmanEncoder.GetEncodedLength(data);
 
-            return bytesGenerated;
+                byte[] huffmanData = new byte[len];
+                HuffmanEncoder.Encode(data, huffmanData);
+
+                data = huffmanData;
+                prefix = 0x80;
+            }
+
+            int bytesGenerated = EncodeInteger(data.Length, prefix, 0x80, headerBlock);
+            data.AsSpan().CopyTo(headerBlock.Slice(bytesGenerated));
+
+            return bytesGenerated + data.Length;
         }
 
         private static readonly HttpHeaderData[] s_staticTable = new HttpHeaderData[]
@@ -460,10 +477,10 @@ namespace System.Net.Test.Common
 
         private static int EncodeHeader(HttpHeaderData headerData, Span<byte> headerBlock)
         {
-            // Always encode as literal, no indexing
+            // Always encode as literal, no indexing.
             int bytesGenerated = EncodeInteger(0, 0, 0b11110000, headerBlock);
-            bytesGenerated += EncodeString(headerData.Name, headerBlock.Slice(bytesGenerated));
-            bytesGenerated += EncodeString(headerData.Value, headerBlock.Slice(bytesGenerated));
+            bytesGenerated += EncodeString(headerData.Name, headerBlock.Slice(bytesGenerated), headerData.HuffmanCode);
+            bytesGenerated += EncodeString(headerData.Value, headerBlock.Slice(bytesGenerated), headerData.HuffmanCode);
             return bytesGenerated;
         }
 
@@ -530,7 +547,7 @@ namespace System.Net.Test.Common
                 (int bytesConsumed, HttpHeaderData headerData) = DecodeHeader(data.Span.Slice(i));
 
                 byte[] headerRaw = data.Span.Slice(i, bytesConsumed).ToArray();
-                headerData = new HttpHeaderData(headerData.Name, headerData.Value, headerRaw);
+                headerData = new HttpHeaderData(headerData.Name, headerData.Value, huffmanCode: headerData.HuffmanCode, headerRaw);
 
                 requestData.Headers.Add(headerData);
                 i += bytesConsumed;

--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -324,12 +324,12 @@ namespace System.Net.Test.Common
             }
         }
 
-        private static int EncodeString(string value, Span<byte> headerBlock, bool huffmanCode)
+        private static int EncodeString(string value, Span<byte> headerBlock, bool huffmanEncode)
         {
             byte[] data = Encoding.ASCII.GetBytes(value);
             byte prefix;
 
-            if (!huffmanCode)
+            if (!huffmanEncode)
             {
                 prefix = 0;
             }
@@ -344,10 +344,14 @@ namespace System.Net.Test.Common
                 prefix = 0x80;
             }
 
-            int bytesGenerated = EncodeInteger(data.Length, prefix, 0x80, headerBlock);
-            data.AsSpan().CopyTo(headerBlock.Slice(bytesGenerated));
+            int bytesGenerated = 0;
 
-            return bytesGenerated + data.Length;
+            bytesGenerated += EncodeInteger(data.Length, prefix, 0x80, headerBlock);
+
+            data.AsSpan().CopyTo(headerBlock.Slice(bytesGenerated));
+            bytesGenerated += data.Length;
+
+            return bytesGenerated;
         }
 
         private static readonly HttpHeaderData[] s_staticTable = new HttpHeaderData[]
@@ -479,8 +483,8 @@ namespace System.Net.Test.Common
         {
             // Always encode as literal, no indexing.
             int bytesGenerated = EncodeInteger(0, 0, 0b11110000, headerBlock);
-            bytesGenerated += EncodeString(headerData.Name, headerBlock.Slice(bytesGenerated), headerData.HuffmanCode);
-            bytesGenerated += EncodeString(headerData.Value, headerBlock.Slice(bytesGenerated), headerData.HuffmanCode);
+            bytesGenerated += EncodeString(headerData.Name, headerBlock.Slice(bytesGenerated), headerData.HuffmanEncoded);
+            bytesGenerated += EncodeString(headerData.Value, headerBlock.Slice(bytesGenerated), headerData.HuffmanEncoded);
             return bytesGenerated;
         }
 
@@ -547,7 +551,7 @@ namespace System.Net.Test.Common
                 (int bytesConsumed, HttpHeaderData headerData) = DecodeHeader(data.Span.Slice(i));
 
                 byte[] headerRaw = data.Span.Slice(i, bytesConsumed).ToArray();
-                headerData = new HttpHeaderData(headerData.Name, headerData.Value, huffmanCode: headerData.HuffmanCode, headerRaw);
+                headerData = new HttpHeaderData(headerData.Name, headerData.Value, headerData.HuffmanEncoded, headerRaw);
 
                 requestData.Headers.Add(headerData);
                 i += bytesConsumed;

--- a/src/Common/tests/System/Net/Http/HuffmanEncoder.cs
+++ b/src/Common/tests/System/Net/Http/HuffmanEncoder.cs
@@ -7,6 +7,7 @@ namespace System.Net.Test.Common
     public static class HuffmanEncoder
     {
         // Stolen from product code
+        // See https://github.com/dotnet/corefx/blob/ae7b3970bb2c8d76004ea397083ce7ceb1238133/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/Huffman.cs#L12
         private static readonly (uint code, int bitLength)[] s_encodingTable = new (uint code, int bitLength)[]
         {
             (0b11111111_11000000_00000000_00000000, 13),

--- a/src/Common/tests/System/Net/Http/HuffmanEncoder.cs
+++ b/src/Common/tests/System/Net/Http/HuffmanEncoder.cs
@@ -1,14 +1,12 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-// See THIRD-PARTY-NOTICES.TXT in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-
-namespace System.Net.Http.HPack
+namespace System.Net.Test.Common
 {
-    internal class Huffman
+    public static class HuffmanEncoder
     {
-        // TODO: this can be constructed from _decodingTable
+        // Stolen from product code
         private static readonly (uint code, int bitLength)[] s_encodingTable = new (uint code, int bitLength)[]
         {
             (0b11111111_11000000_00000000_00000000, 13),
@@ -270,175 +268,44 @@ namespace System.Net.Http.HPack
             (0b11111111_11111111_11111111_11111100, 30)
         };
 
-        private static readonly (int codeLength, int[] codes)[] s_decodingTable = new[]
+        public static int GetEncodedLength(ReadOnlySpan<byte> src)
         {
-            (5, new[] { 48, 49, 50, 97, 99, 101, 105, 111, 115, 116 }),
-            (6, new[] { 32, 37, 45, 46, 47, 51, 52, 53, 54, 55, 56, 57, 61, 65, 95, 98, 100, 102, 103, 104, 108, 109, 110, 112, 114, 117 }),
-            (7, new[] { 58, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 89, 106, 107, 113, 118, 119, 120, 121, 122 }),
-            (8, new[] { 38, 42, 44, 59, 88, 90 }),
-            (10, new[] { 33, 34, 40, 41, 63 }),
-            (11, new[] { 39, 43, 124 }),
-            (12, new[] { 35, 62 }),
-            (13, new[] { 0, 36, 64, 91, 93, 126 }),
-            (14, new[] { 94, 125 }),
-            (15, new[] { 60, 96, 123 }),
-            (19, new[] { 92, 195, 208 }),
-            (20, new[] { 128, 130, 131, 162, 184, 194, 224, 226 }),
-            (21, new[] { 153, 161, 167, 172, 176, 177, 179, 209, 216, 217, 227, 229, 230 }),
-            (22, new[] { 129, 132, 133, 134, 136, 146, 154, 156, 160, 163, 164, 169, 170, 173, 178, 181, 185, 186, 187, 189, 190, 196, 198, 228, 232, 233 }),
-            (23, new[] { 1, 135, 137, 138, 139, 140, 141, 143, 147, 149, 150, 151, 152, 155, 157, 158, 165, 166, 168, 174, 175, 180, 182, 183, 188, 191, 197, 231, 239 }),
-            (24, new[] { 9, 142, 144, 145, 148, 159, 171, 206, 215, 225, 236, 237 }),
-            (25, new[] { 199, 207, 234, 235 }),
-            (26, new[] { 192, 193, 200, 201, 202, 205, 210, 213, 218, 219, 238, 240, 242, 243, 255 }),
-            (27, new[] { 203, 204, 211, 212, 214, 221, 222, 223, 241, 244, 245, 246, 247, 248, 250, 251, 252, 253, 254 }),
-            (28, new[] { 2, 3, 4, 5, 6, 7, 8, 11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 23, 24, 25, 26, 27, 28, 29, 30, 31, 127, 220, 249 }),
-            (30, new[] { 10, 13, 22, 256 })
-        };
+            int bits = 0;
 
-        public static (uint encoded, int bitLength) Encode(int data)
-        {
-            return s_encodingTable[data];
-        }
-
-        /// <summary>
-        /// Decodes a Huffman encoded string from a byte array.
-        /// </summary>
-        /// <param name="src">The source byte array containing the encoded data.</param>
-        /// <param name="dstArray">The destination byte array to store the decoded data.  This may grow if its size is insufficient.</param>
-        /// <param name="maximumDecodeLength">The maximum number of symbols to decode.</param>
-        /// <param name="decodedSymbolsLength">Receives the number of decoded symbols.</param>
-        /// <returns>The number of decoded symbols.</returns>
-        public static bool TryDecode(ReadOnlySpan<byte> src, ref byte[] dstArray, int maximumDecodeLength, out int decodedSymbolsLength)
-        {
-            Debug.Assert(dstArray != null && dstArray.Length > 0);
-
-            Span<byte> dst = dstArray.Length <= maximumDecodeLength ? dstArray.AsSpan() : dstArray.AsSpan(0, maximumDecodeLength);
-
-            int i = 0;
-            int j = 0;
-            int lastDecodedBits = 0;
-            while (i < src.Length)
+            foreach (byte x in src)
             {
-                // Note that if lastDecodeBits is 3 or more, then we will only get 5 bits (or less)
-                // from src[i]. Thus we need to read 5 bytes here to ensure that we always have 
-                // at least 30 bits available for decoding.
-                // TODO ISSUE 31751: Rework this as part of Huffman perf improvements
-                uint next = (uint)(src[i] << 24 + lastDecodedBits);
-                next |= (i + 1 < src.Length ? (uint)(src[i + 1] << 16 + lastDecodedBits) : 0);
-                next |= (i + 2 < src.Length ? (uint)(src[i + 2] << 8 + lastDecodedBits) : 0);
-                next |= (i + 3 < src.Length ? (uint)(src[i + 3] << lastDecodedBits) : 0);
-                next |= (i + 4 < src.Length ? (uint)(src[i + 4] >> (8 - lastDecodedBits)) : 0);
-
-                uint ones = (uint)(int.MinValue >> (8 - lastDecodedBits - 1));
-                if (i == src.Length - 1 && lastDecodedBits > 0 && (next & ones) == ones)
-                {
-                    // The remaining 7 or less bits are all 1, which is padding.
-                    // We specifically check that lastDecodedBits > 0 because padding
-                    // longer than 7 bits should be treated as a decoding error.
-                    // http://httpwg.org/specs/rfc7541.html#rfc.section.5.2
-                    break;
-                }
-
-                // The longest possible symbol size is 30 bits. If we're at the last 4 bytes
-                // of the input, we need to make sure we pass the correct number of valid bits
-                // left, otherwise the trailing 0s in next may form a valid symbol.
-                int validBits = Math.Min(30, (8 - lastDecodedBits) + (src.Length - i - 1) * 8);
-                int ch = DecodeValue(next, validBits, out int decodedBits);
-
-                if (ch == -1)
-                {
-                    // No valid symbol could be decoded with the bits in next
-                    throw new HuffmanDecodingException();
-                }
-                else if (ch == 256)
-                {
-                    // A Huffman-encoded string literal containing the EOS symbol MUST be treated as a decoding error.
-                    // http://httpwg.org/specs/rfc7541.html#rfc.section.5.2
-                    throw new HuffmanDecodingException();
-                }
-
-                if (j == dst.Length)
-                {
-                    if (j == maximumDecodeLength)
-                    {
-                        decodedSymbolsLength = default;
-                        return false;
-                    }
-
-                    Array.Resize(ref dstArray, dst.Length * 2);
-                    dst = dstArray.Length <= maximumDecodeLength ? dstArray.AsSpan() : dstArray.AsSpan(0, maximumDecodeLength);
-                }
-
-                dst[j++] = (byte)ch;
-
-                // If we crossed a byte boundary, advance i so we start at the next byte that's not fully decoded.
-                lastDecodedBits += decodedBits;
-                i += lastDecodedBits / 8;
-
-                // Modulo 8 since we only care about how many bits were decoded in the last byte that we processed.
-                lastDecodedBits %= 8;
+                bits += s_encodingTable[x].bitLength;
             }
 
-            decodedSymbolsLength = j;
-            return true;
+            return (bits + 7) / 8;
         }
 
-        /// <summary>
-        /// Decodes a single symbol from a 32-bit word.
-        /// </summary>
-        /// <param name="data">A 32-bit word containing a Huffman encoded symbol.</param>
-        /// <param name="validBits">
-        /// The number of bits in <paramref name="data"/> that may contain an encoded symbol.
-        /// This is not the exact number of bits that encode the symbol. Instead, it prevents
-        /// decoding the lower bits of <paramref name="data"/> if they don't contain any
-        /// encoded data.
-        /// </param>
-        /// <param name="decodedBits">The number of bits decoded from <paramref name="data"/>.</param>
-        /// <returns>The decoded symbol.</returns>
-        private static int DecodeValue(uint data, int validBits, out int decodedBits)
+        public static int Encode(ReadOnlySpan<byte> src, Span<byte> dst)
         {
-            // The code below implements the decoding logic for a canonical Huffman code.
-            //
-            // To decode a symbol, we scan the decoding table, which is sorted by ascending symbol bit length.
-            // For each bit length b, we determine the maximum b-bit encoded value, plus one (that is codeMax).
-            // This is done with the following logic:
-            //
-            // if we're at the first entry in the table,
-            //    codeMax = the # of symbols encoded in b bits
-            // else,
-            //    left-shift codeMax by the difference between b and the previous entry's bit length,
-            //    then increment codeMax by the # of symbols encoded in b bits
-            //
-            // Next, we look at the value v encoded in the highest b bits of data. If v is less than codeMax,
-            // those bits correspond to a Huffman encoded symbol. We find the corresponding decoded
-            // symbol in the list of values associated with bit length b in the decoding table by indexing it
-            // with codeMax - v.
+            ulong buffer = 0;
+            int bufferLength = 0;
+            int dstIdx = 0;
 
-            int codeMax = 0;
-
-            for (int i = 0; i < s_decodingTable.Length && s_decodingTable[i].codeLength <= validBits; i++)
+            foreach (byte x in src)
             {
-                (int codeLength, int[] codes) = s_decodingTable[i];
+                (uint code, int codeLength) = s_encodingTable[x];
 
-                if (i > 0)
+                buffer = buffer << codeLength | code >> 32 - codeLength;
+                bufferLength += codeLength;
+
+                while (bufferLength >= 8)
                 {
-                    codeMax <<= codeLength - s_decodingTable[i - 1].codeLength;
-                }
-
-                codeMax += codes.Length;
-
-                int mask = int.MinValue >> (codeLength - 1);
-                long masked = (data & mask) >> (32 - codeLength);
-
-                if (masked < codeMax)
-                {
-                    decodedBits = codeLength;
-                    return codes[codes.Length - (codeMax - masked)];
+                    bufferLength -= 8;
+                    dst[dstIdx++] = (byte)(buffer >> bufferLength);
                 }
             }
 
-            decodedBits = 0;
-            return -1;
+            if (bufferLength != 0)
+            {
+                dst[dstIdx++] = (byte)(buffer << (8 - bufferLength) | 0xFFu >> bufferLength);
+            }
+
+            return dstIdx;
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -27,6 +27,7 @@ namespace System.Net.Http.HPack
 
         public const int DefaultHeaderTableSize = 4096;
         public const int DefaultStringOctetsSize = 4096;
+        public const int DefaultMaxResponseHeadersLength = 65536;
 
         // http://httpwg.org/specs/rfc7541.html#rfc.section.6.1
         //   0   1   2   3   4   5   6   7
@@ -83,6 +84,7 @@ namespace System.Net.Http.HPack
         private const int StringLengthPrefix = 7;
 
         private readonly int _maxDynamicTableSize;
+        private readonly int _maxResponseHeadersLength;
         private readonly DynamicTable _dynamicTable;
         private readonly IntegerDecoder _integerDecoder = new IntegerDecoder();
         private byte[] _stringOctets = new byte[DefaultStringOctetsSize];
@@ -98,25 +100,45 @@ namespace System.Net.Http.HPack
         private bool _index;
         private bool _huffman;
         private bool _headersObserved;
+        private int _headerDecodeBudgetRemaining;
 
-        public HPackDecoder(int maxDynamicTableSize = DefaultHeaderTableSize)
-            : this(maxDynamicTableSize, new DynamicTable(maxDynamicTableSize))
+        public HPackDecoder(int maxDynamicTableSize = DefaultHeaderTableSize, int maxResponseHeadersLength = DefaultMaxResponseHeadersLength)
+            : this(maxDynamicTableSize, maxResponseHeadersLength, new DynamicTable(maxDynamicTableSize))
         {
-            _maxDynamicTableSize = maxDynamicTableSize;
         }
 
         // For testing.
-        internal HPackDecoder(int maxDynamicTableSize, DynamicTable dynamicTable)
+        internal HPackDecoder(int maxDynamicTableSize, int maxResponseHeadersLength, DynamicTable dynamicTable)
         {
             _maxDynamicTableSize = maxDynamicTableSize;
+            _maxResponseHeadersLength = maxResponseHeadersLength;
             _dynamicTable = dynamicTable;
         }
 
-        public void Decode(ReadOnlySpan<byte> data, bool endHeaders, HeaderCallback onHeader, object onHeaderState)
+        /// <summary>
+        /// Decodes a block of HPACK data.
+        /// </summary>
+        /// <param name="data">The data to decode.</param>
+        /// <param name="endHeaders">If true, this is the last header block and should finish decoding.</param>
+        /// <param name="onHeader">Called whenever a header has been fully decoded.</param>
+        /// <param name="onHeaderState">State passed to the header <paramref name="onHeader"/>.</param>
+        /// <param name="headerDecodeBudget">The maximum length of data to process, including any compressed data.</param>
+        /// <returns>
+        /// Returns the uncompressed length of data processed. If a header is Huffman-coded, the
+        /// length processed will be the maximum of the encoded and decoded length of data.
+        /// </returns>
+        public int Decode(ReadOnlySpan<byte> data, bool endHeaders, HeaderCallback onHeader, object onHeaderState, int headerDecodeBudget = int.MaxValue)
         {
+            _headerDecodeBudgetRemaining = headerDecodeBudget;
+
             for (int i = 0; i < data.Length; i++)
             {
                 byte b = data[i];
+
+                if (_state != State.HeaderName && _state != State.HeaderValue && --_headerDecodeBudgetRemaining < 0)
+                {
+                    throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _maxResponseHeadersLength));
+                }
 
                 switch (_state)
                 {
@@ -343,6 +365,8 @@ namespace System.Net.Http.HPack
 
                 _headersObserved = false;
             }
+
+            return headerDecodeBudget - _headerDecodeBudgetRemaining;
         }
 
         public void CompleteDecode()
@@ -371,6 +395,13 @@ namespace System.Net.Http.HPack
 
         private void OnStringLength(int length, State nextState)
         {
+            _headerDecodeBudgetRemaining -= length;
+
+            if (_headerDecodeBudgetRemaining < 0)
+            {
+                throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _maxResponseHeadersLength));
+            }
+
             if (length > _stringOctets.Length)
             {
                 _stringOctets = new byte[Math.Max(length, _stringOctets.Length * 2)];
@@ -387,7 +418,19 @@ namespace System.Net.Http.HPack
             {
                 if (_huffman)
                 {
-                    return Huffman.Decode(new ReadOnlySpan<byte>(_stringOctets, 0, _stringLength), ref dst);
+                    int budget = _headerDecodeBudgetRemaining + _stringLength;
+
+                    if (!Huffman.TryDecode(new ReadOnlySpan<byte>(_stringOctets, 0, _stringLength), ref dst, budget, out int decodedSymbolsLength))
+                    {
+                        throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _maxResponseHeadersLength));
+                    }
+
+                    if (decodedSymbolsLength > _stringLength)
+                    {
+                        _headerDecodeBudgetRemaining = budget - decodedSymbolsLength;
+                    }
+
+                    return decodedSymbolsLength;
                 }
                 else
                 {

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/Huffman.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/Huffman.cs
@@ -305,14 +305,11 @@ namespace System.Net.Http.HPack
         /// </summary>
         /// <param name="src">The source byte array containing the encoded data.</param>
         /// <param name="dstArray">The destination byte array to store the decoded data.  This may grow if its size is insufficient.</param>
-        /// <param name="maximumDecodeLength">The maximum number of symbols to decode.</param>
-        /// <param name="decodedSymbolsLength">Receives the number of decoded symbols.</param>
         /// <returns>The number of decoded symbols.</returns>
-        public static bool TryDecode(ReadOnlySpan<byte> src, ref byte[] dstArray, int maximumDecodeLength, out int decodedSymbolsLength)
+        public static int Decode(ReadOnlySpan<byte> src, ref byte[] dstArray)
         {
-            Debug.Assert(dstArray != null && dstArray.Length > 0);
-
-            Span<byte> dst = dstArray.Length <= maximumDecodeLength ? dstArray.AsSpan() : dstArray.AsSpan(0, maximumDecodeLength);
+            Span<byte> dst = dstArray;
+            Debug.Assert(dst != null && dst.Length > 0);
 
             int i = 0;
             int j = 0;
@@ -359,14 +356,8 @@ namespace System.Net.Http.HPack
 
                 if (j == dst.Length)
                 {
-                    if (j == maximumDecodeLength)
-                    {
-                        decodedSymbolsLength = default;
-                        return false;
-                    }
-
                     Array.Resize(ref dstArray, dst.Length * 2);
-                    dst = dstArray.Length <= maximumDecodeLength ? dstArray.AsSpan() : dstArray.AsSpan(0, maximumDecodeLength);
+                    dst = dstArray;
                 }
 
                 dst[j++] = (byte)ch;
@@ -379,8 +370,7 @@ namespace System.Net.Http.HPack
                 lastDecodedBits %= 8;
             }
 
-            decodedSymbolsLength = j;
-            return true;
+            return j;
         }
 
         /// <summary>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -81,6 +81,8 @@ namespace System.Net.Http
                 _pendingWindowUpdate = 0;
 
                 _streamWindow = new CreditManager(initialWindowSize);
+
+                HeaderBudgetRemaining = connection._pool.Settings._maxResponseHeadersLength * 1024;
             }
 
             private object SyncObject => _streamWindow;
@@ -88,6 +90,12 @@ namespace System.Net.Http
             public int StreamId => _streamId;
             public HttpRequestMessage Request => _request;
             public HttpResponseMessage Response => _response;
+
+            /// <summary>
+            /// The length, in bytes, of budget remaining for header decode.
+            /// Set initially via MaxResponseHeadersLength.
+            /// </summary>
+            public int HeaderBudgetRemaining { get; set; }
 
             public async Task SendRequestBodyAsync(CancellationToken cancellationToken)
             {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 
 using Xunit;
 using Xunit.Abstractions;
+using System.Collections;
 
 namespace System.Net.Http.Functional.Tests
 {
@@ -1659,5 +1660,82 @@ namespace System.Net.Http.Functional.Tests
                     }
                 });
         }
+
+        [Theory]
+        [MemberData(nameof(MaxResponseHeadersLength_ExactData))]
+        public async Task MaxResponseHeadersLength_Exact_Success(string _, byte[] headerData)
+        {
+            await Http2LoopbackServer.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    HttpClientHandler handler = CreateHttpClientHandler();
+                    handler.MaxResponseHeadersLength = 1;
+
+                    using HttpClient client = CreateHttpClient(handler);
+                    using HttpResponseMessage response = await client.GetAsync(uri);
+                },
+                async server =>
+                {
+                    Http2LoopbackConnection con = await server.EstablishConnectionAsync();
+                    int streamId = await con.ReadRequestHeaderAsync();
+
+                    HeadersFrame frame = new HeadersFrame(headerData, FrameFlags.EndHeaders | FrameFlags.EndStream, 0, 0, 0, streamId);
+                    await con.WriteFrameAsync(frame);
+
+                    await con.ShutdownIgnoringErrorsAsync(streamId);
+                });
+        }
+
+        [Theory]
+        [MemberData(nameof(MaxResponseHeadersLength_TooLargeData))]
+        public async Task MaxResponseHeadersLength_TooLarge_Throws(string _, byte[] headerData)
+        {
+            await Http2LoopbackServer.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    HttpClientHandler handler = CreateHttpClientHandler();
+                    handler.MaxResponseHeadersLength = 1;
+
+                    using HttpClient client = CreateHttpClient(handler);
+                    await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(uri));
+                },
+                async server =>
+                {
+                    Http2LoopbackConnection con = await server.EstablishConnectionAsync();
+                    int streamId = await con.ReadRequestHeaderAsync();
+
+                    HeadersFrame frame = new HeadersFrame(headerData, FrameFlags.EndHeaders | FrameFlags.EndStream, 0, 0, 0, streamId);
+                    await con.WriteFrameAsync(frame);
+                });
+        }
+
+        // All of these should take exactly 1024 bytes of header decode budget. This includes Huffman-coded strings expanding.
+        // Strategy is to prefix with 0x88 (:status:200) and a dummy header of whatever length in order to fill whatever space is remaining from each test variant.
+        public static TheoryData<string, byte[]> MaxResponseHeadersLength_ExactData => new TheoryData<string, byte[]>
+        {
+            { "plaintext", new byte[]{ 0x88,0x00,0x0C,0x64,0x75,0x6D,0x6D,0x79,0x2D,0x68,0x65,0x61,0x64,0x65,0x72,0x7F,0xD8,0x06 }.Concat(Enumerable.Repeat((byte)0x78, 983)).Concat(_headerPlaintext).ToArray() },
+            { "compressed", new byte[]{ 0x88,0x00,0x0C,0x64,0x75,0x6D,0x6D,0x79,0x2D,0x68,0x65,0x61,0x64,0x65,0x72,0x7F,0xD1,0x06 }.Concat(Enumerable.Repeat((byte)0x78, 976)).Concat(_headerCompressedHuffman).ToArray() },
+            { "expanded", new byte[]{ 0x88,0x00,0x0C,0x64,0x75,0x6D,0x6D,0x79,0x2D,0x68,0x65,0x61,0x64,0x65,0x72,0x7F,0xCF,0x06 }.Concat(Enumerable.Repeat((byte)0x78, 974)).Concat(_headerExpandedHuffman).ToArray() }
+        };
+
+        public static TheoryData<string, byte[]> MaxResponseHeadersLength_TooLargeData => new TheoryData<string, byte[]>
+        {
+            // Same as MaxResponseHeadersLength_ExactData, but with 1 byte more of dummy header length to exceed our budget.
+            { "plaintext", new byte[]{ 0x88,0x00,0x0C,0x64,0x75,0x6D,0x6D,0x79,0x2D,0x68,0x65,0x61,0x64,0x65,0x72,0x7F,0xD9,0x06 }.Concat(Enumerable.Repeat((byte)0x78, 984)).Concat(_headerPlaintext).ToArray() },
+            { "compressed", new byte[]{ 0x88,0x00,0x0C,0x64,0x75,0x6D,0x6D,0x79,0x2D,0x68,0x65,0x61,0x64,0x65,0x72,0x7F,0xD2,0x06 }.Concat(Enumerable.Repeat((byte)0x78, 977)).Concat(_headerCompressedHuffman).ToArray() },
+            { "expanded", new byte[]{ 0x88,0x00,0x0C,0x64,0x75,0x6D,0x6D,0x79,0x2D,0x68,0x65,0x61,0x64,0x65,0x72,0x7F,0xD0,0x06 }.Concat(Enumerable.Repeat((byte)0x78, 975)).Concat(_headerExpandedHuffman).ToArray() },
+
+            // A small malicious/corrupt payload that expands into two 1GB strings. Don't want HPackDecoder to allocate 1GB buffers.
+            { "malicious", new byte[] { 0x88, 0x00, 0x7F, 0x81, 0xFF, 0xFF, 0xFF, 0x03, 0x70, 0x6C, 0x61, 0x69, 0x6E, 0x2D, 0x74, 0x65, 0x78, 0x74, 0x7F, 0x81, 0xFF, 0xFF, 0xFF, 0x03, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61 } }
+        };
+
+        // Plain-text: takes 23 bytes to decode.
+        static readonly byte[] _headerPlaintext = new byte[23] { 0x00, 0x0A, 0x70, 0x6C, 0x61, 0x69, 0x6E, 0x2D, 0x74, 0x65, 0x78, 0x74, 0x0A, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61 };
+
+        // Optimal Huffman-coding: takes 30 bytes to decode, because the decoded value is 3 bytes larger than the encoded value.
+        static readonly byte[] _headerCompressedHuffman = new byte[27] { 0x00, 0x11, 0x73, 0x68, 0x72, 0x69, 0x6E, 0x6B, 0x69, 0x6E, 0x67, 0x2D, 0x68, 0x75, 0x66, 0x66, 0x6D, 0x61, 0x6E, 0x87, 0x18, 0xC6, 0x31, 0x8C, 0x63, 0x18, 0xFF };
+
+        // Non-optimal Huffman-coding: takes 32 bytes to decode, because the decoded version is not larger than the encoded value.
+        static readonly byte[] _headerExpandedHuffman = new byte[32] { 0x00, 0x11, 0x65, 0x78, 0x70, 0x61, 0x6E, 0x64, 0x69, 0x6E, 0x67, 0x2D, 0x68, 0x75, 0x66, 0x66, 0x6D, 0x61, 0x6E, 0x8C, 0xFF, 0xFE, 0x1F, 0xFF, 0xC3, 0xFF, 0xF8, 0x7F, 0xFF, 0x0F, 0xFF, 0xE1 };
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 
 using Xunit;
 using Xunit.Abstractions;
-using System.Collections;
 
 namespace System.Net.Http.Functional.Tests
 {

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -149,7 +149,6 @@
     <Compile Include="HttpClientHandlerTest.Decompression.cs" />
     <Compile Include="HttpClientMiniStressTest.cs" />
     <Compile Include="HttpMethodTest.netcoreapp.cs" />
-    <Compile Include="HuffmanDecodingTests.cs" />
     <Compile Include="NtAuthTests.cs" />
     <Compile Include="ReadOnlyMemoryContentTest.cs" />
     <Compile Include="SocketsHttpHandlerTest.cs" />
@@ -164,6 +163,9 @@
     </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Http\HuffmanDecoder.cs">
       <Link>Common\System\Net\Http\HuffmanDecoder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\Http\HuffmanEncoder.cs">
+      <Link>Common\System\Net\Http\HuffmanEncoder.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'uap'">

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackDecoderTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackDecoderTest.cs
@@ -97,7 +97,7 @@ namespace System.Net.Http.Unit.Tests.HPack
         public HPackDecoderTest()
         {
             _dynamicTable = new DynamicTable(DynamicTableInitialMaxSize);
-            _decoder = new HPackDecoder(DynamicTableInitialMaxSize, _dynamicTable);
+            _decoder = new HPackDecoder(DynamicTableInitialMaxSize, maxResponseHeadersLength: 4096, dynamicTable: _dynamicTable);
         }
 
         void OnHeader(object state, ReadOnlySpan<byte> headerName, ReadOnlySpan<byte> headerValue)

--- a/src/System.Net.Http/tests/UnitTests/HPack/HuffmanDecodingTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HuffmanDecodingTests.cs
@@ -332,9 +332,8 @@ namespace System.Net.Http.Unit.Tests.HPack
             // Worst case decoding is an output byte per 5 input bits, so make the decoded buffer 2 times as big
             byte[] decoded = new byte[encoded.Length * 2];
 
-            bool success = Huffman.TryDecode(new ReadOnlySpan<byte>(encoded, 0, encodedByteCount), ref decoded, int.MaxValue, out int decodedByteCount);
+            int decodedByteCount = Huffman.Decode(new ReadOnlySpan<byte>(encoded, 0, encodedByteCount), ref decoded);
 
-            Assert.True(success);
             Assert.Equal(input.Length, decodedByteCount);
             Assert.Equal(input, decoded.Take(decodedByteCount));
         }
@@ -348,7 +347,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             // Worst case decoding is an output byte per 5 input bits, so make the decoded buffer 2 times as big
             byte[] decoded = new byte[encoded.Length * 2];
 
-            Assert.Throws(s_huffmanDecodingExceptionType, () => Huffman.TryDecode(encoded, ref decoded, int.MaxValue, out int _));
+            Assert.Throws(s_huffmanDecodingExceptionType, () => Huffman.Decode(encoded, ref decoded));
         }
 
         // This input sequence will encode to 17 bits, thus offsetting the next character to encode

--- a/src/System.Net.Http/tests/UnitTests/HPack/HuffmanDecodingTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HuffmanDecodingTests.cs
@@ -3,31 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Xunit;
+using System.Net.Http.HPack;
 
-namespace System.Net.Http.Functional.Tests
+namespace System.Net.Http.Unit.Tests.HPack
 {
     public class HuffmanDecodingTests
     {
-        delegate int DecodeDelegate(ReadOnlySpan<byte> src, ref byte[] dst);
-
-        private static readonly DecodeDelegate s_decodeDelegate = GetDecodeDelegate();
-
-        private static DecodeDelegate GetDecodeDelegate()
-        {
-            Assembly assembly = typeof(HttpClient).Assembly;
-            Type huffmanType = assembly.GetType("System.Net.Http.HPack.Huffman");
-            MethodInfo decodeMethod = huffmanType.GetMethod("Decode", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
-            return (DecodeDelegate)Delegate.CreateDelegate(typeof(DecodeDelegate), decodeMethod);
-        }
-
-        private static int Decode(ReadOnlySpan<byte> source, ref byte[] destination)
-        {
-            return s_decodeDelegate(source, ref destination);
-        }
-
         private static readonly (uint code, int bitLength)[] s_encodingTable = new (uint code, int bitLength)[]
         {
             (0b11111111_11000000_00000000_00000000, 13),
@@ -347,8 +332,9 @@ namespace System.Net.Http.Functional.Tests
             // Worst case decoding is an output byte per 5 input bits, so make the decoded buffer 2 times as big
             byte[] decoded = new byte[encoded.Length * 2];
 
-            int decodedByteCount = Decode(new ReadOnlySpan<byte>(encoded, 0, encodedByteCount), ref decoded);
+            bool success = Huffman.TryDecode(new ReadOnlySpan<byte>(encoded, 0, encodedByteCount), ref decoded, int.MaxValue, out int decodedByteCount);
 
+            Assert.True(success);
             Assert.Equal(input.Length, decodedByteCount);
             Assert.Equal(input, decoded.Take(decodedByteCount));
         }
@@ -362,7 +348,7 @@ namespace System.Net.Http.Functional.Tests
             // Worst case decoding is an output byte per 5 input bits, so make the decoded buffer 2 times as big
             byte[] decoded = new byte[encoded.Length * 2];
 
-            Assert.Throws(s_huffmanDecodingExceptionType, () => Decode(encoded, ref decoded));
+            Assert.Throws(s_huffmanDecodingExceptionType, () => Huffman.TryDecode(encoded, ref decoded, int.MaxValue, out int _));
         }
 
         // This input sequence will encode to 17 bits, thus offsetting the next character to encode

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -409,6 +409,7 @@
     <Compile Include="Headers\WarningHeaderValueTest.cs" />
     <Compile Include="HPack\HPackDecoderTest.cs" />
     <Compile Include="HPack\HPackIntegerTest.cs" />
+    <Compile Include="HPack\HuffmanDecodingTests.cs" />
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpRuleParserTest.cs" />
     <Compile Include="MockContent.cs" />


### PR DESCRIPTION
Resolves #35528.

Implement MaxResponseHeadersLength for HTTP2. This applies the setting post-decode, to string data only rather than raw protocol. We will change docs to reflect this.
Implement huffman-coded header support in Http2LoopbackServer.
Move HuffmanDecodingTests from functional to unit tests to avoid reflection.