### PR TITLE
Additional custom converter support for System.Object

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -44,18 +44,18 @@ namespace System.Text.Json
 
             Debug.Assert(state.Current.IsProcessingEnumerableOrDictionary);
 
-            if (state.Current.PropertyInitialized)
+            if (state.Current.CollectionPropertyInitialized)
             {
                 // A nested json array so push a new stack frame.
                 Type elementType = jsonPropertyInfo.ElementClassInfo.Type;
 
                 state.Push();
                 state.Current.Initialize(elementType, options);
-                state.Current.PropertyInitialized = true;
+                state.Current.CollectionPropertyInitialized = true;
             }
             else
             {
-                state.Current.PropertyInitialized = true;
+                state.Current.CollectionPropertyInitialized = true;
             }
 
             jsonPropertyInfo = state.Current.JsonPropertyInfo;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -23,12 +23,12 @@ namespace System.Text.Json
             Debug.Assert(jsonPropertyInfo != null);
 
             // A nested object or dictionary so push new frame.
-            if (state.Current.PropertyInitialized)
+            if (state.Current.CollectionPropertyInitialized)
             {
                 state.Push();
                 state.Current.JsonClassInfo = jsonPropertyInfo.ElementClassInfo;
                 state.Current.InitializeJsonPropertyInfo();
-                state.Current.PropertyInitialized = true;
+                state.Current.CollectionPropertyInitialized = true;
 
                 ClassType classType = state.Current.JsonClassInfo.ClassType;
                 if (classType == ClassType.Value &&
@@ -56,7 +56,7 @@ namespace System.Text.Json
                 return;
             }
 
-            state.Current.PropertyInitialized = true;
+            state.Current.CollectionPropertyInitialized = true;
 
             if (state.Current.IsProcessingIDictionaryConstructible)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -37,7 +37,7 @@ namespace System.Text.Json
 
             if (state.Current.IsEnumerableProperty || state.Current.IsDictionaryProperty || state.Current.IsIDictionaryConstructibleProperty)
             {
-                bool setPropertyToNull = !state.Current.PropertyInitialized;
+                bool setPropertyToNull = !state.Current.CollectionPropertyInitialized;
                 ApplyObjectToEnumerable(null, ref state, ref reader, setPropertyDirectly: setPropertyToNull);
                 return false;
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleObject.cs
@@ -46,12 +46,6 @@ namespace System.Text.Json
             {
                 state.Current.TempDictionaryValues = (IDictionary)classInfo.CreateObject();
             }
-            else if (state.Current.JsonClassInfo.ClassType == ClassType.Value)
-            {
-                // Custom converter.
-                state.Current.JsonPropertyInfo.Read(JsonTokenType.StartObject, ref state, ref reader);
-                HandleEndObject(options, ref reader, ref state);
-            }
             else
             {
                 state.Current.ReturnValue = classInfo.CreateObject();

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.BadConverters.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.BadConverters.cs
@@ -161,8 +161,8 @@ namespace System.Text.Json.Serialization.Tests
             }
             catch (JsonException ex)
             {
-                Assert.Contains("$.Level2.Level3s[0]", ex.ToString());
-                Assert.Equal(ex.Path, "$.Level2.Level3s[0]");
+                Assert.Contains("$.Level2.Level3s[1]", ex.ToString());
+                Assert.Equal(ex.Path, "$.Level2.Level3s[1]");
             }
         }
 

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -181,14 +181,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void ParseUntyped()
-        {
-            // Not supported until we are able to deserialize into JsonElement.
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>("[]"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<object>("[]"));
-        }
-
-        [Fact]
         public static void ReadClassWithStringToPrimitiveDictionary()
         {
             TestClassWithStringToPrimitiveDictionary obj = JsonSerializer.Parse<TestClassWithStringToPrimitiveDictionary>(TestClassWithStringToPrimitiveDictionary.s_data);

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -149,16 +149,28 @@ namespace System.Text.Json.Serialization.Tests
             JsonSerializer.Parse<EmptyClass>(SimpleTestClassWithNulls.s_json);
         }
 
-        [Fact]
-        public static void ReadObjectFail()
+        [Theory]
+        [InlineData("blah", true)]
+        [InlineData("null.", true)]
+        [InlineData("{{}", true)]
+        [InlineData("{", true)]
+        [InlineData("}", true)]
+        [InlineData("", true)]
+        [InlineData("true", false)]
+        [InlineData("[]", false)]
+        [InlineData("[{}]", false)]
+        public static void ReadObjectFail(string json, bool failsOnObject)
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>("blah"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<object>("blah"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>("true"));
-
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>("null."));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<object>("null."));
+            if (failsOnObject)
+            {
+                Assert.Throws<JsonException>(() => JsonSerializer.Parse<object>(json));
+            }
+            else
+            {
+                Assert.IsType<JsonElement>(JsonSerializer.Parse<object>(json));
+            }
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
@@ -64,6 +64,10 @@ namespace System.Text.Json.Serialization.Tests
 
             obj = JsonSerializer.Parse<object>(@"null");
             Assert.Null(obj);
+
+            obj = JsonSerializer.Parse<object>(@"[]");
+            element = (JsonElement)obj;
+            Assert.Equal(JsonValueType.Array, element.Type);
         }
 
         [Fact]


### PR DESCRIPTION
Allows a System.Object converter to be used for objects and array elements; previously only worked for value types.

Also some misc refactoring and clean-up.