### PR TITLE
Remove Serialization Guard public APIs

### DIFF
--- a/src/Common/src/System/Runtime/Serialization/SerializationGuard.cs
+++ b/src/Common/src/System/Runtime/Serialization/SerializationGuard.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+namespace System.Runtime.Serialization
+{
+    /// <summary>
+    /// Provides access to portions of the Serialization Guard APIs since they're not publicly exposed via contracts.
+    /// </summary>
+    internal static partial class SerializationGuard
+    {
+        private delegate void ThrowIfDeserializationInProgressWithSwitchDel(string switchName, ref int cachedValue);
+        private static readonly ThrowIfDeserializationInProgressWithSwitchDel s_throwIfDeserializationInProgressWithSwitch = CreateThrowIfDeserializationInProgressWithSwitchDelegate();
+
+        /// <summary>
+        /// Equivalent to typeof(DeserializationBlockedException).
+        /// </summary>
+        public static readonly Type DeserializationBlockedExceptionType = GetDeserializationBlockedExceptionType();
+
+        /// <summary>
+        /// Builds a wrapper delegate for SerializationInfo.ThrowIfDeserializationInProgress(string, ref int),
+        /// since it is not exposed via contracts.
+        /// </summary>
+        private static ThrowIfDeserializationInProgressWithSwitchDel CreateThrowIfDeserializationInProgressWithSwitchDelegate()
+        {
+            ThrowIfDeserializationInProgressWithSwitchDel throwIfDeserializationInProgressDelegate = null;
+            MethodInfo throwMethod = typeof(SerializationInfo).GetMethod("ThrowIfDeserializationInProgress",
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public, null, new Type[] { typeof(string), typeof(int).MakeByRefType() }, new ParameterModifier[0]);
+
+            if (throwMethod != null)
+            {
+                throwIfDeserializationInProgressDelegate = (ThrowIfDeserializationInProgressWithSwitchDel)throwMethod.CreateDelegate(typeof(ThrowIfDeserializationInProgressWithSwitchDel));
+            }
+
+            return throwIfDeserializationInProgressDelegate;
+        }
+
+        private static Type GetDeserializationBlockedExceptionType()
+        {
+            return typeof(SerializationInfo).Assembly.GetType("System.Runtime.Serialization.DeserializationBlockedException", throwOnError: false);
+        }
+
+        /// <summary>
+        /// Provides access to the internal "ThrowIfDeserializationInProgress" method on <see cref="SerializationInfo"/>.
+        /// No-ops if the Serialization Guard feature is disabled or unavailable.
+        /// </summary>
+        public static void ThrowIfDeserializationInProgress(string switchSuffix, ref int cachedValue)
+        {
+            s_throwIfDeserializationInProgressWithSwitch?.Invoke(switchSuffix, ref cachedValue);
+        }
+    }
+}

--- a/src/Common/src/System/Runtime/Serialization/SerializationGuard.cs
+++ b/src/Common/src/System/Runtime/Serialization/SerializationGuard.cs
@@ -15,11 +15,6 @@ namespace System.Runtime.Serialization
         private static readonly ThrowIfDeserializationInProgressWithSwitchDel s_throwIfDeserializationInProgressWithSwitch = CreateThrowIfDeserializationInProgressWithSwitchDelegate();
 
         /// <summary>
-        /// Equivalent to typeof(DeserializationBlockedException).
-        /// </summary>
-        public static readonly Type DeserializationBlockedExceptionType = GetDeserializationBlockedExceptionType();
-
-        /// <summary>
         /// Builds a wrapper delegate for SerializationInfo.ThrowIfDeserializationInProgress(string, ref int),
         /// since it is not exposed via contracts.
         /// </summary>
@@ -35,11 +30,6 @@ namespace System.Runtime.Serialization
             }
 
             return throwIfDeserializationInProgressDelegate;
-        }
-
-        private static Type GetDeserializationBlockedExceptionType()
-        {
-            return typeof(SerializationInfo).Assembly.GetType("System.Runtime.Serialization.DeserializationBlockedException", throwOnError: false);
         }
 
         /// <summary>

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{F55047F8-E47B-46E3-B221-C23595AFE168}</ProjectGuid>
@@ -37,6 +37,9 @@
     <Compile Include="System\Diagnostics\ThreadWaitReason.cs" />
     <Compile Include="System\Diagnostics\MonitoringDescriptionAttribute.cs" />
     <Compile Include="System\Collections\Specialized\StringDictionaryWrapper.cs" />
