### PR TITLE
 Remove BytesConsumed and Position from JsonReaderState.

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -172,9 +172,7 @@ namespace System.Text.Json
         private object _dummy;
         private int _dummyPrimitive;
         public JsonReaderState(System.Text.Json.JsonReaderOptions options = default(System.Text.Json.JsonReaderOptions)) { throw null; }
-        public long BytesConsumed { get { throw null; } }
         public System.Text.Json.JsonReaderOptions Options { get { throw null; } }
-        public System.SequencePosition Position { get { throw null; } }
     }
     public static partial class JsonSerializer
     {

--- a/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderState.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/JsonReaderState.cs
@@ -16,7 +16,6 @@ namespace System.Text.Json
     {
         internal long _lineNumber;
         internal long _bytePositionInLine;
-        internal long _bytesConsumed;
         internal bool _inObject;
         internal bool _isNotPrimitive;
         internal char _numberFormat;
@@ -26,20 +25,6 @@ namespace System.Text.Json
         internal JsonTokenType _previousTokenType;
         internal JsonReaderOptions _readerOptions;
         internal BitStack _bitStack;
-        internal SequencePosition _sequencePosition;
-
-        /// <summary>
-        /// Returns the total amount of bytes consumed by the <see cref="Utf8JsonReader"/> so far
-        /// for the given UTF-8 encoded input text.
-        /// </summary>
-        public long BytesConsumed => _bytesConsumed;
-
-        /// <summary>
-        /// Returns the current <see cref="SequencePosition"/> within the provided UTF-8 encoded
-        /// input ReadOnlySequence&lt;byte&gt;. If the <see cref="Utf8JsonReader"/> was constructed
-        /// with a ReadOnlySpan&lt;byte&gt; instead, this will always return a default <see cref="SequencePosition"/>.
-        /// </summary>
-        public SequencePosition Position => _sequencePosition;
 
         /// <summary>
         /// Constructs a new <see cref="JsonReaderState"/> instance.
@@ -60,7 +45,6 @@ namespace System.Text.Json
         {
             _lineNumber = default;
             _bytePositionInLine = default;
-            _bytesConsumed = default;
             _inObject = default;
             _isNotPrimitive = default;
             _numberFormat = default;
@@ -73,8 +57,6 @@ namespace System.Text.Json
             // Only allocate if the user reads a JSON payload beyond the depth that the _allocationFreeContainer can handle.
             // This way we avoid allocations in the common, default cases, and allocate lazily.
             _bitStack = default;
-
-            _sequencePosition = default;
         }
 
         /// <summary>

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -29,7 +29,6 @@ namespace System.Text.Json
             _isFinalBlock = isFinalBlock;
             _isInputSequence = true;
 
-            // Note: We do not retain _bytesConsumed or _sequencePosition as they reset with the new input data
             _lineNumber = state._lineNumber;
             _bytePositionInLine = state._bytePositionInLine;
             _inObject = state._inObject;

--- a/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -180,7 +180,6 @@ namespace System.Text.Json
         {
             _lineNumber = _lineNumber,
             _bytePositionInLine = _bytePositionInLine,
-            _bytesConsumed = BytesConsumed,
             _inObject = _inObject,
             _isNotPrimitive = _isNotPrimitive,
             _numberFormat = _numberFormat,
@@ -190,7 +189,6 @@ namespace System.Text.Json
             _previousTokenType = _previousTokenType,
             _readerOptions = _readerOptions,
             _bitStack = _bitStack,
-            _sequencePosition = Position,
         };
 
         /// <summary>
@@ -212,7 +210,6 @@ namespace System.Text.Json
             _isFinalBlock = isFinalBlock;
             _isInputSequence = false;
 
-            // Note: We do not retain _bytesConsumed or _sequencePosition as they reset with the new input data
             _lineNumber = state._lineNumber;
             _bytePositionInLine = state._bytePositionInLine;
             _inObject = state._inObject;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -58,8 +58,7 @@ namespace System.Text.Json
 
             if (reader.BytesConsumed != utf8Json.Length)
             {
-                readerState = reader.CurrentState;
-                ThrowHelper.ThrowJsonException_DeserializeDataRemaining(utf8Json.Length, utf8Json.Length - readerState.BytesConsumed);
+                ThrowHelper.ThrowJsonException_DeserializeDataRemaining(utf8Json.Length, utf8Json.Length - reader.BytesConsumed);
             }
 
             return result;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -75,9 +75,8 @@ namespace System.Text.Json
 
             if (reader.BytesConsumed != jsonBytes.Length)
             {
-                readerState = reader.CurrentState;
                 ThrowHelper.ThrowJsonException_DeserializeDataRemaining(
-                    jsonBytes.Length, jsonBytes.Length - readerState.BytesConsumed);
+                    jsonBytes.Length, jsonBytes.Length - reader.BytesConsumed);
             }
 
             return result;

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
@@ -305,8 +305,7 @@ namespace System.Text.Json
 
                 if (newReader.BytesConsumed != length)
                 {
-                    state = newReader.CurrentState;
-                    ThrowHelper.ThrowJsonException_DeserializeDataRemaining(length, length - state.BytesConsumed);
+                    ThrowHelper.ThrowJsonException_DeserializeDataRemaining(length, length - newReader.BytesConsumed);
                 }
             }
             catch (JsonException)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -22,6 +22,7 @@ namespace System.Text.Json
             try
             {
                 JsonReaderState initialState = default;
+                long initialBytesConsumed = default;
 
                 while (true)
                 {
@@ -31,6 +32,7 @@ namespace System.Text.Json
                         // as we don't know if the next token is an opening object or
                         // array brace.
                         initialState = reader.CurrentState;
+                        initialBytesConsumed = reader.BytesConsumed;
                     }
 
                     if (!reader.Read())
@@ -60,7 +62,7 @@ namespace System.Text.Json
                         }
                         else if (readStack.Current.IsProcessingValue)
                         {
-                            if (!HandleObjectAsValue(tokenType, options, ref reader, ref readStack, ref initialState))
+                            if (!HandleObjectAsValue(tokenType, options, ref reader, ref readStack, ref initialState, initialBytesConsumed))
                             {
                                 // Need more data
                                 break;
@@ -96,7 +98,7 @@ namespace System.Text.Json
                         {
                             HandleStartArray(options, ref reader, ref readStack);
                         }
-                        else if (!HandleObjectAsValue(tokenType, options, ref reader, ref readStack, ref initialState))
+                        else if (!HandleObjectAsValue(tokenType, options, ref reader, ref readStack, ref initialState, initialBytesConsumed))
                         {
                             // Need more data
                             break;
@@ -141,7 +143,8 @@ namespace System.Text.Json
             JsonSerializerOptions options,
             ref Utf8JsonReader reader,
             ref ReadStack readStack,
-            ref JsonReaderState initialState)
+            ref JsonReaderState initialState,
+            long initialBytesConsumed)
         {
             if (readStack.ReadAhead)
             {
@@ -153,11 +156,11 @@ namespace System.Text.Json
                 // HandleValue below.
 
                 reader = new Utf8JsonReader(
-                    reader.OriginalSpan.Slice(checked((int)initialState.BytesConsumed)),
+                    reader.OriginalSpan.Slice(checked((int)initialBytesConsumed)),
                     isFinalBlock: reader.IsFinalBlock,
                     state: initialState);
                 Debug.Assert(reader.BytesConsumed == 0);
-                readStack.BytesConsumed += initialState.BytesConsumed;
+                readStack.BytesConsumed += initialBytesConsumed;
 
                 if (!complete)
                 {

--- a/src/System.Text.Json/tests/JsonReaderStateAndOptionsTests.cs
+++ b/src/System.Text.Json/tests/JsonReaderStateAndOptionsTests.cs
@@ -13,7 +13,6 @@ namespace System.Text.Json.Tests
         public static void DefaultJsonReaderState()
         {
             JsonReaderState state = default;
-            Assert.Equal(0, state.BytesConsumed);
 
             var expectedOption = new JsonReaderOptions
             {
@@ -27,7 +26,6 @@ namespace System.Text.Json.Tests
         public static void JsonReaderStateDefaultCtor()
         {
             var state = new JsonReaderState();
-            Assert.Equal(0, state.BytesConsumed);
 
             var expectedOption = new JsonReaderOptions
             {
@@ -41,7 +39,6 @@ namespace System.Text.Json.Tests
         public static void JsonReaderStateCtor()
         {
             var state = new JsonReaderState(default);
-            Assert.Equal(0, state.BytesConsumed);
 
             var expectedOption = new JsonReaderOptions
             {
@@ -51,7 +48,6 @@ namespace System.Text.Json.Tests
             Assert.Equal(expectedOption, state.Options);
 
             state = new JsonReaderState(new JsonReaderOptions { CommentHandling = JsonCommentHandling.Disallow, MaxDepth = 0 });
-            Assert.Equal(0, state.BytesConsumed);
             Assert.Equal(expectedOption, state.Options);
 
             expectedOption = new JsonReaderOptions
@@ -60,7 +56,6 @@ namespace System.Text.Json.Tests
                 MaxDepth = 32
             };
             state = new JsonReaderState(new JsonReaderOptions { MaxDepth = 32 });
-            Assert.Equal(0, state.BytesConsumed);
             Assert.Equal(32, state.Options.MaxDepth);
             Assert.Equal(expectedOption, state.Options);
         }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -850,7 +850,7 @@ namespace System.Text.Json.Tests
                 var json = new Utf8JsonReader(sequence.Slice(0, i), isFinalBlock: false, state);
                 VerifyReadLoop(ref json, expected);
 
-                json = new Utf8JsonReader(sequence.Slice(json.BytesConsumed), isFinalBlock: true, state);
+                json = new Utf8JsonReader(sequence.Slice(json.BytesConsumed), isFinalBlock: true, json.CurrentState);
                 VerifyReadLoop(ref json, expected);
             }
         }
@@ -871,7 +871,7 @@ namespace System.Text.Json.Tests
                 var json = new Utf8JsonReader(sequence.Slice(0, i), isFinalBlock: false, state);
                 VerifyReadLoop(ref json, null);
 
-                json = new Utf8JsonReader(sequence.Slice(json.BytesConsumed), isFinalBlock: true, state);
+                json = new Utf8JsonReader(sequence.Slice(json.BytesConsumed), isFinalBlock: true, json.CurrentState);
                 VerifyReadLoop(ref json, null);
             }
         }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -855,6 +855,7 @@ namespace System.Text.Json.Tests
             }
         }
 
+        [ActiveIssue(38927)]
         [Theory]
         [MemberData(nameof(CommentTestLineSeparators))]
         public static void SkipSingleLineCommentMultiSpanTest(string lineSeparator)

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.MultiSegment.cs
@@ -28,8 +28,6 @@ namespace System.Text.Json.Tests
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
-            Assert.Equal(0, json.CurrentState.BytesConsumed);
-            Assert.NotEqual(default, json.CurrentState.Position);
             Assert.Equal(64, json.CurrentState.Options.MaxDepth);
             Assert.False(json.CurrentState.Options.AllowTrailingCommas);
             Assert.Equal(JsonCommentHandling.Disallow, json.CurrentState.Options.CommentHandling);
@@ -54,8 +52,6 @@ namespace System.Text.Json.Tests
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
-            Assert.Equal(0, json.CurrentState.BytesConsumed);
-            Assert.NotEqual(default, json.CurrentState.Position);
             Assert.Equal(64, json.CurrentState.Options.MaxDepth);
             Assert.False(json.CurrentState.Options.AllowTrailingCommas);
             Assert.Equal(JsonCommentHandling.Disallow, json.CurrentState.Options.CommentHandling);
@@ -72,8 +68,6 @@ namespace System.Text.Json.Tests
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.ToArray().AsSpan().SequenceEqual(new byte[] { (byte)'1' }));
 
-            Assert.Equal(2, json.CurrentState.BytesConsumed);
-            Assert.NotEqual(default, json.CurrentState.Position);
             Assert.Equal(64, json.CurrentState.Options.MaxDepth);
             Assert.False(json.CurrentState.Options.AllowTrailingCommas);
             Assert.Equal(JsonCommentHandling.Disallow, json.CurrentState.Options.CommentHandling);
@@ -91,8 +85,6 @@ namespace System.Text.Json.Tests
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
-            Assert.Equal(0, json.CurrentState.BytesConsumed);
-            Assert.NotEqual(default, json.CurrentState.Position);
             Assert.Equal(64, json.CurrentState.Options.MaxDepth);
             Assert.False(json.CurrentState.Options.AllowTrailingCommas);
             Assert.Equal(JsonCommentHandling.Disallow, json.CurrentState.Options.CommentHandling);
@@ -156,12 +148,10 @@ namespace System.Text.Json.Tests
                 string actualStrSequence = Encoding.UTF8.GetString(resultSequence, 0, length);
 
                 long consumed = utf8JsonReader.BytesConsumed;
-                Assert.Equal(consumed, utf8JsonReader.CurrentState.BytesConsumed);
                 utf8JsonReader = new Utf8JsonReader(sequence.Slice(consumed), isFinalBlock: true, utf8JsonReader.CurrentState);
                 resultSequence = JsonTestHelper.ReaderLoop(dataUtf8.Length, out length, ref utf8JsonReader);
                 actualStrSequence += Encoding.UTF8.GetString(resultSequence, 0, length);
                 string message = $"Expected consumed: {dataUtf8.Length - consumed}, Actual consumed: {utf8JsonReader.BytesConsumed}, Index: {j}";
-                Assert.Equal(utf8JsonReader.BytesConsumed, utf8JsonReader.CurrentState.BytesConsumed);
                 Assert.True(dataUtf8.Length - consumed == utf8JsonReader.BytesConsumed, message);
                 Assert.Equal(expectedStr, actualStrSequence);
             }
