### PR TITLE
 Rename JsonSerializer.Parse/ToString to Deserialize/Serialize.

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -178,22 +178,22 @@ namespace System.Text.Json
     }
     public static partial class JsonSerializer
     {
-        public static object Parse(System.ReadOnlySpan<byte> utf8Json, System.Type returnType, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static object Parse(string json, System.Type returnType, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static TValue Parse<TValue>(System.ReadOnlySpan<byte> utf8Json, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static TValue Parse<TValue>(string json, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static System.Threading.Tasks.ValueTask<object> ReadAsync(System.IO.Stream utf8Json, System.Type returnType, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static System.Threading.Tasks.ValueTask<TValue> ReadAsync<TValue>(System.IO.Stream utf8Json, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static object ReadValue(ref System.Text.Json.Utf8JsonReader reader, System.Type returnType, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static TValue ReadValue<TValue>(ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static string ToString(object value, System.Type type, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static string ToString<TValue>(TValue value, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static byte[] ToUtf8Bytes(object value, System.Type type, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static byte[] ToUtf8Bytes<TValue>(TValue value, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
-        public static System.Threading.Tasks.Task WriteAsync(System.IO.Stream utf8Json, object value, System.Type type, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static System.Threading.Tasks.Task WriteAsync<TValue>(System.IO.Stream utf8Json, TValue value, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        public static void WriteValue(System.Text.Json.Utf8JsonWriter writer, object value, System.Type type, System.Text.Json.JsonSerializerOptions options = null) { }
-        public static void WriteValue<TValue>(System.Text.Json.Utf8JsonWriter writer, TValue value, System.Text.Json.JsonSerializerOptions options = null) { }
+        public static object Deserialize(System.ReadOnlySpan<byte> utf8Json, System.Type returnType, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static object Deserialize(string json, System.Type returnType, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static TValue Deserialize<TValue>(System.ReadOnlySpan<byte> utf8Json, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static TValue Deserialize<TValue>(string json, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static System.Threading.Tasks.ValueTask<object> DeserializeAsync(System.IO.Stream utf8Json, System.Type returnType, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.ValueTask<TValue> DeserializeAsync<TValue>(System.IO.Stream utf8Json, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static object Deserialize(ref System.Text.Json.Utf8JsonReader reader, System.Type returnType, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static TValue Deserialize<TValue>(ref System.Text.Json.Utf8JsonReader reader, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static string Serialize(object value, System.Type inputType, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static string Serialize<TValue>(TValue value, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static byte[] SerializeToUtf8Bytes(object value, System.Type inputType, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static byte[] SerializeToUtf8Bytes<TValue>(TValue value, System.Text.Json.JsonSerializerOptions options = null) { throw null; }
+        public static System.Threading.Tasks.Task SerializeAsync(System.IO.Stream utf8Json, object value, System.Type inputType, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static System.Threading.Tasks.Task SerializeAsync<TValue>(System.IO.Stream utf8Json, TValue value, System.Text.Json.JsonSerializerOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public static void Serialize(System.Text.Json.Utf8JsonWriter writer, object value, System.Type inputType, System.Text.Json.JsonSerializerOptions options = null) { }
+        public static void Serialize<TValue>(System.Text.Json.Utf8JsonWriter writer, TValue value, System.Text.Json.JsonSerializerOptions options = null) { }
     }
     public sealed partial class JsonSerializerOptions
     {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterKeyValuePair.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterKeyValuePair.cs
@@ -96,7 +96,7 @@ namespace System.Text.Json.Serialization.Converters
             JsonConverter<T> keyConverter = options.GetConverter(typeToConvert) as JsonConverter<T>;
             if (keyConverter == null)
             {
-                k = JsonSerializer.ReadValue<T>(ref reader, options);
+                k = JsonSerializer.Deserialize<T>(ref reader, options);
             }
             else
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Span.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
-        public static TValue Parse<TValue>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions options = null)
+        public static TValue Deserialize<TValue>(ReadOnlySpan<byte> utf8Json, JsonSerializerOptions options = null)
         {
             return (TValue)ParseCore(utf8Json, typeof(TValue), options);
         }
@@ -37,7 +37,7 @@ namespace System.Text.Json
         /// <paramref name="returnType"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
-        public static object Parse(ReadOnlySpan<byte> utf8Json, Type returnType, JsonSerializerOptions options = null)
+        public static object Deserialize(ReadOnlySpan<byte> utf8Json, Type returnType, JsonSerializerOptions options = null)
         {
             if (returnType == null)
                 throw new ArgumentNullException(nameof(returnType));

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
-        public static ValueTask<TValue> ReadAsync<TValue>(
+        public static ValueTask<TValue> DeserializeAsync<TValue>(
             Stream utf8Json,
             JsonSerializerOptions options = null,
             CancellationToken cancellationToken = default)
@@ -57,7 +57,7 @@ namespace System.Text.Json
         /// the <paramref name="returnType"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
-        public static ValueTask<object> ReadAsync(
+        public static ValueTask<object> DeserializeAsync(
             Stream utf8Json,
             Type returnType,
             JsonSerializerOptions options = null,

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -23,7 +23,7 @@ namespace System.Text.Json
         /// <remarks>Using a <see cref="System.String"/> is not as efficient as using the
         /// UTF-8 methods since the implementation natively uses UTF-8.
         /// </remarks>
-        public static TValue Parse<TValue>(string json, JsonSerializerOptions options = null)
+        public static TValue Deserialize<TValue>(string json, JsonSerializerOptions options = null)
         {
             if (json == null)
                 throw new ArgumentNullException(nameof(json));
@@ -49,7 +49,7 @@ namespace System.Text.Json
         /// <remarks>Using a <see cref="System.String"/> is not as efficient as using the
         /// UTF-8 methods since the implementation natively uses UTF-8.
         /// </remarks>
-        public static object Parse(string json, Type returnType, JsonSerializerOptions options = null)
+        public static object Deserialize(string json, Type returnType, JsonSerializerOptions options = null)
         {
             if (json == null)
                 throw new ArgumentNullException(nameof(json));

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Utf8JsonReader.cs
@@ -47,7 +47,7 @@ namespace System.Text.Json
         ///     Hence, <see cref="JsonReaderOptions.AllowTrailingCommas"/>, <see cref="JsonReaderOptions.MaxDepth"/>, <see cref="JsonReaderOptions.CommentHandling"/> are used while reading.
         ///   </para>
         /// </remarks>
-        public static TValue ReadValue<TValue>(ref Utf8JsonReader reader, JsonSerializerOptions options = null)
+        public static TValue Deserialize<TValue>(ref Utf8JsonReader reader, JsonSerializerOptions options = null)
         {
             return (TValue)ReadValueCore(ref reader, typeof(TValue), options);
         }
@@ -93,7 +93,7 @@ namespace System.Text.Json
         ///     Hence, <see cref="JsonReaderOptions.AllowTrailingCommas"/>, <see cref="JsonReaderOptions.MaxDepth"/>, <see cref="JsonReaderOptions.CommentHandling"/> are used while reading.
         ///   </para>
         /// </remarks>
-        public static object ReadValue(ref Utf8JsonReader reader, Type returnType, JsonSerializerOptions options = null)
+        public static object Deserialize(ref Utf8JsonReader reader, Type returnType, JsonSerializerOptions options = null)
         {
             if (returnType == null)
                 throw new ArgumentNullException(nameof(returnType));

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json
         /// <returns>A UTF-8 representation of the value.</returns>
         /// <param name="value">The value to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
-        public static byte[] ToUtf8Bytes<TValue>(TValue value, JsonSerializerOptions options = null)
+        public static byte[] SerializeToUtf8Bytes<TValue>(TValue value, JsonSerializerOptions options = null)
         {
             return WriteCoreBytes(value, typeof(TValue), options);
         }
@@ -24,7 +24,7 @@ namespace System.Text.Json
         /// <param name="value">The value to convert.</param>
         /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
-        public static byte[] ToUtf8Bytes(object value, Type type, JsonSerializerOptions options = null)
+        public static byte[] SerializeToUtf8Bytes(object value, Type type, JsonSerializerOptions options = null)
         {
             VerifyValueAndType(value, type);
             return WriteCoreBytes(value, type, options);

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json
         /// <param name="value">The value to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
-        public static Task WriteAsync<TValue>(Stream utf8Json, TValue value, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
+        public static Task SerializeAsync<TValue>(Stream utf8Json, TValue value, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
             return WriteAsyncCore(utf8Json, value, typeof(TValue), options, cancellationToken);
         }
@@ -32,7 +32,7 @@ namespace System.Text.Json
         /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the write operation.</param>
-        public static Task WriteAsync(Stream utf8Json, object value, Type type, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
+        public static Task SerializeAsync(Stream utf8Json, object value, Type type, JsonSerializerOptions options = null, CancellationToken cancellationToken = default)
         {
             if (utf8Json == null)
                 throw new ArgumentNullException(nameof(utf8Json));

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -13,10 +13,10 @@ namespace System.Text.Json
         /// <param name="value">The value to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
         /// <remarks>Using a <see cref="System.String"/> is not as efficient as using UTF-8
-        /// encoding since the implementation internally uses UTF-8. See also <see cref="ToUtf8Bytes"/>
-        /// and <see cref="WriteAsync"/>.
+        /// encoding since the implementation internally uses UTF-8. See also <see cref="SerializeToUtf8Bytes"/>
+        /// and <see cref="SerializeAsync"/>.
         /// </remarks>
-        public static string ToString<TValue>(TValue value, JsonSerializerOptions options = null)
+        public static string Serialize<TValue>(TValue value, JsonSerializerOptions options = null)
         {
             return ToStringInternal(value, typeof(TValue), options);
         }
@@ -29,10 +29,10 @@ namespace System.Text.Json
         /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="options">Options to control the conversion behavior.</param>
         /// <remarks>Using a <see cref="System.String"/> is not as efficient as using UTF-8
-        /// encoding since the implementation internally uses UTF-8. See also <see cref="ToUtf8Bytes"/>
-        /// and <see cref="WriteAsync"/>.
+        /// encoding since the implementation internally uses UTF-8. See also <see cref="SerializeToUtf8Bytes"/>
+        /// and <see cref="SerializeAsync"/>.
         /// </remarks>
-        public static string ToString(object value, Type type, JsonSerializerOptions options = null)
+        public static string Serialize(object value, Type type, JsonSerializerOptions options = null)
         {
             VerifyValueAndType(value, type);
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json
         /// <param name="writer">The writer to write.</param>
         /// <param name="value">The value to convert and write.</param>
         /// <param name="options">Options to control the behavior.</param>
-        public static void WriteValue<TValue>(Utf8JsonWriter writer, TValue value, JsonSerializerOptions options = null)
+        public static void Serialize<TValue>(Utf8JsonWriter writer, TValue value, JsonSerializerOptions options = null)
         {
             WriteValueCore(writer, value, typeof(TValue), options);
         }
@@ -24,7 +24,7 @@ namespace System.Text.Json
         /// <param name="value">The value to convert and write.</param>
         /// <param name="type">The type of the <paramref name="value"/> to convert.</param>
         /// <param name="options">Options to control the behavior.</param>
-        public static void WriteValue(Utf8JsonWriter writer, object value, Type type, JsonSerializerOptions options = null)
+        public static void Serialize(Utf8JsonWriter writer, object value, Type type, JsonSerializerOptions options = null)
         {
             VerifyValueAndType(value, type);
             WriteValueCore(writer, value, type, options);

--- a/src/System.Text.Json/tests/NewtonsoftTests/CamelCaseTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/CamelCaseTests.cs
@@ -66,7 +66,7 @@ namespace System.Text.Json.Tests
             person.LastModified = new DateTime(2000, 11, 20, 23, 55, 44, DateTimeKind.Utc);
             person.Name = "Name!";
 
-            string json = JsonSerializer.ToString(person, s_camelCaseAndIndentedOption);
+            string json = JsonSerializer.Serialize(person, s_camelCaseAndIndentedOption);
 
             Assert.Equal(@"{
   ""name"": ""Name!"",
@@ -74,13 +74,13 @@ namespace System.Text.Json.Tests
   ""lastModified"": ""2000-11-20T23:55:44Z""
 }", json);
 
-            Person deserializedPerson = JsonSerializer.Parse<Person>(json, s_camelCaseAndIndentedOption);
+            Person deserializedPerson = JsonSerializer.Deserialize<Person>(json, s_camelCaseAndIndentedOption);
 
             Assert.Equal(person.BirthDate, deserializedPerson.BirthDate);
             Assert.Equal(person.LastModified, deserializedPerson.LastModified);
             Assert.Equal(person.Name, deserializedPerson.Name);
 
-            json = JsonSerializer.ToString(person, new JsonSerializerOptions { WriteIndented = true });
+            json = JsonSerializer.Serialize(person, new JsonSerializerOptions { WriteIndented = true });
             Assert.Equal(@"{
   ""Name"": ""Name!"",
   ""BirthDate"": ""2000-11-20T23:55:44Z"",
@@ -99,7 +99,7 @@ namespace System.Text.Json.Tests
                 Sizes = new[] { "Small", "Medium", "Large" }
             };
 
-            string json = JsonSerializer.ToString(product, s_camelCaseAndIndentedOption);
+            string json = JsonSerializer.Serialize(product, s_camelCaseAndIndentedOption);
 
             Assert.Equal(@"{
   ""name"": ""Widget"",

--- a/src/System.Text.Json/tests/NewtonsoftTests/CustomObjectConverterTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/CustomObjectConverterTests.cs
@@ -46,7 +46,7 @@ namespace System.Text.Json.Tests
                 NullDecimalRange = null
             };
 
-            string json = JsonSerializer.ToString(initial, new JsonSerializerOptions { WriteIndented = true });
+            string json = JsonSerializer.Serialize(initial, new JsonSerializerOptions { WriteIndented = true });
 
             Assert.Equal(@"{
   ""Id"": ""00000001-0002-0003-0405-060708090a0b"",
@@ -82,9 +82,9 @@ namespace System.Text.Json.Tests
   ""NullDecimalRange"": null
 }";
 
-            JsonSerializer.ToString(json, new JsonSerializerOptions { WriteIndented = true });
+            JsonSerializer.Serialize(json, new JsonSerializerOptions { WriteIndented = true });
 
-            NullInterfaceTestClass deserialized = JsonSerializer.Parse<NullInterfaceTestClass>(json);
+            NullInterfaceTestClass deserialized = JsonSerializer.Deserialize<NullInterfaceTestClass>(json);
 
             Assert.Equal("Company!", deserialized.Company);
             Assert.Equal(new Guid(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), deserialized.Id);
@@ -104,7 +104,7 @@ namespace System.Text.Json.Tests
   ""NullByteArray"": null
 }";
 
-            ByteArrayClass c = JsonSerializer.Parse<ByteArrayClass>(json);
+            ByteArrayClass c = JsonSerializer.Deserialize<ByteArrayClass>(json);
             Assert.NotNull(c.ByteArray);
             Assert.Equal(4, c.ByteArray.Length);
             Assert.Equal(new byte[] { 0, 1, 2, 3 }, c.ByteArray);
@@ -117,7 +117,7 @@ namespace System.Text.Json.Tests
             byteArrayClass.ByteArray = s_testData;
             byteArrayClass.NullByteArray = null;
 
-            string json = JsonSerializer.ToString(byteArrayClass, new JsonSerializerOptions { WriteIndented = true });
+            string json = JsonSerializer.Serialize(byteArrayClass, new JsonSerializerOptions { WriteIndented = true });
 
             Assert.Equal(@"{
   ""ByteArray"": ""VGhpcyBpcyBzb21lIHRlc3QgZGF0YSEhIQ=="",
@@ -133,7 +133,7 @@ namespace System.Text.Json.Tests
   ""NullByteArray"": null
 }";
 
-            ByteArrayClass byteArrayClass = JsonSerializer.Parse<ByteArrayClass>(json);
+            ByteArrayClass byteArrayClass = JsonSerializer.Deserialize<ByteArrayClass>(json);
 
             Assert.Equal(s_testData, byteArrayClass.ByteArray);
             Assert.Equal(null, byteArrayClass.NullByteArray);
@@ -149,7 +149,7 @@ namespace System.Text.Json.Tests
                 Value = "Foo",
                 Thing = new MyThing { Number = 456, }
             };
-            string json = JsonSerializer.ToString(myClass);
+            string json = JsonSerializer.Serialize(myClass);
 
             const string expected = @"{""Value"":""Foo"",""Thing"":{""Number"":456}}";
             Assert.Equal(expected, json);
@@ -166,7 +166,7 @@ namespace System.Text.Json.Tests
 }";
             NotSupportedException e = Assert.Throws<NotSupportedException>(() =>
             {
-                JsonSerializer.Parse<List<MyClass>>(json);
+                JsonSerializer.Deserialize<List<MyClass>>(json);
             });
             Assert.Equal("Deserialization of interface types is not supported. Type 'System.Text.Json.Tests.IThing'", e.Message);
         }

--- a/src/System.Text.Json/tests/NewtonsoftTests/DateTimeConverterTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/DateTimeConverterTests.cs
@@ -46,13 +46,13 @@ namespace System.Text.Json.Tests
             DateTime d = new DateTime(2000, 12, 15, 22, 11, 3, 55, DateTimeKind.Utc);
             string result;
 
-            result = JsonSerializer.ToString(d);
+            result = JsonSerializer.Serialize(d);
             Assert.Equal(@"""2000-12-15T22:11:03.055Z""", result);
 
-            Assert.Equal(d, JsonSerializer.Parse<DateTime>(result));
+            Assert.Equal(d, JsonSerializer.Deserialize<DateTime>(result));
 
             d = new DateTime(2000, 12, 15, 22, 11, 3, 55, DateTimeKind.Local);
-            result = JsonSerializer.ToString(d);
+            result = JsonSerializer.Serialize(d);
             Assert.Equal(@"""2000-12-15T22:11:03.055" + GetUtcOffsetText(d) + @"""", result);
         }
 
@@ -62,10 +62,10 @@ namespace System.Text.Json.Tests
             DateTimeOffset d = new DateTimeOffset(2000, 12, 15, 22, 11, 3, 55, TimeSpan.Zero);
             string result;
 
-            result = JsonSerializer.ToString(d);
+            result = JsonSerializer.Serialize(d);
             Assert.Equal(@"""2000-12-15T22:11:03.055+00:00""", result);
 
-            Assert.Equal(d, JsonSerializer.Parse<DateTimeOffset>(result));
+            Assert.Equal(d, JsonSerializer.Deserialize<DateTimeOffset>(result));
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace System.Text.Json.Tests
             TimeSpan offset = new TimeSpan(2, 15, 0);
             DateTimeOffset dto = new DateTimeOffset(2014, 1, 1, 0, 0, 0, 0, offset);
 
-            DateTimeOffset test = JsonSerializer.Parse<DateTimeOffset>("\"2014-01-01T00:00:00+02:15\"");
+            DateTimeOffset test = JsonSerializer.Deserialize<DateTimeOffset>("\"2014-01-01T00:00:00+02:15\"");
 
             Assert.Equal(dto, test);
             Assert.Equal(dto.ToString("o"), test.ToString("o"));
@@ -90,9 +90,9 @@ namespace System.Text.Json.Tests
             c.DateTimeOffsetField = new DateTime(2008, 12, 12, 12, 12, 12, 0, DateTimeKind.Utc).ToLocalTime();
             c.PreField = "Pre";
             c.PostField = "Post";
-            string json = JsonSerializer.ToString(c);
+            string json = JsonSerializer.Serialize(c);
 
-            NullableDateTimeTestClass newOne = JsonSerializer.Parse<NullableDateTimeTestClass>(json);
+            NullableDateTimeTestClass newOne = JsonSerializer.Deserialize<NullableDateTimeTestClass>(json);
             Assert.Equal(newOne.DateTimeField, c.DateTimeField);
             Assert.Equal(newOne.DateTimeOffsetField, c.DateTimeOffsetField);
             Assert.Equal(newOne.PostField, c.PostField);
@@ -102,7 +102,7 @@ namespace System.Text.Json.Tests
             c.DateTimeOffsetField = null;
             c.PreField = "Pre";
             c.PostField = "Post";
-            json = JsonSerializer.ToString(c);
+            json = JsonSerializer.Serialize(c);
             Assert.Equal(@"{""PreField"":""Pre"",""DateTimeField"":null,""DateTimeOffsetField"":null,""PostField"":""Post""}", json);
         }
 
@@ -114,9 +114,9 @@ namespace System.Text.Json.Tests
             c.DateTimeOffsetField = new DateTime(2008, 12, 12, 12, 12, 12, 0, DateTimeKind.Utc).ToLocalTime();
             c.PreField = "Pre";
             c.PostField = "Post";
-            string json = JsonSerializer.ToString(c);
+            string json = JsonSerializer.Serialize(c);
             
-            NullableDateTimeTestClass newOne = JsonSerializer.Parse<NullableDateTimeTestClass>(json);
+            NullableDateTimeTestClass newOne = JsonSerializer.Deserialize<NullableDateTimeTestClass>(json);
             Assert.Equal(newOne.DateTimeField, c.DateTimeField);
             Assert.Equal(newOne.DateTimeOffsetField, c.DateTimeOffsetField);
             Assert.Equal(newOne.PostField, c.PostField);
@@ -127,9 +127,9 @@ namespace System.Text.Json.Tests
             c.DateTimeOffsetField = new DateTime(2008, 1, 1, 1, 1, 1, 0, DateTimeKind.Utc).ToLocalTime();
             c.PreField = "Pre";
             c.PostField = "Post";
-            json = JsonSerializer.ToString(c);
+            json = JsonSerializer.Serialize(c);
             
-            newOne = JsonSerializer.Parse<NullableDateTimeTestClass>(json);
+            newOne = JsonSerializer.Deserialize<NullableDateTimeTestClass>(json);
             Assert.Equal(newOne.DateTimeField, c.DateTimeField);
             Assert.Equal(newOne.DateTimeOffsetField, c.DateTimeOffsetField);
             Assert.Equal(newOne.PostField, c.PostField);
@@ -146,7 +146,7 @@ namespace System.Text.Json.Tests
                 LastModified = new DateTime(2009, 4, 12, 20, 44, 55),
             };
 
-            string jsonText = JsonSerializer.ToString(p, new JsonSerializerOptions { IgnoreNullValues = true});
+            string jsonText = JsonSerializer.Serialize(p, new JsonSerializerOptions { IgnoreNullValues = true});
 
             Assert.Equal(@"{""Name"":""Keith"",""BirthDate"":""1980-03-08T00:00:00"",""LastModified"":""2009-04-12T20:44:55""}", jsonText);
         }

--- a/src/System.Text.Json/tests/NewtonsoftTests/EnumConverterTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/EnumConverterTests.cs
@@ -44,7 +44,7 @@ namespace System.Text.Json.Tests
                 NullableStoreColor2 = null
             };
 
-            string json = JsonSerializer.ToString(enumClass, new JsonSerializerOptions { WriteIndented = true });
+            string json = JsonSerializer.Serialize(enumClass, new JsonSerializerOptions { WriteIndented = true });
 
             Assert.Equal(@"{
   ""StoreColor"": 2,
@@ -63,7 +63,7 @@ namespace System.Text.Json.Tests
                 NullableStoreColor2 = null
             };
 
-            string json = JsonSerializer.ToString(enumClass, new JsonSerializerOptions { WriteIndented = true });
+            string json = JsonSerializer.Serialize(enumClass, new JsonSerializerOptions { WriteIndented = true });
 
             Assert.Equal(@"{
   ""StoreColor"": 1000,
@@ -82,7 +82,7 @@ namespace System.Text.Json.Tests
                 NullableStoreColor2 = StoreColor.Red | StoreColor.White | StoreColor.Black
             };
 
-            string json = JsonSerializer.ToString(enumClass, new JsonSerializerOptions { WriteIndented = true });
+            string json = JsonSerializer.Serialize(enumClass, new JsonSerializerOptions { WriteIndented = true });
 
             Assert.Equal(@"{
   ""StoreColor"": 10,
@@ -98,7 +98,7 @@ namespace System.Text.Json.Tests
             negativeEnumClass.Value1 = NegativeFlagsEnum.NegativeFour | NegativeFlagsEnum.NegativeTwo;
             negativeEnumClass.Value2 = NegativeFlagsEnum.Two | NegativeFlagsEnum.Four;
 
-            string json = JsonSerializer.ToString(negativeEnumClass, new JsonSerializerOptions { WriteIndented = true });
+            string json = JsonSerializer.Serialize(negativeEnumClass, new JsonSerializerOptions { WriteIndented = true });
 
             Assert.Equal(@"{
   ""Value1"": -2,
@@ -115,7 +115,7 @@ namespace System.Text.Json.Tests
                 Value2 = (NegativeEnum)int.MinValue
             };
 
-            string json = JsonSerializer.ToString(negativeEnumClass, new JsonSerializerOptions { WriteIndented = true });
+            string json = JsonSerializer.Serialize(negativeEnumClass, new JsonSerializerOptions { WriteIndented = true });
 
             Assert.Equal(@"{
   ""Value1"": -1,
@@ -137,7 +137,7 @@ namespace System.Text.Json.Tests
                     (Foo)int.MaxValue
                 };
 
-            string json1 = JsonSerializer.ToString(lfoo, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            string json1 = JsonSerializer.Serialize(lfoo, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
             Assert.Equal(@"[
   6,
@@ -148,7 +148,7 @@ namespace System.Text.Json.Tests
   2147483647
 ]", json1);
 
-            IList<Foo> foos = JsonSerializer.Parse<List<Foo>>(json1);
+            IList<Foo> foos = JsonSerializer.Deserialize<List<Foo>>(json1);
 
             Assert.Equal(6, foos.Count);
             Assert.Equal(Foo.Bat | Foo.SerializeAsBaz, foos[0]);
@@ -160,7 +160,7 @@ namespace System.Text.Json.Tests
 
             List<Bar> lbar = new List<Bar>() { Bar.FooBar, Bar.Bat, Bar.SerializeAsBaz };
 
-            string json2 = JsonSerializer.ToString(lbar, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            string json2 = JsonSerializer.Serialize(lbar, new JsonSerializerOptions { WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
             Assert.Equal(@"[
   0,
@@ -168,7 +168,7 @@ namespace System.Text.Json.Tests
   2
 ]", json2);
 
-            IList<Bar> bars = JsonSerializer.Parse<List<Bar>>(json2);
+            IList<Bar> bars = JsonSerializer.Deserialize<List<Bar>>(json2);
 
             Assert.Equal(3, bars.Count);
             Assert.Equal(Bar.FooBar, bars[0]);
@@ -179,7 +179,7 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void TestValidIntegerValue()
         {
-            StoreColor c = JsonSerializer.Parse<StoreColor>("1");
+            StoreColor c = JsonSerializer.Deserialize<StoreColor>("1");
             Assert.Equal(c, StoreColor.Black);
         }
 
@@ -187,7 +187,7 @@ namespace System.Text.Json.Tests
         public static void DuplicateNameEnumTest()
         {
             JsonException e = Assert.Throws<JsonException>(() =>
-                JsonSerializer.Parse<DuplicateNameEnum>("\"foo_bar\""));
+                JsonSerializer.Deserialize<DuplicateNameEnum>("\"foo_bar\""));
         }
 
         [Fact]
@@ -195,18 +195,18 @@ namespace System.Text.Json.Tests
         {
             JsonException ex = Assert.Throws<JsonException>(() =>
             {
-                StoreColor s = JsonSerializer.Parse<StoreColor>("\"1\"");
+                StoreColor s = JsonSerializer.Deserialize<StoreColor>("\"1\"");
             });
         }
 
         [Fact]
         public static void SerializeEnumWithDifferentCases()
         {
-            string json = JsonSerializer.ToString(EnumWithDifferentCases.M);
+            string json = JsonSerializer.Serialize(EnumWithDifferentCases.M);
 
             Assert.Equal("0", json);
 
-            json = JsonSerializer.ToString(EnumWithDifferentCases.m);
+            json = JsonSerializer.Serialize(EnumWithDifferentCases.m);
 
             Assert.Equal("1", json);
         }
@@ -214,21 +214,21 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void DeserializeEnumWithDifferentCases()
         {
-            EnumWithDifferentCases e = JsonSerializer.Parse<EnumWithDifferentCases>("0");
+            EnumWithDifferentCases e = JsonSerializer.Deserialize<EnumWithDifferentCases>("0");
             Assert.Equal(EnumWithDifferentCases.M, e);
 
-            e = JsonSerializer.Parse<EnumWithDifferentCases>("1");
+            e = JsonSerializer.Deserialize<EnumWithDifferentCases>("1");
             Assert.Equal(EnumWithDifferentCases.m, e);
         }
 
         [Fact]
         public static void SerializeEnumMemberWithDifferentCases()
         {
-            string json = JsonSerializer.ToString(EnumMemberWithDifferentCases.Month);
+            string json = JsonSerializer.Serialize(EnumMemberWithDifferentCases.Month);
 
             Assert.Equal("0", json);
 
-            json = JsonSerializer.ToString(EnumMemberWithDifferentCases.Minute);
+            json = JsonSerializer.Serialize(EnumMemberWithDifferentCases.Minute);
 
             Assert.Equal("1", json);
         }
@@ -238,7 +238,7 @@ namespace System.Text.Json.Tests
         {
             JsonException ex = Assert.Throws<JsonException>(() =>
             {
-                JsonSerializer.Parse<StoreColor>("\"-\"");
+                JsonSerializer.Deserialize<StoreColor>("\"-\"");
             });
         }
 
@@ -249,7 +249,7 @@ namespace System.Text.Json.Tests
   ""Value1"": -1,
   ""Value2"": -2147483648
 }";
-            NegativeEnumClass negativeEnumClass = JsonSerializer.Parse<NegativeEnumClass>(json);
+            NegativeEnumClass negativeEnumClass = JsonSerializer.Deserialize<NegativeEnumClass>(json);
             Assert.Equal(NegativeEnum.Negative, negativeEnumClass.Value1);
             Assert.Equal((NegativeEnum)int.MinValue, negativeEnumClass.Value2);
         }
@@ -262,7 +262,7 @@ namespace System.Text.Json.Tests
   ""NullableStoreColor1"": 8,
   ""NullableStoreColor2"": null
 }";
-            EnumClass enumClass = JsonSerializer.Parse<EnumClass>(json);
+            EnumClass enumClass = JsonSerializer.Deserialize<EnumClass>(json);
             Assert.Equal(StoreColor.Red, enumClass.StoreColor);
             Assert.Equal(StoreColor.White, enumClass.NullableStoreColor1);
             Assert.Equal(null, enumClass.NullableStoreColor2);
@@ -276,7 +276,7 @@ namespace System.Text.Json.Tests
   ""NullableStoreColor1"": 0,
   ""NullableStoreColor2"": 11
 }";
-            EnumClass enumClass = JsonSerializer.Parse<EnumClass>(json);
+            EnumClass enumClass = JsonSerializer.Deserialize<EnumClass>(json);
             Assert.Equal(StoreColor.Red | StoreColor.White, enumClass.StoreColor);
             Assert.Equal((StoreColor)0, enumClass.NullableStoreColor1);
             Assert.Equal(StoreColor.Red | StoreColor.White | StoreColor.Black, enumClass.NullableStoreColor2);

--- a/src/System.Text.Json/tests/NewtonsoftTests/ImmutableCollectionsTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/ImmutableCollectionsTests.cs
@@ -47,7 +47,7 @@ namespace System.Text.Json.Tests
                 "3"
             });
 
-            string json = JsonSerializer.ToString(data);
+            string json = JsonSerializer.Serialize(data);
             Assert.Equal(@"[""One"",""II"",""3""]", json);
         }
 
@@ -60,7 +60,7 @@ namespace System.Text.Json.Tests
   ""3""
 ]";
 
-            ImmutableList<string> data = JsonSerializer.Parse<ImmutableList<string>>(json);
+            ImmutableList<string> data = JsonSerializer.Deserialize<ImmutableList<string>>(json);
 
             Assert.Equal(3, data.Count);
             Assert.Equal("One", data[0]);
@@ -77,7 +77,7 @@ namespace System.Text.Json.Tests
         ""Katarina""
       ]";
 
-            IImmutableList<string> champions = JsonSerializer.Parse<IImmutableList<string>>(json);
+            IImmutableList<string> champions = JsonSerializer.Deserialize<IImmutableList<string>>(json);
 
             Assert.Equal(3, champions.Count);
             Assert.Equal("Volibear", champions[0]);
@@ -98,7 +98,7 @@ namespace System.Text.Json.Tests
                 "3"
             });
 
-            string json = JsonSerializer.ToString(data, s_indentedOption);
+            string json = JsonSerializer.Serialize(data, s_indentedOption);
             Assert.Equal(@"[
   ""One"",
   ""II"",
@@ -116,7 +116,7 @@ namespace System.Text.Json.Tests
           ""3""
         ]";
 
-            ImmutableArray<string> data = JsonSerializer.Parse<ImmutableArray<string>>(json);
+            ImmutableArray<string> data = JsonSerializer.Deserialize<ImmutableArray<string>>(json);
 
             Assert.Equal(3, data.Length);
             Assert.Equal("One", data[0]);
@@ -129,7 +129,7 @@ namespace System.Text.Json.Tests
         public void SerializeDefaultArray()
         {
             InvalidOperationException e = Assert.Throws<InvalidOperationException>(
-                () => JsonSerializer.ToString(default(ImmutableArray<int>), s_indentedOption));
+                () => JsonSerializer.Serialize(default(ImmutableArray<int>), s_indentedOption));
             Assert.Equal(e.Message, "This operation cannot be performed on a default instance of ImmutableArray<T>.  Consider initializing the array, or checking the ImmutableArray<T>.IsDefault property.");
         }
         #endregion
@@ -145,7 +145,7 @@ namespace System.Text.Json.Tests
                 "3"
             });
 
-            string json = JsonSerializer.ToString(data);
+            string json = JsonSerializer.Serialize(data);
             Assert.Equal(@"[""One"",""II"",""3""]", json);
         }
 
@@ -158,7 +158,7 @@ namespace System.Text.Json.Tests
   ""3""
 ]";
 
-            ImmutableQueue<string> data = JsonSerializer.Parse<ImmutableQueue<string>>(json);
+            ImmutableQueue<string> data = JsonSerializer.Deserialize<ImmutableQueue<string>>(json);
 
             Assert.False(data.IsEmpty);
             Assert.Equal("One", data.Peek());
@@ -177,7 +177,7 @@ namespace System.Text.Json.Tests
   ""3""
 ]";
 
-            IImmutableQueue<string> data = JsonSerializer.Parse<IImmutableQueue<string>>(json);
+            IImmutableQueue<string> data = JsonSerializer.Deserialize<IImmutableQueue<string>>(json);
 
             Assert.False(data.IsEmpty);
             Assert.Equal("One", data.Peek());
@@ -199,7 +199,7 @@ namespace System.Text.Json.Tests
                 "3"
             });
 
-            string json = JsonSerializer.ToString(data);
+            string json = JsonSerializer.Serialize(data);
             Assert.Equal(@"[""3"",""II"",""One""]", json);
         }
 
@@ -212,7 +212,7 @@ namespace System.Text.Json.Tests
   ""3""
 ]";
 
-            ImmutableStack<string> data = JsonSerializer.Parse<ImmutableStack<string>>(json);
+            ImmutableStack<string> data = JsonSerializer.Deserialize<ImmutableStack<string>>(json);
 
             Assert.False(data.IsEmpty);
             Assert.Equal("3", data.Peek());
@@ -231,7 +231,7 @@ namespace System.Text.Json.Tests
   ""3""
 ]";
 
-            IImmutableStack<string> data = JsonSerializer.Parse<IImmutableStack<string>>(json);
+            IImmutableStack<string> data = JsonSerializer.Deserialize<IImmutableStack<string>>(json);
 
             Assert.False(data.IsEmpty);
             Assert.Equal("3", data.Peek());
@@ -253,9 +253,9 @@ namespace System.Text.Json.Tests
                 "3"
             });
 
-            string json = JsonSerializer.ToString(data, s_indentedOption);
+            string json = JsonSerializer.Serialize(data, s_indentedOption);
 
-            ImmutableHashSet<string> a = JsonSerializer.Parse<ImmutableHashSet<string>>(json);
+            ImmutableHashSet<string> a = JsonSerializer.Deserialize<ImmutableHashSet<string>>(json);
             Assert.Equal(3, a.Count);
             Assert.True(a.Contains("One"));
             Assert.True(a.Contains("II"));
@@ -271,7 +271,7 @@ namespace System.Text.Json.Tests
   ""3""
 ]";
 
-            ImmutableHashSet<string> data = JsonSerializer.Parse<ImmutableHashSet<string>>(json);
+            ImmutableHashSet<string> data = JsonSerializer.Deserialize<ImmutableHashSet<string>>(json);
 
             Assert.Equal(3, data.Count);
             Assert.True(data.Contains("3"));
@@ -288,7 +288,7 @@ namespace System.Text.Json.Tests
   ""3""
 ]";
 
-            IImmutableSet<string> data = JsonSerializer.Parse<IImmutableSet<string>>(json);
+            IImmutableSet<string> data = JsonSerializer.Deserialize<IImmutableSet<string>>(json);
 
             Assert.Equal(3, data.Count);
             Assert.True(data.Contains("3"));
@@ -308,7 +308,7 @@ namespace System.Text.Json.Tests
                 "3"
             });
 
-            string json = JsonSerializer.ToString(data);
+            string json = JsonSerializer.Serialize(data);
             Assert.Equal(@"[""3"",""II"",""One""]", json);
         }
 
@@ -321,7 +321,7 @@ namespace System.Text.Json.Tests
   ""3""
 ]";
 
-            ImmutableSortedSet<string> data = JsonSerializer.Parse<ImmutableSortedSet<string>>(json);
+            ImmutableSortedSet<string> data = JsonSerializer.Deserialize<ImmutableSortedSet<string>>(json);
 
             Assert.Equal(3, data.Count);
             Assert.True(data.Contains("3"));
@@ -342,8 +342,8 @@ namespace System.Text.Json.Tests
                 { 3, "3" }
             });
 
-            string json = JsonSerializer.ToString(data, s_indentedOption);
-            ImmutableDictionary<int, string> a = JsonSerializer.Parse<ImmutableDictionary<int, string>>(json);
+            string json = JsonSerializer.Serialize(data, s_indentedOption);
+            ImmutableDictionary<int, string> a = JsonSerializer.Deserialize<ImmutableDictionary<int, string>>(json);
             Assert.Equal(3, a.Count);
             Assert.Equal("One", (string)a[1]);
             Assert.Equal("II", (string)a[2]);
@@ -360,7 +360,7 @@ namespace System.Text.Json.Tests
   ""3"": ""3""
 }";
 
-            ImmutableDictionary<int, string> data = JsonSerializer.Parse<ImmutableDictionary<int, string>>(json);
+            ImmutableDictionary<int, string> data = JsonSerializer.Deserialize<ImmutableDictionary<int, string>>(json);
 
             Assert.Equal(3, data.Count);
             Assert.Equal("One", data[1]);
@@ -378,7 +378,7 @@ namespace System.Text.Json.Tests
   ""3"": ""3""
 }";
 
-            IImmutableDictionary<int, string> data = JsonSerializer.Parse<IImmutableDictionary<int, string>>(json);
+            IImmutableDictionary<int, string> data = JsonSerializer.Deserialize<IImmutableDictionary<int, string>>(json);
 
             Assert.Equal(3, data.Count);
             Assert.Equal("One", data[1]);
@@ -399,7 +399,7 @@ namespace System.Text.Json.Tests
                 { 3, "3" }
             });
 
-            string json = JsonSerializer.ToString(data, s_indentedOption);
+            string json = JsonSerializer.Serialize(data, s_indentedOption);
             Assert.Equal(@"{
   ""1"": ""One"",
   ""2"": ""II"",
@@ -417,7 +417,7 @@ namespace System.Text.Json.Tests
   ""3"": ""3""
 }";
 
-            ImmutableSortedDictionary<int, string> data = JsonSerializer.Parse<ImmutableSortedDictionary<int, string>>(json);
+            ImmutableSortedDictionary<int, string> data = JsonSerializer.Deserialize<ImmutableSortedDictionary<int, string>>(json);
 
             Assert.Equal(3, data.Count);
             Assert.Equal("One", data[1]);

--- a/src/System.Text.Json/tests/NewtonsoftTests/JsonSerializerTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/JsonSerializerTests.cs
@@ -42,77 +42,77 @@ namespace System.Text.Json.Tests
         public void DeserializeBoolean_Null()
         {
             Assert.Throws<ArgumentNullException>(
-                () => JsonSerializer.Parse<IList<bool>>(@"[null]"));
+                () => JsonSerializer.Deserialize<IList<bool>>(@"[null]"));
         }
 
         [Fact]
         public void DeserializeBoolean_DateTime()
         {
             Assert.Throws<JsonException>(
-                () => JsonSerializer.Parse<IList<bool>>(@"['2000-12-20T10:55:55Z']"));
+                () => JsonSerializer.Deserialize<IList<bool>>(@"['2000-12-20T10:55:55Z']"));
         }
 
         [Fact]
         public void DeserializeBoolean_BadString()
         {
             Assert.Throws<JsonException>(
-                () => JsonSerializer.Parse<IList<bool>>(@"['pie']"));
+                () => JsonSerializer.Deserialize<IList<bool>>(@"['pie']"));
         }
 
         [Fact]
         public void DeserializeBoolean_EmptyString()
         {
             Assert.Throws<JsonException>(
-                () => JsonSerializer.Parse<IList<bool>>(@"['']"));
+                () => JsonSerializer.Deserialize<IList<bool>>(@"['']"));
         }
 
         [Fact]
         public void IncompleteContainers()
         {
-            JsonException e = Assert.Throws<JsonException>(() => JsonSerializer.Parse<IList<object>>("[1,"));
+            JsonException e = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<IList<object>>("[1,"));
             Assert.Equal(e.Message, "Expected start of a property name or value, but instead reached end of data. Path: $[1] | LineNumber: 0 | BytePositionInLine: 2.");
             
-            e = Assert.Throws<JsonException>(() => JsonSerializer.Parse<IList<int>>("[1,"));
+            e = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<IList<int>>("[1,"));
             Assert.Equal(e.Message, "Expected start of a property name or value, but instead reached end of data. Path: $[1] | LineNumber: 0 | BytePositionInLine: 2.");
 
-            e = Assert.Throws<JsonException>(() => JsonSerializer.Parse<IList<int>>("[1"));
+            e = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<IList<int>>("[1"));
             Assert.Equal(e.Message, "'1' is an invalid end of a number. Expected a delimiter. Path: $[0] | LineNumber: 0 | BytePositionInLine: 2.");
 
-            e = Assert.Throws<JsonException>(() => JsonSerializer.Parse<IDictionary<string, int>>("{\"key\":1,"));
+            e = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<IDictionary<string, int>>("{\"key\":1,"));
             Assert.Equal(e.Message, "Expected start of a property name or value, but instead reached end of data. Path: $.key | LineNumber: 0 | BytePositionInLine: 8.");
 
-            e = Assert.Throws<JsonException>(() => JsonSerializer.Parse<IDictionary<string, int>>("{\"key\":1"));
+            e = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<IDictionary<string, int>>("{\"key\":1"));
             Assert.Equal(e.Message, "'1' is an invalid end of a number. Expected a delimiter. Path: $.key | LineNumber: 0 | BytePositionInLine: 8.");
 
-            e = Assert.Throws<JsonException>(() => JsonSerializer.Parse<IncompleteTestClass>("{\"key\":1,"));
+            e = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<IncompleteTestClass>("{\"key\":1,"));
             Assert.Equal(e.Message, "Expected start of a property name or value, but instead reached end of data. Path: $ | LineNumber: 0 | BytePositionInLine: 8.");
         }
 
         [Fact]
         public void NewProperty()
         {
-            Assert.Equal(@"{""IsTransient"":true}", JsonSerializer.ToString(new ChildClass { IsTransient = true }));
+            Assert.Equal(@"{""IsTransient"":true}", JsonSerializer.Serialize(new ChildClass { IsTransient = true }));
 
-            ChildClass childClass = JsonSerializer.Parse<ChildClass>(@"{""IsTransient"":true}");
+            ChildClass childClass = JsonSerializer.Deserialize<ChildClass>(@"{""IsTransient"":true}");
             Assert.Equal(true, childClass.IsTransient);
         }
 
         [Fact]
         public void NewPropertyVirtual()
         {
-            Assert.Equal(@"{""IsTransient"":true}", JsonSerializer.ToString(new ChildClassVirtual { IsTransient = true }));
+            Assert.Equal(@"{""IsTransient"":true}", JsonSerializer.Serialize(new ChildClassVirtual { IsTransient = true }));
 
-            ChildClassVirtual childClass = JsonSerializer.Parse<ChildClassVirtual>(@"{""IsTransient"":true}");
+            ChildClassVirtual childClass = JsonSerializer.Deserialize<ChildClassVirtual>(@"{""IsTransient"":true}");
             Assert.Equal(true, childClass.IsTransient);
         }
 
         [Fact]
         public void DeserializeCommentTestObjectWithComments()
         {
-            CommentTestObject o = JsonSerializer.Parse<CommentTestObject>(@"{/* Test */}", new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip });
+            CommentTestObject o = JsonSerializer.Deserialize<CommentTestObject>(@"{/* Test */}", new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip });
             Assert.Equal(false, o.A);
 
-            o = JsonSerializer.Parse<CommentTestObject>(@"{""A"": true/* Test */}", new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip });
+            o = JsonSerializer.Deserialize<CommentTestObject>(@"{""A"": true/* Test */}", new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip });
             Assert.Equal(true, o.A);
         }
 
@@ -130,7 +130,7 @@ namespace System.Text.Json.Tests
 
             p1.Spouse = p2;
             p2.Spouse = p1;
-            Assert.Throws<JsonException> (() => JsonSerializer.ToString(p1));
+            Assert.Throws<JsonException> (() => JsonSerializer.Serialize(p1));
         }
     }
 

--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Tests
                 SimpleTestClass.s_json +
                 "]";
 
-            SimpleTestClass[] i = JsonSerializer.Parse<SimpleTestClass[]>(Encoding.UTF8.GetBytes(data));
+            SimpleTestClass[] i = JsonSerializer.Deserialize<SimpleTestClass[]>(Encoding.UTF8.GetBytes(data));
 
             i[0].Verify();
             i[1].Verify();
@@ -29,7 +29,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ReadNullByteArray()
         {
             string json = @"null";
-            byte[] arr = JsonSerializer.Parse<byte[]>(json);
+            byte[] arr = JsonSerializer.Deserialize<byte[]>(json);
             Assert.Null(arr);
         }
 
@@ -37,7 +37,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ReadEmptyByteArray()
         {
             string json = @"""""";
-            byte[] arr = JsonSerializer.Parse<byte[]>(json);
+            byte[] arr = JsonSerializer.Deserialize<byte[]>(json);
             Assert.Equal(0, arr.Length);
         }
 
@@ -45,7 +45,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ReadByteArray()
         {
             string json = $"\"{Convert.ToBase64String(new byte[] { 1, 2 })}\"";
-            byte[] arr = JsonSerializer.Parse<byte[]>(json);
+            byte[] arr = JsonSerializer.Deserialize<byte[]>(json);
 
             Assert.Equal(2, arr.Length);
             Assert.Equal(1, arr[0]);
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("AQI=", Convert.ToBase64String(new byte[] { 1, 2 }));
 
             string json = "[\"AQI=\",\"AQI=\"]";
-            byte[][] arr = JsonSerializer.Parse<byte[][]>(json);
+            byte[][] arr = JsonSerializer.Deserialize<byte[][]>(json);
             Assert.Equal(2, arr.Length);
 
             Assert.Equal(2, arr[0].Length);
@@ -77,14 +77,14 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(@"[1, 2]")]  // Currently not support deserializing JSON arrays as byte[] - only Base64 string.
         public static void ReadByteArrayFail(string json)
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte[]>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte[]>(json));
         }
 
         [Fact]
         public static void ReadByteListAsJsonArray()
         {
             string json = $"[1, 2]";
-            List<byte> list = JsonSerializer.Parse<List<byte>>(json);
+            List<byte> list = JsonSerializer.Deserialize<List<byte>>(json);
 
             Assert.Equal(2, list.Count);
             Assert.Equal(1, list[0]);
@@ -95,7 +95,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void DeserializeObjectArray_36167()
         {
             // https://github.com/dotnet/corefx/issues/36167
-            object[] data = JsonSerializer.Parse<object[]>("[1]");
+            object[] data = JsonSerializer.Deserialize<object[]>("[1]");
             Assert.Equal(1, data.Length);
             Assert.IsType<JsonElement>(data[0]);
             Assert.Equal(1, ((JsonElement)data[0]).GetInt32());
@@ -104,7 +104,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadEmptyObjectArray()
         {
-            SimpleTestClass[] data = JsonSerializer.Parse<SimpleTestClass[]>("[{}]");
+            SimpleTestClass[] data = JsonSerializer.Deserialize<SimpleTestClass[]>("[{}]");
             Assert.Equal(1, data.Length);
             Assert.NotNull(data[0]);
         }
@@ -112,7 +112,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveJagged2dArray()
         {
-            int[][] i = JsonSerializer.Parse<int[][]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            int[][] i = JsonSerializer.Deserialize<int[][]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             Assert.Equal(1, i[0][0]);
             Assert.Equal(2, i[0][1]);
             Assert.Equal(3, i[1][0]);
@@ -122,7 +122,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveJagged3dArray()
         {
-            int[][][] i = JsonSerializer.Parse<int[][][]>(Encoding.UTF8.GetBytes(@"[[[11,12],[13,14]], [[21,22],[23,24]]]"));
+            int[][][] i = JsonSerializer.Deserialize<int[][][]>(Encoding.UTF8.GetBytes(@"[[[11,12],[13,14]], [[21,22],[23,24]]]"));
             Assert.Equal(11, i[0][0][0]);
             Assert.Equal(12, i[0][0][1]);
             Assert.Equal(13, i[0][1][0]);
@@ -140,7 +140,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.ReadCommentHandling = JsonCommentHandling.Skip;
 
-            int[][] i = JsonSerializer.Parse<int[][]>(Encoding.UTF8.GetBytes("[[1,2] // Inline [\n,[3, /* Multi\n]] Line*/4]]"), options);
+            int[][] i = JsonSerializer.Deserialize<int[][]>(Encoding.UTF8.GetBytes("[[1,2] // Inline [\n,[3, /* Multi\n]] Line*/4]]"), options);
             Assert.Equal(1, i[0][0]);
             Assert.Equal(2, i[0][1]);
             Assert.Equal(3, i[1][0]);
@@ -150,21 +150,21 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadEmpty()
         {
-            SimpleTestClass[] arr = JsonSerializer.Parse<SimpleTestClass[]>("[]");
+            SimpleTestClass[] arr = JsonSerializer.Deserialize<SimpleTestClass[]>("[]");
             Assert.Equal(0, arr.Length);
 
-            List<SimpleTestClass> list = JsonSerializer.Parse<List<SimpleTestClass>>("[]");
+            List<SimpleTestClass> list = JsonSerializer.Deserialize<List<SimpleTestClass>>("[]");
             Assert.Equal(0, list.Count);
         }
 
         [Fact]
         public static void ReadPrimitiveArray()
         {
-            int[] i = JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            int[] i = JsonSerializer.Deserialize<int[]>(Encoding.UTF8.GetBytes(@"[1,2]"));
             Assert.Equal(1, i[0]);
             Assert.Equal(2, i[1]);
 
-            i = JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[]"));
+            i = JsonSerializer.Deserialize<int[]>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, i.Length);
         }
 
@@ -173,7 +173,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ReadInitializedArrayTest()
         {
             string serialized = "{\"Values\":[1,2,3]}";
-            TestClassWithInitializedArray testClassWithInitializedArray = JsonSerializer.Parse<TestClassWithInitializedArray>(serialized);
+            TestClassWithInitializedArray testClassWithInitializedArray = JsonSerializer.Deserialize<TestClassWithInitializedArray>(serialized);
 
             Assert.Equal(1, testClassWithInitializedArray.Values[0]);
             Assert.Equal(2, testClassWithInitializedArray.Values[1]);
@@ -183,7 +183,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayWithEnums()
         {
-            SampleEnum[] i = JsonSerializer.Parse<SampleEnum[]>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            SampleEnum[] i = JsonSerializer.Deserialize<SampleEnum[]>(Encoding.UTF8.GetBytes(@"[1,2]"));
             Assert.Equal(SampleEnum.One, i[0]);
             Assert.Equal(SampleEnum.Two, i[1]);
         }
@@ -192,13 +192,13 @@ namespace System.Text.Json.Serialization.Tests
         public static void ReadPrimitiveArrayFail()
         {
             // Invalid data
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[1,""a""]")));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int[]>(Encoding.UTF8.GetBytes(@"[1,""a""]")));
 
             // Invalid data
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<List<int?>>(Encoding.UTF8.GetBytes(@"[1,""a""]")));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<List<int?>>(Encoding.UTF8.GetBytes(@"[1,""a""]")));
 
             // Multidimensional arrays currently not supported
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[,]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]")));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int[,]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]")));
         }
 
         public static IEnumerable<object[]> ReadNullJson
@@ -220,13 +220,13 @@ namespace System.Text.Json.Serialization.Tests
         [MemberData(nameof(ReadNullJson))]
         public static void ReadNull(string json, bool element0Null, bool element1Null, bool element2Null)
         {
-            SimpleTestClass[] arr = JsonSerializer.Parse<SimpleTestClass[]>(json);
+            SimpleTestClass[] arr = JsonSerializer.Deserialize<SimpleTestClass[]>(json);
             Assert.Equal(3, arr.Length);
             VerifyReadNull(arr[0], element0Null);
             VerifyReadNull(arr[1], element1Null);
             VerifyReadNull(arr[2], element2Null);
 
-            List<SimpleTestClass> list = JsonSerializer.Parse<List<SimpleTestClass>>(json);
+            List<SimpleTestClass> list = JsonSerializer.Deserialize<List<SimpleTestClass>>(json);
             Assert.Equal(3, list.Count);
             VerifyReadNull(list[0], element0Null);
             VerifyReadNull(list[1], element1Null);
@@ -248,173 +248,173 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadClassWithStringArray()
         {
-            TestClassWithStringArray obj = JsonSerializer.Parse<TestClassWithStringArray>(TestClassWithStringArray.s_data);
+            TestClassWithStringArray obj = JsonSerializer.Deserialize<TestClassWithStringArray>(TestClassWithStringArray.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectList()
         {
-            TestClassWithObjectList obj = JsonSerializer.Parse<TestClassWithObjectList>(TestClassWithObjectList.s_data);
+            TestClassWithObjectList obj = JsonSerializer.Deserialize<TestClassWithObjectList>(TestClassWithObjectList.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectArray()
         {
-            TestClassWithObjectArray obj = JsonSerializer.Parse<TestClassWithObjectArray>(TestClassWithObjectArray.s_data);
+            TestClassWithObjectArray obj = JsonSerializer.Deserialize<TestClassWithObjectArray>(TestClassWithObjectArray.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithGenericList()
         {
-            TestClassWithGenericList obj = JsonSerializer.Parse<TestClassWithGenericList>(TestClassWithGenericList.s_data);
+            TestClassWithGenericList obj = JsonSerializer.Deserialize<TestClassWithGenericList>(TestClassWithGenericList.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectIEnumerable()
         {
-            TestClassWithObjectIEnumerable obj = JsonSerializer.Parse<TestClassWithObjectIEnumerable>(TestClassWithObjectIEnumerable.s_data);
+            TestClassWithObjectIEnumerable obj = JsonSerializer.Deserialize<TestClassWithObjectIEnumerable>(TestClassWithObjectIEnumerable.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectIList()
         {
-            TestClassWithObjectIList obj = JsonSerializer.Parse<TestClassWithObjectIList>(TestClassWithObjectIList.s_data);
+            TestClassWithObjectIList obj = JsonSerializer.Deserialize<TestClassWithObjectIList>(TestClassWithObjectIList.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectICollection()
         {
-            TestClassWithObjectICollection obj = JsonSerializer.Parse<TestClassWithObjectICollection>(TestClassWithObjectICollection.s_data);
+            TestClassWithObjectICollection obj = JsonSerializer.Deserialize<TestClassWithObjectICollection>(TestClassWithObjectICollection.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectIEnumerableT()
         {
-            TestClassWithObjectIEnumerableT obj = JsonSerializer.Parse<TestClassWithObjectIEnumerableT>(TestClassWithObjectIEnumerableT.s_data);
+            TestClassWithObjectIEnumerableT obj = JsonSerializer.Deserialize<TestClassWithObjectIEnumerableT>(TestClassWithObjectIEnumerableT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectIListT()
         {
-            TestClassWithObjectIListT obj = JsonSerializer.Parse<TestClassWithObjectIListT>(TestClassWithObjectIListT.s_data);
+            TestClassWithObjectIListT obj = JsonSerializer.Deserialize<TestClassWithObjectIListT>(TestClassWithObjectIListT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectICollectionT()
         {
-            TestClassWithObjectICollectionT obj = JsonSerializer.Parse<TestClassWithObjectICollectionT>(TestClassWithObjectICollectionT.s_data);
+            TestClassWithObjectICollectionT obj = JsonSerializer.Deserialize<TestClassWithObjectICollectionT>(TestClassWithObjectICollectionT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectIReadOnlyCollectionT()
         {
-            TestClassWithObjectIReadOnlyCollectionT obj = JsonSerializer.Parse<TestClassWithObjectIReadOnlyCollectionT>(TestClassWithObjectIReadOnlyCollectionT.s_data);
+            TestClassWithObjectIReadOnlyCollectionT obj = JsonSerializer.Deserialize<TestClassWithObjectIReadOnlyCollectionT>(TestClassWithObjectIReadOnlyCollectionT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectIReadOnlyListT()
         {
-            TestClassWithObjectIReadOnlyListT obj = JsonSerializer.Parse<TestClassWithObjectIReadOnlyListT>(TestClassWithObjectIReadOnlyListT.s_data);
+            TestClassWithObjectIReadOnlyListT obj = JsonSerializer.Deserialize<TestClassWithObjectIReadOnlyListT>(TestClassWithObjectIReadOnlyListT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithGenericIEnumerable()
         {
-            TestClassWithGenericIEnumerable obj = JsonSerializer.Parse<TestClassWithGenericIEnumerable>(TestClassWithGenericIEnumerable.s_data);
+            TestClassWithGenericIEnumerable obj = JsonSerializer.Deserialize<TestClassWithGenericIEnumerable>(TestClassWithGenericIEnumerable.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithGenericIList()
         {
-            TestClassWithGenericIList obj = JsonSerializer.Parse<TestClassWithGenericIList>(TestClassWithGenericIList.s_data);
+            TestClassWithGenericIList obj = JsonSerializer.Deserialize<TestClassWithGenericIList>(TestClassWithGenericIList.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithGenericICollection()
         {
-            TestClassWithGenericICollection obj = JsonSerializer.Parse<TestClassWithGenericICollection>(TestClassWithGenericICollection.s_data);
+            TestClassWithGenericICollection obj = JsonSerializer.Deserialize<TestClassWithGenericICollection>(TestClassWithGenericICollection.s_data);
         }
 
         public static void ReadClassWithObjectISetT()
         {
-            TestClassWithObjectISetT obj = JsonSerializer.Parse<TestClassWithObjectISetT>(TestClassWithObjectISetT.s_data);
+            TestClassWithObjectISetT obj = JsonSerializer.Deserialize<TestClassWithObjectISetT>(TestClassWithObjectISetT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithGenericIEnumerableT()
         {
-            TestClassWithGenericIEnumerableT obj = JsonSerializer.Parse<TestClassWithGenericIEnumerableT>(TestClassWithGenericIEnumerableT.s_data);
+            TestClassWithGenericIEnumerableT obj = JsonSerializer.Deserialize<TestClassWithGenericIEnumerableT>(TestClassWithGenericIEnumerableT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithGenericIListT()
         {
-            TestClassWithGenericIListT obj = JsonSerializer.Parse<TestClassWithGenericIListT>(TestClassWithGenericIListT.s_data);
+            TestClassWithGenericIListT obj = JsonSerializer.Deserialize<TestClassWithGenericIListT>(TestClassWithGenericIListT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithGenericICollectionT()
         {
-            TestClassWithGenericICollectionT obj = JsonSerializer.Parse<TestClassWithGenericICollectionT>(TestClassWithGenericICollectionT.s_data);
+            TestClassWithGenericICollectionT obj = JsonSerializer.Deserialize<TestClassWithGenericICollectionT>(TestClassWithGenericICollectionT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithGenericIReadOnlyCollectionT()
         {
-            TestClassWithGenericIReadOnlyCollectionT obj = JsonSerializer.Parse<TestClassWithGenericIReadOnlyCollectionT>(TestClassWithGenericIReadOnlyCollectionT.s_data);
+            TestClassWithGenericIReadOnlyCollectionT obj = JsonSerializer.Deserialize<TestClassWithGenericIReadOnlyCollectionT>(TestClassWithGenericIReadOnlyCollectionT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithGenericIReadOnlyListT()
         {
-            TestClassWithGenericIReadOnlyListT obj = JsonSerializer.Parse<TestClassWithGenericIReadOnlyListT>(TestClassWithGenericIReadOnlyListT.s_data);
+            TestClassWithGenericIReadOnlyListT obj = JsonSerializer.Deserialize<TestClassWithGenericIReadOnlyListT>(TestClassWithGenericIReadOnlyListT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithGenericISetT()
         {
-            TestClassWithGenericISetT obj = JsonSerializer.Parse<TestClassWithGenericISetT>(TestClassWithGenericISetT.s_data);
+            TestClassWithGenericISetT obj = JsonSerializer.Deserialize<TestClassWithGenericISetT>(TestClassWithGenericISetT.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectIEnumerableConstructibleTypes()
         {
-            TestClassWithObjectIEnumerableConstructibleTypes obj = JsonSerializer.Parse<TestClassWithObjectIEnumerableConstructibleTypes>(TestClassWithObjectIEnumerableConstructibleTypes.s_data);
+            TestClassWithObjectIEnumerableConstructibleTypes obj = JsonSerializer.Deserialize<TestClassWithObjectIEnumerableConstructibleTypes>(TestClassWithObjectIEnumerableConstructibleTypes.s_data);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadClassWithObjectImmutableTypes()
         {
-            TestClassWithObjectImmutableTypes obj = JsonSerializer.Parse<TestClassWithObjectImmutableTypes>(TestClassWithObjectImmutableTypes.s_data);
+            TestClassWithObjectImmutableTypes obj = JsonSerializer.Deserialize<TestClassWithObjectImmutableTypes>(TestClassWithObjectImmutableTypes.s_data);
             obj.Verify();
         }
 
         public static void ClassWithNoSetter()
         {
             string json = @"{""MyList"":[1]}";
-            ClassWithListButNoSetter obj = JsonSerializer.Parse<ClassWithListButNoSetter>(json);
+            ClassWithListButNoSetter obj = JsonSerializer.Deserialize<ClassWithListButNoSetter>(json);
             Assert.Equal(1, obj.MyList[0]);
         }
 

--- a/src/System.Text.Json/tests/Serialization/Array.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.WriteTests.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void WritePrimitiveArray()
         {
             var input = new int[] { 0, 1 };
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[0,1]", json);
         }
 
@@ -21,7 +21,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void WriteArrayWithEnums()
         {
             var input = new SampleEnum[] { SampleEnum.One, SampleEnum.Two };
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -29,7 +29,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void WriteNullByteArray()
         {
             byte[] input = null;
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal($"null", json);
         }
 
@@ -37,7 +37,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void WriteEmptyByteArray()
         {
             var input = new byte[] {};
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal(@"""""", json);
         }
 
@@ -45,7 +45,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void WriteByteArray()
         {
             var input = new byte[] { 1, 2 };
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal($"\"{Convert.ToBase64String(input)}\"", json);
         }
 
@@ -54,7 +54,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             var inner = new byte[] { 1, 2 };
             var outer = new byte[2][] { inner, inner };
-            string json = JsonSerializer.ToString(outer);
+            string json = JsonSerializer.Serialize(outer);
             Assert.Equal($"[\"{Convert.ToBase64String(inner)}\",\"{Convert.ToBase64String(inner)}\"]", json);
         }
 
@@ -71,11 +71,11 @@ namespace System.Text.Json.Serialization.Tests
                 input[1].Initialize();
                 input[1].Verify();
 
-                json = JsonSerializer.ToString(input);
+                json = JsonSerializer.Serialize(input);
             }
 
             {
-                SimpleTestClass[] output = JsonSerializer.Parse<SimpleTestClass[]>(json);
+                SimpleTestClass[] output = JsonSerializer.Deserialize<SimpleTestClass[]>(json);
                 Assert.Equal(2, output.Length);
                 output[0].Verify();
                 output[1].Verify();
@@ -87,7 +87,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             object[] arr = new object[] { new object() };
 
-            string json = JsonSerializer.ToString(arr);
+            string json = JsonSerializer.Serialize(arr);
             Assert.Equal("[{}]", json);
         }
 
@@ -98,17 +98,17 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new int[] { 1, 2 };
             input[1] = new int[] { 3, 4 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
         [Fact]
         public static void WriteEmpty()
         {
-            string json = JsonSerializer.ToString(new SimpleTestClass[] { });
+            string json = JsonSerializer.Serialize(new SimpleTestClass[] { });
             Assert.Equal("[]", json);
 
-            json = JsonSerializer.ToString(new List<SimpleTestClass>());
+            json = JsonSerializer.Serialize(new List<SimpleTestClass>());
             Assert.Equal("[]", json);
         }
 
@@ -121,16 +121,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithStringArray obj = new TestClassWithStringArray();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithStringArray obj = JsonSerializer.Parse<TestClassWithStringArray>(json);
+                TestClassWithStringArray obj = JsonSerializer.Deserialize<TestClassWithStringArray>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithStringArray obj = JsonSerializer.Parse<TestClassWithStringArray>(TestClassWithStringArray.s_data);
+                TestClassWithStringArray obj = JsonSerializer.Deserialize<TestClassWithStringArray>(TestClassWithStringArray.s_data);
                 obj.Verify();
             }
         }
@@ -144,16 +144,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithObjectList obj = new TestClassWithObjectList();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithObjectList obj = JsonSerializer.Parse<TestClassWithObjectList>(json);
+                TestClassWithObjectList obj = JsonSerializer.Deserialize<TestClassWithObjectList>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithObjectList obj = JsonSerializer.Parse<TestClassWithObjectList>(TestClassWithObjectList.s_data);
+                TestClassWithObjectList obj = JsonSerializer.Deserialize<TestClassWithObjectList>(TestClassWithObjectList.s_data);
                 obj.Verify();
             }
         }
@@ -167,16 +167,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithGenericList obj = new TestClassWithGenericList();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithGenericList obj = JsonSerializer.Parse<TestClassWithGenericList>(json);
+                TestClassWithGenericList obj = JsonSerializer.Deserialize<TestClassWithGenericList>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithGenericList obj = JsonSerializer.Parse<TestClassWithGenericList>(TestClassWithGenericList.s_data);
+                TestClassWithGenericList obj = JsonSerializer.Deserialize<TestClassWithGenericList>(TestClassWithGenericList.s_data);
                 obj.Verify();
             }
         }
@@ -189,16 +189,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithGenericIEnumerableT obj = new TestClassWithGenericIEnumerableT();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithGenericIEnumerableT obj = JsonSerializer.Parse<TestClassWithGenericIEnumerableT>(json);
+                TestClassWithGenericIEnumerableT obj = JsonSerializer.Deserialize<TestClassWithGenericIEnumerableT>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithGenericIEnumerableT obj = JsonSerializer.Parse<TestClassWithGenericIEnumerableT>(TestClassWithGenericIEnumerableT.s_data);
+                TestClassWithGenericIEnumerableT obj = JsonSerializer.Deserialize<TestClassWithGenericIEnumerableT>(TestClassWithGenericIEnumerableT.s_data);
                 obj.Verify();
             }
         }
@@ -212,16 +212,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithGenericIListT obj = new TestClassWithGenericIListT();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithGenericIListT obj = JsonSerializer.Parse<TestClassWithGenericIListT>(json);
+                TestClassWithGenericIListT obj = JsonSerializer.Deserialize<TestClassWithGenericIListT>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithGenericIListT obj = JsonSerializer.Parse<TestClassWithGenericIListT>(TestClassWithGenericIListT.s_data);
+                TestClassWithGenericIListT obj = JsonSerializer.Deserialize<TestClassWithGenericIListT>(TestClassWithGenericIListT.s_data);
                 obj.Verify();
             }
         }
@@ -235,16 +235,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithGenericICollectionT obj = new TestClassWithGenericICollectionT();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithGenericICollectionT obj = JsonSerializer.Parse<TestClassWithGenericICollectionT>(json);
+                TestClassWithGenericICollectionT obj = JsonSerializer.Deserialize<TestClassWithGenericICollectionT>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithGenericICollectionT obj = JsonSerializer.Parse<TestClassWithGenericICollectionT>(TestClassWithGenericICollectionT.s_data);
+                TestClassWithGenericICollectionT obj = JsonSerializer.Deserialize<TestClassWithGenericICollectionT>(TestClassWithGenericICollectionT.s_data);
                 obj.Verify();
             }
         }
@@ -258,16 +258,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithGenericIReadOnlyCollectionT obj = new TestClassWithGenericIReadOnlyCollectionT();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithGenericIReadOnlyCollectionT obj = JsonSerializer.Parse<TestClassWithGenericIReadOnlyCollectionT>(json);
+                TestClassWithGenericIReadOnlyCollectionT obj = JsonSerializer.Deserialize<TestClassWithGenericIReadOnlyCollectionT>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithGenericIReadOnlyCollectionT obj = JsonSerializer.Parse<TestClassWithGenericIReadOnlyCollectionT>(TestClassWithGenericIReadOnlyCollectionT.s_data);
+                TestClassWithGenericIReadOnlyCollectionT obj = JsonSerializer.Deserialize<TestClassWithGenericIReadOnlyCollectionT>(TestClassWithGenericIReadOnlyCollectionT.s_data);
                 obj.Verify();
             }
         }
@@ -281,16 +281,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithGenericIReadOnlyListT obj = new TestClassWithGenericIReadOnlyListT();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithGenericIReadOnlyListT obj = JsonSerializer.Parse<TestClassWithGenericIReadOnlyListT>(json);
+                TestClassWithGenericIReadOnlyListT obj = JsonSerializer.Deserialize<TestClassWithGenericIReadOnlyListT>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithGenericIReadOnlyListT obj = JsonSerializer.Parse<TestClassWithGenericIReadOnlyListT>(TestClassWithGenericIEnumerableT.s_data);
+                TestClassWithGenericIReadOnlyListT obj = JsonSerializer.Deserialize<TestClassWithGenericIReadOnlyListT>(TestClassWithGenericIEnumerableT.s_data);
                 obj.Verify();
             }
         }
@@ -304,16 +304,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithObjectIEnumerableT obj = new TestClassWithObjectIEnumerableT();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithObjectIEnumerableT obj = JsonSerializer.Parse<TestClassWithObjectIEnumerableT>(json);
+                TestClassWithObjectIEnumerableT obj = JsonSerializer.Deserialize<TestClassWithObjectIEnumerableT>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithObjectIEnumerableT obj = JsonSerializer.Parse<TestClassWithObjectIEnumerableT>(TestClassWithObjectIEnumerableT.s_data);
+                TestClassWithObjectIEnumerableT obj = JsonSerializer.Deserialize<TestClassWithObjectIEnumerableT>(TestClassWithObjectIEnumerableT.s_data);
                 obj.Verify();
             }
         }
@@ -327,16 +327,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithObjectIListT obj = new TestClassWithObjectIListT();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithObjectIListT obj = JsonSerializer.Parse<TestClassWithObjectIListT>(json);
+                TestClassWithObjectIListT obj = JsonSerializer.Deserialize<TestClassWithObjectIListT>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithObjectIListT obj = JsonSerializer.Parse<TestClassWithObjectIListT>(TestClassWithObjectIListT.s_data);
+                TestClassWithObjectIListT obj = JsonSerializer.Deserialize<TestClassWithObjectIListT>(TestClassWithObjectIListT.s_data);
                 obj.Verify();
             }
         }
@@ -350,16 +350,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithObjectICollectionT obj = new TestClassWithObjectICollectionT();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithObjectICollectionT obj = JsonSerializer.Parse<TestClassWithObjectICollectionT>(json);
+                TestClassWithObjectICollectionT obj = JsonSerializer.Deserialize<TestClassWithObjectICollectionT>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithObjectICollectionT obj = JsonSerializer.Parse<TestClassWithObjectICollectionT>(TestClassWithObjectICollectionT.s_data);
+                TestClassWithObjectICollectionT obj = JsonSerializer.Deserialize<TestClassWithObjectICollectionT>(TestClassWithObjectICollectionT.s_data);
                 obj.Verify();
             }
         }
@@ -373,16 +373,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithObjectIReadOnlyCollectionT obj = new TestClassWithObjectIReadOnlyCollectionT();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithObjectIReadOnlyCollectionT obj = JsonSerializer.Parse<TestClassWithObjectIReadOnlyCollectionT>(json);
+                TestClassWithObjectIReadOnlyCollectionT obj = JsonSerializer.Deserialize<TestClassWithObjectIReadOnlyCollectionT>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithObjectIReadOnlyCollectionT obj = JsonSerializer.Parse<TestClassWithObjectIReadOnlyCollectionT>(TestClassWithObjectIReadOnlyCollectionT.s_data);
+                TestClassWithObjectIReadOnlyCollectionT obj = JsonSerializer.Deserialize<TestClassWithObjectIReadOnlyCollectionT>(TestClassWithObjectIReadOnlyCollectionT.s_data);
                 obj.Verify();
             }
         }
@@ -396,16 +396,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithObjectIReadOnlyListT obj = new TestClassWithObjectIReadOnlyListT();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithObjectIReadOnlyListT obj = JsonSerializer.Parse<TestClassWithObjectIReadOnlyListT>(json);
+                TestClassWithObjectIReadOnlyListT obj = JsonSerializer.Deserialize<TestClassWithObjectIReadOnlyListT>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithObjectIReadOnlyListT obj = JsonSerializer.Parse<TestClassWithObjectIReadOnlyListT>(TestClassWithObjectIEnumerableT.s_data);
+                TestClassWithObjectIReadOnlyListT obj = JsonSerializer.Deserialize<TestClassWithObjectIReadOnlyListT>(TestClassWithObjectIEnumerableT.s_data);
                 obj.Verify();
             }
         }
@@ -419,16 +419,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithObjectIEnumerableConstructibleTypes obj = new TestClassWithObjectIEnumerableConstructibleTypes();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithObjectIEnumerableConstructibleTypes obj = JsonSerializer.Parse<TestClassWithObjectIEnumerableConstructibleTypes>(json);
+                TestClassWithObjectIEnumerableConstructibleTypes obj = JsonSerializer.Deserialize<TestClassWithObjectIEnumerableConstructibleTypes>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithObjectIEnumerableConstructibleTypes obj = JsonSerializer.Parse<TestClassWithObjectIEnumerableConstructibleTypes>(TestClassWithObjectIEnumerableConstructibleTypes.s_data);
+                TestClassWithObjectIEnumerableConstructibleTypes obj = JsonSerializer.Deserialize<TestClassWithObjectIEnumerableConstructibleTypes>(TestClassWithObjectIEnumerableConstructibleTypes.s_data);
                 obj.Verify();
             }
         }
@@ -442,16 +442,16 @@ namespace System.Text.Json.Serialization.Tests
                 TestClassWithObjectImmutableTypes obj = new TestClassWithObjectImmutableTypes();
                 obj.Initialize();
                 obj.Verify();
-                json = JsonSerializer.ToString(obj);
+                json = JsonSerializer.Serialize(obj);
             }
 
             {
-                TestClassWithObjectImmutableTypes obj = JsonSerializer.Parse<TestClassWithObjectImmutableTypes>(json);
+                TestClassWithObjectImmutableTypes obj = JsonSerializer.Deserialize<TestClassWithObjectImmutableTypes>(json);
                 obj.Verify();
             }
 
             {
-                TestClassWithObjectImmutableTypes obj = JsonSerializer.Parse<TestClassWithObjectImmutableTypes>(TestClassWithObjectImmutableTypes.s_data);
+                TestClassWithObjectImmutableTypes obj = JsonSerializer.Deserialize<TestClassWithObjectImmutableTypes>(TestClassWithObjectImmutableTypes.s_data);
                 obj.Verify();
             }
         }

--- a/src/System.Text.Json/tests/Serialization/CacheTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CacheTests.cs
@@ -17,13 +17,13 @@ namespace System.Text.Json.Serialization.Tests
         {
             void DeserializeObjectFlipped()
             {
-                TestClassForCachingTest obj = JsonSerializer.Parse<TestClassForCachingTest>(SimpleTestClass.s_json_flipped);
+                TestClassForCachingTest obj = JsonSerializer.Deserialize<TestClassForCachingTest>(SimpleTestClass.s_json_flipped);
                 obj.Verify();
             };
 
             void DeserializeObjectNormal()
             {
-                TestClassForCachingTest obj = JsonSerializer.Parse<TestClassForCachingTest>(SimpleTestClass.s_json);
+                TestClassForCachingTest obj = JsonSerializer.Deserialize<TestClassForCachingTest>(SimpleTestClass.s_json);
                 obj.Verify();
             };
 
@@ -31,7 +31,7 @@ namespace System.Text.Json.Serialization.Tests
             {
                 var obj = new TestClassForCachingTest();
                 obj.Initialize();
-                JsonSerializer.ToString(obj);
+                JsonSerializer.Serialize(obj);
             };
 
             Task[] tasks = new Task[4 * 3];
@@ -56,14 +56,14 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
 
             string json = "{}";
-            JsonSerializer.Parse<SimpleTestClass>(json, options);
+            JsonSerializer.Deserialize<SimpleTestClass>(json, options);
 
             SimpleTestClass testObj = new SimpleTestClass();
             testObj.Initialize();
             testObj.Verify();
 
-            json = JsonSerializer.ToString(testObj, options);
-            testObj = JsonSerializer.Parse<SimpleTestClass>(json, options);
+            json = JsonSerializer.Serialize(testObj, options);
+            testObj = JsonSerializer.Deserialize<SimpleTestClass>(json, options);
             testObj.Verify();
         }
 
@@ -78,12 +78,12 @@ namespace System.Text.Json.Serialization.Tests
             testObj.Initialize();
             testObj.Verify();
 
-            string json = JsonSerializer.ToString(testObj, options);
-            testObj = JsonSerializer.Parse<SimpleTestClass>(json, options);
+            string json = JsonSerializer.Serialize(testObj, options);
+            testObj = JsonSerializer.Deserialize<SimpleTestClass>(json, options);
             testObj.Verify();
 
             json = "{}";
-            JsonSerializer.Parse<SimpleTestClass>(json, options);
+            JsonSerializer.Deserialize<SimpleTestClass>(json, options);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Array.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Array.cs
@@ -76,12 +76,12 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new LongArrayConverter());
 
-            long[] arr = JsonSerializer.Parse<long[]>(json, options);
+            long[] arr = JsonSerializer.Deserialize<long[]>(json, options);
             Assert.Equal(1, arr[0]);
             Assert.Equal(2, arr[1]);
             Assert.Equal(3, arr[2]);
 
-            string jsonSerialized = JsonSerializer.ToString(arr, options);
+            string jsonSerialized = JsonSerializer.Serialize(arr, options);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -95,7 +95,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.Parse<long[]>(json, options);
+                JsonSerializer.Deserialize<long[]>(json, options);
                 Assert.True(false, "Expected exception");
             }
             catch (JsonException ex)
@@ -120,14 +120,14 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new LongArrayConverter());
 
-            ClassWithProperty obj = JsonSerializer.Parse<ClassWithProperty>(json, options);
+            ClassWithProperty obj = JsonSerializer.Deserialize<ClassWithProperty>(json, options);
             Assert.Equal(1, obj.Array1[0]);
             Assert.Equal(2, obj.Array1[1]);
             Assert.Equal(3, obj.Array1[2]);
             Assert.Equal(4, obj.Array2[0]);
             Assert.Equal(5, obj.Array2[1]);
 
-            string jsonSerialized = JsonSerializer.ToString(obj, options);
+            string jsonSerialized = JsonSerializer.Serialize(obj, options);
             Assert.Equal(json, jsonSerialized);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Attribute.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Attribute.cs
@@ -42,11 +42,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             const string json = @"{""Point1"":""1,2""}";
 
-            ClassWithPointConverterAttribute obj = JsonSerializer.Parse<ClassWithPointConverterAttribute>(json);
+            ClassWithPointConverterAttribute obj = JsonSerializer.Deserialize<ClassWithPointConverterAttribute>(json);
             Assert.Equal(11, obj.Point1.X);
             Assert.Equal(12, obj.Point1.Y);
 
-            string jsonSerialized = JsonSerializer.ToString(obj);
+            string jsonSerialized = JsonSerializer.Serialize(obj);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -61,11 +61,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             const string json = @"{""Point1"":""1,2""}";
 
-            ClassWithJsonConverterAttribute obj = JsonSerializer.Parse<ClassWithJsonConverterAttribute>(json);
+            ClassWithJsonConverterAttribute obj = JsonSerializer.Deserialize<ClassWithJsonConverterAttribute>(json);
             Assert.Equal(1, obj.Point1.X);
             Assert.Equal(2, obj.Point1.Y);
 
-            string jsonSerialized = JsonSerializer.ToString(obj);
+            string jsonSerialized = JsonSerializer.Serialize(obj);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -135,11 +135,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             const string json = @"""1,2""";
 
-            AttributedPoint point = JsonSerializer.Parse<AttributedPoint>(json);
+            AttributedPoint point = JsonSerializer.Deserialize<AttributedPoint>(json);
             Assert.Equal(1, point.X);
             Assert.Equal(2, point.Y);
 
-            string jsonSerialized = JsonSerializer.ToString(point);
+            string jsonSerialized = JsonSerializer.Serialize(point);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -174,13 +174,13 @@ namespace System.Text.Json.Serialization.Tests
         {
             const string json = @"{""Point1"":""1,2""}";
 
-            ClassWithJsonConverterAttributeOverride point = JsonSerializer.Parse<ClassWithJsonConverterAttributeOverride>(json);
+            ClassWithJsonConverterAttributeOverride point = JsonSerializer.Deserialize<ClassWithJsonConverterAttributeOverride>(json);
             
             // The property attribute overides the type attribute.
             Assert.Equal(101, point.Point1.X);
             Assert.Equal(102, point.Point1.Y);
 
-            string jsonSerialized = JsonSerializer.ToString(point);
+            string jsonSerialized = JsonSerializer.Serialize(point);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -192,13 +192,13 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new AttributedPointConverter(200));
 
-            ClassWithJsonConverterAttributeOverride point = JsonSerializer.Parse<ClassWithJsonConverterAttributeOverride>(json);
+            ClassWithJsonConverterAttributeOverride point = JsonSerializer.Deserialize<ClassWithJsonConverterAttributeOverride>(json);
 
             // The property attribute overides the runtime.
             Assert.Equal(101, point.Point1.X);
             Assert.Equal(102, point.Point1.Y);
 
-            string jsonSerialized = JsonSerializer.ToString(point);
+            string jsonSerialized = JsonSerializer.Serialize(point);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -208,22 +208,22 @@ namespace System.Text.Json.Serialization.Tests
             const string json = @"""1,2""";
 
             // Baseline
-            AttributedPoint point = JsonSerializer.Parse<AttributedPoint>(json);
+            AttributedPoint point = JsonSerializer.Deserialize<AttributedPoint>(json);
             Assert.Equal(1, point.X);
             Assert.Equal(2, point.Y);
-            Assert.Equal(json, JsonSerializer.ToString(point));
+            Assert.Equal(json, JsonSerializer.Serialize(point));
 
             // Now use options.
             var options = new JsonSerializerOptions();
             options.Converters.Add(new AttributedPointConverter(200));
 
-            point = JsonSerializer.Parse<AttributedPoint>(json, options);
+            point = JsonSerializer.Deserialize<AttributedPoint>(json, options);
 
             // The runtime overrides the type attribute.
             Assert.Equal(201, point.X);
             Assert.Equal(202, point.Y);
 
-            string jsonSerialized = JsonSerializer.ToString(point, options);
+            string jsonSerialized = JsonSerializer.Serialize(point, options);
             Assert.Equal(json, jsonSerialized);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.BadConverters.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.BadConverters.cs
@@ -43,23 +43,23 @@ namespace System.Text.Json.Serialization.Tests
             options.Converters.Add(new BadCustomerConverter());
 
             // Incompatible types.
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<int>("0", options));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(0, options));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<PocoWithNoBaseClass>("{}", options));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(new PocoWithNoBaseClass(), options));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<int>("0", options));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(0, options));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<PocoWithNoBaseClass>("{}", options));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new PocoWithNoBaseClass(), options));
 
             // Contravariant to Customer.
-            Assert.Throws<SuccessException>(() => JsonSerializer.Parse<DerivedCustomer>("{}", options));
-            Assert.Throws<SuccessException>(() => JsonSerializer.ToString(new DerivedCustomer(), options));
+            Assert.Throws<SuccessException>(() => JsonSerializer.Deserialize<DerivedCustomer>("{}", options));
+            Assert.Throws<SuccessException>(() => JsonSerializer.Serialize(new DerivedCustomer(), options));
 
             // Covariant to Customer.
-            Assert.Throws<SuccessException>(() => JsonSerializer.Parse<Customer>("{}", options));
-            Assert.Throws<SuccessException>(() => JsonSerializer.ToString(new Customer(), options));
-            Assert.Throws<SuccessException>(() => JsonSerializer.ToString<Customer>(new DerivedCustomer(), options));
+            Assert.Throws<SuccessException>(() => JsonSerializer.Deserialize<Customer>("{}", options));
+            Assert.Throws<SuccessException>(() => JsonSerializer.Serialize(new Customer(), options));
+            Assert.Throws<SuccessException>(() => JsonSerializer.Serialize<Customer>(new DerivedCustomer(), options));
 
-            Assert.Throws<SuccessException>(() => JsonSerializer.Parse<Person>("{}", options));
-            Assert.Throws<SuccessException>(() => JsonSerializer.ToString<Person>(new Customer(), options));
-            Assert.Throws<SuccessException>(() => JsonSerializer.ToString<Person>(new DerivedCustomer(), options));
+            Assert.Throws<SuccessException>(() => JsonSerializer.Deserialize<Person>("{}", options));
+            Assert.Throws<SuccessException>(() => JsonSerializer.Serialize<Person>(new Customer(), options));
+            Assert.Throws<SuccessException>(() => JsonSerializer.Serialize<Person>(new DerivedCustomer(), options));
         }
 
         private class CanConvertNullConverterAttribute : JsonConverterAttribute
@@ -81,8 +81,8 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void AttributeCreateConverterFail()
         {
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(new PocoWithNullConverter()));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<PocoWithNullConverter>("{}"));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new PocoWithNullConverter()));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<PocoWithNullConverter>("{}"));
         }
 
         private class ConverterThatReturnsNull : JsonConverterFactory
@@ -104,8 +104,8 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new ConverterThatReturnsNull());
 
-            Assert.Throws<ArgumentNullException>(() => JsonSerializer.ToString(0, options));
-            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Parse<int>("0", options));
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Serialize(0, options));
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Deserialize<int>("0", options));
         }
 
         private class Level1
@@ -156,7 +156,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.Parse<Level1>(json, options);
+                JsonSerializer.Deserialize<Level1>(json, options);
                 Assert.True(false, "Expected exception");
             }
             catch (JsonException ex)
@@ -174,7 +174,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.ToString(new Level1(), options);
+                JsonSerializer.Serialize(new Level1(), options);
                 Assert.True(false, "Expected exception");
             }
             catch (JsonException ex)
@@ -194,8 +194,8 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void PropertyHasMoreThanOneConverter()
         {
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(new PocoWithTwoConvertersOnProperty()));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<PocoWithTwoConvertersOnProperty>("{}"));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new PocoWithTwoConvertersOnProperty()));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<PocoWithTwoConvertersOnProperty>("{}"));
         }
 
         [CanConvertNullConverter]
@@ -208,8 +208,8 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void TypeHasMoreThanOneConverter()
         {
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(new PocoWithTwoConverters()));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<PocoWithTwoConverters>("{}"));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new PocoWithTwoConverters()));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<PocoWithTwoConverters>("{}"));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Callback.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Callback.cs
@@ -21,7 +21,7 @@ namespace System.Text.Json.Serialization.Tests
             public override Customer Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 // The options are not passed here as that would cause an infinite loop.
-                Customer value = JsonSerializer.ReadValue<Customer>(ref reader);
+                Customer value = JsonSerializer.Deserialize<Customer>(ref reader);
 
                 value.Name = value.Name + "Hello!";
                 return value;
@@ -42,7 +42,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new CustomerCallbackConverter());
 
-            Customer customer = JsonSerializer.Parse<Customer>(json, options);
+            Customer customer = JsonSerializer.Deserialize<Customer>(json, options);
             Assert.Equal("MyNameHello!", customer.Name);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Dictionary.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Dictionary.cs
@@ -78,11 +78,11 @@ namespace System.Text.Json.Serialization.Tests
             options.Converters.Add(new DictionaryConverter(10));
 
             {
-                Dictionary<string, long> dictionary = JsonSerializer.Parse<Dictionary<string, long>>(json, options);
+                Dictionary<string, long> dictionary = JsonSerializer.Deserialize<Dictionary<string, long>>(json, options);
                 Assert.Equal(11, dictionary["Key1"]);
                 Assert.Equal(12, dictionary["Key2"]);
 
-                string jsonSerialized = JsonSerializer.ToString(dictionary, options);
+                string jsonSerialized = JsonSerializer.Serialize(dictionary, options);
                 Assert.Equal(json, jsonSerialized);
             }
         }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Enum.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Enum.cs
@@ -65,21 +65,21 @@ namespace System.Text.Json.Serialization.Tests
             options.Converters.Add(new MyBoolEnumConverter());
 
             {
-                MyBoolEnum value = JsonSerializer.Parse<MyBoolEnum>(@"""TRUE""", options);
+                MyBoolEnum value = JsonSerializer.Deserialize<MyBoolEnum>(@"""TRUE""", options);
                 Assert.Equal(MyBoolEnum.True, value);
-                Assert.Equal(@"""TRUE""", JsonSerializer.ToString(value, options));
+                Assert.Equal(@"""TRUE""", JsonSerializer.Serialize(value, options));
             }
 
             {
-                MyBoolEnum value = JsonSerializer.Parse<MyBoolEnum>(@"""FALSE""", options);
+                MyBoolEnum value = JsonSerializer.Deserialize<MyBoolEnum>(@"""FALSE""", options);
                 Assert.Equal(MyBoolEnum.False, value);
-                Assert.Equal(@"""FALSE""", JsonSerializer.ToString(value, options));
+                Assert.Equal(@"""FALSE""", JsonSerializer.Serialize(value, options));
             }
 
             {
-                MyBoolEnum value = JsonSerializer.Parse<MyBoolEnum>(@"""?""", options);
+                MyBoolEnum value = JsonSerializer.Deserialize<MyBoolEnum>(@"""?""", options);
                 Assert.Equal(MyBoolEnum.Unknown, value);
-                Assert.Equal(@"""?""", JsonSerializer.ToString(value, options));
+                Assert.Equal(@"""?""", JsonSerializer.Serialize(value, options));
             }
         }
 
@@ -90,26 +90,26 @@ namespace System.Text.Json.Serialization.Tests
             options.Converters.Add(new MyBoolEnumConverter());
 
             {
-                MyBoolEnum? value = JsonSerializer.Parse<MyBoolEnum?>(@"null", options);
+                MyBoolEnum? value = JsonSerializer.Deserialize<MyBoolEnum?>(@"null", options);
                 Assert.Null(value);
             }
 
             {
-                MyBoolEnum? value = JsonSerializer.Parse<MyBoolEnum?>(@"""TRUE""", options);
+                MyBoolEnum? value = JsonSerializer.Deserialize<MyBoolEnum?>(@"""TRUE""", options);
                 Assert.Equal(MyBoolEnum.True, value);
-                Assert.Equal(@"""TRUE""", JsonSerializer.ToString(value, options));
+                Assert.Equal(@"""TRUE""", JsonSerializer.Serialize(value, options));
             }
 
             {
-                MyBoolEnum? value = JsonSerializer.Parse<MyBoolEnum?>(@"""FALSE""", options);
+                MyBoolEnum? value = JsonSerializer.Deserialize<MyBoolEnum?>(@"""FALSE""", options);
                 Assert.Equal(MyBoolEnum.False, value);
-                Assert.Equal(@"""FALSE""", JsonSerializer.ToString(value, options));
+                Assert.Equal(@"""FALSE""", JsonSerializer.Serialize(value, options));
             }
 
             {
-                MyBoolEnum? value = JsonSerializer.Parse<MyBoolEnum?>(@"""?""", options);
+                MyBoolEnum? value = JsonSerializer.Deserialize<MyBoolEnum?>(@"""?""", options);
                 Assert.Equal(MyBoolEnum.Unknown, value);
-                Assert.Equal(@"""?""", JsonSerializer.ToString(value, options));
+                Assert.Equal(@"""?""", JsonSerializer.Serialize(value, options));
             }
         }
     }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Exceptions.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Exceptions.cs
@@ -33,15 +33,15 @@ namespace System.Text.Json.Serialization.Tests
             JsonConverter converter = new FailConverter<TException>();
             options.Converters.Add(converter);
 
-            Assert.Throws<TException>(() => JsonSerializer.Parse<int>("0", options));
-            Assert.Throws<TException>(() => JsonSerializer.Parse<int[]>("[0]", options));
-            Assert.Throws<TException>(() => JsonSerializer.ToString(0, options));
-            Assert.Throws<TException>(() => JsonSerializer.ToString(new int[] { 0 }, options));
+            Assert.Throws<TException>(() => JsonSerializer.Deserialize<int>("0", options));
+            Assert.Throws<TException>(() => JsonSerializer.Deserialize<int[]>("[0]", options));
+            Assert.Throws<TException>(() => JsonSerializer.Serialize(0, options));
+            Assert.Throws<TException>(() => JsonSerializer.Serialize(new int[] { 0 }, options));
 
             var obj = new Dictionary<string, int>();
             obj["key"] = 0;
 
-            Assert.Throws<TException>(() => JsonSerializer.ToString(obj, options));
+            Assert.Throws<TException>(() => JsonSerializer.Serialize(obj, options));
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Int32.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Int32.cs
@@ -44,12 +44,12 @@ namespace System.Text.Json.Serialization.Tests
             options.Converters.Add(new Int32Converter());
 
             {
-                int myInt = JsonSerializer.Parse<int>("1", options);
+                int myInt = JsonSerializer.Deserialize<int>("1", options);
                 Assert.Equal(1, myInt);
             }
 
             {
-                int myInt = JsonSerializer.Parse<int>(@"""1""", options);
+                int myInt = JsonSerializer.Deserialize<int>(@"""1""", options);
                 Assert.Equal(1, myInt);
             }
         }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.List.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.List.cs
@@ -130,22 +130,22 @@ namespace System.Text.Json.Serialization.Tests
             options.Converters.Add(new ListConverter(10));
 
             {
-                List<int> list = JsonSerializer.Parse<List<int>>(json, options);
+                List<int> list = JsonSerializer.Deserialize<List<int>>(json, options);
                 Assert.Equal(11, list[0]);
                 Assert.Equal(12, list[1]);
                 Assert.Equal(13, list[2]);
 
-                string jsonSerialized = JsonSerializer.ToString(list, options);
+                string jsonSerialized = JsonSerializer.Serialize(list, options);
                 Assert.Equal(json, jsonSerialized);
             }
 
             {
-                List<long> list = JsonSerializer.Parse<List<long>>(json, options);
+                List<long> list = JsonSerializer.Deserialize<List<long>>(json, options);
                 Assert.Equal(11, list[0]);
                 Assert.Equal(12, list[1]);
                 Assert.Equal(13, list[2]);
 
-                string jsonSerialized = JsonSerializer.ToString(list, options);
+                string jsonSerialized = JsonSerializer.Serialize(list, options);
                 Assert.Equal(json, jsonSerialized);
             }
         }
@@ -158,12 +158,12 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new ListConverter<int>(10));
 
-            List<int> list = JsonSerializer.Parse<List<int>>(json, options);
+            List<int> list = JsonSerializer.Deserialize<List<int>>(json, options);
             Assert.Equal(11, list[0]);
             Assert.Equal(12, list[1]);
             Assert.Equal(13, list[2]);
 
-            string jsonSerialized = JsonSerializer.ToString(list, options);
+            string jsonSerialized = JsonSerializer.Serialize(list, options);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -221,17 +221,17 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new IListConverter());
 
-            IList list = JsonSerializer.Parse<IList>(json, options);
+            IList list = JsonSerializer.Deserialize<IList>(json, options);
             Assert.Equal(11, list[0]);
             Assert.Equal(12, list[1]);
             Assert.Equal(13, list[2]);
 
-            List<int> contraVariantList = JsonSerializer.Parse<List<int>>(json, options);
+            List<int> contraVariantList = JsonSerializer.Deserialize<List<int>>(json, options);
             Assert.Equal(11, contraVariantList[0]);
             Assert.Equal(12, contraVariantList[1]);
             Assert.Equal(13, contraVariantList[2]);
 
-            string jsonSerialized = JsonSerializer.ToString(list, options);
+            string jsonSerialized = JsonSerializer.Serialize(list, options);
             Assert.Equal(json, jsonSerialized);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Object.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Object.cs
@@ -57,32 +57,32 @@ namespace System.Text.Json.Serialization.Tests
 
             {
                 var customer = new Customer();
-                string json = JsonSerializer.ToString<object>(customer, options);
+                string json = JsonSerializer.Serialize<object>(customer, options);
                 Assert.Contains(typeof(Customer).ToString(), json);
 
-                json = JsonSerializer.ToString(customer, options);
+                json = JsonSerializer.Serialize(customer, options);
                 Assert.Contains(typeof(Customer).ToString(), json);
             }
 
             {
-                string json = JsonSerializer.ToString(42, options);
+                string json = JsonSerializer.Serialize(42, options);
                 Assert.Contains(typeof(int).ToString(), json);
             }
 
             {
-                object obj = JsonSerializer.Parse<Customer>("{}", options);
+                object obj = JsonSerializer.Deserialize<Customer>("{}", options);
                 Assert.IsType<Customer>(obj);
                 Assert.Equal("HelloWorld", ((Customer)obj).Name);
             }
 
             {
                 // The converter doesn't handle object.
-                object obj = JsonSerializer.Parse<object>("{}", options);
+                object obj = JsonSerializer.Deserialize<object>("{}", options);
                 Assert.IsType<JsonElement>(obj);
             }
 
             {
-                int obj = JsonSerializer.Parse<int>("0", options);
+                int obj = JsonSerializer.Deserialize<int>("0", options);
                 Assert.Equal(42, obj);
             }
         }
@@ -133,19 +133,19 @@ namespace System.Text.Json.Serialization.Tests
             options.Converters.Add(new ObjectToBoolConverter());
 
             {
-                object obj = JsonSerializer.Parse<object>("true", options);
+                object obj = JsonSerializer.Deserialize<object>("true", options);
                 Assert.IsType<bool>(obj);
                 Assert.True((bool)obj);
             }
 
             {
-                object obj = JsonSerializer.Parse<object>("false", options);
+                object obj = JsonSerializer.Deserialize<object>("false", options);
                 Assert.IsType<bool>(obj);
                 Assert.False((bool)obj);
             }
 
             {
-                object obj = JsonSerializer.Parse<object>("{}", options);
+                object obj = JsonSerializer.Deserialize<object>("{}", options);
                 Assert.IsType<JsonElement>(obj);
             }
         }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Point.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Point.cs
@@ -76,14 +76,14 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new PointConverter());
 
-            Point[] Points = JsonSerializer.Parse<Point[]>(json, options);
+            Point[] Points = JsonSerializer.Deserialize<Point[]>(json, options);
             Assert.Equal(2, Points.Length);
             Assert.Equal(1, Points[0].X);
             Assert.Equal(2, Points[0].Y);
             Assert.Equal(3, Points[1].X);
             Assert.Equal(4, Points[1].Y);
 
-            string jsonSerialized = JsonSerializer.ToString(Points, options);
+            string jsonSerialized = JsonSerializer.Serialize(Points, options);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -95,11 +95,11 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new PointConverter());
 
-            Point obj = JsonSerializer.Parse<Point>(json, options);
+            Point obj = JsonSerializer.Deserialize<Point>(json, options);
             Assert.Equal(1, obj.X);
             Assert.Equal(2, obj.Y);
 
-            string jsonSerialized = JsonSerializer.ToString(obj, options);
+            string jsonSerialized = JsonSerializer.Serialize(obj, options);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -111,11 +111,11 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new PointConverter(100));
 
-            Point obj = JsonSerializer.Parse<Point>(json, options);
+            Point obj = JsonSerializer.Deserialize<Point>(json, options);
             Assert.Equal(101, obj.X);
             Assert.Equal(102, obj.Y);
 
-            string jsonSerialized = JsonSerializer.ToString(obj, options);
+            string jsonSerialized = JsonSerializer.Serialize(obj, options);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -127,7 +127,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new PointConverter());
 
-            Point? obj = JsonSerializer.Parse<Point?>(json, options);
+            Point? obj = JsonSerializer.Deserialize<Point?>(json, options);
             Assert.Null(obj);
         }
 
@@ -140,7 +140,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new PointConverter());
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<Point>(json, options));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Point>(json, options));
         }
 
         [Fact]
@@ -151,11 +151,11 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new PointConverter());
 
-            Point obj = JsonSerializer.Parse<Point>(json, options);
+            Point obj = JsonSerializer.Deserialize<Point>(json, options);
             Assert.Equal(1, obj.X);
             Assert.Equal(2, obj.Y);
 
-            string jsonSerialized = JsonSerializer.ToString(obj, options);
+            string jsonSerialized = JsonSerializer.Serialize(obj, options);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -235,14 +235,14 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new PointObjectConverter());
 
-            Point[] Points = JsonSerializer.Parse<Point[]>(json, options);
+            Point[] Points = JsonSerializer.Deserialize<Point[]>(json, options);
             Assert.Equal(2, Points.Length);
             Assert.Equal(1, Points[0].X);
             Assert.Equal(2, Points[0].Y);
             Assert.Equal(3, Points[1].X);
             Assert.Equal(4, Points[1].Y);
 
-            string jsonSerialized = JsonSerializer.ToString(Points, options);
+            string jsonSerialized = JsonSerializer.Serialize(Points, options);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -254,11 +254,11 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new PointObjectConverter());
 
-            Point obj = JsonSerializer.Parse<Point>(json, options);
+            Point obj = JsonSerializer.Deserialize<Point>(json, options);
             Assert.Equal(1, obj.X);
             Assert.Equal(2, obj.Y);
 
-            string jsonSerialized = JsonSerializer.ToString(obj, options);
+            string jsonSerialized = JsonSerializer.Serialize(obj, options);
             Assert.Equal(json, jsonSerialized);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.Polymorphic.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.Polymorphic.cs
@@ -126,22 +126,22 @@ namespace System.Text.Json.Serialization.Tests
             options.Converters.Add(new PersonConverter());
 
             {
-                Person person = JsonSerializer.Parse<Person>(customerJson, options);
+                Person person = JsonSerializer.Deserialize<Person>(customerJson, options);
                 Assert.IsType<Customer>(person);
                 Assert.Equal(100, ((Customer)person).CreditLimit);
                 Assert.Equal("C", person.Name);
 
-                string json = JsonSerializer.ToString(person, options);
+                string json = JsonSerializer.Serialize(person, options);
                 Assert.Equal(customerJson, json);
             }
 
             {
-                Person person = JsonSerializer.Parse<Person>(employeeJson, options);
+                Person person = JsonSerializer.Deserialize<Person>(employeeJson, options);
                 Assert.IsType<Employee>(person);
                 Assert.Equal("77a", ((Employee)person).OfficeNumber);
                 Assert.Equal("E", person.Name);
 
-                string json = JsonSerializer.ToString(person, options);
+                string json = JsonSerializer.Serialize(person, options);
                 Assert.Equal(employeeJson, json);
             }
         }
@@ -152,7 +152,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new PersonConverter());
 
-            Person person = JsonSerializer.Parse<Person>("null");
+            Person person = JsonSerializer.Deserialize<Person>("null");
             Assert.Null(person);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.ReadAhead.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.ReadAhead.cs
@@ -74,11 +74,11 @@ namespace System.Text.Json.Serialization.Tests
 
             byte[] data = Encoding.UTF8.GetBytes(json);
             MemoryStream stream = new MemoryStream(data);
-            ClassWithStringProperties obj = JsonSerializer.ReadAsync<ClassWithStringProperties>(stream, options).Result;
+            ClassWithStringProperties obj = JsonSerializer.DeserializeAsync<ClassWithStringProperties>(stream, options).Result;
 
             VerifyClassWithStringProperties(obj, stringSize);
 
-            string jsonSerialized = JsonSerializer.ToString(obj, options);
+            string jsonSerialized = JsonSerializer.Serialize(obj, options);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -112,13 +112,13 @@ namespace System.Text.Json.Serialization.Tests
 
             byte[] data = Encoding.UTF8.GetBytes(json);
             MemoryStream stream = new MemoryStream(data);
-            ClassWithNoConverter obj = JsonSerializer.ReadAsync<ClassWithNoConverter>(stream, options).Result;
+            ClassWithNoConverter obj = JsonSerializer.DeserializeAsync<ClassWithNoConverter>(stream, options).Result;
 
             VerifyClassWithStringProperties(obj.Property1, stringSize);
             VerifyClassWithStringProperties(obj.Property2, stringSize);
             VerifyClassWithStringProperties(obj.Property3, stringSize);
 
-            string jsonSerialized = JsonSerializer.ToString(obj, options);
+            string jsonSerialized = JsonSerializer.Serialize(obj, options);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -153,14 +153,14 @@ namespace System.Text.Json.Serialization.Tests
 
             byte[] data = Encoding.UTF8.GetBytes(json);
             MemoryStream stream = new MemoryStream(data);
-            string[] arr = JsonSerializer.ReadAsync<string[]>(stream, options).Result;
+            string[] arr = JsonSerializer.DeserializeAsync<string[]>(stream, options).Result;
 
             for (int i = 0; i < 10; i++)
             {
                 Assert.Equal(new string(i.ToString()[0], stringSize), arr[i]);
             }
 
-            string jsonSerialized = JsonSerializer.ToString(arr, options);
+            string jsonSerialized = JsonSerializer.Serialize(arr, options);
             Assert.Equal(json, jsonSerialized);
         }
 

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.cs
@@ -24,10 +24,10 @@ namespace System.Text.Json.Serialization.Tests
             MyBoolEnum myBoolEnum = MyBoolEnum.Unknown;
             MyBoolEnum? myNullBoolEnum = null;
 
-            string json = JsonSerializer.ToString(new object[] { myBoolEnum, customer, myNullBoolEnum }, options);
+            string json = JsonSerializer.Serialize(new object[] { myBoolEnum, customer, myNullBoolEnum }, options);
             Assert.Equal(expectedJson, json);
 
-            JsonElement jsonElement = JsonSerializer.Parse<JsonElement>(json, options);
+            JsonElement jsonElement = JsonSerializer.Deserialize<JsonElement>(json, options);
             string jsonElementString = jsonElement.ToString();
             Assert.Equal(expectedJson, jsonElementString);
         }

--- a/src/System.Text.Json/tests/Serialization/CyclicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/CyclicTests.cs
@@ -16,7 +16,7 @@ namespace System.Text.Json.Serialization.Tests
             obj.Parent = obj;
 
             // We don't allow graph cycles; we throw JsonException instead of an unrecoverable StackOverflow.
-            Assert.Throws<JsonException>(() => JsonSerializer.ToString(obj));
+            Assert.Throws<JsonException>(() => JsonSerializer.Serialize(obj));
         }
 
         [Theory]
@@ -34,14 +34,14 @@ namespace System.Text.Json.Serialization.Tests
                 options.MaxDepth = depth + 1;
 
                 // No exception since depth was not passed.
-                string json = JsonSerializer.ToString(rootObj, options);
+                string json = JsonSerializer.Serialize(rootObj, options);
                 Assert.False(string.IsNullOrEmpty(json));
             }
 
             {
                 var options = new JsonSerializerOptions();
                 options.MaxDepth = depth;
-                Assert.Throws<JsonException>(() => JsonSerializer.ToString(rootObj, options));
+                Assert.Throws<JsonException>(() => JsonSerializer.Serialize(rootObj, options));
             }
         }
 
@@ -63,7 +63,7 @@ namespace System.Text.Json.Serialization.Tests
             TestClassWithArrayOfElementsOfTheSameClass obj = new TestClassWithArrayOfElementsOfTheSameClass();
 
             // A cycle in just Types (not data) is allowed.
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Equal(@"{""Array"":null}", json);
         }
 
@@ -77,10 +77,10 @@ namespace System.Text.Json.Serialization.Tests
             root.Children.Add(new TestClassWithCycle("child2"));
 
             // A cycle in just Types (not data) is allowed.
-            string json = JsonSerializer.ToString(root);
+            string json = JsonSerializer.Serialize(root);
 
             // Round-trip the JSON.
-            TestClassWithCycle rootCopy = JsonSerializer.Parse<TestClassWithCycle>(json);
+            TestClassWithCycle rootCopy = JsonSerializer.Deserialize<TestClassWithCycle>(json);
             Assert.Equal("root", rootCopy.Name);
             Assert.Equal(2, rootCopy.Children.Count);
 

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -19,122 +19,122 @@ namespace System.Text.Json.Serialization.Tests
             const string ReorderedJsonString = @"{""Hello2"":""World2"",""Hello"":""World""}";
 
             {
-                IDictionary obj = JsonSerializer.Parse<IDictionary>(JsonString);
+                IDictionary obj = JsonSerializer.Deserialize<IDictionary>(JsonString);
                 Assert.Equal("World", ((JsonElement)obj["Hello"]).GetString());
                 Assert.Equal("World2", ((JsonElement)obj["Hello2"]).GetString());
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
 
-                json = JsonSerializer.ToString<object>(obj);
-                Assert.Equal(JsonString, json);
-            }
-
-            {
-                Dictionary<string, string> obj = JsonSerializer.Parse<Dictionary<string, string>>(JsonString);
-                Assert.Equal("World", obj["Hello"]);
-                Assert.Equal("World2", obj["Hello2"]);
-
-                string json = JsonSerializer.ToString(obj);
-                Assert.Equal(JsonString, json);
-
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.Equal(JsonString, json);
             }
 
             {
-                SortedDictionary<string, string> obj = JsonSerializer.Parse<SortedDictionary<string, string>>(JsonString);
+                Dictionary<string, string> obj = JsonSerializer.Deserialize<Dictionary<string, string>>(JsonString);
                 Assert.Equal("World", obj["Hello"]);
                 Assert.Equal("World2", obj["Hello2"]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.Equal(JsonString, json);
             }
 
             {
-                IDictionary<string, string> obj = JsonSerializer.Parse<IDictionary<string, string>>(JsonString);
+                SortedDictionary<string, string> obj = JsonSerializer.Deserialize<SortedDictionary<string, string>>(JsonString);
                 Assert.Equal("World", obj["Hello"]);
                 Assert.Equal("World2", obj["Hello2"]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.Equal(JsonString, json);
             }
 
             {
-                IReadOnlyDictionary<string, string> obj = JsonSerializer.Parse<IReadOnlyDictionary<string, string>>(JsonString);
+                IDictionary<string, string> obj = JsonSerializer.Deserialize<IDictionary<string, string>>(JsonString);
                 Assert.Equal("World", obj["Hello"]);
                 Assert.Equal("World2", obj["Hello2"]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.Equal(JsonString, json);
             }
 
             {
-                ImmutableDictionary<string, string> obj = JsonSerializer.Parse<ImmutableDictionary<string, string>>(JsonString);
+                IReadOnlyDictionary<string, string> obj = JsonSerializer.Deserialize<IReadOnlyDictionary<string, string>>(JsonString);
                 Assert.Equal("World", obj["Hello"]);
                 Assert.Equal("World2", obj["Hello2"]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
+                Assert.Equal(JsonString, json);
+
+                json = JsonSerializer.Serialize<object>(obj);
+                Assert.Equal(JsonString, json);
+            }
+
+            {
+                ImmutableDictionary<string, string> obj = JsonSerializer.Deserialize<ImmutableDictionary<string, string>>(JsonString);
+                Assert.Equal("World", obj["Hello"]);
+                Assert.Equal("World2", obj["Hello2"]);
+
+                string json = JsonSerializer.Serialize(obj);
                 Assert.True(JsonString == json || ReorderedJsonString == json);
 
-                json = JsonSerializer.ToString<object>(obj);
-                Assert.True(JsonString == json || ReorderedJsonString == json);
-            }
-
-            {
-                IImmutableDictionary<string, string> obj = JsonSerializer.Parse<IImmutableDictionary<string, string>>(JsonString);
-                Assert.Equal("World", obj["Hello"]);
-                Assert.Equal("World2", obj["Hello2"]);
-
-                string json = JsonSerializer.ToString(obj);
-                Assert.True(JsonString == json || ReorderedJsonString == json);
-
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.True(JsonString == json || ReorderedJsonString == json);
             }
 
             {
-                ImmutableSortedDictionary<string, string> obj = JsonSerializer.Parse<ImmutableSortedDictionary<string, string>>(JsonString);
+                IImmutableDictionary<string, string> obj = JsonSerializer.Deserialize<IImmutableDictionary<string, string>>(JsonString);
                 Assert.Equal("World", obj["Hello"]);
                 Assert.Equal("World2", obj["Hello2"]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
+                Assert.True(JsonString == json || ReorderedJsonString == json);
+
+                json = JsonSerializer.Serialize<object>(obj);
+                Assert.True(JsonString == json || ReorderedJsonString == json);
+            }
+
+            {
+                ImmutableSortedDictionary<string, string> obj = JsonSerializer.Deserialize<ImmutableSortedDictionary<string, string>>(JsonString);
+                Assert.Equal("World", obj["Hello"]);
+                Assert.Equal("World2", obj["Hello2"]);
+
+                string json = JsonSerializer.Serialize(obj);
                 Assert.True(JsonString == json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.True(JsonString == json);
             }
 
             {
-                Hashtable obj = JsonSerializer.Parse<Hashtable>(JsonString);
+                Hashtable obj = JsonSerializer.Deserialize<Hashtable>(JsonString);
                 Assert.Equal("World", ((JsonElement)obj["Hello"]).GetString());
                 Assert.Equal("World2", ((JsonElement)obj["Hello2"]).GetString());
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.True(JsonString == json || ReorderedJsonString == json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.True(JsonString == json || ReorderedJsonString == json);
             }
 
             {
-                SortedList obj = JsonSerializer.Parse<SortedList>(JsonString);
+                SortedList obj = JsonSerializer.Deserialize<SortedList>(JsonString);
                 Assert.Equal("World", ((JsonElement)obj["Hello"]).GetString());
                 Assert.Equal("World2", ((JsonElement)obj["Hello2"]).GetString());
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.Equal(JsonString, json);
             }
         }
@@ -143,24 +143,24 @@ namespace System.Text.Json.Serialization.Tests
         public static void DictionaryOfObject()
         {
             {
-                Dictionary<string, object> obj = JsonSerializer.Parse<Dictionary<string, object>>(@"{""Key1"":1}");
+                Dictionary<string, object> obj = JsonSerializer.Deserialize<Dictionary<string, object>>(@"{""Key1"":1}");
                 Assert.Equal(1, obj.Count);
                 JsonElement element = (JsonElement)obj["Key1"];
                 Assert.Equal(JsonValueType.Number, element.Type);
                 Assert.Equal(1, element.GetInt32());
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(@"{""Key1"":1}", json);
             }
 
             {
-                IDictionary<string, object> obj = JsonSerializer.Parse<IDictionary<string, object>>(@"{""Key1"":1}");
+                IDictionary<string, object> obj = JsonSerializer.Deserialize<IDictionary<string, object>>(@"{""Key1"":1}");
                 Assert.Equal(1, obj.Count);
                 JsonElement element = (JsonElement)obj["Key1"];
                 Assert.Equal(JsonValueType.Number, element.Type);
                 Assert.Equal(1, element.GetInt32());
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(@"{""Key1"":1}", json);
             }
         }
@@ -174,10 +174,10 @@ namespace System.Text.Json.Serialization.Tests
                 { "Age", 32 }
             });
 
-            string json = JsonSerializer.ToString(input, typeof(IDictionary<string, object>));
+            string json = JsonSerializer.Serialize(input, typeof(IDictionary<string, object>));
             Assert.Equal(@"{""Name"":""David"",""Age"":32}", json);
 
-            IDictionary<string, object> obj = JsonSerializer.Parse<IDictionary<string, object>>(json);
+            IDictionary<string, object> obj = JsonSerializer.Deserialize<IDictionary<string, object>>(json);
             Assert.Equal(2, obj.Count);
             Assert.Equal("David", ((JsonElement)obj["Name"]).GetString());
             Assert.Equal(32, ((JsonElement)obj["Age"]).GetInt32());
@@ -192,10 +192,10 @@ namespace System.Text.Json.Serialization.Tests
                 { "Job", "Software Architect" }
             });
 
-            string json = JsonSerializer.ToString(input, typeof(IDictionary<string, string>));
+            string json = JsonSerializer.Serialize(input, typeof(IDictionary<string, string>));
             Assert.Equal(@"{""Name"":""David"",""Job"":""Software Architect""}", json);
 
-            IDictionary<string, string> obj = JsonSerializer.Parse<IDictionary<string, string>>(json);
+            IDictionary<string, string> obj = JsonSerializer.Deserialize<IDictionary<string, string>>(json);
             Assert.Equal(2, obj.Count);
             Assert.Equal("David", obj["Name"]);
             Assert.Equal("Software Architect", obj["Job"]);
@@ -207,7 +207,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(PocoDictionary), "\"headers\"")]
         public static void InvalidJsonForValueShouldFail(Type type, string json)
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse(json, type));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, type));
         }
 
         [Theory]
@@ -228,19 +228,19 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(typeof(Dictionary<string, int[]>), @"{""test"": [{}]}")]
         public static void InvalidJsonForArrayShouldFail(Type type, string json)
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse(json, type));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, type));
         }
 
         [Fact]
         public static void InvalidEmptyDictionaryInput()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<string>("{}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<string>("{}"));
         }
 
         [Fact]
         public static void PocoWithDictionaryObject()
         {
-            PocoDictionary dict = JsonSerializer.Parse<PocoDictionary>("{\n\t\"key\" : {\"a\" : \"b\", \"c\" : \"d\"}}");
+            PocoDictionary dict = JsonSerializer.Deserialize<PocoDictionary>("{\n\t\"key\" : {\"a\" : \"b\", \"c\" : \"d\"}}");
             Assert.Equal(dict.key["a"], "b");
             Assert.Equal(dict.key["c"], "d");
         }
@@ -259,10 +259,10 @@ namespace System.Text.Json.Serialization.Tests
                 ["key"] = new Poco { Id = 10 },
             };
 
-            string json = JsonSerializer.ToString(dictionary);
+            string json = JsonSerializer.Serialize(dictionary);
             Assert.Equal(@"{""key"":{""Id"":10}}", json);
 
-            dictionary = JsonSerializer.Parse<Dictionary<string, object>>(json);
+            dictionary = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
             Assert.Equal(1, dictionary.Count);
             JsonElement element = (JsonElement)dictionary["key"];
             Assert.Equal(@"{""Id"":10}", element.ToString());
@@ -276,8 +276,8 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void FirstGenericArgNotStringFail()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Parse<Dictionary<int, int>>(@"{1:1}"));
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Parse<ImmutableDictionary<int, int>>(@"{1:1}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<Dictionary<int, int>>(@"{1:1}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ImmutableDictionary<int, int>>(@"{1:1}"));
         }
 
         [Fact]
@@ -286,7 +286,7 @@ namespace System.Text.Json.Serialization.Tests
             const string JsonString = @"{""Key1"":[1,2],""Key2"":[3,4]}";
 
             {
-                IDictionary obj = JsonSerializer.Parse<IDictionary>(JsonString);
+                IDictionary obj = JsonSerializer.Deserialize<IDictionary>(JsonString);
 
                 Assert.Equal(2, obj.Count);
 
@@ -304,12 +304,12 @@ namespace System.Text.Json.Serialization.Tests
                     Assert.Equal(expectedNumber++, value.GetInt32());
                 }
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
             }
 
             {
-                IDictionary<string, List<int>> obj = JsonSerializer.Parse<IDictionary<string, List<int>>>(JsonString);
+                IDictionary<string, List<int>> obj = JsonSerializer.Deserialize<IDictionary<string, List<int>>>(JsonString);
 
                 Assert.Equal(2, obj.Count);
                 Assert.Equal(2, obj["Key1"].Count);
@@ -319,12 +319,12 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(3, obj["Key2"][0]);
                 Assert.Equal(4, obj["Key2"][1]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
             }
 
             {
-                ImmutableDictionary<string, List<int>> obj = JsonSerializer.Parse<ImmutableDictionary<string, List<int>>>(JsonString);
+                ImmutableDictionary<string, List<int>> obj = JsonSerializer.Deserialize<ImmutableDictionary<string, List<int>>>(JsonString);
 
                 Assert.Equal(2, obj.Count);
                 Assert.Equal(2, obj["Key1"].Count);
@@ -334,13 +334,13 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(3, obj["Key2"][0]);
                 Assert.Equal(4, obj["Key2"][1]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 const string ReorderedJsonString = @"{""Key2"":[3,4],""Key1"":[1,2]}";
                 Assert.True(JsonString == json || ReorderedJsonString == json);
             }
 
             {
-                IImmutableDictionary<string, List<int>> obj = JsonSerializer.Parse<IImmutableDictionary<string, List<int>>>(JsonString);
+                IImmutableDictionary<string, List<int>> obj = JsonSerializer.Deserialize<IImmutableDictionary<string, List<int>>>(JsonString);
 
                 Assert.Equal(2, obj.Count);
                 Assert.Equal(2, obj["Key1"].Count);
@@ -351,7 +351,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(4, obj["Key2"][1]);
 
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 const string ReorderedJsonString = @"{""Key2"":[3,4],""Key1"":[1,2]}";
                 Assert.True(JsonString == json || ReorderedJsonString == json);
             }
@@ -361,7 +361,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void DictionaryOfArray()
         {
             const string JsonString = @"{""Key1"":[1,2],""Key2"":[3,4]}";
-            Dictionary<string, int[]> obj = JsonSerializer.Parse<Dictionary<string, int[]>>(JsonString);
+            Dictionary<string, int[]> obj = JsonSerializer.Deserialize<Dictionary<string, int[]>>(JsonString);
 
             Assert.Equal(2, obj.Count);
             Assert.Equal(2, obj["Key1"].Length);
@@ -371,7 +371,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(3, obj["Key2"][0]);
             Assert.Equal(4, obj["Key2"][1]);
 
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Equal(JsonString, json);
         }
 
@@ -381,7 +381,7 @@ namespace System.Text.Json.Serialization.Tests
             const string JsonString = @"[{""Key1"":1,""Key2"":2},{""Key1"":3,""Key2"":4}]";
 
             {
-                List<Dictionary<string, int>> obj = JsonSerializer.Parse<List<Dictionary<string, int>>>(JsonString);
+                List<Dictionary<string, int>> obj = JsonSerializer.Deserialize<List<Dictionary<string, int>>>(JsonString);
 
                 Assert.Equal(2, obj.Count);
                 Assert.Equal(2, obj[0].Count);
@@ -391,14 +391,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(3, obj[1]["Key1"]);
                 Assert.Equal(4, obj[1]["Key2"]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.Equal(JsonString, json);
             }
             {
-                List<ImmutableSortedDictionary<string, int>> obj = JsonSerializer.Parse<List<ImmutableSortedDictionary<string, int>>>(JsonString);
+                List<ImmutableSortedDictionary<string, int>> obj = JsonSerializer.Deserialize<List<ImmutableSortedDictionary<string, int>>>(JsonString);
 
                 Assert.Equal(2, obj.Count);
                 Assert.Equal(2, obj[0].Count);
@@ -408,10 +408,10 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(3, obj[1]["Key1"]);
                 Assert.Equal(4, obj[1]["Key2"]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.Equal(JsonString, json);
             }
         }
@@ -422,7 +422,7 @@ namespace System.Text.Json.Serialization.Tests
             const string JsonString = @"[{""Key1"":1,""Key2"":2},{""Key1"":3,""Key2"":4}]";
 
             {
-                Dictionary<string, int>[] obj = JsonSerializer.Parse<Dictionary<string, int>[]>(JsonString);
+                Dictionary<string, int>[] obj = JsonSerializer.Deserialize<Dictionary<string, int>[]>(JsonString);
 
                 Assert.Equal(2, obj.Length);
                 Assert.Equal(2, obj[0].Count);
@@ -432,15 +432,15 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(3, obj[1]["Key1"]);
                 Assert.Equal(4, obj[1]["Key2"]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.Equal(JsonString, json);
             }
 
             {
-                ImmutableSortedDictionary<string, int>[] obj = JsonSerializer.Parse<ImmutableSortedDictionary<string, int>[]>(JsonString);
+                ImmutableSortedDictionary<string, int>[] obj = JsonSerializer.Deserialize<ImmutableSortedDictionary<string, int>[]>(JsonString);
 
                 Assert.Equal(2, obj.Length);
                 Assert.Equal(2, obj[0].Count);
@@ -450,10 +450,10 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(3, obj[1]["Key1"]);
                 Assert.Equal(4, obj[1]["Key2"]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.Equal(JsonString, json);
             }
         }
@@ -464,7 +464,7 @@ namespace System.Text.Json.Serialization.Tests
             const string JsonString = @"{""Key1"":{""Key1a"":1,""Key1b"":2},""Key2"":{""Key2a"":3,""Key2b"":4}}";
 
             {
-                Dictionary<string, Dictionary<string, int>> obj = JsonSerializer.Parse<Dictionary<string, Dictionary<string, int>>>(JsonString);
+                Dictionary<string, Dictionary<string, int>> obj = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, int>>>(JsonString);
 
                 Assert.Equal(2, obj.Count);
                 Assert.Equal(2, obj["Key1"].Count);
@@ -474,15 +474,15 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(3, obj["Key2"]["Key2a"]);
                 Assert.Equal(4, obj["Key2"]["Key2b"]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.Equal(JsonString, json);
             }
 
             {
-                ImmutableSortedDictionary<string, ImmutableSortedDictionary<string, int>> obj = JsonSerializer.Parse<ImmutableSortedDictionary<string, ImmutableSortedDictionary<string, int>>>(JsonString);
+                ImmutableSortedDictionary<string, ImmutableSortedDictionary<string, int>> obj = JsonSerializer.Deserialize<ImmutableSortedDictionary<string, ImmutableSortedDictionary<string, int>>>(JsonString);
 
                 Assert.Equal(2, obj.Count);
                 Assert.Equal(2, obj["Key1"].Count);
@@ -492,10 +492,10 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(3, obj["Key2"]["Key2a"]);
                 Assert.Equal(4, obj["Key2"]["Key2b"]);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(JsonString, json);
 
-                json = JsonSerializer.ToString<object>(obj);
+                json = JsonSerializer.Serialize<object>(obj);
                 Assert.Equal(JsonString, json);
             }
         }
@@ -504,7 +504,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void DictionaryOfDictionaryOfDictionary()
         {
             const string JsonString = @"{""Key1"":{""Key1"":{""Key1"":1,""Key2"":2},""Key2"":{""Key1"":3,""Key2"":4}},""Key2"":{""Key1"":{""Key1"":5,""Key2"":6},""Key2"":{""Key1"":7,""Key2"":8}}}";
-            Dictionary<string, Dictionary<string, Dictionary<string, int>>> obj = JsonSerializer.Parse<Dictionary<string, Dictionary<string, Dictionary<string, int>>>>(JsonString);
+            Dictionary<string, Dictionary<string, Dictionary<string, int>>> obj = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, Dictionary<string, int>>>>(JsonString);
 
             Assert.Equal(2, obj.Count);
             Assert.Equal(2, obj["Key1"].Count);
@@ -525,11 +525,11 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(7, obj["Key2"]["Key2"]["Key1"]);
             Assert.Equal(8, obj["Key2"]["Key2"]["Key2"]);
 
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Equal(JsonString, json);
 
             // Verify that typeof(object) doesn't interfere.
-            json = JsonSerializer.ToString<object>(obj);
+            json = JsonSerializer.Serialize<object>(obj);
             Assert.Equal(JsonString, json);
         }
 
@@ -537,7 +537,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void DictionaryOfArrayOfDictionary()
         {
             const string JsonString = @"{""Key1"":[{""Key1"":1,""Key2"":2},{""Key1"":3,""Key2"":4}],""Key2"":[{""Key1"":5,""Key2"":6},{""Key1"":7,""Key2"":8}]}";
-            Dictionary<string, Dictionary<string, int>[]> obj = JsonSerializer.Parse<Dictionary<string, Dictionary<string, int>[]>>(JsonString);
+            Dictionary<string, Dictionary<string, int>[]> obj = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, int>[]>>(JsonString);
 
             Assert.Equal(2, obj.Count);
             Assert.Equal(2, obj["Key1"].Length);
@@ -558,11 +558,11 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(7, obj["Key2"][1]["Key1"]);
             Assert.Equal(8, obj["Key2"][1]["Key2"]);
 
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Equal(JsonString, json);
 
             // Verify that typeof(object) doesn't interfere.
-            json = JsonSerializer.ToString<object>(obj);
+            json = JsonSerializer.Serialize<object>(obj);
             Assert.Equal(JsonString, json);
         }
 
@@ -574,12 +574,12 @@ namespace System.Text.Json.Serialization.Tests
 
                 {
                     string json = @"{""Key1"":" + SimpleTestClass.s_json + @",""Key2"":" + SimpleTestClass.s_json + "}";
-                    obj = JsonSerializer.Parse<IDictionary>(json);
+                    obj = JsonSerializer.Deserialize<IDictionary>(json);
                     Assert.Equal(2, obj.Count);
 
                     if (obj["Key1"] is JsonElement element)
                     {
-                        SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(element.GetRawText());
+                        SimpleTestClass result = JsonSerializer.Deserialize<SimpleTestClass>(element.GetRawText());
                         result.Verify();
                     }
                     else
@@ -592,13 +592,13 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     // We can't compare against the json string above because property ordering is not deterministic (based on reflection order)
                     // so just round-trip the json and compare.
-                    string json = JsonSerializer.ToString(obj);
-                    obj = JsonSerializer.Parse<IDictionary>(json);
+                    string json = JsonSerializer.Serialize(obj);
+                    obj = JsonSerializer.Deserialize<IDictionary>(json);
                     Assert.Equal(2, obj.Count);
 
                     if (obj["Key1"] is JsonElement element)
                     {
-                        SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(element.GetRawText());
+                        SimpleTestClass result = JsonSerializer.Deserialize<SimpleTestClass>(element.GetRawText());
                         result.Verify();
                     }
                     else
@@ -609,13 +609,13 @@ namespace System.Text.Json.Serialization.Tests
                 }
 
                 {
-                    string json = JsonSerializer.ToString<object>(obj);
-                    obj = JsonSerializer.Parse<IDictionary>(json);
+                    string json = JsonSerializer.Serialize<object>(obj);
+                    obj = JsonSerializer.Deserialize<IDictionary>(json);
                     Assert.Equal(2, obj.Count);
 
                     if (obj["Key1"] is JsonElement element)
                     {
-                        SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(element.GetRawText());
+                        SimpleTestClass result = JsonSerializer.Deserialize<SimpleTestClass>(element.GetRawText());
                         result.Verify();
                     }
                     else
@@ -631,7 +631,7 @@ namespace System.Text.Json.Serialization.Tests
 
                 {
                     string json = @"{""Key1"":" + SimpleTestClass.s_json + @",""Key2"":" + SimpleTestClass.s_json + "}";
-                    obj = JsonSerializer.Parse<Dictionary<string, SimpleTestClass>>(json);
+                    obj = JsonSerializer.Deserialize<Dictionary<string, SimpleTestClass>>(json);
                     Assert.Equal(2, obj.Count);
                     obj["Key1"].Verify();
                     obj["Key2"].Verify();
@@ -640,16 +640,16 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     // We can't compare against the json string above because property ordering is not deterministic (based on reflection order)
                     // so just round-trip the json and compare.
-                    string json = JsonSerializer.ToString(obj);
-                    obj = JsonSerializer.Parse<Dictionary<string, SimpleTestClass>>(json);
+                    string json = JsonSerializer.Serialize(obj);
+                    obj = JsonSerializer.Deserialize<Dictionary<string, SimpleTestClass>>(json);
                     Assert.Equal(2, obj.Count);
                     obj["Key1"].Verify();
                     obj["Key2"].Verify();
                 }
 
                 {
-                    string json = JsonSerializer.ToString<object>(obj);
-                    obj = JsonSerializer.Parse<Dictionary<string, SimpleTestClass>>(json);
+                    string json = JsonSerializer.Serialize<object>(obj);
+                    obj = JsonSerializer.Deserialize<Dictionary<string, SimpleTestClass>>(json);
                     Assert.Equal(2, obj.Count);
                     obj["Key1"].Verify();
                     obj["Key2"].Verify();
@@ -661,7 +661,7 @@ namespace System.Text.Json.Serialization.Tests
 
                 {
                     string json = @"{""Key1"":" + SimpleTestClass.s_json + @",""Key2"":" + SimpleTestClass.s_json + "}";
-                    obj = JsonSerializer.Parse<ImmutableSortedDictionary<string, SimpleTestClass>>(json);
+                    obj = JsonSerializer.Deserialize<ImmutableSortedDictionary<string, SimpleTestClass>>(json);
                     Assert.Equal(2, obj.Count);
                     obj["Key1"].Verify();
                     obj["Key2"].Verify();
@@ -670,16 +670,16 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     // We can't compare against the json string above because property ordering is not deterministic (based on reflection order)
                     // so just round-trip the json and compare.
-                    string json = JsonSerializer.ToString(obj);
-                    obj = JsonSerializer.Parse<ImmutableSortedDictionary<string, SimpleTestClass>>(json);
+                    string json = JsonSerializer.Serialize(obj);
+                    obj = JsonSerializer.Deserialize<ImmutableSortedDictionary<string, SimpleTestClass>>(json);
                     Assert.Equal(2, obj.Count);
                     obj["Key1"].Verify();
                     obj["Key2"].Verify();
                 }
 
                 {
-                    string json = JsonSerializer.ToString<object>(obj);
-                    obj = JsonSerializer.Parse<ImmutableSortedDictionary<string, SimpleTestClass>>(json);
+                    string json = JsonSerializer.Serialize<object>(obj);
+                    obj = JsonSerializer.Deserialize<ImmutableSortedDictionary<string, SimpleTestClass>>(json);
                     Assert.Equal(2, obj.Count);
                     obj["Key1"].Verify();
                     obj["Key2"].Verify();
@@ -694,7 +694,7 @@ namespace System.Text.Json.Serialization.Tests
             options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
 
             const string JsonString = @"[{""Key1"":1,""Key2"":2},{""Key1"":3,""Key2"":4}]";
-            Dictionary<string, int>[] obj = JsonSerializer.Parse<Dictionary<string, int>[]>(JsonString, options);
+            Dictionary<string, int>[] obj = JsonSerializer.Deserialize<Dictionary<string, int>[]>(JsonString, options);
 
             Assert.Equal(2, obj.Length);
             Assert.Equal(1, obj[0]["key1"]);
@@ -703,10 +703,10 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(4, obj[1]["key2"]);
 
             const string JsonCamel = @"[{""key1"":1,""key2"":2},{""key1"":3,""key2"":4}]";
-            string jsonCamel = JsonSerializer.ToString<object>(obj);
+            string jsonCamel = JsonSerializer.Serialize<object>(obj);
             Assert.Equal(JsonCamel, jsonCamel);
 
-            jsonCamel = JsonSerializer.ToString<object>(obj, options);
+            jsonCamel = JsonSerializer.Serialize<object>(obj, options);
             Assert.Equal(JsonCamel, jsonCamel);
         }
 
@@ -714,11 +714,11 @@ namespace System.Text.Json.Serialization.Tests
         public static void UnicodePropertyNames()
         {
             {
-                Dictionary<string, int> obj = JsonSerializer.Parse<Dictionary<string, int>>(@"{""Aѧ"":1}");
+                Dictionary<string, int> obj = JsonSerializer.Deserialize<Dictionary<string, int>>(@"{""Aѧ"":1}");
                 Assert.Equal(1, obj["Aѧ"]);
 
                 // Verify the name is escaped after serialize.
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Equal(@"{""A\u0467"":1}", json);
             }
 
@@ -728,11 +728,11 @@ namespace System.Text.Json.Serialization.Tests
 
                 string longPropertyName = new string('ѧ', charsInProperty);
 
-                Dictionary<string, int> obj = JsonSerializer.Parse<Dictionary<string, int>>($"{{\"{longPropertyName}\":1}}");
+                Dictionary<string, int> obj = JsonSerializer.Deserialize<Dictionary<string, int>>($"{{\"{longPropertyName}\":1}}");
                 Assert.Equal(1, obj[longPropertyName]);
 
                 // Verify the name is escaped after serialize.
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
 
                 // Duplicate the unicode character 'charsInProperty' times.
                 string longPropertyNameEscaped = new StringBuilder().Insert(0, @"\u0467", charsInProperty).ToString();
@@ -741,7 +741,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expectedJson, json);
 
                 // Verify the name is unescaped after deserialize.
-                obj = JsonSerializer.Parse<Dictionary<string, int>>(json);
+                obj = JsonSerializer.Deserialize<Dictionary<string, int>>(json);
                 Assert.Equal(1, obj[longPropertyName]);
             }
         }
@@ -751,16 +751,16 @@ namespace System.Text.Json.Serialization.Tests
         {
             // Baseline
             string json = @"{""MyDictionary"":{""Key"":""Value""}}";
-            JsonSerializer.Parse<Dictionary<string, object>>(json);
+            JsonSerializer.Deserialize<Dictionary<string, object>>(json);
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<Dictionary<string, string>>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Dictionary<string, string>>(json));
         }
 
         [Fact, ActiveIssue("JsonElement fails since it is a struct.")]
         public static void ObjectToJsonElement()
         {
             string json = @"{""MyDictionary"":{""Key"":""Value""}}";
-            JsonSerializer.Parse<Dictionary<string, JsonElement>>(json);
+            JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
         }
 
         [Fact]
@@ -769,7 +769,7 @@ namespace System.Text.Json.Serialization.Tests
             {
                 IDictionary ht = new Hashtable();
                 ht.Add("Key", "Value");
-                Assert.Throws<NotSupportedException>(() => JsonSerializer.ToString(ht));
+                Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(ht));
             }
         }
 
@@ -777,39 +777,39 @@ namespace System.Text.Json.Serialization.Tests
         public static void DeserializeDictionaryWithDuplicateKeys()
         {
             // Non-generic IDictionary case.
-            IDictionary iDictionary = JsonSerializer.Parse<IDictionary>(@"{""Hello"":""World"", ""Hello"":""NewValue""}");
+            IDictionary iDictionary = JsonSerializer.Deserialize<IDictionary>(@"{""Hello"":""World"", ""Hello"":""NewValue""}");
             Assert.Equal("NewValue", iDictionary["Hello"].ToString());
 
             // Generic IDictionary case.
-            IDictionary<string, string> iNonGenericDictionary = JsonSerializer.Parse<IDictionary<string, string>>(@"{""Hello"":""World"", ""Hello"":""NewValue""}");
+            IDictionary<string, string> iNonGenericDictionary = JsonSerializer.Deserialize<IDictionary<string, string>>(@"{""Hello"":""World"", ""Hello"":""NewValue""}");
             Assert.Equal("NewValue", iNonGenericDictionary["Hello"]);
 
-            IDictionary<string, object> iNonGenericObjectDictionary = JsonSerializer.Parse<IDictionary<string, object>>(@"{""Hello"":""World"", ""Hello"":""NewValue""}");
+            IDictionary<string, object> iNonGenericObjectDictionary = JsonSerializer.Deserialize<IDictionary<string, object>>(@"{""Hello"":""World"", ""Hello"":""NewValue""}");
             Assert.Equal("NewValue", iNonGenericObjectDictionary["Hello"].ToString());
 
             // Strongly-typed IDictionary<,> case.
-            Dictionary<string, string> dictionary = JsonSerializer.Parse<Dictionary<string, string>>(@"{""Hello"":""World"", ""Hello"":""NewValue""}");
+            Dictionary<string, string> dictionary = JsonSerializer.Deserialize<Dictionary<string, string>>(@"{""Hello"":""World"", ""Hello"":""NewValue""}");
             Assert.Equal("NewValue", dictionary["Hello"]);
 
-            dictionary = JsonSerializer.Parse<Dictionary<string, string>>(@"{""Hello"":""World"", ""myKey"" : ""myValue"", ""Hello"":""NewValue""}");
+            dictionary = JsonSerializer.Deserialize<Dictionary<string, string>>(@"{""Hello"":""World"", ""myKey"" : ""myValue"", ""Hello"":""NewValue""}");
             Assert.Equal("NewValue", dictionary["Hello"]);
 
             // Weakly-typed IDictionary case.
-            Dictionary<string, object> dictionaryObject = JsonSerializer.Parse<Dictionary<string, object>>(@"{""Hello"":""World"", ""Hello"": null}");
+            Dictionary<string, object> dictionaryObject = JsonSerializer.Deserialize<Dictionary<string, object>>(@"{""Hello"":""World"", ""Hello"": null}");
             Assert.Null(dictionaryObject["Hello"]);
         }
 
         [Fact]
         public static void DeserializeDictionaryWithDuplicateProperties()
         {
-            PocoDuplicate foo = JsonSerializer.Parse<PocoDuplicate>(@"{""BoolProperty"": false, ""BoolProperty"": true}");
+            PocoDuplicate foo = JsonSerializer.Deserialize<PocoDuplicate>(@"{""BoolProperty"": false, ""BoolProperty"": true}");
             Assert.True(foo.BoolProperty);
 
-            foo = JsonSerializer.Parse<PocoDuplicate>(@"{""BoolProperty"": false, ""IntProperty"" : 1, ""BoolProperty"": true , ""IntProperty"" : 2}");
+            foo = JsonSerializer.Deserialize<PocoDuplicate>(@"{""BoolProperty"": false, ""IntProperty"" : 1, ""BoolProperty"": true , ""IntProperty"" : 2}");
             Assert.True(foo.BoolProperty);
             Assert.Equal(2, foo.IntProperty);
 
-            foo = JsonSerializer.Parse<PocoDuplicate>(@"{""DictProperty"" : {""a"" : ""b"", ""c"" : ""d""},""DictProperty"" : {""b"" : ""b"", ""c"" : ""e""}}");
+            foo = JsonSerializer.Deserialize<PocoDuplicate>(@"{""DictProperty"" : {""a"" : ""b"", ""c"" : ""d""},""DictProperty"" : {""b"" : ""b"", ""c"" : ""e""}}");
             Assert.Equal(3, foo.DictProperty.Count);
             Assert.Equal("e", foo.DictProperty["c"]);
         }
@@ -825,7 +825,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ClassWithNoSetter()
         {
             string json = @"{""MyDictionary"":{""Key"":""Value""}}";
-            ClassWithDictionaryButNoSetter obj = JsonSerializer.Parse<ClassWithDictionaryButNoSetter>(json);
+            ClassWithDictionaryButNoSetter obj = JsonSerializer.Deserialize<ClassWithDictionaryButNoSetter>(json);
             Assert.Equal("Value", obj.MyDictionary["Key"]);
         }
 
@@ -836,7 +836,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.Parse<ClassWithNotSupportedDictionary>(json);
+                JsonSerializer.Deserialize<ClassWithNotSupportedDictionary>(json);
                 Assert.True(false, "Expected NotSupportedException to be thrown.");
             }
             catch (NotSupportedException e)
@@ -851,7 +851,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void DictionaryNotSupportedButIgnored()
         {
             string json = @"{""MyDictionary"":{""Key"":1}}";
-            ClassWithNotSupportedDictionaryButIgnored obj = JsonSerializer.Parse<ClassWithNotSupportedDictionaryButIgnored>(json);
+            ClassWithNotSupportedDictionaryButIgnored obj = JsonSerializer.Deserialize<ClassWithNotSupportedDictionaryButIgnored>(json);
             Assert.Null(obj.MyDictionary);
         }
 
@@ -859,7 +859,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void DeserializeUserDefinedDictionaryThrows()
         {
             string json = @"{""Hello"":1,""Hello2"":2}";
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Parse<IImmutableDictionaryWrapper>(json));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<IImmutableDictionaryWrapper>(json));
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -882,7 +882,7 @@ namespace System.Text.Json.Serialization.Tests
                 }
             };
 
-            var actual = JsonSerializer.ToString(value, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            var actual = JsonSerializer.Serialize(value, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
             // Assert
             Assert.NotNull(actual);
@@ -895,7 +895,7 @@ namespace System.Text.Json.Serialization.Tests
             // Arrange
             string json = "{\"child\":{\"1\":{\"a\":\"1\",\"b\":\"\",\"c\":[],\"d\":[],\"e\":null,\"f\":[],\"g\":null,\"h\":null,\"i\":null,\"j\":null,\"k\":[]}}}";
 
-            var actual = JsonSerializer.Parse<Regression38643_Parent>(json, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            var actual = JsonSerializer.Deserialize<Regression38643_Parent>(json, new JsonSerializerOptions() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
             // Assert
             Assert.NotNull(actual);
@@ -914,7 +914,7 @@ namespace System.Text.Json.Serialization.Tests
                 Child = new Regression38565_Child()
             };
 
-            var actual = JsonSerializer.ToString(value);
+            var actual = JsonSerializer.Serialize(value);
             Assert.Equal("{\"Test\":\"value1\",\"Dict\":null,\"Child\":{\"Test\":null,\"Dict\":null}}", actual);
         }
 
@@ -922,7 +922,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void Regression38565_Deserialize()
         {
             var json = "{\"Test\":\"value1\",\"Dict\":null,\"Child\":{\"Test\":null,\"Dict\":null}}";
-            Regression38565_Parent actual = JsonSerializer.Parse<Regression38565_Parent>(json);
+            Regression38565_Parent actual = JsonSerializer.Deserialize<Regression38565_Parent>(json);
 
             Assert.Equal("value1", actual.Test);
             Assert.Null(actual.Dict);
@@ -940,7 +940,7 @@ namespace System.Text.Json.Serialization.Tests
                 Child = new Regression38565_Child()
             };
 
-            var actual = JsonSerializer.ToString(value, new JsonSerializerOptions { IgnoreNullValues = true });
+            var actual = JsonSerializer.Serialize(value, new JsonSerializerOptions { IgnoreNullValues = true });
             Assert.Equal("{\"Test\":\"value1\",\"Child\":{}}", actual);
         }
 
@@ -948,7 +948,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void Regression38565_Deserialize_IgnoreNullValues()
         {
             var json = "{\"Test\":\"value1\",\"Child\":{}}";
-            Regression38565_Parent actual = JsonSerializer.Parse<Regression38565_Parent>(json);
+            Regression38565_Parent actual = JsonSerializer.Deserialize<Regression38565_Parent>(json);
 
             Assert.Equal("value1", actual.Test);
             Assert.Null(actual.Dict);
@@ -965,7 +965,7 @@ namespace System.Text.Json.Serialization.Tests
                 Test = "value1"
             };
 
-            var actual = JsonSerializer.ToString(dictionaryFirst);
+            var actual = JsonSerializer.Serialize(dictionaryFirst);
             Assert.Equal("{\"Dict\":null,\"Test\":\"value1\"}", actual);
 
             var dictionaryLast = new Regression38557_DictionaryLast()
@@ -973,7 +973,7 @@ namespace System.Text.Json.Serialization.Tests
                 Test = "value1"
             };
 
-            actual = JsonSerializer.ToString(dictionaryLast);
+            actual = JsonSerializer.Serialize(dictionaryLast);
             Assert.Equal("{\"Test\":\"value1\",\"Dict\":null}", actual);
         }
 
@@ -981,13 +981,13 @@ namespace System.Text.Json.Serialization.Tests
         public static void Regression38557_Deserialize()
         {
             var json = "{\"Dict\":null,\"Test\":\"value1\"}";
-            Regression38557_DictionaryFirst dictionaryFirst = JsonSerializer.Parse<Regression38557_DictionaryFirst>(json);
+            Regression38557_DictionaryFirst dictionaryFirst = JsonSerializer.Deserialize<Regression38557_DictionaryFirst>(json);
 
             Assert.Equal("value1", dictionaryFirst.Test);
             Assert.Null(dictionaryFirst.Dict);
 
             json = "{\"Test\":\"value1\",\"Dict\":null}";
-            Regression38557_DictionaryLast dictionaryLast = JsonSerializer.Parse<Regression38557_DictionaryLast>(json);
+            Regression38557_DictionaryLast dictionaryLast = JsonSerializer.Deserialize<Regression38557_DictionaryLast>(json);
 
             Assert.Equal("value1", dictionaryLast.Test);
             Assert.Null(dictionaryLast.Dict);
@@ -1001,7 +1001,7 @@ namespace System.Text.Json.Serialization.Tests
                 Test = "value1"
             };
 
-            var actual = JsonSerializer.ToString(dictionaryFirst, new JsonSerializerOptions { IgnoreNullValues = true });
+            var actual = JsonSerializer.Serialize(dictionaryFirst, new JsonSerializerOptions { IgnoreNullValues = true });
             Assert.Equal("{\"Test\":\"value1\"}", actual);
 
             var dictionaryLast = new Regression38557_DictionaryLast()
@@ -1009,7 +1009,7 @@ namespace System.Text.Json.Serialization.Tests
                 Test = "value1"
             };
 
-            actual = JsonSerializer.ToString(dictionaryLast, new JsonSerializerOptions { IgnoreNullValues = true });
+            actual = JsonSerializer.Serialize(dictionaryLast, new JsonSerializerOptions { IgnoreNullValues = true });
             Assert.Equal("{\"Test\":\"value1\"}", actual);
         }
 
@@ -1017,13 +1017,13 @@ namespace System.Text.Json.Serialization.Tests
         public static void Regression38557_Deserialize_IgnoreNullValues()
         {
             var json = "{\"Test\":\"value1\"}";
-            Regression38557_DictionaryFirst dictionaryFirst = JsonSerializer.Parse<Regression38557_DictionaryFirst>(json);
+            Regression38557_DictionaryFirst dictionaryFirst = JsonSerializer.Deserialize<Regression38557_DictionaryFirst>(json);
 
             Assert.Equal("value1", dictionaryFirst.Test);
             Assert.Null(dictionaryFirst.Dict);
 
             json = "{\"Test\":\"value1\"}";
-            Regression38557_DictionaryLast dictionaryLast = JsonSerializer.Parse<Regression38557_DictionaryLast>(json);
+            Regression38557_DictionaryLast dictionaryLast = JsonSerializer.Deserialize<Regression38557_DictionaryLast>(json);
 
             Assert.Equal("value1", dictionaryLast.Test);
             Assert.Null(dictionaryLast.Dict);

--- a/src/System.Text.Json/tests/Serialization/EnumConverterTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumConverterTests.cs
@@ -15,37 +15,37 @@ namespace System.Text.Json.Serialization.Tests
             JsonSerializerOptions options = new JsonSerializerOptions();
             options.Converters.Add(new JsonStringEnumConverter());
 
-            WhenClass when = JsonSerializer.Parse<WhenClass>(@"{""Day"":""Monday""}", options);
+            WhenClass when = JsonSerializer.Deserialize<WhenClass>(@"{""Day"":""Monday""}", options);
             Assert.Equal(DayOfWeek.Monday, when.Day);
-            DayOfWeek day = JsonSerializer.Parse<DayOfWeek>(@"""Tuesday""", options);
+            DayOfWeek day = JsonSerializer.Deserialize<DayOfWeek>(@"""Tuesday""", options);
             Assert.Equal(DayOfWeek.Tuesday, day);
 
             // We are case insensitive on read
-            day = JsonSerializer.Parse<DayOfWeek>(@"""wednesday""", options);
+            day = JsonSerializer.Deserialize<DayOfWeek>(@"""wednesday""", options);
             Assert.Equal(DayOfWeek.Wednesday, day);
 
             // Numbers work by default
-            day = JsonSerializer.Parse<DayOfWeek>(@"4", options);
+            day = JsonSerializer.Deserialize<DayOfWeek>(@"4", options);
             Assert.Equal(DayOfWeek.Thursday, day);
 
-            string json = JsonSerializer.ToString(DayOfWeek.Friday, options);
+            string json = JsonSerializer.Serialize(DayOfWeek.Friday, options);
             Assert.Equal(@"""Friday""", json);
 
             // Try a unique naming policy
             options = new JsonSerializerOptions();
             options.Converters.Add(new JsonStringEnumConverter(new ToLower()));
 
-            json = JsonSerializer.ToString(DayOfWeek.Friday, options);
+            json = JsonSerializer.Serialize(DayOfWeek.Friday, options);
             Assert.Equal(@"""friday""", json);
 
             // Undefined values should come out as a number (not a string)
-            json = JsonSerializer.ToString((DayOfWeek)(-1), options);
+            json = JsonSerializer.Serialize((DayOfWeek)(-1), options);
             Assert.Equal(@"-1", json);
 
             // Not permitting integers should throw
             options = new JsonSerializerOptions();
             options.Converters.Add(new JsonStringEnumConverter(allowIntegerValues: false));
-            Assert.Throws<JsonException>(() => JsonSerializer.ToString((DayOfWeek)(-1), options));
+            Assert.Throws<JsonException>(() => JsonSerializer.Serialize((DayOfWeek)(-1), options));
         }
 
         public class ToLower : JsonNamingPolicy
@@ -64,49 +64,49 @@ namespace System.Text.Json.Serialization.Tests
             JsonSerializerOptions options = new JsonSerializerOptions();
             options.Converters.Add(new JsonStringEnumConverter());
 
-            FileState state = JsonSerializer.Parse<FileState>(@"{""Attributes"":""ReadOnly""}", options);
+            FileState state = JsonSerializer.Deserialize<FileState>(@"{""Attributes"":""ReadOnly""}", options);
             Assert.Equal(FileAttributes.ReadOnly, state.Attributes);
-            state = JsonSerializer.Parse<FileState>(@"{""Attributes"":""Directory, ReparsePoint""}", options);
+            state = JsonSerializer.Deserialize<FileState>(@"{""Attributes"":""Directory, ReparsePoint""}", options);
             Assert.Equal(FileAttributes.Directory | FileAttributes.ReparsePoint, state.Attributes);
-            FileAttributes attributes = JsonSerializer.Parse<FileAttributes>(@"""Normal""", options);
+            FileAttributes attributes = JsonSerializer.Deserialize<FileAttributes>(@"""Normal""", options);
             Assert.Equal(FileAttributes.Normal, attributes);
-            attributes = JsonSerializer.Parse<FileAttributes>(@"""System, SparseFile""", options);
+            attributes = JsonSerializer.Deserialize<FileAttributes>(@"""System, SparseFile""", options);
             Assert.Equal(FileAttributes.System | FileAttributes.SparseFile, attributes);
 
             // We are case insensitive on read
-            attributes = JsonSerializer.Parse<FileAttributes>(@"""OFFLINE""", options);
+            attributes = JsonSerializer.Deserialize<FileAttributes>(@"""OFFLINE""", options);
             Assert.Equal(FileAttributes.Offline, attributes);
-            attributes = JsonSerializer.Parse<FileAttributes>(@"""compressed, notcontentindexed""", options);
+            attributes = JsonSerializer.Deserialize<FileAttributes>(@"""compressed, notcontentindexed""", options);
             Assert.Equal(FileAttributes.Compressed | FileAttributes.NotContentIndexed, attributes);
 
             // Numbers are cool by default
-            attributes = JsonSerializer.Parse<FileAttributes>(@"131072", options);
+            attributes = JsonSerializer.Deserialize<FileAttributes>(@"131072", options);
             Assert.Equal(FileAttributes.NoScrubData, attributes);
-            attributes = JsonSerializer.Parse<FileAttributes>(@"3", options);
+            attributes = JsonSerializer.Deserialize<FileAttributes>(@"3", options);
             Assert.Equal(FileAttributes.Hidden | FileAttributes.ReadOnly, attributes);
 
-            string json = JsonSerializer.ToString(FileAttributes.Hidden, options);
+            string json = JsonSerializer.Serialize(FileAttributes.Hidden, options);
             Assert.Equal(@"""Hidden""", json);
-            json = JsonSerializer.ToString(FileAttributes.Temporary | FileAttributes.Offline, options);
+            json = JsonSerializer.Serialize(FileAttributes.Temporary | FileAttributes.Offline, options);
             Assert.Equal(@"""Temporary, Offline""", json);
 
             // Try a unique casing
             options = new JsonSerializerOptions();
             options.Converters.Add(new JsonStringEnumConverter(new ToLower()));
 
-            json = JsonSerializer.ToString(FileAttributes.NoScrubData, options);
+            json = JsonSerializer.Serialize(FileAttributes.NoScrubData, options);
             Assert.Equal(@"""noscrubdata""", json);
-            json = JsonSerializer.ToString(FileAttributes.System | FileAttributes.Offline, options);
+            json = JsonSerializer.Serialize(FileAttributes.System | FileAttributes.Offline, options);
             Assert.Equal(@"""system, offline""", json);
 
             // Undefined values should come out as a number (not a string)
-            json = JsonSerializer.ToString((FileAttributes)(-1), options);
+            json = JsonSerializer.Serialize((FileAttributes)(-1), options);
             Assert.Equal(@"-1", json);
 
             // Not permitting integers should throw
             options = new JsonSerializerOptions();
             options.Converters.Add(new JsonStringEnumConverter(allowIntegerValues: false));
-            Assert.Throws<JsonException>(() => JsonSerializer.ToString((FileAttributes)(-1), options));
+            Assert.Throws<JsonException>(() => JsonSerializer.Serialize((FileAttributes)(-1), options));
         }
 
         public class FileState
@@ -136,10 +136,10 @@ namespace System.Text.Json.Serialization.Tests
         public void ConvertEnumUsingAttributes()
         {
             Week week = new Week { WorkStart = DayOfWeek.Monday, WorkEnd = DayOfWeek.Friday, WeekEnd = DayOfWeek.Saturday };
-            string json = JsonSerializer.ToString(week);
+            string json = JsonSerializer.Serialize(week);
             Assert.Equal(@"{""WorkStart"":""Monday"",""WorkEnd"":5,""WeekEnd"":""saturday""}", json);
 
-            week = JsonSerializer.Parse<Week>(json);
+            week = JsonSerializer.Deserialize<Week>(json);
             Assert.Equal(DayOfWeek.Monday, week.WorkStart);
             Assert.Equal(DayOfWeek.Friday, week.WorkEnd);
             Assert.Equal(DayOfWeek.Saturday, week.WeekEnd);

--- a/src/System.Text.Json/tests/Serialization/EnumTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumTests.cs
@@ -37,7 +37,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void EnumAsStringFail()
         {
             string json = @"{ ""MyEnum"" : ""Two"" }";
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClass>(json));
         }
 
         [Theory]
@@ -45,9 +45,9 @@ namespace System.Text.Json.Serialization.Tests
         public static void Parse_OutOfRange_Throws(object value, string name)
         {
             string json = $"{{ \"{ name }\" : { value } }}";
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClass>(json));
             json = $"{{ \"{ name }\" : \"{ value }\" }}";
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClass>(json));
         }
 
         [Theory]
@@ -55,12 +55,12 @@ namespace System.Text.Json.Serialization.Tests
         public static void Parse_WithinRange_Signed_ReturnsWithCorrectType(Type expectedType, string value, string name)
         {
             string json = $"{{ \"{ name }\" : { value } }}";
-            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
+            SimpleTestClass result = JsonSerializer.Deserialize<SimpleTestClass>(json);
             object expected = Enum.ToObject(expectedType, long.Parse(value));
             Assert.Equal(expected, GetProperty(result, name));
 
             json = $"{{ \"{ name }\" : \"{ value }\" }}";
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClass>(json));
         }
 
         [Theory]
@@ -68,11 +68,11 @@ namespace System.Text.Json.Serialization.Tests
         public static void Parse_WithinRange_ReturnsExpected(object expected, long value, string name)
         {
             string json = $"{{ \"{ name }\" : { value } }}";
-            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
+            SimpleTestClass result = JsonSerializer.Deserialize<SimpleTestClass>(json);
             Assert.Equal(expected, GetProperty(result, name));
 
             json = $"{{ \"{ name }\" : \"{ value }\" }}";
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClass>(json));
         }
 
         [Theory]
@@ -80,12 +80,12 @@ namespace System.Text.Json.Serialization.Tests
         public static void Parse_WithinRange_Unsigned_ReturnsWithCorrectType(Type expectedType, string value, string name)
         {
             string json = $"{{ \"{ name }\" : { value } }}";
-            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
+            SimpleTestClass result = JsonSerializer.Deserialize<SimpleTestClass>(json);
             object expected = Enum.ToObject(expectedType, ulong.Parse(value));
             Assert.Equal(expected, GetProperty(result, name));
 
             json = $"{{ \"{ name }\" : \"{ value }\" }}";
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClass>(json));
         }
 
         [Theory]
@@ -93,11 +93,11 @@ namespace System.Text.Json.Serialization.Tests
         public static void Parse_WithinRange_ReturnsExpected(object expected, ulong value, string name)
         {
             string json = $"{{ \"{ name }\" : { value } }}";
-            SimpleTestClass result = JsonSerializer.Parse<SimpleTestClass>(json);
+            SimpleTestClass result = JsonSerializer.Deserialize<SimpleTestClass>(json);
             Assert.Equal(expected, GetProperty(result, name));
 
             json = $"{{ \"{ name }\" : \"{ value }\" }}";
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClass>(json));
         }
 
         private static object GetProperty(SimpleTestClass testClass, string propertyName) 
@@ -107,7 +107,7 @@ namespace System.Text.Json.Serialization.Tests
         [MemberData(nameof(ToString_WithinRange))]
         public static void ToString_WithinRange_ReturnsSameValue(object expected, object enumValue)
         {
-            string json = JsonSerializer.ToString(enumValue);
+            string json = JsonSerializer.Serialize(enumValue);
             Assert.Equal(expected.ToString(), json);
         }
 
@@ -116,7 +116,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ToString_ExceedMaxCapacity_ResetsBackToMinimum(int timesOverflow, string maxCapacity, Type type, long expected)
         {
             object enumValue = Enum.ToObject(type, long.Parse(maxCapacity) * timesOverflow);
-            string json = JsonSerializer.ToString(enumValue);
+            string json = JsonSerializer.Serialize(enumValue);
             Assert.Equal(expected.ToString(), json);
         }
 

--- a/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                int i2 = JsonSerializer.Parse<int>("12bad");
+                int i2 = JsonSerializer.Deserialize<int>("12bad");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -34,7 +34,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<IDictionary<string, string>>(@"{""Key"":1}");
+                JsonSerializer.Deserialize<IDictionary<string, string>>(@"{""Key"":1}");
                 Assert.True(false, "Type Mismatch JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -58,7 +58,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.Parse<BasicCompany>(json);
+                JsonSerializer.Deserialize<BasicCompany>(json);
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -84,7 +84,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<Dictionary<string, int>>(@"{""Key1"":1, ""Key2"":bad}");
+                JsonSerializer.Deserialize<Dictionary<string, int>>(@"{""Key1"":1, ""Key2"":bad}");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -94,7 +94,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.Parse<Dictionary<string, int>>(@"{""Key1"":1, ""Key2"":");
+                JsonSerializer.Deserialize<Dictionary<string, int>>(@"{""Key1"":1, ""Key2"":");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -104,7 +104,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.Parse<Dictionary<string, int>>(@"{""Key1"":1, ""Key2""");
+                JsonSerializer.Deserialize<Dictionary<string, int>>(@"{""Key1"":1, ""Key2""");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -119,7 +119,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<int[]>(@"[1, bad]");
+                JsonSerializer.Deserialize<int[]>(@"[1, bad]");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -129,7 +129,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.Parse<int[]>(@"[1,");
+                JsonSerializer.Deserialize<int[]>(@"[1,");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -139,7 +139,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.Parse<int[]>(@"[1");
+                JsonSerializer.Deserialize<int[]>(@"[1");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -150,7 +150,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.Parse<int[]>(@"[1 /* comment starts but doesn't end");
+                JsonSerializer.Deserialize<int[]>(@"[1 /* comment starts but doesn't end");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -165,7 +165,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<List<int>>(@"[1, bad]");
+                JsonSerializer.Deserialize<List<int>>(@"[1, bad]");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -179,7 +179,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<int[][]>(@"[[1, 2],[3,bad]]");
+                JsonSerializer.Deserialize<int[][]>(@"[[1, 2],[3,bad]]");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -193,7 +193,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<List<List<int>>>(@"[[1, 2],[3,bad]]");
+                JsonSerializer.Deserialize<List<List<int>>>(@"[[1, 2],[3,bad]]");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -207,7 +207,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<RootClass>(@"{""Child"":{""MyInt"":bad]}");
+                JsonSerializer.Deserialize<RootClass>(@"{""Child"":{""MyInt"":bad]}");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -221,7 +221,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<RootClass>(@"{""Child"":{""MyIntArray"":[1, bad]}");
+                JsonSerializer.Deserialize<RootClass>(@"{""Child"":{""MyIntArray"":[1, bad]}");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -235,7 +235,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<RootClass>(@"{""Child"":{""MyDictionary"":{""Key"": bad]");
+                JsonSerializer.Deserialize<RootClass>(@"{""Child"":{""MyDictionary"":{""Key"": bad]");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -249,7 +249,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<RootClass>(@"{""Child"":{""MyDictionary"":{""Key1"":{""Children"":[{""MyDictionary"":{""K.e.y"":""");
+                JsonSerializer.Deserialize<RootClass>(@"{""Child"":{""MyDictionary"":{""Key1"":{""Children"":[{""MyDictionary"":{""K.e.y"":""");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -263,7 +263,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<RootClass>(@"{""Child"":{""Children"":[{}, {""MyDictionary"":{""K.e.y"": {""MyInt"":bad");
+                JsonSerializer.Deserialize<RootClass>(@"{""Child"":{""Children"":[{}, {""MyDictionary"":{""K.e.y"": {""MyInt"":bad");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -277,7 +277,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                ClassWithUnicodeProperty obj = JsonSerializer.Parse<ClassWithUnicodeProperty>(@"{""Aѧ"":bad}");
+                ClassWithUnicodeProperty obj = JsonSerializer.Deserialize<ClassWithUnicodeProperty>(@"{""Aѧ"":bad}");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -292,7 +292,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             try
             {
-                JsonSerializer.Parse<ClassWithExtensionProperty>(@"{""MyNestedClass"":{""UnknownProperty"":bad}}");
+                JsonSerializer.Deserialize<ClassWithExtensionProperty>(@"{""MyNestedClass"":{""UnknownProperty"":bad}}");
                 Assert.True(false, "Expected JsonException was not thrown.");
             }
             catch (JsonException e)
@@ -310,18 +310,18 @@ namespace System.Text.Json.Serialization.Tests
 
             // Baseline (no exception)
             {
-                SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(@"{""myint32"":1}", options);
+                SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(@"{""myint32"":1}", options);
                 Assert.Equal(1, obj.MyInt32);
             }
 
             {
-                SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(@"{""MYINT32"":1}", options);
+                SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(@"{""MYINT32"":1}", options);
                 Assert.Equal(1, obj.MyInt32);
             }
 
             try
             {
-                JsonSerializer.Parse<SimpleTestClass>(@"{""myint32"":bad}", options);
+                JsonSerializer.Deserialize<SimpleTestClass>(@"{""myint32"":bad}", options);
             }
             catch (JsonException e)
             {
@@ -331,7 +331,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.Parse<SimpleTestClass>(@"{""MYINT32"":bad}", options);
+                JsonSerializer.Deserialize<SimpleTestClass>(@"{""MYINT32"":bad}", options);
             }
             catch (JsonException e)
             {

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ExtensionPropertyNotUsed()
         {
             string json = @"{""MyNestedClass"":" + SimpleTestClass.s_json + "}";
-            ClassWithExtensionProperty obj = JsonSerializer.Parse<ClassWithExtensionProperty>(json);
+            ClassWithExtensionProperty obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(json);
             Assert.Null(obj.MyOverflow);
         }
 
@@ -25,14 +25,14 @@ namespace System.Text.Json.Serialization.Tests
 
             {
                 string json = @"{""MyIntMissing"":2, ""MyInt"":1, ""MyNestedClassMissing"":" + SimpleTestClass.s_json + "}";
-                obj = JsonSerializer.Parse<ClassWithExtensionProperty>(json);
+                obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(json);
                 Verify();
             }
 
             // Round-trip the json.
             {
-                string json = JsonSerializer.ToString(obj);
-                obj = JsonSerializer.Parse<ClassWithExtensionProperty>(json);
+                string json = JsonSerializer.Serialize(obj);
+                obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(json);
                 Verify();
             }
 
@@ -58,7 +58,7 @@ namespace System.Text.Json.Serialization.Tests
 
             string json = @"{""MyIntMissing"":2}";
 
-            ClassWithExtensionProperty obj = JsonSerializer.Parse<ClassWithExtensionProperty>(json);
+            ClassWithExtensionProperty obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(json);
             Assert.Equal(2, obj.MyOverflow["MyIntMissing"].GetInt32());
         }
 
@@ -67,7 +67,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             string json = @"{""MyIntMissing"":2}";
 
-            ClassWithExtensionPropertyAsObject obj = JsonSerializer.Parse<ClassWithExtensionPropertyAsObject>(json);
+            ClassWithExtensionPropertyAsObject obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsObject>(json);
             Assert.IsType<JsonElement>(obj.MyOverflow["MyIntMissing"]);
             Assert.Equal(2, ((JsonElement)obj.MyOverflow["MyIntMissing"]).GetInt32());
         }
@@ -83,9 +83,9 @@ namespace System.Text.Json.Serialization.Tests
 
             {
                 // Baseline Pascal-cased json + no casing option.
-                obj = JsonSerializer.Parse<ClassWithExtensionProperty>(jsonWithProperty);
+                obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(jsonWithProperty);
                 Assert.Equal(1, obj.MyOverflow["MyIntMissing"].GetInt32());
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Contains(@"""MyIntMissing"":1", json);
             }
 
@@ -95,17 +95,17 @@ namespace System.Text.Json.Serialization.Tests
                 options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
                 options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
 
-                obj = JsonSerializer.Parse<ClassWithExtensionProperty>(jsonWithProperty, options);
+                obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(jsonWithProperty, options);
                 Assert.Equal(1, obj.MyOverflow["MyIntMissing"].GetInt32());
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Contains(@"""MyIntMissing"":1", json);
             }
 
             {
                 // Baseline camel-cased json + no casing option.
-                obj = JsonSerializer.Parse<ClassWithExtensionProperty>(jsonWithPropertyCamelCased);
+                obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(jsonWithPropertyCamelCased);
                 Assert.Equal(1, obj.MyOverflow["myIntMissing"].GetInt32());
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Contains(@"""myIntMissing"":1", json);
             }
 
@@ -115,9 +115,9 @@ namespace System.Text.Json.Serialization.Tests
                 options.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
                 options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
 
-                obj = JsonSerializer.Parse<ClassWithExtensionProperty>(jsonWithPropertyCamelCased, options);
+                obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(jsonWithPropertyCamelCased, options);
                 Assert.Equal(1, obj.MyOverflow["myIntMissing"].GetInt32());
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Contains(@"""myIntMissing"":1", json);
             }
         }
@@ -130,16 +130,16 @@ namespace System.Text.Json.Serialization.Tests
 
             {
                 // Baseline with no missing.
-                ClassWithExtensionProperty obj = JsonSerializer.Parse<ClassWithExtensionProperty>(json);
+                ClassWithExtensionProperty obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(json);
                 Assert.Null(obj.MyOverflow);
 
-                string outJson = JsonSerializer.ToString(obj);
+                string outJson = JsonSerializer.Serialize(obj);
                 Assert.Contains(@"""MyNestedClass"":null", outJson);
             }
 
             {
                 // Baseline with missing.
-                ClassWithExtensionProperty obj = JsonSerializer.Parse<ClassWithExtensionProperty>(jsonMissing);
+                ClassWithExtensionProperty obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(jsonMissing);
                 Assert.Equal(1, obj.MyOverflow.Count);
                 Assert.Equal(JsonValueType.Null, obj.MyOverflow["MyNestedClassMissing"].Type);
             }
@@ -148,7 +148,7 @@ namespace System.Text.Json.Serialization.Tests
                 JsonSerializerOptions options = new JsonSerializerOptions();
                 options.IgnoreNullValues = true;
 
-                ClassWithExtensionProperty obj = JsonSerializer.Parse<ClassWithExtensionProperty>(jsonMissing, options);
+                ClassWithExtensionProperty obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(jsonMissing, options);
 
                 // Currently we do not ignore nulls in the extension data. The JsonDocument would also need to support this mode
                 // for any lower-level nulls.
@@ -161,17 +161,17 @@ namespace System.Text.Json.Serialization.Tests
         public static void InvalidExtensionPropertyFail()
         {
             // Baseline
-            JsonSerializer.Parse<ClassWithExtensionProperty>(@"{}");
-            JsonSerializer.Parse<ClassWithExtensionPropertyAsObject>(@"{}");
+            JsonSerializer.Deserialize<ClassWithExtensionProperty>(@"{}");
+            JsonSerializer.Deserialize<ClassWithExtensionPropertyAsObject>(@"{}");
 
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<ClassWithInvalidExtensionProperty>(@"{}"));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<ClassWithTwoExtensionPropertys>(@"{}"));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithInvalidExtensionProperty>(@"{}"));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithTwoExtensionPropertys>(@"{}"));
         }
 
         [Fact]
         public static void IgnoredDataShouldNotBeExtensionData()
         {
-            ClassWithIgnoredData obj = JsonSerializer.Parse<ClassWithIgnoredData>(@"{""MyInt"":1}");
+            ClassWithIgnoredData obj = JsonSerializer.Deserialize<ClassWithIgnoredData>(@"{""MyInt"":1}");
 
             Assert.Equal(0, obj.MyInt);
             Assert.Null(obj.MyOverflow);
@@ -181,26 +181,26 @@ namespace System.Text.Json.Serialization.Tests
         public static void ExtensionPropertyObjectValue_Empty()
         {
             // Baseline
-            ClassWithExtensionPropertyAlreadyInstantiated obj = JsonSerializer.Parse<ClassWithExtensionPropertyAlreadyInstantiated>(@"{}");
-            Assert.Equal(@"{""MyOverflow"":{}}", JsonSerializer.ToString(obj));
+            ClassWithExtensionPropertyAlreadyInstantiated obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAlreadyInstantiated>(@"{}");
+            Assert.Equal(@"{""MyOverflow"":{}}", JsonSerializer.Serialize(obj));
         }
 
         [Fact]
         public static void ExtensionPropertyObjectValue()
         {
             // Baseline
-            ClassWithExtensionPropertyAlreadyInstantiated obj = JsonSerializer.Parse<ClassWithExtensionPropertyAlreadyInstantiated>(@"{}");
+            ClassWithExtensionPropertyAlreadyInstantiated obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAlreadyInstantiated>(@"{}");
             obj.MyOverflow.Add("test", new object());
             obj.MyOverflow.Add("test1", 1);
 
-            Assert.Equal(@"{""MyOverflow"":{""test"":{},""test1"":1}}", JsonSerializer.ToString(obj));
+            Assert.Equal(@"{""MyOverflow"":{""test"":{},""test1"":1}}", JsonSerializer.Serialize(obj));
         }
 
         [Fact]
         public static void ExtensionPropertyObjectValue_RoundTrip()
         {
             // Baseline
-            ClassWithExtensionPropertyAlreadyInstantiated obj = JsonSerializer.Parse<ClassWithExtensionPropertyAlreadyInstantiated>(@"{}");
+            ClassWithExtensionPropertyAlreadyInstantiated obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAlreadyInstantiated>(@"{}");
             obj.MyOverflow.Add("test", new object());
             obj.MyOverflow.Add("test1", 1);
             obj.MyOverflow.Add("test2", "text");
@@ -208,7 +208,7 @@ namespace System.Text.Json.Serialization.Tests
             obj.MyOverflow.Add("test4", new DummyStruct() { Prop = "StructProp" });
             obj.MyOverflow.Add("test5", new Dictionary<string, object>() { { "Key", "Value" }, { "Key1", "Value1" }, });
 
-            ClassWithExtensionPropertyAlreadyInstantiated roundTripObj = JsonSerializer.Parse<ClassWithExtensionPropertyAlreadyInstantiated>(JsonSerializer.ToString(obj));
+            ClassWithExtensionPropertyAlreadyInstantiated roundTripObj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAlreadyInstantiated>(JsonSerializer.Serialize(obj));
 
             Assert.Equal(6, roundTripObj.MyOverflow.Count);
 
@@ -242,7 +242,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             string json = @"{""MyIntMissing"":2, ""MyReference"":{""MyIntMissingChild"":3}}";
 
-            ClassWithReference obj = JsonSerializer.Parse<ClassWithReference>(json);
+            ClassWithReference obj = JsonSerializer.Deserialize<ClassWithReference>(json);
             Assert.IsType<JsonElement>(obj.MyOverflow["MyIntMissing"]);
             Assert.Equal(1, obj.MyOverflow.Count);
             Assert.Equal(2, obj.MyOverflow["MyIntMissing"].GetInt32());
@@ -258,10 +258,10 @@ namespace System.Text.Json.Serialization.Tests
         public static void ExtensionProperty_InvalidDictionary()
         {
             ClassWithInvalidExtensionPropertyStringString obj1 = new ClassWithInvalidExtensionPropertyStringString();
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(obj1));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(obj1));
 
             ClassWithInvalidExtensionPropertyObjectString obj2 = new ClassWithInvalidExtensionPropertyObjectString();
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.ToString(obj2));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(obj2));
         }
 
         public class DummyObj

--- a/src/System.Text.Json/tests/Serialization/JsonElementTests.cs
+++ b/src/System.Text.Json/tests/Serialization/JsonElementTests.cs
@@ -13,16 +13,16 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public void SerializeJsonElement()
         {
-            JsonElementClass obj = JsonSerializer.Parse<JsonElementClass>(JsonElementClass.s_json);
+            JsonElementClass obj = JsonSerializer.Deserialize<JsonElementClass>(JsonElementClass.s_json);
             obj.Verify();
-            string reserialized = JsonSerializer.ToString(obj);
+            string reserialized = JsonSerializer.Serialize(obj);
 
             // Properties in the exported json will be in the order that they were reflected, doing a quick check to see that
             // we end up with the same length (i.e. same amount of data) to start.
             Assert.Equal(JsonElementClass.s_json.StripWhitespace().Length, reserialized.Length);
 
             // Shoving it back through the parser should validate round tripping.
-            obj = JsonSerializer.Parse<JsonElementClass>(reserialized);
+            obj = JsonSerializer.Deserialize<JsonElementClass>(reserialized);
             obj.Verify();
         }
 
@@ -91,16 +91,16 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public void SerializeJsonElementArray()
         {
-            JsonElementArrayClass obj = JsonSerializer.Parse<JsonElementArrayClass>(JsonElementArrayClass.s_json);
+            JsonElementArrayClass obj = JsonSerializer.Deserialize<JsonElementArrayClass>(JsonElementArrayClass.s_json);
             obj.Verify();
-            string reserialized = JsonSerializer.ToString(obj);
+            string reserialized = JsonSerializer.Serialize(obj);
 
             // Properties in the exported json will be in the order that they were reflected, doing a quick check to see that
             // we end up with the same length (i.e. same amount of data) to start.
             Assert.Equal(JsonElementArrayClass.s_json.StripWhitespace().Length, reserialized.Length);
 
             // Shoving it back through the parser should validate round tripping.
-            obj = JsonSerializer.Parse<JsonElementArrayClass>(reserialized);
+            obj = JsonSerializer.Deserialize<JsonElementArrayClass>(reserialized);
             obj.Verify();
         }
 
@@ -158,20 +158,20 @@ namespace System.Text.Json.Serialization.Tests
 
             byte[] data = Encoding.UTF8.GetBytes(@"{""Data"":[1,true,{""City"":""MyCity""},null,""foo""]}");
             MemoryStream stream = new MemoryStream(data);
-            JsonElement obj = JsonSerializer.ReadAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result;
+            JsonElement obj = JsonSerializer.DeserializeAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result;
 
             data = Encoding.UTF8.GetBytes(@"[1,true,{""City"":""MyCity""},null,""foo""]");
             stream = new MemoryStream(data);
-            obj = JsonSerializer.ReadAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result;
+            obj = JsonSerializer.DeserializeAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result;
 
             // Ensure we fail with incomplete data
             data = Encoding.UTF8.GetBytes(@"{""Data"":[1,true,{""City"":""MyCity""},null,""foo""]");
             stream = new MemoryStream(data);
-            Assert.Throws<JsonException>(() => JsonSerializer.ReadAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result);
+            Assert.Throws<JsonException>(() => JsonSerializer.DeserializeAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result);
 
             data = Encoding.UTF8.GetBytes(@"[1,true,{""City"":""MyCity""},null,""foo""");
             stream = new MemoryStream(data);
-            Assert.Throws<JsonException>(() => JsonSerializer.ReadAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result);
+            Assert.Throws<JsonException>(() => JsonSerializer.DeserializeAsync<JsonElement>(stream, new JsonSerializerOptions { DefaultBufferSize = defaultBufferSize }).Result);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.ReadTests.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ClassWithNullProperty()
         {
-            TestClassWithNull obj = JsonSerializer.Parse<TestClassWithNull>(TestClassWithNull.s_json);
+            TestClassWithNull obj = JsonSerializer.Deserialize<TestClassWithNull>(TestClassWithNull.s_json);
             obj.Verify();
         }
 
@@ -20,27 +20,27 @@ namespace System.Text.Json.Serialization.Tests
         public static void RootObjectIsNull()
         { 
             {
-                TestClassWithNull obj = JsonSerializer.Parse<TestClassWithNull>("null");
+                TestClassWithNull obj = JsonSerializer.Deserialize<TestClassWithNull>("null");
                 Assert.Null(obj);
             }
 
             {
-                object obj = JsonSerializer.Parse<object>("null");
+                object obj = JsonSerializer.Deserialize<object>("null");
                 Assert.Null(obj);
             }
 
             {
-                string obj = JsonSerializer.Parse<string>("null");
+                string obj = JsonSerializer.Deserialize<string>("null");
                 Assert.Null(obj);
             }
 
             {
-                IEnumerable<int> obj = JsonSerializer.Parse<IEnumerable<int>>("null");
+                IEnumerable<int> obj = JsonSerializer.Deserialize<IEnumerable<int>>("null");
                 Assert.Null(obj);
             }
 
             {
-                Dictionary<string, object> obj = JsonSerializer.Parse<Dictionary<string, object>>("null");
+                Dictionary<string, object> obj = JsonSerializer.Deserialize<Dictionary<string, object>>("null");
                 Assert.Null(obj);
             }
 
@@ -50,17 +50,17 @@ namespace System.Text.Json.Serialization.Tests
         public static void RootArrayIsNull()
         {
             {
-                int[] obj = JsonSerializer.Parse<int[]>("null");
+                int[] obj = JsonSerializer.Deserialize<int[]>("null");
                 Assert.Null(obj);
             }
 
             {
-                object[] obj = JsonSerializer.Parse<object[]>("null");
+                object[] obj = JsonSerializer.Deserialize<object[]>("null");
                 Assert.Null(obj);
             }
 
             {
-                TestClassWithNull[] obj = JsonSerializer.Parse<TestClassWithNull[]>("null");
+                TestClassWithNull[] obj = JsonSerializer.Deserialize<TestClassWithNull[]>("null");
                 Assert.Null(obj);
             }
         }
@@ -68,7 +68,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void DefaultIgnoreNullValuesOnRead()
         {
-            TestClassWithInitializedProperties obj = JsonSerializer.Parse<TestClassWithInitializedProperties>(TestClassWithInitializedProperties.s_null_json);
+            TestClassWithInitializedProperties obj = JsonSerializer.Deserialize<TestClassWithInitializedProperties>(TestClassWithInitializedProperties.s_null_json);
             Assert.Equal(null, obj.MyString);
             Assert.Equal(null, obj.MyInt);
             Assert.Equal(null, obj.MyIntArray);
@@ -81,7 +81,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.IgnoreNullValues = true;
 
-            TestClassWithInitializedProperties obj = JsonSerializer.Parse<TestClassWithInitializedProperties>(TestClassWithInitializedProperties.s_null_json, options);
+            TestClassWithInitializedProperties obj = JsonSerializer.Deserialize<TestClassWithInitializedProperties>(TestClassWithInitializedProperties.s_null_json, options);
             Assert.Equal("Hello", obj.MyString);
             Assert.Equal(1, obj.MyInt);
             Assert.Equal(1, obj.MyIntArray[0]);
@@ -91,20 +91,20 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ParseNullArgumentFail()
         {
-            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Parse<string>((string)null));
-            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Parse("1", (Type)null));
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Deserialize<string>((string)null));
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Deserialize("1", (Type)null));
         }
 
         [Fact]
         public static void NullLiteralObjectInput()
         {
             {
-                string obj = JsonSerializer.Parse<string>("null");
+                string obj = JsonSerializer.Deserialize<string>("null");
                 Assert.Null(obj);
             }
 
             {
-                string obj = JsonSerializer.Parse<string>(@"""null""");
+                string obj = JsonSerializer.Deserialize<string>(@"""null""");
                 Assert.Equal("null", obj);
             }
         }
@@ -113,17 +113,17 @@ namespace System.Text.Json.Serialization.Tests
         public static void NullAcceptsLeadingAndTrailingTrivia()
         {
             {
-                TestClassWithNull obj = JsonSerializer.Parse<TestClassWithNull>(" null");
+                TestClassWithNull obj = JsonSerializer.Deserialize<TestClassWithNull>(" null");
                 Assert.Null(obj);
             }
 
             {
-                object obj = JsonSerializer.Parse<object>("null ");
+                object obj = JsonSerializer.Deserialize<object>("null ");
                 Assert.Null(obj);
             }
 
             {
-                object obj = JsonSerializer.Parse<object>(" null\t");
+                object obj = JsonSerializer.Deserialize<object>(" null\t");
                 Assert.Null(obj);
             }
         }

--- a/src/System.Text.Json/tests/Serialization/Null.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Null.WriteTests.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json.Serialization.Tests
             obj.MyIntArray = null;
             obj.MyIntList = null;
 
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Contains(@"""MyString"":null", json);
             Assert.Contains(@"""MyInt"":null", json);
             Assert.Contains(@"""MyIntArray"":null", json);
@@ -36,7 +36,7 @@ namespace System.Text.Json.Serialization.Tests
             obj.MyIntArray = null;
             obj.MyIntList = null;
 
-            string json = JsonSerializer.ToString(obj, options);
+            string json = JsonSerializer.Serialize(obj, options);
             Assert.Equal(@"{}", json);
         }
 
@@ -61,7 +61,7 @@ namespace System.Text.Json.Serialization.Tests
             obj.NullableIntArray = null;
             obj.Object = null;
 
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Contains(@"""Address"":null", json);
             Assert.Contains(@"""List"":null", json);
             Assert.Contains(@"""Array"":null", json);
@@ -83,26 +83,26 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void NullArrayElement()
         {
-            string json = JsonSerializer.ToString(new ObjectWithObjectProperties[]{ null });
+            string json = JsonSerializer.Serialize(new ObjectWithObjectProperties[]{ null });
             Assert.Equal("[null]", json);
         }
 
         [Fact]
         public static void NullArgumentFail()
         {
-            Assert.Throws<ArgumentNullException>(() => JsonSerializer.ToString("", (Type)null));
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Serialize("", (Type)null));
         }
 
         [Fact]
         public static void NullObjectOutput()
         {
             {
-                string output = JsonSerializer.ToString<string>(null);
+                string output = JsonSerializer.Serialize<string>(null);
                 Assert.Equal("null", output);
             }
 
             {
-                string output = JsonSerializer.ToString<string>(null, null);
+                string output = JsonSerializer.Serialize<string>(null, null);
                 Assert.Equal("null", output);
             }
         }

--- a/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -13,14 +13,14 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadSimpleStruct()
         {
-            SimpleTestStruct obj = JsonSerializer.Parse<SimpleTestStruct>(SimpleTestStruct.s_json);
+            SimpleTestStruct obj = JsonSerializer.Deserialize<SimpleTestStruct>(SimpleTestStruct.s_json);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadSimpleClass()
         {
-            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(SimpleTestClass.s_json);
+            SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(SimpleTestClass.s_json);
             obj.Verify();
         }
 
@@ -41,23 +41,23 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.ReadCommentHandling = JsonCommentHandling.Skip;
 
-            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(leadingTrivia + SimpleTestClass.s_json + trailingTrivia, options);
+            SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(leadingTrivia + SimpleTestClass.s_json + trailingTrivia, options);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadSimpleClassWithObject()
         {
-            SimpleTestClassWithSimpleObject obj = JsonSerializer.Parse<SimpleTestClassWithSimpleObject>(SimpleTestClassWithSimpleObject.s_json);
+            SimpleTestClassWithSimpleObject obj = JsonSerializer.Deserialize<SimpleTestClassWithSimpleObject>(SimpleTestClassWithSimpleObject.s_json);
             obj.Verify();
-            string reserialized = JsonSerializer.ToString(obj);
+            string reserialized = JsonSerializer.Serialize(obj);
 
             // Properties in the exported json will be in the order that they were reflected, doing a quick check to see that
             // we end up with the same length (i.e. same amount of data) to start.
             Assert.Equal(SimpleTestClassWithSimpleObject.s_json.StripWhitespace().Length, reserialized.Length);
 
             // Shoving it back through the parser should validate round tripping.
-            obj = JsonSerializer.Parse<SimpleTestClassWithSimpleObject>(reserialized);
+            obj = JsonSerializer.Deserialize<SimpleTestClassWithSimpleObject>(reserialized);
             obj.Verify();
         }
 
@@ -70,29 +70,29 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("/* Multi\nLine\nComment */ ", "\t// trailing comment\n ")]
         public static void ReadClassWithCommentsThrowsIfDisallowed(string leadingTrivia, string trailingTrivia)
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ClassWithComplexObjects>(leadingTrivia + ClassWithComplexObjects.s_json + trailingTrivia));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithComplexObjects>(leadingTrivia + ClassWithComplexObjects.s_json + trailingTrivia));
         }
 
         [Fact]
         public static void ReadSimpleClassWithObjectArray()
         {
-            SimpleTestClassWithObjectArrays obj = JsonSerializer.Parse<SimpleTestClassWithObjectArrays>(SimpleTestClassWithObjectArrays.s_json);
+            SimpleTestClassWithObjectArrays obj = JsonSerializer.Deserialize<SimpleTestClassWithObjectArrays>(SimpleTestClassWithObjectArrays.s_json);
             obj.Verify();
-            string reserialized = JsonSerializer.ToString(obj);
+            string reserialized = JsonSerializer.Serialize(obj);
 
             // Properties in the exported json will be in the order that they were reflected, doing a quick check to see that
             // we end up with the same length (i.e. same amount of data) to start.
             Assert.Equal(SimpleTestClassWithObjectArrays.s_json.StripWhitespace().Length, reserialized.Length);
 
             // Shoving it back through the parser should validate round tripping.
-            obj = JsonSerializer.Parse<SimpleTestClassWithObjectArrays>(reserialized);
+            obj = JsonSerializer.Deserialize<SimpleTestClassWithObjectArrays>(reserialized);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadArrayInObjectArray()
         {
-            object[] array = JsonSerializer.Parse<object[]>(@"[[]]");
+            object[] array = JsonSerializer.Deserialize<object[]>(@"[[]]");
             Assert.Equal(1, array.Length);
             Assert.IsType<JsonElement>(array[0]);
             Assert.Equal(JsonValueType.Array, ((JsonElement)array[0]).Type);
@@ -101,13 +101,13 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadObjectInObjectArray()
         {
-            object[] array = JsonSerializer.Parse<object[]>(@"[{}]");
+            object[] array = JsonSerializer.Deserialize<object[]>(@"[{}]");
             Assert.Equal(1, array.Length);
             Assert.IsType<JsonElement>(array[0]);
             Assert.Equal(JsonValueType.Object, ((JsonElement)array[0]).Type);
 
             // Scenario described in https://github.com/dotnet/corefx/issues/36169
-            array = JsonSerializer.Parse<object[]>("[1, false]");
+            array = JsonSerializer.Deserialize<object[]>("[1, false]");
             Assert.Equal(2, array.Length);
             Assert.IsType<JsonElement>(array[0]);
             Assert.Equal(JsonValueType.Number, ((JsonElement)array[0]).Type);
@@ -115,7 +115,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.IsType<JsonElement>(array[1]);
             Assert.Equal(JsonValueType.False, ((JsonElement)array[1]).Type);
 
-            array = JsonSerializer.Parse<object[]>(@"[1, false, { ""name"" : ""Person"" }]");
+            array = JsonSerializer.Deserialize<object[]>(@"[1, false, { ""name"" : ""Person"" }]");
             Assert.Equal(3, array.Length);
             Assert.IsType<JsonElement>(array[0]);
             Assert.Equal(JsonValueType.Number, ((JsonElement)array[0]).Type);
@@ -129,16 +129,16 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadClassWithComplexObjects()
         {
-            ClassWithComplexObjects obj = JsonSerializer.Parse<ClassWithComplexObjects>(ClassWithComplexObjects.s_json);
+            ClassWithComplexObjects obj = JsonSerializer.Deserialize<ClassWithComplexObjects>(ClassWithComplexObjects.s_json);
             obj.Verify();
-            string reserialized = JsonSerializer.ToString(obj);
+            string reserialized = JsonSerializer.Serialize(obj);
 
             // Properties in the exported json will be in the order that they were reflected, doing a quick check to see that
             // we end up with the same length (i.e. same amount of data) to start.
             Assert.Equal(ClassWithComplexObjects.s_json.StripWhitespace().Length, reserialized.Length);
 
             // Shoving it back through the parser should validate round tripping.
-            obj = JsonSerializer.Parse<ClassWithComplexObjects>(reserialized);
+            obj = JsonSerializer.Deserialize<ClassWithComplexObjects>(reserialized);
             obj.Verify();
         }
 
@@ -159,7 +159,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.ReadCommentHandling = JsonCommentHandling.Skip;
 
-            ClassWithComplexObjects obj = JsonSerializer.Parse<ClassWithComplexObjects>(leadingTrivia + ClassWithComplexObjects.s_json + trailingTrivia, options);
+            ClassWithComplexObjects obj = JsonSerializer.Deserialize<ClassWithComplexObjects>(leadingTrivia + ClassWithComplexObjects.s_json + trailingTrivia, options);
             obj.Verify();
         }
 
@@ -169,22 +169,22 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.ReadCommentHandling = JsonCommentHandling.Skip;
 
-            TestClassWithNestedObjectCommentsOuter obj = JsonSerializer.Parse<TestClassWithNestedObjectCommentsOuter>(TestClassWithNestedObjectCommentsOuter.s_data, options);
+            TestClassWithNestedObjectCommentsOuter obj = JsonSerializer.Deserialize<TestClassWithNestedObjectCommentsOuter>(TestClassWithNestedObjectCommentsOuter.s_data, options);
             obj.Verify();
         }
 
         [Fact]
         public static void ReadEmpty()
         {
-            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>("{}");
+            SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>("{}");
             Assert.NotNull(obj);
         }
 
         [Fact]
         public static void EmptyClassWithRandomData()
         {
-            JsonSerializer.Parse<EmptyClass>(SimpleTestClass.s_json);
-            JsonSerializer.Parse<EmptyClass>(SimpleTestClassWithNulls.s_json);
+            JsonSerializer.Deserialize<EmptyClass>(SimpleTestClass.s_json);
+            JsonSerializer.Deserialize<EmptyClass>(SimpleTestClassWithNulls.s_json);
         }
 
         [Theory]
@@ -199,22 +199,22 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("[{}]", false)]
         public static void ReadObjectFail(string json, bool failsOnObject)
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<SimpleTestClass>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleTestClass>(json));
 
             if (failsOnObject)
             {
-                Assert.Throws<JsonException>(() => JsonSerializer.Parse<object>(json));
+                Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<object>(json));
             }
             else
             {
-                Assert.IsType<JsonElement>(JsonSerializer.Parse<object>(json));
+                Assert.IsType<JsonElement>(JsonSerializer.Deserialize<object>(json));
             }
         }
 
         [Fact]
         public static void ReadObjectFail_ReferenceTypeMissingParameterlessConstructor()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Parse<PublicParameterizedConstructorTestClass>(@"{""Name"":""Name!""}"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<PublicParameterizedConstructorTestClass>(@"{""Name"":""Name!""}"));
         }
 
         class PublicParameterizedConstructorTestClass
@@ -233,7 +233,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadClassWithStringToPrimitiveDictionary()
         {
-            TestClassWithStringToPrimitiveDictionary obj = JsonSerializer.Parse<TestClassWithStringToPrimitiveDictionary>(TestClassWithStringToPrimitiveDictionary.s_data);
+            TestClassWithStringToPrimitiveDictionary obj = JsonSerializer.Deserialize<TestClassWithStringToPrimitiveDictionary>(TestClassWithStringToPrimitiveDictionary.s_data);
             obj.Verify();
         }
 
@@ -261,7 +261,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.Parse<TestClassWithBadData>(data);
+                JsonSerializer.Deserialize<TestClassWithBadData>(data);
             }
             catch (JsonException exception)
             {
@@ -277,7 +277,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadObject_PublicIndexer()
         {
-            Indexer indexer = JsonSerializer.Parse<Indexer>(@"{""NonIndexerProp"":""Value""}");
+            Indexer indexer = JsonSerializer.Deserialize<Indexer>(@"{""NonIndexerProp"":""Value""}");
             Assert.Equal("Value", indexer.NonIndexerProp);
             Assert.Equal(-1, indexer[0]);
         }
@@ -288,8 +288,8 @@ namespace System.Text.Json.Serialization.Tests
             SimpleStructWithSimpleClass testObject = new SimpleStructWithSimpleClass();
             testObject.Initialize();
 
-            string json = JsonSerializer.ToString(testObject, testObject.GetType());
-            SimpleStructWithSimpleClass obj = JsonSerializer.Parse<SimpleStructWithSimpleClass>(json);
+            string json = JsonSerializer.Serialize(testObject, testObject.GetType());
+            SimpleStructWithSimpleClass obj = JsonSerializer.Deserialize<SimpleStructWithSimpleClass>(json);
             obj.Verify();
         }
 
@@ -298,11 +298,10 @@ namespace System.Text.Json.Serialization.Tests
         {
             SimpleTestStruct testObject = new SimpleTestStruct();
             testObject.Initialize();
-            testObject.MySimpleTestClass = new SimpleTestClass  { MyString = "Hello", MyDouble = 3.14 } ;
+            testObject.MySimpleTestClass = new SimpleTestClass { MyString = "Hello", MyDouble = 3.14 };
 
-            string json = JsonSerializer.ToString(testObject);
-            SimpleTestStruct parsedObject = JsonSerializer.Parse<SimpleTestStruct>(json);
-
+            string json = JsonSerializer.Serialize(testObject);
+            SimpleTestStruct parsedObject = JsonSerializer.Deserialize<SimpleTestStruct>(json);
             parsedObject.Verify();
             Assert.Equal(3.14, parsedObject.MySimpleTestClass.MyDouble);
             Assert.Equal("Hello", parsedObject.MySimpleTestClass.MyString);
@@ -314,10 +313,9 @@ namespace System.Text.Json.Serialization.Tests
             SimpleTestClass testObject = new SimpleTestClass();
             testObject.Initialize();
             testObject.MySimpleTestStruct = new SimpleTestStruct { MyInt64 = 64, MyString = "Hello", MyInt32Array = new int[] { 32 } };
-            
-            string json = JsonSerializer.ToString(testObject);
-            SimpleTestClass parsedObject = JsonSerializer.Parse<SimpleTestClass>(json);
 
+            string json = JsonSerializer.Serialize(testObject);
+            SimpleTestClass parsedObject = JsonSerializer.Deserialize<SimpleTestClass>(json);
             parsedObject.Verify();
             Assert.Equal(64, parsedObject.MySimpleTestStruct.MyInt64);
             Assert.Equal("Hello", parsedObject.MySimpleTestStruct.MyString);
@@ -327,11 +325,18 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void OuterClassHavingPropertiesDefinedAfterClassWithDictionaryTest()
         {
-            OuterClassHavingPropertiesDefinedAfterClassWithDictionary testObject = new OuterClassHavingPropertiesDefinedAfterClassWithDictionary { MyInt = 10, MyIntArray = new int[] { 3 },
-                MyDouble= 3.14, MyList = new List<string> { "Hello" }, MyString = "World",  MyInnerTestClass = new SimpleClassWithDictionary { MyInt = 2 } };
-            string json = JsonSerializer.ToString(testObject);
+            OuterClassHavingPropertiesDefinedAfterClassWithDictionary testObject = new OuterClassHavingPropertiesDefinedAfterClassWithDictionary
+            {
+                MyInt = 10,
+                MyIntArray = new int[] { 3 },
+                MyDouble = 3.14,
+                MyList = new List<string> { "Hello" },
+                MyString = "World",
+                MyInnerTestClass = new SimpleClassWithDictionary { MyInt = 2 }
+            };
+            string json = JsonSerializer.Serialize(testObject);
 
-            OuterClassHavingPropertiesDefinedAfterClassWithDictionary parsedObject = JsonSerializer.Parse<OuterClassHavingPropertiesDefinedAfterClassWithDictionary>(json);
+            OuterClassHavingPropertiesDefinedAfterClassWithDictionary parsedObject = JsonSerializer.Deserialize<OuterClassHavingPropertiesDefinedAfterClassWithDictionary>(json);
 
             Assert.Equal(3.14, parsedObject.MyDouble);
             Assert.Equal(10, parsedObject.MyInt);
@@ -345,7 +350,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ReadStructWithSimpleClassArrayValueTest()
         {
             string json = "{\"MySimpleTestClass\":{\"MyInt32Array\":[1],\"MyStringToStringDict\":null,\"MyStringToStringIDict\":null},\"MyInt32Array\":[2]}";
-            SimpleTestStruct parsedObject = JsonSerializer.Parse<SimpleTestStruct>(json);
+            SimpleTestStruct parsedObject = JsonSerializer.Deserialize<SimpleTestStruct>(json);
 
             Assert.Equal(1, parsedObject.MySimpleTestClass.MyInt32Array[0]);
             Assert.Equal(2, parsedObject.MyInt32Array[0]);

--- a/src/System.Text.Json/tests/Serialization/Object.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Object.WriteTests.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void VerifyTypeFail()
         {
-            Assert.Throws<ArgumentException>(() => JsonSerializer.ToString(1, typeof(string)));
+            Assert.Throws<ArgumentException>(() => JsonSerializer.Serialize(1, typeof(string)));
         }
 
         [Theory]
@@ -24,11 +24,11 @@ namespace System.Text.Json.Serialization.Tests
             {
                 testObj.Initialize();
                 testObj.Verify();
-                json = JsonSerializer.ToString(testObj, testObj.GetType());
+                json = JsonSerializer.Serialize(testObj, testObj.GetType());
             }
 
             {
-                ITestClass obj = (ITestClass)JsonSerializer.Parse(json, testObj.GetType());
+                ITestClass obj = (ITestClass)JsonSerializer.Deserialize(json, testObj.GetType());
                 obj.Verify();
             }
         }
@@ -45,7 +45,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void WriteObjectAsObject()
         {
             var obj = new ObjectObject { Object = new object() };
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Equal(@"{""Object"":{}}", json);
         }
 
@@ -60,7 +60,7 @@ namespace System.Text.Json.Serialization.Tests
             var indexer = new Indexer();
             indexer[42] = 42;
             indexer.NonIndexerProp = "Value";
-            Assert.Equal(@"{""NonIndexerProp"":""Value""}", JsonSerializer.ToString(indexer));
+            Assert.Equal(@"{""NonIndexerProp"":""Value""}", JsonSerializer.Serialize(indexer));
         }
 
         private class Indexer

--- a/src/System.Text.Json/tests/Serialization/OptionsTests.cs
+++ b/src/System.Text.Json/tests/Serialization/OptionsTests.cs
@@ -43,7 +43,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<ArgumentNullException>(() => options.Converters[0] = null);
 
             // Perform serialization.
-            JsonSerializer.Parse<int>("1", options);
+            JsonSerializer.Deserialize<int>("1", options);
 
             // Verify defaults and ensure getters do not throw.
             Assert.False(options.AllowTrailingCommas);
@@ -105,12 +105,12 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void AllowTrailingCommas()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[]>("[1,]"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int[]>("[1,]"));
 
             var options = new JsonSerializerOptions();
             options.AllowTrailingCommas = true;
 
-            int[] value = JsonSerializer.Parse<int[]>("[1,]", options);
+            int[] value = JsonSerializer.Deserialize<int[]>("[1,]", options);
             Assert.Equal(1, value[0]);
         }
 
@@ -121,18 +121,18 @@ namespace System.Text.Json.Serialization.Tests
             obj.Initialize();
 
             // Verify default value.
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.DoesNotContain(Environment.NewLine, json);
 
             // Verify default value on options.
             var options = new JsonSerializerOptions();
-            json = JsonSerializer.ToString(obj, options);
+            json = JsonSerializer.Serialize(obj, options);
             Assert.DoesNotContain(Environment.NewLine, json);
 
             // Change the value on options.
             options = new JsonSerializerOptions();
             options.WriteIndented = true;
-            json = JsonSerializer.ToString(obj, options);
+            json = JsonSerializer.Serialize(obj, options);
             Assert.Contains(Environment.NewLine, json);
         }
 
@@ -143,16 +143,16 @@ namespace System.Text.Json.Serialization.Tests
             const string json = @"{""MyIntMissing"":2,}";
 
             // Verify baseline without options.
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ClassWithExtensionProperty>(json));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithExtensionProperty>(json));
 
             // Verify baseline with options.
             var options = new JsonSerializerOptions();
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ClassWithExtensionProperty>(json, options));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithExtensionProperty>(json, options));
 
             // Set AllowTrailingCommas to true.
             options = new JsonSerializerOptions();
             options.AllowTrailingCommas = true;
-            JsonSerializer.Parse<ClassWithExtensionProperty>(json, options);
+            JsonSerializer.Deserialize<ClassWithExtensionProperty>(json, options);
         }
 
         [Fact]
@@ -160,21 +160,21 @@ namespace System.Text.Json.Serialization.Tests
         {
             // We just verify whitespace.
 
-            ClassWithExtensionProperty obj = JsonSerializer.Parse<ClassWithExtensionProperty>(@"{""MyIntMissing"":2}");
+            ClassWithExtensionProperty obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(@"{""MyIntMissing"":2}");
 
             // Verify baseline without options.
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.False(HasNewLine());
 
             // Verify baseline with options.
             var options = new JsonSerializerOptions();
-            json = JsonSerializer.ToString(obj, options);
+            json = JsonSerializer.Serialize(obj, options);
             Assert.False(HasNewLine());
 
             // Set AllowTrailingCommas to true.
             options = new JsonSerializerOptions();
             options.WriteIndented = true;
-            json = JsonSerializer.ToString(obj, options);
+            json = JsonSerializer.Serialize(obj, options);
             Assert.True(HasNewLine());
 
             bool HasNewLine()
@@ -187,16 +187,16 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadCommentHandling()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<object>("/* commment */"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<object>("/* commment */"));
 
             var options = new JsonSerializerOptions();
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<object>("/* commment */", options));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<object>("/* commment */", options));
 
             options = new JsonSerializerOptions();
             options.ReadCommentHandling = JsonCommentHandling.Skip;
 
-            int value = JsonSerializer.Parse<int>("1 /* commment */", options);
+            int value = JsonSerializer.Deserialize<int>("1 /* commment */", options);
         }
 
         [Theory]
@@ -224,16 +224,16 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void MaxDepthRead()
         {
-            JsonSerializer.Parse<BasicCompany>(BasicCompany.s_data);
+            JsonSerializer.Deserialize<BasicCompany>(BasicCompany.s_data);
 
             var options = new JsonSerializerOptions();
 
-            JsonSerializer.Parse<BasicCompany>(BasicCompany.s_data, options);
+            JsonSerializer.Deserialize<BasicCompany>(BasicCompany.s_data, options);
 
             options = new JsonSerializerOptions();
             options.MaxDepth = 1;
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<BasicCompany>(BasicCompany.s_data, options));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<BasicCompany>(BasicCompany.s_data, options));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PolymorphicTests.cs
@@ -14,58 +14,58 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void PrimitivesAsRootObject()
         {
-            string json = JsonSerializer.ToString<object>(1);
+            string json = JsonSerializer.Serialize<object>(1);
             Assert.Equal("1", json);
-            json = JsonSerializer.ToString(1, typeof(object));
+            json = JsonSerializer.Serialize(1, typeof(object));
             Assert.Equal("1", json);
 
-            json = JsonSerializer.ToString<object>("foo");
+            json = JsonSerializer.Serialize<object>("foo");
             Assert.Equal(@"""foo""", json);
-            json = JsonSerializer.ToString("foo", typeof(object));
+            json = JsonSerializer.Serialize("foo", typeof(object));
             Assert.Equal(@"""foo""", json);
 
-            json = JsonSerializer.ToString<object>(true);
+            json = JsonSerializer.Serialize<object>(true);
             Assert.Equal(@"true", json);
-            json = JsonSerializer.ToString(true, typeof(object));
+            json = JsonSerializer.Serialize(true, typeof(object));
             Assert.Equal(@"true", json);
 
-            json = JsonSerializer.ToString<object>(null);
+            json = JsonSerializer.Serialize<object>(null);
             Assert.Equal(@"null", json);
-            json = JsonSerializer.ToString(null, typeof(object));
+            json = JsonSerializer.Serialize((object)null, typeof(object));
             Assert.Equal(@"null", json);
 
             decimal pi = 3.1415926535897932384626433833m;
-            json = JsonSerializer.ToString<object>(pi);
+            json = JsonSerializer.Serialize<object>(pi);
             Assert.Equal(@"3.1415926535897932384626433833", json);
-            json = JsonSerializer.ToString(pi, typeof(object));
+            json = JsonSerializer.Serialize(pi, typeof(object));
             Assert.Equal(@"3.1415926535897932384626433833", json);
         }
 
         [Fact]
         public static void ReadPrimitivesFail()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<object>(@""));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<object>(@"a"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<object>(@""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<object>(@"a"));
         }
 
         [Fact]
         public static void ParseUntyped()
         {
-            object obj = JsonSerializer.Parse<object>(@"""hello""");
+            object obj = JsonSerializer.Deserialize<object>(@"""hello""");
             Assert.IsType<JsonElement>(obj);
             JsonElement element = (JsonElement)obj;
             Assert.Equal(JsonValueType.String, element.Type);
             Assert.Equal("hello", element.GetString());
 
-            obj = JsonSerializer.Parse<object>(@"true");
+            obj = JsonSerializer.Deserialize<object>(@"true");
             element = (JsonElement)obj;
             Assert.Equal(JsonValueType.True, element.Type);
             Assert.Equal(true, element.GetBoolean());
 
-            obj = JsonSerializer.Parse<object>(@"null");
+            obj = JsonSerializer.Deserialize<object>(@"null");
             Assert.Null(obj);
 
-            obj = JsonSerializer.Parse<object>(@"[]");
+            obj = JsonSerializer.Deserialize<object>(@"[]");
             element = (JsonElement)obj;
             Assert.Equal(JsonValueType.Array, element.Type);
         }
@@ -82,181 +82,181 @@ namespace System.Text.Json.Serialization.Tests
             address.Initialize();
 
             var array = new object[] { 1, true, address, null, "foo" };
-            string json = JsonSerializer.ToString(array);
+            string json = JsonSerializer.Serialize(array);
             Assert.Equal(ExpectedJson, json);
 
             var dictionary = new Dictionary<string, string> { { "City", "MyCity" } };
             var arrayWithDictionary = new object[] { 1, true, dictionary, null, "foo" };
-            json = JsonSerializer.ToString(arrayWithDictionary);
+            json = JsonSerializer.Serialize(arrayWithDictionary);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(array);
+            json = JsonSerializer.Serialize<object>(array);
             Assert.Equal(ExpectedJson, json);
 
             List<object> list = new List<object> { 1, true, address, null, "foo" };
-            json = JsonSerializer.ToString(list);
+            json = JsonSerializer.Serialize(list);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(list);
+            json = JsonSerializer.Serialize<object>(list);
             Assert.Equal(ExpectedJson, json);
 
             IEnumerable ienumerable = new List<object> { 1, true, address, null, "foo" };
-            json = JsonSerializer.ToString(ienumerable);
+            json = JsonSerializer.Serialize(ienumerable);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(ienumerable);
+            json = JsonSerializer.Serialize<object>(ienumerable);
             Assert.Equal(ExpectedJson, json);
 
             IList ilist = new List<object> { 1, true, address, null, "foo" };
-            json = JsonSerializer.ToString(ilist);
+            json = JsonSerializer.Serialize(ilist);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(ilist);
+            json = JsonSerializer.Serialize<object>(ilist);
             Assert.Equal(ExpectedJson, json);
 
             ICollection icollection = new List<object> { 1, true, address, null, "foo" };
-            json = JsonSerializer.ToString(icollection);
+            json = JsonSerializer.Serialize(icollection);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(icollection);
+            json = JsonSerializer.Serialize<object>(icollection);
             Assert.Equal(ExpectedJson, json);
 
             IEnumerable<object> genericIEnumerable = new List<object> { 1, true, address, null, "foo" };
-            json = JsonSerializer.ToString(genericIEnumerable);
+            json = JsonSerializer.Serialize(genericIEnumerable);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(genericIEnumerable);
+            json = JsonSerializer.Serialize<object>(genericIEnumerable);
             Assert.Equal(ExpectedJson, json);
 
             IList<object> genericIList = new List<object> { 1, true, address, null, "foo" };
-            json = JsonSerializer.ToString(genericIList);
+            json = JsonSerializer.Serialize(genericIList);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(genericIList);
+            json = JsonSerializer.Serialize<object>(genericIList);
             Assert.Equal(ExpectedJson, json);
 
             ICollection<object> genericICollection = new List<object> { 1, true, address, null, "foo" };
-            json = JsonSerializer.ToString(genericICollection);
+            json = JsonSerializer.Serialize(genericICollection);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(genericICollection);
+            json = JsonSerializer.Serialize<object>(genericICollection);
             Assert.Equal(ExpectedJson, json);
 
             IReadOnlyCollection<object> genericIReadOnlyCollection = new List<object> { 1, true, address, null, "foo" };
-            json = JsonSerializer.ToString(genericIReadOnlyCollection);
+            json = JsonSerializer.Serialize(genericIReadOnlyCollection);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(genericIReadOnlyCollection);
+            json = JsonSerializer.Serialize<object>(genericIReadOnlyCollection);
             Assert.Equal(ExpectedJson, json);
 
             IReadOnlyList<object> genericIReadonlyList = new List<object> { 1, true, address, null, "foo" };
-            json = JsonSerializer.ToString(genericIReadonlyList);
+            json = JsonSerializer.Serialize(genericIReadonlyList);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(genericIReadonlyList);
+            json = JsonSerializer.Serialize<object>(genericIReadonlyList);
             Assert.Equal(ExpectedJson, json);
 
             ISet<object> iset = new HashSet<object> { 1, true, address, null, "foo" };
-            json = JsonSerializer.ToString(iset);
+            json = JsonSerializer.Serialize(iset);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(iset);
+            json = JsonSerializer.Serialize<object>(iset);
             Assert.Equal(ExpectedJson, json);
 
             Stack<object> stack = new Stack<object>(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(stack);
+            json = JsonSerializer.Serialize(stack);
             Assert.Equal(ReversedExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(stack);
+            json = JsonSerializer.Serialize<object>(stack);
             Assert.Equal(ReversedExpectedJson, json);
 
             Queue<object> queue = new Queue<object>(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(queue);
+            json = JsonSerializer.Serialize(queue);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(queue);
+            json = JsonSerializer.Serialize<object>(queue);
             Assert.Equal(ExpectedJson, json);
 
             HashSet<object> hashset = new HashSet<object>(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(hashset);
+            json = JsonSerializer.Serialize(hashset);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(hashset);
+            json = JsonSerializer.Serialize<object>(hashset);
             Assert.Equal(ExpectedJson, json);
 
             LinkedList<object> linkedlist = new LinkedList<object>(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(linkedlist);
+            json = JsonSerializer.Serialize(linkedlist);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(linkedlist);
+            json = JsonSerializer.Serialize<object>(linkedlist);
             Assert.Equal(ExpectedJson, json);
 
             IImmutableList<object> iimmutablelist = ImmutableList.CreateRange(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(iimmutablelist);
+            json = JsonSerializer.Serialize(iimmutablelist);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(iimmutablelist);
+            json = JsonSerializer.Serialize<object>(iimmutablelist);
             Assert.Equal(ExpectedJson, json);
 
             IImmutableStack<object> iimmutablestack = ImmutableStack.CreateRange(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(iimmutablestack);
+            json = JsonSerializer.Serialize(iimmutablestack);
             Assert.Equal(ReversedExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(iimmutablestack);
+            json = JsonSerializer.Serialize<object>(iimmutablestack);
             Assert.Equal(ReversedExpectedJson, json);
 
             IImmutableQueue<object> iimmutablequeue = ImmutableQueue.CreateRange(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(iimmutablequeue);
+            json = JsonSerializer.Serialize(iimmutablequeue);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(iimmutablequeue);
+            json = JsonSerializer.Serialize<object>(iimmutablequeue);
             Assert.Equal(ExpectedJson, json);
 
             IImmutableSet<object> iimmutableset = ImmutableHashSet.CreateRange(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(iimmutableset);
+            json = JsonSerializer.Serialize(iimmutableset);
             foreach (string obj in expectedObjects)
             {
                 Assert.Contains(obj, json);
             }
 
-            json = JsonSerializer.ToString<object>(iimmutableset);
+            json = JsonSerializer.Serialize<object>(iimmutableset);
             foreach (string obj in expectedObjects)
             {
                 Assert.Contains(obj, json);
             }
 
             ImmutableHashSet<object> immutablehashset = ImmutableHashSet.CreateRange(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(immutablehashset);
+            json = JsonSerializer.Serialize(immutablehashset);
             foreach (string obj in expectedObjects)
             {
                 Assert.Contains(obj, json);
             }
 
-            json = JsonSerializer.ToString<object>(immutablehashset);
+            json = JsonSerializer.Serialize<object>(immutablehashset);
             foreach (string obj in expectedObjects)
             {
                 Assert.Contains(obj, json);
             }
 
             ImmutableList<object> immutablelist = ImmutableList.CreateRange(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(immutablelist);
+            json = JsonSerializer.Serialize(immutablelist);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(immutablelist);
+            json = JsonSerializer.Serialize<object>(immutablelist);
             Assert.Equal(ExpectedJson, json);
 
             ImmutableStack<object> immutablestack = ImmutableStack.CreateRange(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(immutablestack);
+            json = JsonSerializer.Serialize(immutablestack);
             Assert.Equal(ReversedExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(immutablestack);
+            json = JsonSerializer.Serialize<object>(immutablestack);
             Assert.Equal(ReversedExpectedJson, json);
 
             ImmutableQueue<object> immutablequeue = ImmutableQueue.CreateRange(new List<object> { 1, true, address, null, "foo" });
-            json = JsonSerializer.ToString(immutablequeue);
+            json = JsonSerializer.Serialize(immutablequeue);
             Assert.Equal(ExpectedJson, json);
 
-            json = JsonSerializer.ToString<object>(immutablequeue);
+            json = JsonSerializer.Serialize<object>(immutablequeue);
             Assert.Equal(ExpectedJson, json);
         }
 
@@ -272,13 +272,13 @@ namespace System.Text.Json.Serialization.Tests
             obj.Initialize();
 
             // Verify with actual type.
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Contains(@"""MyInt16"":1", json);
             Assert.Contains(@"""MyBooleanTrue"":true", json);
             Assert.Contains(@"""MyInt16Array"":[1]", json);
 
             // Verify with object type.
-            json = JsonSerializer.ToString<object>(obj);
+            json = JsonSerializer.Serialize<object>(obj);
             Assert.Contains(@"""MyInt16"":1", json);
             Assert.Contains(@"""MyBooleanTrue"":true", json);
             Assert.Contains(@"""MyInt16Array"":[1]", json);
@@ -329,10 +329,10 @@ namespace System.Text.Json.Serialization.Tests
 
             var obj = new ObjectWithObjectProperties();
 
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Verify(json);
 
-            json = JsonSerializer.ToString<object>(obj);
+            json = JsonSerializer.Serialize<object>(obj);
             Verify(json);
         }
 
@@ -343,12 +343,12 @@ namespace System.Text.Json.Serialization.Tests
             var obj = new ObjectWithObjectProperties();
             obj.NullableInt = null;
 
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Contains(@"""NullableInt"":null", json);
 
             JsonSerializerOptions options = new JsonSerializerOptions();
             options.IgnoreNullValues = true;
-            json = JsonSerializer.ToString(obj, options);
+            json = JsonSerializer.Serialize(obj, options);
             Assert.DoesNotContain(@"""NullableInt"":null", json);
         }
 
@@ -359,8 +359,8 @@ namespace System.Text.Json.Serialization.Tests
             customer.Initialize();
             customer.Verify();
 
-            string json = JsonSerializer.ToString(customer);
-            Customer deserializedCustomer = JsonSerializer.Parse<Customer>(json);
+            string json = JsonSerializer.Serialize(customer);
+            Customer deserializedCustomer = JsonSerializer.Deserialize<Customer>(json);
             deserializedCustomer.Verify();
         }
 
@@ -374,9 +374,9 @@ namespace System.Text.Json.Serialization.Tests
             Person person = customer;
 
             // Generic inference used <TValue> = <Person>
-            string json = JsonSerializer.ToString(person);
+            string json = JsonSerializer.Serialize(person);
 
-            Customer deserializedCustomer = JsonSerializer.Parse<Customer>(json);
+            Customer deserializedCustomer = JsonSerializer.Deserialize<Customer>(json);
 
             // We only serialized the Person base class, so the Customer fields should be default.
             Assert.Equal(typeof(Customer), deserializedCustomer.GetType());
@@ -393,9 +393,9 @@ namespace System.Text.Json.Serialization.Tests
 
             Person person = customer;
 
-            string json = JsonSerializer.ToString(person, person.GetType());
+            string json = JsonSerializer.Serialize(person, person.GetType());
 
-            Customer deserializedCustomer = JsonSerializer.Parse<Customer>(json);
+            Customer deserializedCustomer = JsonSerializer.Deserialize<Customer>(json);
 
             // We serialized the Customer
             Assert.Equal(typeof(Customer), deserializedCustomer.GetType());
@@ -415,9 +415,9 @@ namespace System.Text.Json.Serialization.Tests
             Customer customer = usaCustomer;
 
             // Generic inference used <TValue> = <Customer>
-            string json = JsonSerializer.ToString(customer);
+            string json = JsonSerializer.Serialize(customer);
 
-            UsaCustomer deserializedCustomer = JsonSerializer.Parse<UsaCustomer>(json);
+            UsaCustomer deserializedCustomer = JsonSerializer.Deserialize<UsaCustomer>(json);
 
             // We only serialized the Customer base class
             Assert.Equal(typeof(UsaCustomer), deserializedCustomer.GetType());
@@ -428,7 +428,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void PolymorphicInterface_NotSupported()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Parse<MyClass>(@"{ ""Value"": ""A value"", ""Thing"": { ""Number"": 123 } }"));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<MyClass>(@"{ ""Value"": ""A value"", ""Thing"": { ""Number"": 123 } }"));
         }
 
         class MyClass

--- a/src/System.Text.Json/tests/Serialization/PropertyNameTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PropertyNameTests.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
 
-            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(@"{""MyInt16"":1}", options);
+            SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(@"{""MyInt16"":1}", options);
 
             // This is 0 (default value) because the data does not match the property "MyInt16" that is assuming camel-casing of "myInt16".
             Assert.Equal(0, obj.MyInt16);
@@ -26,7 +26,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
 
-            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(@"{""myInt16"":1}", options);
+            SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(@"{""myInt16"":1}", options);
 
             // This is 1 because the data matches the property "MyInt16" that is assuming camel-casing of "myInt16".
             Assert.Equal(1, obj.MyInt16);
@@ -38,8 +38,8 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
 
-            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(@"{}", options);
-            string json = JsonSerializer.ToString(obj, options);
+            SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(@"{}", options);
+            string json = JsonSerializer.Serialize(obj, options);
             Assert.Contains(@"""myInt16"":0", json);
             Assert.Contains(@"""myInt32"":0", json);
         }
@@ -50,7 +50,7 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.PropertyNamingPolicy = new UppercaseNamingPolicy();
 
-            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(@"{""MYINT16"":1}", options);
+            SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(@"{""MYINT16"":1}", options);
 
             // This is 1 because the data matches the property "MYINT16" that is uppercase of "myInt16".
             Assert.Equal(1, obj.MyInt16);
@@ -63,7 +63,7 @@ namespace System.Text.Json.Serialization.Tests
             options.PropertyNamingPolicy = new NullNamingPolicy();
 
             // A policy that returns null is not allowed.
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<SimpleTestClass>(@"{}", options));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<SimpleTestClass>(@"{}", options));
         }
 
         [Fact]
@@ -71,21 +71,21 @@ namespace System.Text.Json.Serialization.Tests
         {
             {
                 // A non-match scenario with no options (case-sensitive by default).
-                SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(@"{""myint16"":1}");
+                SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(@"{""myint16"":1}");
                 Assert.Equal(0, obj.MyInt16);
             }
 
             {
                 // A non-match scenario with default options (case-sensitive by default).
                 var options = new JsonSerializerOptions();
-                SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(@"{""myint16"":1}", options);
+                SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(@"{""myint16"":1}", options);
                 Assert.Equal(0, obj.MyInt16);
             }
 
             {
                 var options = new JsonSerializerOptions();
                 options.PropertyNameCaseInsensitive = true;
-                SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(@"{""myint16"":1}", options);
+                SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(@"{""myint16"":1}", options);
                 Assert.Equal(1, obj.MyInt16);
             }
         }
@@ -94,12 +94,12 @@ namespace System.Text.Json.Serialization.Tests
         public static void JsonPropertyNameAttribute()
         {
             {
-                OverridePropertyNameDesignTime_TestClass obj = JsonSerializer.Parse<OverridePropertyNameDesignTime_TestClass>(@"{""Blah"":1}");
+                OverridePropertyNameDesignTime_TestClass obj = JsonSerializer.Deserialize<OverridePropertyNameDesignTime_TestClass>(@"{""Blah"":1}");
                 Assert.Equal(1, obj.myInt);
 
                 obj.myObject = 2;
                 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Contains(@"""Blah"":1", json);
                 Assert.Contains(@"""BlahObject"":2", json);
             }
@@ -110,10 +110,10 @@ namespace System.Text.Json.Serialization.Tests
                 options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
                 options.PropertyNameCaseInsensitive = true;
 
-                OverridePropertyNameDesignTime_TestClass obj = JsonSerializer.Parse<OverridePropertyNameDesignTime_TestClass>(@"{""Blah"":1}", options);
+                OverridePropertyNameDesignTime_TestClass obj = JsonSerializer.Deserialize<OverridePropertyNameDesignTime_TestClass>(@"{""Blah"":1}", options);
                 Assert.Equal(1, obj.myInt);
 
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Contains(@"""Blah"":1", json);
             }
         }
@@ -123,12 +123,12 @@ namespace System.Text.Json.Serialization.Tests
         {
             {
                 var options = new JsonSerializerOptions();
-                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<DuplicatePropertyNameDesignTime_TestClass>("{}", options));
+                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<DuplicatePropertyNameDesignTime_TestClass>("{}", options));
             }
 
             {
                 var options = new JsonSerializerOptions();
-                Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(new DuplicatePropertyNameDesignTime_TestClass(), options));
+                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new DuplicatePropertyNameDesignTime_TestClass(), options));
             }
         }
 
@@ -140,7 +140,7 @@ namespace System.Text.Json.Serialization.Tests
             options.PropertyNameCaseInsensitive = true;
 
             // A null name in JsonPropertyNameAttribute is not allowed.
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(new NullPropertyName_TestClass(), options));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new NullPropertyName_TestClass(), options));
         }
 
         [Fact]
@@ -148,30 +148,30 @@ namespace System.Text.Json.Serialization.Tests
         {
             {
                 // Baseline comparison - no options set.
-                IntPropertyNamesDifferentByCaseOnly_TestClass obj = JsonSerializer.Parse<IntPropertyNamesDifferentByCaseOnly_TestClass>("{}");
-                JsonSerializer.ToString(obj);
+                IntPropertyNamesDifferentByCaseOnly_TestClass obj = JsonSerializer.Deserialize<IntPropertyNamesDifferentByCaseOnly_TestClass>("{}");
+                JsonSerializer.Serialize(obj);
             }
 
             {
                 var options = new JsonSerializerOptions();
                 options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
 
-                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<IntPropertyNamesDifferentByCaseOnly_TestClass>("{}", options));
-                Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(new IntPropertyNamesDifferentByCaseOnly_TestClass(), options));
+                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<IntPropertyNamesDifferentByCaseOnly_TestClass>("{}", options));
+                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new IntPropertyNamesDifferentByCaseOnly_TestClass(), options));
             }
 
             {
                 // Baseline comparison - no options set.
-                ObjectPropertyNamesDifferentByCaseOnly_TestClass obj = JsonSerializer.Parse<ObjectPropertyNamesDifferentByCaseOnly_TestClass>("{}");
-                JsonSerializer.ToString(obj);
+                ObjectPropertyNamesDifferentByCaseOnly_TestClass obj = JsonSerializer.Deserialize<ObjectPropertyNamesDifferentByCaseOnly_TestClass>("{}");
+                JsonSerializer.Serialize(obj);
             }
 
             {
                 var options = new JsonSerializerOptions();
                 options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
 
-                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<ObjectPropertyNamesDifferentByCaseOnly_TestClass>("{}", options));
-                Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(new ObjectPropertyNamesDifferentByCaseOnly_TestClass(), options));
+                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ObjectPropertyNamesDifferentByCaseOnly_TestClass>("{}", options));
+                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ObjectPropertyNamesDifferentByCaseOnly_TestClass(), options));
             }
         }
 
@@ -184,8 +184,8 @@ namespace System.Text.Json.Serialization.Tests
                 var options = new JsonSerializerOptions();
                 options.PropertyNameCaseInsensitive = true;
 
-                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Parse<IntPropertyNamesDifferentByCaseOnly_TestClass>(json, options));
-                Assert.Throws<InvalidOperationException>(() => JsonSerializer.ToString(new IntPropertyNamesDifferentByCaseOnly_TestClass(), options));
+                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<IntPropertyNamesDifferentByCaseOnly_TestClass>(json, options));
+                Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new IntPropertyNamesDifferentByCaseOnly_TestClass(), options));
             }
         }
 
@@ -194,7 +194,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             {
                 // Baseline.
-                string json = JsonSerializer.ToString(new SimpleTestClass());
+                string json = JsonSerializer.Serialize(new SimpleTestClass());
                 Assert.Contains(@"""MyInt16"":0", json);
             }
 
@@ -203,7 +203,7 @@ namespace System.Text.Json.Serialization.Tests
                 var options = new JsonSerializerOptions();
                 options.PropertyNameCaseInsensitive = true;
 
-                string json = JsonSerializer.ToString(new SimpleTestClass(), options);
+                string json = JsonSerializer.Serialize(new SimpleTestClass(), options);
                 Assert.Contains(@"""MyInt16"":0", json);
             }
         }
@@ -217,12 +217,12 @@ namespace System.Text.Json.Serialization.Tests
                 var obj = new EmptyPropertyName_TestClass();
                 obj.MyInt1 = 1;
 
-                string jsonOut = JsonSerializer.ToString(obj);
+                string jsonOut = JsonSerializer.Serialize(obj);
                 Assert.Equal(json, jsonOut);
             }
 
             {
-                EmptyPropertyName_TestClass obj = JsonSerializer.Parse<EmptyPropertyName_TestClass>(json);
+                EmptyPropertyName_TestClass obj = JsonSerializer.Deserialize<EmptyPropertyName_TestClass>(json);
                 Assert.Equal(1, obj.MyInt1);
             }
         }
@@ -231,29 +231,29 @@ namespace System.Text.Json.Serialization.Tests
         public static void UnicodePropertyNames()
         {
             {
-                ClassWithUnicodeProperty obj = JsonSerializer.Parse<ClassWithUnicodeProperty>(@"{""Aѧ"":1}");
+                ClassWithUnicodeProperty obj = JsonSerializer.Deserialize<ClassWithUnicodeProperty>(@"{""Aѧ"":1}");
                 Assert.Equal(1, obj.Aѧ);
 
                 // Verify the name is escaped after serialize.
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Contains(@"""A\u0467"":1", json);
 
                 // Verify the name is unescaped after deserialize.
-                obj = JsonSerializer.Parse<ClassWithUnicodeProperty>(json);
+                obj = JsonSerializer.Deserialize<ClassWithUnicodeProperty>(json);
                 Assert.Equal(1, obj.Aѧ);
             }
 
             {
                 // We want to go over StackallocThreshold=256 to force a pooled allocation, so this property is 400 chars and 401 bytes.
-                ClassWithUnicodeProperty obj = JsonSerializer.Parse<ClassWithUnicodeProperty>(@"{""Aѧ34567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"":1}");
+                ClassWithUnicodeProperty obj = JsonSerializer.Deserialize<ClassWithUnicodeProperty>(@"{""Aѧ34567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"":1}");
                 Assert.Equal(1, obj.Aѧ34567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890);
 
                 // Verify the name is escaped after serialize.
-                string json = JsonSerializer.ToString(obj);
+                string json = JsonSerializer.Serialize(obj);
                 Assert.Contains(@"""A\u046734567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"":1", json);
 
                 // Verify the name is unescaped after deserialize.
-                obj = JsonSerializer.Parse<ClassWithUnicodeProperty>(json);
+                obj = JsonSerializer.Deserialize<ClassWithUnicodeProperty>(json);
                 Assert.Equal(1, obj.Aѧ34567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890);
             }
         }

--- a/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -14,11 +14,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             var obj = new ClassWithNoSetter();
 
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Contains(@"""MyString"":""DefaultValue""", json);
             Assert.Contains(@"""MyInts"":[1,2]", json);
 
-            obj = JsonSerializer.Parse<ClassWithNoSetter>(@"{""MyString"":""IgnoreMe"",""MyInts"":[0]}");
+            obj = JsonSerializer.Deserialize<ClassWithNoSetter>(@"{""MyString"":""IgnoreMe"",""MyInts"":[0]}");
             Assert.Equal("DefaultValue", obj.MyString);
             Assert.Equal(2, obj.MyInts.Length);
         }
@@ -31,14 +31,14 @@ namespace System.Text.Json.Serialization.Tests
 
             var obj = new ClassWithNoSetter();
 
-            string json = JsonSerializer.ToString(obj, options);
+            string json = JsonSerializer.Serialize(obj, options);
             Assert.Equal(@"{}", json);
         }
 
         [Fact]
         public static void NoGetter()
         {
-            ClassWithNoGetter objWithNoGetter = JsonSerializer.Parse<ClassWithNoGetter>(
+            ClassWithNoGetter objWithNoGetter = JsonSerializer.Deserialize<ClassWithNoGetter>(
                 @"{""MyString"":""Hello"",""MyIntArray"":[0],""MyIntList"":[0]}");
 
             Assert.Equal("Hello", objWithNoGetter.GetMyString());
@@ -54,7 +54,7 @@ namespace System.Text.Json.Serialization.Tests
             var obj = new ClassWithPrivateSetterAndGetter();
             obj.SetMyString("Hello");
 
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Equal(@"{}", json);
         }
 
@@ -63,7 +63,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             string json = @"{""MyString"":""Hello""}";
 
-            ClassWithPrivateSetterAndGetter objCopy = JsonSerializer.Parse<ClassWithPrivateSetterAndGetter>(json);
+            ClassWithPrivateSetterAndGetter objCopy = JsonSerializer.Deserialize<ClassWithPrivateSetterAndGetter>(json);
             Assert.Null(objCopy.GetMyString());
         }
 
@@ -72,7 +72,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             // https://github.com/dotnet/corefx/issues/37567
             ClassWithPublicGetterAndPrivateSetter obj
-                = JsonSerializer.Parse<ClassWithPublicGetterAndPrivateSetter>(@"{ ""Class"": {} }");
+                = JsonSerializer.Deserialize<ClassWithPublicGetterAndPrivateSetter>(@"{ ""Class"": {} }");
 
             Assert.NotNull(obj);
             Assert.Null(obj.Class);
@@ -98,21 +98,21 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(1, obj.MyDictionaryWithIgnore["Key"]);
 
             // Verify serialize.
-            string json = JsonSerializer.ToString(obj);
+            string json = JsonSerializer.Serialize(obj);
             Assert.Contains(@"""MyString""", json);
             Assert.DoesNotContain(@"MyStringWithIgnore", json);
             Assert.DoesNotContain(@"MyStringsWithIgnore", json);
             Assert.DoesNotContain(@"MyDictionaryWithIgnore", json);
 
             // Verify deserialize default.
-            obj = JsonSerializer.Parse<ClassWithIgnoreAttributeProperty>(@"{}");
+            obj = JsonSerializer.Deserialize<ClassWithIgnoreAttributeProperty>(@"{}");
             Assert.Equal(@"MyString", obj.MyString);
             Assert.Equal(@"MyStringWithIgnore", obj.MyStringWithIgnore);
             Assert.Equal(2, obj.MyStringsWithIgnore.Length);
             Assert.Equal(1, obj.MyDictionaryWithIgnore["Key"]);
 
             // Verify deserialize ignores the json for MyStringWithIgnore and MyStringsWithIgnore.
-            obj = JsonSerializer.Parse<ClassWithIgnoreAttributeProperty>(
+            obj = JsonSerializer.Deserialize<ClassWithIgnoreAttributeProperty>(
                 @"{""MyString"":""Hello"", ""MyStringWithIgnore"":""IgnoreMe"", ""MyStringsWithIgnore"":[""IgnoreMe""], ""MyDictionaryWithIgnore"":{""Key"":9}}");
             Assert.Contains(@"Hello", obj.MyString);
             Assert.Equal(@"MyStringWithIgnore", obj.MyStringWithIgnore);

--- a/src/System.Text.Json/tests/Serialization/ReadValueTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ReadValueTests.cs
@@ -15,7 +15,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.ThrowsAny<ArgumentNullException>(() =>
             {
                 Utf8JsonReader reader = default;
-                JsonSerializer.ReadValue(ref reader, null);
+                JsonSerializer.Deserialize(ref reader, null);
             });
         }
 
@@ -28,7 +28,7 @@ namespace System.Text.Json.Serialization.Tests
             byte[] utf8 = Encoding.UTF8.GetBytes(@"{""myint16"":1}");
             var reader = new Utf8JsonReader(utf8, isFinalBlock: true, state: default);
 
-            SimpleTestClass obj = JsonSerializer.ReadValue<SimpleTestClass>(ref reader, options);
+            SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(ref reader, options);
             Assert.Equal(1, obj.MyInt16);
 
             Assert.Equal(JsonTokenType.EndObject, reader.TokenType);
@@ -54,7 +54,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() =>
             {
                 var reader = new Utf8JsonReader(utf8, isFinalBlock: false, state);
-                JsonSerializer.ReadValue(ref reader, typeof(int), serializerOptions);
+                JsonSerializer.Deserialize(ref reader, typeof(int), serializerOptions);
             });
         }
 
@@ -71,7 +71,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() =>
             {
                 var reader = new Utf8JsonReader(utf8, isFinalBlock: false, state: default);
-                JsonSerializer.ReadValue(ref reader, typeof(int), serializerOptions);
+                JsonSerializer.Deserialize(ref reader, typeof(int), serializerOptions);
             });
         }
 
@@ -88,7 +88,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() =>
             {
                 var reader = new Utf8JsonReader(utf8, isFinalBlock: false, state: default);
-                JsonSerializer.ReadValue(ref reader, typeof(int), serializerOptions);
+                JsonSerializer.Deserialize(ref reader, typeof(int), serializerOptions);
             });
         }
 
@@ -103,7 +103,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.ReadValue(ref reader, typeof(int[]));
+                JsonSerializer.Deserialize(ref reader, typeof(int[]));
                 Assert.True(false, "Expected ReadValue to throw JsonException for invalid JSON.");
             }
             catch (JsonException) { }
@@ -120,7 +120,7 @@ namespace System.Text.Json.Serialization.Tests
             var reader = new Utf8JsonReader(utf8, isFinalBlock: true, state: default);
             reader.Read();
 
-            SimpleType instance = JsonSerializer.ReadValue<SimpleType>(ref reader);
+            SimpleType instance = JsonSerializer.Deserialize<SimpleType>(ref reader);
             Assert.Equal("abc", instance.Foo);
 
             Assert.Equal(utf8.Length, reader.BytesConsumed);
@@ -144,14 +144,14 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.ReadValue<SimpleTypeWithArray>(ref reader);
+                JsonSerializer.Deserialize<SimpleTypeWithArray>(ref reader);
                 Assert.True(false, "Expected ReadValue to throw JsonException for type mismatch.");
             }
             catch (JsonException) { }
 
             Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
 
-            int[] instance = JsonSerializer.ReadValue<int[]>(ref reader);
+            int[] instance = JsonSerializer.Deserialize<int[]>(ref reader);
             Assert.Equal(new int[] { 1, 2, 3 }, instance);
 
             Assert.Equal(utf8.Length - 1, reader.BytesConsumed);
@@ -177,7 +177,7 @@ namespace System.Text.Json.Serialization.Tests
             reader.Read();
             Assert.Equal(JsonTokenType.StartObject, reader.TokenType);
 
-            SimpleTypeWithArray instance = JsonSerializer.ReadValue<SimpleTypeWithArray>(ref reader);
+            SimpleTypeWithArray instance = JsonSerializer.Deserialize<SimpleTypeWithArray>(ref reader);
 
             Assert.Equal(JsonTokenType.EndObject, reader.TokenType);
             Assert.Equal(new int[] { 1, 2, 3 }, instance.Foo);
@@ -202,7 +202,7 @@ namespace System.Text.Json.Serialization.Tests
 
                 try
                 {
-                    JsonSerializer.ReadValue<SimpleTypeWithArray>(ref reader);
+                    JsonSerializer.Deserialize<SimpleTypeWithArray>(ref reader);
                     Assert.True(false, "Expected ReadValue to throw JsonException for not enough data.");
                 }
                 catch (JsonException) { }
@@ -222,7 +222,7 @@ namespace System.Text.Json.Serialization.Tests
 
                 try
                 {
-                    JsonSerializer.ReadValue<SimpleTypeWithArray>(ref reader);
+                    JsonSerializer.Deserialize<SimpleTypeWithArray>(ref reader);
                     Assert.True(false, "Expected ReadValue to throw JsonException for not enough data.");
                 }
                 catch (JsonException) { }
@@ -245,7 +245,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.ReadValue<SimpleTypeWithArray>(ref reader);
+                JsonSerializer.Deserialize<SimpleTypeWithArray>(ref reader);
                 Assert.True(false, "Expected ReadValue to throw JsonException for invalid token.");
             }
             catch (JsonException ex)
@@ -262,7 +262,7 @@ namespace System.Text.Json.Serialization.Tests
 
             try
             {
-                JsonSerializer.ReadValue<SimpleTypeWithArray>(ref reader);
+                JsonSerializer.Deserialize<SimpleTypeWithArray>(ref reader);
                 Assert.True(false, "Expected ReadValue to throw JsonException for invalid token.");
             }
             catch (JsonException ex)
@@ -293,7 +293,7 @@ namespace System.Text.Json.Serialization.Tests
             var reader = new Utf8JsonReader(utf8, isFinalBlock: true, state: default);
             Assert.Equal(JsonTokenType.None, reader.TokenType);
 
-            object obj = JsonSerializer.ReadValue(ref reader, type);
+            object obj = JsonSerializer.Deserialize(ref reader, type);
             Assert.False(reader.HasValueSequence);
             Assert.Equal(utf8.Length, reader.BytesConsumed);
             Assert.Equal(expected, obj);
@@ -315,7 +315,7 @@ namespace System.Text.Json.Serialization.Tests
             var reader = new Utf8JsonReader(sequence, isFinalBlock: true, state: default);
             Assert.Equal(JsonTokenType.None, reader.TokenType);
 
-            object obj = JsonSerializer.ReadValue(ref reader, type);
+            object obj = JsonSerializer.Deserialize(ref reader, type);
             Assert.True(reader.HasValueSequence);
             Assert.Equal(utf8.Length, reader.BytesConsumed);
             Assert.Equal(expected, obj);
@@ -341,7 +341,7 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     var state = new JsonReaderState(options);
                     var reader = new Utf8JsonReader(utf8, isFinalBlock: false, state);
-                    JsonSerializer.ReadValue(ref reader, typeof(int));
+                    JsonSerializer.Deserialize(ref reader, typeof(int));
                 });
 
             AssertExtensions.Throws<ArgumentException>(
@@ -350,7 +350,7 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     var state = new JsonReaderState(options);
                     var reader = new Utf8JsonReader(utf8, isFinalBlock: true, state);
-                    JsonSerializer.ReadValue(ref reader, typeof(int));
+                    JsonSerializer.Deserialize(ref reader, typeof(int));
                 });
 
             AssertExtensions.Throws<ArgumentException>(
@@ -359,7 +359,7 @@ namespace System.Text.Json.Serialization.Tests
                {
                    var state = new JsonReaderState(options);
                    var reader = new Utf8JsonReader(utf8, isFinalBlock: false, state);
-                   JsonSerializer.ReadValue<int>(ref reader);
+                   JsonSerializer.Deserialize<int>(ref reader);
                });
 
             AssertExtensions.Throws<ArgumentException>(
@@ -368,7 +368,7 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     var state = new JsonReaderState(options);
                     var reader = new Utf8JsonReader(utf8, isFinalBlock: true, state);
-                    JsonSerializer.ReadValue<int>(ref reader);
+                    JsonSerializer.Deserialize<int>(ref reader);
                 });
         }
 
@@ -378,13 +378,13 @@ namespace System.Text.Json.Serialization.Tests
             Assert.ThrowsAny<JsonException>(() =>
             {
                 Utf8JsonReader reader = default;
-                JsonSerializer.ReadValue(ref reader, typeof(int));
+                JsonSerializer.Deserialize(ref reader, typeof(int));
             });
 
             Assert.ThrowsAny<JsonException>(() =>
             {
                 Utf8JsonReader reader = default;
-                JsonSerializer.ReadValue<int>(ref reader);
+                JsonSerializer.Deserialize<int>(ref reader);
             });
         }
 
@@ -393,11 +393,11 @@ namespace System.Text.Json.Serialization.Tests
         {
             byte[] utf8 = Encoding.UTF8.GetBytes(SimpleTestStruct.s_json);
             var reader = new Utf8JsonReader(utf8, isFinalBlock: true, state: default);
-            SimpleTestStruct testStruct = JsonSerializer.ReadValue<SimpleTestStruct>(ref reader);
+            SimpleTestStruct testStruct = JsonSerializer.Deserialize<SimpleTestStruct>(ref reader);
             testStruct.Verify();
 
             reader = new Utf8JsonReader(utf8, isFinalBlock: true, state: default);
-            object obj = JsonSerializer.ReadValue(ref reader, typeof(SimpleTestStruct));
+            object obj = JsonSerializer.Deserialize(ref reader, typeof(SimpleTestStruct));
             ((SimpleTestStruct)obj).Verify();
         }
 
@@ -407,61 +407,61 @@ namespace System.Text.Json.Serialization.Tests
             {
                 byte[] utf8 = Encoding.UTF8.GetBytes(TestClassWithNestedObjectInner.s_json);
                 var reader = new Utf8JsonReader(utf8, isFinalBlock: true, state: default);
-                TestClassWithNestedObjectInner testStruct = JsonSerializer.ReadValue<TestClassWithNestedObjectInner>(ref reader);
+                TestClassWithNestedObjectInner testStruct = JsonSerializer.Deserialize<TestClassWithNestedObjectInner>(ref reader);
                 testStruct.Verify();
 
                 reader = new Utf8JsonReader(utf8, isFinalBlock: true, state: default);
-                object obj = JsonSerializer.ReadValue(ref reader, typeof(TestClassWithNestedObjectInner));
+                object obj = JsonSerializer.Deserialize(ref reader, typeof(TestClassWithNestedObjectInner));
                 ((TestClassWithNestedObjectInner)obj).Verify();
             }
 
             {
                 var reader = new Utf8JsonReader(TestClassWithNestedObjectOuter.s_data, isFinalBlock: true, state: default);
-                TestClassWithNestedObjectOuter testStruct = JsonSerializer.ReadValue<TestClassWithNestedObjectOuter>(ref reader);
+                TestClassWithNestedObjectOuter testStruct = JsonSerializer.Deserialize<TestClassWithNestedObjectOuter>(ref reader);
                 testStruct.Verify();
 
                 reader = new Utf8JsonReader(TestClassWithNestedObjectOuter.s_data, isFinalBlock: true, state: default);
-                object obj = JsonSerializer.ReadValue(ref reader, typeof(TestClassWithNestedObjectOuter));
+                object obj = JsonSerializer.Deserialize(ref reader, typeof(TestClassWithNestedObjectOuter));
                 ((TestClassWithNestedObjectOuter)obj).Verify();
             }
 
             {
                 var reader = new Utf8JsonReader(TestClassWithObjectList.s_data, isFinalBlock: true, state: default);
-                TestClassWithObjectList testStruct = JsonSerializer.ReadValue<TestClassWithObjectList>(ref reader);
+                TestClassWithObjectList testStruct = JsonSerializer.Deserialize<TestClassWithObjectList>(ref reader);
                 testStruct.Verify();
 
                 reader = new Utf8JsonReader(TestClassWithObjectList.s_data, isFinalBlock: true, state: default);
-                object obj = JsonSerializer.ReadValue(ref reader, typeof(TestClassWithObjectList));
+                object obj = JsonSerializer.Deserialize(ref reader, typeof(TestClassWithObjectList));
                 ((TestClassWithObjectList)obj).Verify();
             }
 
             {
                 var reader = new Utf8JsonReader(TestClassWithObjectArray.s_data, isFinalBlock: true, state: default);
-                TestClassWithObjectArray testStruct = JsonSerializer.ReadValue<TestClassWithObjectArray>(ref reader);
+                TestClassWithObjectArray testStruct = JsonSerializer.Deserialize<TestClassWithObjectArray>(ref reader);
                 testStruct.Verify();
 
                 reader = new Utf8JsonReader(TestClassWithObjectArray.s_data, isFinalBlock: true, state: default);
-                object obj = JsonSerializer.ReadValue(ref reader, typeof(TestClassWithObjectArray));
+                object obj = JsonSerializer.Deserialize(ref reader, typeof(TestClassWithObjectArray));
                 ((TestClassWithObjectArray)obj).Verify();
             }
 
             {
                 var reader = new Utf8JsonReader(TestClassWithObjectIEnumerableT.s_data, isFinalBlock: true, state: default);
-                TestClassWithObjectIEnumerableT testStruct = JsonSerializer.ReadValue<TestClassWithObjectIEnumerableT>(ref reader);
+                TestClassWithObjectIEnumerableT testStruct = JsonSerializer.Deserialize<TestClassWithObjectIEnumerableT>(ref reader);
                 testStruct.Verify();
 
                 reader = new Utf8JsonReader(TestClassWithObjectIEnumerableT.s_data, isFinalBlock: true, state: default);
-                object obj = JsonSerializer.ReadValue(ref reader, typeof(TestClassWithObjectIEnumerableT));
+                object obj = JsonSerializer.Deserialize(ref reader, typeof(TestClassWithObjectIEnumerableT));
                 ((TestClassWithObjectIEnumerableT)obj).Verify();
             }
 
             {
                 var reader = new Utf8JsonReader(TestClassWithStringToPrimitiveDictionary.s_data, isFinalBlock: true, state: default);
-                TestClassWithStringToPrimitiveDictionary testStruct = JsonSerializer.ReadValue<TestClassWithStringToPrimitiveDictionary>(ref reader);
+                TestClassWithStringToPrimitiveDictionary testStruct = JsonSerializer.Deserialize<TestClassWithStringToPrimitiveDictionary>(ref reader);
                 testStruct.Verify();
 
                 reader = new Utf8JsonReader(TestClassWithStringToPrimitiveDictionary.s_data, isFinalBlock: true, state: default);
-                object obj = JsonSerializer.ReadValue(ref reader, typeof(TestClassWithStringToPrimitiveDictionary));
+                object obj = JsonSerializer.Deserialize(ref reader, typeof(TestClassWithStringToPrimitiveDictionary));
                 ((TestClassWithStringToPrimitiveDictionary)obj).Verify();
             }
         }
@@ -472,25 +472,25 @@ namespace System.Text.Json.Serialization.Tests
             byte[] utf8 = Encoding.UTF8.GetBytes("[1, 2, 3]");
             var reader = new Utf8JsonReader(utf8, isFinalBlock: true, state: default);
             reader.Read();
-            int[] array = JsonSerializer.ReadValue<int[]>(ref reader);
+            int[] array = JsonSerializer.Deserialize<int[]>(ref reader);
             var expected = new int[3] { 1, 2, 3 };
             Assert.Equal(expected, array);
 
             reader = new Utf8JsonReader(utf8, isFinalBlock: true, state: default);
             reader.Read();
-            object obj = JsonSerializer.ReadValue(ref reader, typeof(int[]));
+            object obj = JsonSerializer.Deserialize(ref reader, typeof(int[]));
             Assert.Equal(expected, obj);
 
             reader = new Utf8JsonReader(utf8, isFinalBlock: true, state: default);
             reader.Read();
             reader.Read();
-            int number = JsonSerializer.ReadValue<int>(ref reader);
+            int number = JsonSerializer.Deserialize<int>(ref reader);
             Assert.Equal(1, number);
 
             reader = new Utf8JsonReader(utf8, isFinalBlock: true, state: default);
             reader.Read();
             reader.Read();
-            obj = JsonSerializer.ReadValue(ref reader, typeof(int));
+            obj = JsonSerializer.Deserialize(ref reader, typeof(int));
             Assert.Equal(1, obj);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/SpanTests.cs
+++ b/src/System.Text.Json/tests/Serialization/SpanTests.cs
@@ -13,14 +13,14 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ParseNullTypeFail()
         {
-            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Parse(new ReadOnlySpan<byte>(), (Type)null));
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Deserialize(new ReadOnlySpan<byte>(), (Type)null));
         }
 
         [Theory]
         [MemberData(nameof(ReadSuccessCases))]
         public static void Read(Type classType, byte[] data)
         {
-            object obj = JsonSerializer.Parse(data, classType);
+            object obj = JsonSerializer.Deserialize(data, classType);
             Assert.IsAssignableFrom(typeof(ITestClass), obj);
             ((ITestClass)obj).Verify();
         }
@@ -30,7 +30,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ReadFromStream(Type classType, byte[] data)
         {
             MemoryStream stream = new MemoryStream(data);
-            object obj = JsonSerializer.ReadAsync(
+            object obj = JsonSerializer.DeserializeAsync(
                 stream,
                 classType).Result;
 
@@ -39,7 +39,7 @@ namespace System.Text.Json.Serialization.Tests
 
             // Try again with a smaller initial buffer size to ensure we handle incomplete data
             stream = new MemoryStream(data);
-            obj = JsonSerializer.ReadAsync(
+            obj = JsonSerializer.DeserializeAsync(
                 stream,
                 classType,
                 new JsonSerializerOptions { DefaultBufferSize = 5 }).Result;
@@ -51,7 +51,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadGenericApi()
         {
-            SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(SimpleTestClass.s_data);
+            SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(SimpleTestClass.s_data);
             obj.Verify();
         }
 
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ParseUntyped()
         {
             byte[] bytes = Encoding.UTF8.GetBytes("42");
-            object obj = JsonSerializer.Parse(bytes, typeof(object));
+            object obj = JsonSerializer.Deserialize(bytes, typeof(object));
             Assert.IsType<JsonElement>(obj);
             JsonElement element = (JsonElement)obj;
             Assert.Equal(JsonValueType.Number, element.Type);
@@ -69,13 +69,13 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ToStringNullTypeFail()
         {
-            Assert.Throws<ArgumentNullException>(() => JsonSerializer.ToString(new object(), (Type)null));
+            Assert.Throws<ArgumentNullException>(() => JsonSerializer.Serialize(new object(), (Type)null));
         }
 
         [Fact]
         public static void VerifyTypeFail()
         {
-            Assert.Throws<ArgumentException>(() => JsonSerializer.ToString(1, typeof(string)));
+            Assert.Throws<ArgumentException>(() => JsonSerializer.Serialize(1, typeof(string)));
         }
 
         [Fact]
@@ -84,12 +84,12 @@ namespace System.Text.Json.Serialization.Tests
             byte[] encodedNull = Encoding.UTF8.GetBytes(@"null");
 
             {
-                byte[] output = JsonSerializer.ToUtf8Bytes(null, null);
+                byte[] output = JsonSerializer.SerializeToUtf8Bytes(null, null);
                 Assert.Equal(encodedNull, output);
             }
 
             {
-                byte[] output = JsonSerializer.ToUtf8Bytes(null, typeof(NullTests));
+                byte[] output = JsonSerializer.SerializeToUtf8Bytes(null, typeof(NullTests));
                 Assert.Equal(encodedNull, output);
             }
         }

--- a/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
@@ -14,8 +14,8 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static async void NullArgumentFail()
         {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.ReadAsync<string>((Stream)null));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.ReadAsync(new MemoryStream(), (Type)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.DeserializeAsync<string>((Stream)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.DeserializeAsync(new MemoryStream(), (Type)null));
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace System.Text.Json.Serialization.Tests
                     DefaultBufferSize = 1
                 };
 
-                SimpleTestClass obj = await JsonSerializer.ReadAsync<SimpleTestClass>(stream, options);
+                SimpleTestClass obj = await JsonSerializer.DeserializeAsync<SimpleTestClass>(stream, options);
                 obj.Verify();
             }
         }
@@ -45,7 +45,7 @@ namespace System.Text.Json.Serialization.Tests
                     ReadCommentHandling = JsonCommentHandling.Skip,
                 };
 
-                SimpleTestClass obj = await JsonSerializer.ReadAsync<SimpleTestClass>(stream, options);
+                SimpleTestClass obj = await JsonSerializer.DeserializeAsync<SimpleTestClass>(stream, options);
                 obj.Verify();
             }
         }
@@ -60,7 +60,7 @@ namespace System.Text.Json.Serialization.Tests
                     DefaultBufferSize = 1
                 };
 
-                int i = await JsonSerializer.ReadAsync<int>(stream, options);
+                int i = await JsonSerializer.DeserializeAsync<int>(stream, options);
                 Assert.Equal(1, i);
             }
         }
@@ -76,7 +76,7 @@ namespace System.Text.Json.Serialization.Tests
                     ReadCommentHandling = JsonCommentHandling.Skip,
                 };
 
-                int i = await JsonSerializer.ReadAsync<int>(stream, options);
+                int i = await JsonSerializer.DeserializeAsync<int>(stream, options);
                 Assert.Equal(1, i);
             }
         }
@@ -86,7 +86,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("null")))
             {
-                IList<object> referenceTypeCollection = await JsonSerializer.ReadAsync<IList<object>>(stream);
+                IList<object> referenceTypeCollection = await JsonSerializer.DeserializeAsync<IList<object>>(stream);
                 Assert.Null(referenceTypeCollection);
             }
         }
@@ -96,7 +96,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("null")))
             {
-                IList<int> valueTypeCollection = await JsonSerializer.ReadAsync<IList<int>>(stream);
+                IList<int> valueTypeCollection = await JsonSerializer.DeserializeAsync<IList<int>>(stream);
                 Assert.Null(valueTypeCollection);
             }
         }
@@ -124,7 +124,7 @@ namespace System.Text.Json.Serialization.Tests
             ulong value;
             using (Stream stream = new MemoryStream(utf8BomAndValueArray))
             {
-                value = await JsonSerializer.ReadAsync<ulong>(stream, options);
+                value = await JsonSerializer.DeserializeAsync<ulong>(stream, options);
             }
             Assert.Equal(expected, value);
         }
@@ -136,7 +136,7 @@ namespace System.Text.Json.Serialization.Tests
             using (Stream stream = new MemoryStream(utf8BomAndValueArray))
             {
                 await Assert.ThrowsAsync<JsonException>(
-                    async () => await JsonSerializer.ReadAsync<byte>(stream));
+                    async () => await JsonSerializer.DeserializeAsync<byte>(stream));
             }
         }
     }

--- a/src/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
@@ -14,21 +14,21 @@ namespace System.Text.Json.Serialization.Tests
         public async static Task VerifyValueFail()
         {
             MemoryStream stream = new MemoryStream();
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.WriteAsync(stream, "", (Type)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.SerializeAsync(stream, "", (Type)null));
         }
 
         [Fact]
         public async static Task VerifyTypeFail()
         {
             MemoryStream stream = new MemoryStream();
-            await Assert.ThrowsAsync<ArgumentException>(async () => await JsonSerializer.WriteAsync(stream, 1, typeof(string)));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await JsonSerializer.SerializeAsync(stream, 1, typeof(string)));
         }
 
         [Fact]
         public static async Task NullObjectValue()
         {
             MemoryStream stream = new MemoryStream();
-            await JsonSerializer.WriteAsync(stream, (object)null);
+            await JsonSerializer.SerializeAsync(stream, (object)null);
 
             stream.Seek(0, SeekOrigin.Begin);
 
@@ -77,17 +77,17 @@ namespace System.Text.Json.Serialization.Tests
             }
             json.Remove(json.Length - 1, 1).Append("}");
 
-            JsonElement root = JsonSerializer.Parse<JsonElement>(json.ToString());
+            JsonElement root = JsonSerializer.Deserialize<JsonElement>(json.ToString());
             var ms = new MemoryStream();
-            await JsonSerializer.WriteAsync(ms, root, root.GetType());
+            await JsonSerializer.SerializeAsync(ms, root, root.GetType());
         }
 
         [Fact]
         public static async Task RoundTripLargeJsonViaPocoAsync()
         {
-            byte[] array = JsonSerializer.Parse<byte[]>(JsonSerializer.ToString(new byte[11056]));
+            byte[] array = JsonSerializer.Deserialize<byte[]>(JsonSerializer.Serialize(new byte[11056]));
             var ms = new MemoryStream();
-            await JsonSerializer.WriteAsync(ms, array, array.GetType());
+            await JsonSerializer.SerializeAsync(ms, array, array.GetType());
         }
 
         private static async Task WriteAsync(TestStream stream)
@@ -103,7 +103,7 @@ namespace System.Text.Json.Serialization.Tests
                 obj.Initialize();
                 obj.Verify();
 
-                await JsonSerializer.WriteAsync(stream, obj, options: options);
+                await JsonSerializer.SerializeAsync(stream, obj, options: options);
             }
 
             // Must be changed if the test classes change:
@@ -124,7 +124,7 @@ namespace System.Text.Json.Serialization.Tests
                 DefaultBufferSize = 1
             };
 
-            LargeDataTestClass obj = await JsonSerializer.ReadAsync<LargeDataTestClass>(stream, options);
+            LargeDataTestClass obj = await JsonSerializer.DeserializeAsync<LargeDataTestClass>(stream, options);
             // Must be changed if the test classes change; may be > since last read may not have filled buffer.
             Assert.InRange(stream.TestRequestedReadBytesCount, 551368, int.MaxValue);
 
@@ -146,7 +146,7 @@ namespace System.Text.Json.Serialization.Tests
                 DefaultBufferSize = 1
             };
 
-            int i = await JsonSerializer.ReadAsync<int>(stream, options);
+            int i = await JsonSerializer.DeserializeAsync<int>(stream, options);
             Assert.Equal(1, i);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/TestClasses.cs
+++ b/src/System.Text.Json/tests/Serialization/TestClasses.cs
@@ -420,7 +420,7 @@ namespace System.Text.Json.Serialization.Tests
             {
                 if (data is JsonElement element)
                 {
-                    SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(element.GetRawText());
+                    SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(element.GetRawText());
                     obj.Verify();
                 }
                 else
@@ -469,7 +469,7 @@ namespace System.Text.Json.Serialization.Tests
             {
                 if (data is JsonElement element)
                 {
-                    SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(element.GetRawText());
+                    SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(element.GetRawText());
                     obj.Verify();
                 }
                 else
@@ -520,7 +520,7 @@ namespace System.Text.Json.Serialization.Tests
             {
                 if (data is JsonElement element)
                 {
-                    SimpleTestClass obj = JsonSerializer.Parse<SimpleTestClass>(element.GetRawText());
+                    SimpleTestClass obj = JsonSerializer.Deserialize<SimpleTestClass>(element.GetRawText());
                     obj.Verify();
                 }
                 else

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.GenericCollections.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadListOfList()
         {
-            List<List<int>> result = JsonSerializer.Parse<List<List<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            List<List<int>> result = JsonSerializer.Deserialize<List<List<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
 
             Assert.Equal(1, result[0][0]);
             Assert.Equal(2, result[0][1]);
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadListOfArray()
         {
-            List<int[]> result = JsonSerializer.Parse<List<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            List<int[]> result = JsonSerializer.Deserialize<List<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
 
             Assert.Equal(1, result[0][0]);
             Assert.Equal(2, result[0][1]);
@@ -35,7 +35,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfList()
         {
-            List<int>[] result = JsonSerializer.Parse<List<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            List<int>[] result = JsonSerializer.Deserialize<List<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
 
             Assert.Equal(1, result[0][0]);
             Assert.Equal(2, result[0][1]);
@@ -46,18 +46,18 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveList()
         {
-            List<int> i = JsonSerializer.Parse<List<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            List<int> i = JsonSerializer.Deserialize<List<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             Assert.Equal(1, i[0]);
             Assert.Equal(2, i[1]);
 
-            i = JsonSerializer.Parse<List<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            i = JsonSerializer.Deserialize<List<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, i.Count);
         }
 
         [Fact]
         public static void ReadIEnumerableTOfIEnumerableT()
         {
-            IEnumerable<IEnumerable<int>> result = JsonSerializer.Parse<IEnumerable<IEnumerable<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IEnumerable<IEnumerable<int>> result = JsonSerializer.Deserialize<IEnumerable<IEnumerable<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IEnumerable<int> ie in result)
@@ -72,7 +72,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadIEnumerableTOfArray()
         {
-            IEnumerable<int[]> result = JsonSerializer.Parse<IEnumerable<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IEnumerable<int[]> result = JsonSerializer.Deserialize<IEnumerable<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -87,7 +87,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIEnumerableT()
         {
-            IEnumerable<int>[] result = JsonSerializer.Parse<IEnumerable<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IEnumerable<int>[] result = JsonSerializer.Deserialize<IEnumerable<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IEnumerable<int> arr in result)
@@ -102,7 +102,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveIEnumerableT()
         {
-            IEnumerable<int> result = JsonSerializer.Parse<IEnumerable<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            IEnumerable<int> result = JsonSerializer.Deserialize<IEnumerable<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -110,14 +110,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<IEnumerable<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<IEnumerable<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadIListTOfIListT()
         {
-            IList<IList<int>> result = JsonSerializer.Parse<IList<IList<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IList<IList<int>> result = JsonSerializer.Deserialize<IList<IList<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IList<int> ie in result)
@@ -132,7 +132,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadIListTOfArray()
         {
-            IList<int[]> result = JsonSerializer.Parse<IList<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IList<int[]> result = JsonSerializer.Deserialize<IList<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -147,7 +147,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIListT()
         {
-            IList<int>[] result = JsonSerializer.Parse<IList<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IList<int>[] result = JsonSerializer.Deserialize<IList<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IList<int> arr in result)
@@ -162,7 +162,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveIListT()
         {
-            IList<int> result = JsonSerializer.Parse<IList<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            IList<int> result = JsonSerializer.Deserialize<IList<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -170,14 +170,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<IList<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<IList<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadICollectionTOfICollectionT()
         {
-            ICollection<ICollection<int>> result = JsonSerializer.Parse<ICollection<ICollection<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ICollection<ICollection<int>> result = JsonSerializer.Deserialize<ICollection<ICollection<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (ICollection<int> ie in result)
@@ -192,7 +192,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadICollectionTOfArray()
         {
-            ICollection<int[]> result = JsonSerializer.Parse<ICollection<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ICollection<int[]> result = JsonSerializer.Deserialize<ICollection<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -207,7 +207,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfICollectionT()
         {
-            ICollection<int>[] result = JsonSerializer.Parse<ICollection<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ICollection<int>[] result = JsonSerializer.Deserialize<ICollection<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (ICollection<int> arr in result)
@@ -222,7 +222,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveICollectionT()
         {
-            ICollection<int> result = JsonSerializer.Parse<ICollection<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            ICollection<int> result = JsonSerializer.Deserialize<ICollection<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -230,14 +230,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<ICollection<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<ICollection<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadIReadOnlyCollectionTOfIReadOnlyCollectionT()
         {
-            IReadOnlyCollection<IReadOnlyCollection<int>> result = JsonSerializer.Parse<IReadOnlyCollection<IReadOnlyCollection<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IReadOnlyCollection<IReadOnlyCollection<int>> result = JsonSerializer.Deserialize<IReadOnlyCollection<IReadOnlyCollection<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IReadOnlyCollection<int> ie in result)
@@ -252,7 +252,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadIReadOnlyCollectionTOfArray()
         {
-            IReadOnlyCollection<int[]> result = JsonSerializer.Parse<IReadOnlyCollection<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IReadOnlyCollection<int[]> result = JsonSerializer.Deserialize<IReadOnlyCollection<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -267,7 +267,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIReadOnlyCollectionT()
         {
-            IReadOnlyCollection<int>[] result = JsonSerializer.Parse<IReadOnlyCollection<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IReadOnlyCollection<int>[] result = JsonSerializer.Deserialize<IReadOnlyCollection<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IReadOnlyCollection<int> arr in result)
@@ -282,7 +282,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveIReadOnlyCollectionT()
         {
-            IReadOnlyCollection<int> result = JsonSerializer.Parse<IReadOnlyCollection<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            IReadOnlyCollection<int> result = JsonSerializer.Deserialize<IReadOnlyCollection<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -290,14 +290,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<IReadOnlyCollection<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<IReadOnlyCollection<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadIReadOnlyListTOfIReadOnlyListT()
         {
-            IReadOnlyList<IReadOnlyList<int>> result = JsonSerializer.Parse<IReadOnlyList<IReadOnlyList<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IReadOnlyList<IReadOnlyList<int>> result = JsonSerializer.Deserialize<IReadOnlyList<IReadOnlyList<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IReadOnlyList<int> ie in result)
@@ -312,7 +312,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadIReadOnlyListTOfArray()
         {
-            IReadOnlyList<int[]> result = JsonSerializer.Parse<IReadOnlyList<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IReadOnlyList<int[]> result = JsonSerializer.Deserialize<IReadOnlyList<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -327,7 +327,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIReadOnlyListT()
         {
-            IReadOnlyList<int>[] result = JsonSerializer.Parse<IReadOnlyList<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IReadOnlyList<int>[] result = JsonSerializer.Deserialize<IReadOnlyList<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IReadOnlyList<int> arr in result)
@@ -342,7 +342,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveIReadOnlyListT()
         {
-            IReadOnlyList<int> result = JsonSerializer.Parse<IReadOnlyList<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            IReadOnlyList<int> result = JsonSerializer.Deserialize<IReadOnlyList<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -350,14 +350,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<IReadOnlyList<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<IReadOnlyList<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadISetTOfISetT_Throws()
         {
-            ISet<ISet<int>> result = JsonSerializer.Parse<ISet<ISet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ISet<ISet<int>> result = JsonSerializer.Deserialize<ISet<ISet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
 
             if (result.First().Contains(1))
             {
@@ -374,7 +374,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadISetTOfHashSetT()
         {
-            ISet<HashSet<int>> result = JsonSerializer.Parse<ISet<HashSet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ISet<HashSet<int>> result = JsonSerializer.Deserialize<ISet<HashSet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
 
             if (result.First().Contains(1))
             {
@@ -391,7 +391,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadHashSetTOfISetT()
         {
-            HashSet<ISet<int>> result = JsonSerializer.Parse<HashSet<ISet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            HashSet<ISet<int>> result = JsonSerializer.Deserialize<HashSet<ISet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
 
             if (result.First().Contains(1))
             {
@@ -408,7 +408,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadISetTOfArray()
         {
-            ISet<int[]> result = JsonSerializer.Parse<ISet<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ISet<int[]> result = JsonSerializer.Deserialize<ISet<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
 
             if (result.First().Contains(1))
             {
@@ -425,7 +425,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfISetT()
         {
-            ISet<int>[] result = JsonSerializer.Parse<ISet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ISet<int>[] result = JsonSerializer.Deserialize<ISet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
 
             Assert.Equal(new HashSet<int> { 1, 2 }, result.First());
             Assert.Equal(new HashSet<int> { 3, 4 }, result.Last());
@@ -434,18 +434,18 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveISetT()
         {
-            ISet<int> result = JsonSerializer.Parse<ISet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            ISet<int> result = JsonSerializer.Deserialize<ISet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
 
             Assert.Equal(new HashSet<int> { 1, 2 }, result);
 
-            result = JsonSerializer.Parse<ISet<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<ISet<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void StackTOfStackT()
         {
-            Stack<Stack<int>> result = JsonSerializer.Parse<Stack<Stack<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Stack<Stack<int>> result = JsonSerializer.Deserialize<Stack<Stack<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 4;
 
             foreach (Stack<int> st in result)
@@ -460,7 +460,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadStackTOfArray()
         {
-            Stack<int[]> result = JsonSerializer.Parse<Stack<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Stack<int[]> result = JsonSerializer.Deserialize<Stack<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 3;
 
             foreach (int[] arr in result)
@@ -477,7 +477,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfStackT()
         {
-            Stack<int>[] result = JsonSerializer.Parse<Stack<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Stack<int>[] result = JsonSerializer.Deserialize<Stack<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 2;
 
             foreach (Stack<int> st in result)
@@ -494,7 +494,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveStackT()
         {
-            Stack<int> result = JsonSerializer.Parse<Stack<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            Stack<int> result = JsonSerializer.Deserialize<Stack<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 2;
 
             foreach (int i in result)
@@ -502,14 +502,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected--, i);
             }
 
-            result = JsonSerializer.Parse<Stack<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<Stack<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadQueueTOfQueueT()
         {
-            Queue<Queue<int>> result = JsonSerializer.Parse<Queue<Queue<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Queue<Queue<int>> result = JsonSerializer.Deserialize<Queue<Queue<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (Queue<int> q in result)
@@ -524,7 +524,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadQueueTOfArray()
         {
-            Queue<int[]> result = JsonSerializer.Parse<Queue<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Queue<int[]> result = JsonSerializer.Deserialize<Queue<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -539,7 +539,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIQueueT()
         {
-            Queue<int>[] result = JsonSerializer.Parse<Queue<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Queue<int>[] result = JsonSerializer.Deserialize<Queue<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (Queue<int> q in result)
@@ -554,14 +554,14 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveQueueT()
         {
-            Queue<int> result = JsonSerializer.Parse<Queue<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            Queue<int> result = JsonSerializer.Deserialize<Queue<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
             {
                 Assert.Equal(expected++, i);
             }
-            result = JsonSerializer.Parse<Queue<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<Queue<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
 
         }
@@ -569,7 +569,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadHashSetTOfHashSetT()
         {
-            HashSet<HashSet<int>> result = JsonSerializer.Parse<HashSet<HashSet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            HashSet<HashSet<int>> result = JsonSerializer.Deserialize<HashSet<HashSet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (HashSet<int> hs in result)
@@ -584,7 +584,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadHashSetTOfArray()
         {
-            HashSet<int[]> result = JsonSerializer.Parse<HashSet<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            HashSet<int[]> result = JsonSerializer.Deserialize<HashSet<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -599,7 +599,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIHashSetT()
         {
-            HashSet<int>[] result = JsonSerializer.Parse<HashSet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            HashSet<int>[] result = JsonSerializer.Deserialize<HashSet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (HashSet<int> hs in result)
@@ -614,7 +614,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveHashSetT()
         {
-            HashSet<int> result = JsonSerializer.Parse<HashSet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            HashSet<int> result = JsonSerializer.Deserialize<HashSet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -622,14 +622,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<HashSet<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<HashSet<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadLinkedListTOfLinkedListT()
         {
-            LinkedList<LinkedList<int>> result = JsonSerializer.Parse<LinkedList<LinkedList<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            LinkedList<LinkedList<int>> result = JsonSerializer.Deserialize<LinkedList<LinkedList<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (LinkedList<int> l in result)
@@ -644,7 +644,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadLinkedListTOfArray()
         {
-            LinkedList<int[]> result = JsonSerializer.Parse<LinkedList<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            LinkedList<int[]> result = JsonSerializer.Deserialize<LinkedList<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -659,7 +659,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfILinkedListT()
         {
-            LinkedList<int>[] result = JsonSerializer.Parse<LinkedList<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            LinkedList<int>[] result = JsonSerializer.Deserialize<LinkedList<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (LinkedList<int> l in result)
@@ -674,7 +674,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveLinkedListT()
         {
-            LinkedList<int> result = JsonSerializer.Parse<LinkedList<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            LinkedList<int> result = JsonSerializer.Deserialize<LinkedList<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -682,14 +682,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<LinkedList<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<LinkedList<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadArrayOfISortedSetT()
         {
-            SortedSet<int>[] result = JsonSerializer.Parse<SortedSet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            SortedSet<int>[] result = JsonSerializer.Deserialize<SortedSet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (SortedSet<int> s in result)
@@ -704,7 +704,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveSortedSetT()
         {
-            SortedSet<int> result = JsonSerializer.Parse<SortedSet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            SortedSet<int> result = JsonSerializer.Deserialize<SortedSet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -712,7 +712,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<SortedSet<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<SortedSet<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
@@ -720,18 +720,18 @@ namespace System.Text.Json.Serialization.Tests
         public static void ReadPrimitiveKeyValuePairFail()
         {
             // Invalid form: no Value
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<KeyValuePair<string, int>>(@"{""Key"": 123}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<KeyValuePair<string, int>>(@"{""Key"": 123}"));
 
             // Invalid form: extra property
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<KeyValuePair<string, int>>(@"{""Key"": ""Key"", ""Value"": 123, ""Value2"": 456}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<KeyValuePair<string, int>>(@"{""Key"": ""Key"", ""Value"": 123, ""Value2"": 456}"));
 
             // Invalid form: does not contain both Key and Value properties
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<KeyValuePair<string, int>>(@"{""Key"": ""Key"", ""Val"": 123"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<KeyValuePair<string, int>>(@"{""Key"": ""Key"", ""Val"": 123"));
         }
 
         public static void ReadListOfKeyValuePair()
         {
-            List<KeyValuePair<string, int>> input = JsonSerializer.Parse<List<KeyValuePair<string, int>>>(@"""Key"":""Key"", ""Value"":[{""123"":123},{""456"": 456}]");
+            List<KeyValuePair<string, int>> input = JsonSerializer.Deserialize<List<KeyValuePair<string, int>>>(@"""Key"":""Key"", ""Value"":[{""123"":123},{""456"": 456}]");
 
             Assert.Equal(2, input.Count);
             Assert.Equal("123", input[0].Key);
@@ -742,7 +742,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public static void ReadKeyValuePairOfList()
         {
-            KeyValuePair<string, List<int>> input = JsonSerializer.Parse<KeyValuePair<string, List<int>>>(@"{""Key"":""Key"", Value:[1, 2, 3]}");
+            KeyValuePair<string, List<int>> input = JsonSerializer.Deserialize<KeyValuePair<string, List<int>>>(@"{""Key"":""Key"", Value:[1, 2, 3]}");
 
             Assert.Equal("Key", input.Key);
             Assert.Equal(3, input.Value.Count);
@@ -754,7 +754,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadKeyValuePairOfKeyValuePair()
         {
-            KeyValuePair<string, KeyValuePair<int, int>> input = JsonSerializer.Parse<KeyValuePair<string, KeyValuePair<int, int>>>(@"{""Key"":""Key"", ""Value"":{""Key"":1, ""Value"":2}}");
+            KeyValuePair<string, KeyValuePair<int, int>> input = JsonSerializer.Deserialize<KeyValuePair<string, KeyValuePair<int, int>>>(@"{""Key"":""Key"", ""Value"":{""Key"":1, ""Value"":2}}");
 
             Assert.Equal("Key", input.Key);
             Assert.Equal(1, input.Value.Key);
@@ -768,7 +768,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(@"{""Value"":{""Value"":2, ""Key"":1}, ""Key"":""Key""}")]
         public static void ReadKeyValuePairOfKeyValuePair(string json)
         {
-            KeyValuePair<string, KeyValuePair<int, int>> input = JsonSerializer.Parse<KeyValuePair<string, KeyValuePair<int, int>>>(json);
+            KeyValuePair<string, KeyValuePair<int, int>> input = JsonSerializer.Deserialize<KeyValuePair<string, KeyValuePair<int, int>>>(json);
 
             Assert.Equal("Key", input.Key);
             Assert.Equal(1, input.Value.Key);

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.ImmutableCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.ImmutableCollections.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadIImmutableListTOfIImmutableListT()
         {
-            IImmutableList<IImmutableList<int>> result = JsonSerializer.Parse<IImmutableList<IImmutableList<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableList<IImmutableList<int>> result = JsonSerializer.Deserialize<IImmutableList<IImmutableList<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IImmutableList<int> l in result)
@@ -29,7 +29,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadIImmutableListTOfArray()
         {
-            IImmutableList<int[]> result = JsonSerializer.Parse<IImmutableList<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableList<int[]> result = JsonSerializer.Deserialize<IImmutableList<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -44,7 +44,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIIImmutableListT()
         {
-            IImmutableList<int>[] result = JsonSerializer.Parse<IImmutableList<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableList<int>[] result = JsonSerializer.Deserialize<IImmutableList<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IImmutableList<int> l in result)
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveIImmutableListT()
         {
-            IImmutableList<int> result = JsonSerializer.Parse<IImmutableList<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            IImmutableList<int> result = JsonSerializer.Deserialize<IImmutableList<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -67,14 +67,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<IImmutableList<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<IImmutableList<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadIImmutableStackTOfIImmutableStackT()
         {
-            IImmutableStack<IImmutableStack<int>> result = JsonSerializer.Parse<IImmutableStack<IImmutableStack<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableStack<IImmutableStack<int>> result = JsonSerializer.Deserialize<IImmutableStack<IImmutableStack<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 4;
 
             foreach (IImmutableStack<int> l in result)
@@ -89,7 +89,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadIImmutableStackTOfArray()
         {
-            IImmutableStack<int[]> result = JsonSerializer.Parse<IImmutableStack<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableStack<int[]> result = JsonSerializer.Deserialize<IImmutableStack<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 3;
 
             foreach (int[] arr in result)
@@ -106,7 +106,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIIImmutableStackT()
         {
-            IImmutableStack<int>[] result = JsonSerializer.Parse<IImmutableStack<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableStack<int>[] result = JsonSerializer.Deserialize<IImmutableStack<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 2;
 
             foreach (IImmutableStack<int> l in result)
@@ -123,7 +123,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveIImmutableStackT()
         {
-            IImmutableStack<int> result = JsonSerializer.Parse<IImmutableStack<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            IImmutableStack<int> result = JsonSerializer.Deserialize<IImmutableStack<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 2;
 
             foreach (int i in result)
@@ -131,14 +131,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected--, i);
             }
 
-            result = JsonSerializer.Parse<IImmutableStack<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<IImmutableStack<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadIImmutableQueueTOfIImmutableQueueT()
         {
-            IImmutableQueue<IImmutableQueue<int>> result = JsonSerializer.Parse<IImmutableQueue<IImmutableQueue<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableQueue<IImmutableQueue<int>> result = JsonSerializer.Deserialize<IImmutableQueue<IImmutableQueue<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IImmutableQueue<int> l in result)
@@ -153,7 +153,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadIImmutableQueueTOfArray()
         {
-            IImmutableQueue<int[]> result = JsonSerializer.Parse<IImmutableQueue<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableQueue<int[]> result = JsonSerializer.Deserialize<IImmutableQueue<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -168,7 +168,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIIImmutableQueueT()
         {
-            IImmutableQueue<int>[] result = JsonSerializer.Parse<IImmutableQueue<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableQueue<int>[] result = JsonSerializer.Deserialize<IImmutableQueue<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IImmutableQueue<int> l in result)
@@ -183,7 +183,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveIImmutableQueueT()
         {
-            IImmutableQueue<int> result = JsonSerializer.Parse<IImmutableQueue<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            IImmutableQueue<int> result = JsonSerializer.Deserialize<IImmutableQueue<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -191,14 +191,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<IImmutableQueue<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<IImmutableQueue<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadIImmutableSetTOfIImmutableSetT()
         {
-            IImmutableSet<IImmutableSet<int>> result = JsonSerializer.Parse<IImmutableSet<IImmutableSet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableSet<IImmutableSet<int>> result = JsonSerializer.Deserialize<IImmutableSet<IImmutableSet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             List<int> expected = new List<int> { 1, 2, 3, 4 };
 
             foreach (IImmutableSet<int> l in result)
@@ -215,7 +215,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadIImmutableSetTOfArray()
         {
-            IImmutableSet<int[]> result = JsonSerializer.Parse<IImmutableSet<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableSet<int[]> result = JsonSerializer.Deserialize<IImmutableSet<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             List<int> expected = new List<int> { 1, 2, 3, 4 };
 
             foreach (int[] arr in result)
@@ -232,7 +232,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIIImmutableSetT()
         {
-            IImmutableSet<int>[] result = JsonSerializer.Parse<IImmutableSet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IImmutableSet<int>[] result = JsonSerializer.Deserialize<IImmutableSet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             List<int> expected = new List<int> { 1, 2, 3, 4 };
 
             foreach (IImmutableSet<int> l in result)
@@ -249,7 +249,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveIImmutableSetT()
         {
-            IImmutableSet<int> result = JsonSerializer.Parse<IImmutableSet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            IImmutableSet<int> result = JsonSerializer.Deserialize<IImmutableSet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             List<int> expected = new List<int> { 1, 2 };
 
             foreach (int i in result)
@@ -259,14 +259,14 @@ namespace System.Text.Json.Serialization.Tests
 
             Assert.Equal(0, expected.Count);
 
-            result = JsonSerializer.Parse<IImmutableSet<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<IImmutableSet<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadImmutableHashSetTOfImmutableHashSetT()
         {
-            ImmutableHashSet<ImmutableHashSet<int>> result = JsonSerializer.Parse<ImmutableHashSet<ImmutableHashSet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableHashSet<ImmutableHashSet<int>> result = JsonSerializer.Deserialize<ImmutableHashSet<ImmutableHashSet<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             List<int> expected = new List<int> { 1, 2, 3, 4 };
 
             foreach (ImmutableHashSet<int> l in result)
@@ -283,7 +283,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadImmutableHashSetTOfArray()
         {
-            ImmutableHashSet<int[]> result = JsonSerializer.Parse<ImmutableHashSet<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableHashSet<int[]> result = JsonSerializer.Deserialize<ImmutableHashSet<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             List<int> expected = new List<int> { 1, 2, 3, 4 };
 
             foreach (int[] arr in result)
@@ -300,7 +300,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIImmutableHashSetT()
         {
-            ImmutableHashSet<int>[] result = JsonSerializer.Parse<ImmutableHashSet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableHashSet<int>[] result = JsonSerializer.Deserialize<ImmutableHashSet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             List<int> expected = new List<int> { 1, 2, 3, 4 };
 
             foreach (ImmutableHashSet<int> l in result)
@@ -317,7 +317,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveImmutableHashSetT()
         {
-            ImmutableHashSet<int> result = JsonSerializer.Parse<ImmutableHashSet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            ImmutableHashSet<int> result = JsonSerializer.Deserialize<ImmutableHashSet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             List<int> expected = new List<int> { 1, 2 };
 
             foreach (int i in result)
@@ -327,14 +327,14 @@ namespace System.Text.Json.Serialization.Tests
 
             Assert.Equal(0, expected.Count);
 
-            result = JsonSerializer.Parse<ImmutableHashSet<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<ImmutableHashSet<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadImmutableListTOfImmutableListT()
         {
-            ImmutableList<ImmutableList<int>> result = JsonSerializer.Parse<ImmutableList<ImmutableList<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableList<ImmutableList<int>> result = JsonSerializer.Deserialize<ImmutableList<ImmutableList<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (ImmutableList<int> l in result)
@@ -349,7 +349,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadImmutableListTOfArray()
         {
-            ImmutableList<int[]> result = JsonSerializer.Parse<ImmutableList<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableList<int[]> result = JsonSerializer.Deserialize<ImmutableList<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -364,7 +364,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIImmutableListT()
         {
-            ImmutableList<int>[] result = JsonSerializer.Parse<ImmutableList<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableList<int>[] result = JsonSerializer.Deserialize<ImmutableList<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (ImmutableList<int> l in result)
@@ -379,7 +379,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveImmutableListT()
         {
-            ImmutableList<int> result = JsonSerializer.Parse<ImmutableList<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            ImmutableList<int> result = JsonSerializer.Deserialize<ImmutableList<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -387,14 +387,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<ImmutableList<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<ImmutableList<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadImmutableStackTOfImmutableStackT()
         {
-            ImmutableStack<ImmutableStack<int>> result = JsonSerializer.Parse<ImmutableStack<ImmutableStack<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableStack<ImmutableStack<int>> result = JsonSerializer.Deserialize<ImmutableStack<ImmutableStack<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 4;
 
             foreach (ImmutableStack<int> l in result)
@@ -409,7 +409,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadImmutableStackTOfArray()
         {
-            ImmutableStack<int[]> result = JsonSerializer.Parse<ImmutableStack<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableStack<int[]> result = JsonSerializer.Deserialize<ImmutableStack<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 3;
 
             foreach (int[] arr in result)
@@ -426,7 +426,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIImmutableStackT()
         {
-            ImmutableStack<int>[] result = JsonSerializer.Parse<ImmutableStack<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableStack<int>[] result = JsonSerializer.Deserialize<ImmutableStack<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 2;
 
             foreach (ImmutableStack<int> l in result)
@@ -443,7 +443,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveImmutableStackT()
         {
-            ImmutableStack<int> result = JsonSerializer.Parse<ImmutableStack<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            ImmutableStack<int> result = JsonSerializer.Deserialize<ImmutableStack<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 2;
 
             foreach (int i in result)
@@ -451,14 +451,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected--, i);
             }
 
-            result = JsonSerializer.Parse<ImmutableStack<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<ImmutableStack<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadImmutableQueueTOfImmutableQueueT()
         {
-            ImmutableQueue<ImmutableQueue<int>> result = JsonSerializer.Parse<ImmutableQueue<ImmutableQueue<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableQueue<ImmutableQueue<int>> result = JsonSerializer.Deserialize<ImmutableQueue<ImmutableQueue<int>>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (ImmutableQueue<int> l in result)
@@ -473,7 +473,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadImmutableQueueTOfArray()
         {
-            ImmutableQueue<int[]> result = JsonSerializer.Parse<ImmutableQueue<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableQueue<int[]> result = JsonSerializer.Deserialize<ImmutableQueue<int[]>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (int[] arr in result)
@@ -488,7 +488,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIImmutableQueueT()
         {
-            ImmutableQueue<int>[] result = JsonSerializer.Parse<ImmutableQueue<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableQueue<int>[] result = JsonSerializer.Deserialize<ImmutableQueue<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (ImmutableQueue<int> l in result)
@@ -503,7 +503,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveImmutableQueueT()
         {
-            ImmutableQueue<int> result = JsonSerializer.Parse<ImmutableQueue<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            ImmutableQueue<int> result = JsonSerializer.Deserialize<ImmutableQueue<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -511,14 +511,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<ImmutableQueue<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<ImmutableQueue<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadArrayOfIImmutableSortedSetT()
         {
-            ImmutableSortedSet<int>[] result = JsonSerializer.Parse<ImmutableSortedSet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ImmutableSortedSet<int>[] result = JsonSerializer.Deserialize<ImmutableSortedSet<int>[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (ImmutableSortedSet<int> l in result)
@@ -533,7 +533,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveImmutableSortedSetT()
         {
-            ImmutableSortedSet<int> result = JsonSerializer.Parse<ImmutableSortedSet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            ImmutableSortedSet<int> result = JsonSerializer.Deserialize<ImmutableSortedSet<int>>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (int i in result)
@@ -541,14 +541,14 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i);
             }
 
-            result = JsonSerializer.Parse<ImmutableSortedSet<int>>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<ImmutableSortedSet<int>>(Encoding.UTF8.GetBytes(@"[]"));
             Assert.Equal(0, result.Count());
         }
 
         [Fact]
         public static void ReadPrimitiveImmutableArrayThrows()
         {
-            Assert.Throws<NotSupportedException>(() => JsonSerializer.Parse<ImmutableArray<int>>(Encoding.UTF8.GetBytes(@"[1,2]")));
+            Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<ImmutableArray<int>>(Encoding.UTF8.GetBytes(@"[1,2]")));
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.NonGenericCollections.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization.Tests
     {
         public static void ReadGenericIEnumerableOfIEnumerable()
         {
-            IEnumerable<IEnumerable> result = JsonSerializer.Parse<IEnumerable<IEnumerable>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IEnumerable<IEnumerable> result = JsonSerializer.Deserialize<IEnumerable<IEnumerable>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IEnumerable ie in result)
@@ -28,7 +28,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadIEnumerableOfArray()
         {
-            IEnumerable result = JsonSerializer.Parse<IEnumerable>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IEnumerable result = JsonSerializer.Deserialize<IEnumerable>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (JsonElement arr in result)
@@ -43,7 +43,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIEnumerable()
         {
-            IEnumerable[] result = JsonSerializer.Parse<IEnumerable[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IEnumerable[] result = JsonSerializer.Deserialize<IEnumerable[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IEnumerable arr in result)
@@ -58,7 +58,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveIEnumerable()
         {
-            IEnumerable result = JsonSerializer.Parse<IEnumerable>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            IEnumerable result = JsonSerializer.Deserialize<IEnumerable>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (JsonElement i in result)
@@ -66,7 +66,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i.GetInt32());
             }
 
-            result = JsonSerializer.Parse<IEnumerable>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<IEnumerable>(Encoding.UTF8.GetBytes(@"[]"));
 
             int count = 0;
             IEnumerator e = result.GetEnumerator();
@@ -79,7 +79,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public static void ReadGenericIListOfIList()
         {
-            IList<IList> result = JsonSerializer.Parse<IList<IList>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IList<IList> result = JsonSerializer.Deserialize<IList<IList>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IList list in result)
@@ -94,7 +94,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadIListOfArray()
         {
-            IList result = JsonSerializer.Parse<IList>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IList result = JsonSerializer.Deserialize<IList>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (JsonElement arr in result)
@@ -109,7 +109,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfIList()
         {
-            IList[] result = JsonSerializer.Parse<IList[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            IList[] result = JsonSerializer.Deserialize<IList[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (IList arr in result)
@@ -124,7 +124,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveIList()
         {
-            IList result = JsonSerializer.Parse<IList>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            IList result = JsonSerializer.Deserialize<IList>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (JsonElement i in result)
@@ -132,7 +132,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i.GetInt32());
             }
 
-            result = JsonSerializer.Parse<IList>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<IList>(Encoding.UTF8.GetBytes(@"[]"));
 
             int count = 0;
             IEnumerator e = result.GetEnumerator();
@@ -145,7 +145,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public static void ReadGenericICollectionOfICollection()
         {
-            ICollection<ICollection> result = JsonSerializer.Parse<ICollection<ICollection>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ICollection<ICollection> result = JsonSerializer.Deserialize<ICollection<ICollection>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (ICollection ie in result)
@@ -160,7 +160,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadICollectionOfArray()
         {
-            ICollection result = JsonSerializer.Parse<ICollection>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ICollection result = JsonSerializer.Deserialize<ICollection>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (JsonElement arr in result)
@@ -175,7 +175,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfICollection()
         {
-            ICollection[] result = JsonSerializer.Parse<ICollection[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ICollection[] result = JsonSerializer.Deserialize<ICollection[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (ICollection arr in result)
@@ -190,7 +190,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveICollection()
         {
-            ICollection result = JsonSerializer.Parse<ICollection>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            ICollection result = JsonSerializer.Deserialize<ICollection>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (JsonElement i in result)
@@ -198,7 +198,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i.GetInt32());
             }
 
-            result = JsonSerializer.Parse<ICollection>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<ICollection>(Encoding.UTF8.GetBytes(@"[]"));
 
             int count = 0;
             IEnumerator e = result.GetEnumerator();
@@ -211,7 +211,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public static void ReadGenericStackOfStack()
         {
-            Stack<Stack> result = JsonSerializer.Parse<Stack<Stack>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Stack<Stack> result = JsonSerializer.Deserialize<Stack<Stack>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 4;
 
             foreach (Stack stack in result)
@@ -226,7 +226,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadStackOfArray()
         {
-            Stack result = JsonSerializer.Parse<Stack>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Stack result = JsonSerializer.Deserialize<Stack>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 3;
 
             foreach (JsonElement arr in result)
@@ -242,7 +242,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfStack()
         {
-            Stack[] result = JsonSerializer.Parse<Stack[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Stack[] result = JsonSerializer.Deserialize<Stack[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 2;
 
             foreach (Stack arr in result)
@@ -258,7 +258,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveStack()
         {
-            Stack result = JsonSerializer.Parse<Stack>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            Stack result = JsonSerializer.Deserialize<Stack>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 2;
 
             foreach (JsonElement i in result)
@@ -266,7 +266,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected--, i.GetInt32());
             }
 
-            result = JsonSerializer.Parse<Stack>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<Stack>(Encoding.UTF8.GetBytes(@"[]"));
 
             int count = 0;
             IEnumerator e = result.GetEnumerator();
@@ -279,7 +279,7 @@ namespace System.Text.Json.Serialization.Tests
 
         public static void ReadGenericQueueOfQueue()
         {
-            Queue<Queue> result = JsonSerializer.Parse<Queue<Queue>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Queue<Queue> result = JsonSerializer.Deserialize<Queue<Queue>>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (Queue ie in result)
@@ -294,7 +294,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadQueueOfArray()
         {
-            Queue result = JsonSerializer.Parse<Queue>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Queue result = JsonSerializer.Deserialize<Queue>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (JsonElement arr in result)
@@ -309,7 +309,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfQueue()
         {
-            Queue[] result = JsonSerializer.Parse<Queue[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            Queue[] result = JsonSerializer.Deserialize<Queue[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (Queue arr in result)
@@ -324,7 +324,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveQueue()
         {
-            Queue result = JsonSerializer.Parse<Queue>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            Queue result = JsonSerializer.Deserialize<Queue>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (JsonElement i in result)
@@ -332,7 +332,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i.GetInt32());
             }
 
-            result = JsonSerializer.Parse<Queue>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<Queue>(Encoding.UTF8.GetBytes(@"[]"));
 
             int count = 0;
             IEnumerator e = result.GetEnumerator();
@@ -346,7 +346,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayListOfArray()
         {
-            ArrayList result = JsonSerializer.Parse<ArrayList>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ArrayList result = JsonSerializer.Deserialize<ArrayList>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (JsonElement arr in result)
@@ -361,7 +361,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadArrayOfArrayList()
         {
-            ArrayList[] result = JsonSerializer.Parse<ArrayList[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
+            ArrayList[] result = JsonSerializer.Deserialize<ArrayList[]>(Encoding.UTF8.GetBytes(@"[[1,2],[3,4]]"));
             int expected = 1;
 
             foreach (ArrayList arr in result)
@@ -376,7 +376,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitiveArrayList()
         {
-            ArrayList result = JsonSerializer.Parse<ArrayList>(Encoding.UTF8.GetBytes(@"[1,2]"));
+            ArrayList result = JsonSerializer.Deserialize<ArrayList>(Encoding.UTF8.GetBytes(@"[1,2]"));
             int expected = 1;
 
             foreach (JsonElement i in result)
@@ -384,7 +384,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(expected++, i.GetInt32());
             }
 
-            result = JsonSerializer.Parse<ArrayList>(Encoding.UTF8.GetBytes(@"[]"));
+            result = JsonSerializer.Deserialize<ArrayList>(Encoding.UTF8.GetBytes(@"[]"));
 
             int count = 0;
             IEnumerator e = result.GetEnumerator();

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -12,69 +12,69 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ReadPrimitives()
         {
-            int i = JsonSerializer.Parse<int>(Encoding.UTF8.GetBytes(@"1"));
+            int i = JsonSerializer.Deserialize<int>(Encoding.UTF8.GetBytes(@"1"));
             Assert.Equal(1, i);
 
-            int i2 = JsonSerializer.Parse<int>("2");
+            int i2 = JsonSerializer.Deserialize<int>("2");
             Assert.Equal(2, i2);
 
-            int? i3 = JsonSerializer.Parse<int?>("null");
+            int? i3 = JsonSerializer.Deserialize<int?>("null");
             Assert.Null(i3);
 
-            long l = JsonSerializer.Parse<long>(Encoding.UTF8.GetBytes(long.MaxValue.ToString()));
+            long l = JsonSerializer.Deserialize<long>(Encoding.UTF8.GetBytes(long.MaxValue.ToString()));
             Assert.Equal(long.MaxValue, l);
 
-            long l2 = JsonSerializer.Parse<long>(long.MaxValue.ToString());
+            long l2 = JsonSerializer.Deserialize<long>(long.MaxValue.ToString());
             Assert.Equal(long.MaxValue, l2);
 
-            string s = JsonSerializer.Parse<string>(Encoding.UTF8.GetBytes(@"""Hello"""));
+            string s = JsonSerializer.Deserialize<string>(Encoding.UTF8.GetBytes(@"""Hello"""));
             Assert.Equal("Hello", s);
 
-            string s2 = JsonSerializer.Parse<string>(@"""Hello""");
+            string s2 = JsonSerializer.Deserialize<string>(@"""Hello""");
             Assert.Equal("Hello", s2);
 
-            Uri u = JsonSerializer.Parse<Uri>(@"""""");
+            Uri u = JsonSerializer.Deserialize<Uri>(@"""""");
             Assert.Equal("", u.OriginalString);
         }
 
         [Fact]
         public static void ReadPrimitivesWithWhitespace()
         {
-            int i = JsonSerializer.Parse<int>(Encoding.UTF8.GetBytes(@" 1 "));
+            int i = JsonSerializer.Deserialize<int>(Encoding.UTF8.GetBytes(@" 1 "));
             Assert.Equal(1, i);
 
-            int i2 = JsonSerializer.Parse<int>("2\t");
+            int i2 = JsonSerializer.Deserialize<int>("2\t");
             Assert.Equal(2, i2);
 
-            int? i3 = JsonSerializer.Parse<int?>("\r\nnull");
+            int? i3 = JsonSerializer.Deserialize<int?>("\r\nnull");
             Assert.Null(i3);
 
-            long l = JsonSerializer.Parse<long>(Encoding.UTF8.GetBytes("\t" + long.MaxValue.ToString()));
+            long l = JsonSerializer.Deserialize<long>(Encoding.UTF8.GetBytes("\t" + long.MaxValue.ToString()));
             Assert.Equal(long.MaxValue, l);
 
-            long l2 = JsonSerializer.Parse<long>(long.MaxValue.ToString() + " \r\n");
+            long l2 = JsonSerializer.Deserialize<long>(long.MaxValue.ToString() + " \r\n");
             Assert.Equal(long.MaxValue, l2);
 
-            string s = JsonSerializer.Parse<string>(Encoding.UTF8.GetBytes(@"""Hello"" "));
+            string s = JsonSerializer.Deserialize<string>(Encoding.UTF8.GetBytes(@"""Hello"" "));
             Assert.Equal("Hello", s);
 
-            string s2 = JsonSerializer.Parse<string>(@"  ""Hello"" ");
+            string s2 = JsonSerializer.Deserialize<string>(@"  ""Hello"" ");
             Assert.Equal("Hello", s2);
 
-            bool b = JsonSerializer.Parse<bool>(" \ttrue ");
+            bool b = JsonSerializer.Deserialize<bool>(" \ttrue ");
             Assert.Equal(true, b);
 
-            bool b2 = JsonSerializer.Parse<bool>(" false\n");
+            bool b2 = JsonSerializer.Deserialize<bool>(" false\n");
             Assert.Equal(false, b2);
         }
 
         [Fact]
         public static void ReadPrimitivesFail()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int>(Encoding.UTF8.GetBytes(@"a")));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[1,a]")));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int>(@"null"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int>(@""""""));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(Encoding.UTF8.GetBytes(@"a")));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int[]>(Encoding.UTF8.GetBytes(@"[1,a]")));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(@"null"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(@""""""));
         }
 
         [Theory]
@@ -100,106 +100,106 @@ namespace System.Text.Json.Serialization.Tests
         public static void PrimitivesShouldFailWithArrayOrObjectAssignment(Type primitiveType)
         {
             // This test lines up with the built in JsonConverters
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse(@"[]", primitiveType));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse(@"{}", primitiveType));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(@"[]", primitiveType));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(@"{}", primitiveType));
         }
 
         [Fact]
         public static void EmptyStringInput()
         {
-            string obj = JsonSerializer.Parse<string>(@"""""");
+            string obj = JsonSerializer.Deserialize<string>(@"""""");
             Assert.Equal(string.Empty, obj);
         }
 
         [Fact]
         public static void ReadPrimitiveExtraBytesFail()
         {
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[]>("[2] {3}"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int[]>(Encoding.UTF8.GetBytes(@"[2] {3}")));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<string>(@"""Hello"" 42"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<string>(Encoding.UTF8.GetBytes(@"""Hello"" 42")));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int[]>("[2] {3}"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int[]>(Encoding.UTF8.GetBytes(@"[2] {3}")));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<string>(@"""Hello"" 42"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<string>(Encoding.UTF8.GetBytes(@"""Hello"" 42")));
         }
 
         [Fact]
         public static void RangeFail()
         {
             // These have custom code because the reader doesn't natively support:
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte>((byte.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte>((byte.MaxValue + 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte?>((byte.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte?>((byte.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte>((byte.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte>((byte.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte?>((byte.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte?>((byte.MaxValue + 1).ToString()));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<sbyte>((sbyte.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<sbyte>((sbyte.MaxValue + 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<sbyte?>((sbyte.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<sbyte?>((sbyte.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte>((sbyte.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte>((sbyte.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte?>((sbyte.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte?>((sbyte.MaxValue + 1).ToString()));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<short>((short.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<short>((short.MaxValue + 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<short?>((short.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<short?>((short.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short>((short.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short>((short.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short?>((short.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short?>((short.MaxValue + 1).ToString()));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ushort>((ushort.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ushort>((ushort.MaxValue + 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ushort?>((ushort.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ushort?>((ushort.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort>((ushort.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort>((ushort.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort?>((ushort.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort?>((ushort.MaxValue + 1).ToString()));
 
             // These are natively supported by the reader:
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int>(((long)int.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int>(((long)int.MaxValue + 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int?>(((long)int.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int?>(((long)int.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(((long)int.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(((long)int.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int?>(((long)int.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int?>(((long)int.MaxValue + 1).ToString()));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<uint>(((long)uint.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<uint>(((long)uint.MaxValue + 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<uint?>(((long)uint.MinValue - 1).ToString()));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<uint?>(((long)uint.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint>(((long)uint.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint>(((long)uint.MaxValue + 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint?>(((long)uint.MinValue - 1).ToString()));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint?>(((long)uint.MaxValue + 1).ToString()));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<long>(long.MinValue.ToString() + "0"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<long>(long.MaxValue.ToString() + "0"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<long?>(long.MinValue.ToString() + "0"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<long?>(long.MaxValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long>(long.MinValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long>(long.MaxValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long?>(long.MinValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long?>(long.MaxValue.ToString() + "0"));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ulong>(ulong.MinValue.ToString() + "0"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ulong>(ulong.MaxValue.ToString() + "0"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ulong?>(ulong.MinValue.ToString() + "0"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ulong?>(ulong.MaxValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong>(ulong.MinValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong>(ulong.MaxValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong?>(ulong.MinValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong?>(ulong.MaxValue.ToString() + "0"));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<decimal>(decimal.MinValue.ToString() + "0"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<decimal>(decimal.MaxValue.ToString() + "0"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<decimal?>(decimal.MinValue.ToString() + "0"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<decimal?>(decimal.MaxValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<decimal>(decimal.MinValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<decimal>(decimal.MaxValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<decimal?>(decimal.MinValue.ToString() + "0"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<decimal?>(decimal.MaxValue.ToString() + "0"));
         }
 
         [Fact]
         public static void RangePass()
         {
-            Assert.Equal(byte.MaxValue, JsonSerializer.Parse<byte>(byte.MaxValue.ToString()));
-            Assert.Equal(byte.MaxValue, JsonSerializer.Parse<byte?>(byte.MaxValue.ToString()));
+            Assert.Equal(byte.MaxValue, JsonSerializer.Deserialize<byte>(byte.MaxValue.ToString()));
+            Assert.Equal(byte.MaxValue, JsonSerializer.Deserialize<byte?>(byte.MaxValue.ToString()));
 
-            Assert.Equal(sbyte.MaxValue, JsonSerializer.Parse<sbyte>(sbyte.MaxValue.ToString()));
-            Assert.Equal(sbyte.MaxValue, JsonSerializer.Parse<sbyte?>(sbyte.MaxValue.ToString()));
+            Assert.Equal(sbyte.MaxValue, JsonSerializer.Deserialize<sbyte>(sbyte.MaxValue.ToString()));
+            Assert.Equal(sbyte.MaxValue, JsonSerializer.Deserialize<sbyte?>(sbyte.MaxValue.ToString()));
 
-            Assert.Equal(short.MaxValue, JsonSerializer.Parse<short>(short.MaxValue.ToString()));
-            Assert.Equal(short.MaxValue, JsonSerializer.Parse<short?>(short.MaxValue.ToString()));
+            Assert.Equal(short.MaxValue, JsonSerializer.Deserialize<short>(short.MaxValue.ToString()));
+            Assert.Equal(short.MaxValue, JsonSerializer.Deserialize<short?>(short.MaxValue.ToString()));
 
-            Assert.Equal(ushort.MaxValue, JsonSerializer.Parse<ushort>(ushort.MaxValue.ToString()));
-            Assert.Equal(ushort.MaxValue, JsonSerializer.Parse<ushort?>(ushort.MaxValue.ToString()));
+            Assert.Equal(ushort.MaxValue, JsonSerializer.Deserialize<ushort>(ushort.MaxValue.ToString()));
+            Assert.Equal(ushort.MaxValue, JsonSerializer.Deserialize<ushort?>(ushort.MaxValue.ToString()));
 
-            Assert.Equal(int.MaxValue, JsonSerializer.Parse<int>(int.MaxValue.ToString()));
-            Assert.Equal(int.MaxValue, JsonSerializer.Parse<int?>(int.MaxValue.ToString()));
+            Assert.Equal(int.MaxValue, JsonSerializer.Deserialize<int>(int.MaxValue.ToString()));
+            Assert.Equal(int.MaxValue, JsonSerializer.Deserialize<int?>(int.MaxValue.ToString()));
 
-            Assert.Equal(uint.MaxValue, JsonSerializer.Parse<uint>(uint.MaxValue.ToString()));
-            Assert.Equal(uint.MaxValue, JsonSerializer.Parse<uint?>(uint.MaxValue.ToString()));
+            Assert.Equal(uint.MaxValue, JsonSerializer.Deserialize<uint>(uint.MaxValue.ToString()));
+            Assert.Equal(uint.MaxValue, JsonSerializer.Deserialize<uint?>(uint.MaxValue.ToString()));
 
-            Assert.Equal(long.MaxValue, JsonSerializer.Parse<long>(long.MaxValue.ToString()));
-            Assert.Equal(long.MaxValue, JsonSerializer.Parse<long?>(long.MaxValue.ToString()));
+            Assert.Equal(long.MaxValue, JsonSerializer.Deserialize<long>(long.MaxValue.ToString()));
+            Assert.Equal(long.MaxValue, JsonSerializer.Deserialize<long?>(long.MaxValue.ToString()));
 
-            Assert.Equal(ulong.MaxValue, JsonSerializer.Parse<ulong>(ulong.MaxValue.ToString()));
-            Assert.Equal(ulong.MaxValue, JsonSerializer.Parse<ulong?>(ulong.MaxValue.ToString()));
+            Assert.Equal(ulong.MaxValue, JsonSerializer.Deserialize<ulong>(ulong.MaxValue.ToString()));
+            Assert.Equal(ulong.MaxValue, JsonSerializer.Deserialize<ulong?>(ulong.MaxValue.ToString()));
 
-            Assert.Equal(decimal.MaxValue, JsonSerializer.Parse<decimal>(decimal.MaxValue.ToString(CultureInfo.InvariantCulture)));
-            Assert.Equal(decimal.MaxValue, JsonSerializer.Parse<decimal?>(decimal.MaxValue.ToString(CultureInfo.InvariantCulture)));
+            Assert.Equal(decimal.MaxValue, JsonSerializer.Deserialize<decimal>(decimal.MaxValue.ToString(CultureInfo.InvariantCulture)));
+            Assert.Equal(decimal.MaxValue, JsonSerializer.Deserialize<decimal?>(decimal.MaxValue.ToString(CultureInfo.InvariantCulture)));
         }
 
         [Fact]
@@ -208,36 +208,36 @@ namespace System.Text.Json.Serialization.Tests
         {
             // Verify overflow\underflow.
             // On NETFX these throw.
-            Assert.True(float.IsNegativeInfinity(JsonSerializer.Parse<float>(double.MinValue.ToString(CultureInfo.InvariantCulture))));
-            Assert.True(float.IsPositiveInfinity(JsonSerializer.Parse<float>(double.MaxValue.ToString(CultureInfo.InvariantCulture))));
-            Assert.True(float.IsNegativeInfinity(JsonSerializer.Parse<float?>(double.MinValue.ToString(CultureInfo.InvariantCulture)).Value));
-            Assert.True(float.IsPositiveInfinity(JsonSerializer.Parse<float?>(double.MaxValue.ToString(CultureInfo.InvariantCulture)).Value));
+            Assert.True(float.IsNegativeInfinity(JsonSerializer.Deserialize<float>(double.MinValue.ToString(CultureInfo.InvariantCulture))));
+            Assert.True(float.IsPositiveInfinity(JsonSerializer.Deserialize<float>(double.MaxValue.ToString(CultureInfo.InvariantCulture))));
+            Assert.True(float.IsNegativeInfinity(JsonSerializer.Deserialize<float?>(double.MinValue.ToString(CultureInfo.InvariantCulture)).Value));
+            Assert.True(float.IsPositiveInfinity(JsonSerializer.Deserialize<float?>(double.MaxValue.ToString(CultureInfo.InvariantCulture)).Value));
 
-            Assert.True(double.IsNegativeInfinity(JsonSerializer.Parse<double>(double.MinValue.ToString(CultureInfo.InvariantCulture) + "0")));
-            Assert.True(double.IsPositiveInfinity(JsonSerializer.Parse<double>(double.MaxValue.ToString(CultureInfo.InvariantCulture) + "0")));
-            Assert.True(double.IsNegativeInfinity(JsonSerializer.Parse<double?>(double.MinValue.ToString(CultureInfo.InvariantCulture) + "0").Value));
-            Assert.True(double.IsPositiveInfinity(JsonSerializer.Parse<double?>(double.MaxValue.ToString(CultureInfo.InvariantCulture) + "0").Value));
+            Assert.True(double.IsNegativeInfinity(JsonSerializer.Deserialize<double>(double.MinValue.ToString(CultureInfo.InvariantCulture) + "0")));
+            Assert.True(double.IsPositiveInfinity(JsonSerializer.Deserialize<double>(double.MaxValue.ToString(CultureInfo.InvariantCulture) + "0")));
+            Assert.True(double.IsNegativeInfinity(JsonSerializer.Deserialize<double?>(double.MinValue.ToString(CultureInfo.InvariantCulture) + "0").Value));
+            Assert.True(double.IsPositiveInfinity(JsonSerializer.Deserialize<double?>(double.MaxValue.ToString(CultureInfo.InvariantCulture) + "0").Value));
 
             // Verify sign is correct.
             // On NETFX a value of -0 does not keep the sign.
-            Assert.Equal(0x0000000000000000ul, (ulong)BitConverter.DoubleToInt64Bits(JsonSerializer.Parse<double>("0")));
-            Assert.Equal(0x8000000000000000ul, (ulong)BitConverter.DoubleToInt64Bits(JsonSerializer.Parse<double>("-0")));
-            Assert.Equal(0x8000000000000000ul, (ulong)BitConverter.DoubleToInt64Bits(JsonSerializer.Parse<double>("-0.0")));
+            Assert.Equal(0x0000000000000000ul, (ulong)BitConverter.DoubleToInt64Bits(JsonSerializer.Deserialize<double>("0")));
+            Assert.Equal(0x8000000000000000ul, (ulong)BitConverter.DoubleToInt64Bits(JsonSerializer.Deserialize<double>("-0")));
+            Assert.Equal(0x8000000000000000ul, (ulong)BitConverter.DoubleToInt64Bits(JsonSerializer.Deserialize<double>("-0.0")));
 
 #if BUILDING_INBOX_LIBRARY
             // Verify sign is correct; SingleToInt32Bits not available on netfx.
-            Assert.Equal(0x00000000u, (uint)BitConverter.SingleToInt32Bits(JsonSerializer.Parse<float>("0")));
-            Assert.Equal(0x80000000u, (uint)BitConverter.SingleToInt32Bits(JsonSerializer.Parse<float>("-0")));
-            Assert.Equal(0x80000000u, (uint)BitConverter.SingleToInt32Bits(JsonSerializer.Parse<float>("-0.0")));
+            Assert.Equal(0x00000000u, (uint)BitConverter.SingleToInt32Bits(JsonSerializer.Deserialize<float>("0")));
+            Assert.Equal(0x80000000u, (uint)BitConverter.SingleToInt32Bits(JsonSerializer.Deserialize<float>("-0")));
+            Assert.Equal(0x80000000u, (uint)BitConverter.SingleToInt32Bits(JsonSerializer.Deserialize<float>("-0.0")));
 #endif
 
             // Verify Round-tripping.
             // On NETFX round tripping is not supported.
-            Assert.Equal(float.MaxValue, JsonSerializer.Parse<float>(float.MaxValue.ToString(CultureInfo.InvariantCulture)));
-            Assert.Equal(float.MaxValue, JsonSerializer.Parse<float?>(float.MaxValue.ToString(CultureInfo.InvariantCulture)));
+            Assert.Equal(float.MaxValue, JsonSerializer.Deserialize<float>(float.MaxValue.ToString(CultureInfo.InvariantCulture)));
+            Assert.Equal(float.MaxValue, JsonSerializer.Deserialize<float?>(float.MaxValue.ToString(CultureInfo.InvariantCulture)));
 
-            Assert.Equal(double.MaxValue, JsonSerializer.Parse<double>(double.MaxValue.ToString(CultureInfo.InvariantCulture)));
-            Assert.Equal(double.MaxValue, JsonSerializer.Parse<double?>(double.MaxValue.ToString(CultureInfo.InvariantCulture)));
+            Assert.Equal(double.MaxValue, JsonSerializer.Deserialize<double>(double.MaxValue.ToString(CultureInfo.InvariantCulture)));
+            Assert.Equal(double.MaxValue, JsonSerializer.Deserialize<double?>(double.MaxValue.ToString(CultureInfo.InvariantCulture)));
         }
 
         [Fact]
@@ -245,60 +245,60 @@ namespace System.Text.Json.Serialization.Tests
         {
             string unexpectedString = @"""unexpected string""";
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<byte?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<sbyte>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<sbyte?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<short>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<short?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ushort>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ushort?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<float>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<float?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<float>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<float?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<int?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<uint>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<uint?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<long>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<long?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ulong>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<ulong?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<decimal>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<decimal?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<decimal>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<decimal?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<double>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<double?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<double>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<double?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<DateTime>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<DateTime?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<DateTime>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<DateTime?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<DateTimeOffset>(unexpectedString));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<DateTimeOffset?>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<DateTimeOffset>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<DateTimeOffset?>(unexpectedString));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<string>("1"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<string>("1"));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<char>("1"));
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<char?>("1"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char>("1"));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<char?>("1"));
 
-            Assert.Throws<JsonException>(() => JsonSerializer.Parse<Enum>(unexpectedString));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Enum>(unexpectedString));
         }
 
         [Fact]
         public static void ReadPrimitiveUri()
         {
-            Uri uri = JsonSerializer.Parse<Uri>(@"""https://domain/path""");
+            Uri uri = JsonSerializer.Deserialize<Uri>(@"""https://domain/path""");
             Assert.Equal("https:\u002f\u002fdomain\u002fpath", uri.ToString());
 
-            uri = JsonSerializer.Parse<Uri>(@"""~/path""");
+            uri = JsonSerializer.Deserialize<Uri>(@"""~/path""");
             Assert.Equal("~/path", uri.ToString());
         }
    }

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.GenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.GenericCollections.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -32,7 +32,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -43,7 +43,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new List<int>() { 1, 2 };
             input[1] = new List<int>() { 3, 4 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -52,7 +52,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             var input = new List<int> { 1, 2 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -65,7 +65,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -78,7 +78,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -89,7 +89,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new List<int>() { 1, 2 };
             input[1] = new List<int>() { 3, 4 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -98,7 +98,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             IEnumerable<int> input = new List<int> { 1, 2 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -111,7 +111,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -124,7 +124,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -135,7 +135,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new List<int>() { 1, 2 };
             input[1] = new List<int>() { 3, 4 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -144,7 +144,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             IList<int> input = new List<int> { 1, 2 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -157,7 +157,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -170,7 +170,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -181,7 +181,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new List<int>() { 1, 2 };
             input[1] = new List<int>() { 3, 4 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -190,7 +190,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ICollection<int> input = new List<int> { 1, 2 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -203,7 +203,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -216,7 +216,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -227,7 +227,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new List<int>() { 1, 2 };
             input[1] = new List<int>() { 3, 4 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -236,7 +236,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             IReadOnlyCollection<int> input = new List<int> { 1, 2 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -249,7 +249,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -262,7 +262,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -273,7 +273,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new List<int>() { 1, 2 };
             input[1] = new List<int>() { 3, 4 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -282,7 +282,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             IReadOnlyList<int> input = new List<int> { 1, 2 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -295,10 +295,10 @@ namespace System.Text.Json.Serialization.Tests
                 new HashSet<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
 
             // Because order isn't guaranteed, roundtrip data to ensure write was accurate.
-            input = JsonSerializer.Parse<ISet<ISet<int>>>(json);
+            input = JsonSerializer.Deserialize<ISet<ISet<int>>>(json);
 
             if (input.First().Contains(1))
             {
@@ -321,10 +321,10 @@ namespace System.Text.Json.Serialization.Tests
                 new HashSet<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
 
             // Because order isn't guaranteed, roundtrip data to ensure write was accurate.
-            input = JsonSerializer.Parse<ISet<HashSet<int>>>(json);
+            input = JsonSerializer.Deserialize<ISet<HashSet<int>>>(json);
 
             if (input.First().Contains(1))
             {
@@ -347,10 +347,10 @@ namespace System.Text.Json.Serialization.Tests
                 new HashSet<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
 
             // Because order isn't guaranteed, roundtrip data to ensure write was accurate.
-            input = JsonSerializer.Parse<HashSet<ISet<int>>>(json);
+            input = JsonSerializer.Deserialize<HashSet<ISet<int>>>(json);
 
             if (input.First().Contains(1))
             {
@@ -373,7 +373,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.True(json.Contains("[1,2]"));
             Assert.True(json.Contains("[3,4]"));
         }
@@ -385,10 +385,10 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new HashSet<int>() { 1, 2 };
             input[1] = new HashSet<int>() { 3, 4 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
 
             // Because order isn't guaranteed, roundtrip data to ensure write was accurate.
-            input = JsonSerializer.Parse<ISet<int>[]>(json);
+            input = JsonSerializer.Deserialize<ISet<int>[]>(json);
             Assert.Equal(new HashSet<int> { 1, 2 }, input.First());
             Assert.Equal(new HashSet<int> { 3, 4 }, input.Last());
         }
@@ -398,7 +398,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ISet<int> input = new HashSet<int> { 1, 2 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.True(json == "[1,2]" || json == "[2,1]");
         }
 
@@ -411,7 +411,7 @@ namespace System.Text.Json.Serialization.Tests
                 new Stack<int>(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[4,3],[2,1]]", json);
         }
 
@@ -424,7 +424,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[3,4],[1,2]]", json);
         }
 
@@ -435,7 +435,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new Stack<int>(new List<int> { 1, 2 });
             input[1] = new Stack<int>(new List<int> { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[2,1],[4,3]]", json);
         }
 
@@ -444,7 +444,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             Stack<int> input = new Stack<int>(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[2,1]", json);
         }
 
@@ -457,7 +457,7 @@ namespace System.Text.Json.Serialization.Tests
                 new Queue<int>(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -470,7 +470,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -481,7 +481,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new Queue<int>(new List<int> { 1, 2 });
             input[1] = new Queue<int>(new List<int> { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -490,7 +490,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             Queue<int> input = new Queue<int>(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -503,10 +503,10 @@ namespace System.Text.Json.Serialization.Tests
                 new HashSet<int>(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
 
             // Because order isn't guaranteed, roundtrip data to ensure write was accurate.
-            input = JsonSerializer.Parse<HashSet<HashSet<int>>>(json);
+            input = JsonSerializer.Deserialize<HashSet<HashSet<int>>>(json);
 
             if (input.First().Contains(1))
             {
@@ -529,7 +529,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.True(json.Contains("[1,2]"));
             Assert.True(json.Contains("[3,4]"));
         }
@@ -541,10 +541,10 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new HashSet<int>(new List<int> { 1, 2 });
             input[1] = new HashSet<int>(new List<int> { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
 
             // Because order isn't guaranteed, roundtrip data to ensure write was accurate.
-            input = JsonSerializer.Parse<HashSet<int>[]>(json);
+            input = JsonSerializer.Deserialize<HashSet<int>[]>(json);
             Assert.Equal(new HashSet<int> { 1, 2 }, input.First());
             Assert.Equal(new HashSet<int> { 3, 4 }, input.Last());
         }
@@ -554,7 +554,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             HashSet<int> input = new HashSet<int>(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.True(json == "[1,2]" || json == "[2,1]");
         }
 
@@ -567,7 +567,7 @@ namespace System.Text.Json.Serialization.Tests
                 new LinkedList<int>(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -580,7 +580,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -591,7 +591,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new LinkedList<int>(new List<int> { 1, 2 });
             input[1] = new LinkedList<int>(new List<int> { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -600,7 +600,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             LinkedList<int> input = new LinkedList<int>(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -611,7 +611,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new SortedSet<int>(new List<int> { 1, 2 });
             input[1] = new SortedSet<int>(new List<int> { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -620,7 +620,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             SortedSet<int> input = new SortedSet<int>(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -629,7 +629,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             KeyValuePair<string, int> input = new KeyValuePair<string, int>("Key", 123) ;
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal(@"{""Key"":""Key"",""Value"":123}", json);
         }
 
@@ -642,7 +642,7 @@ namespace System.Text.Json.Serialization.Tests
                 new KeyValuePair<string, int>("456", 456)
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal(@"[{""Key"":""123"",""Value"":123},{""Key"":""456"",""Value"":456}]", json);
         }
 
@@ -651,7 +651,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             KeyValuePair<string, List<int>> input = new KeyValuePair<string, List<int>>("Key", new List<int> { 1, 2, 3 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal(@"{""Key"":""Key"",""Value"":[1,2,3]}", json);
         }
 
@@ -661,7 +661,7 @@ namespace System.Text.Json.Serialization.Tests
             KeyValuePair<string, KeyValuePair<string, int>> input = new KeyValuePair<string, KeyValuePair<string, int>>(
                 "Key", new KeyValuePair<string, int>("Key", 1));
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal(@"{""Key"":""Key"",""Value"":{""Key"":""Key"",""Value"":1}}", json);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.ImmutableCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.ImmutableCollections.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json.Serialization.Tests
                 ImmutableList.CreateRange(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -31,7 +31,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -42,7 +42,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = ImmutableList.CreateRange(new List<int>() { 1, 2 });
             input[1] = ImmutableList.CreateRange(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -51,7 +51,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             IImmutableList<int> input = ImmutableList.CreateRange(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -63,7 +63,7 @@ namespace System.Text.Json.Serialization.Tests
                 ImmutableStack.CreateRange(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[4,3],[2,1]]", json);
         }
 
@@ -76,7 +76,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[3,4],[1,2]]", json);
         }
 
@@ -87,7 +87,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = ImmutableStack.CreateRange(new List<int>() { 1, 2 });
             input[1] = ImmutableStack.CreateRange(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[2,1],[4,3]]", json);
         }
 
@@ -96,7 +96,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             IImmutableStack<int> input = ImmutableStack.CreateRange(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[2,1]", json);
         }
 
@@ -108,7 +108,7 @@ namespace System.Text.Json.Serialization.Tests
                 ImmutableQueue.CreateRange(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -121,7 +121,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -132,7 +132,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = ImmutableQueue.CreateRange(new List<int>() { 1, 2 });
             input[1] = ImmutableQueue.CreateRange(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -141,7 +141,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             IImmutableQueue<int> input = ImmutableQueue.CreateRange(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -153,7 +153,7 @@ namespace System.Text.Json.Serialization.Tests
                 ImmutableHashSet.CreateRange(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.True(json.Contains("[1,2]"));
             Assert.True(json.Contains("[3,4]"));
         }
@@ -167,7 +167,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.True(json.Contains("[1,2]"));
             Assert.True(json.Contains("[3,4]"));
         }
@@ -179,7 +179,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = ImmutableHashSet.CreateRange(new List<int>() { 1, 2 });
             input[1] = ImmutableHashSet.CreateRange(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -188,7 +188,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             IImmutableSet<int> input = ImmutableHashSet.CreateRange(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -200,7 +200,7 @@ namespace System.Text.Json.Serialization.Tests
                 ImmutableHashSet.CreateRange(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.True(json.Contains("[1,2]"));
             Assert.True(json.Contains("[3,4]"));
         }
@@ -214,7 +214,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.True(json.Contains("[1,2]"));
             Assert.True(json.Contains("[3,4]"));
         }
@@ -226,7 +226,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = ImmutableHashSet.CreateRange(new List<int>() { 1, 2 });
             input[1] = ImmutableHashSet.CreateRange(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -235,7 +235,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ImmutableHashSet<int> input = ImmutableHashSet.CreateRange(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -247,7 +247,7 @@ namespace System.Text.Json.Serialization.Tests
                 ImmutableList.CreateRange(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -260,7 +260,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -271,7 +271,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = ImmutableList.CreateRange(new List<int>() { 1, 2 });
             input[1] = ImmutableList.CreateRange(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -280,7 +280,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ImmutableList<int> input = ImmutableList.CreateRange(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -292,7 +292,7 @@ namespace System.Text.Json.Serialization.Tests
                 ImmutableStack.CreateRange(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[4,3],[2,1]]", json);
         }
 
@@ -305,7 +305,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[3,4],[1,2]]", json);
         }
 
@@ -316,7 +316,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = ImmutableStack.CreateRange(new List<int>() { 1, 2 });
             input[1] = ImmutableStack.CreateRange(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[2,1],[4,3]]", json);
         }
 
@@ -325,7 +325,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ImmutableStack<int> input = ImmutableStack.CreateRange(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[2,1]", json);
         }
 
@@ -337,7 +337,7 @@ namespace System.Text.Json.Serialization.Tests
                 ImmutableQueue.CreateRange(new List<int>() { 3, 4 })
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -350,7 +350,7 @@ namespace System.Text.Json.Serialization.Tests
                 new int[] { 3, 4 }
             });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -361,7 +361,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = ImmutableQueue.CreateRange(new List<int>() { 1, 2 });
             input[1] = ImmutableQueue.CreateRange(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -370,7 +370,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ImmutableQueue<int> input = ImmutableQueue.CreateRange(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -381,7 +381,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = ImmutableSortedSet.CreateRange(new List<int>() { 1, 2 });
             input[1] = ImmutableSortedSet.CreateRange(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -390,7 +390,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ImmutableSortedSet<int> input = ImmutableSortedSet.CreateRange(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.NonGenericCollections.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.NonGenericCollections.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -31,7 +31,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -42,7 +42,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new List<int>() { 1, 2 };
             input[1] = new List<int>() { 3, 4 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -51,7 +51,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             IEnumerable input = new List<int> { 1, 2 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -64,7 +64,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -76,7 +76,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -87,7 +87,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new List<int>() { 1, 2 };
             input[1] = new List<int>() { 3, 4 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -96,7 +96,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             IList input = new List<int> { 1, 2 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -109,7 +109,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -121,7 +121,7 @@ namespace System.Text.Json.Serialization.Tests
                 new List<int>() { 3, 4 }
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -132,7 +132,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new List<int>() { 1, 2 };
             input[1] = new List<int>() { 3, 4 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -141,7 +141,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ICollection input = new List<int> { 1, 2 };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -152,7 +152,7 @@ namespace System.Text.Json.Serialization.Tests
             input.Push(new Stack(new List<int>() { 1, 2 }));
             input.Push(new Stack(new List<int>() { 3, 4 }));
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[4,3],[2,1]]", json);
         }
 
@@ -162,7 +162,7 @@ namespace System.Text.Json.Serialization.Tests
             input.Push(new Stack(new List<int>() { 1, 2 }));
             input.Push(new Stack(new List<int>() { 3, 4 }));
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[4,3],[2,1]]", json);
         }
 
@@ -173,7 +173,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new Stack(new List<int>() { 1, 2 });
             input[1] = new Stack(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[2,1],[4,3]]", json);
         }
 
@@ -182,7 +182,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             Stack input = new Stack( new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[2,1]", json);
         }
 
@@ -193,7 +193,7 @@ namespace System.Text.Json.Serialization.Tests
             input.Enqueue(new Queue(new List<int>() { 1, 2 }));
             input.Enqueue(new Queue(new List<int>() { 3, 4 }));
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -203,7 +203,7 @@ namespace System.Text.Json.Serialization.Tests
             input.Enqueue(new Queue(new List<int>() { 1, 2 }));
             input.Enqueue(new Queue(new List<int>() { 3, 4 }));
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -214,7 +214,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new Queue(new List<int>() { 1, 2 });
             input[1] = new Queue(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -223,7 +223,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             Queue input = new Queue(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
 
@@ -236,7 +236,7 @@ namespace System.Text.Json.Serialization.Tests
                 new ArrayList(new List<int>() { 3, 4 })
             };
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -247,7 +247,7 @@ namespace System.Text.Json.Serialization.Tests
             input[0] = new ArrayList(new List<int>() { 1, 2 });
             input[1] = new ArrayList(new List<int>() { 3, 4 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[[1,2],[3,4]]", json);
         }
 
@@ -256,7 +256,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             ArrayList input = new ArrayList(new List<int> { 1, 2 });
 
-            string json = JsonSerializer.ToString(input);
+            string json = JsonSerializer.Serialize(input);
             Assert.Equal("[1,2]", json);
         }
     }

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
@@ -12,55 +12,55 @@ namespace System.Text.Json.Serialization.Tests
         public static void WritePrimitives()
         {
             {
-                string json = JsonSerializer.ToString(1);
+                string json = JsonSerializer.Serialize(1);
                 Assert.Equal("1", json);
             }
 
             {
                 int? value = 1;
-                string json = JsonSerializer.ToString(value);
+                string json = JsonSerializer.Serialize(value);
                 Assert.Equal("1", json);
             }
 
             {
                 int? value = null;
-                string json = JsonSerializer.ToString(value);
+                string json = JsonSerializer.Serialize(value);
                 Assert.Equal("null", json);
             }
 
             {
-                Span<byte> json = JsonSerializer.ToUtf8Bytes(1);
+                Span<byte> json = JsonSerializer.SerializeToUtf8Bytes(1);
                 Assert.Equal(Encoding.UTF8.GetBytes("1"), json.ToArray());
             }
 
             {
-                string json = JsonSerializer.ToString(long.MaxValue);
+                string json = JsonSerializer.Serialize(long.MaxValue);
                 Assert.Equal(long.MaxValue.ToString(), json);
             }
 
             {
-                Span<byte> json = JsonSerializer.ToUtf8Bytes(long.MaxValue);
+                Span<byte> json = JsonSerializer.SerializeToUtf8Bytes(long.MaxValue);
                 Assert.Equal(Encoding.UTF8.GetBytes(long.MaxValue.ToString()), json.ToArray());
             }
 
             {
-                string json = JsonSerializer.ToString("Hello");
+                string json = JsonSerializer.Serialize("Hello");
                 Assert.Equal(@"""Hello""", json);
             }
 
             {
-                Span<byte> json = JsonSerializer.ToUtf8Bytes("Hello");
+                Span<byte> json = JsonSerializer.SerializeToUtf8Bytes("Hello");
                 Assert.Equal(Encoding.UTF8.GetBytes(@"""Hello"""), json.ToArray());
             }
 
             {
                 Uri uri = new Uri("https://domain/path");
-                Assert.Equal(@"""https:\u002f\u002fdomain\u002fpath""", JsonSerializer.ToString(uri));
+                Assert.Equal(@"""https:\u002f\u002fdomain\u002fpath""", JsonSerializer.Serialize(uri));
             }
 
             {
                 Uri.TryCreate("~/path", UriKind.RelativeOrAbsolute, out Uri uri);
-                Assert.Equal(@"""~\u002fpath""", JsonSerializer.ToString(uri));
+                Assert.Equal(@"""~\u002fpath""", JsonSerializer.Serialize(uri));
             }
         }
     }

--- a/src/System.Text.Json/tests/Serialization/WriteValueTests.cs
+++ b/src/System.Text.Json/tests/Serialization/WriteValueTests.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json.Serialization.Tests
 
             writer.WriteStartObject();
             writer.WriteStartArray("test");
-            JsonSerializer.WriteValue<int>(writer, 1);
+            JsonSerializer.Serialize<int>(writer, 1);
             writer.WriteEndArray();
             writer.WriteEndObject();
             writer.Flush();

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -4359,7 +4359,7 @@ namespace System.Text.Json.Tests
         public void WriteDateTime_TrimsFractionCorrectly_SerializerRoundtrip()
         {
             DateTime utcNow = DateTime.UtcNow;
-            Assert.Equal(utcNow, JsonSerializer.Parse(JsonSerializer.ToUtf8Bytes(utcNow), typeof(DateTime)));
+            Assert.Equal(utcNow, JsonSerializer.Deserialize(JsonSerializer.SerializeToUtf8Bytes(utcNow), typeof(DateTime)));
         }
 
         private static void WriteTooLargeHelper(JsonWriterOptions options, ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, bool noThrow = false)


### PR DESCRIPTION
Based on feedback from the usability study, renaming the `JsonSerializer` APIs.

cc @steveharter, @bartonjs, @terrajobst, @JeremyKuhne, @rynowak, @BrennanConroy   