### PR TITLE
Enforce JsonSerializerOptions.MaxDepth on write

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
@@ -51,9 +51,16 @@ namespace System.Text.Json
                             break;
                     }
 
-                    if (finishedSerializing && writer.CurrentDepth == 0)
+                    if (finishedSerializing)
                     {
-                        break;
+                        if (writer.CurrentDepth == 0)
+                        {
+                            break;
+                        }
+                    }
+                    else if (writer.CurrentDepth >= options.EffectiveMaxDepth)
+                    {
+                        ThrowHelper.ThrowJsonException_DepthTooLarge(writer.CurrentDepth, state, options);
                     }
 
                     // If serialization is not yet end and we surpass beyond flush threshold return false and flush stream.

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -174,6 +174,7 @@ namespace System.Text.Json
             }
         }
 
+        // The default is 64 because that is what the reader uses, so re-use the same JsonReaderOptions.DefaultMaxDepth constant.
         internal int EffectiveMaxDepth { get; private set; } = JsonReaderOptions.DefaultMaxDepth;
 
         /// <summary>

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -170,8 +170,11 @@ namespace System.Text.Json
             {
                 VerifyMutable();
                 _maxDepth = value;
+                EffectiveMaxDepth = (value == 0 ? JsonReaderOptions.DefaultMaxDepth : value);
             }
         }
+
+        internal int EffectiveMaxDepth { get; private set; } = JsonReaderOptions.DefaultMaxDepth;
 
         /// <summary>
         /// Specifies the policy used to convert a property's name on an object to another format, such as camel-casing.

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -55,6 +55,14 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowJsonException_DepthTooLarge(int currentDepth, in WriteStack writeStack, JsonSerializerOptions options)
+        {
+            var ex = new JsonException(SR.Format(SR.DepthTooLarge, currentDepth, options.EffectiveMaxDepth));
+            AddExceptionInformation(writeStack, ex);
+            throw ex;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_SerializationConverterRead(in Utf8JsonReader reader, string path, string converter)
         {
             ThrowJsonException(SR.Format(SR.SerializationConverterRead, converter), reader, path);

--- a/src/System.Text.Json/tests/Serialization/CyclicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CyclicTests.cs
@@ -33,8 +33,9 @@ namespace System.Text.Json.Serialization.Tests
                 var options = new JsonSerializerOptions();
                 options.MaxDepth = depth + 1;
 
-                // No exception
-                JsonSerializer.ToString(rootObj, options);
+                // No exception since depth was not passed.
+                string json = JsonSerializer.ToString(rootObj, options);
+                Assert.False(string.IsNullOrEmpty(json));
             }
 
             {

--- a/src/System.Text.Json/tests/Serialization/CyclicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CyclicTests.cs
@@ -10,13 +10,50 @@ namespace System.Text.Json.Serialization.Tests
     public static class CyclicTests
     {
         [Fact]
-        public static void WriteCyclicFail()
+        public static void WriteCyclicFailDefault()
         {
             TestClassWithCycle obj = new TestClassWithCycle();
             obj.Parent = obj;
 
             // We don't allow graph cycles; we throw JsonException instead of an unrecoverable StackOverflow.
             Assert.Throws<JsonException>(() => JsonSerializer.ToString(obj));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(10)]
+        [InlineData(70)]
+        public static void WriteCyclicFail(int depth)
+        {
+            var rootObj = new TestClassWithCycle("root");
+            CreateObjectHierarchy(1, depth, rootObj);
+
+            {
+                var options = new JsonSerializerOptions();
+                options.MaxDepth = depth + 1;
+
+                // No exception
+                JsonSerializer.ToString(rootObj, options);
+            }
+
+            {
+                var options = new JsonSerializerOptions();
+                options.MaxDepth = depth;
+                Assert.Throws<JsonException>(() => JsonSerializer.ToString(rootObj, options));
+            }
+        }
+
+        private static TestClassWithCycle CreateObjectHierarchy(int i, int max, TestClassWithCycle previous)
+        {
+            if (i == max)
+            {
+                return null;
+            }
+
+            var obj = new TestClassWithCycle(i.ToString());
+            previous.Parent = obj;
+            return CreateObjectHierarchy(++i, max, obj);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/36510

It appears the `Utf8JsonWriter` now has an upper limit of 1,000 so we would never get a `StackOverflowException`.