@@ -211,10 +201,8 @@ namespace System.Text.Json.Tests
                 while (json.Read())
                     ;
                 Assert.Equal(sequence.Length, json.BytesConsumed);
-                Assert.Equal(sequence.Length, json.CurrentState.BytesConsumed);
 
                 Assert.True(sequence.Slice(json.Position).IsEmpty);
-                Assert.True(sequence.Slice(json.CurrentState.Position).IsEmpty);
             }
         }
 
@@ -247,12 +235,10 @@ namespace System.Text.Json.Tests
                     JsonReaderState jsonState = json.CurrentState;
                     byte[] consumedArray = sequence.Slice(0, consumed).ToArray();
                     Assert.Equal(consumedArray, sequence.Slice(0, json.Position).ToArray());
-                    Assert.True(json.Position.Equals(jsonState.Position));
                     json = new Utf8JsonReader(sequence.Slice(consumed), isFinalBlock: true, jsonState);
                     while (json.Read())
                         ;
                     Assert.Equal(dataUtf8.Length - consumed, json.BytesConsumed);
-                    Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
                 }
             }
         }
@@ -471,12 +457,10 @@ namespace System.Text.Json.Tests
                 string actualStrSequence = Encoding.UTF8.GetString(resultSequence, 0, length);
 
                 long consumed = utf8JsonReader.BytesConsumed;
