### PR TITLE
Adapt existing HttpClientMiniStress tests to support HTTP/2

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -194,8 +194,7 @@ namespace System.Net.Test.Common
 
             if (_options.UseSsl)
             {
-                var sslStream = new SslStream(_connectionStream, false, delegate
-                { return true; });
+                var sslStream = new SslStream(_connectionStream, false, delegate { return true; });
                 using (var cert = Configuration.Certificates.GetServerCertificate())
                 {
                     SslServerAuthenticationOptions options = new SslServerAuthenticationOptions();

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -93,8 +93,7 @@ namespace System.Net.Test.Common
                 Stream stream = new NetworkStream(s, ownsSocket: false);
                 if (_options.UseSsl)
                 {
-                    var sslStream = new SslStream(stream, false, delegate
-                    { return true; });
+                    var sslStream = new SslStream(stream, false, delegate { return true; });
                     using (var cert = Configuration.Certificates.GetServerCertificate())
                     {
                         await sslStream.AuthenticateAsServerAsync(

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
@@ -34,7 +34,7 @@ namespace System.Net.Http.Functional.Tests
 
         protected static Version GetVersion(bool http2) => http2 ? new Version(2, 0) : HttpVersion.Version11;
 
-        protected HttpClient CreateHttpClient() => CreateHttpClient(CreateHttpClientHandler());
+        protected virtual HttpClient CreateHttpClient() => CreateHttpClient(CreateHttpClientHandler());
 
         protected HttpClient CreateHttpClient(HttpMessageHandler handler)
         {

--- a/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -165,12 +165,6 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => false;
     }
 
-    public sealed class PlatformHandler_HttpClientMiniStress : HttpClientMiniStress
-    {
-        public PlatformHandler_HttpClientMiniStress(ITestOutputHelper output) : base(output) { }
-        protected override bool UseSocketsHttpHandler => false;
-    }
-
     public sealed class PlatformHandler_HttpClientHandlerTest : HttpClientHandlerTest
     {
         public PlatformHandler_HttpClientHandlerTest(ITestOutputHelper output) : base(output) { }

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -941,12 +941,6 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => true;
     }
 
-    public sealed class SocketsHttpHandler_HttpClientMiniStress : HttpClientMiniStress
-    {
-        public SocketsHttpHandler_HttpClientMiniStress(ITestOutputHelper output) : base(output) { }
-        protected override bool UseSocketsHttpHandler => true;
-    }
-
     public sealed class SocketsHttpHandler_HttpClientHandlerTest : HttpClientHandlerTest
     {
         public SocketsHttpHandler_HttpClientHandlerTest(ITestOutputHelper output) : base(output) { }

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -114,7 +114,6 @@
     <Compile Include="HttpClientHandlerTestBase.cs" />
     <Compile Include="HttpClientTest.cs" />
     <Compile Include="HttpClientEKUTest.cs" />
-    <Compile Include="HttpClientMiniStressTest.cs" />
     <Compile Include="HttpClient.SelectedSitesTest.cs" />
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpMessageInvokerTest.cs" />
@@ -141,18 +140,19 @@
     <Compile Include="DefaultCredentialsTest.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Compile Include="CustomContent.netcore.cs" />
+    <Compile Include="HPackTest.cs" />
+    <Compile Include="HttpClientTest.netcoreapp.cs" />
+    <Compile Include="HttpClientHandlerTest.Http1.cs" />
+    <Compile Include="HttpClientHandlerTest.Http2.cs" />
     <Compile Include="HttpClientHandlerTest.AcceptAllCerts.cs" />
     <Compile Include="HttpClientHandlerTest.Decompression.cs" />
-    <Compile Include="HttpClientTest.netcoreapp.cs" />
+    <Compile Include="HttpClientMiniStressTest.cs" />
     <Compile Include="HttpMethodTest.netcoreapp.cs" />
     <Compile Include="HuffmanDecodingTests.cs" />
     <Compile Include="NtAuthTests.cs" />
     <Compile Include="ReadOnlyMemoryContentTest.cs" />
     <Compile Include="SocketsHttpHandlerTest.cs" />
-    <Compile Include="HttpClientHandlerTest.Http1.cs" />
-    <Compile Include="HttpClientHandlerTest.Http2.cs" />
-    <Compile Include="CustomContent.netcore.cs" />
-    <Compile Include="HPackTest.cs" />
     <Compile Include="$(CommonTestPath)\System\Net\Http\Http2Frames.cs">
       <Link>Common\System\Net\Http\Http2Frames.cs</Link>
     </Compile>


### PR DESCRIPTION
This adapts the existing HttpClientMiniStress tests to run with HTTP/2 as well as HTTP/1.1.  Some caveats, though:
- All of these existing tests spin up a new server per request, so they're not stressing arguably the most important aspect of the client's HTTP/2 implementation, that of sharing the single connection across all requests.  Our loopback server is not currently robust enough to handle concurrent requests; we should look at switching over to using Kestrel.
- The tests run really slowly, ~40x slower than for HTTP/1.1.  However, the HTTP/1.1 tests are non-SSL, these are of course SSL, and it looks like that's actually the difference.  In particular, something about how our test server gets its test certificate appears to be taking the vast majority of the time. (We should separately see if we could tweak that, not just for this purpose, but more so to help speed up the whole suite.)

Fixes https://github.com/dotnet/corefx/issues/38229