### PR TITLE
Generate APICatalog drop as part of official builds

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -14,7 +14,15 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
+    <Dependency Name="Microsoft.AspNetCore.App.Ref" Version="3.0.0-preview7.19322.3">
+      <Uri>https://github.com/aspnet/AspNetCore</Uri>
+      <Sha>6761dec9c69ffb4cd5b14a0a663ab73aa01fc7e2</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview7-27822-05">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>1af2ba41a56e09064091dc82264057289b56bd15</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="3.0.0-preview7-27822-05">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>1af2ba41a56e09064091dc82264057289b56bd15</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -42,6 +42,7 @@
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview7-27822-05</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostPackageVersion>3.0.0-preview7-27822-05</MicrosoftNETCoreDotNetHostPackageVersion>
     <MicrosoftNETCoreDotNetHostPolicyPackageVersion>3.0.0-preview7-27822-05</MicrosoftNETCoreDotNetHostPolicyPackageVersion>
+    <MicrosoftWindowsDesktopAppRefPackageVersion>3.0.0-preview7-27822-05</MicrosoftWindowsDesktopAppRefPackageVersion>
     <!-- Coreclr dependencies -->
     <MicrosoftNETCoreILAsmPackageVersion>3.0.0-preview7.19320.3</MicrosoftNETCoreILAsmPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>3.0.0-preview7.19320.3</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
@@ -80,6 +81,8 @@
     <MicrosoftPrivateIntellisensePackageVersion>3.0.0-preview3-190305-0</MicrosoftPrivateIntellisensePackageVersion>
     <!-- ILLink -->
     <ILLinkTasksPackageVersion>0.1.5-preview-1461378</ILLinkTasksPackageVersion>
+    <!-- ASP.Net -->
+    <MicrosoftAspNetCoreAppRefPackageVersion>3.0.0-preview7.19322.3</MicrosoftAspNetCoreAppRefPackageVersion>
   </PropertyGroup>
   <!-- Override isolated build dependency versions with versions from Repo API. -->
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -151,45 +151,46 @@ jobs:
                     /p:SymbolServerPAT=$(symweb-symbol-server-pat)
             displayName: Publish symbols to symweb
 
-      - job: GenerateApiCatalogLayout
-        displayName: Generate API Catalog Layout
-        timeoutInMinutes: 60
-        continueOnError: true
+      - ${{ if eq($(Build.SourceBranchName) 'master') }}:
+        - job: GenerateApiCatalogLayout
+          displayName: Generate API Catalog Layout
+          timeoutInMinutes: 60
+          continueOnError: true
 
-        ${{ if ne(parameters.dependsOn, '') }}:
-          dependsOn: ${{ parameters.dependsOn }}
+          ${{ if ne(parameters.dependsOn, '') }}:
+            dependsOn: ${{ parameters.dependsOn }}
 
-        pool:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2017
+          pool:
+            name: NetCoreInternal-Pool
+            queue: buildpool.windows.10.amd64.vs2017
 
-        workspace:
-          clean: all
+          workspace:
+            clean: all
 
-        variables:
-          - group: Publish-Build-Assets
-          - group: DotNet-Blob-Feed
-          - _dotnetFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-          - _maestroApiEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
-          - _TeamName: DotNetCore
-          - _SignType: real
+          variables:
+            - group: Publish-Build-Assets
+            - group: DotNet-Blob-Feed
+            - _dotnetFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+            - _maestroApiEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
+            - _TeamName: DotNetCore
+            - _SignType: real
 
-        steps:
-          - task: DownloadBuildArtifacts@0
-            displayName: Download packages from build
-            inputs:
-              artifactName: packages
-              downloadPath: ${{ parameters.artifactsDir }}
+          steps:
+            - task: DownloadBuildArtifacts@0
+              displayName: Download packages from build
+              inputs:
+                artifactName: packages
+                downloadPath: ${{ parameters.artifactsDir }}
 
-          - script: build.cmd -restore -ci
-            displayName: Restore Tools
+            - script: build.cmd -restore -ci
+              displayName: Restore Tools
 
-          - script: powershell pkg\Microsoft.Windows.Compatibility\tests\publishcompatibilityassets.ps1
-            displayName: Generate local APICatalog layout
+            - script: powershell pkg\Microsoft.Windows.Compatibility\tests\publishcompatibilityassets.ps1
+              displayName: Generate local APICatalog layout
 