-                Assert.Equal(consumed, utf8JsonReader.CurrentState.BytesConsumed);
                 utf8JsonReader = new Utf8JsonReader(sequence.Slice(consumed), isFinalBlock: true, utf8JsonReader.CurrentState);
                 resultSequence = JsonTestHelper.ReaderLoop(dataUtf8.Length, out length, ref utf8JsonReader);
                 actualStrSequence += Encoding.UTF8.GetString(resultSequence, 0, length);
                 string message = $"Expected consumed: {dataUtf8.Length - consumed}, Actual consumed: {utf8JsonReader.BytesConsumed}, Index: {j}";
-                Assert.Equal(utf8JsonReader.BytesConsumed, utf8JsonReader.CurrentState.BytesConsumed);
                 Assert.True(dataUtf8.Length - consumed == utf8JsonReader.BytesConsumed, message);
                 Assert.Equal(expectedString, actualStrSequence);
             }
@@ -501,12 +485,10 @@ namespace System.Text.Json.Tests
                 Assert.Equal(0, utf8JsonReader.TokenStartIndex);
 
                 long consumed = utf8JsonReader.BytesConsumed;
-                Assert.Equal(consumed, utf8JsonReader.CurrentState.BytesConsumed);
                 utf8JsonReader = new Utf8JsonReader(sequence.Slice(consumed), isFinalBlock: true, utf8JsonReader.CurrentState);
                 resultSequence = JsonTestHelper.ReaderLoop(dataUtf8.Length, out length, ref utf8JsonReader);
                 actualStrSequence += Encoding.UTF8.GetString(resultSequence, 0, length);
                 string message = $"Expected consumed: {dataUtf8.Length - consumed}, Actual consumed: {utf8JsonReader.BytesConsumed}, Index: {j}";
