### PR TITLE
 Fixing up HandleNull in JsonSerializer.Read to reset the property for dictionaries.

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -39,6 +39,13 @@ namespace System.Text.Json
             {
                 bool setPropertyToNull = !state.Current.CollectionPropertyInitialized;
                 ApplyObjectToEnumerable(null, ref state, ref reader, setPropertyDirectly: setPropertyToNull);
+
+                if (setPropertyToNull)
+                {
+                    // The property itself was set to null, in which case we should
+                    // reset so that `Is*Property` no longer returns true
+                    state.Current.ResetProperty();
+                }
                 return false;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -25,8 +25,12 @@ namespace System.Text.Json
                 enumerable = (IEnumerable)jsonPropertyInfo.GetValueAsObject(state.Current.CurrentValue);
                 if (enumerable == null)
                 {
-                    // Write a null object or enumerable.
-                    state.Current.WriteObjectOrArrayStart(ClassType.Dictionary, writer, writeNull: true);
+                    if (!state.Current.JsonPropertyInfo.IgnoreNullValues)
+                    {
+                        // Write a null object or enumerable.
+                        state.Current.WriteObjectOrArrayStart(ClassType.Enumerable, writer, writeNull: true);
+                    }
+
                     return true;
                 }
 

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -915,12 +915,14 @@ namespace System.Text.Json.Serialization.Tests
             };
 
             var actual = JsonSerializer.ToString(value, new JsonSerializerOptions { IgnoreNullValues = true });
-            Assert.Equal("{\"Test\":\"value1\",\"Dict\":null,\"Child\":{\"Dict\":null}}", actual);
+            Assert.Equal("{\"Test\":\"value1\",\"Child\":{}}", actual);
         }
 
         [Fact]
         public static void Regression38565_Deserialize()
         {
+            // The json contains nulls to ensure that the dictionary is properly closed
+
             var json = "{\"Test\":\"value1\",\"Dict\":null,\"Child\":{\"Dict\":null}}";
             var actual = JsonSerializer.Parse<Regression38565_Parent>(json);
 

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -905,6 +905,32 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("1", actual.Child["1"].A);
         }
 
+        [Fact]
+        public static void Regression38565_Serialize()
+        {
+            var value = new Regression38565_Parent()
+            {
+                Test = "value1",
+                Child = new Regression38565_Child()
+            };
+
+            var actual = JsonSerializer.ToString(value, new JsonSerializerOptions { IgnoreNullValues = true });
+            Assert.Equal("{\"Test\":\"value1\",\"Dict\":null,\"Child\":{\"Dict\":null}}", actual);
+        }
+
+        [Fact]
+        public static void Regression38565_Deserialize()
+        {
+            var json = "{\"Test\":\"value1\",\"Dict\":null,\"Child\":{\"Dict\":null}}";
+            var actual = JsonSerializer.Parse<Regression38565_Parent>(json);
+
+            Assert.True(actual.Test == "value1");
+            Assert.Null(actual.Dict);
+            Assert.NotNull(actual.Child);
+            Assert.Null(actual.Child.Dict);
+            Assert.Null(actual.Child.Test);
+        }
+
         public class ClassWithDictionaryButNoSetter
         {
             public Dictionary<string, string> MyDictionary { get; } = new Dictionary<string, string>();
@@ -938,6 +964,19 @@ namespace System.Text.Json.Serialization.Tests
             public int? I { get; set; }
             public int? J { get; set; }
             public string[] K { get; set; }
+        }
+
+        public class Regression38565_Parent
+        {
+            public string Test { get; set; }
+            public Dictionary<string, string> Dict { get; set; }
+            public Regression38565_Child Child { get; set; }
+        }
+
+        public class Regression38565_Child
+        {
+            public string Test { get; set; }
+            public Dictionary<string, string> Dict { get; set; }
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -914,23 +914,119 @@ namespace System.Text.Json.Serialization.Tests
                 Child = new Regression38565_Child()
             };
 
