### PR TITLE
Fix the failure in RegionInfo Tests

### DIFF
--- a/src/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -96,7 +96,7 @@ namespace System.Globalization.Tests
         public void EnglishName(string name, string[] expected)
         {
             string result = new RegionInfo(name).EnglishName;
-            Assert.True(expected.Contains(result), $"RegionInfo.EnglishName({name})='{result}' not fond in the possible names ({String.Join(", ", expected)}) ");
+            Assert.True(expected.Contains(result), $"RegionInfo.EnglishName({name})='{result}' not found in the possible names ({String.Join(", ", expected)}) ");
         }
 
         [Theory]

--- a/src/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -91,12 +91,12 @@ namespace System.Globalization.Tests
         [Theory]
         [InlineData("en-US", new string[] { "United States" })]
         [InlineData("US", new string[] { "United States" })]
-        [InlineData("zh-CN", new string[] { "China", "People's Republic of China" })]
-        [InlineData("CN", new string[] { "China", "People's Republic of China" })]
+        [InlineData("zh-CN", new string[] { "China", "People's Republic of China", "China mainland" })]
+        [InlineData("CN", new string[] { "China", "People's Republic of China", "China mainland" })]
         public void EnglishName(string name, string[] expected)
         {
             string result = new RegionInfo(name).EnglishName;
-            Assert.True(expected.Contains(result));
+            Assert.True(expected.Contains(result), $"RegionInfo.EnglishName({name})='{result}' not fond in the possible names ({String.Join(", ", expected)}) ");
         }
 
         [Theory]


### PR DESCRIPTION
China region name has changed to "China mainland", we are updating the test to accept this new name too.

#38553