### PR TITLE
Use SpanTestHelpers from Common within StringTests rather than TestHelpers which doesn't exist

### DIFF
--- a/src/Common/tests/Tests/System/SpanTestHelpers.cs
+++ b/src/Common/tests/Tests/System/SpanTestHelpers.cs
@@ -10,8 +10,26 @@ namespace System.Tests
     {
         public delegate void AssertThrowsActionReadOnly<T>(ReadOnlySpan<T> span);
 
+        public delegate void AssertThrowsAction<T>(Span<T> span);
+
         // Cannot use standard Assert.Throws() when testing Span - Span and closures don't get along.
         public static void AssertThrows<E, T>(ReadOnlySpan<T> span, AssertThrowsActionReadOnly<T> action) where E : Exception
+        {
+            try
+            {
+                action(span);
+                Assert.False(true, "Expected exception: " + typeof(E).GetType());
+            }
+            catch (E)
+            {
+            }
+            catch (Exception wrongException)
+            {
+                Assert.False(true, "Wrong exception thrown: Expected " + typeof(E).GetType() + ": Actual: " + wrongException.GetType());
+            }
+        }
+
+        public static void AssertThrows<E, T>(Span<T> span, AssertThrowsAction<T> action) where E : Exception
         {
             try
             {

--- a/src/Common/tests/Tests/System/StringTests.cs
+++ b/src/Common/tests/Tests/System/StringTests.cs
@@ -1019,9 +1019,9 @@ namespace System.Tests
             Assert.Throws<ArgumentException>(() => string.Compare(value, value, (StringComparison)6));
             
             ReadOnlySpan<char> span = value.AsSpan();
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.CompareTo(_span, StringComparison.CurrentCulture - 1));
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.CompareTo(_span, StringComparison.OrdinalIgnoreCase + 1));
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.CompareTo(_span, (StringComparison)6));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.CompareTo(_span, StringComparison.CurrentCulture - 1));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.CompareTo(_span, StringComparison.OrdinalIgnoreCase + 1));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.CompareTo(_span, (StringComparison)6));
         }
         
         [Fact]
@@ -1314,9 +1314,9 @@ namespace System.Tests
         public static void ContainsUnknownComparisonType_StringComparison()
         {                        
             ReadOnlySpan<char> span = "456".AsSpan();
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Contains(_span, StringComparison.CurrentCulture - 1));
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Contains(_span, StringComparison.OrdinalIgnoreCase + 1));
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Contains(_span, (StringComparison)6));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Contains(_span, StringComparison.CurrentCulture - 1));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Contains(_span, StringComparison.OrdinalIgnoreCase + 1));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Contains(_span, (StringComparison)6));
         }
 
         [Fact]
@@ -2149,9 +2149,9 @@ namespace System.Tests
             Assert.Throws<ArgumentException>(() => value.EndsWith(value, (StringComparison)6));
 
             ReadOnlySpan<char> span = value.AsSpan();
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.EndsWith(_span, StringComparison.CurrentCulture - 1));
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.EndsWith(_span, StringComparison.OrdinalIgnoreCase + 1));
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.EndsWith(_span, (StringComparison)6));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.EndsWith(_span, StringComparison.CurrentCulture - 1));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.EndsWith(_span, StringComparison.OrdinalIgnoreCase + 1));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.EndsWith(_span, (StringComparison)6));
         }
 
         [Fact]
