### PR TITLE
Guard for large array support in System.Drawing.Common tests

### DIFF
--- a/src/System.Drawing.Common/tests/Drawing2D/BlendTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/BlendTests.cs
@@ -32,7 +32,7 @@ namespace System.Drawing.Drawing2D.Tests
             Assert.Throws<OverflowException>(() => new Blend(-1));
         }
         
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotIntMaxValueArrayIndexSupported))]
         public void Ctor_LargeCount_ThrowsOutOfMemoryException()
         {
             Assert.Throws<OutOfMemoryException>(() => new Blend(int.MaxValue));

--- a/src/System.Drawing.Common/tests/Drawing2D/ColorBlendTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/ColorBlendTests.cs
@@ -32,7 +32,7 @@ namespace System.Drawing.Drawing2D.Tests
             Assert.Throws<OverflowException>(() => new ColorBlend(-1));
         }
         
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotIntMaxValueArrayIndexSupported))]
         public void Ctor_LargeCount_ThrowsOutOfMemoryException()
         {
             Assert.Throws<OutOfMemoryException>(() => new ColorBlend(int.MaxValue));


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/15189.