### PR TITLE
Fix http2 tests (SettingsFrame does not propagate flags)

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2Frames.cs
+++ b/src/Common/tests/System/Net/Http/Http2Frames.cs
@@ -413,10 +413,15 @@ namespace System.Net.Test.Common
     {
         public List<SettingsEntry> Entries;
 
-        public SettingsFrame(params SettingsEntry[] entries) :
-            base(entries.Length * 6, FrameType.Settings, FrameFlags.None, 0)
+        public SettingsFrame(FrameFlags flags, SettingsEntry[] entries) :
+            base(entries.Length * 6, FrameType.Settings, flags, 0)
         {
             Entries = new List<SettingsEntry>(entries);
+        }
+
+        public SettingsFrame(params SettingsEntry[] entries) :
+            this(FrameFlags.None, entries)
+        {
         }
 
         public static SettingsFrame ReadFrom(Frame header, ReadOnlySpan<byte> buffer)
@@ -433,7 +438,7 @@ namespace System.Net.Test.Common
                 entries.Add(new SettingsEntry { SettingId = id, Value = value });
             }
 
-            return new SettingsFrame(entries.ToArray());
+            return new SettingsFrame(header.Flags, entries.ToArray());
         }
 
         public override void WriteTo(Span<byte> buffer)


### PR DESCRIPTION
Recently we have added this line
https://github.com/dotnet/corefx/blob/master/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs#L160

but SettingsFrame does not propagate flags when using ReadFrom which is causing following to loop forever:
https://github.com/dotnet/corefx/blob/3863ec17c8ea61e72ef2240f23e4518788a2e8ae/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs#L95-L102