@@ -5152,7 +5152,7 @@ namespace System.Tests
             Assert.Equal(expected, s1.ToLower(CultureInfo.CurrentCulture).ToArray());
             Assert.Equal(expected, s1.ToLowerInvariant().ToArray());
             {
-                MemoryTestHelpers.AssertThrows<InvalidOperationException, char>(a, a => 
+                TestHelpers.AssertThrows<InvalidOperationException, char>(a, a => 
                 {
                     ReadOnlySpan<char> source = a;
                     Span<char> destination = a;
@@ -5161,7 +5161,7 @@ namespace System.Tests
                 });
             }
             {
-                MemoryTestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
+                TestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
                 {
                     ReadOnlySpan<char> source = a;
                     Span<char> destination = a;
@@ -5184,7 +5184,7 @@ namespace System.Tests
 
                 var source = new ReadOnlySpan<char>(a, 1, 3);
 
-                MemoryTestHelpers.AssertThrows<InvalidOperationException,char>(source, source =>
+                TestHelpers.AssertThrows<InvalidOperationException,char>(source, source =>
                 { 
                     var destination = new Span<char>(a, 3, 3);
                     source.ToLower(destination, CultureInfo.CurrentCulture);
@@ -5198,7 +5198,7 @@ namespace System.Tests
 
                 var source = new ReadOnlySpan<char>(a, 1, 3);
 
-                MemoryTestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
+                TestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
                 {
                     var destination = new Span<char>(a, 3, 3);
                     source.ToLowerInvariant(destination);
@@ -5365,7 +5365,7 @@ namespace System.Tests
             Assert.Equal(expected, s1.ToUpper(CultureInfo.CurrentCulture).ToArray());
             Assert.Equal(expected, s1.ToUpperInvariant().ToArray());
             {
-                MemoryTestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
+                TestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
                 {
                     ReadOnlySpan<char> source = a;
                     Span<char> destination = a;
@@ -5374,7 +5374,7 @@ namespace System.Tests
                 });
             }
             {
-                MemoryTestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
+                TestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
                 {
                     ReadOnlySpan<char> source = a;
                     Span<char> destination = a;
@@ -5397,7 +5397,7 @@ namespace System.Tests
 
                 var source = new ReadOnlySpan<char>(a, 1, 3);
 
-                MemoryTestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
+                TestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
                 {
                     var destination = new Span<char>(a, 3, 3);
                     source.ToUpper(destination, CultureInfo.CurrentCulture);
@@ -5410,7 +5410,7 @@ namespace System.Tests
                 Assert.Equal(expectedDestination, s1.ToUpperInvariant().ToArray());
 
                 var source = new ReadOnlySpan<char>(a, 1, 3);
-                MemoryTestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
+                TestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
                 {
                     var destination = new Span<char>(a, 3, 3);
                     source.ToUpperInvariant(destination);
@@ -6984,9 +6984,9 @@ namespace System.Tests
             Assert.Throws<ArgumentException>(() => s1.StartsWith(s1, (StringComparison)6));
 
             ReadOnlySpan<char> span = s1.AsSpan();
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.StartsWith(_span, StringComparison.CurrentCulture - 1));
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.StartsWith(_span, StringComparison.OrdinalIgnoreCase + 1));
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.StartsWith(_span, (StringComparison)6));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.StartsWith(_span, StringComparison.CurrentCulture - 1));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.StartsWith(_span, StringComparison.OrdinalIgnoreCase + 1));
+            SpanTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.StartsWith(_span, (StringComparison)6));
         }
 
         [Fact]

--- a/src/Common/tests/Tests/System/StringTests.cs
+++ b/src/Common/tests/Tests/System/StringTests.cs
@@ -5152,7 +5152,7 @@ namespace System.Tests
             Assert.Equal(expected, s1.ToLower(CultureInfo.CurrentCulture).ToArray());
             Assert.Equal(expected, s1.ToLowerInvariant().ToArray());
             {
-                TestHelpers.AssertThrows<InvalidOperationException, char>(a, a => 
+                SpanTestHelpers.AssertThrows<InvalidOperationException, char>(a, a => 
                 {
                     ReadOnlySpan<char> source = a;
                     Span<char> destination = a;
@@ -5161,7 +5161,7 @@ namespace System.Tests
                 });
             }
             {
-                TestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
+                SpanTestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
                 {
                     ReadOnlySpan<char> source = a;
                     Span<char> destination = a;
@@ -5184,7 +5184,7 @@ namespace System.Tests
 
                 var source = new ReadOnlySpan<char>(a, 1, 3);
 
-                TestHelpers.AssertThrows<InvalidOperationException,char>(source, source =>
+                SpanTestHelpers.AssertThrows<InvalidOperationException,char>(source, source =>
                 { 
                     var destination = new Span<char>(a, 3, 3);
                     source.ToLower(destination, CultureInfo.CurrentCulture);
@@ -5198,7 +5198,7 @@ namespace System.Tests
 
                 var source = new ReadOnlySpan<char>(a, 1, 3);
 
-                TestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
+                SpanTestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
                 {
                     var destination = new Span<char>(a, 3, 3);
                     source.ToLowerInvariant(destination);
@@ -5365,7 +5365,7 @@ namespace System.Tests
             Assert.Equal(expected, s1.ToUpper(CultureInfo.CurrentCulture).ToArray());
             Assert.Equal(expected, s1.ToUpperInvariant().ToArray());
             {
-                TestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
+                SpanTestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
                 {
                     ReadOnlySpan<char> source = a;
                     Span<char> destination = a;
@@ -5374,7 +5374,7 @@ namespace System.Tests
                 });
             }
             {
-                TestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
+                SpanTestHelpers.AssertThrows<InvalidOperationException, char>(a, a =>
                 {
                     ReadOnlySpan<char> source = a;
                     Span<char> destination = a;
@@ -5397,7 +5397,7 @@ namespace System.Tests
 
                 var source = new ReadOnlySpan<char>(a, 1, 3);
 
-                TestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
+                SpanTestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
                 {
                     var destination = new Span<char>(a, 3, 3);
                     source.ToUpper(destination, CultureInfo.CurrentCulture);
@@ -5410,7 +5410,7 @@ namespace System.Tests
                 Assert.Equal(expectedDestination, s1.ToUpperInvariant().ToArray());
 
                 var source = new ReadOnlySpan<char>(a, 1, 3);
-                TestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
+                SpanTestHelpers.AssertThrows<InvalidOperationException, char>(source, source =>
                 {
                     var destination = new Span<char>(a, 3, 3);
                     source.ToUpperInvariant(destination);

--- a/src/System.Memory/tests/Binary/BinaryReaderUnitTests.cs
+++ b/src/System.Memory/tests/Binary/BinaryReaderUnitTests.cs
@@ -159,23 +159,23 @@ namespace System.Buffers.Binary.Tests
             Assert.True(MemoryMarshal.TryRead(span, out byte byteValue));
             Assert.Equal(1, byteValue);
 
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<short>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<short>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out short shortValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<int>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<int>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out int intValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<long>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<long>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out long longValue));
 
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<ushort>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<ushort>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out ushort ushortValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<uint>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<uint>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out uint uintValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<ulong>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<ulong>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out ulong ulongValue));
 
             Span<byte> largeSpan = new byte[100];
-            MemoryTestHelpers.AssertThrows<ArgumentException, byte>(largeSpan, (_span) => MemoryMarshal.Read<MemoryTestHelpers.TestValueTypeWithReference>(_span));
-            MemoryTestHelpers.AssertThrows<ArgumentException, byte>(largeSpan, (_span) => MemoryMarshal.TryRead(_span, out MemoryTestHelpers.TestValueTypeWithReference stringValue));
+            TestHelpers.AssertThrows<ArgumentException, byte>(largeSpan, (_span) => MemoryMarshal.Read<TestHelpers.TestValueTypeWithReference>(_span));
+            TestHelpers.AssertThrows<ArgumentException, byte>(largeSpan, (_span) => MemoryMarshal.TryRead(_span, out TestHelpers.TestValueTypeWithReference stringValue));
         }
 
         [Fact]
@@ -187,23 +187,23 @@ namespace System.Buffers.Binary.Tests
             Assert.True(MemoryMarshal.TryRead(span, out byte byteValue));
             Assert.Equal(1, byteValue);
 
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<short>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<short>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out short shortValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<int>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<int>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out int intValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<long>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<long>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out long longValue));
 
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<ushort>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<ushort>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out ushort ushortValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<uint>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<uint>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out uint uintValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<ulong>(_span));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Read<ulong>(_span));
             Assert.False(MemoryMarshal.TryRead(span, out ulong ulongValue));
 
             ReadOnlySpan<byte> largeSpan = new byte[100];
-            MemoryTestHelpers.AssertThrows<ArgumentException, byte>(largeSpan, (_span) => MemoryMarshal.Read<MemoryTestHelpers.TestValueTypeWithReference>(_span));
-            MemoryTestHelpers.AssertThrows<ArgumentException, byte>(largeSpan, (_span) => MemoryMarshal.TryRead(_span, out MemoryTestHelpers.TestValueTypeWithReference stringValue));
+            TestHelpers.AssertThrows<ArgumentException, byte>(largeSpan, (_span) => MemoryMarshal.Read<TestHelpers.TestValueTypeWithReference>(_span));
+            TestHelpers.AssertThrows<ArgumentException, byte>(largeSpan, (_span) => MemoryMarshal.TryRead(_span, out TestHelpers.TestValueTypeWithReference stringValue));
         }
 
         [Fact]
@@ -326,9 +326,9 @@ namespace System.Buffers.Binary.Tests
         public void ReadingStructFieldByFieldOrReadAndReverseEndianness()
         {
             Assert.True(BitConverter.IsLittleEndian);
-            Span<byte> spanBE = new byte[Unsafe.SizeOf<MemoryTestHelpers.TestStructExplicit>()];
+            Span<byte> spanBE = new byte[Unsafe.SizeOf<TestHelpers.TestStructExplicit>()];
 
-            var testExplicitStruct = new MemoryTestHelpers.TestStructExplicit
+            var testExplicitStruct = new TestHelpers.TestStructExplicit
             {
                 S0 = short.MaxValue,
                 I0 = int.MaxValue,
@@ -361,7 +361,7 @@ namespace System.Buffers.Binary.Tests
 
             ReadOnlySpan<byte> readOnlySpanBE = new ReadOnlySpan<byte>(spanBE.ToArray());
 
-            MemoryTestHelpers.TestStructExplicit readStructAndReverse = MemoryMarshal.Read<MemoryTestHelpers.TestStructExplicit>(spanBE);
+            TestHelpers.TestStructExplicit readStructAndReverse = MemoryMarshal.Read<TestHelpers.TestStructExplicit>(spanBE);
             if (BitConverter.IsLittleEndian)
             {
                 readStructAndReverse.S0 = ReverseEndianness(readStructAndReverse.S0);
@@ -378,7 +378,7 @@ namespace System.Buffers.Binary.Tests
                 readStructAndReverse.UL1 = ReverseEndianness(readStructAndReverse.UL1);
             }
 
-            var readStructFieldByField = new MemoryTestHelpers.TestStructExplicit
+            var readStructFieldByField = new TestHelpers.TestStructExplicit
             {
                 S0 = ReadInt16BigEndian(spanBE),
                 I0 = ReadInt32BigEndian(spanBE.Slice(2)),
@@ -394,7 +394,7 @@ namespace System.Buffers.Binary.Tests
                 UL1 = ReadUInt64BigEndian(spanBE.Slice(48))
             };
 
-            MemoryTestHelpers.TestStructExplicit readStructAndReverseFromReadOnlySpan = MemoryMarshal.Read<MemoryTestHelpers.TestStructExplicit>(readOnlySpanBE);
+            TestHelpers.TestStructExplicit readStructAndReverseFromReadOnlySpan = MemoryMarshal.Read<TestHelpers.TestStructExplicit>(readOnlySpanBE);
             if (BitConverter.IsLittleEndian)
             {
                 readStructAndReverseFromReadOnlySpan.S0 = ReverseEndianness(readStructAndReverseFromReadOnlySpan.S0);
@@ -411,7 +411,7 @@ namespace System.Buffers.Binary.Tests
                 readStructAndReverseFromReadOnlySpan.UL1 = ReverseEndianness(readStructAndReverseFromReadOnlySpan.UL1);
             }
 
-            var readStructFieldByFieldFromReadOnlySpan = new MemoryTestHelpers.TestStructExplicit
+            var readStructFieldByFieldFromReadOnlySpan = new TestHelpers.TestStructExplicit
             {
                 S0 = ReadInt16BigEndian(readOnlySpanBE),
                 I0 = ReadInt32BigEndian(readOnlySpanBE.Slice(2)),

--- a/src/System.Memory/tests/Binary/BinaryWriterUnitTests.cs
+++ b/src/System.Memory/tests/Binary/BinaryWriterUnitTests.cs
@@ -20,51 +20,51 @@ namespace System.Buffers.Binary.Tests
 
             byte byteValue = 0x11;
             MemoryMarshal.Write<byte>(span, ref byteValue);
-            MemoryTestHelpers.Validate<byte>(span, byteValue);
+            TestHelpers.Validate<byte>(span, byteValue);
             Assert.True(MemoryMarshal.TryWrite<byte>(span, ref byteValue));
-            MemoryTestHelpers.Validate<byte>(span, byteValue);
+            TestHelpers.Validate<byte>(span, byteValue);
 
             sbyte sbyteValue = 0x11;
             MemoryMarshal.Write<sbyte>(span, ref sbyteValue);
-            MemoryTestHelpers.Validate<sbyte>(span, sbyteValue);
+            TestHelpers.Validate<sbyte>(span, sbyteValue);
             Assert.True(MemoryMarshal.TryWrite<sbyte>(span, ref sbyteValue));
-            MemoryTestHelpers.Validate<sbyte>(span, sbyteValue);
+            TestHelpers.Validate<sbyte>(span, sbyteValue);
 
             ushort ushortValue = 0x1122;
             MemoryMarshal.Write<ushort>(span, ref ushortValue);
-            MemoryTestHelpers.Validate<ushort>(span, ushortValue);
+            TestHelpers.Validate<ushort>(span, ushortValue);
             Assert.True(MemoryMarshal.TryWrite<ushort>(span, ref ushortValue));
-            MemoryTestHelpers.Validate<ushort>(span, ushortValue);
+            TestHelpers.Validate<ushort>(span, ushortValue);
 
             uint uintValue = 0x11223344;
             MemoryMarshal.Write<uint>(span, ref uintValue);
-            MemoryTestHelpers.Validate<uint>(span, uintValue);
+            TestHelpers.Validate<uint>(span, uintValue);
             Assert.True(MemoryMarshal.TryWrite<uint>(span, ref uintValue));
-            MemoryTestHelpers.Validate<uint>(span, uintValue);
+            TestHelpers.Validate<uint>(span, uintValue);
 
             ulong ulongValue = 0x1122334455667788;
             MemoryMarshal.Write<ulong>(span, ref ulongValue);
-            MemoryTestHelpers.Validate<ulong>(span, ulongValue);
+            TestHelpers.Validate<ulong>(span, ulongValue);
             Assert.True(MemoryMarshal.TryWrite<ulong>(span, ref ulongValue));
-            MemoryTestHelpers.Validate<ulong>(span, ulongValue);
+            TestHelpers.Validate<ulong>(span, ulongValue);
 
             short shortValue = 0x1122;
             MemoryMarshal.Write<short>(span, ref shortValue);
-            MemoryTestHelpers.Validate<short>(span, shortValue);
+            TestHelpers.Validate<short>(span, shortValue);
             Assert.True(MemoryMarshal.TryWrite<short>(span, ref shortValue));
-            MemoryTestHelpers.Validate<short>(span, shortValue);
+            TestHelpers.Validate<short>(span, shortValue);
 
             int intValue = 0x11223344;
             MemoryMarshal.Write<int>(span, ref intValue);
-            MemoryTestHelpers.Validate<int>(span, intValue);
+            TestHelpers.Validate<int>(span, intValue);
             Assert.True(MemoryMarshal.TryWrite<int>(span, ref intValue));
-            MemoryTestHelpers.Validate<int>(span, intValue);
+            TestHelpers.Validate<int>(span, intValue);
 
             long longValue = 0x1122334455667788;
             MemoryMarshal.Write<long>(span, ref longValue);
-            MemoryTestHelpers.Validate<long>(span, longValue);
+            TestHelpers.Validate<long>(span, longValue);
             Assert.True(MemoryMarshal.TryWrite<long>(span, ref longValue));
-            MemoryTestHelpers.Validate<long>(span, longValue);
+            TestHelpers.Validate<long>(span, longValue);
         }
 
         [Theory]
@@ -289,23 +289,23 @@ namespace System.Buffers.Binary.Tests
             readSbyte = MemoryMarshal.Read<sbyte>(span);
             Assert.Equal<sbyte>(sbyteValue, readSbyte);
 
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<short>(_span, ref shortValue));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<short>(_span, ref shortValue));
             Assert.False(MemoryMarshal.TryWrite<short>(span, ref shortValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<int>(_span, ref intValue));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<int>(_span, ref intValue));
             Assert.False(MemoryMarshal.TryWrite<int>(span, ref intValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<long>(_span, ref longValue));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<long>(_span, ref longValue));
             Assert.False(MemoryMarshal.TryWrite<long>(span, ref longValue));
 
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<ushort>(_span, ref ushortValue));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<ushort>(_span, ref ushortValue));
             Assert.False(MemoryMarshal.TryWrite<ushort>(span, ref ushortValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<uint>(_span, ref uintValue));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<uint>(_span, ref uintValue));
             Assert.False(MemoryMarshal.TryWrite<uint>(span, ref uintValue));
-            MemoryTestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<ulong>(_span, ref ulongValue));
+            TestHelpers.AssertThrows<ArgumentOutOfRangeException, byte>(span, (_span) => MemoryMarshal.Write<ulong>(_span, ref ulongValue));
             Assert.False(MemoryMarshal.TryWrite<ulong>(span, ref ulongValue));
 
-            var structValue = new MemoryTestHelpers.TestValueTypeWithReference { I = 1, S = "1" };
-            MemoryTestHelpers.AssertThrows<ArgumentException, byte>(span, (_span) => MemoryMarshal.Write<MemoryTestHelpers.TestValueTypeWithReference>(_span, ref structValue));
-            MemoryTestHelpers.AssertThrows<ArgumentException, byte>(span, (_span) => MemoryMarshal.TryWrite<MemoryTestHelpers.TestValueTypeWithReference>(_span, ref structValue));
+            var structValue = new TestHelpers.TestValueTypeWithReference { I = 1, S = "1" };
+            TestHelpers.AssertThrows<ArgumentException, byte>(span, (_span) => MemoryMarshal.Write<TestHelpers.TestValueTypeWithReference>(_span, ref structValue));
+            TestHelpers.AssertThrows<ArgumentException, byte>(span, (_span) => MemoryMarshal.TryWrite<TestHelpers.TestValueTypeWithReference>(_span, ref structValue));
         }
     }
 }

