### PR TITLE
System.Drawing: Consolidate BitmapData class

### DIFF
--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -121,6 +121,7 @@
     <Compile Include="System\Drawing\SystemBrushes.cs" />
     <Compile Include="System\Drawing\TextureBrush.cs" />
     <Compile Include="System\Drawing\Drawing2D\CustomLineCapType.cs" />
+    <Compile Include="System\Drawing\Imaging\BitmapData.cs" />
     <Compile Include="System\Drawing\Imaging\EmfPlusFlags.cs" />
     <Compile Include="System\Drawing\Imaging\MetafileHeaderWmf.cs" />
     <Compile Include="System\Drawing\Imaging\MetafileHeaderEmf.cs" />

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/BitmapData.Unix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/BitmapData.Unix.cs
@@ -37,14 +37,14 @@ namespace System.Drawing.Imaging
     // MUST BE KEPT IN SYNC WITH gdip.h in libgdiplus!
     // The first 6 fields MUST also match MS definition
     [StructLayout(LayoutKind.Sequential)]
-    public sealed class BitmapData
+    public sealed partial class BitmapData
     {
-        private int width;
-        private int height;
-        private int stride;
-        private PixelFormat pixel_format; // int
-        private IntPtr scan0;
-        private int reserved;
+        private int _width;
+        private int _height;
+        private int _stride;
+        private PixelFormat _pixelFormat;
+        private IntPtr _scan0;
+        private int _reserved;
 #pragma warning disable 169
         // *** Warning ***    don't depend on those fields in managed
         //            code as they won't exists when using MS
@@ -62,84 +62,5 @@ namespace System.Drawing.Imaging
         private int transparent;
         // *** Warning ***
 #pragma warning restore 169
-
-        public int Height
-        {
-            get
-            {
-                return height;
-            }
-
-            set
-            {
-                height = value;
-            }
-        }
-
-        public int Width
-        {
-            get
-            {
-                return width;
-            }
-
-            set
-            {
-                width = value;
-            }
-        }
-
-        public PixelFormat PixelFormat
-        {
-            get
-            {
-
-                return pixel_format;
-            }
-
-            set
-            {
-                pixel_format = value;
-            }
-        }
-
-        public int Reserved
-        {
-            get
-            {
-                return reserved;
-            }
-
-            set
-            {
-                reserved = value;
-            }
-        }
-
-        public IntPtr Scan0
-        {
-            get
-            {
-                return scan0;
-            }
-
-            set
-            {
-                scan0 = value;
-            }
-        }
-
-        public int Stride
-        {
-            get
-            {
-                return stride;
-            }
-
-            set
-            {
-                stride = value;
-            }
-        }
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/BitmapData.Windows.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/BitmapData.Windows.cs
@@ -10,101 +10,13 @@ namespace System.Drawing.Imaging
     /// Specifies the attributes of a bitmap image.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public sealed class BitmapData
+    public sealed partial class BitmapData
     {
         private int _width;
         private int _height;
         private int _stride;
-        private int _pixelFormat;
+        private PixelFormat _pixelFormat;
         private IntPtr _scan0;
         private int _reserved;
-
-        /// <summary>
-        /// Specifies the pixel width of the <see cref='Bitmap'/>.
-        /// </summary>
-        public int Width
-        {
-            get { return _width; }
-            set { _width = value; }
-        }
-
-        /// <summary>
-        /// Specifies the pixel height of the <see cref='Bitmap'/>.
-        /// </summary>
-        public int Height
-        {
-            get { return _height; }
-            set { _height = value; }
-        }
-
-        /// <summary>
-        /// Specifies the stride width of the <see cref='Bitmap'/>.
-        /// </summary>
-        public int Stride
-        {
-            get { return _stride; }
-            set { _stride = value; }
-        }
-
-        /// <summary>
-        /// Specifies the format of the pixel information in this <see cref='Bitmap'/>.
-        /// </summary>
-        public PixelFormat PixelFormat
-        {
-            get { return (PixelFormat)_pixelFormat; }
-            set
-            {
-                switch (value)
-                {
-                    case PixelFormat.DontCare:
-                    // case PixelFormat.Undefined: same as DontCare
-                    case PixelFormat.Max:
-                    case PixelFormat.Indexed:
-                    case PixelFormat.Gdi:
-                    case PixelFormat.Format16bppRgb555:
-                    case PixelFormat.Format16bppRgb565:
-                    case PixelFormat.Format24bppRgb:
-                    case PixelFormat.Format32bppRgb:
-                    case PixelFormat.Format1bppIndexed:
-                    case PixelFormat.Format4bppIndexed:
-                    case PixelFormat.Format8bppIndexed:
-                    case PixelFormat.Alpha:
-                    case PixelFormat.Format16bppArgb1555:
-                    case PixelFormat.PAlpha:
-                    case PixelFormat.Format32bppPArgb:
-                    case PixelFormat.Extended:
-                    case PixelFormat.Format16bppGrayScale:
-                    case PixelFormat.Format48bppRgb:
-                    case PixelFormat.Format64bppPArgb:
-                    case PixelFormat.Canonical:
-                    case PixelFormat.Format32bppArgb:
-                    case PixelFormat.Format64bppArgb:
-                        break;
-                    default:
-                        throw new System.ComponentModel.InvalidEnumArgumentException(nameof(value), unchecked((int)value), typeof(PixelFormat));
-                }
-
-
-                _pixelFormat = (int)value;
-            }
-        }
-
-        /// <summary>
-        /// Specifies the address of the pixel data.
-        /// </summary>
-        public IntPtr Scan0
-        {
-            get { return _scan0; }
-            set { _scan0 = value; }
-        }
-
-        /// <summary>
-        /// Reserved. Do not use.
-        /// </summary>
-        public int Reserved
-        {
-            get { return _reserved; }
-            set { _reserved = value; }
-        }
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/BitmapData.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/BitmapData.cs
@@ -41,9 +41,34 @@ namespace System.Drawing.Imaging
             get { return _pixelFormat; }
             set
             {
-                if (!Enum.IsDefined(typeof(PixelFormat), value))
+                switch (value)
                 {
-                    throw new System.ComponentModel.InvalidEnumArgumentException(nameof(value), unchecked((int)value), typeof(PixelFormat));
+                    case PixelFormat.DontCare:
+                    // case PixelFormat.Undefined: same as DontCare
+                    case PixelFormat.Max:
+                    case PixelFormat.Indexed:
+                    case PixelFormat.Gdi:
+                    case PixelFormat.Format16bppRgb555:
+                    case PixelFormat.Format16bppRgb565:
+                    case PixelFormat.Format24bppRgb:
+                    case PixelFormat.Format32bppRgb:
+                    case PixelFormat.Format1bppIndexed:
+                    case PixelFormat.Format4bppIndexed:
+                    case PixelFormat.Format8bppIndexed:
+                    case PixelFormat.Alpha:
+                    case PixelFormat.Format16bppArgb1555:
+                    case PixelFormat.PAlpha:
+                    case PixelFormat.Format32bppPArgb:
+                    case PixelFormat.Extended:
+                    case PixelFormat.Format16bppGrayScale:
+                    case PixelFormat.Format48bppRgb:
+                    case PixelFormat.Format64bppPArgb:
+                    case PixelFormat.Canonical:
+                    case PixelFormat.Format32bppArgb:
+                    case PixelFormat.Format64bppArgb:
+                        break;
+                    default:
+                        throw new System.ComponentModel.InvalidEnumArgumentException(nameof(value), unchecked((int)value), typeof(PixelFormat));
                 }
 
                 _pixelFormat = value;

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/BitmapData.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/BitmapData.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Drawing.Imaging
+{
+    public partial class BitmapData
+    {
+        /// <summary>
+        /// Specifies the pixel width of the <see cref='Bitmap'/>.
+        /// </summary>
+        public int Width
+        {
+            get { return _width; }
+            set { _width = value; }
+        }
+
+        /// <summary>
+        /// Specifies the pixel height of the <see cref='Bitmap'/>.
+        /// </summary>
+        public int Height
+        {
+            get { return _height; }
+            set { _height = value; }
+        }
+
+        /// <summary>
+        /// Specifies the stride width of the <see cref='Bitmap'/>.
+        /// </summary>
+        public int Stride
+        {
+            get { return _stride; }
+            set { _stride = value; }
+        }
+
+        /// <summary>
+        /// Specifies the format of the pixel information in this <see cref='Bitmap'/>.
+        /// </summary>
+        public PixelFormat PixelFormat
+        {
+            get { return _pixelFormat; }
+            set
+            {
+                if (!Enum.IsDefined(typeof(PixelFormat), value))
+                {
+                    throw new System.ComponentModel.InvalidEnumArgumentException(nameof(value), unchecked((int)value), typeof(PixelFormat));
+                }
+
+                _pixelFormat = value;
+            }
+        }
+
+        /// <summary>
+        /// Specifies the address of the pixel data.
+        /// </summary>
+        public IntPtr Scan0
+        {
+            get { return _scan0; }
+            set { _scan0 = value; }
+        }
+
+        /// <summary>
+        /// Reserved. Do not use.
+        /// </summary>
+        public int Reserved
+        {
+            get { return _reserved; }
+            set { _reserved = value; }
+        }
+    }
+}

--- a/src/System.Drawing.Common/tests/Imaging/BitmapDataTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/BitmapDataTests.cs
@@ -106,7 +106,6 @@ namespace System.Drawing.Imaging.Tests
             Assert.Equal(pixelFormat, bd.PixelFormat);
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void PixelFormat_SetInvalid_ThrowsInvalidEnumException()
         {


### PR DESCRIPTION
The properties used for `BitmapData` can be shared across the Windows & Unix implementation. Doing this also enables the argument validation on the `PixelFormat` property, which means one less test which needs to disable on Unix.