+    <Compile Include="$(CommonPath)\System\Runtime\Serialization\SerializationGuard.cs">
+      <Link>Common\System\Runtime\Serialization\SerializationGuard.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\CoreLib\System\PasteArguments.cs">
       <Link>Common\CoreLib\System\PasteArguments.cs</Link>
     </Compile>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -7,7 +7,6 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
-using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
@@ -84,8 +83,6 @@ namespace System.Diagnostics
         internal bool _pendingErrorRead;
 
         private static int s_cachedSerializationSwitch = 0;
-        delegate void ThrowIfDeserializationInProgressWithSwitchDel(string switchName, ref int cachedValue);
-        private static ThrowIfDeserializationInProgressWithSwitchDel s_throwIfDeserializationInProgressWithSwitch = CreateThrowIfDeserializationInProgressWithSwitchDelegate();
 
         /// <devdoc>
         ///    <para>
@@ -1179,23 +1176,6 @@ namespace System.Diagnostics
         /// <summary>Additional optional configuration hook after a process ID is set.</summary>
         partial void ConfigureAfterProcessIdSet();
 
-        /// <summary>
-        /// Builds a wrapper delegate for SerializationInfo.ThrowIfDeserializationInProgress(string, ref int),
-        /// since it is not exposed via contracts.
-        /// </summary>
-        private static ThrowIfDeserializationInProgressWithSwitchDel CreateThrowIfDeserializationInProgressWithSwitchDelegate()
-        {
-            ThrowIfDeserializationInProgressWithSwitchDel throwIfDeserializationInProgressDelegate = null;
-            MethodInfo throwMethod = typeof(SerializationInfo).GetMethod("ThrowIfDeserializationInProgress",
-                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public, null, new Type[] { typeof(string), typeof(int).MakeByRefType() }, new ParameterModifier[0]);
-            if (throwMethod != null)
-            {
-                throwIfDeserializationInProgressDelegate = (ThrowIfDeserializationInProgressWithSwitchDel)throwMethod.CreateDelegate(typeof(ThrowIfDeserializationInProgressWithSwitchDel));
-            }
-
-            return throwIfDeserializationInProgressDelegate;
-        }
-
         /// <devdoc>
         ///    <para>
         ///       Starts a process specified by the <see cref='System.Diagnostics.Process.StartInfo'/> property of this <see cref='System.Diagnostics.Process'/>
@@ -1237,10 +1217,7 @@ namespace System.Diagnostics
                 throw new ObjectDisposedException(GetType().Name);
             }
 
-            if (s_throwIfDeserializationInProgressWithSwitch != null)
-            {
-                s_throwIfDeserializationInProgressWithSwitch("AllowProcessCreation", ref s_cachedSerializationSwitch);
-            }
+            SerializationGuard.ThrowIfDeserializationInProgress("AllowProcessCreation", ref s_cachedSerializationSwitch);
 
             return StartCore(startInfo);
         }

--- a/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
+++ b/src/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectManager.cs
@@ -773,17 +773,8 @@ namespace System.Runtime.Serialization
             {
                 throw new SerializationException(SR.Format(SR.Serialization_ConstructorNotFound, t), e);
             }
-            try
-            {
-                constInfo.Invoke(obj, new object[] { info, context });
-            }
-            // This will only throw TargetInvocationExceptions, but to provide a better exception for dangerous deserialization, unwrap that
-            // and re-wrap it in a DeserializationBlockedException (while preserving its stack)
-            catch (TargetInvocationException outerException) when (outerException.InnerException is DeserializationBlockedException)
-            {
-                throw new DeserializationBlockedException(outerException.InnerException);
-            }
 
+            constInfo.Invoke(obj, new object[] { info, context });
         }
 
         internal static ConstructorInfo GetDeserializationConstructor(Type t)

--- a/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
@@ -73,7 +73,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
             ms.Position = 0;
 
             BinaryFormatter reader = new BinaryFormatter();
