### PR TITLE
Fix infinite loop in JsonSerializer.WriteValue

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.cs
@@ -19,6 +19,7 @@ namespace System.Text.Json
             ref WriteStack state)
         {
             bool finishedSerializing;
+            int currentDepth = writer.CurrentDepth;
 
             try
             {
@@ -52,7 +53,7 @@ namespace System.Text.Json
 
                     if (finishedSerializing)
                     {
-                        if (writer.CurrentDepth == 0)
+                        if (writer.CurrentDepth == 0 || writer.CurrentDepth == currentDepth)
                         {
                             break;
                         }

--- a/src/System.Text.Json/tests/Serialization/WriteValueTests.cs
+++ b/src/System.Text.Json/tests/Serialization/WriteValueTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static partial class WriteValueTests
+    {
+        [Fact]
+        public static void CanWriteValueToJsonArray()
+        {
+            using MemoryStream memoryStream = new MemoryStream();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(memoryStream);
+
+            writer.WriteStartObject();
+            writer.WriteStartArray("test");
+            JsonSerializer.WriteValue<int>(writer, 1);
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+            writer.Flush();
+
+            string json = Encoding.UTF8.GetString(memoryStream.ToArray());
+            Assert.Equal("{\"test\":[1]}", json);
+        }
+    }
+}

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Serialization\Value.WriteTests.GenericCollections.cs" />
     <Compile Include="Serialization\Value.WriteTests.ImmutableCollections.cs" />
     <Compile Include="Serialization\Value.WriteTests.NonGenericCollections.cs" />
+    <Compile Include="Serialization\WriteValueTests.cs" />
     <Compile Include="TestCaseType.cs" />
     <Compile Include="TestClasses.ClassWithComplexObjects.cs" />
     <Compile Include="Utf8JsonReaderTests.cs" />


### PR DESCRIPTION
@ahsonkhan @steveharter 

I'm not super sure why the `write.CurrentDepth == 0` check exists and removing it breaks a lot of tests.
So I'm not sure if this is the correct fix, but at least it's a start.