### PR TITLE
Adding validation to ensure all runtime-only files are present on all runtime-specific packages

### DIFF
--- a/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.NETCoreApp/Microsoft.Private.CoreFx.NETCoreApp.pkgproj
@@ -34,22 +34,24 @@
     <ExcludeFromClosure Include="System.Transactions" />
     <ExcludeFromClosure Include="WindowsBase" />
 
+    <AllowedRuntimeOnlyFiles Include="Microsoft.Win32.Registry" />
+    <AllowedRuntimeOnlyFiles Include="System.IO.FileSystem.AccessControl" />
+    <AllowedRuntimeOnlyFiles Include="System.IO.Pipes.AccessControl" />
+    <AllowedRuntimeOnlyFiles Include="System.Private.DataContractSerialization" />
+    <AllowedRuntimeOnlyFiles Include="System.Private.Uri" />
+    <AllowedRuntimeOnlyFiles Include="System.Private.Xml" />
+    <AllowedRuntimeOnlyFiles Include="System.Private.Xml.Linq" />
+    <AllowedRuntimeOnlyFiles Include="System.Runtime.WindowsRuntime" />
+    <AllowedRuntimeOnlyFiles Include="System.Runtime.WindowsRuntime.UI.Xaml" />
+    <AllowedRuntimeOnlyFiles Include="System.Security.AccessControl" />
+    <AllowedRuntimeOnlyFiles Include="System.Security.Cryptography.Cng" />
+    <AllowedRuntimeOnlyFiles Include="System.Security.Cryptography.OpenSsl" />
+    <AllowedRuntimeOnlyFiles Include="System.Security.Principal.Windows" />
+
     <!-- Permit the following implementation-only assemblies -->
     <ValidatePackageSuppression Condition="'$(PackageTargetRuntime)' != ''" Include="PermitInbox">
       <Value>
-        Microsoft.Win32.Registry;
-        System.IO.FileSystem.AccessControl;
-        System.IO.Pipes.AccessControl;
-        System.Private.DataContractSerialization;
-        System.Private.Uri;
-        System.Private.Xml;
-        System.Private.Xml.Linq;
-        System.Runtime.WindowsRuntime;
-        System.Runtime.WindowsRuntime.UI.Xaml;
-        System.Security.AccessControl;
-        System.Security.Cryptography.Cng;
-        System.Security.Cryptography.OpenSsl;
-        System.Security.Principal.Windows;
+        @(AllowedRuntimeOnlyFiles);
       </Value>
     </ValidatePackageSuppression>
     <!-- Permit missing Inbox since this used to be a shim and it is now OOB -->
@@ -59,6 +61,19 @@
         </Value>
     </ValidatePackageSuppression>
   </ItemGroup>
+
+  <Target Name="VerifyRuntimeOnlyFilesArePresentOnAllRuntimePackages"
+      DependsOnTargets="GetClosureFiles"
+      AfterTargets="ValidatePackage"
+      Condition="'$(PackageTargetRuntime)' != ''"
+      Inputs="%(ClosureFile.FileSet)"
+      Outputs="batching-on-FileSet-metadata">
+
+    <ItemGroup>
+      <_RuntimeOnlyMissingFile Include="@(AllowedRuntimeOnlyFiles)" Exclude="@(ClosureFile->'%(FileName)')" />
+    </ItemGroup>
+    <Error Condition="'@(_RuntimeOnlyMissingFile)' != ''" Text="Files '@(_RuntimeOnlyMissingFile)' should be present on all runtime-specific packages, but are not present for the package RID '$(PackageTargetRuntime)'" />
+  </Target>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.targets))\Directory.Build.targets" />
 </Project>


### PR DESCRIPTION
fixes #33944

cc: @ericstj 

This will add validation to ensure that all of the files that we are permitting to be inbox runtime-only, to be present on all runtime specific packages.