-                Assert.Equal(utf8JsonReader.BytesConsumed, utf8JsonReader.CurrentState.BytesConsumed);
                 Assert.True(dataUtf8.Length - consumed == utf8JsonReader.BytesConsumed, message);
                 Assert.Equal(expectedString, actualStrSequence);
 
@@ -627,7 +609,6 @@ namespace System.Text.Json.Tests
 
             Assert.Equal(expectedWithComments, builder.ToString());
             Assert.Equal(inputData, sequence.Slice(0, json.Position).ToArray());
-            Assert.True(json.Position.Equals(json.CurrentState.Position));
 
             state = new JsonReaderState(options: new JsonReaderOptions { CommentHandling = JsonCommentHandling.Skip });
             json = new Utf8JsonReader(sequence, isFinalBlock: true, state);
@@ -651,7 +632,6 @@ namespace System.Text.Json.Tests
 
             Assert.Equal(expectedWithoutComments, builder.ToString());
             Assert.Equal(inputData, sequence.Slice(0, json.Position).ToArray());
-            Assert.True(json.Position.Equals(json.CurrentState.Position));
         }
 
         [Theory]
@@ -696,9 +676,7 @@ namespace System.Text.Json.Tests
                     Assert.Equal(2, json.TokenStartIndex);
                 }
 
-                Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
                 Assert.Equal(inputData, sequence.Slice(0, json.Position).ToArray());
-                Assert.True(json.Position.Equals(json.CurrentState.Position));
             }
         }
 
@@ -872,7 +850,7 @@ namespace System.Text.Json.Tests
                 var json = new Utf8JsonReader(sequence.Slice(0, i), isFinalBlock: false, state);
                 VerifyReadLoop(ref json, expected);
 
-                json = new Utf8JsonReader(sequence.Slice(state.BytesConsumed), isFinalBlock: true, state);
+                json = new Utf8JsonReader(sequence.Slice(json.BytesConsumed), isFinalBlock: true, state);
                 VerifyReadLoop(ref json, expected);
             }
         }
@@ -893,7 +871,7 @@ namespace System.Text.Json.Tests
                 var json = new Utf8JsonReader(sequence.Slice(0, i), isFinalBlock: false, state);
                 VerifyReadLoop(ref json, null);
 
-                json = new Utf8JsonReader(sequence.Slice(state.BytesConsumed), isFinalBlock: true, state);
+                json = new Utf8JsonReader(sequence.Slice(json.BytesConsumed), isFinalBlock: true, state);
                 VerifyReadLoop(ref json, null);
             }
         }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.TryGet.cs
