### PR TITLE
Default distro version for tests

### DIFF
--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformApis.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformApis.Unix.cs
@@ -203,12 +203,13 @@ namespace System
                     }
                 }
             }
+            // possibly should fall back to /usr/lib/os-release here
 
             if (result != null)
             {
                 result = NormalizeDistroInfo(result);
             }
-            
+
             return result;
         }
 
@@ -238,7 +239,7 @@ namespace System
 
             // In some distros/versions we cannot discover the distro version; return something valid.
             // Pick a high version number, since this seems to happen on newer distros.
-            if (String.IsNullOrEmpty(_distroInfo.Value?.VersionId))
+            if (String.IsNullOrEmpty(distroInfo.VersionId))
             {
                 distroInfo.VersionId = (new Version(Int32.MaxValue, Int32.MaxValue)).ToString();
             }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformApis.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformApis.Unix.cs
@@ -239,9 +239,9 @@ namespace System
 
             // In some distros/versions we cannot discover the distro version; return something valid.
             // Pick a high version number, since this seems to happen on newer distros.
-            if (String.IsNullOrEmpty(distroInfo.VersionId))
+            if (string.IsNullOrEmpty(distroInfo.VersionId))
             {
-                distroInfo.VersionId = (new Version(Int32.MaxValue, Int32.MaxValue)).ToString();
+                distroInfo.VersionId = new Version(Int32.MaxValue, Int32.MaxValue).ToString();
             }
 
             return distroInfo;

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformApis.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformApis.Unix.cs
@@ -238,7 +238,7 @@ namespace System
 
             // In some distros/versions we cannot discover the distro version; return something valid.
             // Pick a high version number, since this seems to happen on newer distros.
-            if (String.IsNullOrEmpty(_distroInfo.Value?.VersionId)
+            if (String.IsNullOrEmpty(_distroInfo.Value?.VersionId))
             {
                 distroInfo.VersionId = (new Version(Int32.MaxValue, Int32.MaxValue)).ToString();
             }

--- a/src/CoreFx.Private.TestUtilities/src/System/PlatformApis.Unix.cs
+++ b/src/CoreFx.Private.TestUtilities/src/System/PlatformApis.Unix.cs
@@ -236,6 +236,13 @@ namespace System
                 distroInfo.VersionId = distroInfo.VersionId.Substring(0, lastVersionNumberSeparatorIndex);
             }
 
+            // In some distros/versions we cannot discover the distro version; return something valid.
+            // Pick a high version number, since this seems to happen on newer distros.
+            if (String.IsNullOrEmpty(_distroInfo.Value?.VersionId)
+            {
+                distroInfo.VersionId = (new Version(Int32.MaxValue, Int32.MaxValue)).ToString();
+            }
+
             return distroInfo;
         }
 


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/38443

I removed VERSION_ID from my etc/os-release and verified it fails without this change, passes with it.