### PR TITLE
Have consistent Dispose behaviors for AsymmetricAlgorithm objects

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DSACng.ImportExport.cs
+++ b/src/Common/src/System/Security/Cryptography/DSACng.ImportExport.cs
@@ -59,6 +59,24 @@ namespace System.Security.Cryptography
                 ImportKeyBlob(blob, hasPrivateKey);
             }
 
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<byte> passwordBytes,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ThrowIfDisposed();
+                base.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
+            }
+
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<char> password,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ThrowIfDisposed();
+                base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
+            }
+
             public override byte[] ExportEncryptedPkcs8PrivateKey(
                 ReadOnlySpan<byte> passwordBytes,
                 PbeParameters pbeParameters)

--- a/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -328,6 +328,8 @@ namespace System.Security.Cryptography
 
             private void SetKey(SafeDsaHandle newKey)
             {
+                ThrowIfDisposed();
+
                 // Use ForceSet instead of the property setter to ensure that LegalKeySizes doesn't interfere
                 // with the already loaded key.
                 ForceSetKeySize(BitsPerByte * Interop.Crypto.DsaKeySize(newKey));

--- a/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using Internal.Cryptography;
@@ -35,7 +34,7 @@ namespace System.Security.Cryptography
             public DSAOpenSsl(int keySize)
             {
                 LegalKeySizesValue = s_legalKeySizes;
-                KeySize = keySize;
+                base.KeySize = keySize;
                 _key = new Lazy<SafeDsaHandle>(GenerateKey);
             }
 
@@ -51,6 +50,7 @@ namespace System.Security.Cryptography
                     // Set the KeySize before FreeKey so that an invalid value doesn't throw away the key
                     base.KeySize = value;
 
+                    ThrowIfDisposed();
                     FreeKey();
                     _key = new Lazy<SafeDsaHandle>(GenerateKey);
                 }