-          - task: CopyFiles@2
-            displayName: Copy API Catalog Layout to CPVSBuild
-            inputs:
-              sourceFolder: ${{ parameters.artifactsDir }}/ApiCatalogLayout/GeneratedLayout
-              contents: '**\*'
-              targetFolder: \\cpvsbuild\drops\DotNetCore\DotNet-CoreFx-APICatalog-LayoutDrop\$(Build.BuildNumber)
+            - task: CopyFiles@2
+              displayName: Copy API Catalog Layout to CPVSBuild
+              inputs:
+                sourceFolder: ${{ parameters.artifactsDir }}/ApiCatalogLayout/GeneratedLayout
+                contents: '**\*'
+                targetFolder: \\cpvsbuild\drops\DotNetCore\DotNet-CoreFx-APICatalog-LayoutDrop\$(Build.BuildNumber)

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -190,6 +190,6 @@ jobs:
           - task: CopyFiles@2
             displayName: Copy API Catalog Layout to CPVSBuild
             inputs:
-              sourceFolder: ${{ parameters.artifactsDir }}/ApiCatalogLayout
+              sourceFolder: ${{ parameters.artifactsDir }}/ApiCatalogLayout/GeneratedLayout
               contents: '**\*'
               targetFolder: \\cpvsbuild\drops\DotNetCore\DotNet-CoreFx-APICatalog-LayoutDrop\$(Build.BuildNumber)

--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -150,3 +150,46 @@ jobs:
                     /p:SymbolServerPath=$(_symwebSymbolServerUrl)
                     /p:SymbolServerPAT=$(symweb-symbol-server-pat)
             displayName: Publish symbols to symweb
+
+      - job: GenerateApiCatalogLayout
+        displayName: Generate API Catalog Layout
+        timeoutInMinutes: 60
+        continueOnError: true
+
+        ${{ if ne(parameters.dependsOn, '') }}:
+          dependsOn: ${{ parameters.dependsOn }}
+
+        pool:
+          name: NetCoreInternal-Pool
+          queue: buildpool.windows.10.amd64.vs2017
+
+        workspace:
+          clean: all
+
+        variables:
+          - group: Publish-Build-Assets
+          - group: DotNet-Blob-Feed
+          - _dotnetFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+          - _maestroApiEndpoint: https://maestro-prod.westus2.cloudapp.azure.com
+          - _TeamName: DotNetCore
+          - _SignType: real
+
+        steps:
+          - task: DownloadBuildArtifacts@0
+            displayName: Download packages from build
+            inputs:
+              artifactName: packages
+              downloadPath: ${{ parameters.artifactsDir }}
+
+          - script: build.cmd -restore -ci
+            displayName: Restore Tools
+
+          - script: powershell pkg\Microsoft.Windows.Compatibility\tests\publishcompatibilityassets.ps1
+            displayName: Generate local APICatalog layout
+
+          - task: CopyFiles@2
+            displayName: Copy API Catalog Layout to CPVSBuild
+            inputs:
+              sourceFolder: ${{ parameters.artifactsDir }}/ApiCatalogLayout
+              contents: '**\*'
+              targetFolder: \\cpvsbuild\drops\DotNetCore\DotNet-CoreFx-APICatalog-LayoutDrop\$(Build.BuildNumber)

