### PR TITLE
Update the PackageReference for Pkcs in netstandard.depproj

### DIFF
--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -60,7 +60,8 @@
       <Version>4.5.0</Version>
     </PackageReference>
     <PackageReference Include="System.Security.Cryptography.Pkcs">
-      <Version>4.5.0</Version>
+      <!-- netstandard2.0 ref had extra (MissingMethodException) property setters which were removed in 4.5.1 -->
+      <Version>4.5.1</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/external/netstandard/netstandard.depproj
+++ b/external/netstandard/netstandard.depproj
@@ -57,11 +57,10 @@
       <Version>4.5.0</Version>
     </PackageReference>
     <PackageReference Include="System.Security.Cryptography.OpenSsl">
-      <Version>4.5.0</Version>
+      <Version>4.5.1</Version>
     </PackageReference>
     <PackageReference Include="System.Security.Cryptography.Pkcs">
-      <!-- netstandard2.0 ref had extra (MissingMethodException) property setters which were removed in 4.5.1 -->
-      <Version>4.5.1</Version>
+      <Version>4.5.2</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/shims/ApiCompatBaseline.netcoreapp.netstandard.txt
+++ b/src/shims/ApiCompatBaseline.netcoreapp.netstandard.txt
@@ -22,10 +22,6 @@ CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultEventAttribute' 
 CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultPropertyAttribute' exists on 'System.Diagnostics.Process' in the contract but not the implementation.
 Compat issues with assembly System.IO.FileSystem.Watcher:
 CannotRemoveAttribute : Attribute 'System.ComponentModel.DefaultEventAttribute' exists on 'System.IO.FileSystemWatcher' in the contract but not the implementation.
-Compat issues with assembly System.Security.Cryptography.Pkcs:
-MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner.Certificates.set(System.Security.Cryptography.X509Certificates.X509Certificate2Collection)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner.SignedAttributes.set(System.Security.Cryptography.CryptographicAttributeObjectCollection)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner.UnsignedAttributes.set(System.Security.Cryptography.CryptographicAttributeObjectCollection)' does not exist in the implementation but it does exist in the contract.
 Compat issues with assembly System.ComponentModel.TypeConverter:
 CannotSealType : Type 'System.ComponentModel.BaseNumberConverter' is effectively (has a private constructor) sealed in the implementation but not sealed in the contract.
 MembersMustExist : Member 'System.ComponentModel.BaseNumberConverter..ctor()' does not exist in the implementation but it does exist in the contract.
@@ -71,4 +67,4 @@ MembersMustExist : Member 'System.Linq.EnumerableQuery..ctor()' does not exist i
 MembersMustExist : Member 'System.Threading.Tasks.TaskExtensions.ConfigureAwait(System.IAsyncDisposable, System.Boolean)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Threading.Tasks.TaskExtensions.ConfigureAwait<T>(System.Collections.Generic.IAsyncEnumerable<T>, System.Boolean)' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Threading.Tasks.TaskExtensions.WithCancellation<T>(System.Collections.Generic.IAsyncEnumerable<T>, System.Threading.CancellationToken)' does not exist in the implementation but it does exist in the contract.
-Total Issues: 62
+Total Issues: 59

--- a/src/shims/ApiCompatBaseline.netfx.netstandard.txt
+++ b/src/shims/ApiCompatBaseline.netfx.netstandard.txt
@@ -57,10 +57,6 @@ TypesMustExist : Type 'System.Security.Cryptography.DSAOpenSsl' does not exist i
 TypesMustExist : Type 'System.Security.Cryptography.ECDsaOpenSsl' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.Cryptography.RSAOpenSsl' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.Cryptography.SafeEvpPKeyHandle' does not exist in the implementation but it does exist in the contract.
-Compat issues with assembly System.Security.Cryptography.Pkcs:
-MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner.Certificates.set(System.Security.Cryptography.X509Certificates.X509Certificate2Collection)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner.SignedAttributes.set(System.Security.Cryptography.CryptographicAttributeObjectCollection)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner.UnsignedAttributes.set(System.Security.Cryptography.CryptographicAttributeObjectCollection)' does not exist in the implementation but it does exist in the contract.
 Compat issues with assembly System.Security.Permissions:
 MembersMustExist : Member 'System.Security.Permissions.KeyContainerPermissionAccessEntryCollection..ctor()' does not exist in the implementation but it does exist in the contract.
 MembersMustExist : Member 'System.Security.Permissions.KeyContainerPermissionAccessEntryCollection.CopyTo(System.Array, System.Int32)' does not exist in the implementation but it does exist in the contract.
@@ -103,4 +99,4 @@ MembersMustExist : Member 'System.Security.Principal.WellKnownSidType System.Sec
 Compat issues with assembly System.ServiceProcess.ServiceController:
 CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.IsReadOnlyAttribute' exists on 'System.ServiceProcess.SessionChangeDescription' in the contract but not the implementation.
 TypeCannotChangeClassification : Type 'System.ServiceProcess.SessionChangeDescription' is marked as readonly in the contract so it must also be marked readonly in the implementation.
-Total Issues: 95
+Total Issues: 92

--- a/src/shims/ApiCompatBaseline.uap.netstandard.txt
+++ b/src/shims/ApiCompatBaseline.uap.netstandard.txt
@@ -95,10 +95,6 @@ TypesMustExist : Type 'System.Security.Cryptography.DSAOpenSsl' does not exist i
 TypesMustExist : Type 'System.Security.Cryptography.ECDsaOpenSsl' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.Cryptography.RSAOpenSsl' does not exist in the implementation but it does exist in the contract.
 TypesMustExist : Type 'System.Security.Cryptography.SafeEvpPKeyHandle' does not exist in the implementation but it does exist in the contract.
-Compat issues with assembly System.Security.Cryptography.Pkcs:
-MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner.Certificates.set(System.Security.Cryptography.X509Certificates.X509Certificate2Collection)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner.SignedAttributes.set(System.Security.Cryptography.CryptographicAttributeObjectCollection)' does not exist in the implementation but it does exist in the contract.
-MembersMustExist : Member 'System.Security.Cryptography.Pkcs.CmsSigner.UnsignedAttributes.set(System.Security.Cryptography.CryptographicAttributeObjectCollection)' does not exist in the implementation but it does exist in the contract.
 Compat issues with assembly System.ComponentModel.TypeConverter:
 CannotSealType : Type 'System.ComponentModel.BaseNumberConverter' is effectively (has a private constructor) sealed in the implementation but not sealed in the contract.
 MembersMustExist : Member 'System.ComponentModel.BaseNumberConverter..ctor()' does not exist in the implementation but it does exist in the contract.
@@ -141,4 +137,4 @@ CannotSealType : Type 'System.Linq.EnumerableExecutor' is effectively (has a pri
 MembersMustExist : Member 'System.Linq.EnumerableExecutor..ctor()' does not exist in the implementation but it does exist in the contract.
 CannotSealType : Type 'System.Linq.EnumerableQuery' is effectively (has a private constructor) sealed in the implementation but not sealed in the contract.
 MembersMustExist : Member 'System.Linq.EnumerableQuery..ctor()' does not exist in the implementation but it does exist in the contract.
-Total Issues: 124
+Total Issues: 121


### PR DESCRIPTION
The 4.5.0 ref/netstandard2.0 had three properties declared get/set which were
actually get-only.  Updating the depproj version allows removal of the
ApiCompat errors in the shims.

Fixes #32178.