### PR TITLE
Minor follow-ups/cleanups in Http2Connection and Http2Stream

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -115,7 +115,7 @@ namespace System.Net.Test.Common
         public async Task<Frame> ReadFrameAsync(TimeSpan timeout)
         {
             using CancellationTokenSource timeoutCts = new CancellationTokenSource(timeout);
-            return await ReadFrameAsync(timeoutCts.Token);
+            return await ReadFrameAsync(timeoutCts.Token).ConfigureAwait(false);
         }
 
         private async Task<Frame> ReadFrameAsync(CancellationToken cancellationToken)
@@ -241,8 +241,8 @@ namespace System.Net.Test.Common
         {
             try
             {
-                await SendGoAway(lastStreamId);
-                await WaitForConnectionShutdownAsync();
+                await SendGoAway(lastStreamId).ConfigureAwait(false);
+                await WaitForConnectionShutdownAsync().ConfigureAwait(false);
             }
             catch (IOException)
             {
@@ -545,7 +545,7 @@ namespace System.Net.Test.Common
             if (readBody && (frame.Flags & FrameFlags.EndStream) == 0)
             {
                 // Read body until end of stream if needed.
-                requestData.Body = await ReadBodyAsync();
+                requestData.Body = await ReadBodyAsync().ConfigureAwait(false);
             }
 
             return (streamId, requestData);

--- a/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -94,7 +94,7 @@ namespace System.Net.Test.Common
 
         public async Task<Http2LoopbackConnection> EstablishConnectionAsync(params SettingsEntry[] settingsEntries)
         {
-            (Http2LoopbackConnection connection, _) = await EstablishConnectionGetSettingsAsync();
+            (Http2LoopbackConnection connection, _) = await EstablishConnectionGetSettingsAsync().ConfigureAwait(false);
             return connection;
         }
 
@@ -183,7 +183,7 @@ namespace System.Net.Test.Common
                 Task clientTask = clientFunc(server.Address);
                 Task serverTask = serverFunc(server);
 
-                await new Task[] { clientTask, serverTask }.WhenAllOrAnyFailed(timeout);
+                await new Task[] { clientTask, serverTask }.WhenAllOrAnyFailed(timeout).ConfigureAwait(false);
             }
         }
     }

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -162,7 +162,7 @@ namespace System.Net.Test.Common
             await AcceptConnectionAsync(async connection =>
             {
                 lines = await connection.ReadRequestHeaderAndSendCustomResponseAsync(response).ConfigureAwait(false);
-            });
+            }).ConfigureAwait(false);
 
             return lines;
         }
@@ -176,7 +176,7 @@ namespace System.Net.Test.Common
             await AcceptConnectionAsync(async connection =>
             {
                 lines = await connection.ReadRequestHeaderAndSendCustomResponseAsync(response).ConfigureAwait(false);
-            });
+            }).ConfigureAwait(false);
 
             return lines;
         }
@@ -190,7 +190,7 @@ namespace System.Net.Test.Common
             await AcceptConnectionAsync(async connection =>
             {
                 lines = await connection.ReadRequestHeaderAndSendResponseAsync(statusCode, additionalHeaders + "Connection: close\r\n", content).ConfigureAwait(false);
-            });
+            }).ConfigureAwait(false);
 
             return lines;
         }
@@ -700,7 +700,7 @@ namespace System.Net.Test.Common
 
                 if (readBody)
                 {
-                    requestData.Body = await ReadRequestBodyAsync();
+                    requestData.Body = await ReadRequestBodyAsync().ConfigureAwait(false);
                     _bodyRead = true;
                 }
 
@@ -789,22 +789,22 @@ namespace System.Net.Test.Common
                     headerString = GetHttpResponseHeaders(statusCode, headerString, contentLength, connectionClose : true);
                 }
 
-                await SendResponseAsync(headerString);
-                await SendResponseAsync(content);
+                await SendResponseAsync(headerString).ConfigureAwait(false);
+                await SendResponseAsync(content).ConfigureAwait(false);
             }
 
             public override async Task SendResponseBodyAsync(byte[] body, bool isFinal = true, int requestId = 0)
             {
-                await SendResponseAsync(Encoding.UTF8.GetString(body));
+                await SendResponseAsync(Encoding.UTF8.GetString(body)).ConfigureAwait(false);
             }
         }
 
         public override async Task<HttpRequestData> HandleRequestAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string content = null)
         {
-            using (Connection connection = await EstablishConnectionAsync())
+            using (Connection connection = await EstablishConnectionAsync().ConfigureAwait(false))
             {
-                HttpRequestData requestData = await connection.ReadRequestDataAsync();
-                await connection.SendResponseAsync(statusCode, headers, content : content);
+                HttpRequestData requestData = await connection.ReadRequestDataAsync().ConfigureAwait(false);
+                await connection.SendResponseAsync(statusCode, headers, content: content).ConfigureAwait(false);
 
                 return requestData;
             }

--- a/src/Common/tests/System/Net/RemoteServerQuery.cs
+++ b/src/Common/tests/System/Net/RemoteServerQuery.cs
@@ -32,7 +32,7 @@ namespace System.Net.Test.Common
         {
             try
             {
-                return await testCode();
+                return await testCode().ConfigureAwait(false);
             }
             catch (Exception actualException)
             {
@@ -49,7 +49,7 @@ namespace System.Net.Test.Common
         {
             try
             {
-                await testCode();
+                await testCode().ConfigureAwait(false);
             }
             catch (Exception actualException)
             {

--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -553,7 +553,7 @@ namespace System.Net.Http
             // cancellation (e.g. WebException when reading from canceled response stream).
             if (cts.IsCancellationRequested && e is HttpRequestException)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Canceled");
+                if (NetEventSource.IsEnabled) NetEventSource.Error(this, "Canceled");
                 throw new OperationCanceledException(cts.Token);
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -63,7 +63,7 @@ namespace System.Net.Http
                     if (NetEventSource.IsEnabled) Trace($"Exception from asynchronous processing: {e}");
                 }
             }
-    }
+        }
 
     }
 }


### PR DESCRIPTION
Some follow-ups to https://github.com/dotnet/corefx/pull/38226.
cc: @wfurt, @geoffkizer, @davidsh

- Fix/adjust several uses of string interpolation in SocketsHttpHandler.
- Remove a Task.WhenAny allocation from SendAsync in the common case where there is no request content or where the request content sending completes synchronously.
- In GetWaiterTask use CT.UnsafeRegister instead of Register, as the callback doesn't need ExecutionContext flowed.
- In GetWaiterTask, avoid allocating an unnecessary Task for the _waitSource if the token isn't cancelable.
- In GetWaiter task's cancellation callback, avoid allocating an OCE not associated with the wait.  Instead, just complete the waiter, and then rely on the subsequent cancellation check to propagate cancellation appropriately.
- Use CompareExchange to write to _abortException so that _abortException never changes its value once it's non-null.  We currently have several code paths that check the type of _abortException and then do something based on it, and that could cause issues if its type could change between the check and the action.
- Clean up HTTP2 SendAsync method, e.g. remove unnecessary tmps, remove duplicated await, use slightly more descriptive variable names, only wrap OCE with one for cancellationToken if cancellationToken has had cancellation requested.
- Replace a use of ExceptionDispatchInfo.Throw with just throw.  The former should be used when and only when throwing an exception object that may previously have been thrown; in this case we're throwing a new object that was never thrown before.
- Add detailed comment describing thread-safety around Http2Stream._waitSource
- Clean up a few comments
- Add some missing .ConfigureAwait(false) in loopback servers