### PR TITLE
Region tests: Add using statements

### DIFF
--- a/src/System.Drawing.Common/tests/RegionTests.cs
+++ b/src/System.Drawing.Common/tests/RegionTests.cs
@@ -592,7 +592,7 @@ namespace System.Drawing.Tests
             };
 
             var createdRegion = new Region();
-            yield return new object[] { new Region(), createdRegion, true };
+            yield return new object[] { createdRegion, createdRegion, true };
             yield return new object[] { new Region(), new Region(), true };
             yield return new object[] { new Region(), empty(), false };
             yield return new object[] { new Region(), new Region(new Rectangle(1, 2, 3, 4)), false };


### PR DESCRIPTION
`Region` uses native resources, so should be disposed of.

- Use a single instance of a disposed `Region`
- Replace `try`/`finally` with `using`
- Add a bunch of `using` statements