### PR TITLE
Clean up System.Drawing.Common unit tests

### DIFF
--- a/src/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/BitmapTests.cs
@@ -176,11 +176,13 @@ namespace System.Drawing.Tests
         [InlineData(5, 15)]
         public void Ctor_Width_Height(int width, int height)
         {
-            var bitmap = new Bitmap(width, height);
-            Assert.Equal(width, bitmap.Width);
-            Assert.Equal(height, bitmap.Height);
-            Assert.Equal(PixelFormat.Format32bppArgb, bitmap.PixelFormat);
-            Assert.Equal(ImageFormat.MemoryBmp, bitmap.RawFormat);
+            using (var bitmap = new Bitmap(width, height))
+            {
+                Assert.Equal(width, bitmap.Width);
+                Assert.Equal(height, bitmap.Height);
+                Assert.Equal(PixelFormat.Format32bppArgb, bitmap.PixelFormat);
+                Assert.Equal(ImageFormat.MemoryBmp, bitmap.RawFormat);
+            }
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]

--- a/src/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
+++ b/src/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace System.Drawing.Tests
@@ -249,13 +250,16 @@ namespace System.Drawing.Tests
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void AllocateBufferedGraphicsContext() => new BufferedGraphicsContext();
+
+
         [Fact]
         public void Finalize_Invoke_Success()
         {
             // Don't allocate anything as this would leak memory.
             // This makes sure than finalization doesn't cause any errors or debug assertions.
-            var context = new BufferedGraphicsContext();
-            context = null;
+            AllocateBufferedGraphicsContext();
 
             GC.Collect();
             GC.WaitForPendingFinalizers();

--- a/src/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
+++ b/src/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
@@ -257,7 +257,6 @@ namespace System.Drawing.Tests
         [Fact]
         public void Finalize_Invoke_Success()
         {
-            // Don't allocate anything as this would leak memory.
             // This makes sure than finalization doesn't cause any errors or debug assertions.
             AllocateBufferedGraphicsContext();
 

--- a/src/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
+++ b/src/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
@@ -254,7 +254,9 @@ namespace System.Drawing.Tests
         {
             // Don't allocate anything as this would leak memory.
             // This makes sure than finalization doesn't cause any errors or debug assertions.
-            var context = new BufferedGraphicsContext();
+            using (var context = new BufferedGraphicsContext())
+            {
+            }
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]

--- a/src/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
+++ b/src/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
@@ -254,9 +254,11 @@ namespace System.Drawing.Tests
         {
             // Don't allocate anything as this would leak memory.
             // This makes sure than finalization doesn't cause any errors or debug assertions.
-            using (var context = new BufferedGraphicsContext())
-            {
-            }
+            var context = new BufferedGraphicsContext();
+            context = null;
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]

--- a/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
@@ -1736,16 +1736,18 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void StartClose_AddCurve()
         {
-            GraphicsPath path = new GraphicsPath();
-            path.AddLine(1, 1, 2, 2);
-            path.AddCurve(new Point[3] { new Point(1, 1), new Point(2, 2), new Point(3, 3) });
-            path.AddLine(10, 10, 20, 20);
-            byte[] types = path.PathTypes;
+            using (GraphicsPath path = new GraphicsPath())
+            {
+                path.AddLine(1, 1, 2, 2);
+                path.AddCurve(new Point[3] { new Point(1, 1), new Point(2, 2), new Point(3, 3) });
+                path.AddLine(10, 10, 20, 20);
+                byte[] types = path.PathTypes;
 
-            Assert.Equal(0, types[0]);
-            Assert.Equal(1, types[2]);
-            Assert.Equal(3, types[path.PointCount - 3]);
-            Assert.Equal(1, types[path.PointCount - 1]);
+                Assert.Equal(0, types[0]);
+                Assert.Equal(1, types[2]);
+                Assert.Equal(3, types[path.PointCount - 3]);
+                Assert.Equal(1, types[path.PointCount - 1]);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1769,16 +1771,18 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void StartClose_AddLine()
         {
-            GraphicsPath path = new GraphicsPath();
-            path.AddLine(1, 1, 2, 2);
-            path.AddLine(5, 5, 10, 10);
-            path.AddLine(10, 10, 20, 20);
-            byte[] types = path.PathTypes;
+            using (GraphicsPath path = new GraphicsPath())
+            {
+                path.AddLine(1, 1, 2, 2);
+                path.AddLine(5, 5, 10, 10);
+                path.AddLine(10, 10, 20, 20);
+                byte[] types = path.PathTypes;
 
-            Assert.Equal(0, types[0]);
-            Assert.Equal(1, types[2]);
-            Assert.Equal(1, types[path.PointCount - 3]);
-            Assert.Equal(1, types[path.PointCount - 1]);
+                Assert.Equal(0, types[0]);
+                Assert.Equal(1, types[2]);
+                Assert.Equal(1, types[path.PointCount - 3]);
+                Assert.Equal(1, types[path.PointCount - 1]);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1820,35 +1824,39 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void StartClose_AddPath_NoConnect()
         {
-            GraphicsPath inner = new GraphicsPath();
-            inner.AddArc(10, 10, 100, 100, 90, 180);
-            GraphicsPath path = new GraphicsPath();
-            path.AddLine(1, 1, 2, 2);
-            path.AddPath(inner, false);
-            path.AddLine(10, 10, 20, 20);
-            byte[] types = path.PathTypes;
+            using (GraphicsPath inner = new GraphicsPath())
+            using (GraphicsPath path = new GraphicsPath())
+            {
+                inner.AddArc(10, 10, 100, 100, 90, 180);
+                path.AddLine(1, 1, 2, 2);
+                path.AddPath(inner, false);
+                path.AddLine(10, 10, 20, 20);
+                byte[] types = path.PathTypes;
 
-            Assert.Equal(0, types[0]);
-            Assert.Equal(0, types[2]);
-            Assert.Equal(3, types[path.PointCount - 3]);
-            Assert.Equal(1, types[path.PointCount - 1]);
+                Assert.Equal(0, types[0]);
+                Assert.Equal(0, types[2]);
+                Assert.Equal(3, types[path.PointCount - 3]);
+                Assert.Equal(1, types[path.PointCount - 1]);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void StartClose_AddPie()
         {
-            GraphicsPath path = new GraphicsPath();
-            path.AddLine(1, 1, 2, 2);
-            path.AddPie(10, 10, 10, 10, 90, 180);
-            path.AddLine(10, 10, 20, 20);
-            byte[] types = path.PathTypes;
+            using (GraphicsPath path = new GraphicsPath())
+            {
+                path.AddLine(1, 1, 2, 2);
+                path.AddPie(10, 10, 10, 10, 90, 180);
+                path.AddLine(10, 10, 20, 20);
+                byte[] types = path.PathTypes;
 
-            Assert.Equal(0, types[0]);
-            Assert.Equal(0, types[2]);
+                Assert.Equal(0, types[0]);
+                Assert.Equal(0, types[2]);
 
-            Assert.Equal((types[path.PointCount - 3] & 128), 128);
-            Assert.Equal(0, types[path.PointCount - 2]);
-            Assert.Equal(1, types[path.PointCount - 1]);
+                Assert.Equal((types[path.PointCount - 3] & 128), 128);
+                Assert.Equal(0, types[path.PointCount - 2]);
+                Assert.Equal(1, types[path.PointCount - 1]);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/System.Drawing.Common/tests/Drawing2D/HatchBrushTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/HatchBrushTests.cs
@@ -18,13 +18,15 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Ctor_HatchStyle_ForeColor_TestData))]
         public void Ctor_HatchStyle_ForeColor(HatchStyle hatchStyle, Color foreColor)
         {
-            var brush = new HatchBrush(hatchStyle, foreColor);
-            Assert.Equal(hatchStyle, brush.HatchStyle);
+            using (var brush = new HatchBrush(hatchStyle, foreColor))
+            {
+                Assert.Equal(hatchStyle, brush.HatchStyle);
 
-            Assert.NotEqual(foreColor, brush.ForegroundColor);
-            Assert.Equal(foreColor.ToArgb(), brush.ForegroundColor.ToArgb());
+                Assert.NotEqual(foreColor, brush.ForegroundColor);
+                Assert.Equal(foreColor.ToArgb(), brush.ForegroundColor.ToArgb());
 
-            Assert.Equal(Color.FromArgb(255, 0, 0, 0), brush.BackgroundColor);
+                Assert.Equal(Color.FromArgb(255, 0, 0, 0), brush.BackgroundColor);
+            }
         }
 
         public static IEnumerable<object[]> Ctor_HatchStyle_ForeColor_BackColor_TestData()
@@ -37,14 +39,16 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Ctor_HatchStyle_ForeColor_BackColor_TestData))]
         public void Ctor_HatchStyle_ForeColor_BackColor(HatchStyle hatchStyle, Color foreColor, Color backColor)
         {
-            var brush = new HatchBrush(hatchStyle, foreColor, backColor);
-            Assert.Equal(hatchStyle, brush.HatchStyle);
+            using (var brush = new HatchBrush(hatchStyle, foreColor, backColor))
+            {
+                Assert.Equal(hatchStyle, brush.HatchStyle);
 
-            Assert.NotEqual(foreColor, brush.ForegroundColor);
-            Assert.Equal(foreColor.ToArgb(), brush.ForegroundColor.ToArgb());
+                Assert.NotEqual(foreColor, brush.ForegroundColor);
+                Assert.Equal(foreColor.ToArgb(), brush.ForegroundColor.ToArgb());
 
-            Assert.NotEqual(backColor, brush.BackgroundColor);
-            Assert.Equal(backColor.ToArgb(), brush.BackgroundColor.ToArgb());
+                Assert.NotEqual(backColor, brush.BackgroundColor);
+                Assert.Equal(backColor.ToArgb(), brush.BackgroundColor.ToArgb());
+            }
         }
 
         [Theory]
@@ -59,13 +63,15 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clone_Brush_ReturnsClone()
         {
-            var brush = new HatchBrush(HatchStyle.DarkDownwardDiagonal, Color.Magenta, Color.Peru);
-            HatchBrush clone = Assert.IsType<HatchBrush>(brush.Clone());
+            using (var brush = new HatchBrush(HatchStyle.DarkDownwardDiagonal, Color.Magenta, Color.Peru))
+            {
+                HatchBrush clone = Assert.IsType<HatchBrush>(brush.Clone());
 
-            Assert.NotSame(clone, brush);
-            Assert.Equal(brush.HatchStyle, clone.HatchStyle);
-            Assert.Equal(brush.ForegroundColor, clone.ForegroundColor);
-            Assert.Equal(brush.BackgroundColor, clone.BackgroundColor);
+                Assert.NotSame(clone, brush);
+                Assert.Equal(brush.HatchStyle, clone.HatchStyle);
+                Assert.Equal(brush.ForegroundColor, clone.ForegroundColor);
+                Assert.Equal(brush.BackgroundColor, clone.BackgroundColor);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
@@ -29,29 +29,32 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Ctor_Point_TestData))]
         public void Ctor_PointF_PointF_Color_Color(Point point1, Point point2, Color color1, Color color2, RectangleF expectedRectangle)
         {
-            var brush = new LinearGradientBrush((PointF)point1, point2, color1, color2);
+            using (var brush = new LinearGradientBrush((PointF)point1, point2, color1, color2))
+            {
+                Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
+                Assert.Equal(1, brush.Blend.Positions.Length);
 
-            Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
-            Assert.Equal(1, brush.Blend.Positions.Length);
+                Assert.False(brush.GammaCorrection);
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+                Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
+                Assert.Equal(expectedRectangle, brush.Rectangle);
+                Assert.Equal(WrapMode.Tile, brush.WrapMode);
 
-            Assert.False(brush.GammaCorrection);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
-            Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
-            Assert.Equal(expectedRectangle, brush.Rectangle);
-            Assert.Equal(WrapMode.Tile, brush.WrapMode);
-
-            Assert.False(brush.Transform.IsIdentity);
+                Assert.False(brush.Transform.IsIdentity);
+            }
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_PointF_PointF_Color_Color_FloatRanges()
         {
-            var brush = new LinearGradientBrush(new PointF(float.NaN, float.NaN), new PointF(float.PositiveInfinity, float.NegativeInfinity), Color.Plum, Color.Red);
-            Assert.Equal(float.PositiveInfinity, brush.Rectangle.X);
-            Assert.Equal(float.NegativeInfinity, brush.Rectangle.Y);
-            Assert.Equal(float.NaN, brush.Rectangle.Width);
-            Assert.Equal(float.NaN, brush.Rectangle.Height);
+            using (var brush = new LinearGradientBrush(new PointF(float.NaN, float.NaN), new PointF(float.PositiveInfinity, float.NegativeInfinity), Color.Plum, Color.Red))
+            {
+                Assert.Equal(float.PositiveInfinity, brush.Rectangle.X);
+                Assert.Equal(float.NegativeInfinity, brush.Rectangle.Y);
+                Assert.Equal(float.NaN, brush.Rectangle.Width);
+                Assert.Equal(float.NaN, brush.Rectangle.Height);
+            }
         }
 
         [ActiveIssue(32706, TestPlatforms.AnyUnix)] 
@@ -59,18 +62,19 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Ctor_Point_TestData))]
         public void Ctor_Point_Point_Color_Color(Point point1, Point point2, Color color1, Color color2, RectangleF expectedRectangle)
         {
-            var brush = new LinearGradientBrush(point1, point2, color1, color2);
+            using (var brush = new LinearGradientBrush(point1, point2, color1, color2))
+            {
+                Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
+                Assert.Equal(1, brush.Blend.Positions.Length);
 
-            Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
-            Assert.Equal(1, brush.Blend.Positions.Length);
+                Assert.False(brush.GammaCorrection);
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+                Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
+                Assert.Equal(expectedRectangle, brush.Rectangle);
+                Assert.Equal(WrapMode.Tile, brush.WrapMode);
 
-            Assert.False(brush.GammaCorrection);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
-            Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
-            Assert.Equal(expectedRectangle, brush.Rectangle);
-            Assert.Equal(WrapMode.Tile, brush.WrapMode);
-
-            Assert.False(brush.Transform.IsIdentity);
+                Assert.False(brush.Transform.IsIdentity);
+            }
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
@@ -95,36 +99,38 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Ctor_Rectangle_LinearGradientMode_TestData))]
         public void Ctor_Rectangle_Color_Color_LinearGradientMode(Rectangle rectangle, Color color1, Color color2, LinearGradientMode linearGradientMode)
         {
-            var brush = new LinearGradientBrush(rectangle, color1, color2, linearGradientMode);
+            using (var brush = new LinearGradientBrush(rectangle, color1, color2, linearGradientMode))
+            {
+                Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
+                Assert.Equal(1, brush.Blend.Positions.Length);
 
-            Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
-            Assert.Equal(1, brush.Blend.Positions.Length);
+                Assert.False(brush.GammaCorrection);
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+                Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
+                Assert.Equal(rectangle, brush.Rectangle);
+                Assert.Equal(WrapMode.Tile, brush.WrapMode);
 
-            Assert.False(brush.GammaCorrection);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
-            Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
-            Assert.Equal(rectangle, brush.Rectangle);
-            Assert.Equal(WrapMode.Tile, brush.WrapMode);
-
-            Assert.Equal(linearGradientMode == LinearGradientMode.Horizontal, brush.Transform.IsIdentity);
+                Assert.Equal(linearGradientMode == LinearGradientMode.Horizontal, brush.Transform.IsIdentity);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Rectangle_LinearGradientMode_TestData))]
         public void Ctor_RectangleF_Color_Color_LinearGradientMode(Rectangle rectangle, Color color1, Color color2, LinearGradientMode linearGradientMode)
         {
-            var brush = new LinearGradientBrush((RectangleF)rectangle, color1, color2, linearGradientMode);
+            using (var brush = new LinearGradientBrush((RectangleF)rectangle, color1, color2, linearGradientMode))
+            {
+                Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
+                Assert.Equal(1, brush.Blend.Positions.Length);
 
-            Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
-            Assert.Equal(1, brush.Blend.Positions.Length);
+                Assert.False(brush.GammaCorrection);
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+                Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
+                Assert.Equal(rectangle, brush.Rectangle);
+                Assert.Equal(WrapMode.Tile, brush.WrapMode);
 
-            Assert.False(brush.GammaCorrection);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
-            Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
-            Assert.Equal(rectangle, brush.Rectangle);
-            Assert.Equal(WrapMode.Tile, brush.WrapMode);
-
-            Assert.Equal(linearGradientMode == LinearGradientMode.Horizontal, brush.Transform.IsIdentity);
+                Assert.Equal(linearGradientMode == LinearGradientMode.Horizontal, brush.Transform.IsIdentity);
+            }
         }
 
         public static IEnumerable<object[]> Ctor_Rectangle_Angle_TestData()
