### PR TITLE
updates to packaging APIs and fixes

### DIFF
--- a/src/System.IO.Packaging/ref/System.IO.Packaging.PackUriScheme.cs
+++ b/src/System.IO.Packaging/ref/System.IO.Packaging.PackUriScheme.cs
@@ -15,6 +15,5 @@ namespace System.IO.Packaging
         public static System.Uri Create(System.Uri packageUri, System.Uri partUri, string fragment) { throw null; }
         public static int ComparePackUri(Uri firstPackUri, Uri secondPackUri) { throw null; }
         public static System.Uri GetPartUri(System.Uri packUri) { throw null; }
-
     }
 }

--- a/src/System.IO.Packaging/ref/System.IO.Packaging.PackUriScheme.cs
+++ b/src/System.IO.Packaging/ref/System.IO.Packaging.PackUriScheme.cs
@@ -14,5 +14,7 @@ namespace System.IO.Packaging
         public static System.Uri Create(System.Uri packageUri, System.Uri partUri) { throw null; }
         public static System.Uri Create(System.Uri packageUri, System.Uri partUri, string fragment) { throw null; }
         public static int ComparePackUri(Uri firstPackUri, Uri secondPackUri) { throw null; }
+        public static System.Uri GetPartUri(System.Uri packUri) { throw null; }
+
     }
 }

--- a/src/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.PackUriScheme.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.PackUriScheme.cs
@@ -133,6 +133,29 @@ namespace System.IO.Packaging
         }
 
         /// <summary>
+        /// This method parses the pack uri and returns the absolute 
+        /// path of the URI. This corresponds to the part within the 
+        /// package. This corresponds to the absolute path component in 
+        /// the Uri. If there is no part component present, this method
+        /// returns a null
+        /// </summary>
+        /// <param name="packUri">Returns a relative Uri that represents the
+        /// part within the package. If the pack Uri points to the entire
+        /// package then we return a null</param>
+        /// <returns>Returns a relative URI with an absolute path that points to a part within a package</returns>
+        /// <exception cref="ArgumentNullException">If packUri parameter is null</exception>
+        /// <exception cref="ArgumentException">If packUri parameter is not an absolute Uri</exception>
+        /// <exception cref="ArgumentException">If packUri parameter does not have "pack://" scheme</exception>
+        /// <exception cref="ArgumentException">If partUri extracted from packUri does not conform to the valid partUri syntax</exception>
+        public static Uri GetPartUri(Uri packUri)
+        {
+            //Parameter Validation is done in the following method
+            ValidateAndGetPackUriComponents(packUri, out _, out Uri partUri);
+
+            return partUri;
+        }
+
+        /// <summary>
         /// This method compares two pack uris and returns an int to indicate the equivalence. 
         /// </summary>
         /// <param name="firstPackUri">First Uri of pack:// scheme to be compared</param>

--- a/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
@@ -837,10 +837,6 @@ namespace System.IO.Packaging
 
             if (packageMode == FileMode.OpenOrCreate && packageAccess != FileAccess.ReadWrite)
                 throw new ArgumentException(SR.UnsupportedCombinationOfModeAccess);
-            if (packageMode == FileMode.Create && ((packageAccess & FileAccess.Write) == 0))
-                throw new ArgumentException(SR.UnsupportedCombinationOfModeAccess);
-            if (packageMode == FileMode.CreateNew && ((packageAccess & FileAccess.Write) == 0))
-                throw new ArgumentException(SR.UnsupportedCombinationOfModeAccess);
             if (packageMode == FileMode.Open && packageAccess == FileAccess.Write)
                 throw new ArgumentException(SR.UnsupportedCombinationOfModeAccess);
             if (packageMode == FileMode.Truncate && packageAccess == FileAccess.Read)

--- a/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
+++ b/src/System.IO.Packaging/src/System/IO/Packaging/Package.cs
@@ -837,9 +837,9 @@ namespace System.IO.Packaging
 
             if (packageMode == FileMode.OpenOrCreate && packageAccess != FileAccess.ReadWrite)
                 throw new ArgumentException(SR.UnsupportedCombinationOfModeAccess);