@@ -157,7 +157,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Fact]
@@ -300,7 +299,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -340,7 +338,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -380,7 +377,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -420,7 +416,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -460,7 +455,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -499,7 +493,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -539,7 +532,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -579,7 +571,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -618,7 +609,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -645,7 +635,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -669,7 +658,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -704,7 +692,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Fact]
@@ -983,7 +970,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -1058,7 +1044,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -1359,7 +1344,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -1383,7 +1367,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -1407,7 +1390,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -1431,7 +1413,6 @@ namespace System.Text.Json.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -1499,7 +1480,6 @@ namespace System.Text.Json.Tests
             Assert.Equal(expected, json.GetGuid());
 
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
         }
 
         [Theory]

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -2969,8 +2969,7 @@ namespace System.Text.Json.Tests
                 var json = new Utf8JsonReader(dataUtf8.AsSpan(0, i), isFinalBlock: false, state);
                 VerifyReadLoop(ref json, expected);
 
-                int consumed = (int)json.BytesConsumed;
-                json = new Utf8JsonReader(dataUtf8.AsSpan(consumed), isFinalBlock: true, state);
+                json = new Utf8JsonReader(dataUtf8.AsSpan((int)json.BytesConsumed), isFinalBlock: true, json.CurrentState);
                 VerifyReadLoop(ref json, expected);
             }
         }
@@ -2989,7 +2988,7 @@ namespace System.Text.Json.Tests
                 var json = new Utf8JsonReader(dataUtf8.AsSpan(0, i), isFinalBlock: false, state);
                 VerifyReadLoop(ref json, null);
 
-                json = new Utf8JsonReader(dataUtf8.AsSpan((int)json.BytesConsumed), isFinalBlock: true, state);
+                json = new Utf8JsonReader(dataUtf8.AsSpan((int)json.BytesConsumed), isFinalBlock: true, json.CurrentState);
                 VerifyReadLoop(ref json, null);
             }
         }

--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -29,8 +29,6 @@ namespace System.Text.Json.Tests
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
-            Assert.Equal(0, json.CurrentState.BytesConsumed);
-            Assert.Equal(default, json.CurrentState.Position);
             Assert.Equal(0, json.CurrentState.Options.MaxDepth);
             Assert.False(json.CurrentState.Options.AllowTrailingCommas);
             Assert.Equal(JsonCommentHandling.Disallow, json.CurrentState.Options.CommentHandling);
@@ -126,8 +124,6 @@ namespace System.Text.Json.Tests
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
-            Assert.Equal(0, json.CurrentState.BytesConsumed);
-            Assert.Equal(default, json.CurrentState.Position);
             Assert.Equal(64, json.CurrentState.Options.MaxDepth);
             Assert.False(json.CurrentState.Options.AllowTrailingCommas);
             Assert.Equal(JsonCommentHandling.Disallow, json.CurrentState.Options.CommentHandling);
@@ -152,8 +148,6 @@ namespace System.Text.Json.Tests
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
-            Assert.Equal(0, json.CurrentState.BytesConsumed);
-            Assert.Equal(default, json.CurrentState.Position);
             Assert.Equal(64, json.CurrentState.Options.MaxDepth);
             Assert.False(json.CurrentState.Options.AllowTrailingCommas);
             Assert.Equal(JsonCommentHandling.Disallow, json.CurrentState.Options.CommentHandling);
@@ -170,8 +164,6 @@ namespace System.Text.Json.Tests
             Assert.True(json.ValueSpan.SequenceEqual(new byte[] { (byte)'1' }));
             Assert.True(json.ValueSequence.IsEmpty);
 
-            Assert.Equal(2, json.CurrentState.BytesConsumed);
-            Assert.Equal(default, json.CurrentState.Position);
             Assert.Equal(64, json.CurrentState.Options.MaxDepth);
             Assert.False(json.CurrentState.Options.AllowTrailingCommas);
             Assert.Equal(JsonCommentHandling.Disallow, json.CurrentState.Options.CommentHandling);
@@ -190,8 +182,6 @@ namespace System.Text.Json.Tests
             Assert.True(json.ValueSpan.SequenceEqual(default));
             Assert.True(json.ValueSequence.IsEmpty);
 
-            Assert.Equal(0, json.CurrentState.BytesConsumed);
-            Assert.Equal(default, json.CurrentState.Position);
             Assert.Equal(64, json.CurrentState.Options.MaxDepth);
             Assert.False(json.CurrentState.Options.AllowTrailingCommas);
             Assert.Equal(JsonCommentHandling.Disallow, json.CurrentState.Options.CommentHandling);
@@ -290,7 +280,6 @@ namespace System.Text.Json.Tests
                 int written = firstLength;
 
                 long consumed = json.BytesConsumed;
-                Assert.Equal(consumed, json.CurrentState.BytesConsumed);
                 Assert.Equal(default, json.Position);
 
                 json = new Utf8JsonReader(dataUtf8.AsSpan((int)consumed), isFinalBlock: true, json.CurrentState);
@@ -298,9 +287,7 @@ namespace System.Text.Json.Tests
                 output.AsSpan(0, length).CopyTo(outputSpan.Slice(written));
                 written += length;
                 Assert.Equal(dataUtf8.Length - consumed, json.BytesConsumed);
-                Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
                 Assert.Equal(default, json.Position);