--- a/src/System.Memory/tests/Memory/Span.cs
+++ b/src/System.Memory/tests/Memory/Span.cs
@@ -141,10 +141,10 @@ namespace System.MemoryTests
         {
             Memory<int> memory;
 
-            memory = MemoryTestHelpers.DangerousCreateMemory<int>(new int[4], 0, 5);
+            memory = TestHelpers.DangerousCreateMemory<int>(new int[4], 0, 5);
             Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
 
-            memory = MemoryTestHelpers.DangerousCreateMemory<int>(new int[4], 3, 2);
+            memory = TestHelpers.DangerousCreateMemory<int>(new int[4], 3, 2);
             Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
         }
 
@@ -153,10 +153,10 @@ namespace System.MemoryTests
         {
             Memory<char> memory;
 
-            memory = MemoryTestHelpers.DangerousCreateMemory<char>("1234", 0, 5);
+            memory = TestHelpers.DangerousCreateMemory<char>("1234", 0, 5);
             Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
 
-            memory = MemoryTestHelpers.DangerousCreateMemory<char>("1234", 3, 2);
+            memory = TestHelpers.DangerousCreateMemory<char>("1234", 3, 2);
             Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
         }
     }

--- a/src/System.Memory/tests/Memory/ToString.cs
+++ b/src/System.Memory/tests/Memory/ToString.cs
@@ -96,7 +96,7 @@ namespace System.MemoryTests
         [Fact]
         public static void ToStringMemoryOverFullStringReturnsOriginal()
         {
-            string original = MemoryTestHelpers.BuildString(10, 42);
+            string original = TestHelpers.BuildString(10, 42);
 
             ReadOnlyMemory<char> readOnlyMemory = original.AsMemory();
             Memory<char> memory = MemoryMarshal.AsMemory(readOnlyMemory);

--- a/src/System.Memory/tests/MemoryMarshal/AsBytesReadOnlySpan.cs
+++ b/src/System.Memory/tests/MemoryMarshal/AsBytesReadOnlySpan.cs
@@ -24,8 +24,8 @@ namespace System.SpanTests
         [Fact]
         public static void ReadOnlySpan_AsBytesContainsReferences()
         {
-            ReadOnlySpan<MemoryTestHelpers.StructWithReferences> span = new ReadOnlySpan<MemoryTestHelpers.StructWithReferences>(Array.Empty<MemoryTestHelpers.StructWithReferences>());
-            MemoryTestHelpers.AssertThrows<ArgumentException, MemoryTestHelpers.StructWithReferences>(span, (_span) => MemoryMarshal.AsBytes(_span).DontBox());
+            ReadOnlySpan<TestHelpers.StructWithReferences> span = new ReadOnlySpan<TestHelpers.StructWithReferences>(Array.Empty<TestHelpers.StructWithReferences>());
+            TestHelpers.AssertThrows<ArgumentException, TestHelpers.StructWithReferences>(span, (_span) => MemoryMarshal.AsBytes(_span).DontBox());
         }
     }
 }

