### PR TITLE
Prevent OpenSSL unload at process exit

### DIFF
--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -1322,6 +1322,8 @@ static int32_t EnsureOpenSsl11Initialized()
             OPENSSL_INIT_ADD_ALL_CIPHERS |
             OPENSSL_INIT_ADD_ALL_DIGESTS |
             OPENSSL_INIT_LOAD_CONFIG |
+        // Do not unload on process exit, as the CLR may still have threads running
+            OPENSSL_INIT_NO_ATEXIT |
         // ERR_load_crypto_strings
             OPENSSL_INIT_LOAD_CRYPTO_STRINGS |
             OPENSSL_INIT_LOAD_SSL_STRINGS,

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -1313,6 +1313,11 @@ done:
 
 #ifdef NEED_OPENSSL_1_1
 
+// Only defined in OpenSSL 1.1.1+, has no effect on 1.1.0.
+#ifndef OPENSSL_INIT_NO_ATEXIT
+    #define OPENSSL_INIT_NO_ATEXIT 0x00080000L
+#endif
+
 static int32_t EnsureOpenSsl11Initialized()
 {
     // In OpenSSL 1.0 we call OPENSSL_add_all_algorithms_conf() and ERR_load_crypto_strings(),

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -116,7 +116,6 @@ typedef struct stack_st OPENSSL_STACK;
 #define OPENSSL_INIT_ADD_ALL_DIGESTS 0x00000008L
 #define OPENSSL_INIT_LOAD_CONFIG 0x00000040L
 #define OPENSSL_INIT_LOAD_SSL_STRINGS 0x00200000L
-#define OPENSSL_INIT_NO_ATEXIT 0x00080000L
 
 const BIGNUM* DSA_get0_key(const DSA* dsa, const BIGNUM** pubKey, const BIGNUM** privKey);
 void DSA_get0_pqg(const DSA* dsa, const BIGNUM** p, const BIGNUM** q, const BIGNUM** g);

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -107,6 +107,12 @@ int SSL_library_init(void);
 void SSL_load_error_strings(void);
 int SSL_state(const SSL* ssl);
 unsigned long SSLeay(void);
+
+// Only defined in OpenSSL 1.1.1+, has no effect on 1.1.0.
+#ifndef OPENSSL_INIT_NO_ATEXIT
+    #define OPENSSL_INIT_NO_ATEXIT 0x00080000L
+#endif
+
 #else
 typedef struct ossl_init_settings_st OPENSSL_INIT_SETTINGS;
 typedef struct stack_st OPENSSL_STACK;
@@ -116,6 +122,7 @@ typedef struct stack_st OPENSSL_STACK;
 #define OPENSSL_INIT_ADD_ALL_DIGESTS 0x00000008L
 #define OPENSSL_INIT_LOAD_CONFIG 0x00000040L
 #define OPENSSL_INIT_LOAD_SSL_STRINGS 0x00200000L
+#define OPENSSL_INIT_NO_ATEXIT 0x00080000L
 
 const BIGNUM* DSA_get0_key(const DSA* dsa, const BIGNUM** pubKey, const BIGNUM** privKey);
 void DSA_get0_pqg(const DSA* dsa, const BIGNUM** p, const BIGNUM** q, const BIGNUM** g);

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -107,12 +107,6 @@ int SSL_library_init(void);
 void SSL_load_error_strings(void);
 int SSL_state(const SSL* ssl);
 unsigned long SSLeay(void);
-
-// Only defined in OpenSSL 1.1.1+, has no effect on 1.1.0.
-#ifndef OPENSSL_INIT_NO_ATEXIT
-    #define OPENSSL_INIT_NO_ATEXIT 0x00080000L
-#endif
-
 #else
 typedef struct ossl_init_settings_st OPENSSL_INIT_SETTINGS;
 typedef struct stack_st OPENSSL_STACK;


### PR DESCRIPTION
OpenSSL 1.1.x registers a handler with the Unix `atexit` callback to unload the string tables and other self-cleanup that lets leak detection tools be happy to watch all allocated elements get deallocated before process shutdown.

The CLR, however, does a "dirty" shutdown, and doesn't promise to have stopped running threads when atexit gets called.

If a CLR thread gets an OpenSSL error between the time that OpenSSL unloads the pthreads locks and the process actually terminates, the call to ask what the string for that error locks a null lock and turns a probably-successful shutdown into a crash.

This change asks OpenSSL to not register the atexit handler.  OpenSSL 1.1.0 does not listen to the request, so certain crashes are still possible on Debian 9, and other 1.1.0-based platforms.  But the 1.1.1-based platforms (Ubuntu 19.04, Debian 10, Alpine 3.9, et al) will no longer see shutdown-related SIGSEGV caused by `ERR_reason_error_string`/`pthread_rwlock_timedrdlock`.

This takes care of #35956 in master.