### PR TITLE
Remove TargetSite checks from DictionaryConcurrentAccessDetection

### DIFF
--- a/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.ConcurrentAccessDetection.netcoreapp.cs
+++ b/src/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.ConcurrentAccessDetection.netcoreapp.cs
@@ -28,10 +28,10 @@ namespace Generic.Dictionary
 
                 Assert.Equal(comparer, dictionary.GetType().GetField("_comparer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(dictionary));
                 Assert.Equal(isValueType, dictionary.GetType().GetGenericArguments()[0].IsValueType);
-                Assert.Equal("ThrowInvalidOperationException_ConcurrentOperationsNotSupported", Assert.Throws<InvalidOperationException>(() => add(dictionary)).TargetSite.Name);
-                Assert.Equal("ThrowInvalidOperationException_ConcurrentOperationsNotSupported", Assert.Throws<InvalidOperationException>(() => get(dictionary)).TargetSite.Name);
-                Assert.Equal("ThrowInvalidOperationException_ConcurrentOperationsNotSupported", Assert.Throws<InvalidOperationException>(() => remove(dictionary)).TargetSite.Name);
-                Assert.Equal("ThrowInvalidOperationException_ConcurrentOperationsNotSupported", Assert.Throws<InvalidOperationException>(() => removeOutParam(dictionary)).TargetSite.Name);
+                Assert.Throws<InvalidOperationException>(() => add(dictionary));
+                Assert.Throws<InvalidOperationException>(() => get(dictionary));
+                Assert.Throws<InvalidOperationException>(() => remove(dictionary));
+                Assert.Throws<InvalidOperationException>(() => removeOutParam(dictionary));
             }, TaskCreationOptions.LongRunning);
 
             // If Dictionary regresses, we do not want to hang here indefinitely


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38852
cc: @danmosemsft, @safern 