--- a/src/System.Memory/tests/MemoryMarshal/AsBytesSpan.cs
+++ b/src/System.Memory/tests/MemoryMarshal/AsBytesSpan.cs
@@ -24,8 +24,8 @@ namespace System.SpanTests
         [Fact]
         public static void Span_AsBytesContainsReferences()
         {
-            Span<MemoryTestHelpers.StructWithReferences> span = new Span<MemoryTestHelpers.StructWithReferences>(Array.Empty<MemoryTestHelpers.StructWithReferences>());
-            MemoryTestHelpers.AssertThrows<ArgumentException, MemoryTestHelpers.StructWithReferences>(span, (_span) => MemoryMarshal.AsBytes(_span).DontBox());
+            Span<TestHelpers.StructWithReferences> span = new Span<TestHelpers.StructWithReferences>(Array.Empty<TestHelpers.StructWithReferences>());
+            TestHelpers.AssertThrows<ArgumentException, TestHelpers.StructWithReferences>(span, (_span) => MemoryMarshal.AsBytes(_span).DontBox());
         }
     }
 }

--- a/src/System.Memory/tests/MemoryMarshal/AsReadOnlyRef.cs
+++ b/src/System.Memory/tests/MemoryMarshal/AsReadOnlyRef.cs
@@ -21,7 +21,7 @@ namespace System.SpanTests
 
             var array = new byte[100];
             Array.Fill<byte>(array, 0x42);
-            ref readonly MemoryTestHelpers.TestStructExplicit asStruct = ref MemoryMarshal.AsRef<MemoryTestHelpers.TestStructExplicit>(new ReadOnlySpan<byte>(array));
+            ref readonly TestHelpers.TestStructExplicit asStruct = ref MemoryMarshal.AsRef<TestHelpers.TestStructExplicit>(new ReadOnlySpan<byte>(array));
 
             Assert.Equal(asStruct.UI1, (uint)0x42424242);
         }
@@ -30,9 +30,9 @@ namespace System.SpanTests
         public static void AsReadOnlyRefFail()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => MemoryMarshal.AsRef<uint>(new ReadOnlySpan<byte>(new byte[] { 1 })));
-            Assert.Throws<ArgumentOutOfRangeException>(() => MemoryMarshal.AsRef<MemoryTestHelpers.TestStructExplicit>(new ReadOnlySpan<byte>(new byte[] { 1 })));
+            Assert.Throws<ArgumentOutOfRangeException>(() => MemoryMarshal.AsRef<TestHelpers.TestStructExplicit>(new ReadOnlySpan<byte>(new byte[] { 1 })));
 
-            Assert.Throws<ArgumentException>(() => MemoryMarshal.AsRef<MemoryTestHelpers.StructWithReferences>(new ReadOnlySpan<byte>(new byte[100])));
+            Assert.Throws<ArgumentException>(() => MemoryMarshal.AsRef<TestHelpers.StructWithReferences>(new ReadOnlySpan<byte>(new byte[100])));
         }
     }
 }

--- a/src/System.Memory/tests/MemoryMarshal/AsRef.cs
+++ b/src/System.Memory/tests/MemoryMarshal/AsRef.cs
@@ -21,7 +21,7 @@ namespace System.SpanTests
 
             var array = new byte[100];
             Array.Fill<byte>(array, 0x42);
