### PR TITLE
Normalize generate ref source paths correctly

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -145,7 +145,7 @@
     <PropertyGroup>
       <_GenAPICmd>$(_GenAPICommand)</_GenAPICmd>
       <_GenAPICmd>$(_GenAPICmd) "@(IntermediateAssembly)"</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) --lib-path "$(RefPath)"</_GenAPICmd>
+      <_GenAPICmd>$(_GenAPICmd) --lib-path "$(RefPath.Trim('\/'))"</_GenAPICmd>
       <_GenAPICmd>$(_GenAPICmd) --out "$(_RefSourceFileOutputPath)"</_GenAPICmd>
       <_GenAPICmd>$(_GenAPICmd) --exclude-attributes-list "$(_ExcludeAPIList)"</_GenAPICmd>
       <_GenAPICmd>$(_GenAPICmd) --header-file "$(_LicenseHeaderTxtPath)"</_GenAPICmd>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -137,7 +137,7 @@
 
   <Target Name="GenerateReferenceSource">
     <PropertyGroup>
-      <_RefSourceFileOutputPath>$(MSBuildProjectDirectory)/../ref/$(AssemblyName).cs</_RefSourceFileOutputPath>
+      <_RefSourceFileOutputPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', '$(AssemblyName).cs'))</_RefSourceFileOutputPath>
       <_ExcludeAPIList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</_ExcludeAPIList>
       <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath>
     </PropertyGroup>

--- a/eng/ReferenceAssemblies.props
+++ b/eng/ReferenceAssemblies.props
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsReferenceAssembly)'=='true'">
-    <OutputPath>$(ReferenceAssemblyOutputPath)$(MSBuildProjectName)/$(Configuration)</OutputPath>
-    <IntermediateOutputPath>$(ArtifactsObjDir)ref/$(MSBuildProjectName)/$(Configuration)</IntermediateOutputPath>
+    <OutputPath>$([MSBuild]::NormalizeDirectory('$(ReferenceAssemblyOutputPath)', '$(MSBuildProjectName)', '$(Configuration)'))</OutputPath>
+    <IntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'ref', '$(MSBuildProjectName)', '$(Configuration)'))</IntermediateOutputPath>
 
     <!-- disable warnings about unused fields -->
     <NoWarn>$(NoWarn);CS0169;CS0649;CS8618</NoWarn>


### PR DESCRIPTION
Fixes the following error on desktop msbuild. This was probably introduced when we started quoting the paths to handle paths with white-spaces.

```
Unhandled Exception: System.ArgumentException: Illegal characters in path.
     at System.IO.Path.CheckInvalidPathChars(String path, Boolean checkAdditional)
     at System.IO.Path.Combine(String path1, String path2)
     at Microsoft.Cci.Extensions.HostEnvironment.Probe(String probeDir, AssemblyIdentity referencedAssembly) in /_/src/Microsoft.Cci.Extensions/HostEnvironment.cs:line 196
     at Microsoft.Cci.Extensions.HostEnvironment.ProbeLibPaths(AssemblyIdentity identity) in /_/src/Microsoft.Cci.Extensions/HostEnvironment.cs:line 138
     at Microsoft.Cci.Extensions.HostEnvironment.ResolveCoreAssemblyIdentity(IAssembly assembly) in /_/src/Microsoft.Cci.Extensions/HostEnvironment.cs:line 255
     at Microsoft.Cci.Extensions.HostEnvironment.GetCoreAssemblySymbolicIdentity() in /_/src/Microsoft.Cci.Extensions/HostEnvironment.cs:line 233
     at Microsoft.Cci.MetadataHostEnvironment.get_CoreAssemblySymbolicIdentity()
     at Microsoft.Cci.MetadataReader.CoreTypes..ctor(PEFileToObjectModel peFileToObjectModel)
     at Microsoft.Cci.MetadataReader.PEFileToObjectModel.get_CoreTypes()
     at Microsoft.Cci.MetadataReader.PEFileToObjectModel.LoadTypesInNamespace(Namespace moduleNamespace)
     at Microsoft.Cci.MetadataReader.ObjectModelImplementation.Namespace.LoadMembers()
     at Microsoft.Cci.MetadataReader.ObjectModelImplementation.ScopedContainerMetadataObject`3.<get_Members>d__15.MoveNext()
     at System.Linq.Enumerable.<OfTypeIterator>d__95`1.MoveNext()
     at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
     at System.Linq.Enumerable.<>c__DisplayClass6_0`1.<CombinePredicates>b__0(TSource x)
     at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
     at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
     at System.Linq.OrderedEnumerable`1.<GetEnumerator>d__1.MoveNext()
     at Microsoft.Cci.Traversers.SimpleTypeMemberTraverser.Visit(IEnumerable`1 namespaces) in /_/src/Microsoft.Cci.Extensions/Traversers/SimpleTypeMemberTraverser.cs:line 43
     at Microsoft.Cci.Writers.CSharpWriter.Visit(IAssembly assembly) in /_/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs:line 91
     at Microsoft.Cci.Writers.CSharpWriter.WriteAssemblies(IEnumerable`1 assemblies) in /_/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs:line 79
     at Microsoft.DotNet.GenAPI.Program.<>c__DisplayClass0_0.<Main>b__0() in /_/src/Microsoft.DotNet.GenAPI/Program.cs:line 97
     at Microsoft.DotNet.GenAPI.Program.Main(String[] args) in /_/src/Microsoft.DotNet.GenAPI/Program.cs:line 54
```

cc @ericstj 