### PR TITLE
Fix: XPathDescendantIterator.MoveNext starts iterating again when MoveNext is called after it is done

### DIFF
--- a/src/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/System.Private.Xml/src/System.Private.Xml.csproj
@@ -567,7 +567,6 @@
     <Reference Include="System.Reflection.Emit.Lightweight" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.Threading.Tasks.Extensions\src\System.Threading.Tasks.Extensions.csproj" />
     <Reference Include="System.Collections" />
     <Reference Include="System.Collections.Concurrent" />
     <Reference Include="System.Collections.NonGeneric" />

--- a/src/System.Private.Xml/src/System/Xml/XPath/Internal/XPathDescendantIterator.cs
+++ b/src/System.Private.Xml/src/System/Xml/XPath/Internal/XPathDescendantIterator.cs
@@ -9,6 +9,7 @@ namespace MS.Internal.Xml.XPath
     internal class XPathDescendantIterator : XPathAxisIterator
     {
         private int _level = 0;
+        private bool _done = false;
 
         public XPathDescendantIterator(XPathNavigator nav, XPathNodeType type, bool matchSelf) : base(nav, type, matchSelf) { }
         public XPathDescendantIterator(XPathNavigator nav, string name, string namespaceURI, bool matchSelf) : base(nav, name, namespaceURI, matchSelf) { }
@@ -16,6 +17,7 @@ namespace MS.Internal.Xml.XPath
         public XPathDescendantIterator(XPathDescendantIterator it) : base(it)
         {
             _level = it._level;
+            _done = it._done;
         }
 
         public override XPathNodeIterator Clone()
@@ -25,6 +27,11 @@ namespace MS.Internal.Xml.XPath
 
         public override bool MoveNext()
         {
+            if (_done)
+            {
+                return false;
+            }
+
             if (first)
             {
                 first = false;

--- a/src/System.Private.Xml/src/System/Xml/XPath/Internal/XPathDescendantIterator.cs
+++ b/src/System.Private.Xml/src/System/Xml/XPath/Internal/XPathDescendantIterator.cs
@@ -54,6 +54,7 @@ namespace MS.Internal.Xml.XPath
                     {
                         if (_level == 0)
                         {
+                            _done = true;
                             return false;
                         }
                         if (nav.MoveToNext())

--- a/src/System.Private.Xml/src/System/Xml/XPath/Internal/XPathDescendantIterator.cs
+++ b/src/System.Private.Xml/src/System/Xml/XPath/Internal/XPathDescendantIterator.cs
@@ -9,7 +9,6 @@ namespace MS.Internal.Xml.XPath
     internal class XPathDescendantIterator : XPathAxisIterator
     {
         private int _level = 0;
-        private bool _done = false;
 
         public XPathDescendantIterator(XPathNavigator nav, XPathNodeType type, bool matchSelf) : base(nav, type, matchSelf) { }
         public XPathDescendantIterator(XPathNavigator nav, string name, string namespaceURI, bool matchSelf) : base(nav, name, namespaceURI, matchSelf) { }
@@ -17,7 +16,6 @@ namespace MS.Internal.Xml.XPath
         public XPathDescendantIterator(XPathDescendantIterator it) : base(it)
         {
             _level = it._level;
-            _done = it._done;
         }
 
         public override XPathNodeIterator Clone()
@@ -27,8 +25,9 @@ namespace MS.Internal.Xml.XPath
 
         public override bool MoveNext()
         {
-            if (_done)
+            if (_level == -1)
             {
+                // We can only get here when we already iterated over all descendants
                 return false;
             }
 
@@ -54,7 +53,11 @@ namespace MS.Internal.Xml.XPath
                     {
                         if (_level == 0)
                         {
-                            _done = true;
+                            // In an attempt to find next descendant we ended up being back in the root node
+                            // which means we are done iterating descendants.
+                            // If we have called this method again MoveToFirstChild would cause iteration to start over.
+                            // We will use _level == -1 to mark that we are already done iterating.
+                            _level = -1;
                             return false;
                         }
                         if (nav.MoveToNext())


### PR DESCRIPTION
Don't review in 3.0 timeline. Opening PR while I still remember about this.

This is fixing an issue where certain scenarios can cause endless looping:
- when MoveNext is called the last time it returns false
- when you call it again after it already returned false it will return true and move back to the first element