-            ref MemoryTestHelpers.TestStructExplicit asStruct = ref MemoryMarshal.AsRef<MemoryTestHelpers.TestStructExplicit>(new Span<byte>(array));
+            ref TestHelpers.TestStructExplicit asStruct = ref MemoryMarshal.AsRef<TestHelpers.TestStructExplicit>(new Span<byte>(array));
 
             Assert.Equal(asStruct.UI1, (uint)0x42424242);
         }
@@ -30,9 +30,9 @@ namespace System.SpanTests
         public static void AsRefFail()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => MemoryMarshal.AsRef<uint>(new Span<byte>(new byte[] { 1 })));
-            Assert.Throws<ArgumentOutOfRangeException>(() => MemoryMarshal.AsRef<MemoryTestHelpers.TestStructExplicit>(new Span<byte>(new byte[] { 1 })));
+            Assert.Throws<ArgumentOutOfRangeException>(() => MemoryMarshal.AsRef<TestHelpers.TestStructExplicit>(new Span<byte>(new byte[] { 1 })));
 
-            Assert.Throws<ArgumentException>(() => MemoryMarshal.AsRef<MemoryTestHelpers.StructWithReferences>(new Span<byte>(new byte[100])));
+            Assert.Throws<ArgumentException>(() => MemoryMarshal.AsRef<TestHelpers.StructWithReferences>(new Span<byte>(new byte[100])));
         }
     }
 }

--- a/src/System.Memory/tests/MemoryMarshal/CastReadOnlySpan.cs
+++ b/src/System.Memory/tests/MemoryMarshal/CastReadOnlySpan.cs
@@ -35,24 +35,24 @@ namespace System.SpanTests
         [Fact]
         public static unsafe void CastReadOnlySpanOverflow()
         {
-            ReadOnlySpan<MemoryTestHelpers.TestStructExplicit> span = new ReadOnlySpan<MemoryTestHelpers.TestStructExplicit>(null, int.MaxValue);
+            ReadOnlySpan<TestHelpers.TestStructExplicit> span = new ReadOnlySpan<TestHelpers.TestStructExplicit>(null, int.MaxValue);
 
-            MemoryTestHelpers.AssertThrows<OverflowException, MemoryTestHelpers.TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<MemoryTestHelpers.TestStructExplicit, byte>(_span).DontBox());
-            MemoryTestHelpers.AssertThrows<OverflowException, MemoryTestHelpers.TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<MemoryTestHelpers.TestStructExplicit, ulong>(_span).DontBox());
+            TestHelpers.AssertThrows<OverflowException, TestHelpers.TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<TestHelpers.TestStructExplicit, byte>(_span).DontBox());
+            TestHelpers.AssertThrows<OverflowException, TestHelpers.TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<TestHelpers.TestStructExplicit, ulong>(_span).DontBox());
         }
 
         [Fact]
         public static void CastReadOnlySpanToTypeContainsReferences()
         {
             ReadOnlySpan<uint> span = new ReadOnlySpan<uint>(Array.Empty<uint>());
-            MemoryTestHelpers.AssertThrows<ArgumentException, uint>(span, (_span) => MemoryMarshal.Cast<uint, MemoryTestHelpers.StructWithReferences>(_span).DontBox());
+            TestHelpers.AssertThrows<ArgumentException, uint>(span, (_span) => MemoryMarshal.Cast<uint, TestHelpers.StructWithReferences>(_span).DontBox());
         }
 
         [Fact]
         public static void CastReadOnlySpanFromTypeContainsReferences()
         {
-            ReadOnlySpan<MemoryTestHelpers.StructWithReferences> span = new ReadOnlySpan<MemoryTestHelpers.StructWithReferences>(Array.Empty<MemoryTestHelpers.StructWithReferences>());
-            MemoryTestHelpers.AssertThrows<ArgumentException, MemoryTestHelpers.StructWithReferences>(span, (_span) => MemoryMarshal.Cast<MemoryTestHelpers.StructWithReferences, uint>(_span).DontBox());
+            ReadOnlySpan<TestHelpers.StructWithReferences> span = new ReadOnlySpan<TestHelpers.StructWithReferences>(Array.Empty<TestHelpers.StructWithReferences>());
+            TestHelpers.AssertThrows<ArgumentException, TestHelpers.StructWithReferences>(span, (_span) => MemoryMarshal.Cast<TestHelpers.StructWithReferences, uint>(_span).DontBox());
         }
     }
 }

--- a/src/System.Memory/tests/MemoryMarshal/CastSpan.cs
+++ b/src/System.Memory/tests/MemoryMarshal/CastSpan.cs
@@ -47,24 +47,24 @@ namespace System.SpanTests
         [Fact]
         public static unsafe void CastSpanOverflow()
         {
-            Span<MemoryTestHelpers.TestStructExplicit> span = new Span<MemoryTestHelpers.TestStructExplicit>(null, int.MaxValue);
+            Span<TestHelpers.TestStructExplicit> span = new Span<TestHelpers.TestStructExplicit>(null, int.MaxValue);
 
-            MemoryTestHelpers.AssertThrows<OverflowException, MemoryTestHelpers.TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<MemoryTestHelpers.TestStructExplicit, byte>(_span).DontBox());
-            MemoryTestHelpers.AssertThrows<OverflowException, MemoryTestHelpers.TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<MemoryTestHelpers.TestStructExplicit, ulong>(_span).DontBox());
+            TestHelpers.AssertThrows<OverflowException, TestHelpers.TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<TestHelpers.TestStructExplicit, byte>(_span).DontBox());
+            TestHelpers.AssertThrows<OverflowException, TestHelpers.TestStructExplicit>(span, (_span) => MemoryMarshal.Cast<TestHelpers.TestStructExplicit, ulong>(_span).DontBox());
         }
 
         [Fact]
         public static void CastSpanToTypeContainsReferences()
         {
             Span<uint> span = new Span<uint>(Array.Empty<uint>());
-            MemoryTestHelpers.AssertThrows<ArgumentException, uint>(span, (_span) => MemoryMarshal.Cast<uint, MemoryTestHelpers.StructWithReferences>(_span).DontBox());
+            TestHelpers.AssertThrows<ArgumentException, uint>(span, (_span) => MemoryMarshal.Cast<uint, TestHelpers.StructWithReferences>(_span).DontBox());
         }
 
         [Fact]
         public static void CastSpanFromTypeContainsReferences()
         {
-            Span<MemoryTestHelpers.StructWithReferences> span = new Span<MemoryTestHelpers.StructWithReferences>(Array.Empty<MemoryTestHelpers.StructWithReferences>());
-            MemoryTestHelpers.AssertThrows<ArgumentException, MemoryTestHelpers.StructWithReferences>(span, (_span) => MemoryMarshal.Cast<MemoryTestHelpers.StructWithReferences, uint>(_span).DontBox());
+            Span<TestHelpers.StructWithReferences> span = new Span<TestHelpers.StructWithReferences>(Array.Empty<TestHelpers.StructWithReferences>());
+            TestHelpers.AssertThrows<ArgumentException, TestHelpers.StructWithReferences>(span, (_span) => MemoryMarshal.Cast<TestHelpers.StructWithReferences, uint>(_span).DontBox());
         }
     }
 }

