### PR TITLE
Generate framework manifest file

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -338,8 +338,18 @@
     <NETCoreAppTestHostFxrPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'host', 'fxr', '$(ProductVersion)'))</NETCoreAppTestHostFxrPath>
     <NETCoreAppTestSharedFrameworkPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'shared', 'Microsoft.NETCore.App', '$(ProductVersion)'))</NETCoreAppTestSharedFrameworkPath>
     <!-- For UAP, we'll produce the layout and hard-link this into each test's directory -->
-    <UAPTestSharedFrameworkPath>$(TestHostRootPath)UAPLayout</UAPTestSharedFrameworkPath>
+    <UAPTestSharedFrameworkPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'UAPLayout'))</UAPTestSharedFrameworkPath>
+
+    <TestHostRuntimePath Condition="'$(BinPlaceTestSharedFramework)' == 'true'">$(NETCoreAppTestSharedFrameworkPath)</TestHostRuntimePath>
+    <TestHostRuntimePath Condition="'$(BinPlaceUAPFramework)' == 'true'">$(UAPTestSharedFrameworkPath)</TestHostRuntimePath>
+    <TestHostRuntimePath Condition="'$(BinPlaceNETFXRuntime)' == 'true'">$(TestHostRootPath)</TestHostRuntimePath>
+
+    <PlatformManifestFile Condition="'$(BinplaceTestSharedFramework)' == 'true'">$(TestHostRuntimePath)PlatformManifest.txt</PlatformManifestFile>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(PlatformManifestFile)' != '' and '$(IsTestProject)' == 'true'">
+    <PackageConflictPlatformManifests Include="$(PlatformManifestFile)" />
+  </ItemGroup>
 
   <!-- AOT only asset that we currently don't support. -->
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -344,7 +344,7 @@
     <TestHostRuntimePath Condition="'$(BinPlaceUAPFramework)' == 'true'">$(UAPTestSharedFrameworkPath)</TestHostRuntimePath>
     <TestHostRuntimePath Condition="'$(BinPlaceNETFXRuntime)' == 'true'">$(TestHostRootPath)</TestHostRuntimePath>
 
-    <PlatformManifestFile Condition="'$(BinplaceTestSharedFramework)' == 'true'">$(TestHostRuntimePath)PlatformManifest.txt</PlatformManifestFile>
+    <PlatformManifestFile>$(TestHostRuntimePath)PlatformManifest.txt</PlatformManifestFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(PlatformManifestFile)' != '' and '$(IsTestProject)' == 'true'">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -100,11 +100,7 @@
       <RefPath>$(RefRootPath)uap10.0.16299/</RefPath>
     </BinPlaceConfiguration>
     <!-- for BuildAllConfigurations make sure all refpaths are created.  -->
-    <_TargetGroupsWithIsAot Condition="'$(BuildAllConfigurations)' == 'true'" Include="@(TargetGroups)">
-      <IsAot>$([System.String]::new('%(Identity)').Contains('aot'))</IsAot>
-    </_TargetGroupsWithIsAot>
-    <BinPlaceConfiguration Condition="'$(BuildAllConfigurations)' == 'true'"
-                           Include="@(_TargetGroupsWithIsAot->WithMetadataValue('IsAot', 'false'))">
+    <BinPlaceConfiguration Condition="'$(BuildAllConfigurations)' == 'true'" Include="@(TargetGroups)">
       <RefPath>$(RefRootPath)%(Identity)/</RefPath>
     </BinPlaceConfiguration>
     <!-- for BuildAllConfigurations make sure runtimepaths are created for all vertical targetgroups. -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -34,65 +34,65 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>b8761d4848d42040c81ec25c8b51fd386b97f5f4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
     <Dependency Name="NETStandard.Library" Version="2.1.0-prerelease.19328.3">
       <Uri>https://github.com/dotnet/standard</Uri>
       <Sha>1f584e7228d2addac9f334536a111908ba136da1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="2.0.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="1.0.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="1.0.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="1.0.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="1.0.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="2.4.1-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="2.4.1-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.5.1-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="1.0.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="1.0.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="1.0.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.CoreFxTesting" Version="1.0.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="1.0.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="1.0.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Configuration" Version="1.0.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="2.2.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="1.0.0-beta.19328.2">