@@ -140,36 +146,38 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Ctor_Rectangle_Angle_TestData))]
         public void Ctor_Rectangle_Color_Color_Angle(Rectangle rectangle, Color color1, Color color2, float angle)
         {
-            var brush = new LinearGradientBrush(rectangle, color1, color2, angle);
+            using (var brush = new LinearGradientBrush(rectangle, color1, color2, angle))
+            {
+                Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
+                Assert.Equal(1, brush.Blend.Positions.Length);
 
-            Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
-            Assert.Equal(1, brush.Blend.Positions.Length);
+                Assert.False(brush.GammaCorrection);
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+                Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
+                Assert.Equal(rectangle, brush.Rectangle);
+                Assert.Equal(WrapMode.Tile, brush.WrapMode);
 
-            Assert.False(brush.GammaCorrection);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
-            Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
-            Assert.Equal(rectangle, brush.Rectangle);
-            Assert.Equal(WrapMode.Tile, brush.WrapMode);
-
-            Assert.Equal((angle % 360) == 0, brush.Transform.IsIdentity);
+                Assert.Equal((angle % 360) == 0, brush.Transform.IsIdentity);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Rectangle_Angle_TestData))]
         public void Ctor_RectangleF_Color_Color_Angle(Rectangle rectangle, Color color1, Color color2, float angle)
         {
-            var brush = new LinearGradientBrush((RectangleF)rectangle, color1, color2, angle);
+            using (var brush = new LinearGradientBrush((RectangleF)rectangle, color1, color2, angle))
+            {
+                Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
+                Assert.Equal(1, brush.Blend.Positions.Length);
 
-            Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
-            Assert.Equal(1, brush.Blend.Positions.Length);
+                Assert.False(brush.GammaCorrection);
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+                Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
+                Assert.Equal(rectangle, brush.Rectangle);
+                Assert.Equal(WrapMode.Tile, brush.WrapMode);
 
-            Assert.False(brush.GammaCorrection);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
-            Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
-            Assert.Equal(rectangle, brush.Rectangle);
-            Assert.Equal(WrapMode.Tile, brush.WrapMode);
-
-            Assert.Equal((angle % 360) == 0, brush.Transform.IsIdentity);
+                Assert.Equal((angle % 360) == 0, brush.Transform.IsIdentity);
+            }
         }
 
         public static IEnumerable<object[]> Ctor_Rectangle_Angle_IsAngleScalable_TestData()
@@ -184,36 +192,38 @@ namespace System.Drawing.Drawing2D.Tests
         [MemberData(nameof(Ctor_Rectangle_Angle_IsAngleScalable_TestData))]
         public void Ctor_Rectangle_Color_Color_Angle_IsAngleScalable(Rectangle rectangle, Color color1, Color color2, float angle, bool isAngleScalable)
         {
-            var brush = new LinearGradientBrush(rectangle, color1, color2, angle, isAngleScalable);
+            using (var brush = new LinearGradientBrush(rectangle, color1, color2, angle, isAngleScalable))
+            {
+                Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
+                Assert.Equal(1, brush.Blend.Positions.Length);
 
-            Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
-            Assert.Equal(1, brush.Blend.Positions.Length);
+                Assert.False(brush.GammaCorrection);
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+                Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
+                Assert.Equal(rectangle, brush.Rectangle);
+                Assert.Equal(WrapMode.Tile, brush.WrapMode);
 
-            Assert.False(brush.GammaCorrection);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
-            Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
-            Assert.Equal(rectangle, brush.Rectangle);
-            Assert.Equal(WrapMode.Tile, brush.WrapMode);
-
-            Assert.Equal((angle % 360) == 0, brush.Transform.IsIdentity);
+                Assert.Equal((angle % 360) == 0, brush.Transform.IsIdentity);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(Ctor_Rectangle_Angle_IsAngleScalable_TestData))]
         public void Ctor_RectangleF_Color_Color_Angle_IsAngleScalable(Rectangle rectangle, Color color1, Color color2, float angle, bool isAngleScalable)
         {
-            var brush = new LinearGradientBrush((RectangleF)rectangle, color1, color2, angle, isAngleScalable);
+            using (var brush = new LinearGradientBrush((RectangleF)rectangle, color1, color2, angle, isAngleScalable))
+            {
+                Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
+                Assert.Equal(1, brush.Blend.Positions.Length);
 
-            Assert.Equal(new float[] { 1 }, brush.Blend.Factors);
-            Assert.Equal(1, brush.Blend.Positions.Length);
+                Assert.False(brush.GammaCorrection);
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+                Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
+                Assert.Equal(rectangle, brush.Rectangle);
+                Assert.Equal(WrapMode.Tile, brush.WrapMode);
 
-            Assert.False(brush.GammaCorrection);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
-            Assert.Equal(new Color[] { Color.FromArgb(color1.ToArgb()), Color.FromArgb(color2.ToArgb()) }, brush.LinearColors);
-            Assert.Equal(rectangle, brush.Rectangle);
-            Assert.Equal(WrapMode.Tile, brush.WrapMode);
-
-            Assert.Equal((angle % 360) == 0, brush.Transform.IsIdentity);
+                Assert.Equal((angle % 360) == 0, brush.Transform.IsIdentity);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -250,15 +260,17 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clone_Brush_ReturnsClone()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            LinearGradientBrush clone = Assert.IsType<LinearGradientBrush>(brush.Clone());
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                LinearGradientBrush clone = Assert.IsType<LinearGradientBrush>(brush.Clone());
 
-            Assert.NotSame(clone, brush);
-            Assert.Equal(brush.Blend.Factors, clone.Blend.Factors);
-            Assert.Equal(brush.Blend.Positions.Length, clone.Blend.Positions.Length);
-            Assert.Equal(brush.LinearColors, clone.LinearColors);
-            Assert.Equal(brush.Rectangle, clone.Rectangle);
-            Assert.Equal(brush.Transform, clone.Transform);
+                Assert.NotSame(clone, brush);
+                Assert.Equal(brush.Blend.Factors, clone.Blend.Factors);
+                Assert.Equal(brush.Blend.Positions.Length, clone.Blend.Positions.Length);
+                Assert.Equal(brush.LinearColors, clone.LinearColors);
+                Assert.Equal(brush.Rectangle, clone.Rectangle);
+                Assert.Equal(brush.Transform, clone.Transform);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -274,15 +286,17 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Blend_GetWithInterpolationColorsSet_ReturnsNull()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            var blend = new ColorBlend
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
             {
-                Colors = new Color[] { Color.Red, Color.PeachPuff, Color.PowderBlue },
-                Positions = new float[] { 0, 10, 1 }
-            };
+                var blend = new ColorBlend
+                {
+                    Colors = new Color[] { Color.Red, Color.PeachPuff, Color.PowderBlue },
+                    Positions = new float[] { 0, 10, 1 }
+                };
 
-            brush.InterpolationColors = blend;
-            Assert.Null(brush.Blend);
+                brush.InterpolationColors = blend;
+                Assert.Null(brush.Blend);
+            }
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
@@ -298,16 +312,18 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(new float[] { 1 }, new float[] { 1, 2 })]
         public void Blend_Set_Success(float[] factors, float[] positions)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            var blend = new Blend
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
             {
-                Factors = factors,
-                Positions = positions
-            };
-            brush.Blend = blend;
+                var blend = new Blend
+                {
+                    Factors = factors,
+                    Positions = positions
+                };
+                brush.Blend = blend;
 
