### PR TITLE
Change DiagnosticsHandler to special-case base cancellation exception

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -111,7 +111,7 @@ namespace System.Net.Http
 
                 return await responseTask.ConfigureAwait(false);
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException)
             {
                 // we'll report task status in HttpRequestOut.Stop
                 throw;


### PR DESCRIPTION
It should be treating all OperationCanceledExceptions as cancellation, not just TaskCanceledException.

cc: @lmolkova 