### PR TITLE
Allow Ignore and JsonName attributes to use same property name

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace System.Text.Json
@@ -81,6 +82,24 @@ namespace System.Text.Json
                         .ToArray()
 #endif
                 );
+        }
+
+        /// <summary>
+        /// Emulates Dictionary.TryAdd on netstandard.
+        /// </summary>
+        internal static bool TryAdd<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+        {
+#if netstandard
+            if (!dictionary.ContainsKey(key))
+            {
+                dictionary[key] = value;
+                return true;
+            }
+
+            return false;
+#else
+            return dictionary.TryAdd(key, value);
+#endif
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -216,5 +216,94 @@ namespace System.Text.Json.Serialization.Tests
             [JsonIgnore]
             public string[] MyStringsWithIgnore { get; set; }
         }
+
+        private enum MyEnum
+        {
+            Case1 = 0,
+            Case2 = 1,
+        }
+
+        private struct ClassWithOverride
+        {
+            [JsonIgnore]
+            public MyEnum EnumValue { get; set; }
+
+            [JsonPropertyName("EnumValue")]
+            public string EnumString
+            {
+                get => EnumValue.ToString();
+                set
+                {
+                    if (value == "Case1")
+                    {
+                        EnumValue = MyEnum.Case1;
+                    }
+                    if (value == "Case2")
+                    {
+                        EnumValue = MyEnum.Case2;
+                    }
+                    else
+                    {
+                        throw new Exception("Unknown value!");
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public static void OverrideJsonIgnorePropertyUsingJsonPropertyName()
+        {
+            const string json = @"{""EnumValue"":""Case2""}";
+
+            ClassWithOverride obj = JsonSerializer.Parse<ClassWithOverride>(json);
+
+            Assert.Equal(MyEnum.Case2, obj.EnumValue);
+            Assert.Equal("Case2", obj.EnumString);
+
+            string jsonSerialized = JsonSerializer.ToString(obj);
+            Assert.Equal(json, jsonSerialized);
+        }
+
+        private struct ClassWithOverrideReversed
+        {
+            // Same as ClassWithOverride except the order of the properties is different, which should cause different reflection order.
+            [JsonPropertyName("EnumValue")]
+            public string EnumString
+            {
+                get => EnumValue.ToString();
+                set
+                {
+                    if (value == "Case1")
+                    {
+                        EnumValue = MyEnum.Case1;
+                    }
+                    if (value == "Case2")
+                    {
+                        EnumValue = MyEnum.Case2;
+                    }
+                    else
+                    {
+                        throw new Exception("Unknown value!");
+                    }
+                }
+            }
+
+            [JsonIgnore]
+            public MyEnum EnumValue { get; set; }
+        }
+
+        [Fact]
+        public static void OverrideJsonIgnorePropertyUsingJsonPropertyNameReversed()
+        {
+            const string json = @"{""EnumValue"":""Case2""}";
+
+            ClassWithOverrideReversed obj = JsonSerializer.Parse<ClassWithOverrideReversed>(json);
+
+            Assert.Equal(MyEnum.Case2, obj.EnumValue);
+            Assert.Equal("Case2", obj.EnumString);
+
+            string jsonSerialized = JsonSerializer.ToString(obj);
+            Assert.Equal(json, jsonSerialized);
+        }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -255,12 +255,12 @@ namespace System.Text.Json.Serialization.Tests
         {
             const string json = @"{""EnumValue"":""Case2""}";
 
-            ClassWithOverride obj = JsonSerializer.Parse<ClassWithOverride>(json);
+            ClassWithOverride obj = JsonSerializer.Deserialize<ClassWithOverride>(json);
 
             Assert.Equal(MyEnum.Case2, obj.EnumValue);
             Assert.Equal("Case2", obj.EnumString);
 
-            string jsonSerialized = JsonSerializer.ToString(obj);
+            string jsonSerialized = JsonSerializer.Serialize(obj);
             Assert.Equal(json, jsonSerialized);
         }
 
@@ -297,12 +297,12 @@ namespace System.Text.Json.Serialization.Tests
         {
             const string json = @"{""EnumValue"":""Case2""}";
 
-            ClassWithOverrideReversed obj = JsonSerializer.Parse<ClassWithOverrideReversed>(json);
+            ClassWithOverrideReversed obj = JsonSerializer.Deserialize<ClassWithOverrideReversed>(json);
 
             Assert.Equal(MyEnum.Case2, obj.EnumValue);
             Assert.Equal("Case2", obj.EnumString);
 
-            string jsonSerialized = JsonSerializer.ToString(obj);
+            string jsonSerialized = JsonSerializer.Serialize(obj);
             Assert.Equal(json, jsonSerialized);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38668