-            Assert.Equal(blend.Factors, brush.Blend.Factors);
-            Assert.Equal(factors.Length, brush.Blend.Positions.Length);
+                Assert.Equal(blend.Factors, brush.Blend.Factors);
+                Assert.Equal(factors.Length, brush.Blend.Positions.Length);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -317,48 +333,60 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(new float[] { 0, 0, 0 }, new float[] { 0, 0, 0 })]
         public void Blend_InvalidBlend_ThrowsArgumentException(float[] factors, float[] positions)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            var blend = new Blend
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
             {
-                Factors = factors,
-                Positions = positions
-            };
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Blend = blend);
+                var blend = new Blend
+                {
+                    Factors = factors,
+                    Positions = positions
+                };
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.Blend = blend);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Blend_SetNullBlend_ThrowsNullReferenceException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Assert.Throws<NullReferenceException>(() => brush.Blend = null);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Assert.Throws<NullReferenceException>(() => brush.Blend = null);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Blend_SetNullBlendFactors_ThrowsNullReferenceException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Assert.Throws<NullReferenceException>(() => brush.Blend = new Blend { Factors = null });
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Assert.Throws<NullReferenceException>(() => brush.Blend = new Blend { Factors = null });
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Blend_SetNullBlendPositions_ThrowsArgumentNullException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentNullException>("source", () => brush.Blend = new Blend { Factors = new float[2], Positions = null });
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentNullException>("source", () => brush.Blend = new Blend { Factors = new float[2], Positions = null });
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Blend_SetFactorsLengthGreaterThanPositionsLength_ThrowsArgumentOutOfRangeException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentOutOfRangeException>(null, () => brush.Blend = new Blend { Factors = new float[2], Positions = new float[1] });
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentOutOfRangeException>(null, () => brush.Blend = new Blend { Factors = new float[2], Positions = new float[1] });
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Blend_SetInvalidBlendFactorsLength_ThrowsArgumentException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.Blend = new Blend { Factors = new float[0], Positions = new float[0] });
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.Blend = new Blend { Factors = new float[0], Positions = new float[0] });
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -376,8 +404,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(false)]
         public void GammaCorrection_Set_GetReturnsExpected(bool gammaCorrection)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true) { GammaCorrection = gammaCorrection };
-            Assert.Equal(gammaCorrection, brush.GammaCorrection);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true) { GammaCorrection = gammaCorrection })
+            {
+                Assert.Equal(gammaCorrection, brush.GammaCorrection);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -398,52 +428,59 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(float.NegativeInfinity)]
         public void InterpolationColors_SetValid_GetReturnsExpected(float value)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            var blend = new ColorBlend
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
             {
-                Colors = new Color[] { Color.Red, Color.PeachPuff, Color.PowderBlue },
-                Positions = new float[] { 0, 10, 1 }
-            };
+                var blend = new ColorBlend
+                {
+                    Colors = new Color[] { Color.Red, Color.PeachPuff, Color.PowderBlue },
+                    Positions = new float[] { 0, 10, 1 }
+                };
 
-            brush.InterpolationColors = blend;
-            Assert.Equal(blend.Colors.Select(c => Color.FromArgb(c.ToArgb())), brush.InterpolationColors.Colors);
-            Assert.Equal(blend.Positions, brush.InterpolationColors.Positions);
+                brush.InterpolationColors = blend;
+                Assert.Equal(blend.Colors.Select(c => Color.FromArgb(c.ToArgb())), brush.InterpolationColors.Colors);
+                Assert.Equal(blend.Positions, brush.InterpolationColors.Positions);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void InterpolationColors_SetWithExistingInterpolationColors_OverwritesInterpolationColors()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true)
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true)
             {
                 InterpolationColors = new ColorBlend
                 {
                     Colors = new Color[] { Color.Wheat, Color.Yellow },
                     Positions = new float[] { 0, 1 }
                 }
-            };
-
-            var blend = new ColorBlend
+            })
             {
-                Colors = new Color[] { Color.Red, Color.PeachPuff, Color.PowderBlue },
-                Positions = new float[] { 0, 0.5f, 1f }
-            };
-            brush.InterpolationColors = blend;
-            Assert.Equal(blend.Colors.Select(c => Color.FromArgb(c.ToArgb())), brush.InterpolationColors.Colors);
-            Assert.Equal(blend.Positions, brush.InterpolationColors.Positions);
+                var blend = new ColorBlend
+                {
+                    Colors = new Color[] { Color.Red, Color.PeachPuff, Color.PowderBlue },
+                    Positions = new float[] { 0, 0.5f, 1f }
+                };
+                brush.InterpolationColors = blend;
+                Assert.Equal(blend.Colors.Select(c => Color.FromArgb(c.ToArgb())), brush.InterpolationColors.Colors);
+                Assert.Equal(blend.Positions, brush.InterpolationColors.Positions);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void InterpolationColors_SetNullBlend_ThrowsArgumentException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors = null);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors = null);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void InterpolationColors_SetBlendWithNullColors_ThrowsNullReferenceException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Assert.Throws<NullReferenceException>(() => brush.InterpolationColors = new ColorBlend { Colors = null });
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Assert.Throws<NullReferenceException>(() => brush.InterpolationColors = new ColorBlend { Colors = null });
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -451,15 +488,19 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(1)]
         public void InterpolationColors_SetBlendWithTooFewColors_ThrowsArgumentException(int colorsLength)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors = new ColorBlend { Colors = new Color[colorsLength] });
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors = new ColorBlend { Colors = new Color[colorsLength] });
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void InterpolationColors_SetNullBlendPositions_ThrowsNullReferenceException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Assert.Throws<NullReferenceException>(() => brush.InterpolationColors = new ColorBlend { Colors = new Color[2], Positions = null });
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Assert.Throws<NullReferenceException>(() => brush.InterpolationColors = new ColorBlend { Colors = new Color[2], Positions = null });
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -468,12 +509,14 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(3)]
         public void InterpolationColors_SetInvalidBlendPositionsLength_ThrowsArgumentException(int positionsLength)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors = new ColorBlend
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
             {
-                Colors = new Color[2],
-                Positions = new float[positionsLength]
-            });
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors = new ColorBlend
+                {
+                    Colors = new Color[2],
+                    Positions = new float[positionsLength]
+                });
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -513,55 +556,63 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void InterpolationColors_SetBlendTriangularShape_ThrowsArgumentException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true)
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true)
             {
                 InterpolationColors = new ColorBlend
                 {
                     Colors = new Color[] { Color.Red, Color.PeachPuff, Color.PowderBlue },
                     Positions = new float[] { 0, 0.5f, 1 }
                 }
-            };
-            Assert.NotNull(brush.InterpolationColors);
+            })
+            {
+                Assert.NotNull(brush.InterpolationColors);
 
-            brush.SetBlendTriangularShape(0.5f);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+                brush.SetBlendTriangularShape(0.5f);
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+            }
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void InterpolationColors_SetBlend_ThrowsArgumentException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true)
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true)
             {
                 InterpolationColors = new ColorBlend
                 {
                     Colors = new Color[] { Color.Red, Color.PeachPuff, Color.PowderBlue },
                     Positions = new float[] { 0, 0.5f, 1 }
                 }
-            };
-            Assert.NotNull(brush.InterpolationColors);
-
-            brush.Blend = new Blend
+            })
             {
-                Factors = new float[1],
-                Positions = new float[1]
-            };
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+                Assert.NotNull(brush.InterpolationColors);
+
+                brush.Blend = new Blend
+                {
+                    Factors = new float[1],
+                    Positions = new float[1]
+                };
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.InterpolationColors);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void LinearColors_SetValid_GetReturnsExpected()
         {
             Color[] colors = new Color[] { Color.Red, Color.Blue, Color.AntiqueWhite };
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true) { LinearColors = colors };
-            Assert.Equal(colors.Take(2).Select(c => Color.FromArgb(c.ToArgb())), brush.LinearColors);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true) { LinearColors = colors })
+            {
+                Assert.Equal(colors.Take(2).Select(c => Color.FromArgb(c.ToArgb())), brush.LinearColors);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void LinearColors_SetNull_ThrowsNullReferenceException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Assert.Throws<NullReferenceException>(() => brush.LinearColors = null);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Assert.Throws<NullReferenceException>(() => brush.LinearColors = null);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -569,8 +620,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(1)]
         public void LinearColors_SetInvalidLength_ThrowsIndexOutOfRangeException(int length)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Assert.Throws<IndexOutOfRangeException>(() => brush.LinearColors = new Color[length]);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Assert.Throws<IndexOutOfRangeException>(() => brush.LinearColors = new Color[length]);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -596,16 +649,20 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Transform_SetValid_GetReturnsExpected()
         {
-            var transform = new Matrix(1, 2, 3, 4, 5, 6);
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true) { Transform = transform };
-            Assert.Equal(transform, brush.Transform);
+            using (var transform = new Matrix(1, 2, 3, 4, 5, 6))
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true) { Transform = transform })
+            {
+                Assert.Equal(transform, brush.Transform);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Transform_SetNull_ThrowsArgumentNullException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentNullException>("value", "matrix", () => brush.Transform = null);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentNullException>("value", "matrix", () => brush.Transform = null);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -625,8 +682,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(WrapMode.TileFlipY)]
         public void WrapMode_SetValid_GetReturnsExpected(WrapMode wrapMode)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true) { WrapMode = wrapMode };
-            Assert.Equal(wrapMode, brush.WrapMode);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true) { WrapMode = wrapMode })
+            {
+                Assert.Equal(wrapMode, brush.WrapMode);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -634,15 +693,19 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(WrapMode.Clamp + 1)]
         public void WrapMode_SetInvalid_ThrowsInvalidEnumArgumentException(WrapMode wrapMode)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Assert.ThrowsAny<ArgumentException>(() => brush.WrapMode = wrapMode);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Assert.ThrowsAny<ArgumentException>(() => brush.WrapMode = wrapMode);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void WrapMode_Clamp_ThrowsArgumentException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.WrapMode = WrapMode.Clamp);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.WrapMode = WrapMode.Clamp);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -658,11 +721,13 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ResetTransform_Invoke_SetsTransformToIdentity()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Assert.False(brush.Transform.IsIdentity);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Assert.False(brush.Transform.IsIdentity);
 
-            brush.ResetTransform();
-            Assert.True(brush.Transform.IsIdentity);
+                brush.ResetTransform();
+                Assert.True(brush.Transform.IsIdentity);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -677,13 +742,15 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void MultiplyTransform_NoOrder_Success()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            var matrix = new Matrix(1, 2, 3, 4, 5, 6);
-            Matrix expectedTransform = brush.Transform;
-            expectedTransform.Multiply(matrix);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            using (var matrix = new Matrix(1, 2, 3, 4, 5, 6))
+            {
+                Matrix expectedTransform = brush.Transform;
+                expectedTransform.Multiply(matrix);
 
-            brush.MultiplyTransform(matrix);
-            Assert.Equal(expectedTransform, brush.Transform);
+                brush.MultiplyTransform(matrix);
+                Assert.Equal(expectedTransform, brush.Transform);
+            }
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
@@ -694,22 +761,24 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(MatrixOrder.Append + 1)]
         public void MultiplyTransform_Order_Success(MatrixOrder order)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            var matrix = new Matrix(1, 2, 3, 4, 5, 6);
-            Matrix expectedTransform = brush.Transform;
-
-            if (order == MatrixOrder.Append || order == MatrixOrder.Prepend)
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            using (var matrix = new Matrix(1, 2, 3, 4, 5, 6))
             {
-                expectedTransform.Multiply(matrix, order);
-            }
-            else
-            {
-                // Invalid MatrixOrder is interpreted as MatrixOrder.Append.
-                expectedTransform.Multiply(matrix, MatrixOrder.Append);
-            }
+                Matrix expectedTransform = brush.Transform;
 
