### PR TITLE
Add HPACK integer validation to prevent wrapping and overlong encodings.

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -519,4 +519,7 @@
   <data name="net_http_hpack_late_dynamic_table_size_update" xml:space="preserve">
     <value>Dynamic table size update received after beginning of header block.</value>
   </data>
+  <data name="net_http_hpack_bad_integer" xml:space="preserve">
+    <value>HPACK integer exceeds limits or has an overlong encoding.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/IntegerDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/IntegerDecoder.cs
@@ -17,11 +17,27 @@ namespace System.Net.Http.HPack
         /// <summary>
         /// Decodes the first byte of the integer.
         /// </summary>
-        /// <param name="prefixLength">The length of the prefix, in bits, that the integer was encoded with. Must be between 1 and 8.</param>
-        /// <returns>If the integer has been fully decoded, true. Otherwise, false -- <see cref="Decode(byte)"/> must be called on subsequent bytes.</returns>
+        /// <param name="b">
+        /// The first byte of the variable-length encoded integer.
+        /// </param>
+        /// <param name="prefixLength">
+        /// The number of lower bits in this prefix byte that the
+        /// integer has been encoded into. Must be between 1 and 8.
+        /// Upper bits must be zero.
+        /// </param>
+        /// <returns>
+        /// If the integer has been fully decoded, true.
+        /// Otherwise, false -- <see cref="Decode(byte)"/> must be called on subsequent bytes.
+        /// </returns>
+        /// <remarks>
+        /// The term "prefix" can be confusing. From the HPACK spec:
+        /// An integer is represented in two parts: a prefix that fills the current octet and an
+        /// optional list of octets that are used if the integer value does not fit within the prefix.
+        /// </remarks>
         public bool StartDecode(byte b, int prefixLength)
         {
             Debug.Assert(prefixLength >= 1 && prefixLength <= 8);
+            Debug.Assert((b & ~((1 << prefixLength) - 1)) == 0, "bits other than prefix data must be set to 0.");
 
             if (b < ((1 << prefixLength) - 1))
             {

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackIntegerTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackIntegerTest.cs
@@ -76,6 +76,7 @@ namespace System.Net.Http.Unit.Tests.HPack
 
         [Theory]
         [InlineData(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x08 })] // 1 bit too large
+        [InlineData(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F })]
         [InlineData(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x80 })] // A continuation byte (0x80) where the byte after it would be too large.
         [InlineData(new byte[] { 0xFF, 0xFF, 0x00 })] // Encoded with 1 byte too many.
         public void HPack_Integer_TooLarge(byte[] encoded)
@@ -84,7 +85,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             {
                 var dec = new IntegerDecoder();
 
-                if (!dec.StartDecode(encoded[0], 7))
+                if (!dec.StartDecode((byte)(encoded[0] & 0x7F), 7))
                 {
                     for (int i = 1; !dec.Decode(encoded[i]); ++i)
                     {

--- a/src/System.Net.Http/tests/UnitTests/HPack/HPackIntegerTest.cs
+++ b/src/System.Net.Http/tests/UnitTests/HPack/HPackIntegerTest.cs
@@ -73,5 +73,26 @@ namespace System.Net.Http.Unit.Tests.HPack
                 }
             }
         }
+
+        [Theory]
+        [InlineData(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x08 })] // 1 bit too large
+        [InlineData(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x80 })] // A continuation byte (0x80) where the byte after it would be too large.
+        [InlineData(new byte[] { 0xFF, 0xFF, 0x00 })] // Encoded with 1 byte too many.
+        public void HPack_Integer_TooLarge(byte[] encoded)
+        {
+            Assert.Throws<HPackDecodingException>(() =>
+            {
+                var dec = new IntegerDecoder();
+
+                if (!dec.StartDecode(encoded[0], 7))
+                {
+                    for (int i = 1; !dec.Decode(encoded[i]); ++i)
+                    {
+                    }
+                }
+
+                return dec.Value;
+            });
+        }
     }
 }


### PR DESCRIPTION
Resolves #38626. This prevents integers greater than `int.MaxValue` from wrapping negative or otherwise corrupting during decode. It also disallows overlong encodings.

For any curious, these checks result in about a 20% perf hit for any integer taking more than 1 byte.