+    <Dependency Name="Microsoft.DotNet.VersionTools.Tasks" Version="1.0.0-beta.19329.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a68bcce61fa64598cbd30c00780b1f6ca8e7a9ef</Sha>
+      <Sha>3ebba82f29f338a3cb14f4b3e1b6da0fd69be694</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.IBC.CoreFx" Version="99.99.99-master-20190624.3">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -29,16 +29,16 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->
-    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19328.2</MicrosoftDotNetApiCompatPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19328.2</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19328.2</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19328.2</MicrosoftDotNetGenFacadesPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.1-beta.19328.2</MicrosoftDotNetXUnitExtensionsPackageVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.5.1-beta.19328.2</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19328.2</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>1.0.0-beta.19328.2</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19328.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftDotNetVersionToolsTasksPackageVersion>1.0.0-beta.19328.2</MicrosoftDotNetVersionToolsTasksPackageVersion>
+    <MicrosoftDotNetApiCompatPackageVersion>1.0.0-beta.19329.2</MicrosoftDotNetApiCompatPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>1.0.0-beta.19329.2</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>1.0.0-beta.19329.2</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenFacadesPackageVersion>1.0.0-beta.19329.2</MicrosoftDotNetGenFacadesPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>2.4.1-beta.19329.2</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.5.1-beta.19329.2</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
+    <MicrosoftDotNetBuildTasksPackagingPackageVersion>1.0.0-beta.19329.2</MicrosoftDotNetBuildTasksPackagingPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>1.0.0-beta.19329.2</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>2.2.0-beta.19329.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetVersionToolsTasksPackageVersion>1.0.0-beta.19329.2</MicrosoftDotNetVersionToolsTasksPackageVersion>
     <!-- Core-setup dependencies -->
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview7-27826-04</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostPackageVersion>3.0.0-preview7-27826-04</MicrosoftNETCoreDotNetHostPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,12 +57,11 @@
     <RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeWinX64RuntimeNativeSystemDataSqlClientSniPackageVersion>
     <RuntimeNativeSystemDataSqlClientSniPackageVersion>4.4.0</RuntimeNativeSystemDataSqlClientSniPackageVersion>
     <!-- Testing -->
-    <MicrosoftNETTestSdkPackageVersion>15.9.2</MicrosoftNETTestSdkPackageVersion>
-    <XUnitPackageVersion>2.4.1-pre.build.4059</XUnitPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>16.2.0</MicrosoftNETTestSdkPackageVersion>
+    <XUnitPackageVersion>2.4.1</XUnitPackageVersion>
     <TraceEventPackageVersion>2.0.5</TraceEventPackageVersion>
     <MicrosoftDotNetUapTestToolsPackageVersion>1.0.31</MicrosoftDotNetUapTestToolsPackageVersion>
     <NewtonsoftJsonPackageVersion>12.0.1</NewtonsoftJsonPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview6-27804-01</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>3.0.0-preview6-27804-01</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <!-- Test data -->
     <SystemIOCompressionTestDataPackageVersion>1.0.13</SystemIOCompressionTestDataPackageVersion>

--- a/eng/referenceFromRuntime.targets
+++ b/eng/referenceFromRuntime.targets
@@ -1,11 +1,9 @@
 <Project>
   <Target Name="AddReferenceFromRuntimeForTests"
-          AfterTargets="ResolveAssemblyReferences"
+          BeforeTargets="SetupDefaultReferences"
           Condition="'$(IsTestProject)'=='true' AND '@(ReferenceFromRuntime)' != ''">
     <ItemGroup>
-      <!-- tests can use anything from the RuntimePath -->
-      <ReferencePath Include="@(ReferenceFromRuntime->'$(RuntimePath)%(Identity).dll')" />
-      <ReferenceCopyLocalPaths Condition="'%(ReferenceFromRuntime.Private)' == 'true'" Include="@(ReferenceFromRuntime->'$(RuntimePath)%(Identity).dll')" />
+      <Reference Include="@(ReferenceFromRuntime->'$(RuntimePath)%(Identity).dll')" />
     </ItemGroup>
   </Target>
   