--- a/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
+++ b/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
@@ -7,7 +7,6 @@
     <!-- Setting NETCoreAppMaximumVersion to a high version so that the sdk doesn't complain if we're restoring/publishing for a higher version than the sdk. -->
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
     <PackageConflictPreferredPackages Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Microsoft.Private.CoreFx.NETCoreApp;runtime.$(RuntimeIdentifiers).Microsoft.Private.CoreFx.NETCoreApp;$(PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
-    <DisableImplicitFrameworkReferences Condition="$(TargetFramework.Contains('netcoreapp'))">true</DisableImplicitFrameworkReferences>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 </Project>

--- a/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
+++ b/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
@@ -1,15 +1,11 @@
 <Project>
   <PropertyGroup>
     <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
-    <BaseIntermediateOutputPath>bin</BaseIntermediateOutputPath>
-    <NuGetTargetMoniker Condition="'$(NugetMonikerVersion)' != ''">.NETCoreApp,Version=v$(NugetMonikerVersion)</NuGetTargetMoniker>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <!-- Setting NETCoreAppMaximumVersion to a high version so that the sdk doesn't complain if we're restoring/publishing for a higher version than the sdk. -->
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
     <PackageConflictPreferredPackages Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Microsoft.Private.CoreFx.NETCoreApp;runtime.$(RuntimeIdentifiers).Microsoft.Private.CoreFx.NETCoreApp;$(PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <IntermediateOutputPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</IntermediateOutputPath>
-    <OutputPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</OutputPath>
-    <MSBuildProjectExtensionsPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</MSBuildProjectExtensionsPath>
+    <BaseIntermediateOutputPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</BaseIntermediateOutputPath>
   </PropertyGroup>
 </Project>

--- a/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
+++ b/pkg/Microsoft.Windows.Compatibility/tests/Directory.Build.props
@@ -8,5 +8,8 @@
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
     <PackageConflictPreferredPackages Condition="'$(TargetFramework)' != 'netcoreapp2.0'">Microsoft.Private.CoreFx.NETCoreApp;runtime.$(RuntimeIdentifiers).Microsoft.Private.CoreFx.NETCoreApp;$(PackageConflictPreferredPackages)</PackageConflictPreferredPackages>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <IntermediateOutputPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</IntermediateOutputPath>
+    <OutputPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</OutputPath>
+    <MSBuildProjectExtensionsPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</MSBuildProjectExtensionsPath>
   </PropertyGroup>
 </Project>

--- a/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
+++ b/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
@@ -8,10 +8,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp" Version="$(PrivateCorefxNetCoreAppPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.App.Ref" Version="$(MicrosoftAspNetCoreAppRefPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true" />
-    <Reference Include="$(PkgMicrosoftAspNetCoreAppRef)\ref\$(TargetFramework)\*.dll" />
+    <Reference Include="$(PkgMicrosoft_AspNetCore_App_Ref)\ref\$(TargetFramework)\*.dll" />
     <PackageReference Include="Microsoft.WindowsDesktop.App.Ref" Version="$(MicrosoftWindowsDesktopAppRefPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true"  />
-    <Reference Include="$(PkgMicrosoftWindowsDesktopAppRef)\ref\$(TargetFramework)\*.dll" />
-    <!-- CoreFx -->
+    <Reference Include="$(PkgMicrosoft_WindowsDesktop_App_Ref)\ref\$(TargetFramework)\*.dll" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'uap10.0.16300'">
@@ -28,9 +27,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>uap10.0.16300;netcoreapp3.0</TargetFrameworks>
-    <IntermediateOutputPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</IntermediateOutputPath>
-    <OutputPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</OutputPath>
-    <MSBuildProjectExtensionsPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</MSBuildProjectExtensionsPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('uap'))">
@@ -39,7 +35,7 @@
     <DisableStandardFrameworkResolution>true</DisableStandardFrameworkResolution>
   </PropertyGroup>
 
-  <Target Name="GetReferences" DependsOnTargets="Restore">
+  <Target Name="GetReferences">
     <ItemGroup>
       <_targetFrameworks Include="$(TargetFrameworks)" />
     </ItemGroup>

--- a/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
+++ b/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
@@ -16,14 +16,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'uap10.0.16300'">
     <PackageReference Include="Microsoft.Private.CoreFx.UAP" Version="$(PrivateCorefxUAPPackageVersion)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.NETCore.App" Version="2.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="Microsoft.NETCore.App" Version="2.0.9" />
-  </ItemGroup>
 
   <PropertyGroup>
     <TargetFrameworks>uap10.0.16300;netcoreapp3.0</TargetFrameworks>
@@ -35,17 +27,17 @@
     <DisableStandardFrameworkResolution>true</DisableStandardFrameworkResolution>
   </PropertyGroup>
 
-  <Target Name="GetReferences">
+  <Target Name="CopyReferences">
     <ItemGroup>
       <_targetFrameworks Include="$(TargetFrameworks)" />
     </ItemGroup>
     <MSBuild Projects="$(MSBuildProjectFile)"
-             Targets="_getReferences"
+             Targets="_copyReferences"
              Condition="'$(TargetFramework)' == ''"
              Properties="TargetFramework=%(_targetFrameworks.Identity)" />
   </Target>
 
-  <Target Name="_getReferences" DependsOnTargets="ResolveReferences">
+  <Target Name="_copyReferences" DependsOnTargets="ResolveReferences">
     <ItemGroup>
       <_docFiles Include="@(ReferencePath->'%(RootDir)%(Directory)%(FileName).xml')" />
       <_docFilesExists Include="@(_docFiles)" Condition="Exists('%(FullPath)')" />

--- a/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
+++ b/pkg/Microsoft.Windows.Compatibility/tests/Microsoft.Windows.Compatibility.Validation.csproj
@@ -1,19 +1,63 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../../../eng/Versions.props" />
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="$(CompatibilityPackageVersion)" />
-   </ItemGroup>
-   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp" Version="$(PrivateCorefxPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="3.0.0-*" />
-    <PackageReference Include="Microsoft.DesktopUI.App" Version="3.0.0-*" />
-    <PackageReference Include="System.Windows.Extensions" Version="4.6.0-*" />
-   </ItemGroup>
-   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp" Version="$(PrivateCorefxNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.App.Ref" Version="$(MicrosoftAspNetCoreAppRefPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true" />
+    <Reference Include="$(PkgMicrosoftAspNetCoreAppRef)\ref\$(TargetFramework)\*.dll" />
+    <PackageReference Include="Microsoft.WindowsDesktop.App.Ref" Version="$(MicrosoftWindowsDesktopAppRefPackageVersion)" ExcludeAssets="All" GeneratePathProperty="true"  />
+    <Reference Include="$(PkgMicrosoftWindowsDesktopAppRef)\ref\$(TargetFramework)\*.dll" />
+    <!-- CoreFx -->
+    <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'uap10.0.16300'">
+    <PackageReference Include="Microsoft.Private.CoreFx.UAP" Version="$(PrivateCorefxUAPPackageVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.NETCore.App" Version="2.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
-   </ItemGroup>
-   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.0.9" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>uap10.0.16300;netcoreapp3.0</TargetFrameworks>
+    <IntermediateOutputPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</IntermediateOutputPath>
+    <OutputPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</OutputPath>
+    <MSBuildProjectExtensionsPath Condition="'$(RestoreOutputPath)' != ''">$(RestoreOutputPath)</MSBuildProjectExtensionsPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('uap'))">
+    <TargetFrameworkIdentifier>UAP</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v$(TargetFramework.SubString(3))</TargetFrameworkVersion>
+    <DisableStandardFrameworkResolution>true</DisableStandardFrameworkResolution>
+  </PropertyGroup>
+
+  <Target Name="GetReferences" DependsOnTargets="Restore">
+    <ItemGroup>
+      <_targetFrameworks Include="$(TargetFrameworks)" />
+    </ItemGroup>
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="_getReferences"
+             Condition="'$(TargetFramework)' == ''"
+             Properties="TargetFramework=%(_targetFrameworks.Identity)" />
+  </Target>
+
+  <Target Name="_getReferences" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <_docFiles Include="@(ReferencePath->'%(RootDir)%(Directory)%(FileName).xml')" />
+      <_docFilesExists Include="@(_docFiles)" Condition="Exists('%(FullPath)')" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(ReferencePath)" DestinationFolder="$(RestoreOutputPath)\GeneratedLayout\$(TargetFramework)\ref" />
+    <Copy SourceFiles="@(_docFilesExists)" DestinationFolder="$(RestoreOutputPath)\GeneratedLayout\$(TargetFramework)\xml" />
+  </Target>
+
+
 </Project>

--- a/pkg/Microsoft.Windows.Compatibility/tests/publishcompatibilityassets.ps1
+++ b/pkg/Microsoft.Windows.Compatibility/tests/publishcompatibilityassets.ps1
@@ -46,6 +46,9 @@ $privateNetcoreappPackageVersion = _getPackageVersion "Microsoft.Private.CoreFx.
 $privateUAPPackageVersion = _getPackageVersion "Microsoft.Private.CoreFx.UAP"
 $systemWindowsExtensionsVersion = _getPackageVersion "System.Windows.Extensions"
 
+Write-Output "Restoring packages for APICatalog Layout"
+& $dotnetPath restore --packages $restoreOutputPath /p:RestoreSources="$restoreSources" /p:CompatibilityPackageVersion=$compatPackageVersion /p:PrivateCorefxNetCoreAppPackageVersion=$privateNetcoreappPackageVersion /p:PrivateCorefxUAPPackageVersion=$privateUAPPackageVersion /p:SystemWindowsExtensionsVersion=$systemWindowsExtensionsVersion /p:RestoreOutputPath=$restoreOutputPath $csprojPath
+
 Write-Output "Generating APICatalog Layout"
 & $dotnetPath msbuild /t:GetReferences /p:RestoreSources="$restoreSources" /p:CompatibilityPackageVersion=$compatPackageVersion /p:PrivateCorefxNetCoreAppPackageVersion=$privateNetcoreappPackageVersion /p:PrivateCorefxUAPPackageVersion=$privateUAPPackageVersion /p:SystemWindowsExtensionsVersion=$systemWindowsExtensionsVersion /p:RestoreOutputPath=$restoreOutputPath $csprojPath
 

--- a/pkg/Microsoft.Windows.Compatibility/tests/publishcompatibilityassets.ps1
+++ b/pkg/Microsoft.Windows.Compatibility/tests/publishcompatibilityassets.ps1
@@ -46,7 +46,7 @@ Write-Output "Restoring packages for APICatalog Layout"
 & $dotnetPath restore --packages $restoreOutputPath /p:RestoreSources="$restoreSources" /p:CompatibilityPackageVersion=$compatPackageVersion /p:PrivateCorefxNetCoreAppPackageVersion=$privateNetcoreappPackageVersion /p:PrivateCorefxUAPPackageVersion=$privateUAPPackageVersion /p:SystemWindowsExtensionsVersion=$systemWindowsExtensionsVersion /p:RestoreOutputPath=$restoreOutputPath $csprojPath
 
 Write-Output "Generating APICatalog Layout"
-& $dotnetPath msbuild /t:GetReferences /p:RestoreSources="$restoreSources" /p:CompatibilityPackageVersion=$compatPackageVersion /p:PrivateCorefxNetCoreAppPackageVersion=$privateNetcoreappPackageVersion /p:PrivateCorefxUAPPackageVersion=$privateUAPPackageVersion /p:SystemWindowsExtensionsVersion=$systemWindowsExtensionsVersion /p:RestoreOutputPath=$restoreOutputPath $csprojPath
+& $dotnetPath msbuild /t:CopyReferences /p:RestoreSources="$restoreSources" /p:CompatibilityPackageVersion=$compatPackageVersion /p:PrivateCorefxNetCoreAppPackageVersion=$privateNetcoreappPackageVersion /p:PrivateCorefxUAPPackageVersion=$privateUAPPackageVersion /p:SystemWindowsExtensionsVersion=$systemWindowsExtensionsVersion /p:RestoreOutputPath=$restoreOutputPath $csprojPath
 
 if (!(Test-Path $restoreOutputPath))
 {

--- a/pkg/Microsoft.Windows.Compatibility/tests/publishcompatibilityassets.ps1
+++ b/pkg/Microsoft.Windows.Compatibility/tests/publishcompatibilityassets.ps1
@@ -26,17 +26,13 @@ $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 $repoRoot = ((get-item $PSScriptRoot).parent.parent.parent.FullName)
 $dotnetPath = -join($repoRoot, "\.dotnet\dotnet.exe")
 $csprojPath = -join($PSScriptRoot, "\", (Get-ChildItem $PSScriptRoot"\*.csproj" | Select-Object -ExpandProperty Name))
-$localPackageSourcePath = -join($repoRoot, "\artifacts\packages\Debug\")
+$localPackageSourcePath = -join($repoRoot, "\artifacts\packages\")
 $restoreOutputPath = -join($repoRoot, "\artifacts\ApiCatalogLayout\")
 
 if (!(Test-Path $localPackageSourcePath))
 {
-	$localPackageSourcePath = -join($repoRoot, "\artifacts\packages\Release\")
-	if (!(Test-Path $localPackageSourcePath))
-	{
-		Write-Error -Message (-join('Local package source must exist ', $localPackageSourcePath))
-		Exit;
-	}
+	Write-Error -Message (-join('Local package source must exist ', $localPackageSourcePath))
+	Exit;
 }
 
 $restoreSources = -join("https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json;", $localPackageSourcePath)


### PR DESCRIPTION
Attempts to resolve https://github.com/dotnet/corefx/issues/36613

Creates a drop at `cpvsbuild` with the ref assemblies & .xml files from CoreFx (netcoreapp/uap), WPF/Winforms, and ASPNetCore, for API Catalog generation. The layout is simplified a bit:

> {tfm}
    -->ref
        ---->\*.dll
    -->xml
        ---->\*.xml

The current state of this doesn't copy the packages to cpvsbuild (the previous tool did copy packages, but that can be fixed).

The task is designated as `ContinueOnError`, so it shouldn't make the official builds flakier.

This will also require adding a DARC subscription from AspNetCore -> CoreFx. We can also disable the old VSTS job that generated drops.

I have a local drop with the generated layout, if anyone wants to inspect what it looks like. I'm still in the process of making sure we didn't drop any assemblies that used to be copied to `cpvsbuild`, but I figured I'd throw this up in the meantime to get some eyes on it.

@ericstj @safern @ViktorHofer PTAL

CC @terrajobst for the APICatalog aspect
