### PR TITLE
Fix helper thread stack size for Alpine

### DIFF
--- a/src/Native/Unix/System.Native/pal_signal.c
+++ b/src/Native/Unix/System.Native/pal_signal.c
@@ -239,6 +239,36 @@ static void InstallSignalHandler(int sig, bool skipWhenSigIgn)
     assert(rv == 0);
 }
 
+static bool CreateSignalHandlerThread(int* readFdPtr)
+{
+    pthread_attr_t attr;
+    if (pthread_attr_init(&attr) != 0)
+    {
+        return false;
+    }
+
+    bool success = false;
+
+    // Set the thread stack size to 512kB. This is to fix a problem on Alpine
+    // Linux where the default secondary thread stack size is just about 85kB
+    // and our testing have hit cases when that was not enough in debug
+    // and checked builds due to some large frames in JIT code.
+    if (pthread_attr_setstacksize(&attr, 512 * 1024) == 0)
+    {
+        pthread_t handlerThread;
+        if (pthread_create(&handlerThread, NULL, SignalHandlerLoop, readFdPtr) == 0)
+        {
+            success = true;
+        }
+    }
+
+    int err = errno;
+    pthread_attr_destroy(&attr);
+    errno = err;
+
+    return success;
+}
+
 int32_t InitializeSignalHandlingCore()
 {
     // Create a pipe we'll use to communicate with our worker
@@ -263,8 +293,8 @@ int32_t InitializeSignalHandlingCore()
     *readFdPtr = g_signalPipe[0];
 
     // The pipe is created.  Create the worker thread.
-    pthread_t handlerThread;
-    if (pthread_create(&handlerThread, NULL, SignalHandlerLoop, readFdPtr) != 0)
+
+    if (!CreateSignalHandlerThread(readFdPtr))
     {
         int err = errno;
         free(readFdPtr);

--- a/src/Native/Unix/System.Native/pal_signal.c
+++ b/src/Native/Unix/System.Native/pal_signal.c
@@ -248,15 +248,16 @@ static bool CreateSignalHandlerThread(int* readFdPtr)
     }
 
     bool success = false;
-
+#ifdef DEBUG
     // Set the thread stack size to 512kB. This is to fix a problem on Alpine
     // Linux where the default secondary thread stack size is just about 85kB
     // and our testing have hit cases when that was not enough in debug
     // and checked builds due to some large frames in JIT code.
     if (pthread_attr_setstacksize(&attr, 512 * 1024) == 0)
+#endif
     {
         pthread_t handlerThread;
-        if (pthread_create(&handlerThread, NULL, SignalHandlerLoop, readFdPtr) == 0)
+        if (pthread_create(&handlerThread, &attr, SignalHandlerLoop, readFdPtr) == 0)
         {
             success = true;
         }


### PR DESCRIPTION
CoreFX creates a helper thread for handling some signals. This thread is
created using pthread API without explicit setting of stack size. That
means that on Alpine, it gets only 85kB of stack. We have hit stack
overflow in one of our coreclr tests in checked build due to that.

This change sets the default stack size of that thread to 512kB,
which should be sufficient.