### PR TITLE
Increase sample size of random number generation

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.netcoreapp.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.netcoreapp.cs
@@ -208,8 +208,8 @@ namespace System.Security.Cryptography.RNG.Tests
         [Fact]
         public static void GetInt32_NegativeBounds1000d20()
         {
-            int numberToGenerate = 1000;
-            Span<int> generated = stackalloc int[numberToGenerate];
+            int numberToGenerate = 10_000;
+            Span<int> generated = new int[numberToGenerate];
 
             for (int i = 0; i < numberToGenerate; i++)
             {
@@ -222,8 +222,8 @@ namespace System.Security.Cryptography.RNG.Tests
         [Fact]
         public static void GetInt32_1000d6()
         {
-            int numberToGenerate = 1000;
-            Span<int> generated = stackalloc int[numberToGenerate];
+            int numberToGenerate = 10_000;
+            Span<int> generated = new int[numberToGenerate];
 
             for (int i = 0; i < numberToGenerate; i++)
             {
@@ -243,8 +243,8 @@ namespace System.Security.Cryptography.RNG.Tests
         [InlineData(16_777_214, 16_777_217)]
         public static void GetInt32_MaskRangeCorrect(int fromInclusive, int toExclusive)
         {
-            int numberToGenerate = 1000;
-            Span<int> generated = stackalloc int[numberToGenerate];
+            int numberToGenerate = 10_000;
+            Span<int> generated = new int[numberToGenerate];
 
             for (int i = 0; i < numberToGenerate; i++)
             {


### PR DESCRIPTION
This increases the sample size of the random number generator tests to improve stability of the tests. The sample size increased by an order of a magnitude, but this only marginally increases test execution time. It adds about half a second to the entire test suite for me, though that is on a fairly strong desktop. I don't know how well this will perform on the ARM64 leg.

@bartonjs I looked at other approaches like variance/stddev but had similar issues, which is that the population of data is relatively small to make any strong conclusions about randomness. I'll continue to look at ways to improve these tests overall. However, in the mean time this simpler change will improve the reliability of these tests so folks can get green CI runs.

Fix #38402 