-            brush.MultiplyTransform(matrix, order);
-            Assert.Equal(expectedTransform, brush.Transform);
+                if (order == MatrixOrder.Append || order == MatrixOrder.Prepend)
+                {
+                    expectedTransform.Multiply(matrix, order);
+                }
+                else
+                {
+                    // Invalid MatrixOrder is interpreted as MatrixOrder.Append.
+                    expectedTransform.Multiply(matrix, MatrixOrder.Append);
+                }
+
+                brush.MultiplyTransform(matrix, order);
+                Assert.Equal(expectedTransform, brush.Transform);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -741,11 +810,12 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void MultiplyTransform_NonInvertibleMatrix_ThrowsArgumentException()
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            var matrix = new Matrix(123, 24, 82, 16, 47, 30);
-
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.MultiplyTransform(matrix));
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.MultiplyTransform(matrix, MatrixOrder.Append));
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            using (var matrix = new Matrix(123, 24, 82, 16, 47, 30))
+            {
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.MultiplyTransform(matrix));
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.MultiplyTransform(matrix, MatrixOrder.Append));
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -764,12 +834,14 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(1, 2)]
         public void TranslateTransform_NoOrder_Success(float dx, float dy)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Matrix expectedTransform = brush.Transform;
-            expectedTransform.Translate(dx, dy);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Matrix expectedTransform = brush.Transform;
+                expectedTransform.Translate(dx, dy);
 
-            brush.TranslateTransform(dx, dy);
-            Assert.Equal(expectedTransform, brush.Transform);
+                brush.TranslateTransform(dx, dy);
+                Assert.Equal(expectedTransform, brush.Transform);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -781,12 +853,14 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(-1, -1, MatrixOrder.Append)]
         public void TranslateTransform_Order_Success(float dx, float dy, MatrixOrder order)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Matrix expectedTransform = brush.Transform;
-            expectedTransform.Translate(dx, dy, order);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Matrix expectedTransform = brush.Transform;
+                expectedTransform.Translate(dx, dy, order);
 
-            brush.TranslateTransform(dx, dy, order);
-            Assert.Equal(expectedTransform, brush.Transform);
+                brush.TranslateTransform(dx, dy, order);
+                Assert.Equal(expectedTransform, brush.Transform);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -794,8 +868,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(MatrixOrder.Append + 1)]
         public void TranslateTransform_InvalidOrder_ThrowsArgumentException(MatrixOrder order)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.TranslateTransform(0, 0, order));
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.TranslateTransform(0, 0, order));
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -814,12 +890,14 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(1, 2)]
         public void ScaleTransform_NoOrder_Success(float sx, float sy)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Matrix expectedTransform = brush.Transform;
-            expectedTransform.Scale(sx, sy);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Matrix expectedTransform = brush.Transform;
+                expectedTransform.Scale(sx, sy);
 
-            brush.ScaleTransform(sx, sy);
-            Assert.Equal(expectedTransform, brush.Transform);
+                brush.ScaleTransform(sx, sy);
+                Assert.Equal(expectedTransform, brush.Transform);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -831,12 +909,14 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(-1, -1, MatrixOrder.Append)]
         public void ScaleTransform_Order_Success(float sx, float sy, MatrixOrder order)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Matrix expectedTransform = brush.Transform;
-            expectedTransform.Scale(sx, sy, order);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Matrix expectedTransform = brush.Transform;
+                expectedTransform.Scale(sx, sy, order);
 
-            brush.ScaleTransform(sx, sy, order);
-            Assert.Equal(expectedTransform, brush.Transform);
+                brush.ScaleTransform(sx, sy, order);
+                Assert.Equal(expectedTransform, brush.Transform);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -844,8 +924,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(MatrixOrder.Append + 1)]
         public void ScaleTransform_InvalidOrder_ThrowsArgumentException(MatrixOrder order)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.ScaleTransform(0, 0, order));
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.ScaleTransform(0, 0, order));
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -865,12 +947,14 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(360)]
         public void RotateTransform_NoOrder_Success(float angle)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Matrix expectedTransform = brush.Transform;
-            expectedTransform.Rotate(angle);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Matrix expectedTransform = brush.Transform;
+                expectedTransform.Rotate(angle);
 
-            brush.RotateTransform(angle);
-            Assert.Equal(expectedTransform, brush.Transform);
+                brush.RotateTransform(angle);
+                Assert.Equal(expectedTransform, brush.Transform);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -882,12 +966,14 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(-1, MatrixOrder.Append)]
         public void RotateTransform_Order_Success(float angle, MatrixOrder order)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            Matrix expectedTransform = brush.Transform;
-            expectedTransform.Rotate(angle, order);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                Matrix expectedTransform = brush.Transform;
+                expectedTransform.Rotate(angle, order);
 
-            brush.RotateTransform(angle, order);
-            Assert.Equal(expectedTransform, brush.Transform);
+                brush.RotateTransform(angle, order);
+                Assert.Equal(expectedTransform, brush.Transform);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -895,8 +981,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(MatrixOrder.Append + 1)]
         public void RotateTransform_InvalidOrder_ThrowsArgumentException(MatrixOrder order)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>(null, () => brush.RotateTransform(0, order));
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentException>(null, () => brush.RotateTransform(0, order));
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -916,8 +1004,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(float.NaN)]
         public void SetSigmalBellShape(float focus)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            brush.SetSigmaBellShape(focus);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                brush.SetSigmaBellShape(focus);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -927,9 +1017,11 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(float.NegativeInfinity)]
         public void SetSigmalBellShape_InvalidFocus_ThrowsArgumentException(float focus)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>("focus", null, () => brush.SetSigmaBellShape(focus));
-            AssertExtensions.Throws<ArgumentException>("focus", null, () => brush.SetSigmaBellShape(focus, 1));
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentException>("focus", null, () => brush.SetSigmaBellShape(focus));
+                AssertExtensions.Throws<ArgumentException>("focus", null, () => brush.SetSigmaBellShape(focus, 1));
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -939,8 +1031,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(float.NegativeInfinity)]
         public void SetSigmalBellShape_InvalidScale_ThrowsArgumentException(float scale)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>("scale", null, () => brush.SetSigmaBellShape(0.1f, scale));
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentException>("scale", null, () => brush.SetSigmaBellShape(0.1f, scale));
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -959,11 +1053,13 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(1, new float[] { 0, 1 }, new float[] { 0, 1 })]
         public void SetBlendTriangularShape_Success(float focus, float[] expectedFactors, float[] expectedPositions)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 0, true);
-            brush.SetBlendTriangularShape(focus);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 0, true))
+            {
+                brush.SetBlendTriangularShape(focus);
 
-            Assert.Equal(expectedFactors, brush.Blend.Factors);
-            Assert.Equal(expectedPositions, brush.Blend.Positions);
+                Assert.Equal(expectedFactors, brush.Blend.Factors);
+                Assert.Equal(expectedPositions, brush.Blend.Positions);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -973,11 +1069,13 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(1, 0.5, new float[] { 0, 0.5f }, new float[] { 0, 1 })]
         public void SetBlendTriangularShape_Scale_Success(float focus, float scale, float[] expectedFactors, float[] expectedPositions)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 0, true);
-            brush.SetBlendTriangularShape(focus, scale);
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 0, true))
+            {
+                brush.SetBlendTriangularShape(focus, scale);
 
-            Assert.Equal(expectedFactors, brush.Blend.Factors);
-            Assert.Equal(expectedPositions, brush.Blend.Positions);
+                Assert.Equal(expectedFactors, brush.Blend.Factors);
+                Assert.Equal(expectedPositions, brush.Blend.Positions);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -987,9 +1085,11 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(float.NegativeInfinity)]
         public void SetBlendTriangularShape_InvalidFocus_ThrowsArgumentException(float focus)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>("focus", null, () => brush.SetBlendTriangularShape(focus));
-            AssertExtensions.Throws<ArgumentException>("focus", null, () => brush.SetBlendTriangularShape(focus, 1));
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentException>("focus", null, () => brush.SetBlendTriangularShape(focus));
+                AssertExtensions.Throws<ArgumentException>("focus", null, () => brush.SetBlendTriangularShape(focus, 1));
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -999,8 +1099,10 @@ namespace System.Drawing.Drawing2D.Tests
         [InlineData(float.NegativeInfinity)]
         public void SetBlendTriangularShape_InvalidScale_ThrowsArgumentException(float scale)
         {
-            var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true);
-            AssertExtensions.Throws<ArgumentException>("scale", null, () => brush.SetBlendTriangularShape(0.1f, scale));
+            using (var brush = new LinearGradientBrush(new Rectangle(1, 2, 3, 4), Color.Plum, Color.Red, 45, true))
+            {
+                AssertExtensions.Throws<ArgumentException>("scale", null, () => brush.SetBlendTriangularShape(0.1f, scale));
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
@@ -32,12 +32,11 @@ namespace System.Drawing.Drawing2D.Tests
 {
     public class MatrixTests
     {
-        private static Matrix s_disposedMatrix;
-
-        static MatrixTests()
+        private static Matrix CreateDisposedMatrix()
         {
-            s_disposedMatrix = new Matrix();
-            s_disposedMatrix.Dispose();
+            var matrix = new Matrix();
+            matrix.Dispose();
+            return matrix;
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -176,7 +175,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clone_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Clone());
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Clone());
         }
 
         public static IEnumerable<object[]> Equals_TestData()
@@ -222,19 +221,19 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Equals_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Equals(new Matrix()));
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Equals(new Matrix()));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Equals_DisposedOther_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new Matrix().Equals(s_disposedMatrix));
+            AssertExtensions.Throws<ArgumentException>(null, () => new Matrix().Equals(CreateDisposedMatrix()));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Elements_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Elements);
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Elements);
         }
 
         public static IEnumerable<object[]> Invert_TestData()
@@ -281,19 +280,19 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Invert_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Invert());
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Invert());
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsIdentity_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.IsIdentity);
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().IsIdentity);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsInvertible_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.IsInvertible);
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().IsInvertible);
         }
 
         public static IEnumerable<object[]> Multiply_TestData()
@@ -375,20 +374,24 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Multiply_Disposed_ThrowsArgumentException()
         {
+            var disposedMatrix = CreateDisposedMatrix();
+
             using (var other = new Matrix())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Multiply(other));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Multiply(other, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Multiply(other));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Multiply(other, MatrixOrder.Prepend));
             }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Multiply_DisposedMatrix_ThrowsArgumentException()
         {
+            var disposedMatrix = CreateDisposedMatrix();
+
             using (var matrix = new Matrix())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => matrix.Multiply(s_disposedMatrix));
-                AssertExtensions.Throws<ArgumentException>(null, () => matrix.Multiply(s_disposedMatrix, MatrixOrder.Prepend));
+                AssertExtensions.Throws<ArgumentException>(null, () => matrix.Multiply(disposedMatrix));
+                AssertExtensions.Throws<ArgumentException>(null, () => matrix.Multiply(disposedMatrix, MatrixOrder.Prepend));
             }
         }
 
@@ -418,7 +421,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Reset_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Reset());
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Reset());
         }
 
         public static IEnumerable<object[]> Rotate_TestData()
@@ -511,7 +514,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Rotate_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Rotate(1, MatrixOrder.Append));
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedMatrix().Rotate(1, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -528,8 +531,10 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void RotateAt_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.RotateAt(1, PointF.Empty));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.RotateAt(1, PointF.Empty, MatrixOrder.Append));
+            var disposedMatrix = CreateDisposedMatrix();
+
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.RotateAt(1, PointF.Empty));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.RotateAt(1, PointF.Empty, MatrixOrder.Append));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -614,8 +619,10 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Scale_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Scale(1, 2));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Scale(1, 2, MatrixOrder.Append));
+            var disposedMatrix = CreateDisposedMatrix();
+
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Scale(1, 2));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Scale(1, 2, MatrixOrder.Append));
         }
 
         public static IEnumerable<object[]> Shear_TestData()
@@ -690,8 +697,10 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Shear_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Shear(1, 2));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Shear(1, 2, MatrixOrder.Append));
+            var disposedMatrix = CreateDisposedMatrix();
+
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Shear(1, 2));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Shear(1, 2, MatrixOrder.Append));
         }
 
         public static IEnumerable<object[]> Translate_TestData()
