### PR TITLE
Remove extended option in System.Reflection.AssemblyNameTests.FullName

### DIFF
--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -302,10 +302,9 @@ namespace System.Reflection.Tests
             AssemblyName assemblyName = new AssemblyName(name);
 
             expectedName = expectedName.ToLowerInvariant();
-            string extended = $"{expectedName}, Culture=neutral, PublicKeyToken=null".ToLowerInvariant();
             string afn = assemblyName.FullName.ToLowerInvariant();
 
-            Assert.True(afn == expectedName || afn == extended, $"Expected\n{afn} == {expectedName}\nor\n{afn} == {extended}");
+            Assert.True(afn == expectedName, $"Expected\n{afn} == {expectedName}");
         }
 
         [Fact]

--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -403,7 +403,7 @@ namespace System.Reflection.Tests
 
             string expected = "MyAssemblyName, Version=" + versionString;
 
-            Assert.Equal(assemblyName.FullName, expected);
+            Assert.Equal(expected, assemblyName.FullName);
         }
 
         [Fact]

--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -402,10 +402,8 @@ namespace System.Reflection.Tests
             assemblyName.Version = version;
 
             string expected = "MyAssemblyName, Version=" + versionString;
-            string extended = expected + ", Culture=neutral, PublicKeyToken=null";
 
-            Assert.True(assemblyName.FullName == expected || assemblyName.FullName == extended,
-                        $"Expected\n{assemblyName.FullName} == {expected}\nor\n{assemblyName.FullName} == {extended}");
+            Assert.Equal(assemblyName.FullName, expected);
         }
 
         [Fact]

--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -301,8 +301,8 @@ namespace System.Reflection.Tests
         {
             AssemblyName assemblyName = new AssemblyName(name);
 
-            expectedName = expectedName.ToLowerInvariant();
-            string afn = assemblyName.FullName.ToLowerInvariant();
+            expectedName = expectedName;
+            string afn = assemblyName.FullName;
 
             Assert.True(afn == expectedName, $"Expected\n{afn} == {expectedName}");
         }

--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -48,7 +48,7 @@ namespace System.Reflection.Tests
         public void Ctor_String(string name, string expectedName)
         {
             AssemblyName assemblyName = new AssemblyName(name);
-            Assert.Equal(expectedName.ToLowerInvariant(), assemblyName.Name.ToLowerInvariant());
+            Assert.Equal(expectedName, assemblyName.Name);
             Assert.Equal(ProcessorArchitecture.None, assemblyName.ProcessorArchitecture);
         }
 

--- a/src/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/System.Reflection/tests/AssemblyNameTests.cs
@@ -300,11 +300,7 @@ namespace System.Reflection.Tests
         public void FullName(string name, string expectedName)
         {
             AssemblyName assemblyName = new AssemblyName(name);
-
-            expectedName = expectedName;
-            string afn = assemblyName.FullName;
-
-            Assert.True(afn == expectedName, $"Expected\n{afn} == {expectedName}");
+            Assert.Equal(expectedName, assemblyName.FullName);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38615