### PR TITLE
ignore invalid frames on closed streams

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -565,7 +565,11 @@ namespace System.Net.Test.Common
         {
             PingFrame ping = new PingFrame(new byte[8] { 1, 2, 3, 4, 50, 60, 70, 80 }, FrameFlags.None, 0);
             await WriteFrameAsync(ping).ConfigureAwait(false);
-            await ReadFrameAsync(Timeout).ConfigureAwait(false);
+            Frame pingAck = await ReadFrameAsync(Timeout).ConfigureAwait(false);
+            if (pingAck.Type != FrameType.Ping || !pingAck.AckFlag)
+            {
+                throw new Exception("Expected PING ACK");
+            }
         }
 
         public async Task SendDefaultResponseHeadersAsync(int streamId)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -626,7 +626,6 @@ namespace System.Net.Http
                 if (bytesRead != 0)
                 {
                     ExtendWindow(bytesRead);
-                    _connection.ExtendWindow(bytesRead);
                 }
 
                 return bytesRead;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -201,6 +201,12 @@ namespace System.Net.Http
 
                 lock (SyncObject)
                 {
+                    if (_state == StreamState.Aborted)
+                    {
+                        // We could have aborted while processing the header block.
+                        return;
+                    }
+
                     if (name[0] == (byte)':')
                     {
                         if (_state != StreamState.ExpectingHeaders && _state != StreamState.ExpectingStatus)
@@ -306,6 +312,11 @@ namespace System.Net.Http
             {
                 lock (SyncObject)
                 {
+                    if (_state == StreamState.Aborted)
+                    {
+                        return;
+                    }
+
                     if (_state != StreamState.ExpectingStatus && _state != StreamState.ExpectingData)
                     {
                         throw new Http2ProtocolException(SR.Format(SR.net_http_http2_protocol_state, "headers", _state));
@@ -323,6 +334,11 @@ namespace System.Net.Http
                 bool signalWaiter;
                 lock (SyncObject)
                 {
+                    if (_state == StreamState.Aborted)
+                    {
+                        return;
+                    }
+
                     if (_state != StreamState.ExpectingHeaders && _state != StreamState.ExpectingTrailingHeaders && _state != StreamState.ExpectingIgnoredHeaders)
                     {
                         throw new Http2ProtocolException(SR.Format(SR.net_http_http2_protocol_state, "headers", _state));
@@ -375,6 +391,11 @@ namespace System.Net.Http
                 lock (SyncObject)
                 {
                     if (_disposed)
+                    {
+                        return;
+                    }
+
+                    if (_state == StreamState.Aborted)
                     {
                         return;
                     }


### PR DESCRIPTION
Contributes to #38913 
Contributes to #35652 

Ignore any frames received on a closed stream -- more specifically, on a stream that is no longer in the stream dictionary. 

We don't distinguish between streams closed because they were reset by the client (due to cancellation etc) or streams closed because they completed. The former is valid, while the latter is technically invalid per RFC. However, to avoid having to track why the stream was closed, we just ignore these frames in both cases. This matches WinHttp behavior.

We are still not handling the case where a stream is cancelled during the processing of a HEADER or DATA frame.

@dotnet/ncl 