-            var actual = JsonSerializer.ToString(value, new JsonSerializerOptions { IgnoreNullValues = true });
-            Assert.Equal("{\"Test\":\"value1\",\"Child\":{}}", actual);
+            var actual = JsonSerializer.ToString(value);
+            Assert.Equal("{\"Test\":\"value1\",\"Dict\":null,\"Child\":{\"Test\":null,\"Dict\":null}}", actual);
         }
 
         [Fact]
         public static void Regression38565_Deserialize()
         {
-            // The json contains nulls to ensure that the dictionary is properly closed
+            var json = "{\"Test\":\"value1\",\"Dict\":null,\"Child\":{\"Test\":null,\"Dict\":null}}";
+            Regression38565_Parent actual = JsonSerializer.Parse<Regression38565_Parent>(json);
 
-            var json = "{\"Test\":\"value1\",\"Dict\":null,\"Child\":{\"Dict\":null}}";
-            var actual = JsonSerializer.Parse<Regression38565_Parent>(json);
-
-            Assert.True(actual.Test == "value1");
+            Assert.Equal("value1", actual.Test);
             Assert.Null(actual.Dict);
             Assert.NotNull(actual.Child);
             Assert.Null(actual.Child.Dict);
             Assert.Null(actual.Child.Test);
+        }
+
+        [Fact]
+        public static void Regression38565_Serialize_IgnoreNullValues()
+        {
+            var value = new Regression38565_Parent()
+            {
+                Test = "value1",
+                Child = new Regression38565_Child()
+            };
+
+            var actual = JsonSerializer.ToString(value, new JsonSerializerOptions { IgnoreNullValues = true });
+            Assert.Equal("{\"Test\":\"value1\",\"Child\":{}}", actual);
+        }
+
+        [Fact]
+        public static void Regression38565_Deserialize_IgnoreNullValues()
+        {
+            var json = "{\"Test\":\"value1\",\"Child\":{}}";
+            Regression38565_Parent actual = JsonSerializer.Parse<Regression38565_Parent>(json);
+
+            Assert.Equal("value1", actual.Test);
+            Assert.Null(actual.Dict);
+            Assert.NotNull(actual.Child);
+            Assert.Null(actual.Child.Dict);
+            Assert.Null(actual.Child.Test);
+        }
+
+        [Fact]
+        public static void Regression38557_Serialize()
+        {
+            var dictionaryFirst = new Regression38557_DictionaryFirst()
+            {
+                Test = "value1"
+            };
+
+            var actual = JsonSerializer.ToString(dictionaryFirst);
+            Assert.Equal("{\"Dict\":null,\"Test\":\"value1\"}", actual);
+
+            var dictionaryLast = new Regression38557_DictionaryLast()
+            {
+                Test = "value1"
+            };
+
+            actual = JsonSerializer.ToString(dictionaryLast);
+            Assert.Equal("{\"Test\":\"value1\",\"Dict\":null}", actual);
+        }
+
+        [Fact]
+        public static void Regression38557_Deserialize()
+        {
+            var json = "{\"Dict\":null,\"Test\":\"value1\"}";
+            Regression38557_DictionaryFirst dictionaryFirst = JsonSerializer.Parse<Regression38557_DictionaryFirst>(json);
+
+            Assert.Equal("value1", dictionaryFirst.Test);
+            Assert.Null(dictionaryFirst.Dict);
+
+            json = "{\"Test\":\"value1\",\"Dict\":null}";
+            Regression38557_DictionaryLast dictionaryLast = JsonSerializer.Parse<Regression38557_DictionaryLast>(json);
+
+            Assert.Equal("value1", dictionaryLast.Test);
+            Assert.Null(dictionaryLast.Dict);
+        }
+
+        [Fact]
+        public static void Regression38557_Serialize_IgnoreNullValues()
+        {
+            var dictionaryFirst = new Regression38557_DictionaryFirst()
+            {
+                Test = "value1"
+            };
+
+            var actual = JsonSerializer.ToString(dictionaryFirst, new JsonSerializerOptions { IgnoreNullValues = true });
+            Assert.Equal("{\"Test\":\"value1\"}", actual);
+
+            var dictionaryLast = new Regression38557_DictionaryLast()
+            {
+                Test = "value1"
+            };
+
+            actual = JsonSerializer.ToString(dictionaryLast, new JsonSerializerOptions { IgnoreNullValues = true });
+            Assert.Equal("{\"Test\":\"value1\"}", actual);
+        }
+
+        [Fact]
+        public static void Regression38557_Deserialize_IgnoreNullValues()
+        {
+            var json = "{\"Test\":\"value1\"}";
+            Regression38557_DictionaryFirst dictionaryFirst = JsonSerializer.Parse<Regression38557_DictionaryFirst>(json);
+
+            Assert.Equal("value1", dictionaryFirst.Test);
+            Assert.Null(dictionaryFirst.Dict);
+
+            json = "{\"Test\":\"value1\"}";
+            Regression38557_DictionaryLast dictionaryLast = JsonSerializer.Parse<Regression38557_DictionaryLast>(json);
+
+            Assert.Equal("value1", dictionaryLast.Test);
+            Assert.Null(dictionaryLast.Dict);
         }
 
         public class ClassWithDictionaryButNoSetter
@@ -979,6 +1075,18 @@ namespace System.Text.Json.Serialization.Tests
         {
             public string Test { get; set; }
             public Dictionary<string, string> Dict { get; set; }
+        }
+
+        public class Regression38557_DictionaryLast
+        {
+            public string Test { get; set; }
+            public Dictionary<string, string> Dict { get; set; }
+        }
+
+        public class Regression38557_DictionaryFirst
+        {
+            public Dictionary<string, string> Dict { get; set; }
+            public string Test { get; set; }
         }
     }
 }


### PR DESCRIPTION
This resolves #38565 
This resolves #38557