-                Assert.Equal(default, json.CurrentState.Position);
 
                 Assert.Equal(outputSpan.Length, written);
                 string actualStr = Encoding.UTF8.GetString(outputArray);
@@ -338,7 +325,6 @@ namespace System.Text.Json.Tests
                 int written = firstLength;
 
                 long consumed = json.BytesConsumed;
-                Assert.Equal(consumed, json.CurrentState.BytesConsumed);
                 Assert.Equal(default, json.Position);
 
                 for (long j = consumed; j < dataUtf8.Length - consumed; j++)
@@ -358,15 +344,12 @@ namespace System.Text.Json.Tests
                     written += length;
 
                     long consumedInner = json.BytesConsumed;
-                    Assert.Equal(consumedInner, json.CurrentState.BytesConsumed);
                     json = new Utf8JsonReader(dataUtf8.AsSpan((int)(consumed + consumedInner)), isFinalBlock: true, json.CurrentState);
                     output = JsonTestHelper.ReaderLoop(outputSpan.Length - written, out length, ref json);
                     output.AsSpan(0, length).CopyTo(outputSpan.Slice(written));
                     written += length;
                     Assert.Equal(dataUtf8.Length - consumedInner - consumed, json.BytesConsumed);
-                    Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
                     Assert.Equal(default, json.Position);
-                    Assert.Equal(default, json.CurrentState.Position);
 
                     Assert.Equal(outputSpan.Length, written);
                     string actualStr = Encoding.UTF8.GetString(outputArray);
@@ -396,7 +379,6 @@ namespace System.Text.Json.Tests
                 int written = firstLength;
 
                 long consumed = json.BytesConsumed;
-                Assert.Equal(consumed, json.CurrentState.BytesConsumed);
                 Assert.Equal(default, json.Position);
                 Assert.Equal(0, json.TokenStartIndex);
 
@@ -417,15 +399,12 @@ namespace System.Text.Json.Tests
                     written += length;
 
                     long consumedInner = json.BytesConsumed;
-                    Assert.Equal(consumedInner, json.CurrentState.BytesConsumed);
                     json = new Utf8JsonReader(dataUtf8.AsSpan((int)(consumed + consumedInner)), isFinalBlock: true, json.CurrentState);
                     output = JsonTestHelper.ReaderLoop(outputSpan.Length - written, out length, ref json);
                     output.AsSpan(0, length).CopyTo(outputSpan.Slice(written));
                     written += length;
                     Assert.Equal(dataUtf8.Length - consumedInner - consumed, json.BytesConsumed);
-                    Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
                     Assert.Equal(default, json.Position);
-                    Assert.Equal(default, json.CurrentState.Position);
                     Assert.Equal(0, json.TokenStartIndex);
 
                     Assert.Equal(outputSpan.Length, written);
@@ -821,7 +800,6 @@ namespace System.Text.Json.Tests
                 ValidateNextTrySkip(ref json);
 
                 long consumed = json.BytesConsumed;
-                Assert.Equal(consumed, json.CurrentState.BytesConsumed);
 
                 json = new Utf8JsonReader(dataUtf8.AsSpan((int)consumed), isFinalBlock: true, json.CurrentState);
                 while (json.TrySkip())
@@ -853,7 +831,6 @@ namespace System.Text.Json.Tests
                 ValidateNextTrySkip(ref json);
 
                 long consumed = json.BytesConsumed;
-                Assert.Equal(consumed, json.CurrentState.BytesConsumed);
 
                 json = new Utf8JsonReader(dataUtf8.AsSpan((int)consumed), isFinalBlock: true, json.CurrentState);
                 long bytesConsumed = json.BytesConsumed;
@@ -900,7 +877,6 @@ namespace System.Text.Json.Tests
                 ValidateNextTrySkip(ref json);
 
                 long consumed = json.BytesConsumed;
-                Assert.Equal(consumed, json.CurrentState.BytesConsumed);
 
                 json = new Utf8JsonReader(dataUtf8.AsSpan((int)consumed), isFinalBlock: true, json.CurrentState);
                 while (json.Read())
@@ -986,7 +962,6 @@ namespace System.Text.Json.Tests
                 }
 
                 long consumed = json.BytesConsumed;
-                Assert.Equal(consumed, json.CurrentState.BytesConsumed);
 
                 json = new Utf8JsonReader(dataUtf8.AsSpan((int)consumed), isFinalBlock: true, json.CurrentState);
                 while (true)
@@ -1018,7 +993,6 @@ namespace System.Text.Json.Tests
                     ;
 
                 long consumed = json.BytesConsumed;
-                Assert.Equal(consumed, json.CurrentState.BytesConsumed);
 
                 json = new Utf8JsonReader(dataUtf8.AsSpan((int)consumed), isFinalBlock: true, json.CurrentState);
                 long bytesConsumed = json.BytesConsumed;
@@ -1517,9 +1491,6 @@ namespace System.Text.Json.Tests
                     var json = new Utf8JsonReader(dataUtf8.AsSpan(0, i), isFinalBlock: false, state);
                     while (json.Read())
                         ;
