### PR TITLE
Fix factory converters used as attributes

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -444,6 +444,7 @@ namespace System.Text.Json.Serialization
     }
     public sealed class JsonStringEnumConverter : System.Text.Json.Serialization.JsonConverterFactory
     {
+        public JsonStringEnumConverter() { }
         public JsonStringEnumConverter(System.Text.Json.JsonNamingPolicy namingPolicy = null, bool allowIntegerValues = true) { }
         public override bool CanConvert(System.Type type) { throw null; }
         protected override System.Text.Json.Serialization.JsonConverter CreateConverter(System.Type type) { throw null; }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
@@ -135,11 +135,6 @@ namespace System.Text.Json
                 args: null,
                 culture: null);
 
-            if (converter is JsonConverterFactory factory)
-            {
-                converter = factory.GetConverterInternal(runtimePropertyType);
-            }
-
             jsonInfo.Initialize(parentClassType, declaredPropertyType, runtimePropertyType, propertyInfo, collectionElementType, converter, options);
 
             return jsonInfo;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.AddProperty.cs
@@ -135,6 +135,11 @@ namespace System.Text.Json
                 args: null,
                 culture: null);
 
+            if (converter is JsonConverterFactory factory)
+            {
+                converter = factory.GetConverterInternal(runtimePropertyType);
+            }
+
             jsonInfo.Initialize(parentClassType, declaredPropertyType, runtimePropertyType, propertyInfo, collectionElementType, converter, options);
 
             return jsonInfo;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -86,6 +86,11 @@ namespace System.Text.Json
                 converter = GetConverter(runtimePropertyType);
             }
 
+            if (converter is JsonConverterFactory factory)
+            {
+                converter = factory.GetConverterInternal(runtimePropertyType);
+            }
+
             return converter;
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
@@ -19,6 +19,16 @@ namespace System.Text.Json.Serialization
         private readonly EnumConverterOptions _converterOptions;
 
         /// <summary>
+        /// Constructor. Creates the <see cref="JsonStringEnumConverter"/> with the
+        /// default naming policy and allows integer values.
+        /// </summary>
+        public JsonStringEnumConverter()
+            : this(namingPolicy: null, allowIntegerValues: true)
+        {
+            // An empty constructor is needed for construction via attributes
+        }
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="namingPolicy">

--- a/src/System.Text.Json/tests/Serialization/EnumConverterTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumConverterTests.cs
@@ -113,5 +113,36 @@ namespace System.Text.Json.Serialization.Tests
         {
             public FileAttributes Attributes { get; set; }
         }
+
+        public class Week
+        {
+            [JsonConverter(typeof(JsonStringEnumConverter))]
+            public DayOfWeek WorkStart { get; set; }
+            public DayOfWeek WorkEnd { get; set; }
+            [LowerCaseEnum]
+            public DayOfWeek WeekEnd { get; set; }
+        }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = false)]
+        private class LowerCaseEnumAttribute : JsonConverterAttribute
+        {
+            public LowerCaseEnumAttribute() { }
+
+            public override JsonConverter CreateConverter(Type typeToConvert)
+                => new JsonStringEnumConverter(new ToLower());
+        }
+
+        [Fact]
+        public void ConvertEnumUsingAttributes()
+        {
+            Week week = new Week { WorkStart = DayOfWeek.Monday, WorkEnd = DayOfWeek.Friday, WeekEnd = DayOfWeek.Saturday };
+            string json = JsonSerializer.ToString(week);
+            Assert.Equal(@"{""WorkStart"":""Monday"",""WorkEnd"":5,""WeekEnd"":""saturday""}", json);
+
+            week = JsonSerializer.Parse<Week>(json);
+            Assert.Equal(DayOfWeek.Monday, week.WorkStart);
+            Assert.Equal(DayOfWeek.Friday, week.WorkEnd);
+            Assert.Equal(DayOfWeek.Saturday, week.WeekEnd);
+        }
     }
 }


### PR DESCRIPTION
Need to unpack the type specific converter when associating directly with a property.

Add default constructor to StringEnum converter.