### PR TITLE
Move XamlAccessLevel to System.Windows.Extensions.dll

### DIFF
--- a/src/System.Security.Permissions/ref/System.Security.Permissions.Forwards.cs
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.Forwards.cs
@@ -18,3 +18,6 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.PermissionSet))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Permissions.PermissionState))]
 #endif
+#if netcoreapp
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Xaml.Permissions.XamlAccessLevel))]
+#endif

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.Forwards.cs
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.Forwards.cs
@@ -18,6 +18,4 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.PermissionSet))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Permissions.PermissionState))]
 #endif
-#if netcoreapp
-[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Xaml.Permissions.XamlAccessLevel))]
-#endif
+

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -2091,18 +2091,11 @@ namespace System.Web
         Unrestricted = 600,
     }
 }
+
+#if netcoreapp
+
 namespace System.Xaml.Permissions
 {
-    public partial class XamlAccessLevel
-    {
-        internal XamlAccessLevel() { }
-        public System.Reflection.AssemblyName AssemblyAccessToAssemblyName { get { throw null; } }
-        public string PrivateAccessToTypeName { get { throw null; } }
-        public static System.Xaml.Permissions.XamlAccessLevel AssemblyAccessTo(System.Reflection.Assembly assembly) { throw null; }
-        public static System.Xaml.Permissions.XamlAccessLevel AssemblyAccessTo(System.Reflection.AssemblyName assemblyName) { throw null; }
-        public static System.Xaml.Permissions.XamlAccessLevel PrivateAccessTo(string assemblyQualifiedTypeName) { throw null; }
-        public static System.Xaml.Permissions.XamlAccessLevel PrivateAccessTo(System.Type type) { throw null; }
-    }
     public sealed partial class XamlLoadPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
     {
         public XamlLoadPermission(System.Collections.Generic.IEnumerable<System.Xaml.Permissions.XamlAccessLevel> allowedAccess) { }
@@ -2121,3 +2114,4 @@ namespace System.Xaml.Permissions
         public override System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
     }
 }
+#endif 

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -2092,26 +2092,3 @@ namespace System.Web
     }
 }
 