@@ -756,8 +765,10 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Translate_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Translate(1, 2));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.Translate(1, 2, MatrixOrder.Append));
+            var disposedMatrix = CreateDisposedMatrix();
+
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Translate(1, 2));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Translate(1, 2, MatrixOrder.Append));
         }
 
         public static IEnumerable<object[]> TransformPoints_TestData()
@@ -813,8 +824,10 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TransformPoints_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.TransformPoints(new Point[1]));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.TransformPoints(new PointF[1]));
+            var disposedMatrix = CreateDisposedMatrix();
+
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.TransformPoints(new Point[1]));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.TransformPoints(new PointF[1]));
         }
 
         public static IEnumerable<object[]> TransformVectors_TestData()
@@ -883,9 +896,11 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TransformVectors_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.VectorTransformPoints(new Point[1]));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.TransformPoints(new Point[1]));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedMatrix.TransformVectors(new PointF[1]));
+            var disposedMatrix = CreateDisposedMatrix();
+
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.VectorTransformPoints(new Point[1]));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.TransformPoints(new Point[1]));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.TransformVectors(new PointF[1]));
         }
 
         private static void AssertEqualFloatArray(float[] expected, float[] actual)

--- a/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
@@ -374,7 +374,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Multiply_Disposed_ThrowsArgumentException()
         {
-            var disposedMatrix = CreateDisposedMatrix();
+            Matrix disposedMatrix = CreateDisposedMatrix();
 
             using (var other = new Matrix())
             {
@@ -386,7 +386,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Multiply_DisposedMatrix_ThrowsArgumentException()
         {
-            var disposedMatrix = CreateDisposedMatrix();
+            Matrix disposedMatrix = CreateDisposedMatrix();
 
             using (var matrix = new Matrix())
             {
@@ -531,7 +531,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void RotateAt_Disposed_ThrowsArgumentException()
         {
-            var disposedMatrix = CreateDisposedMatrix();
+            Matrix disposedMatrix = CreateDisposedMatrix();
 
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.RotateAt(1, PointF.Empty));
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.RotateAt(1, PointF.Empty, MatrixOrder.Append));
@@ -619,7 +619,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Scale_Disposed_ThrowsArgumentException()
         {
-            var disposedMatrix = CreateDisposedMatrix();
+            Matrix disposedMatrix = CreateDisposedMatrix();
 
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Scale(1, 2));
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Scale(1, 2, MatrixOrder.Append));
@@ -697,7 +697,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Shear_Disposed_ThrowsArgumentException()
         {
-            var disposedMatrix = CreateDisposedMatrix();
+            Matrix disposedMatrix = CreateDisposedMatrix();
 
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Shear(1, 2));
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Shear(1, 2, MatrixOrder.Append));
@@ -765,7 +765,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Translate_Disposed_ThrowsArgumentException()
         {
-            var disposedMatrix = CreateDisposedMatrix();
+            Matrix disposedMatrix = CreateDisposedMatrix();
 
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Translate(1, 2));
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.Translate(1, 2, MatrixOrder.Append));
@@ -824,7 +824,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TransformPoints_Disposed_ThrowsArgumentException()
         {
-            var disposedMatrix = CreateDisposedMatrix();
+            Matrix disposedMatrix = CreateDisposedMatrix();
 
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.TransformPoints(new Point[1]));
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.TransformPoints(new PointF[1]));
@@ -896,7 +896,7 @@ namespace System.Drawing.Drawing2D.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TransformVectors_Disposed_ThrowsArgumentException()
         {
-            var disposedMatrix = CreateDisposedMatrix();
+            Matrix disposedMatrix = CreateDisposedMatrix();
 
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.VectorTransformPoints(new Point[1]));
             AssertExtensions.Throws<ArgumentException>(null, () => disposedMatrix.TransformPoints(new Point[1]));

--- a/src/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
@@ -239,7 +239,7 @@ namespace System.Drawing.Drawing2D.Tests
         {
             using (PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints))
             {
-                AssertExtensions.Throws<ArgumentNullException>(null, () => brush.SurroundColors = null);
+                AssertExtensions.Throws<NullReferenceException>(null, () => brush.SurroundColors = null);
             }
         }
 

--- a/src/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
@@ -235,11 +235,11 @@ namespace System.Drawing.Drawing2D.Tests
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void SurroundColors_Null_ThrowsArgumentNullException()
+        public void SurroundColors_Null_ThrowsNullReferenceException()
         {
             using (PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints))
             {
-                AssertExtensions.Throws<NullReferenceException>(null, () => brush.SurroundColors = null);
+                AssertExtensions.Throws<NullReferenceException>(() => brush.SurroundColors = null);
             }
         }
 

--- a/src/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
@@ -234,7 +234,7 @@ namespace System.Drawing.Drawing2D.Tests
             }
         }
 
-        [ConditionalTheory(Helpers.IsDrawingSupported)]
+        [ConditionalFact(Helpers.IsDrawingSupported)]
         public void SurroundColors_Null_ThrowsArgumentNullException()
         {
             using (PathGradientBrush brush = new PathGradientBrush(_defaultFloatPoints))

--- a/src/System.Drawing.Common/tests/FontFamilyTests.cs
+++ b/src/System.Drawing.Common/tests/FontFamilyTests.cs
@@ -67,8 +67,10 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_NoSuchFontNameInCollection_ThrowsArgumentException()
         {
-            var fontCollection = new PrivateFontCollection();
-            Assert.Throws<ArgumentException>(null, () => new FontFamily("Times New Roman", fontCollection));
+            using (var fontCollection = new PrivateFontCollection())
+            {
+                Assert.Throws<ArgumentException>(null, () => new FontFamily("Times New Roman", fontCollection));
+            }
         }
 
         public static IEnumerable<object[]> Equals_TestData()

--- a/src/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.cs
@@ -1634,7 +1634,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ConditionalTheory(Helpers.IsDrawingSupported)]
+        [ConditionalFact(Helpers.IsDrawingSupported)]
         public void ScaleTransform_ZeroZero_ThrowsArgumentException()
         {
             using (var image = new Bitmap(10, 10))

--- a/src/System.Drawing.Common/tests/Imaging/EncoderParameterTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/EncoderParameterTests.cs
@@ -44,8 +44,10 @@ namespace System.Drawing.Imaging.Tests
         [MemberData(nameof(Ctor_Encoder_Byte_TestData))]
         public void Ctor_Encoder_Byte(Encoder encoder, byte value)
         {
-            EncoderParameter ep = new EncoderParameter(encoder, value);
-            CheckEncoderParameter(ep, encoder, EncoderParameterValueType.ValueTypeByte, 1);
+            using (EncoderParameter ep = new EncoderParameter(encoder, value))
+            {
+                CheckEncoderParameter(ep, encoder, EncoderParameterValueType.ValueTypeByte, 1);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -63,8 +65,10 @@ namespace System.Drawing.Imaging.Tests
         [InlineData(short.MaxValue)]
         public void Ctor_Encoder_Short(short value)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, value);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeShort, 1);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, value))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeShort, 1);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -73,8 +77,10 @@ namespace System.Drawing.Imaging.Tests
         [InlineData(long.MaxValue)]
         public void Ctor_Encoder_Long(long value)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, value);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeLong, 1);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, value))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeLong, 1);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -83,8 +89,10 @@ namespace System.Drawing.Imaging.Tests
         [InlineData(-10, -5)]
         public void Ctor_Encoder_Numerator_Denominator(int numerator, int denominator)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, numerator, denominator);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeRational, 1);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, numerator, denominator))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeRational, 1);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -92,8 +100,10 @@ namespace System.Drawing.Imaging.Tests
         [InlineData(1, 2, 3, 4)]
         public void Ctor_Encoder_Numerator1_Denominator1_Numerator2_Denominator2(int numerator1, int denominator1, int numerator2, int denominator2)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, numerator1, denominator1, numerator2, denominator2);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeRationalRange, 1);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, numerator1, denominator1, numerator2, denominator2))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeRationalRange, 1);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -101,8 +111,10 @@ namespace System.Drawing.Imaging.Tests
         [InlineData(1, 2)]
         public void Ctor_Encoder_RangeBegin_RangeEnd(long rangeBegin, long rangeEnd)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, rangeBegin, rangeEnd);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeLongRange, 1);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, rangeBegin, rangeEnd))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeLongRange, 1);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -110,8 +122,10 @@ namespace System.Drawing.Imaging.Tests
         [InlineData("")]
         public void Ctor_Encoder_String(string value)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, value);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeAscii, value.Length);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, value))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeAscii, value.Length);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -119,8 +133,10 @@ namespace System.Drawing.Imaging.Tests
         [InlineData(new byte[] { 0, 1, 2, 3 })]
         public void Ctor_Encoder_ByteArray(byte[] value)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, value);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeByte, value.Length);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, value))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeByte, value.Length);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -128,8 +144,10 @@ namespace System.Drawing.Imaging.Tests
         [InlineData(new byte[] { 1, 2 }, true, EncoderParameterValueType.ValueTypeUndefined)]
         public void Ctor_Encoder_ByteArray_Bool(byte[] value, bool undefined, EncoderParameterValueType expected)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, value, undefined);
-            CheckEncoderParameter(ep, s_anyEncoder, expected, value.Length);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, value, undefined))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, expected, value.Length);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -137,8 +155,10 @@ namespace System.Drawing.Imaging.Tests
         [InlineData(new short[] { 0, 1, 2, 3 })]
         public void Ctor_Encoder_ShortArray(short[] value)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, value);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeShort, value.Length);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, value))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeShort, value.Length);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -146,32 +166,40 @@ namespace System.Drawing.Imaging.Tests
         [InlineData(new long[] { 0, 1, 2, 3 })]
         public void Ctor_Encoder_LongArray(long[] value)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, value);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeLong, value.Length);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, value))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeLong, value.Length);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(new int[] { 0, 1, 2, 3 }, new int[] { 5, 6, 7, 8 })]
         public void Ctor_Encoder_NumeratorArray_DenominatorArray(int[] numerator, int[] denominator)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, numerator, denominator);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeRational, numerator.Length);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, numerator, denominator))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeRational, numerator.Length);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(new long[] { 0, 1, 2, 3 }, new long[] { 5, 6, 7, 8 })]
         public void Ctor_Encoder_RangeBeginArray_RangeEndArray(long[] rangeBegin, long[] rangeEnd)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, rangeBegin, rangeEnd);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeLongRange, rangeBegin.Length);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, rangeBegin, rangeEnd))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeLongRange, rangeBegin.Length);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(new int[] { 0, 1, 2, 3 }, new int[] { 4, 5, 6, 7 }, new int[] { 8, 9, 10, 11 }, new int[] { 12, 13, 14, 15 })]
         public void Ctor_Encoder_Numerator1Array_Denominator1Array_Numerator2Array_Denominator2Array(int[] numerator1, int[] denominator1, int[] numerator2, int[] denominator2)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, numerator1, denominator1, numerator2, denominator2);
-            CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeRationalRange, numerator1.Length);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, numerator1, denominator1, numerator2, denominator2))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, EncoderParameterValueType.ValueTypeRationalRange, numerator1.Length);
+            }
         }
 
         public static IEnumerable<object[]> Encoder_NumberOfValues_TestData