-            Assert.Throws<DeserializationBlockedException>(() => reader.Deserialize(ms));
+            Assert.Throws(SerializationGuard.DeserializationBlockedExceptionType, () => reader.Deserialize(ms));
         }
     }
 

--- a/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
@@ -73,7 +73,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
             ms.Position = 0;
 
             BinaryFormatter reader = new BinaryFormatter();
-            Assert.Throws(SerializationGuard.DeserializationBlockedExceptionType, () => reader.Deserialize(ms));
+            Assert.ThrowsAny<SerializationException>(() => reader.Deserialize(ms));
         }
     }
 

--- a/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
+++ b/src/System.Runtime.Serialization.Formatters/tests/SerializationGuardTests.cs
@@ -73,7 +73,8 @@ namespace System.Runtime.Serialization.Formatters.Tests
             ms.Position = 0;
 
             BinaryFormatter reader = new BinaryFormatter();
-            Assert.ThrowsAny<SerializationException>(() => reader.Deserialize(ms));
+            TargetInvocationException tie = Assert.Throws<TargetInvocationException>(() => reader.Deserialize(ms));
+            Assert.IsAssignableFrom(typeof(SerializationException), tie.InnerException);
         }
     }
 

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -23,9 +23,6 @@
     <Compile Include="SurrogateSelectorTests.cs" />
     <Compile Include="TargetFrameworkMoniker.cs" />
     <Compile Include="TypeSerializableValue.cs" />
-    <Compile Include="$(CommonPath)\System\Runtime\Serialization\SerializationGuard.cs">
-      <Link>Common\System\Runtime\Serialization\SerializationGuard.cs</Link>
-    </Compile>
     <Compile Include="$(CommonTestPath)\System\NonRuntimeType.cs">
       <Link>Common\System\NonRuntimeType.cs</Link>
     </Compile>

--- a/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -23,6 +23,9 @@
     <Compile Include="SurrogateSelectorTests.cs" />
     <Compile Include="TargetFrameworkMoniker.cs" />
     <Compile Include="TypeSerializableValue.cs" />
+    <Compile Include="$(CommonPath)\System\Runtime\Serialization\SerializationGuard.cs">
+      <Link>Common\System\Runtime\Serialization\SerializationGuard.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\NonRuntimeType.cs">
       <Link>Common\System\NonRuntimeType.cs</Link>
     </Compile>

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -7169,12 +7169,6 @@ namespace System.Runtime.Remoting
 }
 namespace System.Runtime.Serialization
 {
-    public sealed partial class DeserializationBlockedException : System.Exception
-    {
-        public DeserializationBlockedException() { }
-        public DeserializationBlockedException(System.Exception? innerException) { }
-        public DeserializationBlockedException(string? message) { }
-    }
     public partial interface IDeserializationCallback
     {
         void OnDeserialization(object? sender);

--- a/src/System.Runtime/src/MatchingRefApiCompatBaseline.txt
+++ b/src/System.Runtime/src/MatchingRefApiCompatBaseline.txt
@@ -15,7 +15,6 @@ MembersMustExist : Member 'System.Collections.ObjectModel.Collection<T>.RemoveRa
 MembersMustExist : Member 'System.Collections.ObjectModel.Collection<T>.ReplaceItemsRange(System.Int32, System.Int32, System.Collections.Generic.IEnumerable<T>)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Collections.ObjectModel.Collection<T>.ReplaceRange(System.Int32, System.Int32, System.Collections.Generic.IEnumerable<T>)' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Reflection.Module.GetModuleHandleImpl()' does not exist in the reference but it does exist in the implementation.
-CannotRemoveBaseTypeOrInterface : Type 'System.Runtime.Serialization.DeserializationBlockedException' does not inherit from base type 'System.Runtime.Serialization.SerializationException' in the reference but it does in the implementation.
 MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.DeserializationInProgress.get()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.StartDeserialization()' does not exist in the reference but it does exist in the implementation.
 MembersMustExist : Member 'System.Runtime.Serialization.SerializationInfo.ThrowIfDeserializationInProgress()' does not exist in the reference but it does exist in the implementation.


### PR DESCRIPTION
Removes public APIs per https://github.com/dotnet/corefx/issues/36723 and our conversations over email. Also refactors the reflection-based code out of the `Process` class and into its own standalone file so that it can be shared by future components if needed.

There are no behavioral changes from this PR.