-#if netcoreapp
-
-namespace System.Xaml.Permissions
-{
-    public sealed partial class XamlLoadPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
-    {
-        public XamlLoadPermission(System.Collections.Generic.IEnumerable<System.Xaml.Permissions.XamlAccessLevel> allowedAccess) { }
-        public XamlLoadPermission(System.Security.Permissions.PermissionState state) { }
-        public XamlLoadPermission(System.Xaml.Permissions.XamlAccessLevel allowedAccess) { }
-        public System.Collections.Generic.IList<System.Xaml.Permissions.XamlAccessLevel> AllowedAccess { get { throw null; } }
-        public override System.Security.IPermission Copy() { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public override void FromXml(System.Security.SecurityElement elem) { }
-        public override int GetHashCode() { throw null; }
-        public bool Includes(System.Xaml.Permissions.XamlAccessLevel requestedAccess) { throw null; }
-        public override System.Security.IPermission Intersect(System.Security.IPermission target) { throw null; }
-        public override bool IsSubsetOf(System.Security.IPermission target) { throw null; }
-        public bool IsUnrestricted() { throw null; }
-        public override System.Security.SecurityElement ToXml() { throw null; }
-        public override System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
-    }
-}
-#endif 

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{07CAF142-B259-418E-86EF-C4BD8B50253E}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
@@ -38,5 +38,8 @@
     <ProjectReference Include="..\..\System.Security.Cryptography.X509Certificates\ref\System.Security.Cryptography.X509Certificates.csproj" />
     <ProjectReference Include="..\..\System.Text.RegularExpressions\ref\System.Text.RegularExpressions.csproj" />
     <ProjectReference Include="..\..\System.Threading\ref\System.Threading.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <ProjectReference Include="..\..\System.Windows.Extensions\ref\System.Windows.Extensions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -4,10 +4,13 @@
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
     <Configurations>net461-Debug;net461-Release;netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System.Security.Permissions.cs" />
     <Compile Include="System.Security.Permissions.Forwards.cs" />
     <SuppressPackageTargetFrameworkCompatibility Include="$(UAPvNextTFM)" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System.Security.Permissions.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
     <Reference Include="mscorlib" />

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -4,12 +4,12 @@
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
     <Configurations>net461-Debug;net461-Release;netcoreapp-Debug;netcoreapp-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release;uap-Debug;uap-Release</Configurations>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+  <ItemGroup>
     <Compile Include="System.Security.Permissions.cs" />
     <Compile Include="System.Security.Permissions.Forwards.cs" />
     <SuppressPackageTargetFrameworkCompatibility Include="$(UAPvNextTFM)" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System.Security.Permissions.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.netcoreapp.cs
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.netcoreapp.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.Xaml.Permissions
+{
+    public sealed partial class XamlLoadPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public XamlLoadPermission(System.Collections.Generic.IEnumerable<System.Xaml.Permissions.XamlAccessLevel> allowedAccess) { }
+        public XamlLoadPermission(System.Security.Permissions.PermissionState state) { }
+        public XamlLoadPermission(System.Xaml.Permissions.XamlAccessLevel allowedAccess) { }
+        public System.Collections.Generic.IList<System.Xaml.Permissions.XamlAccessLevel> AllowedAccess { get { throw null; } }
+        public override System.Security.IPermission Copy() { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override void FromXml(System.Security.SecurityElement elem) { }
+        public override int GetHashCode() { throw null; }
+        public bool Includes(System.Xaml.Permissions.XamlAccessLevel requestedAccess) { throw null; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { throw null; }
+        public override bool IsSubsetOf(System.Security.IPermission target) { throw null; }
+        public bool IsUnrestricted() { throw null; }
+        public override System.Security.SecurityElement ToXml() { throw null; }
+        public override System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
+    }
+}

--- a/src/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -178,6 +178,8 @@
     <Compile Include="System\Web\AspNetHostingPermission.cs" />
     <Compile Include="System\Web\AspNetHostingPermissionAttribute.cs" />
     <Compile Include="System\Web\AspNetHostingPermissionLevel.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System\Xaml\Permissions\XamlLoadPermission.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
@@ -226,6 +228,8 @@
     <Reference Include="System.Text.RegularExpressions" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Reference Include="System.Windows.Extensions" />
   </ItemGroup>
 </Project>

--- a/src/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{07390899-C8F6-4E83-A3A9-6867B8CB46A0}</ProjectGuid>
     <RootNamespace>System.Security.Permissions</RootNamespace>
@@ -178,7 +178,6 @@
     <Compile Include="System\Web\AspNetHostingPermission.cs" />
     <Compile Include="System\Web\AspNetHostingPermissionAttribute.cs" />
     <Compile Include="System\Web\AspNetHostingPermissionLevel.cs" />
-    <Compile Include="System\Xaml\Permissions\XamlAccessLevel.cs" />
     <Compile Include="System\Xaml\Permissions\XamlLoadPermission.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
@@ -227,5 +226,6 @@
     <Reference Include="System.Text.RegularExpressions" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
+    <Reference Include="System.Windows.Extensions" />
   </ItemGroup>
 </Project>

--- a/src/System.Security.Permissions/tests/PermissionTests.cs
+++ b/src/System.Security.Permissions/tests/PermissionTests.cs
@@ -7,7 +7,6 @@ using System.Configuration;
 using System.DirectoryServices;
 using System.Reflection;
 using System.Web;
-using System.Xaml.Permissions;
 
 namespace System.Security.Permissions.Tests
 {
@@ -442,26 +441,6 @@ namespace System.Security.Permissions.Tests
         {
             WebBrowserPermissionAttribute wpa = new WebBrowserPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = wpa.CreatePermission();
-        }
-
-        [Fact]
-        public static void XamlLoadPermissionCallMethods()
-        {
-            XamlAccessLevel accessLevel = XamlAccessLevel.AssemblyAccessTo(Assembly.GetExecutingAssembly().GetName());
-            XamlLoadPermission xp = new XamlLoadPermission(accessLevel);
-            XamlLoadPermission xp2 = new XamlLoadPermission(PermissionState.Unrestricted);
-            XamlLoadPermission xp3 = new XamlLoadPermission(Array.Empty<XamlAccessLevel>());
-            bool testbool = xp.IsUnrestricted();
-            IPermission ip = xp.Copy();
-            IPermission ip2 = xp.Intersect(ip);
-            IPermission ip3 = xp.Union(ip);
-            testbool = xp.IsSubsetOf(ip);
-            testbool = xp.Equals(new object());
-            testbool = xp.Includes(accessLevel);
-            int hash = xp.GetHashCode();
-            SecurityElement se = new SecurityElement("");
-            xp.FromXml(se);
-            se = xp.ToXml();
         }
 
         [Fact]

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -19,4 +19,7 @@
     <Compile Include="SecurityElementTests.cs" />
     <Compile Include="TrustManagerContextTests.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Compile Include="XamlLoadPermissionTests.cs"/>
+  </ItemGroup>
 </Project>

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -18,6 +18,5 @@
     <Compile Include="PrincipalPermissionTests.cs" />
     <Compile Include="SecurityElementTests.cs" />
     <Compile Include="TrustManagerContextTests.cs" />
-    <Compile Include="XamlAccessLevelTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -19,7 +19,7 @@
     <Compile Include="SecurityElementTests.cs" />
     <Compile Include="TrustManagerContextTests.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' And '$(TargetsWindows)' == 'true'">
     <Compile Include="XamlLoadPermissionTests.cs"/>
   </ItemGroup>
 </Project>

--- a/src/System.Security.Permissions/tests/XamlLoadPermissionTests.cs
+++ b/src/System.Security.Permissions/tests/XamlLoadPermissionTests.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Configuration;
+using System.DirectoryServices;
+using System.Reflection;
+using System.Web;
+using System.Xaml.Permissions;
+
+namespace System.Xaml.Permissions.Tests
+{
+    public class XamlLoadPermissionTests
+    {
+        [Fact]
+        public static void XamlLoadPermissionCallMethods()
+        {
+            XamlAccessLevel accessLevel = XamlAccessLevel.AssemblyAccessTo(Assembly.GetExecutingAssembly().GetName());
+            XamlLoadPermission xp = new XamlLoadPermission(accessLevel);
+            XamlLoadPermission xp2 = new XamlLoadPermission(PermissionState.Unrestricted);
+            XamlLoadPermission xp3 = new XamlLoadPermission(Array.Empty<XamlAccessLevel>());
+            bool testbool = xp.IsUnrestricted();
+            IPermission ip = xp.Copy();
+            IPermission ip2 = xp.Intersect(ip);
+            IPermission ip3 = xp.Union(ip);
+            testbool = xp.IsSubsetOf(ip);
+            testbool = xp.Equals(new object());
+            testbool = xp.Includes(accessLevel);
+            int hash = xp.GetHashCode();
+            SecurityElement se = new SecurityElement("");
+            xp.FromXml(se);
+            se = xp.ToXml();
+        }
+    }
+}

--- a/src/System.Security.Permissions/tests/XamlLoadPermissionTests.cs
+++ b/src/System.Security.Permissions/tests/XamlLoadPermissionTests.cs
@@ -6,6 +6,8 @@ using Xunit;
 using System.Configuration;
 using System.DirectoryServices;
 using System.Reflection;
+using System.Security;
+using System.Security.Permissions;
 using System.Web;
 using System.Xaml.Permissions;
 

--- a/src/System.Windows.Extensions/ref/System.Windows.Extensions.cs
+++ b/src/System.Windows.Extensions/ref/System.Windows.Extensions.cs
@@ -133,3 +133,16 @@ namespace System.Security.Cryptography.X509Certificates
         MultiSelection = 1,
     }
 }
+namespace System.Xaml.Permissions
+{
+    public partial class XamlAccessLevel
+    {
+        internal XamlAccessLevel() { }
+        public System.Reflection.AssemblyName AssemblyAccessToAssemblyName { get { throw null; } }
+        public string PrivateAccessToTypeName { get { throw null; } }
+        public static System.Xaml.Permissions.XamlAccessLevel AssemblyAccessTo(System.Reflection.Assembly assembly) { throw null; }
+        public static System.Xaml.Permissions.XamlAccessLevel AssemblyAccessTo(System.Reflection.AssemblyName assemblyName) { throw null; }
+        public static System.Xaml.Permissions.XamlAccessLevel PrivateAccessTo(string assemblyQualifiedTypeName) { throw null; }
+        public static System.Xaml.Permissions.XamlAccessLevel PrivateAccessTo(System.Type type) { throw null; }
+    }
+}

--- a/src/System.Windows.Extensions/src/System.Windows.Extensions.csproj
+++ b/src/System.Windows.Extensions/src/System.Windows.Extensions.csproj
@@ -71,6 +71,7 @@
     <Compile Include="System\Media\SoundPlayer.cs" />
     <Compile Include="System\Media\SystemSound.cs" />
     <Compile Include="System\Media\SystemSounds.cs" />
+    <Compile Include="System\Xaml\Permissions\XamlAccessLevel.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Reference Include="System.Buffers" />

--- a/src/System.Windows.Extensions/src/System/Xaml/Permissions/XamlAccessLevel.cs
+++ b/src/System.Windows.Extensions/src/System/Xaml/Permissions/XamlAccessLevel.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
+++ b/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
@@ -6,6 +6,7 @@
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="X509Certificate2UITests.cs" />
     <Compile Include="X509Certificate2UIManualTests.cs" />
+    <Compile Include="XamlAccessLevelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Drawing\Helpers.cs">
@@ -21,7 +22,6 @@
     <Compile Include="System\Media\SoundPlayerTests.cs" />
     <Compile Include="System\Media\SystemSoundTests.cs" />
     <Compile Include="System\Media\SystemSoundsTests.cs" />
-    <Compile Include="XamlAccessLevelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="$(SystemComponentModelTypeConverterTestDataPackageVersion)" />

--- a/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
+++ b/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="System\Media\SoundPlayerTests.cs" />
     <Compile Include="System\Media\SystemSoundTests.cs" />
     <Compile Include="System\Media\SystemSoundsTests.cs" />
+    <Compile Include="XamlAccessLevelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="$(SystemComponentModelTypeConverterTestDataPackageVersion)" />

--- a/src/System.Windows.Extensions/tests/XamlAccessLevelTests.cs
+++ b/src/System.Windows.Extensions/tests/XamlAccessLevelTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Windows.Extensions/tests/XamlAccessLevelTests.cs
+++ b/src/System.Windows.Extensions/tests/XamlAccessLevelTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
-using System.Xaml.Permissions;
 using Xunit;
 
 namespace System.Security.Permissions.Tests

--- a/src/System.Windows.Extensions/tests/XamlAccessLevelTests.cs
+++ b/src/System.Windows.Extensions/tests/XamlAccessLevelTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using System.Xaml.Permissions;
 using Xunit;
 
 namespace System.Security.Permissions.Tests


### PR DESCRIPTION
As part of https://github.com/dotnet/wpf/pull/969 (and other PR's), WPF is trying to remove its references to `System.Security.Permissions` and remove CAS related code-patterns. In order to complete this work, `XamlAccessLevel` and `XamlLoadPermission` had been moved to `System.Windows.Extensions.dll`

The idea was to decouple WPF from `XamlLoadPermission` and `XamlAccessLevel` completely. We have come to realize that decoupling from `XamlLoadPermission` has been relatively straightforward, but removing the dependency on `XamlAccessLevel` is proving to be hard. WPF depends on `XamlAccessLevel` for non-CAS related patterns (and exposes these to developers). 

We believe that we need continued access to `XamlAccessLevel`. In order to do this right, one approach being proposed here is to move `XamlAccessLevel` to `System.Windows.Extensions.dll`. 

Note that I'm proposing that `XamlLoadPermission` would continue to reside in `System.Security.Permission.dll` - moving this type to `System.Windows.Extensions.dll` would make it so that accessing `XamlAccessLevel` would pull in a reference to `System.Security.Permissions.dll`  - an effect we'd like to avoid. 

/cc @ericstj , @rladuca , @ojhad 
/cc @dotnet/wpf-developers 

Edit: updating description to reflect change in proposal. instead of introducing a new assembly `System.Xaml.Permissions.dll`, the proposal is now to move `XamlAccessLevel` to `System.Windows.Extensions.dll`