@@ -194,18 +222,23 @@ namespace System.Drawing.Imaging.Tests
         [MemberData(nameof(Encoder_NumberOfValues_TestData))]
         public void Ctor_Encoder_NumberOfValues_Type_Value(int numberOfValues, EncoderParameterValueType type, IntPtr value)
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, numberOfValues, type, value);
-            CheckEncoderParameter(ep, s_anyEncoder, type, numberOfValues);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, numberOfValues, type, value))
+            {
+                CheckEncoderParameter(ep, s_anyEncoder, type, numberOfValues);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Encoder_ReturnsExpecetd()
         {
             Encoder encoder = new Encoder(Guid.NewGuid());
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, 0);
-            ep.Encoder = encoder;
-
-            Assert.Equal(encoder.Guid, ep.Encoder.Guid);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, 0)
+            {
+                Encoder = encoder
+            })
+            {
+                Assert.Equal(encoder.Guid, ep.Encoder.Guid);
+            }
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -229,8 +262,10 @@ namespace System.Drawing.Imaging.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Encoder_Null_ThrowsNullReferenceException()
         {
-            EncoderParameter ep = new EncoderParameter(s_anyEncoder, 0);
-            Assert.Throws<NullReferenceException>(() => ep.Encoder = null);
+            using (EncoderParameter ep = new EncoderParameter(s_anyEncoder, 0))
+            {
+                Assert.Throws<NullReferenceException>(() => ep.Encoder = null);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]

--- a/src/System.Drawing.Common/tests/Imaging/EncoderParametersTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/EncoderParametersTests.cs
@@ -12,18 +12,22 @@ namespace System.Drawing.Imaging.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_Default()
         {
-            EncoderParameters ep = new EncoderParameters();
-            Assert.NotNull(ep.Param);
-            Assert.Equal(new EncoderParameter[1], ep.Param);
+            using (EncoderParameters ep = new EncoderParameters())
+            {
+                Assert.NotNull(ep.Param);
+                Assert.Equal(new EncoderParameter[1], ep.Param);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [InlineData(1)]
         public void Ctor_Count_Default(int count)
         {
-            EncoderParameters ep = new EncoderParameters(count);
-            Assert.NotNull(ep.Param);
-            Assert.Equal(new EncoderParameter[count], ep.Param);
+            using (EncoderParameters ep = new EncoderParameters(count))
+            {
+                Assert.NotNull(ep.Param);
+                Assert.Equal(new EncoderParameter[count], ep.Param);
+            }
         }
 
         public static IEnumerable<object[]> Param_TestData
@@ -40,9 +44,11 @@ namespace System.Drawing.Imaging.Tests
         [MemberData(nameof(Param_TestData))]
         public void Param_Success(EncoderParameter[] param)
         {
-            EncoderParameters ep = new EncoderParameters();
-            ep.Param = param;
-            Assert.Equal(param, ep.Param);
+            using (EncoderParameters ep = new EncoderParameters())
+            {
+                ep.Param = param;
+                Assert.Equal(param, ep.Param);
+            }
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]

--- a/src/System.Drawing.Common/tests/RegionTests.cs
+++ b/src/System.Drawing.Common/tests/RegionTests.cs
@@ -572,7 +572,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Complement_Disposed_ThrowsArgumentException()
         {
-            var disposedRegion = CreateDisposedRegion();
+            Region disposedRegion = CreateDisposedRegion();
 
             using (var graphicPath = new GraphicsPath())
             using (var other = new Region())
@@ -682,7 +682,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Equals_Disposed_ThrowsArgumentException()
         {
-            var disposedRegion = CreateDisposedRegion();
+            Region disposedRegion = CreateDisposedRegion();
 
             AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Equals(new Region(), s_graphic));
             AssertExtensions.Throws<ArgumentException>(null, () => new Region().Equals(disposedRegion, s_graphic));
@@ -992,7 +992,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Exclude_Disposed_ThrowsArgumentException()
         {
-            var disposedRegion = CreateDisposedRegion();
+            Region disposedRegion = CreateDisposedRegion();
 
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
@@ -1407,7 +1407,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Intersect_Disposed_ThrowsArgumentException()
         {
-            var disposedRegion = CreateDisposedRegion();
+            Region disposedRegion = CreateDisposedRegion();
 
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
@@ -1573,7 +1573,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsVisible_Disposed_ThrowsArgumentException()
         {
-            var disposedRegion = CreateDisposedRegion();
+            Region disposedRegion = CreateDisposedRegion();
 
             AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1f, 2f));
             AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new PointF(1, 2)));
@@ -1981,7 +1981,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Union_Disposed_ThrowsArgumentException()
         {
-            var disposedRegion = CreateDisposedRegion();
+            Region disposedRegion = CreateDisposedRegion();
 
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
@@ -2181,7 +2181,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Translate_Disposed_ThrowsArgumentException()
         {
-            var disposedRegion = CreateDisposedRegion();
+            Region disposedRegion = CreateDisposedRegion();
 
             AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Translate(1, 2));
             AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Translate(1f, 2f));
@@ -2397,7 +2397,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Xor_Disposed_ThrowsArgumentException()
         {
-            var disposedRegion = CreateDisposedRegion();
+            Region disposedRegion = CreateDisposedRegion();
 
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())

--- a/src/System.Drawing.Common/tests/RegionTests.cs
+++ b/src/System.Drawing.Common/tests/RegionTests.cs
@@ -592,7 +592,7 @@ namespace System.Drawing.Tests
             };
 
             var createdRegion = new Region();
-            yield return new object[] { new Region(), createdRegion, true };
+            yield return new object[] { createdRegion, createdRegion, true };
             yield return new object[] { new Region(), new Region(), true };
             yield return new object[] { new Region(), empty(), false };
             yield return new object[] { new Region(), new Region(new Rectangle(1, 2, 3, 4)), false };

--- a/src/System.Drawing.Common/tests/RegionTests.cs
+++ b/src/System.Drawing.Common/tests/RegionTests.cs
@@ -32,12 +32,12 @@ namespace System.Drawing.Tests
     public class RegionTests
     {
         private static readonly Graphics s_graphic = Graphics.FromImage(new Bitmap(1, 1));
-        private static readonly Region s_disposedRegion;
 
-        static RegionTests()
+        private static Region CreateDisposedRegion()
         {
-            s_disposedRegion = new Region();
-            s_disposedRegion.Dispose();
+            var region = new Region();
+            region.Dispose();
+            return region;
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -302,7 +302,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clone_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Clone());
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().Clone());
         }
 
         public static IEnumerable<object[]> Complement_TestData()
@@ -451,7 +451,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Complement_DisposedRegion_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Complement(s_disposedRegion));
+            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Complement(CreateDisposedRegion()));
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
@@ -572,13 +572,15 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Complement_Disposed_ThrowsArgumentException()
         {
+            var disposedRegion = CreateDisposedRegion();
+
             using (var graphicPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Complement(graphicPath));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Complement(new Rectangle()));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Complement(new RectangleF()));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Complement(s_disposedRegion));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Complement(graphicPath));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Complement(new Rectangle()));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Complement(new RectangleF()));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Complement(disposedRegion));
             }
         }
 
@@ -680,8 +682,10 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Equals_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Equals(new Region(), s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Equals(s_disposedRegion, s_graphic));
+            var disposedRegion = CreateDisposedRegion();
+
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Equals(new Region(), s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Equals(disposedRegion, s_graphic));
         }
 
         public static IEnumerable<object[]> Exclude_TestData()
@@ -891,7 +895,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Exclude_DisposedRegion_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Exclude(s_disposedRegion));
+            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Exclude(CreateDisposedRegion()));
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
@@ -988,13 +992,15 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Exclude_Disposed_ThrowsArgumentException()
         {
+            var disposedRegion = CreateDisposedRegion();
+
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Exclude(graphicsPath));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Exclude(new Rectangle()));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Exclude(new RectangleF()));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Exclude(other));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Exclude(graphicsPath));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Exclude(new Rectangle()));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Exclude(new RectangleF()));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Exclude(other));
             }
         }
 
@@ -1066,7 +1072,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHrgn_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.GetHrgn(s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().GetHrgn(s_graphic));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1102,13 +1108,13 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetBounds_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.GetBounds(s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().GetBounds(s_graphic));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetRegionData_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.GetRegionData());
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().GetRegionData());
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
@@ -1141,7 +1147,7 @@ namespace System.Drawing.Tests
         {
             using (var matrix = new Matrix())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.GetRegionScans(matrix));
+                AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().GetRegionScans(matrix));
             }
         }
 
@@ -1278,7 +1284,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Intersect_DisposedRegion_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Intersect(s_disposedRegion));
+            AssertExtensions.Throws<ArgumentException>(null, () => new Region().Intersect(CreateDisposedRegion()));
         }
 
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
@@ -1401,13 +1407,15 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Intersect_Disposed_ThrowsArgumentException()
         {
+            var disposedRegion = CreateDisposedRegion();
+
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Intersect(graphicsPath));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Intersect(new Rectangle()));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Intersect(new RectangleF()));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Intersect(other));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Intersect(graphicsPath));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Intersect(new Rectangle()));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Intersect(new RectangleF()));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Intersect(other));
             }
         }
 
@@ -1423,7 +1431,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsEmpty_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsEmpty(s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().IsEmpty(s_graphic));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -1450,7 +1458,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsInfinite_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsInfinite(s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().IsInfinite(s_graphic));
         }
 
         public static IEnumerable<object[]> IsVisible_Rectangle_TestData()
@@ -1565,25 +1573,27 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void IsVisible_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(1f, 2f));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(new PointF(1, 2)));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(new Point(1, 2)));
+            var disposedRegion = CreateDisposedRegion();
 
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(1f, 2f, s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(new PointF(1, 2), s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(new Point(1, 2), s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1f, 2f));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new PointF(1, 2)));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new Point(1, 2)));
 
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(1f, 2f, 3f, 4f));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4)));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4)));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1f, 2f, s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new PointF(1, 2), s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new Point(1, 2), s_graphic));
 
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(1f, 2f, 3f, 4f, s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4), s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4), s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1f, 2f, 3f, 4f));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4)));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4)));
 
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(1, 2, s_graphic));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(1, 2, 3, 4));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.IsVisible(1, 2, 3, 4, s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1f, 2f, 3f, 4f, s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new Rectangle(1, 2, 3, 4), s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(new RectangleF(1, 2, 3, 4), s_graphic));
+
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1, 2, s_graphic));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1, 2, 3, 4));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.IsVisible(1, 2, 3, 4, s_graphic));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1610,7 +1620,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void MakeEmpty_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.MakeEmpty());
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().MakeEmpty());
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -1633,7 +1643,7 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void MakeInfinite_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.MakeInfinite());
+            AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().MakeInfinite());
         }
 
         public static IEnumerable<object[]> Union_TestData()
@@ -1876,7 +1886,7 @@ namespace System.Drawing.Tests
         {
             using (var region = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => region.Union(s_disposedRegion));
+                AssertExtensions.Throws<ArgumentException>(null, () => region.Union(CreateDisposedRegion()));
             }
         }
 
@@ -1971,13 +1981,15 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Union_Disposed_ThrowsArgumentException()
         {
+            var disposedRegion = CreateDisposedRegion();
+
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Union(graphicsPath));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Union(new Rectangle()));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Union(new RectangleF()));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Union(s_disposedRegion));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Union(graphicsPath));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Union(new Rectangle()));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Union(new RectangleF()));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Union(disposedRegion));
             }
         }
 
@@ -2073,7 +2085,7 @@ namespace System.Drawing.Tests
         {
             using (var matrix = new Matrix())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Transform(matrix));
+                AssertExtensions.Throws<ArgumentException>(null, () => CreateDisposedRegion().Transform(matrix));
             }
         }
 
@@ -2169,8 +2181,10 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Translate_Disposed_ThrowsArgumentException()
         {
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Translate(1, 2));
-            AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Translate(1f, 2f));
+            var disposedRegion = CreateDisposedRegion();
+
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Translate(1, 2));
+            AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Translate(1f, 2f));
         }
 
         public static IEnumerable<object[]> Xor_TestData()
@@ -2285,7 +2299,7 @@ namespace System.Drawing.Tests
         {
             using (var region = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => region.Xor(s_disposedRegion));
+                AssertExtensions.Throws<ArgumentException>(null, () => region.Xor(CreateDisposedRegion()));
             }
         }
 
@@ -2383,13 +2397,15 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Xor_Disposed_ThrowsArgumentException()
         {
+            var disposedRegion = CreateDisposedRegion();
+
             using (var graphicsPath = new GraphicsPath())
             using (var other = new Region())
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Xor(graphicsPath));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Xor(new Rectangle()));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Xor(new RectangleF()));
-                AssertExtensions.Throws<ArgumentException>(null, () => s_disposedRegion.Xor(other));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Xor(graphicsPath));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Xor(new Rectangle()));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Xor(new RectangleF()));
+                AssertExtensions.Throws<ArgumentException>(null, () => disposedRegion.Xor(other));
             }
         }
     }

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -504,67 +504,48 @@ namespace MonoTests.System.Drawing
 
         // Rotate 1- and 4-bit bitmaps in different ways and check the
         // resulting pixels using MD5
