### PR TITLE
Improve AssertExtensions.Equal performance for large arrays

### DIFF
--- a/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
+++ b/src/CoreFx.Private.TestUtilities/ref/CoreFx.Private.TestUtilities.cs
@@ -15,7 +15,7 @@ namespace System
     public static partial class AssertExtensions
     {
         public static void Contains(string value, string substring) { }
-        public static void Equal(byte[] expected, byte[] actual) { }
+        public static void Equal<T>(T[] expected, T[] actual) where T : System.IEquatable<T> { }
         public static void Equal<T>(System.Collections.Generic.HashSet<T> expected, System.Collections.Generic.HashSet<T> actual) { }
         public static void GreaterThanOrEqualTo<T>(T actual, T greaterThanOrEqualTo, string userMessage = null) where T : System.IComparable { }
         public static void GreaterThan<T>(T actual, T greaterThan, string userMessage = null) where T : System.IComparable { }

--- a/src/CoreFx.Private.TestUtilities/src/System/AssertExtensions.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/AssertExtensions.cs
@@ -312,18 +312,16 @@ namespace System
         }
 
         /// <summary>
-        /// Validates that the actual byte array is equal to the expected byte array. XUnit only displays the first 5 values
+        /// Validates that the actual array is equal to the expected array. XUnit only displays the first 5 values
         /// of each collection if the test fails. This doesn't display at what point or how the equality assertion failed.
         /// </summary>
-        /// <param name="expected">The byte array that <paramref name="actual"/> should be equal to.</param>
+        /// <param name="expected">The array that <paramref name="actual"/> should be equal to.</param>
         /// <param name="actual"></param>
-        public static void Equal(byte[] expected, byte[] actual)
+        public static void Equal<T>(T[] expected, T[] actual) where T: IEquatable<T>
         {
-            try
-            {
-                Assert.Equal(expected, actual);
-            }
-            catch (AssertActualExpectedException)
+            // Use the SequenceEqual to compare the arrays for better performance. The default Assert.Equal method compares
+            // the arrays by boxing each element that is very slow for large arrays.
+            if (!expected.AsSpan().SequenceEqual(actual.AsSpan()))
             {
                 string expectedString = string.Join(", ", expected);
                 string actualString = string.Join(", ", actual);

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -137,7 +137,7 @@ namespace System.IO.Tests
             {
                 char[] readData = new char[data.Length];
                 stream.Read(readData, 0, data.Length);
-                Assert.Equal(data, readData);
+                AssertExtensions.Equal(data, readData);
             }
 
             // Ensure last write/access time on the new file is appropriate
@@ -269,7 +269,7 @@ namespace System.IO.Tests
             {
                 char[] readData = new char[sourceData.Length];
                 stream.Read(readData, 0, sourceData.Length);
-                Assert.Equal(sourceData, readData);
+                AssertExtensions.Equal(sourceData, readData);
             }
         }
 
@@ -295,7 +295,7 @@ namespace System.IO.Tests
             {
                 char[] readData = new char[sourceData.Length];
                 stream.Read(readData, 0, sourceData.Length);
-                Assert.Equal(destData, readData);
+                AssertExtensions.Equal(destData, readData);
             }
         }
 


### PR DESCRIPTION
Assert.Equal on arrays boxes each element and then performs a complex
operation to compare each box. This is slow for large arrays, and extremely
slow for large arrays on checked CoreCLR.

Use AssertExtensions.Equal for large arrays in File.Copy tests to make
them reasonably fast on checked CoreCLR.