### PR TITLE
Disable InvokeOnEventsThreadRunsAsynchronously test on netfx

### DIFF
--- a/src/Microsoft.Win32.SystemEvents/tests/SystemEvents.InvokeOnEventsThread.cs
+++ b/src/Microsoft.Win32.SystemEvents/tests/SystemEvents.InvokeOnEventsThread.cs
@@ -14,12 +14,13 @@ namespace Microsoft.Win32.SystemEventsTests
 {
     public class InvokeOnEventsThreadTests : SystemEventsTest
     {
+        [ActiveIssue(38661, TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         public void InvokeOnEventsThreadRunsAsynchronously()
         {
             var invoked = new AutoResetEvent(false);
             SystemEvents.InvokeOnEventsThread(new Action(() => invoked.Set()));
-            Assert.True(invoked.WaitOne(PostMessageWait * SystemEventsTest.ExpectedEventMultiplier));
+            Assert.True(invoked.WaitOne(PostMessageWait));
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -44,7 +45,7 @@ namespace Microsoft.Win32.SystemEventsTests
                     actualThreadId = Thread.CurrentThread.ManagedThreadId;
                     invoked.Set();
                 }));
-                Assert.True(invoked.WaitOne(PostMessageWait * SystemEventsTest.ExpectedEventMultiplier));
+                Assert.True(invoked.WaitOne(PostMessageWait));
                 Assert.Equal(expectedThreadId, actualThreadId);
             }
             finally

--- a/src/Microsoft.Win32.SystemEvents/tests/SystemEventsTest.cs
+++ b/src/Microsoft.Win32.SystemEvents/tests/SystemEventsTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Win32.SystemEventsTests
     {
         IntPtr s_hwnd = IntPtr.Zero;
 
-        public const int PostMessageWait = 10000;
+        public const int PostMessageWait = 30_000;
         public const int ExpectedEventMultiplier = 1000;
         public const int UnexpectedEventMultiplier = 10;
 
@@ -56,7 +56,7 @@ namespace Microsoft.Win32.SystemEventsTests
             {
                 // on an STA thread the HWND is created in the same thread synchronously when attaching to an event handler
                 // if we're on an MTA thread, a new thread is created to handle events and that thread creates the window, wait for it to complete.
-                Assert.True(windowReadyEvent.WaitOne(PostMessageWait * ExpectedEventMultiplier));
+                Assert.True(windowReadyEvent.WaitOne(PostMessageWait));
             }
         }
     }


### PR DESCRIPTION
And avoid the whole suite from hanging by changing an ~3hr timeout to a 30s timeout.

https://github.com/dotnet/corefx/issues/38661