-        [ConditionalFact(Helpers.RecentGdiplusIsAvailable)]
+        [ConditionalTheory(Helpers.IsDrawingSupported)]
+        [InlineData("1bit.png", RotateFlipType.RotateNoneFlipNone, "A4DAF507C92BDE10626BC7B34FEFE5")]
+        [InlineData("1bit.png", RotateFlipType.Rotate180FlipXY, "A4DAF507C92BDE10626BC7B34FEFE5")]
+        [InlineData("1bit.png", RotateFlipType.Rotate90FlipNone, "C0975EAFD2FC1CC9CC7AF20B92FC9F")]
+        [InlineData("1bit.png", RotateFlipType.Rotate270FlipXY, "C0975EAFD2FC1CC9CC7AF20B92FC9F")]
+        [InlineData("1bit.png", RotateFlipType.Rotate180FlipNone, "64AE60858A02228F7B1B18C7812FB6")]
+        [InlineData("1bit.png", RotateFlipType.RotateNoneFlipXY, "64AE60858A02228F7B1B18C7812FB6")]
+        [InlineData("1bit.png", RotateFlipType.Rotate270FlipNone, "E96D3390938350F9DE2608C4364424")]
+        [InlineData("1bit.png", RotateFlipType.Rotate90FlipXY, "E96D3390938350F9DE2608C4364424")]
+        [InlineData("1bit.png", RotateFlipType.RotateNoneFlipX, "23947CE822C1DDE6BEA69C01F8D0D9")]
+        [InlineData("1bit.png", RotateFlipType.Rotate180FlipY, "23947CE822C1DDE6BEA69C01F8D0D9")]
+        [InlineData("1bit.png", RotateFlipType.Rotate90FlipX, "BE45F685BDEBD7079AA1B2CBA46723")]
+        [InlineData("1bit.png", RotateFlipType.Rotate270FlipY, "BE45F685BDEBD7079AA1B2CBA46723")]
+        [InlineData("1bit.png", RotateFlipType.Rotate180FlipX, "353E937CFF31B1BF6C3DD0A031ACB5")]
+        [InlineData("1bit.png", RotateFlipType.RotateNoneFlipY, "353E937CFF31B1BF6C3DD0A031ACB5")]
+        [InlineData("1bit.png", RotateFlipType.Rotate270FlipX, "AEA18A770A845E25B6A8CE28DD6DCB")]
+        [InlineData("1bit.png", RotateFlipType.Rotate90FlipY, "AEA18A770A845E25B6A8CE28DD6DCB")]
+        [InlineData("4bit.png", RotateFlipType.RotateNoneFlipNone, "3CC874B571902366AACED5D619E87D")]
+        [InlineData("4bit.png", RotateFlipType.Rotate180FlipXY, "3CC874B571902366AACED5D619E87D")]
+        [InlineData("4bit.png", RotateFlipType.Rotate90FlipNone, "8DE25C7E1BE4A3B535DB5D83198D83")]
+        [InlineData("4bit.png", RotateFlipType.Rotate270FlipXY, "8DE25C7E1BE4A3B535DB5D83198D83")]
+        [InlineData("4bit.png", RotateFlipType.Rotate180FlipNone, "27CF5E9CE70BE9EBC47FB996721B95")]
+        [InlineData("4bit.png", RotateFlipType.RotateNoneFlipXY, "27CF5E9CE70BE9EBC47FB996721B95")]
+        [InlineData("4bit.png", RotateFlipType.Rotate270FlipNone, "A919CCB8F97CAD7DC1F01026D11A5D")]
+        [InlineData("4bit.png", RotateFlipType.Rotate90FlipXY, "A919CCB8F97CAD7DC1F01026D11A5D")]
+        [InlineData("4bit.png", RotateFlipType.RotateNoneFlipX, "545876C99ACF833E69FBFFBF436034")]
+        [InlineData("4bit.png", RotateFlipType.Rotate180FlipY, "545876C99ACF833E69FBFFBF436034")]
+        [InlineData("4bit.png", RotateFlipType.Rotate90FlipX, "5DB56687757CDEFC52D89C77CA9223")]
+        [InlineData("4bit.png", RotateFlipType.Rotate270FlipY, "5DB56687757CDEFC52D89C77CA9223")]
+        [InlineData("4bit.png", RotateFlipType.Rotate180FlipX, "05A77EDDCDF20D5B0AC0169E95D7D7")]
+        [InlineData("4bit.png", RotateFlipType.RotateNoneFlipY, "05A77EDDCDF20D5B0AC0169E95D7D7")]
+        [InlineData("4bit.png", RotateFlipType.Rotate270FlipX, "B6B6245796C836923ABAABDF368B29")]
+        [InlineData("4bit.png", RotateFlipType.Rotate90FlipY, "B6B6245796C836923ABAABDF368B29")]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public void Rotate1bit4bit()
+        public void Rotate1bit4bit(string file, RotateFlipType type, string md5)
         {
-            string[] files = {
-                               Helpers.GetTestBitmapPath ("1bit.png"),
-                               Helpers.GetTestBitmapPath ("4bit.png")
-                             };
-
             StringBuilder md5s = new StringBuilder();
 
-            foreach (string file in files)
+            using (Bitmap bmp = new Bitmap(Helpers.GetTestBitmapPath(file)))
             {
-                using (Bitmap bmp = new Bitmap(file))
-                {
-                    foreach (RotateFlipType type in Enum.GetValues(typeof(RotateFlipType)))
-                    {
-                        md5s.Append(RotateIndexedBmp(bmp, type));
-                    }
-                }
+                Assert.Equal(md5, RotateIndexedBmp(bmp, type));
             }
-
-            using (StreamWriter writer = new StreamWriter("/tmp/md5s.txt"))
-            {
-                writer.WriteLine(md5s);
-            }
-
-            Assert.Equal(
-                "A4DAF507C92BDE10626BC7B34FEFE5" + // 1-bit RotateNoneFlipNone
-                "A4DAF507C92BDE10626BC7B34FEFE5" + // 1-bit Rotate180FlipXY
-                "C0975EAFD2FC1CC9CC7AF20B92FC9F" + // 1-bit Rotate90FlipNone
-                "C0975EAFD2FC1CC9CC7AF20B92FC9F" + // 1-bit Rotate270FlipXY
-                "64AE60858A02228F7B1B18C7812FB6" + // 1-bit Rotate180FlipNone
-                "64AE60858A02228F7B1B18C7812FB6" + // 1-bit RotateNoneFlipXY
-                "E96D3390938350F9DE2608C4364424" + // 1-bit Rotate270FlipNone
-                "E96D3390938350F9DE2608C4364424" + // 1-bit Rotate90FlipXY
-                "23947CE822C1DDE6BEA69C01F8D0D9" + // 1-bit RotateNoneFlipX
-                "23947CE822C1DDE6BEA69C01F8D0D9" + // 1-bit Rotate180FlipY
-                "BE45F685BDEBD7079AA1B2CBA46723" + // 1-bit Rotate90FlipX
-                "BE45F685BDEBD7079AA1B2CBA46723" + // 1-bit Rotate270FlipY
-                "353E937CFF31B1BF6C3DD0A031ACB5" + // 1-bit Rotate180FlipX
-                "353E937CFF31B1BF6C3DD0A031ACB5" + // 1-bit RotateNoneFlipY
-                "AEA18A770A845E25B6A8CE28DD6DCB" + // 1-bit Rotate270FlipX
-                "AEA18A770A845E25B6A8CE28DD6DCB" + // 1-bit Rotate90FlipY
-                "3CC874B571902366AACED5D619E87D" + // 4-bit RotateNoneFlipNone
-                "3CC874B571902366AACED5D619E87D" + // 4-bit Rotate180FlipXY
-                "8DE25C7E1BE4A3B535DB5D83198D83" + // 4-bit Rotate90FlipNone
-                "8DE25C7E1BE4A3B535DB5D83198D83" + // 4-bit Rotate270FlipXY
-                "27CF5E9CE70BE9EBC47FB996721B95" + // 4-bit Rotate180FlipNone
-                "27CF5E9CE70BE9EBC47FB996721B95" + // 4-bit RotateNoneFlipXY
-                "A919CCB8F97CAD7DC1F01026D11A5D" + // 4-bit Rotate270FlipNone
-                "A919CCB8F97CAD7DC1F01026D11A5D" + // 4-bit Rotate90FlipXY
-                "545876C99ACF833E69FBFFBF436034" + // 4-bit RotateNoneFlipX
-                "545876C99ACF833E69FBFFBF436034" + // 4-bit Rotate180FlipY
-                "5DB56687757CDEFC52D89C77CA9223" + // 4-bit Rotate90FlipX
-                "5DB56687757CDEFC52D89C77CA9223" + // 4-bit Rotate270FlipY
-                "05A77EDDCDF20D5B0AC0169E95D7D7" + // 4-bit Rotate180FlipX
-                "05A77EDDCDF20D5B0AC0169E95D7D7" + // 4-bit RotateNoneFlipY
-                "B6B6245796C836923ABAABDF368B29" + // 4-bit Rotate270FlipX
-                "B6B6245796C836923ABAABDF368B29",  // 4-bit Rotate90FlipY
-                md5s.ToString());
         }
 
         private Bitmap CreateBitmap(int width, int height, PixelFormat fmt)

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -258,37 +258,41 @@ namespace MonoTests.System.Drawing
             RectangleF[] rects;
             using (Bitmap bmp = new Bitmap(200, 200))
             {
-                Graphics g = Graphics.FromImage(bmp);
-                // Region
-                g.SetClip(new Region(new Rectangle(50, 40, 210, 220)), CombineMode.Replace);
-                rects = g.Clip.GetRegionScans(new Matrix());
-                Assert.Equal(1, rects.Length);
-                Assert.Equal(50, rects[0].X);
-                Assert.Equal(40, rects[0].Y);
-                Assert.Equal(210, rects[0].Width);
-                Assert.Equal(220, rects[0].Height);
-                g.Dispose();
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    // Region
+                    g.SetClip(new Region(new Rectangle(50, 40, 210, 220)), CombineMode.Replace);
+                    rects = g.Clip.GetRegionScans(new Matrix());
+                    Assert.Equal(1, rects.Length);
+                    Assert.Equal(50, rects[0].X);
+                    Assert.Equal(40, rects[0].Y);
+                    Assert.Equal(210, rects[0].Width);
+                    Assert.Equal(220, rects[0].Height);
+                }
 
                 // RectangleF
-                g = Graphics.FromImage(bmp);
-                g.SetClip(new RectangleF(50, 40, 210, 220));
-                rects = g.Clip.GetRegionScans(new Matrix());
-                Assert.Equal(1, rects.Length);
-                Assert.Equal(50, rects[0].X);
-                Assert.Equal(40, rects[0].Y);
-                Assert.Equal(210, rects[0].Width);
-                Assert.Equal(220, rects[0].Height);
-                g.Dispose();
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    g.SetClip(new RectangleF(50, 40, 210, 220));
+                    rects = g.Clip.GetRegionScans(new Matrix());
+                    Assert.Equal(1, rects.Length);
+                    Assert.Equal(50, rects[0].X);
+                    Assert.Equal(40, rects[0].Y);
+                    Assert.Equal(210, rects[0].Width);
+                    Assert.Equal(220, rects[0].Height);
+                }
 
                 // Rectangle
-                g = Graphics.FromImage(bmp);
-                g.SetClip(new Rectangle(50, 40, 210, 220));
-                rects = g.Clip.GetRegionScans(new Matrix());
-                Assert.Equal(1, rects.Length);
-                Assert.Equal(50, rects[0].X);
-                Assert.Equal(40, rects[0].Y);
-                Assert.Equal(210, rects[0].Width);
-                Assert.Equal(220, rects[0].Height);
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    g.SetClip(new Rectangle(50, 40, 210, 220));
+                    rects = g.Clip.GetRegionScans(new Matrix());
+                    Assert.Equal(1, rects.Length);
+                    Assert.Equal(50, rects[0].X);
+                    Assert.Equal(40, rects[0].Y);
+                    Assert.Equal(210, rects[0].Width);
+                    Assert.Equal(220, rects[0].Height);
+                }
             }
         }
 