-            if (packageMode == FileMode.Create && packageAccess != FileAccess.ReadWrite)
+            if (packageMode == FileMode.Create && ((packageAccess & FileAccess.Write) == 0))
                 throw new ArgumentException(SR.UnsupportedCombinationOfModeAccess);
-            if (packageMode == FileMode.CreateNew && packageAccess != FileAccess.ReadWrite)
+            if (packageMode == FileMode.CreateNew && ((packageAccess & FileAccess.Write) == 0))
                 throw new ArgumentException(SR.UnsupportedCombinationOfModeAccess);
             if (packageMode == FileMode.Open && packageAccess == FileAccess.Write)
                 throw new ArgumentException(SR.UnsupportedCombinationOfModeAccess);

--- a/src/System.IO.Packaging/tests/Tests.cs
+++ b/src/System.IO.Packaging/tests/Tests.cs
@@ -3236,7 +3236,7 @@ namespace System.IO.Packaging.Tests
         public void T112_String_CreateNew_Read_Create_Read()
         {
             var tempGuidName = GetTempFileInfoWithExtension(".docx");
-            AssertExtensions.Throws<ArgumentException>(null, () =>
+            Assert.Throws<ArgumentException>(() =>
             {
                 Package package = Package.Open(tempGuidName.FullName, FileMode.CreateNew, FileAccess.Read);
             });
@@ -3537,7 +3537,7 @@ namespace System.IO.Packaging.Tests
         public void T100_String_Create_Read_Star()
         {
             var tempGuidName = GetTempFileInfoWithExtension(".docx");
-            AssertExtensions.Throws<ArgumentException>(null, () =>
+            Assert.Throws<ArgumentException>(() =>
             {
                 Package package = Package.Open(tempGuidName.FullName, FileMode.Create, FileAccess.Read);
             });
@@ -3791,12 +3791,21 @@ namespace System.IO.Packaging.Tests
             Uri returnedPackageUri = PackUriHelper.GetPackageUri(combinedUri);
             Uri returnedSamePackageUri = PackUriHelper.GetPackageUri(sameCombinedUri);
 
-            // Validate the PackageUri returned from PackUriHelper.GetPackageHelper matches what was given to PackUriHelper.Create
+            // Validate the PackageUri returned from PackUriHelper.GetPackageUri matches what was given to PackUriHelper.Create
             Assert.Equal(packageUri, returnedPackageUri);
             Assert.Equal(packageUri, returnedSamePackageUri);
 
             // Validate PackUriHelper.ComparePackUri correctly validates identical pack uri's.
             Assert.Equal(0, PackUriHelper.ComparePackUri(combinedUri, sameCombinedUri));
+
+            // Validate the PackageUri returned from PackUriHelper.GetPartUri matches what was given to PackUriHelper.Create
+            Uri returnedPartUri = PackUriHelper.GetPartUri(combinedUri);
+            Uri returnedSamePartUri = PackUriHelper.GetPartUri(sameCombinedUri);
+            Assert.Equal(partUri, returnedPartUri);
+            Assert.Equal(partUri, returnedSamePartUri);
+
+            // Validate PackUriHelper.ComparePartUri correctly validates identical pack uri's.
+            Assert.Equal(0, PackUriHelper.ComparePartUri(partUri, returnedPartUri));
         }
 
         [Fact]
@@ -3829,6 +3838,16 @@ namespace System.IO.Packaging.Tests
             Assert.NotEqual(0, PackUriHelper.ComparePackUri(combinedUriWithPart, combinedUriWithDifferentPart));
             Assert.NotEqual(0, PackUriHelper.ComparePackUri(combinedUriWithPart, combinedUriNoPart));
             Assert.NotEqual(0, PackUriHelper.ComparePackUri(combinedUriNoPart, combinedUriWithDifferentPart));
+
+            Uri returnedPartUri = PackUriHelper.GetPartUri(combinedUriWithPart);
+            Uri returnedPartUriDifferentPart = PackUriHelper.GetPartUri(combinedUriWithDifferentPart);
+
+            // Validate the PartUri returned from PackUriHelper.GetPartHelper matches what was given to PackUriHelper.Create
+            Assert.Equal(partUri, returnedPartUri);
+            Assert.Equal(differentPartUri, returnedPartUriDifferentPart);
+
+            // Validate the two different parts are considered different
+            Assert.NotEqual(0, PackUriHelper.ComparePartUri(partUri, differentPartUri));
         }
 
         [Fact]
@@ -3859,6 +3878,14 @@ namespace System.IO.Packaging.Tests
             // Validate PackUriHelper.ComparePackUri correctly compares pack uri's with different packages.
             Assert.NotEqual(0, PackUriHelper.ComparePackUri(packageUriWithPart, differentPackageSamePart));
             Assert.NotEqual(0, PackUriHelper.ComparePackUri(samePackageNoPart, differentPackageSamePart));
+
+            Uri returnedPartUri = PackUriHelper.GetPartUri(packageUriWithPart);
+            Uri returnedPartUriDifferentPackage = PackUriHelper.GetPartUri(differentPackageSamePart);
+            Assert.Equal(returnedPartUri, returnedPartUriDifferentPackage);
+            Assert.Equal(partUri, returnedPartUri);
+
+            // Validate the two parts are considered the same
+            Assert.Equal(0, PackUriHelper.ComparePartUri(returnedPartUri, returnedPartUriDifferentPackage));
         }
 
         [Fact]

--- a/src/System.IO.Packaging/tests/Tests.cs
+++ b/src/System.IO.Packaging/tests/Tests.cs
@@ -3224,6 +3224,7 @@ namespace System.IO.Packaging.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop doesn't support Package.Open with FileAccess.Write and FileMode.CreateNew")]
         public void T113_String_CreateNew_Write_Open_Read()
         {
             var tempGuidName = GetTempFileInfoWithExtension(".docx");
@@ -3244,6 +3245,7 @@ namespace System.IO.Packaging.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Desktop doesn't support Package.Open with FileAccess.Write and FileMode.Create")]
         public void T111_String_Create_Write_Star()
         {
             var tempGuidName = GetTempFileInfoWithExtension(".docx");

--- a/src/System.IO.Packaging/tests/Tests.cs
+++ b/src/System.IO.Packaging/tests/Tests.cs
@@ -3227,10 +3227,8 @@ namespace System.IO.Packaging.Tests
         public void T113_String_CreateNew_Write_Open_Read()
         {
             var tempGuidName = GetTempFileInfoWithExtension(".docx");
-            AssertExtensions.Throws<ArgumentException>(null, () =>
-            {
-                Package package = Package.Open(tempGuidName.FullName, FileMode.CreateNew, FileAccess.Write);
-            });
+            Package package = Package.Open(tempGuidName.FullName, FileMode.CreateNew, FileAccess.Write);
+            package.Close();
             tempGuidName.Delete();
         }
 
@@ -3250,7 +3248,8 @@ namespace System.IO.Packaging.Tests
         {
             var tempGuidName = GetTempFileInfoWithExtension(".docx");
             // opening the package attempts to read the package, and no permissions.
-            AssertExtensions.Throws<ArgumentException>(null, () => Package.Open(tempGuidName.FullName, FileMode.Create, FileAccess.Write));
+            Package package = Package.Open(tempGuidName.FullName, FileMode.Create, FileAccess.Write);
+            package.Close();
             tempGuidName.Delete();
         }
 


### PR DESCRIPTION
## Issue 36707
Adding back `PackUriHelper.GetPartUri` which was an API that exists in .NET Fx in the implementation contained in WindowsBase. There was no reason this wasn't added as part of #36493, it was just missed.

Fixes #36707

## Issue 36794
The checks that exist in the `Package.Open` API that takes a string are more restrictive then they should be. These checks were brought over from the implementation in WindowsBase and we don't need to restrict on only having `FileAccess.ReadWrite`  being passed in when `FileMode.Create` or `FileMode.CreateNew` are specified.

Fixes #36794