--- a/external/binplacePackages/binplacePackages.depproj
+++ b/external/binplacePackages/binplacePackages.depproj
@@ -18,11 +18,11 @@
   <ItemGroup Condition="'$(TargetsNetStandard)' != 'true'">
     <BinPlaceConfiguration Include="$(Configuration)">
       <ItemName>BinPlaceLib</ItemName>
-      <RuntimePath>$(TestHostRootPath)</RuntimePath>
+      <RuntimePath>$(RuntimePath)</RuntimePath>
     </BinPlaceConfiguration>
     <BinPlaceConfiguration Include="$(Configuration)">
       <ItemName>BinPlaceLib</ItemName>
-      <RuntimePath>$(RuntimePath)</RuntimePath>
+      <RuntimePath>$(TestHostRuntimePath)</RuntimePath>
     </BinPlaceConfiguration>
   </ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -3,10 +3,10 @@
     "dotnet": "3.0.100-preview7-012630"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19328.2",
-    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19328.2",
-    "Microsoft.DotNet.Build.Tasks.Configuration": "1.0.0-beta.19328.2",
-    "Microsoft.DotNet.CoreFxTesting": "1.0.0-beta.19328.2",
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19329.2",
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19329.2",
+    "Microsoft.DotNet.Build.Tasks.Configuration": "1.0.0-beta.19329.2",
+    "Microsoft.DotNet.CoreFxTesting": "1.0.0-beta.19329.2",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "3.0.0-preview8.19327.3"
   }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,6 +11,7 @@
     <GenerateResourceUsePreserializedResources>false</GenerateResourceUsePreserializedResources>
 
     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleset>
+    <DisableXUnitAnalyzer>true</DisableXUnitAnalyzer>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true' AND '$(IsTestSupportProject)' != 'true'">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -36,6 +36,22 @@
     
   </Target>
 
+  <Target Name="AddConflictResolutionAssetsForTests"
+          BeforeTargets="_HandlePackageFileConflicts"
+          Condition="'$(IsTestProject)' == 'true' and '@(DefaultReferenceExclusions)' != ''">
+    <ItemGroup>
+      <Reference Include="@(DefaultReferenceExclusions->'$(RefPath)%(Identity).dll')" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="RemoveConflictResolutionAssetsForTests"
+          AfterTargets="_HandlePackageFileConflicts"
+          Condition="'$(IsTestProject)' == 'true' and '@(DefaultReferenceExclusions)' != ''">
+    <ItemGroup>
+      <Reference Remove="@(DefaultReferenceExclusions->'$(RefPath)%(Identity).dll')" />
+    </ItemGroup>
+  </Target>
+
   <PropertyGroup>
     <!--
     Hack workaround to skip the GenerateCompiledExpressionsTempFile target in

--- a/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -11,6 +11,8 @@
     <GeneratorRuntimeConfig>$(MSBuildToolsPath)\MSBuild.runtimeconfig.json</GeneratorRuntimeConfig>
     <GeneratorCommand Condition="'$(TargetsNetCoreApp)' == 'true'">"$(TestHostRootPath)$([System.IO.Path]::GetFileName('$(DotNetTool)'))" --fx-version $(ProductVersion)</GeneratorCommand>
     <GeneratorCommand Condition="'$(TargetsNetCoreApp)' != 'true'">"$(DotNetTool)"</GeneratorCommand>
