### PR TITLE
Add additional deserialization array tests

### DIFF
--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -71,27 +71,12 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(2, arr[1][1]);
         }
 
-        [Fact]
-        public static void ReadByteArrayFail()
-        {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte[]>(@"""1"""));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte[]>(@"""A==="""));
-        }
-
         [Theory]
-        [InlineData(typeof(int[]), @"[{}]")]
-        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")]
-        public static void InvalidJsonForArrayShouldFail(Type type, string json)
+        [InlineData(@"""1""")]
+        [InlineData(@"""A===""")]
+        [InlineData(@"[1, 2]")]  // Currently not support deserializing JSON arrays as byte[] - only Base64 string.
+        public static void ReadByteArrayFail(string json)
         {
-            // These fail because the int converter sees the StartObject token.
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse(json, type));
-        }
-
-        [Fact]
-        public static void ReadByteArrayAsJsonArrayFail()
-        {
-            string json = $"[1, 2]";
-            // Currently no support deserializing JSON arrays as byte[] - only Base64 string.
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte[]>(json));
         }
 

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -78,6 +78,15 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte[]>(@"""A==="""));
         }
 
+        [Theory]
+        [InlineData(typeof(int[]), @"[{}]")]
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")]
+        public static void InvalidJsonForArrayShouldFail(Type type, string json)
+        {
+            // These fail because the int converter sees the StartObject token.
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse(json, type));
+        }
+
         [Fact]
         public static void ReadByteArrayAsJsonArrayFail()
         {

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -217,7 +217,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(int[]), @"{}")]
         [InlineData(typeof(int[]), @"[""test""")]
         [InlineData(typeof(int[]), @"[true]")]
-        // [InlineData(typeof(int[]), @"[{}]")] TODO #38485: Uncomment when fixed
+        [InlineData(typeof(int[]), @"[{}]")]
         [InlineData(typeof(int[]), @"[[]]")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": {}}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": ""test""}")]
@@ -225,7 +225,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": true}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [""test""]}")]
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [[]]}")]
-        // [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")] TODO #38485: Uncomment when fixed
+        [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")]
         public static void InvalidJsonForArrayShouldFail(Type type, string json)
         {
             Assert.Throws<JsonException>(() => JsonSerializer.Parse(json, type));


### PR DESCRIPTION
These tests now fail as expected due to the recent custom converter feature.

Fixes https://github.com/dotnet/corefx/issues/38485