--- a/src/System.Memory/tests/MemoryMarshal/CreateReadOnlySpan.cs
+++ b/src/System.Memory/tests/MemoryMarshal/CreateReadOnlySpan.cs
@@ -6,7 +6,7 @@ using Xunit;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-using static System.MemoryTestHelpers;
+using static System.TestHelpers;
 
 namespace System.SpanTests
 {

--- a/src/System.Memory/tests/MemoryMarshal/CreateSpan.cs
+++ b/src/System.Memory/tests/MemoryMarshal/CreateSpan.cs
@@ -6,7 +6,7 @@ using Xunit;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-using static System.MemoryTestHelpers;
+using static System.TestHelpers;
 
 namespace System.SpanTests
 {

--- a/src/System.Memory/tests/MemoryMarshal/GetReference.cs
+++ b/src/System.Memory/tests/MemoryMarshal/GetReference.cs
@@ -6,7 +6,7 @@ using Xunit;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-using static System.MemoryTestHelpers;
+using static System.TestHelpers;
 
 namespace System.SpanTests
 {

--- a/src/System.Memory/tests/ReadOnlyMemory/CtorArray.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/CtorArray.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using static System.MemoryTestHelpers;
+using static System.TestHelpers;
 
 namespace System.MemoryTests
 {

--- a/src/System.Memory/tests/ReadOnlyMemory/Span.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Span.cs
@@ -140,10 +140,10 @@ namespace System.MemoryTests
         {
             ReadOnlyMemory<int> memory;
 
-            memory = MemoryTestHelpers.DangerousCreateReadOnlyMemory<int>(new int[4], 0, 5);
+            memory = TestHelpers.DangerousCreateReadOnlyMemory<int>(new int[4], 0, 5);
             Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
 
-            memory = MemoryTestHelpers.DangerousCreateReadOnlyMemory<int>(new int[4], 3, 2);
+            memory = TestHelpers.DangerousCreateReadOnlyMemory<int>(new int[4], 3, 2);
             Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
         }
 
@@ -152,10 +152,10 @@ namespace System.MemoryTests
         {
             ReadOnlyMemory<char> memory;
 
-            memory = MemoryTestHelpers.DangerousCreateReadOnlyMemory<char>("1234", 0, 5);
+            memory = TestHelpers.DangerousCreateReadOnlyMemory<char>("1234", 0, 5);
             Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
 
-            memory = MemoryTestHelpers.DangerousCreateReadOnlyMemory<char>("1234", 3, 2);
+            memory = TestHelpers.DangerousCreateReadOnlyMemory<char>("1234", 3, 2);
             Assert.Throws<ArgumentOutOfRangeException>(() => memory.Span.DontBox());
         }
     }

--- a/src/System.Memory/tests/ReadOnlyMemory/Strings.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/Strings.cs
@@ -110,7 +110,7 @@ namespace System.MemoryTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.StringSliceTestData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.StringSliceTestData), MemberType = typeof(TestHelpers))]
         public static unsafe void AsMemory_StartAndLength(string text, int start, int length)
         {
             ReadOnlyMemory<char> m;
@@ -144,14 +144,14 @@ namespace System.MemoryTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.StringSlice2ArgTestOutOfRangeData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.StringSlice2ArgTestOutOfRangeData), MemberType = typeof(TestHelpers))]
         public static unsafe void AsMemory_2Arg_OutOfRange(string text, int start)
         {
             AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsMemory(start));
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.StringSlice3ArgTestOutOfRangeData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.StringSlice3ArgTestOutOfRangeData), MemberType = typeof(TestHelpers))]
         public static unsafe void AsMemory_3Arg_OutOfRange(string text, int start, int length)
         {
             AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsMemory(start, length));

--- a/src/System.Memory/tests/ReadOnlyMemory/ToString.cs
+++ b/src/System.Memory/tests/ReadOnlyMemory/ToString.cs
@@ -95,7 +95,7 @@ namespace System.MemoryTests
         [Fact]
         public static void ToStringMemoryOverFullStringReturnsOriginal()
         {
-            string original = MemoryTestHelpers.BuildString(10, 42);
+            string original = TestHelpers.BuildString(10, 42);
 
             ReadOnlyMemory<char> memory = original.AsMemory();
 

--- a/src/System.Memory/tests/ReadOnlySpan/AsSpan.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/AsSpan.cs
@@ -59,7 +59,7 @@ namespace System.SpanTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.StringSliceTestData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.StringSliceTestData), MemberType = typeof(TestHelpers))]
         public static unsafe void AsSpan_StartAndLength(string text, int start, int length)
         {
             ReadOnlySpan<char> span;
@@ -90,14 +90,14 @@ namespace System.SpanTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.StringSlice2ArgTestOutOfRangeData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.StringSlice2ArgTestOutOfRangeData), MemberType = typeof(TestHelpers))]
         public static unsafe void AsSpan_2Arg_OutOfRange(string text, int start)
         {
             AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsSpan(start).DontBox());
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.StringSlice3ArgTestOutOfRangeData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.StringSlice3ArgTestOutOfRangeData), MemberType = typeof(TestHelpers))]
         public static unsafe void AsSpan_3Arg_OutOfRange(string text, int start, int length)
         {
             AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => text.AsSpan(start, length).DontBox());

--- a/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CopyTo.cs
@@ -92,7 +92,7 @@ namespace System.SpanTests
             int[] dst = { 99, 100 };
 
             ReadOnlySpan<int> srcSpan = new ReadOnlySpan<int>(src);
-            MemoryTestHelpers.AssertThrows<ArgumentException, int>(srcSpan, (_srcSpan) => _srcSpan.CopyTo(dst));
+            TestHelpers.AssertThrows<ArgumentException, int>(srcSpan, (_srcSpan) => _srcSpan.CopyTo(dst));
             int[] expected = { 99, 100 };
             Assert.Equal<int>(expected, dst);  // CopyTo() checks for sufficient space before doing any copying.
         }

--- a/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CtorArray.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using static System.MemoryTestHelpers;
+using static System.TestHelpers;
 
 namespace System.SpanTests
 {

--- a/src/System.Memory/tests/ReadOnlySpan/CtorPointerInt.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/CtorPointerInt.cs
@@ -58,7 +58,7 @@ namespace System.SpanTests
                 new ReadOnlySpan<int>((void*)null, 0);
                 new ReadOnlySpan<int?>((void*)null, 0);
                 AssertExtensions.Throws<ArgumentException>(null, () => new ReadOnlySpan<object>((void*)null, 0).DontBox());
-                AssertExtensions.Throws<ArgumentException>(null, () => new ReadOnlySpan<MemoryTestHelpers.StructWithReferences>((void*)null, 0).DontBox());
+                AssertExtensions.Throws<ArgumentException>(null, () => new ReadOnlySpan<TestHelpers.StructWithReferences>((void*)null, 0).DontBox());
             }
         }
     }

