### PR TITLE
Config ReaderQotas.MaxStringContentLength has no effect for some test…

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
@@ -424,6 +424,8 @@ namespace System.Xml
                         {
                             if (sb == null)
                                 sb = new StringBuilder(result);
+                            if (sb.Length > maxStringContentLength - value.Length)
+                                XmlExceptionHelper.ThrowMaxStringContentLengthExceeded(this, maxStringContentLength);
                             sb.Append(value);
                         }
                         break;
@@ -454,6 +456,8 @@ namespace System.Xml
             }
             if (sb != null)
                 result = sb.ToString();
+            if (result.Length > maxStringContentLength)
+                XmlExceptionHelper.ThrowMaxStringContentLengthExceeded(this, maxStringContentLength);
             return result;
         }
 


### PR DESCRIPTION
… data on NetCore.

For wcf issue [#3408](https://github.com/dotnet/wcf/issues/3408)
@mconnew , @StephenBonikowsky .