### PR TITLE
Add support for NumericString to X500DistinguishedName

### DIFF
--- a/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnCharacterStringEncodings.cs
+++ b/src/Common/src/System/Security/Cryptography/Asn1Reader/AsnCharacterStringEncodings.cs
@@ -14,6 +14,7 @@ namespace System.Security.Cryptography.Asn1
         private static readonly Text.Encoding s_bmpEncoding = new BMPEncoding();
         private static readonly Text.Encoding s_ia5Encoding = new IA5Encoding();
         private static readonly Text.Encoding s_visibleStringEncoding = new VisibleStringEncoding();
+        private static readonly Text.Encoding s_numericStringEncoding = new NumericStringEncoding();
         private static readonly Text.Encoding s_printableStringEncoding = new PrintableStringEncoding();
         private static readonly Text.Encoding s_t61Encoding = new T61Encoding();
 
@@ -23,6 +24,8 @@ namespace System.Security.Cryptography.Asn1
             {
                 case UniversalTagNumber.UTF8String:
                     return s_utf8Encoding;
+                case UniversalTagNumber.NumericString:
+                    return s_numericStringEncoding;
                 case UniversalTagNumber.PrintableString:
                     return s_printableStringEncoding;
                 case UniversalTagNumber.IA5String:
@@ -149,6 +152,16 @@ namespace System.Security.Cryptography.Asn1
         // Space is ASCII 0x20.
         internal VisibleStringEncoding()
             : base(0x20, 0x7E)
+        {
+        }
+    }
+
+    internal class NumericStringEncoding : RestrictedAsciiStringEncoding
+    {
+        // T-REC-X.680-201508 sec 41.2 (Table 9)
+        // 0, 1, ... 9 + space
+        internal NumericStringEncoding()
+            : base("0123456789 ")
         {
         }
     }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -212,7 +212,7 @@ namespace Internal.Cryptography
 
     internal static class DictionaryStringHelper
     {
-        internal static string ReadDirectoryOrIA5String(this AsnReader tavReader)
+        internal static string ReadAnyAsnString(this AsnReader tavReader)
         {
             Asn1Tag tag = tavReader.PeekTag();
 
@@ -225,6 +225,7 @@ namespace Internal.Cryptography
             {
                 case UniversalTagNumber.BMPString:
                 case UniversalTagNumber.IA5String:
+                case UniversalTagNumber.NumericString:
                 case UniversalTagNumber.PrintableString:
                 case UniversalTagNumber.UTF8String:
                 case UniversalTagNumber.T61String:

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificateData.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificateData.cs
@@ -343,7 +343,7 @@ namespace Internal.Cryptography.Pal
                 {
                     AsnReader tavReader = rdnReader.ReadSequence();
                     string oid = tavReader.ReadObjectIdentifierAsString();
-                    string value = tavReader.ReadDirectoryOrIA5String();
+                    string value = tavReader.ReadAnyAsnString();
                     tavReader.ThrowIfNotEmpty();
                     yield return new KeyValuePair<string, string>(oid, value);
                 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ManagedCertificateFinder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ManagedCertificateFinder.cs
@@ -136,7 +136,7 @@ namespace Internal.Cryptography.Pal
                     {
                         // Try a V1 template structure, just a string:
                         AsnReader reader = new AsnReader(ext.RawData, AsnEncodingRules.DER);
-                        string decodedName = reader.ReadDirectoryOrIA5String();
+                        string decodedName = reader.ReadAnyAsnString();
                         reader.ThrowIfNotEmpty();
 
                         // If this doesn't match, maybe a V2 template will

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.ManagedDecode.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.ManagedDecode.cs
@@ -91,7 +91,7 @@ namespace Internal.Cryptography.Pal
                 {
                     AsnReader tavReader = rdnReader.ReadSequence();
                     string oid = tavReader.ReadObjectIdentifierAsString();
-                    string attributeValue = tavReader.ReadDirectoryOrIA5String();
+                    string attributeValue = tavReader.ReadAnyAsnString();
 
                     tavReader.ThrowIfNotEmpty();
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
+using Test.Cryptography;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests
@@ -238,6 +239,29 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     X509Chain chain = new X509Chain();
                     Assert.False(chain.Build(ee));
                     Assert.Equal(1, chain.ChainElements.Count);
+                }
+            }
+        }
+
+        [Fact]
+        public static void VerifyNumericStringSubject()
+        {
+            X500DistinguishedName dn = new X500DistinguishedName(
+                "302431133011060100120C313233203635342037383930310D300B0603550403130454657374".HexToByteArray());
+
+            using (RSA key = RSA.Create())
+            {
+                CertificateRequest req = new CertificateRequest(
+                    dn,
+                    key,
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
+
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                using (X509Certificate2 cert = req.CreateSelfSigned(now.AddDays(-1), now.AddDays(1)))
+                {
+                    Assert.Equal("CN=Test, OID.0.0=123 654 7890", cert.Subject);
                 }
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -244,6 +244,10 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        // macOS (10.14) will not load certificates with NumericString in their subject
+        // if the 0x12 (NumericString) is changed to 0x13 (PrintableString) then the cert
+        // import doesn't fail.
+        [PlatformSpecific(~TestPlatforms.OSX)]
         public static void VerifyNumericStringSubject()
         {
             X500DistinguishedName dn = new X500DistinguishedName(

--- a/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -247,7 +247,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         public static void VerifyNumericStringSubject()
         {
             X500DistinguishedName dn = new X500DistinguishedName(
-                "302431133011060100120C313233203635342037383930310D300B0603550403130454657374".HexToByteArray());
+                "30283117301506052901020203120C313233203635342037383930310D300B0603550403130454657374".HexToByteArray());
 
             using (RSA key = RSA.Create())
             {
@@ -261,7 +261,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 using (X509Certificate2 cert = req.CreateSelfSigned(now.AddDays(-1), now.AddDays(1)))
                 {
-                    Assert.Equal("CN=Test, OID.0.0=123 654 7890", cert.Subject);
+                    Assert.Equal("CN=Test, OID.1.1.1.2.2.3=123 654 7890", cert.Subject);
                 }
             }
         }

--- a/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
@@ -201,6 +201,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal("TPMManufacturer=id:564D5700, TPMModel=\"\", TPMVersion=id:0020065", dn2.Decode(X500DistinguishedNameFlags.None));
         }
 
+        [Fact]
+        public static void NameWithNumericString()
+        {
+            X500DistinguishedName dn = new X500DistinguishedName(
+                "302431133011060100120C313233203635342037383930310D300B0603550403130454657374".HexToByteArray());
+
+            Assert.Equal("OID.0.0=123 654 7890, CN=Test", dn.Decode(X500DistinguishedNameFlags.None));
+        }
+
         public static readonly object[][] WhitespaceBeforeCases =
         {
             // Regular space.

--- a/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
@@ -205,9 +205,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         public static void NameWithNumericString()
         {
             X500DistinguishedName dn = new X500DistinguishedName(
-                "302431133011060100120C313233203635342037383930310D300B0603550403130454657374".HexToByteArray());
+                "30283117301506052901020203120C313233203635342037383930310D300B0603550403130454657374".HexToByteArray());
 
-            Assert.Equal("OID.0.0=123 654 7890, CN=Test", dn.Decode(X500DistinguishedNameFlags.None));
+            Assert.Equal("OID.1.1.1.2.2.3=123 654 7890, CN=Test", dn.Decode(X500DistinguishedNameFlags.None));
         }
 
         public static readonly object[][] WhitespaceBeforeCases =


### PR DESCRIPTION
An X500DN which contains a valid NumericString will now not cause the
entire string to turn into the empty string; which (per the tests) matches the
Windows/NetFX behavior.

Fixes #38014.