### PR TITLE
Disable nano in PR CI

### DIFF
--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -30,7 +30,7 @@ jobs:
               _BuildConfig: Debug
               _architecture: x64
               _framework: netcoreapp
-              _helixQueues: $(netcoreappWindowsQueues)+$(nanoQueues)
+              _helixQueues: $(netcoreappWindowsQueues) # Temporarily disable Nano for issue 38858: +$(nanoQueues)
 
             x86_Release:
               _BuildConfig: Release


### PR DESCRIPTION
Nano failures are currently taking out almost every PR.
https://github.com/dotnet/corefx/issues/38858
cc: @ViktorHofer, @safern