### PR TITLE
Begin SocketAsyncEngine work processing on threadpool

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
@@ -21,11 +21,11 @@ internal static partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct SocketEvent
+        internal readonly struct SocketEvent
         {
-            public IntPtr Data;
-            public SocketEvents Events;
-            private int _padding;
+            public readonly IntPtr Data;
+            public readonly SocketEvents Events;
+            private readonly int _padding;
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventPort")]


### PR DESCRIPTION
This means with "Tweak preferLocal value in System.Net.Sockets" https://github.com/dotnet/corefx/pull/37369 the individual work items will be queued to the thread's local queues (for lower contention between engine threads when queuing) rather than the global queue; also the epoll thread will return to listening for events sooner.

/cc @tmds @adamsitnik 