+    <GeneratorCommand Condition="'$(OS)' == 'Windows_NT'">set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
+    <GeneratorCommand Condition="'$(OS)' != 'Windows_NT'">export DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
   </PropertyGroup>
   <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
     <Compile Include=".\SGenTests.cs" />

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -14,16 +14,6 @@
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
-    <ProjectReference Include="..\..\System.Diagnostics.Tools\src\System.Diagnostics.Tools.csproj" />
-    <ProjectReference Include="..\..\System.Collections\src\System.Collections.csproj" />
-    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj" />
-    <ProjectReference Include="..\..\System.ObjectModel\src\System.ObjectModel.csproj" />
-    <ProjectReference Include="..\..\System.Reflection.Primitives\src\System.Reflection.Primitives.csproj" />
-    <ProjectReference Include="..\..\System.Linq\src\System.Linq.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="$(CommonPath)\System\Collections\Generic\ArrayBuilder.cs">
       <Link>Common\System\Collections\Generic\ArrayBuilder.cs</Link>
     </Compile>
@@ -222,6 +212,18 @@
     <Compile Include="System\Linq\Expressions\Interpreter\Utilities.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+    <Reference Include="System.Collections" />
+    <Reference Include="System.Diagnostics.Debug" />
+    <Reference Include="System.Diagnostics.Tools" />
+    <Reference Include="System.Linq" />
+    <Reference Include="System.ObjectModel" />
+    <Reference Include="System.Reflection.Emit" />
+    <Reference Include="System.Reflection.Emit.ILGeneration" />
+    <Reference Include="System.Reflection.Emit.Lightweight" />
+    <Reference Include="System.Reflection.Primitives" />
+    <Reference Include="System.Resources.ResourceManager" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Extensions" />
+    <Reference Include="System.Threading" />
   </ItemGroup>
 </Project>

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -9,32 +9,10 @@
     <IsInterpreting>false</IsInterpreting>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
-    <IncludeDefaultReferences>false</IncludeDefaultReferences>
   </PropertyGroup>
   <ItemGroup>
     <DefaultReferenceExclusions Include="System.Linq.Expressions" />
     <ReferenceFromRuntime Include="System.Linq.Expressions" />
-  </ItemGroup>
-  <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
-    <ReferenceFromRuntime Include="System.Runtime" />
-    <ReferenceFromRuntime Include="System.Collections" />
-    <ReferenceFromRuntime Include="System.Reflection.Primitives" />
-    <ReferenceFromRuntime Include="Microsoft.CSharp" />
-    <ReferenceFromRuntime Include="System.Runtime.Extensions" />
-    <ReferenceFromRuntime Include="System.Private.Uri" />
-    <ReferenceFromRuntime Include="System.Text.RegularExpressions" />
-    <ReferenceFromRuntime Include="System.Diagnostics.Debug" />
-    <ReferenceFromRuntime Include="System.ObjectModel" />
-    <ReferenceFromRuntime Include="System.Threading.Thread" />
-    <ReferenceFromRuntime Include="System.Threading.Tasks" />
-    <ReferenceFromRuntime Include="System.Linq" />
-    <ReferenceFromRuntime Include="System.Linq.Queryable" />
-    <ReferenceFromRuntime Include="System.Reflection" />
-    <ReferenceFromRuntime Include="System.IO.FileSystem" />
-    <ReferenceFromRuntime Include="System.Runtime.InteropServices.RuntimeInformation" />
-    <ReferenceFromRuntime Include="System.Runtime.InteropServices" />
-    <ReferenceFromRuntime Include="netstandard" />
   </ItemGroup>
   <ItemGroup>
     <AssembliesBeingTested Include="Microsoft.CSharp" />

--- a/src/pretest.proj
+++ b/src/pretest.proj
@@ -17,7 +17,10 @@
           Condition="'$(PlatformManifestFile)' != ''"
           BeforeTargets="GenerateFileVersionProps">
     <ItemGroup>
-      <SharedFrameworkRuntimeFiles Include="$(TestHostRuntimePath)*"
+      <_manualSharedFrameworkRuntimeFiles Include="System.Security.Cryptography.Native.OpenSsl.so" />
+      <_manualSharedFrameworkRuntimeFiles Include="System.Security.Cryptography.Native.Apple.dylib" />
+      <_manualSharedFrameworkRuntimeFiles Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
+      <SharedFrameworkRuntimeFiles Include="$(TestHostRuntimePath)*;@(_manualSharedFrameworkRuntimeFiles->'$(TestHostRuntimePath)%(Identity)')"
                                    Exclude="$(TestHostRuntimePath)dotnet-Microsoft.XmlSerializer.Generator.*"
                                    TargetPath="runtimes/" />
     </ItemGroup>

