### PR TITLE
Fix failing PostAsyncExpect100Continue_LateForbiddenResponse_Ok

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -234,6 +234,21 @@ namespace System.Net.Test.Common
             _ignoreWindowUpdates = false;
         }
 
+        // This is similiar to WaitForConnectionShutdownAsync but will send GOAWAY for you
+        // and will ignore any errors if client has already shutdown
+        public async Task ShutdownIgnoringErrorsAsync(int lastStreamId)
+        {
+            try
+            {
+                await SendGoAway(lastStreamId);
+                await WaitForConnectionShutdownAsync();
+            }
+            catch (IOException)
+            {
+                // Ignore connection errors
+            }
+        }
+
         public async Task<int> ReadRequestHeaderAsync()
         {
             // Receive HEADERS frame for request.


### PR DESCRIPTION
Fixes: #38734

Seems https://github.com/dotnet/corefx/commit/3fac6ad5bc4576eb2216ccb24fbed2bf173d41f4 has uncovered a test issue.

The problem is that client gets diposed a bit too early causing unexpected errors