@@ -76,9 +76,7 @@ namespace System.Security.Cryptography
             public override DSAParameters ExportParameters(bool includePrivateParameters)
             {
                 // It's entirely possible that this line will cause the key to be generated in the first place.
-                SafeDsaHandle key = _key.Value;
-
-                CheckInvalidKey(key);
+                SafeDsaHandle key = GetKey();
 
                 DSAParameters dsaParameters = Interop.Crypto.ExportDsaParameters(key, includePrivateParameters);
                 bool hasPrivateKey = dsaParameters.X != null;
@@ -108,6 +106,8 @@ namespace System.Security.Cryptography
                 if (hasPrivateKey && parameters.X.Length != parameters.Q.Length)
                     throw new ArgumentException(SR.Cryptography_InvalidDsaParameters_MismatchedQX);
 
+                ThrowIfDisposed();
+
                 SafeDsaHandle key;
                 if (!Interop.Crypto.DsaKeyCreateByExplicitParameters(
                     out key,
@@ -123,11 +123,30 @@ namespace System.Security.Cryptography
                 SetKey(key);
             }
 
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<byte> passwordBytes,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ThrowIfDisposed();
+                base.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
+            }
+
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<char> password,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ThrowIfDisposed();
+                base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
+            }
+
             protected override void Dispose(bool disposing)
             {
                 if (disposing)
                 {
                     FreeKey();
+                    _key = null;
                 }
 
                 base.Dispose(disposing);
@@ -188,7 +207,7 @@ namespace System.Security.Cryptography
                 if (rgbHash == null)
                     throw new ArgumentNullException(nameof(rgbHash));
 
-                SafeDsaHandle key = _key.Value;
+                SafeDsaHandle key = GetKey();
                 int signatureSize = Interop.Crypto.DsaEncodedSignatureSize(key);
                 byte[] signature = CryptoPool.Rent(signatureSize);
                 try
@@ -218,7 +237,7 @@ namespace System.Security.Cryptography
             public override bool TryCreateSignature(ReadOnlySpan<byte> hash, Span<byte> destination, out int bytesWritten)
             {
                 byte[] converted;
-                SafeDsaHandle key = _key.Value;
+                SafeDsaHandle key = GetKey();
                 int signatureSize = Interop.Crypto.DsaEncodedSignatureSize(key);
                 byte[] signature = CryptoPool.Rent(signatureSize);
                 try
@@ -269,7 +288,7 @@ namespace System.Security.Cryptography
 
             public override bool VerifySignature(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature)
             {
-                SafeDsaHandle key = _key.Value;
+                SafeDsaHandle key = GetKey();
 
                 int expectedSignatureBytes = Interop.Crypto.DsaSignatureFieldSize(key) * 2;
                 if (signature.Length != expectedSignatureBytes)
@@ -281,6 +300,30 @@ namespace System.Security.Cryptography
                 byte[] openSslFormat = AsymmetricAlgorithmHelpers.ConvertIeee1363ToDer(signature);
 
                 return Interop.Crypto.DsaVerify(key, hash, openSslFormat);
+            }
+
+            private void ThrowIfDisposed()
+            {
+                if (_key == null)
+                {
+                    throw new ObjectDisposedException(
+#if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
+                        nameof(DSA)
+#else
+                        nameof(DSAOpenSsl)
+#endif
+                    );
+                }
+            }
+
+            private SafeDsaHandle GetKey()
+            {
+                ThrowIfDisposed();
+
+                SafeDsaHandle key = _key.Value;
+                CheckInvalidKey(key);
+
+                return key;
             }
 
             private void SetKey(SafeDsaHandle newKey)

--- a/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -328,7 +328,7 @@ namespace System.Security.Cryptography
 
             private void SetKey(SafeDsaHandle newKey)
             {
-                ThrowIfDisposed();
+                // Do not call ThrowIfDisposed here, as it breaks the SafeEvpPKey ctor
 
                 // Use ForceSet instead of the property setter to ensure that LegalKeySizes doesn't interfere
                 // with the already loaded key.

--- a/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
@@ -86,8 +86,7 @@ namespace System.Security.Cryptography
                     const string ExportPassword = "DotnetExportPassphrase";
                     SecKeyPair keys = GetKeys();
 
-                    if (keys.PublicKey == null ||
-                        (includePrivateParameters && keys.PrivateKey == null))
+                    if (includePrivateParameters && keys.PrivateKey == null)
                     { 
                         throw new CryptographicException(SR.Cryptography_OpenInvalidHandle);
                     }

--- a/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
@@ -5,7 +5,6 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.IO;
-using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.Apple;
 using System.Security.Cryptography.Asn1;
@@ -28,6 +27,7 @@ namespace System.Security.Cryptography
             public sealed partial class DSASecurityTransforms : DSA
             {
                 private SecKeyPair _keys;
+                private bool _disposed;
 
                 public DSASecurityTransforms()
                     : this(1024)
@@ -36,7 +36,7 @@ namespace System.Security.Cryptography
 
                 public DSASecurityTransforms(int keySize)
                 {
-                    KeySize = keySize;
+                    base.KeySize = keySize;
                 }
 
                 internal DSASecurityTransforms(SafeSecKeyRefHandle publicKey)
@@ -70,6 +70,8 @@ namespace System.Security.Cryptography
 
                         // Set the KeySize before freeing the key so that an invalid value doesn't throw away the key
                         base.KeySize = value;
+
+                        ThrowIfDisposed();
 
                         if (_keys != null)
                         {
@@ -151,6 +153,8 @@ namespace System.Security.Cryptography
                     if (parameters.Q.Length != 20)
                         throw new CryptographicException(SR.Cryptography_InvalidDsaParameters_QRestriction_ShortKey);
 
+                    ThrowIfDisposed();
+
                     if (hasPrivateKey)
                     {
                         SafeSecKeyRefHandle privateKey = ImportKey(parameters);
@@ -176,6 +180,24 @@ namespace System.Security.Cryptography
                         SafeSecKeyRefHandle publicKey = ImportKey(parameters);
                         SetKey(SecKeyPair.PublicOnly(publicKey));
                     }
+                }
+
+                public override void ImportEncryptedPkcs8PrivateKey(
+                    ReadOnlySpan<byte> passwordBytes,
+                    ReadOnlySpan<byte> source,
+                    out int bytesRead)
+                {
+                    ThrowIfDisposed();
+                    base.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
+                }
+
+                public override void ImportEncryptedPkcs8PrivateKey(
+                    ReadOnlySpan<char> password,
+                    ReadOnlySpan<byte> source,
+                    out int bytesRead)
+                {
+                    ThrowIfDisposed();
+                    base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
                 }
 
                 private static SafeSecKeyRefHandle ImportKey(DSAParameters parameters)
@@ -217,6 +239,8 @@ namespace System.Security.Cryptography
                     ReadOnlySpan<byte> source,
                     out int bytesRead)
                 {
+                    ThrowIfDisposed();
+
                     fixed (byte* ptr = &MemoryMarshal.GetReference(source))
                     {
                         using (MemoryManager<byte> manager = new PointerMemoryManager<byte>(ptr, source.Length))
@@ -305,13 +329,30 @@ namespace System.Security.Cryptography
                             _keys.Dispose();
                             _keys = null;
                         }
+
+                        _disposed = true;
                     }
 
                     base.Dispose(disposing);
                 }
 
+                private void ThrowIfDisposed()
+                {
+                    // The other SecurityTransforms types use _keys.PublicKey == null,
+                    // but since Apple doesn't provide DSA key generation we can't easily tell
+                    // if a failed attempt to generate a key happened, or we're in a pristine state.
+                    //
+                    // So this type uses an explicit field, rather than inferred state.
+                    if (_disposed)
+                    {
+                        throw new ObjectDisposedException(nameof(DSA));
+                    }
+                }
+
                 internal SecKeyPair GetKeys()
                 {
+                    ThrowIfDisposed();
+
                     SecKeyPair current = _keys;
 
                     if (current != null)
@@ -329,6 +370,8 @@ namespace System.Security.Cryptography
 
                 private void SetKey(SecKeyPair newKeyPair)
                 {
+                    ThrowIfDisposed();
+
                     SecKeyPair current = _keys;
                     _keys = newKeyPair;
                     current?.Dispose();

--- a/src/Common/src/System/Security/Cryptography/ECDiffieHellmanCng.ImportExport.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDiffieHellmanCng.ImportExport.cs
@@ -15,6 +15,8 @@ namespace System.Security.Cryptography
             public override void ImportParameters(ECParameters parameters)
             {
                 parameters.Validate();
+                ThrowIfDisposed();
+
                 ECCurve curve = parameters.Curve;
                 bool includePrivateParamerters = (parameters.D != null);
 
@@ -92,6 +94,7 @@ namespace System.Security.Cryptography
 
             public override void ImportPkcs8PrivateKey(ReadOnlySpan<byte> source, out int bytesRead)
             {
+                ThrowIfDisposed();
                 CngPkcs8.Pkcs8Response response = CngPkcs8.ImportPkcs8PrivateKey(source, out int localRead);
 
                 ProcessPkcs8Response(response);
@@ -103,6 +106,7 @@ namespace System.Security.Cryptography
                 ReadOnlySpan<byte> source,
                 out int bytesRead)
             {
+                ThrowIfDisposed();
                 CngPkcs8.Pkcs8Response response = CngPkcs8.ImportEncryptedPkcs8PrivateKey(
                     passwordBytes,
                     source,
@@ -117,6 +121,7 @@ namespace System.Security.Cryptography
                 ReadOnlySpan<byte> source,
                 out int bytesRead)
             {
+                ThrowIfDisposed();
                 CngPkcs8.Pkcs8Response response = CngPkcs8.ImportEncryptedPkcs8PrivateKey(
                     password,
                     source,

--- a/src/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.Derive.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDiffieHellmanOpenSsl.Derive.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
 using System.Diagnostics;
 using Microsoft.Win32.SafeHandles;
 
@@ -31,6 +30,8 @@ namespace System.Security.Cryptography
                 if (string.IsNullOrEmpty(hashAlgorithm.Name))
                     throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
 
+                ThrowIfDisposed();
+
                 return ECDiffieHellmanDerivation.DeriveKeyFromHash(
                     otherPartyPublicKey,
                     hashAlgorithm,
@@ -51,6 +52,8 @@ namespace System.Security.Cryptography
                 if (string.IsNullOrEmpty(hashAlgorithm.Name))
                     throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
 
+                ThrowIfDisposed();
+
                 return ECDiffieHellmanDerivation.DeriveKeyFromHmac(
                     otherPartyPublicKey,
                     hashAlgorithm,
@@ -68,6 +71,8 @@ namespace System.Security.Cryptography
                     throw new ArgumentNullException(nameof(prfLabel));
                 if (prfSeed == null)
                     throw new ArgumentNullException(nameof(prfSeed));
+
+                ThrowIfDisposed();
 
                 return ECDiffieHellmanDerivation.DeriveKeyTls(
                     otherPartyPublicKey,

--- a/src/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
@@ -15,7 +15,7 @@ namespace System.Security.Cryptography
 
             public ECDiffieHellmanSecurityTransforms()
             {
-                KeySize = 521;
+                base.KeySize = 521;
             }
 
             internal ECDiffieHellmanSecurityTransforms(SafeSecKeyRefHandle publicKey)
@@ -51,8 +51,13 @@ namespace System.Security.Cryptography
 
                     // Set the KeySize before freeing the key so that an invalid value doesn't throw away the key
                     base.KeySize = value;
-                    _ecc.Dispose();
+                    _ecc.DisposeKey();
                 }
+            }
+
+            private void ThrowIfDisposed()
+            {
+                _ecc.ThrowIfDisposed();
             }
 
             protected override void Dispose(bool disposing)
@@ -87,6 +92,24 @@ namespace System.Security.Cryptography
                 KeySizeValue = _ecc.ImportSubjectPublicKeyInfo(source, out bytesRead);
             }
 
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<byte> passwordBytes,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ThrowIfDisposed();
+                base.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
+            }
+
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<char> password,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ThrowIfDisposed();
+                base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
+            }
+
             public override void GenerateKey(ECCurve curve)
             {
                 KeySizeValue = _ecc.GenerateKey(curve);
@@ -111,6 +134,8 @@ namespace System.Security.Cryptography
                 if (string.IsNullOrEmpty(hashAlgorithm.Name))
                     throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
 
+                ThrowIfDisposed();
+
                 return ECDiffieHellmanDerivation.DeriveKeyFromHash(
                     otherPartyPublicKey,
                     hashAlgorithm,
@@ -131,6 +156,8 @@ namespace System.Security.Cryptography
                 if (string.IsNullOrEmpty(hashAlgorithm.Name))
                     throw new ArgumentException(SR.Cryptography_HashAlgorithmNameNullOrEmpty, nameof(hashAlgorithm));
 
+                ThrowIfDisposed();
+
                 return ECDiffieHellmanDerivation.DeriveKeyFromHmac(
                     otherPartyPublicKey,
                     hashAlgorithm,
@@ -149,6 +176,8 @@ namespace System.Security.Cryptography
                     throw new ArgumentNullException(nameof(prfLabel));
                 if (prfSeed == null)
                     throw new ArgumentNullException(nameof(prfSeed));
+
+                ThrowIfDisposed();
 
                 return ECDiffieHellmanDerivation.DeriveKeyTls(
                     otherPartyPublicKey,
@@ -258,7 +287,6 @@ namespace System.Security.Cryptography
                     if (disposing)
                     {
                         _ecc.Dispose();
-                        _ecc = null;
                     }
 
                     base.Dispose(disposing);
@@ -267,29 +295,11 @@ namespace System.Security.Cryptography
                 public override ECParameters ExportExplicitParameters() =>
                     throw new PlatformNotSupportedException(SR.Cryptography_ECC_NamedCurvesOnly);
 
-                public override ECParameters ExportParameters()
-                {
-                    if (_ecc == null)
-                    {
-                        throw new ObjectDisposedException(typeof(ECDiffieHellmanSecurityTransformsPublicKey).Name);
-                    }
+                public override ECParameters ExportParameters() =>
+                    _ecc.ExportParameters(includePrivateParameters: false, keySizeInBits: -1);
 
-                    return _ecc.ExportParameters(includePrivateParameters: false, keySizeInBits: -1);
-                }
-
-                internal SafeSecKeyRefHandle KeyHandle
-                {
-                    get
-                    {
-                        if (_ecc == null)
-                        {
-                            throw new ObjectDisposedException(
-                                typeof(ECDiffieHellmanSecurityTransformsPublicKey).Name);
-                        }
-
-                        return _ecc.GetOrGenerateKeys(-1).PublicKey;
-                    }
-                }
+                internal SafeSecKeyRefHandle KeyHandle =>
+                    _ecc.GetOrGenerateKeys(-1).PublicKey;
             }
         }
     }

--- a/src/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
@@ -11,7 +11,7 @@ namespace System.Security.Cryptography
     {
         public sealed partial class ECDiffieHellmanSecurityTransforms : ECDiffieHellman
         {
-            private readonly EccSecurityTransforms _ecc = new EccSecurityTransforms();
+            private readonly EccSecurityTransforms _ecc = new EccSecurityTransforms(nameof(ECDiffieHellman));
 
             public ECDiffieHellmanSecurityTransforms()
             {
@@ -235,7 +235,7 @@ namespace System.Security.Cryptography
                 public ECDiffieHellmanSecurityTransformsPublicKey(ECParameters ecParameters)
                 {
                     Debug.Assert(ecParameters.D == null);
-                    _ecc = new EccSecurityTransforms();
+                    _ecc = new EccSecurityTransforms(nameof(ECDiffieHellmanPublicKey));
                     _ecc.ImportParameters(ecParameters);
                 }
 

--- a/src/Common/src/System/Security/Cryptography/ECDsaCng.ImportExport.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaCng.ImportExport.cs
@@ -30,6 +30,8 @@ namespace System.Security.Cryptography
             public override void ImportParameters(ECParameters parameters)
             {
                 parameters.Validate();
+                ThrowIfDisposed();
+
                 ECCurve curve = parameters.Curve;
                 bool includePrivateParameters = (parameters.D != null);
 
@@ -102,6 +104,8 @@ namespace System.Security.Cryptography
 
             public override void ImportPkcs8PrivateKey(ReadOnlySpan<byte> source, out int bytesRead)
             {
+                ThrowIfDisposed();
+
                 CngPkcs8.Pkcs8Response response = CngPkcs8.ImportPkcs8PrivateKey(source, out int localRead);
 
                 ProcessPkcs8Response(response);
@@ -113,6 +117,8 @@ namespace System.Security.Cryptography
                 ReadOnlySpan<byte> source,
                 out int bytesRead)
             {
+                ThrowIfDisposed();
+
                 CngPkcs8.Pkcs8Response response = CngPkcs8.ImportEncryptedPkcs8PrivateKey(
                     passwordBytes,
                     source,
@@ -127,6 +133,8 @@ namespace System.Security.Cryptography
                 ReadOnlySpan<byte> source,
                 out int bytesRead)
             {
+                ThrowIfDisposed();
+
                 CngPkcs8.Pkcs8Response response = CngPkcs8.ImportEncryptedPkcs8PrivateKey(
                     password,
                     source,

--- a/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaOpenSsl.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
-using System.Diagnostics;
 using System.IO;
 using Internal.Cryptography;
 using Microsoft.Win32.SafeHandles;
@@ -43,9 +41,10 @@ namespace System.Security.Cryptography
             /// <param name="keySize">Size of the key to generate, in bits.</param>
             public ECDsaOpenSsl(int keySize)
             {
-                KeySize = keySize;
-                // Setting KeySize wakes up _key.
-                Debug.Assert(_key != null);
+                // Use the base setter to get the validation and field assignment without the
+                // side effect of dereferencing _key.
+                base.KeySize = keySize;
+                _key = new ECOpenSsl(this);
             }
 
             /// <summary>
@@ -78,6 +77,7 @@ namespace System.Security.Cryptography
                 if (hash == null)
                     throw new ArgumentNullException(nameof(hash));
 
+                ThrowIfDisposed();
                 SafeEcKeyHandle key = _key.Value;
                 int signatureLength = Interop.Crypto.EcDsaSize(key);
                 byte[] signature = new byte[signatureLength];
@@ -91,6 +91,7 @@ namespace System.Security.Cryptography
 
             public override bool TrySignHash(ReadOnlySpan<byte> hash, Span<byte> destination, out int bytesWritten)
             {
+                ThrowIfDisposed();
                 SafeEcKeyHandle key = _key.Value;
 
                 byte[] converted;
@@ -135,6 +136,8 @@ namespace System.Security.Cryptography
 
             public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature)
             {
+                ThrowIfDisposed();
+
                 // The signature format for .NET is r.Concat(s). Each of r and s are of length BitsToBytes(KeySize), even
                 // when they would have leading zeroes.  If it's the correct size, then we need to encode it from
                 // r.Concat(s) to SEQUENCE(INTEGER(r), INTEGER(s)), because that's the format that OpenSSL expects.
@@ -165,7 +168,8 @@ namespace System.Security.Cryptography
             {
                 if (disposing)
                 {
-                    _key.Dispose();
+                    _key?.Dispose();
+                    _key = null;
                 }
 
                 base.Dispose(disposing);
@@ -185,15 +189,15 @@ namespace System.Security.Cryptography
                     // Set the KeySize before FreeKey so that an invalid value doesn't throw away the key
                     base.KeySize = value;
 
-                    // This is the only place where _key can be null, because it's called by the constructor
-                    // which sets KeySize.
-                    _key?.Dispose();
+                    ThrowIfDisposed();
+                    _key.Dispose();
                     _key = new ECOpenSsl(this);
                 }
             }
 
             public override void GenerateKey(ECCurve curve)
             {
+                ThrowIfDisposed();
                 _key.GenerateKey(curve);
 
                 // Use ForceSet instead of the property setter to ensure that LegalKeySizes doesn't interfere
@@ -203,16 +207,54 @@ namespace System.Security.Cryptography
 
             public override void ImportParameters(ECParameters parameters)
             {
+                ThrowIfDisposed();
                 _key.ImportParameters(parameters);
                 ForceSetKeySize(_key.KeySize);
             }
 
-            public override ECParameters ExportExplicitParameters(bool includePrivateParameters) =>
-                ECOpenSsl.ExportExplicitParameters(_key.Value, includePrivateParameters);
+            public override ECParameters ExportExplicitParameters(bool includePrivateParameters)
+            {
+                ThrowIfDisposed();
+                return ECOpenSsl.ExportExplicitParameters(_key.Value, includePrivateParameters);
+            }
 
-            public override ECParameters ExportParameters(bool includePrivateParameters) =>
-                ECOpenSsl.ExportParameters(_key.Value, includePrivateParameters);
+            public override ECParameters ExportParameters(bool includePrivateParameters)
+            {
+                ThrowIfDisposed();
+                return ECOpenSsl.ExportParameters(_key.Value, includePrivateParameters);
+            }
 
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<byte> passwordBytes,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ThrowIfDisposed();
+                base.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
+            }
+
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<char> password,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ThrowIfDisposed();
+                base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
+            }
+
+            private void ThrowIfDisposed()
+            {
+                if (_key == null)
+                {
+                    throw new ObjectDisposedException(
+#if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
+                        nameof(ECDsa)
+#else
+                        nameof(ECDsaOpenSsl)
+#endif
+                    );
+                }
+            }
         }
 #if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
     }

--- a/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography
         {
             public sealed partial class ECDsaSecurityTransforms : ECDsa
             {
-                private readonly EccSecurityTransforms _ecc = new EccSecurityTransforms();
+                private readonly EccSecurityTransforms _ecc = new EccSecurityTransforms(nameof(ECDsa));
 
                 public ECDsaSecurityTransforms()
                 {

--- a/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography
 
                 public ECDsaSecurityTransforms()
                 {
-                    KeySize = 521;
+                    base.KeySize = 521;
                 }
 
                 internal ECDsaSecurityTransforms(SafeSecKeyRefHandle publicKey)
@@ -91,7 +91,7 @@ namespace System.Security.Cryptography
 
                         // Set the KeySize before freeing the key so that an invalid value doesn't throw away the key
                         base.KeySize = value;
-                        _ecc.Dispose();
+                        _ecc.DisposeKey();
                     }
                 }
 
@@ -157,6 +157,8 @@ namespace System.Security.Cryptography
 
                 public override bool VerifyHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature)
                 {
+                    ThrowIfDisposed();
+
                     // The signature format for .NET is r.Concat(s). Each of r and s are of length BitsToBytes(KeySize), even
                     // when they would have leading zeroes.  If it's the correct size, then we need to encode it from
                     // r.Concat(s) to SEQUENCE(INTEGER(r), INTEGER(s)), because that's the format that OpenSSL expects.
@@ -182,6 +184,11 @@ namespace System.Security.Cryptography
                 protected override bool TryHashData(ReadOnlySpan<byte> source, Span<byte> destination, HashAlgorithmName hashAlgorithm, out int bytesWritten) =>
                     AsymmetricAlgorithmHelpers.TryHashData(source, destination, hashAlgorithm, out bytesWritten);
 
+                private void ThrowIfDisposed()
+                {
+                    _ecc.ThrowIfDisposed();
+                }
+
                 protected override void Dispose(bool disposing)
                 {
                     if (disposing)
@@ -205,6 +212,24 @@ namespace System.Security.Cryptography
                 public override void ImportParameters(ECParameters parameters)
                 {
                     KeySizeValue = _ecc.ImportParameters(parameters);
+                }
+
+                public override void ImportEncryptedPkcs8PrivateKey(
+                    ReadOnlySpan<byte> passwordBytes,
+                    ReadOnlySpan<byte> source,
+                    out int bytesRead)
+                {
+                    ThrowIfDisposed();
+                    base.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
+                }
+
+                public override void ImportEncryptedPkcs8PrivateKey(
+                    ReadOnlySpan<char> password,
+                    ReadOnlySpan<byte> source,
+                    out int bytesRead)
+                {
+                    ThrowIfDisposed();
+                    base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
                 }
 
                 public override void GenerateKey(ECCurve curve)

--- a/src/Common/src/System/Security/Cryptography/EccSecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/EccSecurityTransforms.cs
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography
 
         internal void DisposeKey()
         {
-            _keys.Dispose();
+            _keys?.Dispose();
             _keys = null;
         }
 

--- a/src/Common/src/System/Security/Cryptography/EccSecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/EccSecurityTransforms.cs
@@ -7,13 +7,19 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.Apple;
 using System.Security.Cryptography.Asn1;
-using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
     internal sealed class EccSecurityTransforms : IDisposable
     {
         private SecKeyPair _keys;
+        private readonly string _disposedName;
+
+        internal EccSecurityTransforms(string disposedTypeName)
+        {
+            Debug.Assert(disposedTypeName != null);
+            _disposedName = disposedTypeName;
+        }
 
         public void Dispose()
         {
@@ -70,6 +76,11 @@ namespace System.Security.Cryptography
 
             if (current != null)
             {
+                if (current.PublicKey == null)
+                {
+                    throw new ObjectDisposedException(_disposedName);
+                }
+
                 return current;
             }
 
@@ -97,8 +108,7 @@ namespace System.Security.Cryptography
             const string ExportPassword = "DotnetExportPassphrase";
             SecKeyPair keys = GetOrGenerateKeys(keySizeInBits);
 
-            if (keys.PublicKey == null ||
-                (includePrivateParameters && keys.PrivateKey == null))
+            if (includePrivateParameters && keys.PrivateKey == null)
             { 
                 throw new CryptographicException(SR.Cryptography_OpenInvalidHandle);
             }

--- a/src/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
@@ -112,6 +112,8 @@ namespace System.Security.Cryptography
 
             public override void ImportPkcs8PrivateKey(ReadOnlySpan<byte> source, out int bytesRead)
             {
+                ThrowIfDisposed();
+
                 CngPkcs8.Pkcs8Response response = CngPkcs8.ImportPkcs8PrivateKey(source, out int localRead);
 
                 ProcessPkcs8Response(response);
@@ -123,6 +125,8 @@ namespace System.Security.Cryptography
                 ReadOnlySpan<byte> source,
                 out int bytesRead)
             {
+                ThrowIfDisposed();
+
                 CngPkcs8.Pkcs8Response response = CngPkcs8.ImportEncryptedPkcs8PrivateKey(
                     passwordBytes,
                     source,
@@ -137,6 +141,8 @@ namespace System.Security.Cryptography
                 ReadOnlySpan<byte> source,
                 out int bytesRead)
             {
+                ThrowIfDisposed();
+
                 CngPkcs8.Pkcs8Response response = CngPkcs8.ImportEncryptedPkcs8PrivateKey(
                     password,
                     source,

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography
 
         public RSAOpenSsl(int keySize)
         {
-            KeySize = keySize;
+            base.KeySize = keySize;
             _key = new Lazy<SafeRsaHandle>(GenerateKey);
         }
 
@@ -53,6 +53,7 @@ namespace System.Security.Cryptography
                 // Set the KeySize before FreeKey so that an invalid value doesn't throw away the key
                 base.KeySize = value;
 
+                ThrowIfDisposed();
                 FreeKey();
                 _key = new Lazy<SafeRsaHandle>(GenerateKey);
             }
@@ -88,8 +89,7 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(padding));
 
             Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor oaepProcessor);
-            SafeRsaHandle key = _key.Value;
-            CheckInvalidKey(key);
+            SafeRsaHandle key = GetKey();
 
             int rsaSize = Interop.Crypto.RsaSize(key);
             byte[] buf = null;
@@ -127,8 +127,7 @@ namespace System.Security.Cryptography
             }
 
             Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor oaepProcessor);
-            SafeRsaHandle key = _key.Value;
-            CheckInvalidKey(key);
+            SafeRsaHandle key = GetKey();
 
             int keySizeBytes = Interop.Crypto.RsaSize(key);
 
@@ -261,9 +260,8 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(padding));
 
             Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor oaepProcessor);
-            SafeRsaHandle key = _key.Value;
-            CheckInvalidKey(key);
-
+            SafeRsaHandle key = GetKey();
+            
             byte[] buf = new byte[Interop.Crypto.RsaSize(key)];
 
             bool encrypted = TryEncrypt(
@@ -291,8 +289,7 @@ namespace System.Security.Cryptography
             }
 
             Interop.Crypto.RsaPadding rsaPadding = GetInteropPadding(padding, out RsaPaddingProcessor oaepProcessor);
-            SafeRsaHandle key = _key.Value;
-            CheckInvalidKey(key);
+            SafeRsaHandle key = GetKey();
 
             return TryEncrypt(key, data, destination, rsaPadding, oaepProcessor, out bytesWritten);
         }
@@ -375,9 +372,7 @@ namespace System.Security.Cryptography
         public override RSAParameters ExportParameters(bool includePrivateParameters)
         {
             // It's entirely possible that this line will cause the key to be generated in the first place.
-            SafeRsaHandle key = _key.Value;
-
-            CheckInvalidKey(key);
+            SafeRsaHandle key = GetKey();
 
             RSAParameters rsaParameters = Interop.Crypto.ExportRsaParameters(key, includePrivateParameters);
             bool hasPrivateKey = rsaParameters.D != null;
@@ -393,6 +388,7 @@ namespace System.Security.Cryptography
         public override void ImportParameters(RSAParameters parameters)
         {
             ValidateParameters(ref parameters);
+            ThrowIfDisposed();
 
             SafeRsaHandle key = Interop.Crypto.RsaCreate();
             bool imported = false;
@@ -443,6 +439,8 @@ namespace System.Security.Cryptography
 
         public override unsafe void ImportRSAPublicKey(ReadOnlySpan<byte> source, out int bytesRead)
         {
+            ThrowIfDisposed();
+
             fixed (byte* ptr = &MemoryMarshal.GetReference(source))
             {
                 using (MemoryManager<byte> manager = new PointerMemoryManager<byte>(ptr, source.Length))
@@ -466,11 +464,30 @@ namespace System.Security.Cryptography
             }
         }
 
+        public override void ImportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<byte> passwordBytes,
+            ReadOnlySpan<byte> source,
+            out int bytesRead)
+        {
+            ThrowIfDisposed();
+            base.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
+        }
+
+        public override void ImportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<char> password,
+            ReadOnlySpan<byte> source,
+            out int bytesRead)
+        {
+            ThrowIfDisposed();
+            base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
                 FreeKey();
+                _key = null;
             }
 
             base.Dispose(disposing);
@@ -522,12 +539,32 @@ namespace System.Security.Cryptography
             return true;
         }
 
-        private static void CheckInvalidKey(SafeRsaHandle key)
+        private void ThrowIfDisposed()
         {
+            if (_key == null)
+            {
+                throw new ObjectDisposedException(
+#if INTERNAL_ASYMMETRIC_IMPLEMENTATIONS
+                    nameof(RSA)
+#else
+                    nameof(RSAOpenSsl)
+#endif
+                );
+            }
+        }
+
+        private SafeRsaHandle GetKey()
+        {
+            ThrowIfDisposed();    
+
+            SafeRsaHandle key = _key.Value;
+
             if (key == null || key.IsInvalid)
             {
                 throw new CryptographicException(SR.Cryptography_OpenInvalidHandle);
             }
+
+            return key;
         }
 
         private static void CheckReturn(int returnValue)
@@ -663,7 +700,7 @@ namespace System.Security.Cryptography
             if (padding.Mode == RSASignaturePaddingMode.Pkcs1)
             {
                 int algorithmNid = GetAlgorithmNid(hashAlgorithm);
-                SafeRsaHandle rsa = _key.Value;
+                SafeRsaHandle rsa = GetKey();
 
                 int bytesRequired = Interop.Crypto.RsaSize(rsa);
 
@@ -695,7 +732,7 @@ namespace System.Security.Cryptography
             else if (padding.Mode == RSASignaturePaddingMode.Pss)
             {
                 RsaPaddingProcessor processor = RsaPaddingProcessor.OpenProcessor(hashAlgorithm);
-                SafeRsaHandle rsa = _key.Value;
+                SafeRsaHandle rsa = GetKey();
 
                 int bytesRequired = Interop.Crypto.RsaSize(rsa);
 
@@ -766,13 +803,13 @@ namespace System.Security.Cryptography
             if (padding == RSASignaturePadding.Pkcs1)
             {
                 int algorithmNid = GetAlgorithmNid(hashAlgorithm);
-                SafeRsaHandle rsa = _key.Value;
+                SafeRsaHandle rsa = GetKey();
                 return Interop.Crypto.RsaVerify(algorithmNid, hash, signature, rsa);
             }
             else if (padding == RSASignaturePadding.Pss)
             {
                 RsaPaddingProcessor processor = RsaPaddingProcessor.OpenProcessor(hashAlgorithm);
-                SafeRsaHandle rsa = _key.Value;
+                SafeRsaHandle rsa = GetKey();
 
                 int requiredBytes = Interop.Crypto.RsaSize(rsa);
 

--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -92,8 +92,7 @@ namespace System.Security.Cryptography
                 const string ExportPassword = "DotnetExportPassphrase";
                 SecKeyPair keys = GetKeys();
 
-                if (keys.PublicKey == null ||
-                    (includePrivateParameters && keys.PrivateKey == null))
+                if (includePrivateParameters && keys.PrivateKey == null)
                 { 
                     throw new CryptographicException(SR.Cryptography_OpenInvalidHandle);
                 }
@@ -695,8 +694,8 @@ namespace System.Security.Cryptography
                 {
                     if (_keys != null)
                     {
+                        // Do not set _keys to null, in order to prevent rehydration.
                         _keys.Dispose();
-                        _keys = null;
                     }
                 }
 
@@ -742,6 +741,11 @@ namespace System.Security.Cryptography
 
                 if (current != null)
                 {
+                    if (current.PublicKey == null)
+                    {
+                        throw new ObjectDisposedException(nameof(RSA));
+                    }
+
                     return current;
                 }
 

--- a/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -36,7 +36,7 @@ namespace System.Security.Cryptography
 
             public RSASecurityTransforms(int keySize)
             {
-                KeySize = keySize;
+                base.KeySize = keySize;
             }
 
             internal RSASecurityTransforms(SafeSecKeyRefHandle publicKey)
@@ -76,6 +76,8 @@ namespace System.Security.Cryptography
 
                     // Set the KeySize before freeing the key so that an invalid value doesn't throw away the key
                     base.KeySize = value;
+
+                    ThrowIfDisposed();
 
                     if (_keys != null)
                     {
@@ -149,6 +151,9 @@ namespace System.Security.Cryptography
 
             public override void ImportParameters(RSAParameters parameters)
             {
+                ValidateParameters(parameters);
+                ThrowIfDisposed();
+
                 bool isPrivateKey = parameters.D != null;
 
                 if (isPrivateKey)
@@ -189,6 +194,8 @@ namespace System.Security.Cryptography
                 ReadOnlySpan<byte> source,
                 out int bytesRead)
             {
+                ThrowIfDisposed();
+
                 fixed (byte* ptr = &MemoryMarshal.GetReference(source))
                 {
                     using (MemoryManager<byte> manager = new PointerMemoryManager<byte>(ptr, source.Length))
@@ -208,6 +215,8 @@ namespace System.Security.Cryptography
 
             public override unsafe void ImportRSAPublicKey(ReadOnlySpan<byte> source, out int bytesRead)
             {
+                ThrowIfDisposed();
+
                 fixed (byte* ptr = &MemoryMarshal.GetReference(source))
                 {
                     using (MemoryManager<byte> manager = new PointerMemoryManager<byte>(ptr, source.Length))
@@ -236,6 +245,24 @@ namespace System.Security.Cryptography
                 }
             }
 
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<byte> passwordBytes,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ThrowIfDisposed();
+                base.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
+            }
+
+            public override void ImportEncryptedPkcs8PrivateKey(
+                ReadOnlySpan<char> password,
+                ReadOnlySpan<byte> source,
+                out int bytesRead)
+            {
+                ThrowIfDisposed();
+                base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
+            }
+
             public override byte[] Encrypt(byte[] data, RSAEncryptionPadding padding)
             {
                 if (data == null)
@@ -246,6 +273,8 @@ namespace System.Security.Cryptography
                 {
                     throw new ArgumentNullException(nameof(padding));
                 }
+
+                ThrowIfDisposed();
 
                 // The size of encrypt is always the keysize (in ceiling-bytes)
                 int outputSize = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
@@ -267,6 +296,8 @@ namespace System.Security.Cryptography
                 {
                     throw new ArgumentNullException(nameof(padding));
                 }
+
+                ThrowIfDisposed();
 
                 int rsaSize = RsaPaddingProcessor.BytesRequiredForBitCount(KeySize);
 
@@ -467,6 +498,8 @@ namespace System.Security.Cryptography
                 if (padding == null)
                     throw new ArgumentNullException(nameof(padding));
 
+                ThrowIfDisposed();
+
                 if (padding == RSASignaturePadding.Pkcs1)
                 {
                     SecKeyPair keys = GetKeys();
@@ -522,6 +555,8 @@ namespace System.Security.Cryptography
                 {
                     throw new ArgumentNullException(nameof(padding));
                 }
+
+                ThrowIfDisposed();
 
                 RsaPaddingProcessor processor = null;
 
@@ -626,6 +661,8 @@ namespace System.Security.Cryptography
                 {
                     throw new ArgumentNullException(nameof(padding));
                 }
+
+                ThrowIfDisposed();
 
                 if (padding == RSASignaturePadding.Pkcs1)
                 {
@@ -735,17 +772,23 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmName.Name);
             }
 
+            private void ThrowIfDisposed()
+            {
+                SecKeyPair current = _keys;
+
+                if (current != null && current.PublicKey == null)
+                {
+                    throw new ObjectDisposedException(nameof(RSA));
+                }
+            }
+
             internal SecKeyPair GetKeys()
             {
+                ThrowIfDisposed();
                 SecKeyPair current = _keys;
 
                 if (current != null)
                 {
-                    if (current.PublicKey == null)
-                    {
-                        throw new ObjectDisposedException(nameof(RSA));
-                    }
-
                     return current;
                 }
 
@@ -761,6 +804,8 @@ namespace System.Security.Cryptography
 
             private void SetKey(SecKeyPair newKeyPair)
             {
+                ThrowIfDisposed();
+
                 SecKeyPair current = _keys;
                 _keys = newKeyPair;
                 current?.Dispose();
@@ -787,6 +832,43 @@ namespace System.Security.Cryptography
                         return Interop.AppleCrypto.ImportEphemeralKey(pkcs1PublicKey.EncodeAsSpan(), false);
                     }
                 }
+            }
+
+            private static void ValidateParameters(in RSAParameters parameters)
+            {
+                if (parameters.Modulus == null || parameters.Exponent == null)
+                    throw new CryptographicException(SR.Argument_InvalidValue);
+
+                if (!HasConsistentPrivateKey(parameters))
+                    throw new CryptographicException(SR.Argument_InvalidValue);
+            }
+
+            private static bool HasConsistentPrivateKey(in RSAParameters parameters)
+            {
+                if (parameters.D == null)
+                {
+                    if (parameters.P != null ||
+                        parameters.DP != null ||
+                        parameters.Q != null ||
+                        parameters.DQ != null ||
+                        parameters.InverseQ != null)
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (parameters.P == null ||
+                        parameters.DP == null ||
+                        parameters.Q == null ||
+                        parameters.DQ == null ||
+                        parameters.InverseQ == null)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             }
         }
 

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAImportExport.cs
@@ -147,7 +147,7 @@ namespace System.Security.Cryptography.Dsa.Tests
                 {
                     key.CreateSignature(hash);
                 }
-                catch (CryptographicException) when (!SupportsKeyGeneration)
+                catch (PlatformNotSupportedException) when (!SupportsKeyGeneration)
                 {
                 }
             }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAImportExport.cs
@@ -132,6 +132,31 @@ namespace System.Security.Cryptography.Dsa.Tests
             }
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void ExportAfterDispose(bool importKey)
+        {
+            DSA key = importKey ? DSAFactory.Create(DSATestData.GetDSA1024Params()) : DSAFactory.Create(512);
+            byte[] hash = new byte[20];
+
+            // Ensure that the key got created, and then Dispose it.
+            using (key)
+            {
+                try
+                {
+                    key.CreateSignature(hash);
+                }
+                catch (CryptographicException) when (!SupportsKeyGeneration)
+                {
+                }
+            }
+
+            Assert.Throws<ObjectDisposedException>(() => key.ExportParameters(false));
+            Assert.Throws<ObjectDisposedException>(() => key.ExportParameters(true));
+            Assert.Throws<ObjectDisposedException>(() => key.ImportParameters(DSATestData.GetDSA1024Params()));
+        }
+
         internal static void AssertKeyEquals(in DSAParameters expected, in DSAParameters actual)
         {
             Assert.Equal(expected.G, actual.G);

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -15,6 +15,15 @@ namespace System.Security.Cryptography.Dsa.Tests
         public override bool VerifyData(DSA dsa, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm) =>
             dsa.VerifyData(data, signature, hashAlgorithm);
 
+        protected override void UseAfterDispose(DSA dsa, byte[] data, byte[] sig)
+        {
+            base.UseAfterDispose(dsa, data, sig);
+            byte[] hash = new byte[20];
+
+            Assert.Throws<ObjectDisposedException>(() => dsa.CreateSignature(hash));
+            Assert.Throws<ObjectDisposedException>(() => dsa.VerifySignature(hash, sig));
+        }
+
         [Fact]
         public void InvalidStreamArrayArguments_Throws()
         {
@@ -65,6 +74,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
     }
 
+#if netcoreapp
     public sealed class DSASignVerify_Span : DSASignVerify
     {
         public override byte[] SignData(DSA dsa, byte[] data, HashAlgorithmName hashAlgorithm) =>
@@ -72,6 +82,15 @@ namespace System.Security.Cryptography.Dsa.Tests
 
         public override bool VerifyData(DSA dsa, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm) =>
             dsa.VerifyData((ReadOnlySpan<byte>)data, (ReadOnlySpan<byte>)signature, hashAlgorithm);
+
+        protected override void UseAfterDispose(DSA dsa, byte[] data, byte[] sig)
+        {
+            base.UseAfterDispose(dsa, data, sig);
+            byte[] hash = new byte[20];
+
+            Assert.Throws<ObjectDisposedException>(() => dsa.TryCreateSignature(hash, sig, out _));
+            Assert.Throws<ObjectDisposedException>(() => dsa.VerifySignature(hash.AsSpan(), sig.AsSpan()));
+        }
 
         private static byte[] TryWithOutputArray(Func<byte[], (bool, int)> func)
         {
@@ -87,7 +106,7 @@ namespace System.Security.Cryptography.Dsa.Tests
             }
         }
     }
-
+#endif
     public abstract partial class DSASignVerify
     {
         public abstract byte[] SignData(DSA dsa, byte[] data, HashAlgorithmName hashAlgorithm);
@@ -105,6 +124,56 @@ namespace System.Security.Cryptography.Dsa.Tests
 
                 Assert.True(VerifyData(dsa, DSATestData.HelloBytes, signature, HashAlgorithmName.SHA1));
             }
+        }
+
+        [ConditionalFact(nameof(SupportsKeyGeneration))]
+        public void UseAfterDispose_NewKey()
+        {
+            UseAfterDispose(false);
+        }
+
+        [Fact]
+        public void UseAfterDispose_ImportedKey()
+        {
+            UseAfterDispose(true);
+        }
+
+        private void UseAfterDispose(bool importKey)
+        {
+            DSA key = importKey ? DSAFactory.Create(DSATestData.GetDSA1024Params()) : DSAFactory.Create(512);
+            byte[] data = { 1 };
+            byte[] sig;
+
+            // Ensure the key is populated, then dispose it.
+            using (key)
+            {
+                sig = SignData(key, data, HashAlgorithmName.SHA256);
+            }
+
+            key.Dispose();
+
+            UseAfterDispose(key, data, sig);
+
+            Assert.Throws<ObjectDisposedException>(() => key.ImportParameters(DSATestData.GetDSA1024Params()));
+
+            // Either set_KeySize or SignData should throw.
+            Assert.Throws<ObjectDisposedException>(
+                () =>
+                {
+                    key.KeySize = 576;
+                    SignData(key, data, HashAlgorithmName.SHA256);
+                });
+
+            Assert.False(true);
+        }
+
+        protected virtual void UseAfterDispose(DSA dsa, byte[] data, byte[] sig)
+        {
+            Assert.Throws<ObjectDisposedException>(
+                () => SignData(dsa, data, HashAlgorithmName.SHA256));
+
+            Assert.Throws<ObjectDisposedException>(
+                () => VerifyData(dsa, data, sig, HashAlgorithmName.SHA256));
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -163,8 +163,6 @@ namespace System.Security.Cryptography.Dsa.Tests
                     key.KeySize = 576;
                     SignData(key, data, HashAlgorithmName.SHA256);
                 });
-
-            Assert.False(true);
         }
 
         protected virtual void UseAfterDispose(DSA dsa, byte[] data, byte[] sig)

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -147,7 +147,7 @@ namespace System.Security.Cryptography.Dsa.Tests
             // Ensure the key is populated, then dispose it.
             using (key)
             {
-                sig = SignData(key, data, HashAlgorithmName.SHA256);
+                sig = SignData(key, data, HashAlgorithmName.SHA1);
             }
 
             key.Dispose();
@@ -161,17 +161,17 @@ namespace System.Security.Cryptography.Dsa.Tests
                 () =>
                 {
                     key.KeySize = 576;
-                    SignData(key, data, HashAlgorithmName.SHA256);
+                    SignData(key, data, HashAlgorithmName.SHA1);
                 });
         }
 
         protected virtual void UseAfterDispose(DSA dsa, byte[] data, byte[] sig)
         {
             Assert.Throws<ObjectDisposedException>(
-                () => SignData(dsa, data, HashAlgorithmName.SHA256));
+                () => SignData(dsa, data, HashAlgorithmName.SHA1));
 
             Assert.Throws<ObjectDisposedException>(
-                () => VerifyData(dsa, data, sig, HashAlgorithmName.SHA256));
+                () => VerifyData(dsa, data, sig, HashAlgorithmName.SHA1));
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/EccTestData.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/EccTestData.cs
@@ -20,7 +20,6 @@ namespace System.Security.Cryptography.Tests
             ("a232cec7be26319e53db0d48470232d37793b06b99e8ed82fac1996b3d1596449087769927d64af657cce62d853c4cf7ff4c"
            + "d069eda230d1c524d225756ffbaf").HexToByteArray();
 
-#if netcoreapp
         internal static ECCurve GetNistP256ExplicitCurve()
         {
             // SEC2-Ver-1.0, 2.7.2
@@ -239,6 +238,5 @@ namespace System.Security.Cryptography.Tests
                 },
                 D = "00B4F1AE1E7FDCD4B0E82053C08A908852B26231E6C01670FCC6C3EA2C5D3FED40EDF037".HexToByteArray(),
             };
-#endif // netcoreapp
     }
 }

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
@@ -171,8 +171,13 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
             UseAfterDispose(ecdsa, data, sig);
 
-            Assert.Throws<ObjectDisposedException>(() => ecdsa.GenerateKey(ECCurve.NamedCurves.nistP256));
-            Assert.Throws<ObjectDisposedException>(() => ecdsa.ImportParameters(EccTestData.GetNistP256ReferenceKey()));
+            if (!(PlatformDetection.IsFullFramework && ecdsa.GetType().Name.EndsWith("Cng")))
+            {
+                Assert.Throws<ObjectDisposedException>(() => ecdsa.GenerateKey(ECCurve.NamedCurves.nistP256));
+
+                Assert.Throws<ObjectDisposedException>(
+                    () => ecdsa.ImportParameters(EccTestData.GetNistP256ReferenceKey()));
+            }
 
             // Either set_KeySize or SignData should throw.
             Assert.Throws<ObjectDisposedException>(

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography.Tests;
 using System.Text;
 using Xunit;
 
@@ -17,6 +18,15 @@ namespace System.Security.Cryptography.EcDsa.Tests
             ecdsa.VerifyData(data, offset, count, signature, hashAlgorithm);
         protected override byte[] SignData(ECDsa ecdsa, byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
             ecdsa.SignData(data, offset, count, hashAlgorithm);
+
+        protected override void UseAfterDispose(ECDsa ecdsa, byte[] data, byte[] sig)
+        {
+            base.UseAfterDispose(ecdsa, data, sig);
+            byte[] hash = new byte[32];
+
+            Assert.Throws<ObjectDisposedException>(() => ecdsa.VerifyHash(hash, sig));
+            Assert.Throws<ObjectDisposedException>(() => ecdsa.SignHash(hash));
+        }
 
         [Theory, MemberData(nameof(RealImplementations))]
         public void SignData_InvalidArguments_Throws(ECDsa ecdsa)
@@ -130,6 +140,57 @@ namespace System.Security.Cryptography.EcDsa.Tests
             };
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        [Theory]
+        [MemberData(nameof(RealImplementations))]
+        public void UseAfterDispose_Import(ECDsa ecdsa)
+        {
+            ecdsa.ImportParameters(EccTestData.GetNistP256ReferenceKey());
+            UseAfterDispose(ecdsa);
+        }
+
+        [Theory]
+        [MemberData(nameof(RealImplementations))]
+        public void UseAfterDispose_NewKey(ECDsa ecdsa)
+        {
+            UseAfterDispose(ecdsa);
+        }
+
+        private void UseAfterDispose(ECDsa ecdsa)
+        {
+            byte[] data = { 1 };
+            byte[] sig;
+
+            // Ensure the key is populated, then dispose it.
+            using (ecdsa)
+            {
+                sig = SignData(ecdsa, data, HashAlgorithmName.SHA256);
+            }
+
+            ecdsa.Dispose();
+
+            UseAfterDispose(ecdsa, data, sig);
+
+            Assert.Throws<ObjectDisposedException>(() => ecdsa.GenerateKey(ECCurve.NamedCurves.nistP256));
+            Assert.Throws<ObjectDisposedException>(() => ecdsa.ImportParameters(EccTestData.GetNistP256ReferenceKey()));
+
+            // Either set_KeySize or SignData should throw.
+            Assert.Throws<ObjectDisposedException>(
+                () =>
+                {
+                    ecdsa.KeySize = 384;
+                    SignData(ecdsa, data, HashAlgorithmName.SHA256);
+                });
+        }
+
+        protected virtual void UseAfterDispose(ECDsa ecdsa, byte[] data, byte[] sig)
+        {
+            Assert.Throws<ObjectDisposedException>(
+                () => SignData(ecdsa, data, HashAlgorithmName.SHA256));
+
+            Assert.Throws<ObjectDisposedException>(
+                () => VerifyData(ecdsa, data, sig, HashAlgorithmName.SHA256));
+        }
 
         [Theory]
         [MemberData(nameof(RealImplementations))]

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.netcoreapp.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.netcoreapp.cs
@@ -15,6 +15,15 @@ namespace System.Security.Cryptography.EcDsa.Tests
         protected override byte[] SignData(ECDsa ecdsa, byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm) =>
             TryWithOutputArray(dest => ecdsa.TrySignData(new ReadOnlySpan<byte>(data, offset, count), dest, hashAlgorithm, out int bytesWritten) ? (true, bytesWritten) : (false, 0));
 
+        protected override void UseAfterDispose(ECDsa ecdsa, byte[] data, byte[] sig)
+        {
+            base.UseAfterDispose(ecdsa, data, sig);
+            byte[] hash = new byte[32];
+
+            Assert.Throws<ObjectDisposedException>(() => ecdsa.VerifyHash(hash.AsSpan(), sig.AsSpan()));
+            Assert.Throws<ObjectDisposedException>(() => ecdsa.TrySignHash(hash, sig, out _));
+        }
+
         [Theory, MemberData(nameof(RealImplementations))]
         public void SignData_InvalidArguments_Throws(ECDsa ecdsa)
         {

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -43,6 +43,24 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void UseAfterDispose(bool importKey)
+        {
+            RSA rsa = importKey ? RSAFactory.Create(TestData.RSA2048Params) : RSAFactory.Create(1024);
+            byte[] data = TestData.HelloBytes;
+            byte[] enc;
+
+            using (rsa)
+            {
+                enc = Encrypt(rsa, data, RSAEncryptionPadding.Pkcs1);
+            }
+
+            Assert.Throws<ObjectDisposedException>(
+                () => Decrypt(rsa, enc, RSAEncryptionPadding.Pkcs1));
+        }
+
         [Fact]
         public void DecryptSavedAnswer()
         {

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -304,7 +304,11 @@ namespace System.Security.Cryptography.Rsa.Tests
 
             Assert.Throws<ObjectDisposedException>(() => rsa.ExportParameters(false));
             Assert.Throws<ObjectDisposedException>(() => rsa.ExportParameters(true));
-            Assert.Throws<ObjectDisposedException>(() => rsa.ImportParameters(TestData.RSA1024Params));
+
+            if (!(PlatformDetection.IsFullFramework && rsa.GetType().Name.EndsWith("Cng")))
+            {
+                Assert.Throws<ObjectDisposedException>(() => rsa.ImportParameters(TestData.RSA1024Params));
+            }
         }
 
         internal static void AssertKeyEquals(in RSAParameters expected, in RSAParameters actual)

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -289,6 +289,24 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static void ExportAfterDispose(bool importKey)
+        {
+            RSA rsa = importKey ? RSAFactory.Create(TestData.RSA2048Params) : RSAFactory.Create(1024);
+            
+            // Ensure that the key got created, and then Dispose it.
+            using (rsa)
+            {
+                rsa.Encrypt(TestData.HelloBytes, RSAEncryptionPadding.Pkcs1);
+            }
+
+            Assert.Throws<ObjectDisposedException>(() => rsa.ExportParameters(false));
+            Assert.Throws<ObjectDisposedException>(() => rsa.ExportParameters(true));
+            Assert.Throws<ObjectDisposedException>(() => rsa.ImportParameters(TestData.RSA1024Params));
+        }
+
         internal static void AssertKeyEquals(in RSAParameters expected, in RSAParameters actual)
         {
             Assert.Equal(expected.Modulus, actual.Modulus);

--- a/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -130,12 +130,20 @@ namespace System.Security.Cryptography
         public override void FromXmlString(string xmlString) { }
         protected virtual byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         protected virtual byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public override void ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
+        public override void ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public abstract void ImportParameters(System.Security.Cryptography.DSAParameters parameters);
+        public override void ImportPkcs8PrivateKey(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
+        public override void ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public virtual byte[] SignData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public virtual byte[] SignData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public override string ToXmlString(bool includePrivateParameters) { throw null; }
         public virtual bool TryCreateSignature(System.ReadOnlySpan<byte> hash, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected virtual bool TryHashData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
         public virtual bool TrySignData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
         public bool VerifyData(byte[] data, byte[] signature, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
@@ -246,9 +254,17 @@ namespace System.Security.Cryptography
         public override void FromXmlString(string xmlString) { }
         public virtual void GenerateKey(System.Security.Cryptography.ECCurve curve) { }
         public virtual void ImportECPrivateKey(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
+        public override void ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
+        public override void ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public virtual void ImportParameters(System.Security.Cryptography.ECParameters parameters) { }
+        public override void ImportPkcs8PrivateKey(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
+        public override void ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public override string ToXmlString(bool includePrivateParameters) { throw null; }
         public virtual bool TryExportECPrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public abstract partial class ECDiffieHellmanPublicKey : System.IDisposable
     {
@@ -278,13 +294,21 @@ namespace System.Security.Cryptography
         protected virtual byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         protected virtual byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public virtual void ImportECPrivateKey(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
+        public override void ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
+        public override void ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public virtual void ImportParameters(System.Security.Cryptography.ECParameters parameters) { }
+        public override void ImportPkcs8PrivateKey(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
+        public override void ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public virtual byte[] SignData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public virtual byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public virtual byte[] SignData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public abstract byte[] SignHash(byte[] hash);
         public override string ToXmlString(bool includePrivateParameters) { throw null; }
         public virtual bool TryExportECPrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected virtual bool TryHashData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
         public virtual bool TrySignData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
         public virtual bool TrySignHash(System.ReadOnlySpan<byte> hash, System.Span<byte> destination, out int bytesWritten) { throw null; }
@@ -490,9 +514,13 @@ namespace System.Security.Cryptography
         public override void FromXmlString(string xmlString) { }
         protected virtual byte[] HashData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         protected virtual byte[] HashData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
+        public override void ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
+        public override void ImportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public abstract void ImportParameters(System.Security.Cryptography.RSAParameters parameters);
+        public override void ImportPkcs8PrivateKey(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public virtual void ImportRSAPrivateKey(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public virtual void ImportRSAPublicKey(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
+        public override void ImportSubjectPublicKeyInfo(System.ReadOnlySpan<byte> source, out int bytesRead) { throw null; }
         public virtual byte[] SignData(byte[] data, int offset, int count, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
         public byte[] SignData(byte[] data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
         public virtual byte[] SignData(System.IO.Stream data, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding) { throw null; }
@@ -500,8 +528,12 @@ namespace System.Security.Cryptography
         public override string ToXmlString(bool includePrivateParameters) { throw null; }
         public virtual bool TryDecrypt(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.Security.Cryptography.RSAEncryptionPadding padding, out int bytesWritten) { throw null; }
         public virtual bool TryEncrypt(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.Security.Cryptography.RSAEncryptionPadding padding, out int bytesWritten) { throw null; }
+        public override bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<byte> passwordBytes, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportEncryptedPkcs8PrivateKey(System.ReadOnlySpan<char> password, System.Security.Cryptography.PbeParameters pbeParameters, System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportPkcs8PrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
         public virtual bool TryExportRSAPrivateKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
         public virtual bool TryExportRSAPublicKey(System.Span<byte> destination, out int bytesWritten) { throw null; }
+        public override bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }
         protected virtual bool TryHashData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, out int bytesWritten) { throw null; }
         public virtual bool TrySignData(System.ReadOnlySpan<byte> data, System.Span<byte> destination, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding, out int bytesWritten) { throw null; }
         public virtual bool TrySignHash(System.ReadOnlySpan<byte> hash, System.Span<byte> destination, System.Security.Cryptography.HashAlgorithmName hashAlgorithm, System.Security.Cryptography.RSASignaturePadding padding, out int bytesWritten) { throw null; }

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanCng.Key.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanCng.Key.cs
@@ -11,7 +11,7 @@ namespace System.Security.Cryptography
     {
         public sealed partial class ECDiffieHellmanCng : ECDiffieHellman
         {
-            private readonly ECCngKey _key = new ECCngKey(BCryptNative.AlgorithmName.ECDH);
+            private readonly ECCngKey _key = new ECCngKey(BCryptNative.AlgorithmName.ECDH, nameof(ECDiffieHellman));
 
             private string GetCurveName(out string oidValue) => _key.GetCurveName(KeySize, out oidValue);
 

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
@@ -12,6 +12,21 @@ namespace System.Security.Cryptography
     {
         public sealed partial class ECDiffieHellmanCng : ECDiffieHellman
         {
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _key.FullDispose();
+                }
+
+                base.Dispose(disposing);
+            }
+
+            private void ThrowIfDisposed()
+            {
+                _key.ThrowIfDisposed();
+            }
+
             private void ImportFullKeyBlob(byte[] ecfullKeyBlob, bool includePrivateParameters)
             {
                 string blobType = includePrivateParameters ?

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanCngPublicKey.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDiffieHellmanCngPublicKey.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography
 
             protected override void Dispose(bool disposing)
             {
+                _keyBlob = null;
                 base.Dispose(disposing);
             }
 
@@ -48,6 +49,11 @@ namespace System.Security.Cryptography
             /// <returns>The key and explicit curve parameters used by the ECC object.</returns>
             public override ECParameters ExportExplicitParameters()
             {
+                if (_keyBlob == null)
+                {
+                    throw new ObjectDisposedException(nameof(ECDiffieHellmanPublicKey));
+                }
+
                 ECParameters ecparams = new ECParameters();
                 ECCng.ExportPrimeCurveParameters(ref ecparams, _keyBlob, includePrivateParameters: false);
                 return ecparams;
@@ -64,6 +70,11 @@ namespace System.Security.Cryptography
             /// <returns>The key and named curve parameters used by the ECC object.</returns>
             public override ECParameters ExportParameters()
             {
+                if (_keyBlob == null)
+                {
+                    throw new ObjectDisposedException(nameof(ECDiffieHellmanPublicKey));
+                }
+
                 if (string.IsNullOrEmpty(_curveName))
                 {
                     return ExportExplicitParameters();

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaCng.Key.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaCng.Key.cs
@@ -11,7 +11,7 @@ namespace System.Security.Cryptography
     {
         public sealed partial class ECDsaCng : ECDsa
         {
-            private readonly ECCngKey _key = new ECCngKey(AlgorithmName.ECDsa);
+            private readonly ECCngKey _key = new ECCngKey(AlgorithmName.ECDsa, nameof(ECDsa));
 
             private string GetCurveName(out string oidValue) => _key.GetCurveName(KeySize, out oidValue);
             

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECDsaCng.cs
@@ -48,6 +48,21 @@ namespace System.Security.Cryptography
     {
         public sealed partial class ECDsaCng : ECDsa
         {
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _key?.FullDispose();
+                }
+
+                base.Dispose(disposing);
+            }
+
+            private void ThrowIfDisposed()
+            {
+                _key.ThrowIfDisposed();
+            }
+
             private void ImportFullKeyBlob(byte[] ecfullKeyBlob, bool includePrivateParameters)
             {
                 string blobType = includePrivateParameters ?

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngAlgorithmCore.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/CngAlgorithmCore.cs
@@ -15,8 +15,15 @@ namespace Internal.Cryptography
     //
     internal struct CngAlgorithmCore
     {
+        private readonly string _disposedName;
         public CngAlgorithm DefaultKeyType;
         private CngKey _lazyKey;
+        private bool _disposed;
+
+        public CngAlgorithmCore(string disposedName) : this()
+        {
+            _disposedName = disposedName;
+        }
 
         public static CngKey Duplicate(CngKey key)
         {
@@ -28,6 +35,7 @@ namespace Internal.Cryptography
 
         public bool IsKeyGeneratedNamedCurve()
         {
+            ThrowIfDisposed();
             return (_lazyKey != null && _lazyKey.IsECNamedCurve());
         }
 
@@ -42,6 +50,8 @@ namespace Internal.Cryptography
 
         public CngKey GetOrGenerateKey(int keySize, CngAlgorithm algorithm)
         {
+            ThrowIfDisposed();
+
             // If our key size was changed, we need to generate a new key.
             if (_lazyKey != null)
             {
@@ -68,6 +78,8 @@ namespace Internal.Cryptography
 
         public CngKey GetOrGenerateKey(ECCurve? curve)
         {
+            ThrowIfDisposed();
+
             if (_lazyKey != null)
             {
                 return _lazyKey;
@@ -123,6 +135,7 @@ namespace Internal.Cryptography
         public void SetKey(CngKey key)
         {
             Debug.Assert(key != null);
+            ThrowIfDisposed();
 
             // If we already have a key, clear it out.
             DisposeKey();
@@ -133,6 +146,15 @@ namespace Internal.Cryptography
         public void Dispose()
         {
             DisposeKey();
+            _disposed = true;
+        }
+
+        internal void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(_disposedName);
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/DSACng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/DSACng.cs
@@ -8,6 +8,8 @@ namespace System.Security.Cryptography
 {
     public sealed partial class DSACng : DSA
     {
+        private CngAlgorithmCore _core = new CngAlgorithmCore(nameof(DSACng));
+
         /// <summary>
         ///     Creates a new DSACng object that will use the specified key. The key's
         ///     <see cref="CngKey.AlgorithmGroup" /> must be Dsa. This constructor
@@ -33,6 +35,9 @@ namespace System.Security.Cryptography
             _core.Dispose();
         }
 
-        private CngAlgorithmCore _core;
+        private void ThrowIfDisposed()
+        {
+            _core.ThrowIfDisposed();
+        }
     }
 }

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDiffieHellmanCng.cs
@@ -21,7 +21,7 @@ namespace System.Security.Cryptography
     /// </summary>
     public sealed partial class ECDiffieHellmanCng : ECDiffieHellman
     {
-        private CngAlgorithmCore _core = new CngAlgorithmCore { DefaultKeyType = CngAlgorithm.ECDiffieHellman };
+        private CngAlgorithmCore _core = new CngAlgorithmCore(nameof(ECDiffieHellmanCng)) { DefaultKeyType = CngAlgorithm.ECDiffieHellman };
         private CngAlgorithm _hashAlgorithm = CngAlgorithm.Sha256;
         private ECDiffieHellmanKeyDerivationFunction _kdf = ECDiffieHellmanKeyDerivationFunction.Hash;
         private byte[] _hmacKey;
@@ -139,6 +139,11 @@ namespace System.Security.Cryptography
         protected override void Dispose(bool disposing)
         {
             _core.Dispose();
+        }
+
+        private void ThrowIfDisposed()
+        {
+            _core.ThrowIfDisposed();
         }
 
         private void DisposeKey()

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDiffieHellmanCngPublicKey.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDiffieHellmanCngPublicKey.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography
     {
         private CngKeyBlobFormat _format;
         private string _curveName;
+        private bool _disposed;
 
         /// <summary>
         /// Wrap a CNG key
@@ -24,6 +25,11 @@ namespace System.Security.Cryptography
 
         protected override void Dispose(bool disposing)
         {
+            if (disposing)
+            {
+                _disposed = true;
+            }
+
             base.Dispose(disposing);
         }
 
@@ -84,6 +90,11 @@ namespace System.Security.Cryptography
         /// <returns></returns>
         public CngKey Import()
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(ECDiffieHellmanCngPublicKey));
+            }
+
             return CngKey.Import(ToByteArray(), _curveName, BlobFormat);
         }
 

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography
 {
     public sealed partial class ECDsaCng : ECDsa
     {
-        private CngAlgorithmCore _core;
+        private CngAlgorithmCore _core = new CngAlgorithmCore(nameof(ECDsaCng));
         private CngAlgorithm _hashAlgorithm = CngAlgorithm.Sha256;
 
         /// <summary>
@@ -50,6 +50,11 @@ namespace System.Security.Cryptography
         protected override void Dispose(bool disposing)
         {
             _core.Dispose();
+        }
+
+        private void ThrowIfDisposed()
+        {
+            _core.ThrowIfDisposed();
         }
 
         private void DisposeKey()

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/RSACng.cs
@@ -2,15 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
 {
     public sealed partial class RSACng : RSA
     {
+        private CngAlgorithmCore _core = new CngAlgorithmCore(nameof(RSACng));
+
         /// <summary>
         ///     Creates a new RSACng object that will use the specified key. The key's
         ///     <see cref="CngKey.AlgorithmGroup" /> must be Rsa. This constructor
@@ -36,6 +35,9 @@ namespace System.Security.Cryptography
             _core.Dispose();
         }
 
-        private CngAlgorithmCore _core;
+        private void ThrowIfDisposed()
+        {
+            _core.ThrowIfDisposed();
+        }
     }
 }

--- a/src/System.Security.Cryptography.Cng/tests/Configurations.props
+++ b/src/System.Security.Cryptography.Cng/tests/Configurations.props
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp-Windows_NT;
-      net462-Windows_NT;
-      net47-Windows_NT;
       netfx-Windows_NT;
       uap-Windows_NT;
     </BuildConfigurations>

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
@@ -119,6 +119,22 @@ namespace System.Security.Cryptography
             _publicOnly = (parameters.X == null);
         }
 
+        public override void ImportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<byte> passwordBytes,
+            ReadOnlySpan<byte> source,
+            out int bytesRead)
+        {
+            _impl.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
+        }
+
+        public override void ImportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<char> password,
+            ReadOnlySpan<byte> source,
+            out int bytesRead)
+        {
+            _impl.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
+        }
+
         public override string KeyExchangeAlgorithm => _impl.KeyExchangeAlgorithm;
 
         public override int KeySize

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Windows.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Windows.cs
@@ -5,7 +5,6 @@
 using System.Diagnostics;
 using System.IO;
 using Internal.NativeCrypto;
-using Microsoft.Win32.SafeHandles;
 
 namespace System.Security.Cryptography
 {
@@ -18,6 +17,7 @@ namespace System.Security.Cryptography
         private SafeProvHandle _safeProvHandle;
         private SHA1 _sha1;
         private static volatile CspProviderFlags s_useMachineKeyStore = 0;
+        private bool _disposed;
 
         /// <summary>
         /// Initializes a new instance of the DSACryptoServiceProvider class.
@@ -268,17 +268,22 @@ namespace System.Security.Cryptography
 
         protected override void Dispose(bool disposing)
         {
+            if (disposing)
+            {
+                if (_safeKeyHandle != null && !_safeKeyHandle.IsClosed)
+                {
+                    _safeKeyHandle.Dispose();
+                }
+
+                if (_safeProvHandle != null && !_safeProvHandle.IsClosed)
+                {
+                    _safeProvHandle.Dispose();
+                }
+
+                _disposed = true;
+            }
+
             base.Dispose(disposing);
-
-            if (_safeKeyHandle != null && !_safeKeyHandle.IsClosed)
-            {
-                _safeKeyHandle.Dispose();
-            }
-
-            if (_safeProvHandle != null && !_safeProvHandle.IsClosed)
-            {
-                _safeProvHandle.Dispose();
-            }
         }
 
         /// <summary>
@@ -325,6 +330,8 @@ namespace System.Security.Cryptography
         /// <param name="keyBlob">A byte array that represents a DSA key blob.</param>
         public void ImportCspBlob(byte[] keyBlob)
         {
+            ThrowIfDisposed();
+
             SafeKeyHandle safeKeyHandle;
 
             if (IsPublic(keyBlob))
@@ -348,6 +355,24 @@ namespace System.Security.Cryptography
         {
             byte[] keyBlob = parameters.ToKeyBlob();
             ImportCspBlob(keyBlob);
+        }
+
+        public override void ImportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<byte> passwordBytes,
+            ReadOnlySpan<byte> source,
+            out int bytesRead)
+        {
+            ThrowIfDisposed();
+            base.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
+        }
+
+        public override void ImportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<char> password,
+            ReadOnlySpan<byte> source,
+            out int bytesRead)
+        {
+            ThrowIfDisposed();
+            base.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
         }
 
         /// <summary>
@@ -521,6 +546,14 @@ namespace System.Security.Cryptography
             }
 
             return true;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(DSACryptoServiceProvider));
+            }
         }
     }
 }

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/RSACryptoServiceProvider.Unix.cs
@@ -151,6 +151,22 @@ namespace System.Security.Cryptography
             _publicOnly = (parameters.P == null || parameters.P.Length == 0);
         }
 
+        public override void ImportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<byte> passwordBytes,
+            ReadOnlySpan<byte> source,
+            out int bytesRead)
+        {
+            _impl.ImportEncryptedPkcs8PrivateKey(passwordBytes, source, out bytesRead);
+        }
+
+        public override void ImportEncryptedPkcs8PrivateKey(
+            ReadOnlySpan<char> password,
+            ReadOnlySpan<byte> source,
+            out int bytesRead)
+        {
+            _impl.ImportEncryptedPkcs8PrivateKey(password, source, out bytesRead);
+        }
+
         public override string KeyExchangeAlgorithm => _impl.KeyExchangeAlgorithm;
 
         public override int KeySize

--- a/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/DSAOpenSsl.cs
+++ b/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/DSAOpenSsl.cs
@@ -10,6 +10,8 @@ namespace System.Security.Cryptography
     {
         public DSAOpenSsl(DSAParameters parameters)
         {
+            // Make _key be non-null before calling ImportParameters
+            _key = new Lazy<SafeDsaHandle>();
             ImportParameters(parameters);
         }
 

--- a/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -10,6 +10,8 @@ namespace System.Security.Cryptography
     {
         public RSAOpenSsl(RSAParameters parameters)
         {
+            // Make _key be non-null before calling ImportParameters
+            _key = new Lazy<SafeRsaHandle>();
             ImportParameters(parameters);
         }
 

--- a/src/System.Security.Cryptography.OpenSsl/tests/DsaOpenSslTests.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/DsaOpenSslTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Cryptography.Dsa.Tests;
 using Test.Cryptography;
 using Xunit;
 
@@ -95,6 +96,17 @@ namespace System.Security.Cryptography.OpenSsl.Tests
             using (SafeEvpPKeyHandle pkey = ecdsa.DuplicateKeyHandle())
             {
                 Assert.ThrowsAny<CryptographicException>(() => new DSAOpenSsl(pkey));
+            }
+        }
+
+        [Fact]
+        public static void VerifyParameterCtor()
+        {
+            using (DSA dsa = new DSAOpenSsl(DSATestData.Dsa576Parameters))
+            {
+                DSAImportExport.AssertKeyEquals(
+                    DSATestData.Dsa576Parameters,
+                    dsa.ExportParameters(true));
             }
         }
     }

--- a/src/System.Security.Cryptography.OpenSsl/tests/RsaOpenSslTests.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/RsaOpenSslTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Security.Cryptography.Rsa.Tests;
 using Test.Cryptography;
 using Xunit;
 
@@ -95,6 +96,15 @@ namespace System.Security.Cryptography.OpenSsl.Tests
             using (SafeEvpPKeyHandle pkey = ecdsa.DuplicateKeyHandle())
             {
                 Assert.ThrowsAny<CryptographicException>(() => new RSAOpenSsl(pkey));
+            }
+        }
+
+        [Fact]
+        public static void VerifyParameterCtor()
+        {
+            using (RSA rsa = new RSAOpenSsl(TestData.RSA1032Parameters))
+            {
+                ImportExport.AssertKeyEquals(TestData.RSA1032Parameters, rsa.ExportParameters(true));
             }
         }
     }


### PR DESCRIPTION
The AsymmetricAlgorithm types weren't consistent in how they handled Dispose.  There were four predominant behaviors on use-after-Dispose

* NullReferenceException (mainly from the OpenSsl implementations)
* Generate a new key, like the object was fresh (the public Cng implementations)
* Not notice that anything was Disposed, keep on keepin' on (the private Cng implementations in Algorithms)
* Indirect ObjectDisposedExceptions 95% of the time (the Windows CSP types)

This change makes all of the types consistently go into (and stay in) a Disposed state, throwing ObjectDisposedExceptions when asked to do work in that state.

Fixes #33018.