@@ -369,7 +373,7 @@ namespace MonoTests.System.Drawing
                 Assert.Equal(PixelFormat.Format4bppIndexed, img.PixelFormat);
                 Exception exception = AssertExtensions.Throws<ArgumentException, Exception>(() => Graphics.FromImage(img));
                 if (exception is ArgumentException argumentException)
-                    Assert.Equal("image", argumentException.ParamName);                
+                    Assert.Equal("image", argumentException.ParamName);
             }
         }
 
@@ -444,11 +448,11 @@ namespace MonoTests.System.Drawing
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Transform_NonInvertibleMatrix()
         {
-            Matrix matrix = new Matrix(123, 24, 82, 16, 47, 30);
-            Assert.False(matrix.IsInvertible);
-
+            using (Matrix matrix = new Matrix(123, 24, 82, 16, 47, 30))
             using (var b = new BitmapAndGraphics(16, 16))
             {
+                Assert.False(matrix.IsInvertible);
+
                 var g = b.Graphics;
                 Assert.Throws<ArgumentException>(() => g.Transform = matrix);
             }
@@ -458,10 +462,11 @@ namespace MonoTests.System.Drawing
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Multiply_NonInvertibleMatrix()
         {
-            Matrix matrix = new Matrix(123, 24, 82, 16, 47, 30);
-            Assert.False(matrix.IsInvertible);
+            using (Matrix matrix = new Matrix(123, 24, 82, 16, 47, 30))
             using (var b = new BitmapAndGraphics(16, 16))
             {
+                Assert.False(matrix.IsInvertible);
+
                 var g = b.Graphics;
                 Assert.Throws<ArgumentException>(() => g.MultiplyTransform(matrix));
             }
@@ -532,14 +537,16 @@ namespace MonoTests.System.Drawing
             {
                 var g = b.Graphics;
                 g.Clip = new Region(new Rectangle(0, 0, 8, 8));
-                Region clone = g.Clip.Clone();
                 g.TranslateTransform(8, 8);
                 CheckBounds("translate.ClipBounds", g.ClipBounds, -8, -8, 8, 8);
                 CheckBounds("translate.Clip.GetBounds", g.Clip.GetBounds(g), -8, -8, 8, 8);
 
-                g.SetClip(clone, CombineMode.Replace);
-                CheckBounds("setclip.ClipBounds", g.Clip.GetBounds(g), 0, 0, 8, 8);
-                CheckBounds("setclip.Clip.GetBounds", g.Clip.GetBounds(g), 0, 0, 8, 8);
+                using (Region clone = g.Clip.Clone())
+                {
+                    g.SetClip(clone, CombineMode.Replace);
+                    CheckBounds("setclip.ClipBounds", g.Clip.GetBounds(g), 0, 0, 8, 8);
+                    CheckBounds("setclip.Clip.GetBounds", g.Clip.GetBounds(g), 0, 0, 8, 8);
+                }
             }
         }
 
@@ -1784,8 +1791,8 @@ namespace MonoTests.System.Drawing
         public void MeasureString_StringFormat_Alignment()
         {
             string text = "Hello Mono::";
-            StringFormat string_format = new StringFormat();
 
+            using (StringFormat string_format = new StringFormat())
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
             {
@@ -1810,12 +1817,12 @@ namespace MonoTests.System.Drawing
         public void MeasureString_StringFormat_Alignment_DirectionVertical()
         {
             string text = "Hello Mono::";
-            StringFormat string_format = new StringFormat();
-            string_format.FormatFlags = StringFormatFlags.DirectionVertical;
-
+            using (StringFormat string_format = new StringFormat())
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
             {
+                string_format.FormatFlags = StringFormatFlags.DirectionVertical;
+
                 string_format.Alignment = StringAlignment.Near;
                 SizeF near = g.MeasureString(text, font, int.MaxValue, string_format);
 
@@ -1837,8 +1844,7 @@ namespace MonoTests.System.Drawing
         public void MeasureString_StringFormat_LineAlignment()
         {
             string text = "Hello Mono::";
-            StringFormat string_format = new StringFormat();
-
+            using (StringFormat string_format = new StringFormat())
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
             {
@@ -1863,12 +1869,12 @@ namespace MonoTests.System.Drawing
         public void MeasureString_StringFormat_LineAlignment_DirectionVertical()
         {
             string text = "Hello Mono::";
-            StringFormat string_format = new StringFormat();
-            string_format.FormatFlags = StringFormatFlags.DirectionVertical;
-
+            using (StringFormat string_format = new StringFormat())
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
             {
+                string_format.FormatFlags = StringFormatFlags.DirectionVertical;
+
                 string_format.LineAlignment = StringAlignment.Near;
                 SizeF near = g.MeasureString(text, font, int.MaxValue, string_format);
 
@@ -1891,9 +1897,8 @@ namespace MonoTests.System.Drawing
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
+            using (StringFormat string_format = new StringFormat())
             {
-                StringFormat string_format = new StringFormat();
-
                 string text1 = "Test\nTest123\nTest 456\nTest 1,2,3,4,5...";
                 string text2 = "Test 1,2,3,4,5...";
 
@@ -2020,13 +2025,13 @@ namespace MonoTests.System.Drawing
             ranges[0] = new CharacterRange(0, 5);
             ranges[1] = new CharacterRange(5, 9);
 
-            StringFormat string_format = new StringFormat();
-            string_format.FormatFlags = StringFormatFlags.NoClip;
-            string_format.SetMeasurableCharacterRanges(ranges);
-
+            using (StringFormat string_format = new StringFormat())
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
             {
+                string_format.FormatFlags = StringFormatFlags.NoClip;
+                string_format.SetMeasurableCharacterRanges(ranges);
+
                 SizeF size = g.MeasureString(text, font, new Point(0, 0), string_format);
                 RectangleF layout_rect = new RectangleF(0.0f, 0.0f, size.Width, size.Height);
                 Region[] regions = g.MeasureCharacterRanges(text, font, layout_rect, string_format);
@@ -2041,13 +2046,13 @@ namespace MonoTests.System.Drawing
             CharacterRange[] ranges = new CharacterRange[1];
             ranges[0] = new CharacterRange(first, length);
 
-            StringFormat string_format = new StringFormat();
-            string_format.FormatFlags = StringFormatFlags.NoClip;
-            string_format.SetMeasurableCharacterRanges(ranges);
-
+            using (StringFormat string_format = new StringFormat())
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
             {
+                string_format.FormatFlags = StringFormatFlags.NoClip;
+                string_format.SetMeasurableCharacterRanges(ranges);
+
                 SizeF size = g.MeasureString(text, font, new Point(0, 0), string_format);
                 RectangleF layout_rect = new RectangleF(0.0f, 0.0f, size.Width, size.Height);
                 g.MeasureCharacterRanges(text, font, layout_rect, string_format);
@@ -2075,12 +2080,12 @@ namespace MonoTests.System.Drawing
             CharacterRange[] ranges = new CharacterRange[1];
             ranges[0] = new CharacterRange(5, 4);
 
-            StringFormat string_format = new StringFormat();
-            string_format.SetMeasurableCharacterRanges(ranges);
-
+            using (StringFormat string_format = new StringFormat())
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
             {
+                string_format.SetMeasurableCharacterRanges(ranges);
+
                 SizeF size = g.MeasureString(text, font, new Point(0, 0), string_format);
                 RectangleF layout_rect = new RectangleF(0.0f, 0.0f, size.Width, size.Height);
 
@@ -2200,11 +2205,11 @@ namespace MonoTests.System.Drawing
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
+            using (StringFormat fmt = new StringFormat())
             {
                 Rectangle rect = Rectangle.Empty;
                 rect.Location = new Point(10, 10);
                 rect.Size = new Size(1, 20);
-                StringFormat fmt = new StringFormat();
                 fmt.Alignment = StringAlignment.Center;
                 fmt.LineAlignment = StringAlignment.Center;
                 fmt.FormatFlags = StringFormatFlags.NoWrap;
@@ -2218,11 +2223,11 @@ namespace MonoTests.System.Drawing
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
+            using (StringFormat fmt = new StringFormat())
             {
                 Rectangle rect = Rectangle.Empty;
                 rect.Location = new Point(10, 10);
                 rect.Size = new Size(1, 20);
-                StringFormat fmt = new StringFormat();
                 fmt.Alignment = StringAlignment.Center;
                 fmt.LineAlignment = StringAlignment.Center;
                 fmt.Trimming = StringTrimming.EllipsisWord;
@@ -2236,14 +2241,12 @@ namespace MonoTests.System.Drawing
             string text = "this is really long text........................................... with a lot o periods.";
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
+            using (StringFormat format = new StringFormat())
             {
-                using (StringFormat format = new StringFormat())
-                {
-                    format.Alignment = StringAlignment.Center;
-                    SizeF sz = g.MeasureString(text, font, 80, format);
-                    Assert.True(sz.Width <= 80);
-                    Assert.True(sz.Height > font.Height * 2);
-                }
+                format.Alignment = StringAlignment.Center;
+                SizeF sz = g.MeasureString(text, font, 80, format);
+                Assert.True(sz.Width <= 80);
+                Assert.True(sz.Height > font.Height * 2);
             }
         }
 
@@ -2988,8 +2991,8 @@ namespace MonoTests.System.Drawing
             Rectangle r = new Rectangle(1, 2, 3, 4);
             using (Bitmap bmp = new Bitmap(40, 40))
             using (Graphics g = Graphics.FromImage(bmp))
+            using (ImageAttributes ia = new ImageAttributes())
             {
-                ImageAttributes ia = new ImageAttributes();
                 g.DrawImage(bmp, pts, r, GraphicsUnit.Pixel, ia);
             }
         }
@@ -3200,7 +3203,7 @@ namespace MonoTests.System.Drawing
                 Assert.Equal(-12156236, bmp.GetPixel(1, 9).ToArgb());
             }
         }
-        
+
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void TransformPoints()

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -537,12 +537,12 @@ namespace MonoTests.System.Drawing
             {
                 var g = b.Graphics;
                 g.Clip = new Region(new Rectangle(0, 0, 8, 8));
-                g.TranslateTransform(8, 8);
-                CheckBounds("translate.ClipBounds", g.ClipBounds, -8, -8, 8, 8);
-                CheckBounds("translate.Clip.GetBounds", g.Clip.GetBounds(g), -8, -8, 8, 8);
-
                 using (Region clone = g.Clip.Clone())
                 {
+                    g.TranslateTransform(8, 8);
+                    CheckBounds("translate.ClipBounds", g.ClipBounds, -8, -8, 8, 8);
+                    CheckBounds("translate.Clip.GetBounds", g.Clip.GetBounds(g), -8, -8, 8, 8);
+
                     g.SetClip(clone, CombineMode.Replace);
                     CheckBounds("setclip.ClipBounds", g.Clip.GetBounds(g), 0, 0, 8, 8);
                     CheckBounds("setclip.Clip.GetBounds", g.Clip.GetBounds(g), 0, 0, 8, 8);
@@ -1057,7 +1057,6 @@ namespace MonoTests.System.Drawing
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
             {
-
                 CheckDefaultProperties("default", g);
                 Assert.Equal(new Point(0, 0), g.RenderingOrigin);
 


### PR DESCRIPTION
- A lot of the types in System.Drawing.Common implement `IDisposable` and use native resources. Make sure these types are wrapped in a `using` statement in the unit tests.
- Convert `BitmapTests.Rotate1bit4bit` to a theory, and prevent it from using `/tmp` directly
- Convert `ScaleTransform_ZeroZero_ThrowsArgumentException` and `SurroundColors_Null_ThrowsArgumentNullException` from a theory to a fact (they have no test parameters)