### PR TITLE
Fix and re-enable AddFontFile_Directory_ThrowsFileNotFoundException test, rename GetAdjustedPalette_InvalidTypes_ThrowsArgumentException

### DIFF
--- a/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
@@ -1511,7 +1511,7 @@ namespace System.Drawing.Imaging.Tests
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ColorAdjustType_InvalidTypes_TestData))]
-        public void GetAdjustedPalette_Disposed_ThrowsArgumentException(ColorAdjustType type)
+        public void GetAdjustedPalette_InvalidTypes_ThrowsArgumentException(ColorAdjustType type)
         {
             using (var bitmap = new Bitmap(_rectangle.Width, _rectangle.Height))
             using (var imageAttr = new ImageAttributes())

--- a/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
+++ b/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
@@ -149,19 +149,12 @@ namespace System.Drawing.Text.Tests
             }
         }
 
-        [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         [ConditionalFact(Helpers.IsDrawingSupported)]
-        public void AddFontFile_Directory_ThrowsExternalException()
+        public void AddFontFile_Directory_ThrowsFileNotFoundException()
         {
-            // GDI+ on Windows 7 and Windows 8.1 incorrectly does not throw.
-            if (PlatformDetection.IsWindows || PlatformDetection.IsWindows8x)
-            {
-                return;
-            }
-
             using (var fontCollection = new PrivateFontCollection())
             {
-                Assert.Throws<ExternalException>(() => fontCollection.AddFontFile(AppContext.BaseDirectory));
+                Assert.Throws<FileNotFoundException>(() => fontCollection.AddFontFile(AppContext.BaseDirectory));
             }
         }
 

--- a/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
+++ b/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
@@ -154,7 +154,7 @@ namespace System.Drawing.Text.Tests
         {
             using (var fontCollection = new PrivateFontCollection())
             {
-                Assert.Throws<FileNotFoundException>(() => fontCollection.AddFontFile(AppContext.BaseDirectory));
+                AssertExtensions.Throws<FileNotFoundException, ExternalException>(() => fontCollection.AddFontFile(AppContext.BaseDirectory));
             }
         }
 


### PR DESCRIPTION
- `AddFontFile_Directory_ThrowsFileNotFoundException` did not test anything, as it:
  * Was disabled on Unix (`[ActiveIssue(20884, TestPlatforms.AnyUnix)]`)
  * Would immediately return on Windows (`if (PlatformDetection.IsWindows || PlatformDetection.IsWindows8x)`)
  * [The code base actually throws a `FileNotFoundException`](https://github.com/dotnet/corefx/blob/master/src/System.Drawing.Common/src/System/Drawing/Text/PrivateFontCollection.cs#L78) (the test asserts other behavior, probably because #23191 and #21552 crossed)
- `GetAdjustedPalette_InvalidTypes_ThrowsArgumentException` was incorrectly named `GetAdjustedPalette_Disposed_ThrowsArgumentException`. Another test with the same name (but different arguments) already exists, throwing xUnit off guard.