### PR TITLE
ignore invalid http headers rather than throw exceptions

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -933,7 +933,8 @@ namespace System.Net.Http
                 if (pos == line.Length)
                 {
                     // Invalid header line that doesn't contain ':'.
-                    throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_line, Encoding.ASCII.GetString(line)));
+                    //throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_line, Encoding.ASCII.GetString(line)));
+                    return
                 }
             }
 


### PR DESCRIPTION
we use httpclient to download some file from old web servers. 
the http header is not invalid like this:

HTTP/1.1 200 OK
Tue, 18 Jun 2019 03:46:29 GMT
Content-Type:text/html; charset=utf-8
Server:GitHub.com
Status: 200 OK

Please don't throw the exception. In this way we can't use dotnet core anymore.
