### PR TITLE
Remove StructLayoutAttribute from GdipImageCodecInfo

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/NativeStructs.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/NativeStructs.Unix.cs
@@ -54,6 +54,7 @@ namespace System.Drawing
         internal string lfFaceName;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
     internal struct GdipImageCodecInfo  /*Size 76 bytes*/
     {
         internal Guid Clsid;

--- a/src/System.Drawing.Common/src/System/Drawing/NativeStructs.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/NativeStructs.Unix.cs
@@ -55,7 +55,7 @@ namespace System.Drawing
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal struct GdipImageCodecInfo  /*Size 76 bytes*/
+    internal struct GdipImageCodecInfo
     {
         internal Guid Clsid;
         internal Guid FormatID;

--- a/src/System.Drawing.Common/src/System/Drawing/NativeStructs.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/NativeStructs.Unix.cs
@@ -54,7 +54,6 @@ namespace System.Drawing
         internal string lfFaceName;
     }
 
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct GdipImageCodecInfo  /*Size 76 bytes*/
     {
         internal Guid Clsid;


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/36722

This attribute seems unnecessary because this struct doesn't have any string and `LayoutKind.Sequential` is the default layout.

cc: @jkoritzinsky @jkotas @danmosemsft 