### PR TITLE
Fix ipv6 address parsing with leading compressor

### DIFF
--- a/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
+++ b/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
@@ -411,17 +411,15 @@ namespace System
                 int toIndex = NumberOfLabels - 1;
                 int fromIndex = index - 1;
 
-                // if fromIndex and toIndex are the same mean that "zero bits" are already in the correct place
+                // if fromIndex and toIndex are the same, it means that "zero bits" are already in the correct place
                 // it happens for leading and trailing compression
-                if (fromIndex == toIndex)
+                if (fromIndex != toIndex)
                 {
-                    return;
-                }
-
-                for (int i = index - compressorIndex; i > 0; --i)
-                {
-                    numbers[toIndex--] = numbers[fromIndex];
-                    numbers[fromIndex--] = 0;
+                    for (int i = index - compressorIndex; i > 0; --i)
+                    {
+                        numbers[toIndex--] = numbers[fromIndex];
+                        numbers[fromIndex--] = 0;
+                    }
                 }
             }
         }

--- a/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
+++ b/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
@@ -411,6 +411,13 @@ namespace System
                 int toIndex = NumberOfLabels - 1;
                 int fromIndex = index - 1;
 
+                // if fromIndex and toIndex are the same 0 bits are already in the correct place
+                // it happens for leading and trailing compression
+                if (fromIndex == toIndex)
+                {
+                    return;
+                }
+
                 for (int i = index - compressorIndex; i > 0; --i)
                 {
                     numbers[toIndex--] = numbers[fromIndex];

--- a/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
+++ b/src/Common/src/System/Net/IPv6AddressHelper.Common.cs
@@ -411,7 +411,7 @@ namespace System
                 int toIndex = NumberOfLabels - 1;
                 int fromIndex = index - 1;
 
-                // if fromIndex and toIndex are the same 0 bits are already in the correct place
+                // if fromIndex and toIndex are the same mean that "zero bits" are already in the correct place
                 // it happens for leading and trailing compression
                 if (fromIndex == toIndex)
                 {

--- a/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -255,6 +255,8 @@ namespace System.Net.Primitives.Functional.Tests
             new object[] { "E:E:E:E:E:0:0:1", "E:E:E:E:E::1" },
             new object[] { "E:E:E:E:E:0:2:2", "E:E:E:E:E:0:2:2" },
             new object[] { "E:E:E:E:E:E:0:1", "E:E:E:E:E:E:0:1" },
+            new object[] { "::2:3:4:5:6:7:8", "0:2:3:4:5:6:7:8" },
+            new object[] { "1:2:3:4:5:6:7::", "1:2:3:4:5:6:7:0" },
             new object[] { "::FFFF:192.168.0.1", "::FFFF:192.168.0.1" },
             new object[] { "::FFFF:0.168.0.1", "::FFFF:0.168.0.1" },
             new object[] { "::0.0.255.255", "::FFFF" },

--- a/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -282,6 +282,8 @@ namespace System.PrivateUri.Tests
         [InlineData("1:0:0:1:0:0:1:1", "1::1:0:0:1:1")]
         [InlineData("1:1:0:0:0:1:0:1", "1:1::1:0:1")]
         [InlineData("1:0:0:0:1:0:1:1", "1::1:0:1:1")]
+        [InlineData("::2:3:4:5:6:7:8", "0:2:3:4:5:6:7:8")]
+        [InlineData("1:2:3:4:5:6:7::", "1:2:3:4:5:6:7:0")]
         public void UriIPv6Host_CompressionRangeSelection_Success(string address, string expected)
         {
             ParseIPv6Address(address, expected);


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38634

There is a bug if address has got leading compressor.
Bug doesn't raise if we have trailing compressor because compressor index math  exists loop after one cycle.
Added a fix that skip expansion if from/to index calculation ends with same value, mean that zeros are already in the right place.

cc: @davidsh @wfurt @caesar-chen @rmkerr @karelz @scalablecory

I didn't found area owner for System.Net.Primitives https://github.com/dotnet/corefx/blob/d3942d4671919edb0cca6ddc1840190f524a809d/Documentation/project-docs/issue-guide.md#areas