-
-                    long consumed = json.BytesConsumed;
-                    Assert.Equal(consumed, json.CurrentState.BytesConsumed);
                 }
             }
         }
@@ -1541,7 +1512,6 @@ namespace System.Text.Json.Tests
                         ;
 
                     long consumed = json.BytesConsumed;
-                    Assert.Equal(consumed, json.CurrentState.BytesConsumed);
 
                     for (long j = consumed; j < dataUtf8.Length - consumed; j++)
                     {
@@ -1558,12 +1528,10 @@ namespace System.Text.Json.Tests
                             ;
 
                         long consumedInner = json.BytesConsumed;
-                        Assert.Equal(consumedInner, json.CurrentState.BytesConsumed);
                         json = new Utf8JsonReader(dataUtf8.AsSpan((int)(consumed + consumedInner)), isFinalBlock: true, json.CurrentState);
                         while (json.Read())
                             ;
                         Assert.Equal(dataUtf8.Length - consumedInner - consumed, json.BytesConsumed);
-                        Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
                     }
                 }
             }
@@ -1714,7 +1682,6 @@ namespace System.Text.Json.Tests
                     }
 
                     long consumed = json.BytesConsumed;
-                    Assert.Equal(consumed, json.CurrentState.BytesConsumed);
                     json = new Utf8JsonReader(data.AsSpan((int)consumed), true, json.CurrentState);
                     while (json.Read())
                     {
@@ -1723,7 +1690,6 @@ namespace System.Text.Json.Tests
                             builder.Append(Encoding.UTF8.GetString(json.ValueSpan.ToArray()));
                     }
                     Assert.Equal(data.Length - consumed, json.BytesConsumed);
-                    Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
 
                     Assert.Equal(commentHandling == JsonCommentHandling.Allow ? expectedWithComments : expectedWithoutComments, builder.ToString());
                 }
@@ -1838,7 +1804,6 @@ namespace System.Text.Json.Tests
                     }
 
                     long consumed = json.BytesConsumed;
-                    Assert.Equal(consumed, json.CurrentState.BytesConsumed);
                     json = new Utf8JsonReader(dataUtf8.AsSpan((int)consumed), true, json.CurrentState);
                     while (json.Read())
                     {
@@ -1852,7 +1817,6 @@ namespace System.Text.Json.Tests
                         }
                     }
                     Assert.Equal(dataUtf8.Length - consumed, json.BytesConsumed);
-                    Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
                 }
             }
         }
@@ -1887,17 +1851,13 @@ namespace System.Text.Json.Tests
                 while (json.Read())
                     ;
                 Assert.Equal(consumed, json.BytesConsumed);
-                Assert.Equal(consumed, json.CurrentState.BytesConsumed);
                 Assert.Equal(default, json.Position);
-                Assert.Equal(default, json.CurrentState.Position);
 
                 json = new Utf8JsonReader(dataUtf8.AsSpan((int)json.BytesConsumed), true, json.CurrentState);
                 while (json.Read())
                     ;
                 Assert.Equal(dataUtf8.Length - consumed, json.BytesConsumed);
-                Assert.Equal(json.BytesConsumed, json.CurrentState.BytesConsumed);
                 Assert.Equal(default, json.Position);
-                Assert.Equal(default, json.CurrentState.Position);
             }
         }
 
@@ -1920,7 +1880,6 @@ namespace System.Text.Json.Tests
                 while (json.Read())
                     ;
                 Assert.Equal(consumed, json.BytesConsumed);
-                Assert.Equal(consumed, json.CurrentState.BytesConsumed);
 
                 json = new Utf8JsonReader(dataUtf8.AsSpan((int)json.BytesConsumed), true, json.CurrentState);
                 try
@@ -2035,7 +1994,6 @@ namespace System.Text.Json.Tests
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
                     Assert.Equal(expectedBytePosition, ex.BytePositionInLine);
                     Assert.Equal(default, json.Position);
-                    Assert.Equal(default, json.CurrentState.Position);
                 }
             }
         }
@@ -2074,9 +2032,7 @@ namespace System.Text.Json.Tests
                             ;
 
                         long consumed = jsonSlice.BytesConsumed;
-                        Assert.Equal(consumed, jsonSlice.CurrentState.BytesConsumed);
                         Assert.Equal(default, json.Position);
-                        Assert.Equal(default, json.CurrentState.Position);
 
                         JsonReaderState jsonState = jsonSlice.CurrentState;
 
@@ -2097,7 +2053,6 @@ namespace System.Text.Json.Tests
                         errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
                         Assert.True(expectedBytePosition == ex.BytePositionInLine, errorMessage);
                         Assert.Equal(default, json.Position);
-                        Assert.Equal(default, json.CurrentState.Position);
                     }
                 }
             }
@@ -2156,7 +2111,6 @@ namespace System.Text.Json.Tests
                             break;
                         foundComment = true;
                         indexAfterFirstComment = json.BytesConsumed;
