### PR TITLE
Adding unit test to cover NullReferenceException when passing null to a collection

### DIFF
--- a/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -83,14 +82,18 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static async Task ReadCollectionPassingNullValue()
+        public static async Task ReadCollectionPassingNullValueAsync()
         {
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("null")))
             {
-                JsonSerializerOptions options = new JsonSerializerOptions();
+                IList<object> referenceTypeCollection  = await JsonSerializer.ReadAsync<IList<object>>(stream);
+                Assert.Null(referenceTypeCollection);
+            }
 
-                var collection  = await JsonSerializer.ReadAsync<IList<object>>(stream, options);
-                Assert.Null(collection);
+            using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("null")))
+            {
+                IList<int> valueTypeCollection = await JsonSerializer.ReadAsync<IList<int>>(stream);
+                Assert.Null(valueTypeCollection);
             }
         }
     }

--- a/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
@@ -82,14 +82,18 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static async Task ReadCollectionPassingNullValueAsync()
+        public static async Task ReadReferenceTypeCollectionPassingNullValueAsync()
         {
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("null")))
             {
                 IList<object> referenceTypeCollection  = await JsonSerializer.ReadAsync<IList<object>>(stream);
                 Assert.Null(referenceTypeCollection);
             }
+        }
 
+        [Fact]
+        public static async Task ReadValueTypeCollectionPassingNullValueAsync()
+        {
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("null")))
             {
                 IList<int> valueTypeCollection = await JsonSerializer.ReadAsync<IList<int>>(stream);

--- a/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Xunit;
@@ -77,6 +79,18 @@ namespace System.Text.Json.Serialization.Tests
 
                 int i = await JsonSerializer.ReadAsync<int>(stream, options);
                 Assert.Equal(1, i);
+            }
+        }
+
+        [Fact]
+        public static async Task ReadCollectionPassingNullValue()
+        {
+            using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("null")))
+            {
+                JsonSerializerOptions options = new JsonSerializerOptions();
+
+                var collection  = await JsonSerializer.ReadAsync<IList<object>>(stream, options);
+                Assert.Null(collection);
             }
         }
     }


### PR DESCRIPTION
Fixes #37078 
Problem: in v3.0.0-preview4, passing `null` to a collection through `JsonSerializer.ReadAsync` will throw an unexpected NullRef error.

Fix: Since I was able to reproduce the reported issue in v3.0.0-preview4 with the unit test specified in #37078, I added a simplified version of it to our tests. This error does not happen in our latest build and therefore is considered as corrected.