--- a/src/pretest.proj
+++ b/src/pretest.proj
@@ -2,14 +2,26 @@
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
-    <!-- Enable GenerateTestSharedFrameworkDepsFile from CoreFxTesting package -->
-    <GenerateTestSharedFrameworkDepsFile Condition="'$(BinplaceTestSharedFramework)' == 'true'">true</GenerateTestSharedFrameworkDepsFile>
+    <BuildDependsOnTargets>FilterProjects;GenerateLaunchSettingsFiles</BuildDependsOnTargets>
+    <BuildDependsOnTargets Condition="'$(BinplaceTestSharedFramework)' == 'true'">$(BuildDependsOnTargets);GenerateTestSharedFrameworkDepsFile</BuildDependsOnTargets>
+    <BuildDependsOnTargets Condition="'$(PlatformManifestFile)' != ''">$(BuildDependsOnTargets);GenerateFileVersionProps</BuildDependsOnTargets>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- This is necessary as inside VS project references that aren't part of the sln aren't built. -->
     <Project Include="$(CommonTestPath)\CoreFx.Private.TestUtilities\CoreFx.Private.TestUtilities.csproj" />
   </ItemGroup>
+
+  <!-- Microsoft.XmlSerializer.Generator should not be marked as a platform item and be copy-local instead. -->
+  <Target Name="CollectSharedFrameworkRuntimeFiles"
+          Condition="'$(PlatformManifestFile)' != ''"
+          BeforeTargets="GenerateFileVersionProps">
+    <ItemGroup>
+      <SharedFrameworkRuntimeFiles Include="$(TestHostRuntimePath)*"
+                                   Exclude="$(TestHostRuntimePath)dotnet-Microsoft.XmlSerializer.Generator.*"
+                                   TargetPath="runtimes/" />
+    </ItemGroup>
+  </Target>
 
   <!-- Generate launch settings support files to enable VS debugging. -->
   <Target Name="GenerateLaunchSettingsFiles" Condition="'$(EnableLaunchSettings)' == 'true'">
@@ -31,7 +43,7 @@
 
   <Target Name="Build"
           Condition="'$(SkipPrepareTest)' != 'true'"
-          DependsOnTargets="FilterProjects;GenerateTestSharedFrameworkDepsFile;GenerateLaunchSettingsFiles">
+          DependsOnTargets="$(BuildDependsOnTargets)">
 
     <MSBuild Targets="Build"
              Projects="@(Project)"

--- a/src/pretest.proj
+++ b/src/pretest.proj
@@ -16,10 +16,12 @@
   <Target Name="CollectSharedFrameworkRuntimeFiles"
           Condition="'$(PlatformManifestFile)' != ''"
           BeforeTargets="GenerateFileVersionProps">
-    <ItemGroup>
+    <ItemGroup Condition="'$(BuildingNETCoreAppVertical)' == 'true'">
       <_manualSharedFrameworkRuntimeFiles Include="System.Security.Cryptography.Native.OpenSsl.so" />
       <_manualSharedFrameworkRuntimeFiles Include="System.Security.Cryptography.Native.Apple.dylib" />
       <_manualSharedFrameworkRuntimeFiles Include="System.Security.Cryptography.Native.OpenSsl.dylib" />
+    </ItemGroup>
+    <ItemGroup>
       <SharedFrameworkRuntimeFiles Include="$(TestHostRuntimePath)*;@(_manualSharedFrameworkRuntimeFiles->'$(TestHostRuntimePath)%(Identity)')"
                                    Exclude="$(TestHostRuntimePath)dotnet-Microsoft.XmlSerializer.Generator.*"
                                    TargetPath="runtimes/" />


### PR DESCRIPTION
Requires https://github.com/dotnet/corefx/pull/36207

The property that points to the manifest which is passed down to the `_HandlePackageFileConflicts` task is set in CoreFxTesting. The only work necessary here is to generate the manifest file.