### PR TITLE
Fix SslStream client auth with intermediate certificates on Linux

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
@@ -170,8 +171,16 @@ internal static partial class Interop
             Debug.Assert(chain != null, "X509Chain should not be null");
             Debug.Assert(chain.ChainElements.Count > 0, "chain.Build should have already been called");
 
-            // Don't count the last item (the root)
-            int stop = chain.ChainElements.Count - 1;
+            // If not trusted then include the last item (root). Otherwise, don't include it.
+            int stop;
+            if (chain.ChainStatus.Any(s => (s.Status & X509ChainStatusFlags.PartialChain) != 0))
+            {
+                stop = chain.ChainElements.Count;
+            }
+            else
+            {
+                stop = chain.ChainElements.Count - 1;
+            }
 
             // Don't include the first item (the cert whose private key we have)
             for (int i = 1; i < stop; i++)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
@@ -172,14 +171,14 @@ internal static partial class Interop
             Debug.Assert(chain.ChainElements.Count > 0, "chain.Build should have already been called");
 
             // If the last certificate is a root certificate, don't send it. PartialChain means the last cert wasn't a root.
-            int stop;
-            if (chain.ChainStatus.Any(s => (s.Status & X509ChainStatusFlags.PartialChain) != 0))
+            int stop = chain.ChainElements.Count - 1;
+            foreach (X509ChainStatus s in chain.ChainStatus)
             {
-                stop = chain.ChainElements.Count;
-            }
-            else
-            {
-                stop = chain.ChainElements.Count - 1;
+                if ((s.Status & X509ChainStatusFlags.PartialChain) != 0)
+                {
+                    stop++;
+                    break;
+                }
             }
 
             // Don't include the first item (the cert whose private key we have)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -171,7 +171,7 @@ internal static partial class Interop
             Debug.Assert(chain != null, "X509Chain should not be null");
             Debug.Assert(chain.ChainElements.Count > 0, "chain.Build should have already been called");
 
-            // If not trusted then include the last item (root). Otherwise, don't include it.
+            // If the last certificate is a root certificate, don't send it. PartialChain means the last cert wasn't a root.
             int stop;
             if (chain.ChainStatus.Any(s => (s.Status & X509ChainStatusFlags.PartialChain) != 0))
             {

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -707,7 +707,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Reference Include="System.Diagnostics.StackTrace" />
-    <Reference Include="System.Linq" />
     <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Encoding" />

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -707,6 +707,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Reference Include="System.Diagnostics.StackTrace" />
+    <Reference Include="System.Linq" />
     <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Encoding" />


### PR DESCRIPTION
On Linux, a client TLS certificate chaining to multiple intermediate certificates wasn't
sending the complete list of intermediates because the final one in the chain wasn't
trusted. This differs from Windows behavior. This was causing the application to fail
to authenticate to the payment provider in the repro.

This PR fixes SslStream so that it will send the complete list of intermediates if the
chain build operation results in a "PartialChain" instead of a fully trusted chain.

Due to the complexity of this scenario, I didn't write a standalone CI test. But I was
able to run the original repro (using a docker container) to validate the fix.

Fixes #37927