### PR TITLE
Disable running tests on ilproj non test projects

### DIFF
--- a/src/tests.proj
+++ b/src/tests.proj
@@ -11,11 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(BuildAllConfigurations)' != 'true'">
+    <!-- We currently only test with C# projects. -->
     <Project Include="$(SourceDir)*\tests\**\*.Tests.csproj" />
-
-    <!-- Harcoded list of non-csproj test projects to reduce time spent on file globbing. -->
-    <Project Include="$(SourceDir)System.Runtime\tests\TestStructs\System.TestStructs.ilproj" />
-    <Project Include="$(SourceDir)System.Runtime\tests\TestModule\System.Reflection.TestModule.ilproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildAllConfigurations)' == 'true'">


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38673

These two projects were added for restoring purposes but we didn't take that path and instead decided to still up-front restore ilasm/ildasm. This didn't show up in CI as we don't run the tests directly there.