--- a/src/System.Memory/tests/ReadOnlySpan/Equals.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/Equals.cs
@@ -163,9 +163,9 @@ namespace System.SpanTests
         {
             char[] a = { '4', '5', '6' };
             var span = new ReadOnlySpan<char>(a);
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Equals(_span, StringComparison.CurrentCulture - 1));
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Equals(_span, StringComparison.OrdinalIgnoreCase + 1));
-            MemoryTestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Equals(_span, (StringComparison)6));
+            TestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Equals(_span, StringComparison.CurrentCulture - 1));
+            TestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Equals(_span, StringComparison.OrdinalIgnoreCase + 1));
+            TestHelpers.AssertThrows<ArgumentException, char>(span, (_span) => _span.Equals(_span, (StringComparison)6));
         }
       
     }

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOf.T.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOf.T.cs
@@ -187,7 +187,7 @@ namespace System.SpanTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.IndexOfNullData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.IndexOfNullData), MemberType = typeof(TestHelpers))]
         public static void IndexOfNull_String(string[] spanInput, int expected)
         {
             ReadOnlySpan<string> theStrings = spanInput;

--- a/src/System.Memory/tests/ReadOnlySpan/IndexOfSequence.T.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/IndexOfSequence.T.cs
@@ -233,7 +233,7 @@ namespace System.SpanTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.IndexOfNullSequenceData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.IndexOfNullSequenceData), MemberType = typeof(TestHelpers))]
         public static void IndexOfNullSequence_String(string[] spanInput, string[] searchInput, int expected)
         {
             ReadOnlySpan<string> theStrings = spanInput;

--- a/src/System.Memory/tests/ReadOnlySpan/LastIndexOf.T.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/LastIndexOf.T.cs
@@ -187,7 +187,7 @@ namespace System.SpanTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.LastIndexOfNullData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.LastIndexOfNullData), MemberType = typeof(TestHelpers))]
         public static void LastIndexOfNull_String(string[] spanInput, int expected)
         {
             ReadOnlySpan<string> theStrings = spanInput;

--- a/src/System.Memory/tests/ReadOnlySpan/LastIndexOfSequence.T.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/LastIndexOfSequence.T.cs
@@ -243,7 +243,7 @@ namespace System.SpanTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.LastIndexOfNullSequenceData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.LastIndexOfNullSequenceData), MemberType = typeof(TestHelpers))]
         public static void LastIndexOfNullSequence_String(string[] spanInput, string[] searchInput, int expected)
         {
             ReadOnlySpan<string> theStrings = spanInput;

--- a/src/System.Memory/tests/ReadOnlySpan/ToString.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/ToString.cs
@@ -63,7 +63,7 @@ namespace System.SpanTests
         [Fact]
         public static void ToStringSpanOverSubstringDoesNotReturnOriginal()
         {
-            string original = MemoryTestHelpers.BuildString(10, 42);
+            string original = TestHelpers.BuildString(10, 42);
             ReadOnlySpan<char> span = original.AsSpan();
 
             string returnedString = span.ToString();

--- a/src/System.Memory/tests/ReadOnlySpan/ToUpperLower.cs
+++ b/src/System.Memory/tests/ReadOnlySpan/ToUpperLower.cs
@@ -13,53 +13,53 @@ namespace System.SpanTests
         {
             // full overlap, overlap in the middle, overlap at start, overlap at the end
 
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLower(buffer, null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLower(buffer.Slice(1, 1), null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLower(buffer.Slice(0, 1), null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLower(buffer.Slice(2, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLower(buffer, null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLower(buffer.Slice(1, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLower(buffer.Slice(0, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLower(buffer.Slice(2, 1), null) };
 
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLower(buffer, buffer, null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLower(buffer, buffer.Slice(1, 1), null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLower(buffer, buffer.Slice(0, 1), null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLower(buffer, buffer.Slice(2, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLower(buffer, buffer, null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLower(buffer, buffer.Slice(1, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLower(buffer, buffer.Slice(0, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLower(buffer, buffer.Slice(2, 1), null) };
 
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLowerInvariant(buffer) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLowerInvariant(buffer.Slice(1, 1)) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLowerInvariant(buffer.Slice(0, 1)) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLowerInvariant(buffer.Slice(2, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLowerInvariant(buffer) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLowerInvariant(buffer.Slice(1, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLowerInvariant(buffer.Slice(0, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToLowerInvariant(buffer.Slice(2, 1)) };
 
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLowerInvariant(buffer, buffer) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLowerInvariant(buffer, buffer.Slice(1, 1)) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLowerInvariant(buffer, buffer.Slice(0, 1)) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLowerInvariant(buffer, buffer.Slice(2, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLowerInvariant(buffer, buffer) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLowerInvariant(buffer, buffer.Slice(1, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLowerInvariant(buffer, buffer.Slice(0, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToLowerInvariant(buffer, buffer.Slice(2, 1)) };
 
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpper(buffer, null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpper(buffer.Slice(1, 1), null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpper(buffer.Slice(0, 1), null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpper(buffer.Slice(2, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpper(buffer, null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpper(buffer.Slice(1, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpper(buffer.Slice(0, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpper(buffer.Slice(2, 1), null) };
 
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpper(buffer, buffer, null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpper(buffer, buffer.Slice(1, 1), null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpper(buffer, buffer.Slice(0, 1), null) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpper(buffer, buffer.Slice(2, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpper(buffer, buffer, null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpper(buffer, buffer.Slice(1, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpper(buffer, buffer.Slice(0, 1), null) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpper(buffer, buffer.Slice(2, 1), null) };
 
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpperInvariant(buffer) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpperInvariant(buffer.Slice(1, 1)) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpperInvariant(buffer.Slice(0, 1)) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpperInvariant(buffer.Slice(2, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpperInvariant(buffer) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpperInvariant(buffer.Slice(1, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpperInvariant(buffer.Slice(0, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => ((ReadOnlySpan<char>)buffer).ToUpperInvariant(buffer.Slice(2, 1)) };
 
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpperInvariant(buffer, buffer) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpperInvariant(buffer, buffer.Slice(1, 1)) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpperInvariant(buffer, buffer.Slice(0, 1)) };
-            yield return new MemoryTestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpperInvariant(buffer, buffer.Slice(2, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpperInvariant(buffer, buffer) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpperInvariant(buffer, buffer.Slice(1, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpperInvariant(buffer, buffer.Slice(0, 1)) };
+            yield return new TestHelpers.AssertThrowsAction<char>[] { (Span<char> buffer) => MemoryExtensions.ToUpperInvariant(buffer, buffer.Slice(2, 1)) };
         }
 
         [Theory]
         [MemberData(nameof(MemoryExtensionsToUpperLowerOverlapping))]
-        public static void MemoryExtensionsToUpperLowerOverlappingThrows(MemoryTestHelpers.AssertThrowsAction<char> action)
+        public static void MemoryExtensionsToUpperLowerOverlappingThrows(TestHelpers.AssertThrowsAction<char> action)
         {
             Span<char> buffer = new char[] { 'a', 'b', 'c', 'd' };
-            MemoryTestHelpers.AssertThrows<InvalidOperationException, char>(buffer, action);
+            TestHelpers.AssertThrows<InvalidOperationException, char>(buffer, action);
         }
     }
 }

--- a/src/System.Memory/tests/Span/Clear.cs
+++ b/src/System.Memory/tests/Span/Clear.cs
@@ -5,7 +5,7 @@
 using Xunit;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using static System.MemoryTestHelpers;
+using static System.TestHelpers;
 
 namespace System.SpanTests
 {

--- a/src/System.Memory/tests/Span/CopyTo.cs
+++ b/src/System.Memory/tests/Span/CopyTo.cs
@@ -92,7 +92,7 @@ namespace System.SpanTests
             int[] dst = { 99, 100 };
 
             Span<int> srcSpan = new Span<int>(src);
-            MemoryTestHelpers.AssertThrows<ArgumentException, int>(srcSpan, (_srcSpan) => _srcSpan.CopyTo(dst));
+            TestHelpers.AssertThrows<ArgumentException, int>(srcSpan, (_srcSpan) => _srcSpan.CopyTo(dst));
             int[] expected = { 99, 100 };
             Assert.Equal<int>(expected, dst);  // CopyTo() checks for sufficient space before doing any copying.
         }
@@ -177,7 +177,7 @@ namespace System.SpanTests
             int[] src = { 1, 2, 3 };
             int[] dst = new int[2] { 99, 100 };
 
-            MemoryTestHelpers.AssertThrows<ArgumentException, int>(src, (_src) => _src.CopyTo(dst));
+            TestHelpers.AssertThrows<ArgumentException, int>(src, (_src) => _src.CopyTo(dst));
             int[] expected = { 99, 100 };
             Assert.Equal<int>(expected, dst);  // CopyTo() checks for sufficient space before doing any copying.
         }

--- a/src/System.Memory/tests/Span/CtorPointerInt.cs
+++ b/src/System.Memory/tests/Span/CtorPointerInt.cs
@@ -58,7 +58,7 @@ namespace System.SpanTests
                 new Span<int>((void*)null, 0);
                 new Span<int?>((void*)null, 0);
                 AssertExtensions.Throws<ArgumentException>(null, () => new Span<object>((void*)null, 0).DontBox());
-                AssertExtensions.Throws<ArgumentException>(null, () => new Span<MemoryTestHelpers.StructWithReferences>((void*)null, 0).DontBox());
+                AssertExtensions.Throws<ArgumentException>(null, () => new Span<TestHelpers.StructWithReferences>((void*)null, 0).DontBox());
             }
         }
     }

--- a/src/System.Memory/tests/Span/Fill.cs
+++ b/src/System.Memory/tests/Span/Fill.cs
@@ -4,7 +4,7 @@
 
 using System.Runtime.InteropServices;
 using Xunit;
-using static System.MemoryTestHelpers;
+using static System.TestHelpers;
 
 namespace System.SpanTests
 {

--- a/src/System.Memory/tests/Span/IndexOf.T.cs
+++ b/src/System.Memory/tests/Span/IndexOf.T.cs
@@ -187,7 +187,7 @@ namespace System.SpanTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.IndexOfNullData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.IndexOfNullData), MemberType = typeof(TestHelpers))]
         public static void IndexOfNull_String(string[] spanInput, int expected)
         {
             Span<string> theStrings = spanInput;

--- a/src/System.Memory/tests/Span/IndexOfSequence.T.cs
+++ b/src/System.Memory/tests/Span/IndexOfSequence.T.cs
@@ -233,7 +233,7 @@ namespace System.SpanTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.IndexOfNullSequenceData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.IndexOfNullSequenceData), MemberType = typeof(TestHelpers))]
         public static void IndexOfNullSequence_String(string[] spanInput, string[] searchInput, int expected)
         {
             Span<string> theStrings = spanInput;

--- a/src/System.Memory/tests/Span/LastIndexOf.T.cs
+++ b/src/System.Memory/tests/Span/LastIndexOf.T.cs
@@ -187,7 +187,7 @@ namespace System.SpanTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.LastIndexOfNullData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.LastIndexOfNullData), MemberType = typeof(TestHelpers))]
         public static void LastIndexOfNull_String(string[] spanInput, int expected)
         {
             Span<string> theStrings = spanInput;

--- a/src/System.Memory/tests/Span/LastIndexOfSequence.T.cs
+++ b/src/System.Memory/tests/Span/LastIndexOfSequence.T.cs
@@ -243,7 +243,7 @@ namespace System.SpanTests
         }
 
         [Theory]
-        [MemberData(nameof(MemoryTestHelpers.LastIndexOfNullSequenceData), MemberType = typeof(MemoryTestHelpers))]
+        [MemberData(nameof(TestHelpers.LastIndexOfNullSequenceData), MemberType = typeof(TestHelpers))]
         public static void LastIndexOfNullSequence_String(string[] spanInput, string[] searchInput, int expected)
         {
             Span<string> theStrings = spanInput;

--- a/src/System.Memory/tests/Span/Reverse.cs
+++ b/src/System.Memory/tests/Span/Reverse.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using static System.MemoryTestHelpers;
+using static System.TestHelpers;
 
 namespace System.SpanTests
 {

--- a/src/System.Memory/tests/Span/ToString.cs
+++ b/src/System.Memory/tests/Span/ToString.cs
@@ -59,7 +59,7 @@ namespace System.SpanTests
         [Fact]
         public static void ToStringSpanOverFullStringDoesNotReturnOriginal()
         {
-            string original = MemoryTestHelpers.BuildString(10, 42);
+            string original = TestHelpers.BuildString(10, 42);
 
             ReadOnlyMemory<char> readOnlyMemory = original.AsMemory();
             Memory<char> memory = MemoryMarshal.AsMemory(readOnlyMemory);

--- a/src/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/System.Memory/tests/System.Memory.Tests.csproj
@@ -41,10 +41,8 @@
     <Compile Include="AllocationHelper.cs" />
     <Compile Include="TInt.cs" />
     <Compile Include="TestException.cs" />
+    <Compile Include="TestHelpers.cs" />
     <Compile Include="TestMemory.cs" />
-    <Compile Include="$(CommonTestPath)\System\MemoryTestHelpers.cs">
-      <Link>System\MemoryTestHelpers.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BuffersExtensions\BuffersExtensionsTests.cs" />

--- a/src/System.Memory/tests/TestHelpers.cs
+++ b/src/System.Memory/tests/TestHelpers.cs
@@ -13,7 +13,7 @@ using System.Reflection;
 
 namespace System
 {
-    public static class MemoryTestHelpers
+    public static class TestHelpers
     {
         public static void Validate<T>(this Span<T> span, params T[] expected) where T : struct, IEquatable<T>
         {

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -14,9 +14,6 @@
     <Compile Include="$(CommonTestPath)\System\MockType.cs">
       <Link>Common\System\MockType.cs</Link>
     </Compile>
-    <Compile Include="$(CommonTestPath)\System\MemoryTestHelpers.cs">
-      <Link>System\MemoryTestHelpers.cs</Link>
-    </Compile>
     <Compile Include="$(CommonTestPath)\System\Collections\CollectionAsserts.cs">
       <Link>Common\System\Collections\CollectionAsserts.cs</Link>
     </Compile>


### PR DESCRIPTION
Adjusts https://github.com/dotnet/corefx/pull/38782 to use `SpanTestHelpers` within StringTests (rather than `TestHelpers`) and revert https://github.com/dotnet/corefx/commit/af179e58770276d0e3ad6d7135cd5e6b00a9a6bf from https://github.com/dotnet/corefx/pull/38782 since it was making too many unnecessary changes.

cc @MarcoRossignoli, @safern 