### PR TITLE
Eat SocketException during Http2LoopbackConnection.ShutdownIgnoringErrorsAsync

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -248,6 +248,10 @@ namespace System.Net.Test.Common
             {
                 // Ignore connection errors
             }
+            catch (SocketException)
+            {
+                // Ignore connection errors
+            }
         }
 
         public async Task<int> ReadRequestHeaderAsync()


### PR DESCRIPTION
This stray exception getting through is causing random CI innerloop failures.

cc @davidsh