-                        Assert.Equal(indexAfterFirstComment, json.CurrentState.BytesConsumed);
                         string actualComment = json.GetComment();
                         Assert.Equal(expectedComment, actualComment);
                         break;
@@ -2226,7 +2180,6 @@ namespace System.Text.Json.Tests
                             break;
                         foundComment = true;
                         indexAfterFirstComment = json.BytesConsumed;
-                        Assert.Equal(indexAfterFirstComment, json.CurrentState.BytesConsumed);
                         string actualComment = json.GetComment();
                         Assert.Equal(expectedComment, actualComment);
                         break;
@@ -2253,7 +2206,6 @@ namespace System.Text.Json.Tests
                                 break;
                             foundComment = true;
                             indexAfterFirstComment = jsonSlice.BytesConsumed;
-                            Assert.Equal(indexAfterFirstComment, jsonSlice.CurrentState.BytesConsumed);
                             string actualComment = jsonSlice.GetComment();
                             Assert.Equal(expectedComment, actualComment);
                             break;
@@ -2261,7 +2213,6 @@ namespace System.Text.Json.Tests
                 }
 
                 int consumed = (int)jsonSlice.BytesConsumed;
-                Assert.Equal(consumed, jsonSlice.CurrentState.BytesConsumed);
                 jsonSlice = new Utf8JsonReader(dataUtf8.AsSpan(consumed), isFinalBlock: true, jsonSlice.CurrentState);
 
                 if (!foundComment)
@@ -2277,7 +2228,6 @@ namespace System.Text.Json.Tests
                                     break;
                                 foundComment = true;
                                 indexAfterFirstComment = jsonSlice.BytesConsumed;
-                                Assert.Equal(indexAfterFirstComment, jsonSlice.CurrentState.BytesConsumed);
                                 string actualComment = jsonSlice.GetComment();
                                 Assert.Equal(expectedComment, actualComment);
                                 break;
@@ -2343,7 +2293,6 @@ namespace System.Text.Json.Tests
                 prevTokenType = tokenType;
             }
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(dataUtf8.Length, json.CurrentState.BytesConsumed);
         }
 
         [Theory]
@@ -2398,7 +2347,6 @@ namespace System.Text.Json.Tests
                 }
             }
             Assert.Equal(dataUtf8.Length, json.BytesConsumed);
-            Assert.Equal(dataUtf8.Length, json.CurrentState.BytesConsumed);
 
             for (int i = 0; i < dataUtf8.Length; i++)
             {
@@ -2417,7 +2365,6 @@ namespace System.Text.Json.Tests
                 }
 
                 int prevConsumed = (int)jsonSlice.BytesConsumed;
-                Assert.Equal(prevConsumed, jsonSlice.CurrentState.BytesConsumed);
                 jsonSlice = new Utf8JsonReader(dataUtf8.AsSpan(prevConsumed), isFinalBlock: true, jsonSlice.CurrentState);
 
                 while (jsonSlice.Read())
@@ -2432,7 +2379,6 @@ namespace System.Text.Json.Tests
                 }
 
                 Assert.Equal(dataUtf8.Length - prevConsumed, jsonSlice.BytesConsumed);
-                Assert.Equal(jsonSlice.BytesConsumed, jsonSlice.CurrentState.BytesConsumed);
             }
         }
 
@@ -2571,7 +2517,6 @@ namespace System.Text.Json.Tests
                         }
                     }
 
-                    Assert.Equal(jsonSlice.BytesConsumed, jsonSlice.CurrentState.BytesConsumed);
                     jsonSlice = new Utf8JsonReader(dataUtf8.AsSpan((int)jsonSlice.BytesConsumed), isFinalBlock: true, jsonSlice.CurrentState);
                     while (jsonSlice.Read())
                     {
@@ -3024,7 +2969,8 @@ namespace System.Text.Json.Tests
                 var json = new Utf8JsonReader(dataUtf8.AsSpan(0, i), isFinalBlock: false, state);
                 VerifyReadLoop(ref json, expected);
 
-                json = new Utf8JsonReader(dataUtf8.AsSpan((int)state.BytesConsumed), isFinalBlock: true, state);
+                int consumed = (int)json.BytesConsumed;
+                json = new Utf8JsonReader(dataUtf8.AsSpan(consumed), isFinalBlock: true, state);
                 VerifyReadLoop(ref json, expected);
             }
         }
@@ -3043,7 +2989,7 @@ namespace System.Text.Json.Tests
                 var json = new Utf8JsonReader(dataUtf8.AsSpan(0, i), isFinalBlock: false, state);
                 VerifyReadLoop(ref json, null);
 
-                json = new Utf8JsonReader(dataUtf8.AsSpan((int)state.BytesConsumed), isFinalBlock: true, state);
+                json = new Utf8JsonReader(dataUtf8.AsSpan((int)json.BytesConsumed), isFinalBlock: true, state);
                 VerifyReadLoop(ref json, null);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/35252

cc @steveharter, @bartonjs, @JeremyKuhne 