### PR TITLE
Revert "Tweak preferLocal value in System.Net.Sockets"

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -254,7 +254,7 @@ namespace System.Net.Sockets
                     // we can't pool the object, as ProcessQueue may still have a reference to it, due to
                     // using a pattern whereby it takes the lock to grab an item, but then releases the lock
                     // to do further processing on the item that's still in the list.
-                    ThreadPool.UnsafeQueueUserWorkItem(s => s.InvokeCallback(allowPooling: false), this, preferLocal: true);
+                    ThreadPool.UnsafeQueueUserWorkItem(o => ((AsyncOperation)o).InvokeCallback(allowPooling: false), this);
                 }
 
                 Trace("Exit");
@@ -275,7 +275,7 @@ namespace System.Net.Sockets
                 else
                 {
                     // Async operation.  Process the IO on the threadpool.
-                    ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: true);
+                    ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
                 }
             }
 


### PR DESCRIPTION
Reverts dotnet/corefx#37369.  Offline experiments have not shown this to have benefits, and in fact have actually shown small regressions.  We can revert the revert if/when it demonstrates wins.