### PR TITLE
Fix XmlLicenseTransformTest.ItDecryptsLicense test

### DIFF
--- a/src/System.Security.Cryptography.Xml/tests/XmlLicenseTransformTest.cs
+++ b/src/System.Security.Cryptography.Xml/tests/XmlLicenseTransformTest.cs
@@ -168,8 +168,8 @@ namespace System.Security.Cryptography.Xml.Tests
                 string expected;
                 string encryptedLicenseWithGrants = GenerateLicenseXmlWithEncryptedGrants(key, out expected);
 
-                Assert.Contains("hello", expected);
-                Assert.DoesNotContain("hello", encryptedLicenseWithGrants);
+                Assert.Contains("hello!", expected);
+                Assert.DoesNotContain("hello!", encryptedLicenseWithGrants);
 
                 XmlNamespaceManager nsManager;
                 XmlDocument toDecrypt = LoadXmlWithLicenseNs(encryptedLicenseWithGrants, out nsManager);
@@ -224,7 +224,7 @@ namespace System.Security.Cryptography.Xml.Tests
             <r:principal varRef=""p0"" />
             <x:bar xmlns:x=""urn:foo"" />
             <r:digitalResource>
-                <testItem>hello</testItem>
+                <testItem>hello!</testItem>
             </r:digitalResource>
             <renderer xmlns=""urn:mpeg:mpeg21:2003:01-REL-MX-NS"">
                 <mx:wildcard xmlns:mx=""urn:mpeg:mpeg21:2003:01-REL-MX-NS"">


### PR DESCRIPTION
Use a phrase that can't be valid base64.
Fixes https://github.com/dotnet/corefx/issues/38843
cc: @bartonjs