### PR TITLE
Add TypeProvider tests and fix some NREs in the product code

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -70,6 +70,7 @@
     <SystemComponentModelTypeConverterTestDataPackageVersion>1.0.4</SystemComponentModelTypeConverterTestDataPackageVersion>
     <SystemDrawingCommonTestDataPackageVersion>1.0.12</SystemDrawingCommonTestDataPackageVersion>
     <SystemWindowsExtensionsTestDataPackageVersion>1.0.5</SystemWindowsExtensionsTestDataPackageVersion>
+    <MoqPackageVersion>4.12.0</MoqPackageVersion>
     <!-- Code coverage package version -->
     <CoverletConsolePackageVersion>1.5.0</CoverletConsolePackageVersion>
     <DotNetReportGeneratorGlobalToolPackageVersion>4.1.4</DotNetReportGeneratorGlobalToolPackageVersion>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptionProvider.cs
@@ -133,7 +133,7 @@ namespace System.ComponentModel
                 return _parent.GetFullComponentName(component);
             }
 
-            return GetTypeDescriptor(component).GetComponentName();
+            return GetTypeDescriptor(component)?.GetComponentName();
         }
 
         /// <summary>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -2839,7 +2839,9 @@ namespace System.ComponentModel
 
             public int Compare(object left, object right)
             {
-                return CultureInfo.InvariantCulture.CompareInfo.Compare(((MemberDescriptor)left).Name, ((MemberDescriptor)right).Name);
+                MemberDescriptor leftMember = left as MemberDescriptor;
+                MemberDescriptor rightMember = right as MemberDescriptor;
+                return CultureInfo.InvariantCulture.CompareInfo.Compare(leftMember?.Name, rightMember?.Name);
             }
         }
 

--- a/src/System.ComponentModel.TypeConverter/tests/CustomTypeDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/CustomTypeDescriptorTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using Moq;
 using Xunit;
 
 namespace System.ComponentModel.Tests
@@ -9,97 +11,449 @@ namespace System.ComponentModel.Tests
     public class CustomTypeDescriptorTests
     {
         [Fact]
-        public void ReturnsDefaultValues()
+        public void GetAttributes_InvokeWithoutParent_ReturnsEmpty()
         {
-            var defaultCustomTypeDescriptor = new CallEmptyConstructor();
+            var descriptor = new SubCustomTypeDescriptor();
+            Assert.Same(AttributeCollection.Empty, descriptor.GetAttributes());
 
-            Assert.Same(AttributeCollection.Empty, defaultCustomTypeDescriptor.GetAttributes());
-            Assert.Null(defaultCustomTypeDescriptor.GetClassName());
-            Assert.Null(defaultCustomTypeDescriptor.GetComponentName());
-            Assert.NotNull(defaultCustomTypeDescriptor.GetConverter());
-            Assert.Null(defaultCustomTypeDescriptor.GetDefaultEvent());
-            Assert.Null(defaultCustomTypeDescriptor.GetDefaultProperty());
-            Assert.Null(defaultCustomTypeDescriptor.GetEditor(typeof(int)));
-            Assert.Same(EventDescriptorCollection.Empty, defaultCustomTypeDescriptor.GetEvents());
-            Assert.Same(EventDescriptorCollection.Empty, defaultCustomTypeDescriptor.GetEvents(new Attribute[0]));
-            Assert.Same(PropertyDescriptorCollection.Empty, defaultCustomTypeDescriptor.GetProperties());
-            Assert.Same(PropertyDescriptorCollection.Empty, defaultCustomTypeDescriptor.GetProperties(new Attribute[0]));
-            Assert.Null(defaultCustomTypeDescriptor.GetPropertyOwner(null));
+            // Call again.
+            Assert.Same(AttributeCollection.Empty, descriptor.GetAttributes());
+        }
+
+        public static IEnumerable<object[]> GetAttributes_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new AttributeCollection(new EditorBrowsableAttribute()) };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAttributes_TestData))]
+        public void GetAttributes_InvokeWithParent_ReturnsExpected(AttributeCollection result)
+        {
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetAttributes())
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetAttributes());
+            mockParentDescriptor.Verify(d => d.GetAttributes(), Times.Once());
+
+            // Call again.
+            Assert.Same(result, descriptor.GetAttributes());
+            mockParentDescriptor.Verify(d => d.GetAttributes(), Times.Exactly(2));
         }
 
         [Fact]
-        public void ReturnsParentValues()
+        public void GetClassName_InvokeWithoutParent_ReturnsNull()
         {
-            var parent = new ParentCustomTypeDescriptor();
-            var customTypeDescriptor = new InjectsParent(parent);
+            var descriptor = new SubCustomTypeDescriptor();
+            Assert.Null(descriptor.GetClassName());
 
-            Assert.Same(parent.GetAttributes(), customTypeDescriptor.GetAttributes());
-            Assert.Same(parent.GetClassName(), customTypeDescriptor.GetClassName());
-            Assert.Same(parent.GetComponentName(), customTypeDescriptor.GetComponentName());
-            Assert.Same(parent.GetConverter(), customTypeDescriptor.GetConverter());
-            Assert.Same(parent.GetDefaultEvent(), customTypeDescriptor.GetDefaultEvent());
-            Assert.Same(parent.GetDefaultProperty(), customTypeDescriptor.GetDefaultProperty());
-            Assert.Same(parent.GetEditor(/* any value */ null), customTypeDescriptor.GetEditor(/* any value */ null));
-            Assert.Same(parent.GetEvents(), customTypeDescriptor.GetEvents());
-            Assert.Same(parent.GetEvents(/* any value */ null), customTypeDescriptor.GetEvents(/* any value */ null));
-            Assert.Same(parent.GetProperties(), customTypeDescriptor.GetProperties());
-            Assert.Same(parent.GetProperties(/* any value */ null), customTypeDescriptor.GetProperties(/* any value */ null));
-            Assert.Same(parent.GetPropertyOwner(/* any value */ null), customTypeDescriptor.GetPropertyOwner(/* any value */ null));
+            // Call again.
+            Assert.Null(descriptor.GetClassName());
         }
 
-        private class CallEmptyConstructor : CustomTypeDescriptor
+        [Theory]
+        [InlineData(null)]
+        [InlineData("name")]
+        public void GetClassName_InvokeWithParent_ReturnsExpected(string result)
         {
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetClassName())
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetClassName());
+            mockParentDescriptor.Verify(d => d.GetClassName(), Times.Once());
+
+            // Call again.
+            Assert.Same(result, descriptor.GetClassName());
+            mockParentDescriptor.Verify(d => d.GetClassName(), Times.Exactly(2));
         }
 
-        private class InjectsParent : CustomTypeDescriptor
+        [Fact]
+        public void GetComponentName_InvokeWithoutParent_ReturnsNull()
         {
-            public InjectsParent(ICustomTypeDescriptor parent)
-                : base(parent)
-            { }
+            var descriptor = new SubCustomTypeDescriptor();
+            Assert.Null(descriptor.GetComponentName());
+
+            // Call again.
+            Assert.Null(descriptor.GetComponentName());
         }
 
-        /// <summary>
-        /// An implementation of ICustomTypeDescriptor to be used to mock the parent injected into
-        /// CustomTypeDescriptor. All of the items it returns are cached so they are the same instance
-        /// each time the method is called. This way, the tests can verify that the parent instance is
-        /// being returned by CustomTypeDescriptor for each of the methods.
-        /// </summary>
-        private class ParentCustomTypeDescriptor : ICustomTypeDescriptor
+        [Theory]
+        [InlineData(null)]
+        [InlineData("name")]
+        public void GetComponentName_InvokeWithParent_ReturnsExpected(string result)
         {
-            private readonly TypeConverter _converter = new TypeConverter();
-            private readonly AttributeCollection _attributes = new AttributeCollection(null);
-            private readonly EventDescriptor _defaultEvent = new MockEventDescriptor();
-            private readonly PropertyDescriptor _defaultProperty = new MockPropertyDescriptor();
-            private readonly EventDescriptorCollection _events1 = new EventDescriptorCollection(null);
-            private readonly EventDescriptorCollection _events2 = new EventDescriptorCollection(null);
-            private readonly PropertyDescriptorCollection _properties1 = new PropertyDescriptorCollection(null);
-            private readonly PropertyDescriptorCollection _properties2 = new PropertyDescriptorCollection(null);
-            private readonly object _editor = new object();
-            private readonly object _propertyOwner = new object();
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetComponentName())
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetComponentName());
+            mockParentDescriptor.Verify(d => d.GetComponentName(), Times.Once());
 
-            public AttributeCollection GetAttributes() => _attributes;
+            // Call again.
+            Assert.Same(result, descriptor.GetComponentName());
+            mockParentDescriptor.Verify(d => d.GetComponentName(), Times.Exactly(2));
+        }
 
-            public string GetClassName() => "ClassName";
+        [Fact]
+        public void GetConverter_InvokeWithoutParent_ReturnsExpected()
+        {
+            var descriptor = new SubCustomTypeDescriptor();
+            TypeConverter result1 = Assert.IsType<TypeConverter>(descriptor.GetConverter());
+            Assert.NotNull(result1);
 
-            public string GetComponentName() => "ComponentName";
+            // Call again.
+            TypeConverter result2 = Assert.IsType<TypeConverter>(descriptor.GetConverter());
+            Assert.NotSame(result1, result2);
+        }
 
-            public TypeConverter GetConverter() => _converter;
+        public static IEnumerable<object[]> GetConverter_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new Int32Converter() };
+        }
 
-            public EventDescriptor GetDefaultEvent() => _defaultEvent;
+        [Theory]
+        [MemberData(nameof(GetConverter_TestData))]
+        public void GetConverter_InvokeWithParent_ReturnsExpected(TypeConverter result)
+        {
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetConverter())
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetConverter());
+            mockParentDescriptor.Verify(d => d.GetConverter(), Times.Once());
 
-            public PropertyDescriptor GetDefaultProperty() => _defaultProperty;
+            // Call again.
+            Assert.Same(result, descriptor.GetConverter());
+            mockParentDescriptor.Verify(d => d.GetConverter(), Times.Exactly(2));
+        }
 
-            public object GetEditor(Type editorBaseType) => _editor;
+        [Fact]
+        public void GetDefaultEvent_InvokeWithoutParent_ReturnsNull()
+        {
+            var descriptor = new SubCustomTypeDescriptor();
+            Assert.Null(descriptor.GetDefaultEvent());
 
-            public EventDescriptorCollection GetEvents() => _events1;
+            // Call again.
+            Assert.Null(descriptor.GetDefaultEvent());
+        }
 
-            public EventDescriptorCollection GetEvents(Attribute[] attributes) => _events2;
+        public static IEnumerable<object[]> GetDefaultEvent_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new Mock<EventDescriptor>(MockBehavior.Strict, "Event", new Attribute[0]).Object };
+        }
 
-            public PropertyDescriptorCollection GetProperties() => _properties1;
+        [Theory]
+        [MemberData(nameof(GetDefaultEvent_TestData))]
+        public void GetDefaultEvent_InvokeWithParent_ReturnsExpected(EventDescriptor result)
+        {
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetDefaultEvent())
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetDefaultEvent());
+            mockParentDescriptor.Verify(d => d.GetDefaultEvent(), Times.Once());
 
-            public PropertyDescriptorCollection GetProperties(Attribute[] attributes) => _properties2;
+            // Call again.
+            Assert.Same(result, descriptor.GetDefaultEvent());
+            mockParentDescriptor.Verify(d => d.GetDefaultEvent(), Times.Exactly(2));
+        }
 
-            public object GetPropertyOwner(PropertyDescriptor pd) => _propertyOwner;
+        [Fact]
+        public void GetDefaultProperty_InvokeWithoutParent_ReturnsNull()
+        {
+            var descriptor = new SubCustomTypeDescriptor();
+            Assert.Null(descriptor.GetDefaultProperty());
+
+            // Call again.
+            Assert.Null(descriptor.GetDefaultProperty());
+        }
+
+        public static IEnumerable<object[]> GetDefaultProperty_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new Mock<PropertyDescriptor>(MockBehavior.Strict, "Property", new Attribute[0]).Object };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDefaultProperty_TestData))]
+        public void GetDefaultProperty_InvokeWithParent_ReturnsExpected(PropertyDescriptor result)
+        {
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetDefaultProperty())
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetDefaultProperty());
+            mockParentDescriptor.Verify(d => d.GetDefaultProperty(), Times.Once());
+
+            // Call again.
+            Assert.Same(result, descriptor.GetDefaultProperty());
+            mockParentDescriptor.Verify(d => d.GetDefaultProperty(), Times.Exactly(2));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(typeof(int))]
+        public void GetEditor_InvokeWithoutParent_ReturnsNull(Type editorBaseType)
+        {
+            var descriptor = new SubCustomTypeDescriptor();
+            Assert.Null(descriptor.GetEditor(editorBaseType));
+
+            // Call again.
+            Assert.Null(descriptor.GetEditor(editorBaseType));
+        }
+
+        public static IEnumerable<object[]> GetEditor_TestData()
+        {
+            foreach (Type result in new Type[] { null, typeof(int) })
+            {
+                yield return new object[] { null, result };
+                yield return new object[] { typeof(object), result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEditor_TestData))]
+        public void GetEditor_InvokeWithParent_ReturnsExpected(Type editorBaseType, Type result)
+        {
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetEditor(editorBaseType))
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetEditor(editorBaseType));
+            mockParentDescriptor.Verify(d => d.GetEditor(editorBaseType), Times.Once());
+
+            // Call again.
+            Assert.Same(result, descriptor.GetEditor(editorBaseType));
+            mockParentDescriptor.Verify(d => d.GetEditor(editorBaseType), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void GetEvents_InvokeWithoutParent_ReturnsEmpty()
+        {
+            var descriptor = new SubCustomTypeDescriptor();
+            Assert.Same(EventDescriptorCollection.Empty, descriptor.GetEvents());
+
+            // Call again.
+            Assert.Same(EventDescriptorCollection.Empty, descriptor.GetEvents());
+        }
+
+        public static IEnumerable<object[]> GetEvents_WithParent_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new EventDescriptorCollection(new EventDescriptor[] { null }) };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEvents_WithParent_TestData))]
+        public void GetEvents_InvokeWithParent_ReturnsExpected(EventDescriptorCollection result)
+        {
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetEvents())
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetEvents());
+            mockParentDescriptor.Verify(d => d.GetEvents(), Times.Once());
+
+            // Call again.
+            Assert.Same(result, descriptor.GetEvents());
+            mockParentDescriptor.Verify(d => d.GetEvents(), Times.Exactly(2));
+        }
+
+        public static IEnumerable<object[]> GetEvents_AttributesWithoutParent_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new Attribute[] { new EditorBrowsableAttribute() } };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEvents_AttributesWithoutParent_TestData))]
+        public void GetEvents_InvokeAttributesWithoutParent_ReturnsEmpty(Attribute[] attributes)
+        {
+            var descriptor = new SubCustomTypeDescriptor();
+            Assert.Same(EventDescriptorCollection.Empty, descriptor.GetEvents(attributes));
+
+            // Call again.
+            Assert.Same(EventDescriptorCollection.Empty, descriptor.GetEvents(attributes));
+        }
+
+        public static IEnumerable<object[]> GetEvents_AttributesWithParent_TestData()
+        {
+            foreach (EventDescriptorCollection result in new EventDescriptorCollection[] { null, new EventDescriptorCollection(new EventDescriptor[] { null }) })
+            {
+                yield return new object[] { null, result };
+                yield return new object[] { new Attribute[] { new EditorBrowsableAttribute() }, result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEvents_AttributesWithParent_TestData))]
+        public void GetEvents_InvokeAttributesWithParent_ReturnsExpected(Attribute[] attributes, EventDescriptorCollection result)
+        {
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetEvents(attributes))
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetEvents(attributes));
+            mockParentDescriptor.Verify(d => d.GetEvents(attributes), Times.Once());
+
+            // Call again.
+            Assert.Same(result, descriptor.GetEvents(attributes));
+            mockParentDescriptor.Verify(d => d.GetEvents(attributes), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void GetProperties_InvokeWithoutParent_ReturnsEmpty()
+        {
+            var descriptor = new SubCustomTypeDescriptor();
+            Assert.Same(PropertyDescriptorCollection.Empty, descriptor.GetProperties());
+
+            // Call again.
+            Assert.Same(PropertyDescriptorCollection.Empty, descriptor.GetProperties());
+        }
+
+        public static IEnumerable<object[]> GetProperties_WithParent_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new PropertyDescriptorCollection(new PropertyDescriptor[] { null }) };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetProperties_WithParent_TestData))]
+        public void GetProperties_InvokeWithParent_ReturnsExpected(PropertyDescriptorCollection result)
+        {
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetProperties())
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetProperties());
+            mockParentDescriptor.Verify(d => d.GetProperties(), Times.Once());
+
+            // Call again.
+            Assert.Same(result, descriptor.GetProperties());
+            mockParentDescriptor.Verify(d => d.GetProperties(), Times.Exactly(2));
+        }
+
+        public static IEnumerable<object[]> GetProperties_AttributesWithoutParent_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new Attribute[] { new EditorBrowsableAttribute() } };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetProperties_AttributesWithoutParent_TestData))]
+        public void GetProperties_InvokeAttributesWithoutParent_ReturnsEmpty(Attribute[] attributes)
+        {
+            var descriptor = new SubCustomTypeDescriptor();
+            Assert.Same(PropertyDescriptorCollection.Empty, descriptor.GetProperties(attributes));
+
+            // Call again.
+            Assert.Same(PropertyDescriptorCollection.Empty, descriptor.GetProperties(attributes));
+        }
+
+        public static IEnumerable<object[]> GetProperties_AttributesWithParent_TestData()
+        {
+            foreach (PropertyDescriptorCollection result in new PropertyDescriptorCollection[] { null, new PropertyDescriptorCollection(new PropertyDescriptor[] { null }) })
+            {
+                yield return new object[] { null, result };
+                yield return new object[] { new Attribute[] { new EditorBrowsableAttribute() }, result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetProperties_AttributesWithParent_TestData))]
+        public void GetProperties_InvokeAttributesWithParent_ReturnsExpected(Attribute[] attributes, PropertyDescriptorCollection result)
+        {
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetProperties(attributes))
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetProperties(attributes));
+            mockParentDescriptor.Verify(d => d.GetProperties(attributes), Times.Once());
+
+            // Call again.
+            Assert.Same(result, descriptor.GetProperties(attributes));
+            mockParentDescriptor.Verify(d => d.GetProperties(attributes), Times.Exactly(2));
+        }
+
+        public static IEnumerable<object[]> GetPropertyOwner_WithoutParent_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new Mock<PropertyDescriptor>(MockBehavior.Strict, "Name", new Attribute[0]).Object };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetPropertyOwner_WithoutParent_TestData))]
+        public void GetPropertyOwner_InvokeWithoutParent_ReturnsNull(PropertyDescriptor pd)
+        {
+            var descriptor = new SubCustomTypeDescriptor();
+            Assert.Null(descriptor.GetPropertyOwner(pd));
+
+            // Call again.
+            Assert.Null(descriptor.GetPropertyOwner(pd));
+        }
+
+        public static IEnumerable<object[]> GetPropertyOwner_WithParent_TestData()
+        {
+            foreach (object result in new object[] { null, new object() })
+            {
+                yield return new object[] { null, result };
+                yield return new object[] { new Mock<PropertyDescriptor>(MockBehavior.Strict, "Name", new Attribute[0]).Object, result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetPropertyOwner_WithParent_TestData))]
+        public void GetPropertyOwner_InvokeWithParent_ReturnsExpected(PropertyDescriptor pd, object result)
+        {
+            var mockParentDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockParentDescriptor
+                .Setup(d => d.GetPropertyOwner(pd))
+                .Returns(result)
+                .Verifiable();
+            var descriptor = new SubCustomTypeDescriptor(mockParentDescriptor.Object);
+            Assert.Same(result, descriptor.GetPropertyOwner(pd));
+            mockParentDescriptor.Verify(d => d.GetPropertyOwner(pd), Times.Once());
+
+            // Call again.
+            Assert.Same(result, descriptor.GetPropertyOwner(pd));
+            mockParentDescriptor.Verify(d => d.GetPropertyOwner(pd), Times.Exactly(2));
+        }
+
+        private class SubCustomTypeDescriptor : CustomTypeDescriptor
+        {
+            public SubCustomTypeDescriptor() : base()
+            {
+            }
+
+            public SubCustomTypeDescriptor(ICustomTypeDescriptor parent) : base(parent)
+            {
+            }
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/Design/DesignerVerbTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Design/DesignerVerbTests.cs
@@ -2,56 +2,153 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using Xunit;
 
 namespace System.ComponentModel.Design.Tests
 {
     public class DesignerVerbTests
     {
-        public static IEnumerable<object[]> Ctor_Text_EventHandler_TestData()
+        public static IEnumerable<object[]> Ctor_String_EventHandler_TestData()
         {
-            yield return new object[] { "Text", new EventHandler(EventHandler), "Text" };
-            yield return new object[] { "(&.)Text", new EventHandler(EventHandler), "Text" };
-            yield return new object[] { null, null, null };
+            yield return new object[] { "Text", new EventHandler(EventHandler), "Text", "Text" };
+            yield return new object[] { "(&.)Text", new EventHandler(EventHandler), "Text", "Text" };
+            yield return new object[] { null, null, string.Empty, null };
         }
 
         [Theory]
-        [MemberData(nameof(Ctor_Text_EventHandler_TestData))]
-        public void Ctor_Text_EventHandler(string text, EventHandler handler, string expectedText)
+        [MemberData(nameof(Ctor_String_EventHandler_TestData))]
+        public void Ctor_String_EventHandler(string text, EventHandler handler, string expectedText, string expectedPropertiesText)
         {
             var verb = new DesignerVerb(text, handler);
-            Assert.Equal(expectedText ?? string.Empty, verb.Text);
             Assert.Equal(new Guid("{74D21313-2AEE-11d1-8BFB-00A0C90F26F7}"), verb.CommandID.Guid);
             Assert.Equal(0x2000, verb.CommandID.ID);
             Assert.Empty(verb.Description);
+            Assert.True(verb.Enabled);
+            Assert.Equal(3, verb.OleStatus);
+            Assert.True(verb.Enabled);
+            Assert.Equal(expectedText, verb.Text);
+            Assert.IsType<HybridDictionary>(verb.Properties);
+            Assert.Same(verb.Properties, verb.Properties);
+            DictionaryEntry entry = Assert.IsType<DictionaryEntry>(Assert.Single(verb.Properties));
+            Assert.Equal("Text", entry.Key);
+            Assert.Equal(expectedPropertiesText, entry.Value);
+            Assert.True(verb.Supported);
+            Assert.True(verb.Visible);
         }
 
-        public static IEnumerable<object[]> Ctor_Text_EventHandler_CommandID_TestData()
+        public static IEnumerable<object[]> Ctor_String_EventHandler_CommandID_TestData()
         {
-            yield return new object[] { "Text", new EventHandler(EventHandler), new CommandID(Guid.NewGuid(), 10), "Text" };
-            yield return new object[] { "(&.)Text", new EventHandler(EventHandler), new CommandID(Guid.NewGuid(), 10), "Text" };
-            yield return new object[] { null, null, null, null };
+            yield return new object[] { "Text", new EventHandler(EventHandler), new CommandID(Guid.NewGuid(), 10), "Text", "Text" };
+            yield return new object[] { "(&.)Text", new EventHandler(EventHandler), new CommandID(Guid.NewGuid(), 10), "Text", "Text" };
+            yield return new object[] { null, null, null, string.Empty, null };
         }
 
         [Theory]
-        [MemberData(nameof(Ctor_Text_EventHandler_CommandID_TestData))]
-        public void Ctor_Text_EventHandler_CommandID(string text, EventHandler handler, CommandID commandID, string expectedText)
+        [MemberData(nameof(Ctor_String_EventHandler_CommandID_TestData))]
+        public void Ctor_String_EventHandler_CommandID(string text, EventHandler handler, CommandID commandID, string expectedText, string expectedPropertiesText)
         {
             var verb = new DesignerVerb(text, handler, commandID);
-            Assert.Equal(expectedText ?? string.Empty, verb.Text);
-            Assert.Same(commandID, verb.CommandID);
+            Assert.Equal(commandID, verb.CommandID);
             Assert.Empty(verb.Description);
+            Assert.True(verb.Enabled);
+            Assert.Equal(3, verb.OleStatus);
+            Assert.True(verb.Enabled);
+            Assert.Equal(expectedText, verb.Text);
+            Assert.IsType<HybridDictionary>(verb.Properties);
+            Assert.Same(verb.Properties, verb.Properties);
+            DictionaryEntry entry = Assert.IsType<DictionaryEntry>(Assert.Single(verb.Properties));
+            Assert.Equal("Text", entry.Key);
+            Assert.Equal(expectedPropertiesText, entry.Value);
+            Assert.True(verb.Supported);
+            Assert.True(verb.Visible);
+        }
+
+        [Fact]
+        public void Ctor_NullProperties_ThrowsNullReferenceException()
+        {
+            Assert.Throws<NullReferenceException>(() => new NullPropertiesDesignerVerb("Text", new EventHandler(EventHandler)));
+            Assert.Throws<NullReferenceException>(() => new NullPropertiesDesignerVerb("Text", new EventHandler(EventHandler), new CommandID(Guid.NewGuid(), 10)));
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("Description")]
-        public void Description_Set_GetReturnsExpected(string value)
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("Description", "Description")]
+        public void Description_GetWithProperties_ReturnsExpected(string value, string expected)
         {
-            var verb = new DesignerVerb("Text", new EventHandler(EventHandler)) { Description = value };
-            Assert.Equal(value ?? string.Empty, verb.Description);
+            var verb = new DesignerVerb("Text", new EventHandler(EventHandler));
+            verb.Properties["Description"] = value;
+            Assert.Equal(expected, verb.Description);
+        }
+
+        [Fact]
+        public void Description_GetWithPropertiesInvalidType_ThrowsInvalidCastException()
+        {
+            var verb = new DesignerVerb("Text", new EventHandler(EventHandler));
+            verb.Properties["Description"] = new object();
+            Assert.Throws<InvalidCastException>(() => verb.Description);
+        }
+
+        [Fact]
+        public void Description_GetWithNullProperties_ThrowsNullReferenceException()
+        {
+            var verb = new NullPropertiesAfterConstructionDesignerVerb("Text", new EventHandler(EventHandler));
+            Assert.Throws<NullReferenceException>(() => verb.Description = "value");
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("Description", "Description")]
+        public void Description_Set_GetReturnsExpected(string value, string expected)
+        {
+            var verb = new DesignerVerb("Text", new EventHandler(EventHandler))
+            {
+                Description = value
+            };
+            Assert.Equal(expected, verb.Description);
+            Assert.Equal(value, verb.Properties["Description"]);
+
+            // Set same.
+            verb.Description = value;
+            Assert.Equal(expected, verb.Description);
+            Assert.Equal(value, verb.Properties["Description"]);
+        }
+
+        [Fact]
+        public void Description_SetWithNullProperties_ThrowsNullReferenceException()
+        {
+            var verb = new NullPropertiesAfterConstructionDesignerVerb("Text", new EventHandler(EventHandler));
+            Assert.Throws<NullReferenceException>(() => verb.Description);
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("Text", "Text")]
+        public void Text_GetWithProperties_ReturnsExpected(string value, string expected)
+        {
+            var verb = new DesignerVerb("Text", new EventHandler(EventHandler));
+            verb.Properties["Text"] = value;
+            Assert.Equal(expected, verb.Text);
+        }
+
+        [Fact]
+        public void Text_GetWithPropertiesInvalidType_ThrowsInvalidCastException()
+        {
+            var verb = new DesignerVerb("Text", new EventHandler(EventHandler));
+            verb.Properties["Text"] = new object();
+            Assert.Throws<InvalidCastException>(() => verb.Text);
+        }
+
+        [Fact]
+        public void Text_GetWithNullProperties_ThrowsNullReferenceException()
+        {
+            var verb = new NullPropertiesAfterConstructionDesignerVerb("Text", new EventHandler(EventHandler));
+            Assert.Throws<NullReferenceException>(() => verb.Text);
         }
 
         [Fact]
@@ -62,5 +159,45 @@ namespace System.ComponentModel.Design.Tests
         }
 
         private static void EventHandler(object sender, EventArgs e) { }
+
+        private class NullPropertiesDesignerVerb : DesignerVerb
+        {
+            public NullPropertiesDesignerVerb(string text, EventHandler handler) : base(text, handler)
+            {
+            }
+
+            public NullPropertiesDesignerVerb(string text, EventHandler handler, CommandID startCommandID) : base(text, handler, startCommandID)
+            {
+            }
+
+            public override IDictionary Properties => null;
+        }
+
+        private class NullPropertiesAfterConstructionDesignerVerb : DesignerVerb
+        {
+            public NullPropertiesAfterConstructionDesignerVerb(string text, EventHandler handler) : base(text, handler)
+            {
+            }
+
+            public NullPropertiesAfterConstructionDesignerVerb(string text, EventHandler handler, CommandID startCommandID) : base(text, handler, startCommandID)
+            {
+            }
+
+            private bool Constructed { get; set; }
+
+            public override IDictionary Properties
+            {
+                get
+                {
+                    if (!Constructed)
+                    {
+                        Constructed = true;
+                        return base.Properties;
+                    }
+
+                    return null;
+                }
+            }
+        }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/Design/MenuCommandTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Design/MenuCommandTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using Xunit;
 
 namespace System.ComponentModel.Design.Tests
@@ -20,57 +21,277 @@ namespace System.ComponentModel.Design.Tests
         public void Ctor_EventHandler_CommandID(EventHandler handler, CommandID commandId)
         {
             var command = new MenuCommand(handler, commandId);
-            Assert.Same(commandId, command.CommandID);
-            Assert.Empty(command.Properties);
-
-            Assert.True(command.Enabled);
             Assert.False(command.Checked);
+            Assert.Same(commandId, command.CommandID);
+            Assert.True(command.Enabled);
+            Assert.Equal(3, command.OleStatus);
+            Assert.IsType<HybridDictionary>(command.Properties);
+            Assert.Empty(command.Properties);
+            Assert.Same(command.Properties, command.Properties);
             Assert.True(command.Supported);
             Assert.True(command.Visible);
-            Assert.Equal(3, command.OleStatus);
+        }
+
+        [Theory]
+        [InlineData(true, 7, 3)]
+        [InlineData(false, 3, 7)]
+        public void Checked_Set_GetReturnsExpected(bool value, int expectedOleStatus1, int expectedOleStatus2)
+        {
+            var command = new MenuCommand(null, null)
+            {
+                Checked = value 
+            };
+            Assert.Equal(value, command.Checked);
+            Assert.Equal(expectedOleStatus1, command.OleStatus);
+
+            // Set same.
+            command.Checked = value;
+            Assert.Equal(value, command.Checked);
+            Assert.Equal(expectedOleStatus1, command.OleStatus);
+
+            // Set different.
+            command.Checked = !value;
+            Assert.Equal(!value, command.Checked);
+            Assert.Equal(expectedOleStatus2, command.OleStatus);
         }
 
         [Fact]
-        public void Properties_GetMultipleTimes_ReturnsEmpty()
+        public void Checked_SetWithCommandChanged_CallsHandler()
         {
             var command = new MenuCommand(null, null);
-            Assert.Same(command.Properties, command.Properties);
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(command, sender);
+                Assert.Same(EventArgs.Empty, e);
+                callCount++;
+            };
+            command.CommandChanged += handler;
+
+            // Set different.
+            command.Checked = true;
+            Assert.True(command.Checked);
+            Assert.Equal(1, callCount);
+
+            // Set same.
+            command.Checked = true;
+            Assert.True(command.Checked);
+            Assert.Equal(1, callCount);
+
+            // Set different.
+            command.Checked = false;
+            Assert.False(command.Checked);
+            Assert.Equal(2, callCount);
+
+            // Remove handler.
+            command.CommandChanged -= handler;
+            command.Checked = true;
+            Assert.True(command.Checked);
+            Assert.Equal(2, callCount);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Enabled_Set_GetReturnsExpected(bool value)
+        [InlineData(true, 3, 1)]
+        [InlineData(false, 1, 3)]
+        public void Enabled_Set_GetReturnsExpected(bool value, int expectedOleStatus1, int expectedOleStatus2)
         {
-            var command = new MenuCommand(null, null) { Enabled = value };
+            var command = new MenuCommand(null, null)
+            {
+                Enabled = value
+            };
             Assert.Equal(value, command.Enabled);
+            Assert.Equal(expectedOleStatus1, command.OleStatus);
+
+            // Set same.
+            command.Enabled = value;
+            Assert.Equal(value, command.Enabled);
+            Assert.Equal(expectedOleStatus1, command.OleStatus);
+
+            // Set different.
+            command.Enabled = !value;
+            Assert.Equal(!value, command.Enabled);
+            Assert.Equal(expectedOleStatus2, command.OleStatus);
+        }
+
+        [Fact]
+        public void Enabled_SetWithCommandChanged_CallsHandler()
+        {
+            var command = new MenuCommand(null, null);
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(command, sender);
+                Assert.Same(EventArgs.Empty, e);
+                callCount++;
+            };
+            command.CommandChanged += handler;
+
+            // Set different.
+            command.Enabled = false;
+            Assert.False(command.Enabled);
+            Assert.Equal(1, callCount);
+
+            // Set same.
+            command.Enabled = false;
+            Assert.False(command.Enabled);
+            Assert.Equal(1, callCount);
+
+            // Set different.
+            command.Enabled = true;
+            Assert.True(command.Enabled);
+            Assert.Equal(2, callCount);
+
+            // Remove handler.
+            command.CommandChanged -= handler;
+            command.Enabled = false;
+            Assert.False(command.Enabled);
+            Assert.Equal(2, callCount);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Checked_Set_GetReturnsExpected(bool value)
+        [InlineData(true, 3, 2)]
+        [InlineData(false, 2, 3)]
+        public void Supported_Set_GetReturnsExpected(bool value, int expectedOleStatus1, int expectedOleStatus2)
         {
-            var command = new MenuCommand(null, null) { Checked = value };
-            Assert.Equal(value, command.Checked);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Supported_Set_GetReturnsExpected(bool value)
-        {
-            var command = new MenuCommand(null, null) { Supported = value };
+            var command = new MenuCommand(null, null)
+            {
+                Supported = value
+            };
             Assert.Equal(value, command.Supported);
+            Assert.Equal(expectedOleStatus1, command.OleStatus);
+
+            // Set same.
+            command.Supported = value;
+            Assert.Equal(value, command.Supported);
+            Assert.Equal(expectedOleStatus1, command.OleStatus);
+
+            // Set different.
+            command.Supported = !value;
+            Assert.Equal(!value, command.Supported);
+            Assert.Equal(expectedOleStatus2, command.OleStatus);
+        }
+
+        [Fact]
+        public void Supported_SetWithCommandChanged_CallsHandler()
+        {
+            var command = new MenuCommand(null, null);
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(command, sender);
+                Assert.Same(EventArgs.Empty, e);
+                callCount++;
+            };
+            command.CommandChanged += handler;
+
+            // Set different.
+            command.Supported = false;
+            Assert.False(command.Supported);
+            Assert.Equal(1, callCount);
+
+            // Set same.
+            command.Supported = false;
+            Assert.False(command.Supported);
+            Assert.Equal(1, callCount);
+
+            // Set different.
+            command.Supported = true;
+            Assert.True(command.Supported);
+            Assert.Equal(2, callCount);
+
+            // Remove handler.
+            command.CommandChanged -= handler;
+            command.Supported = false;
+            Assert.False(command.Supported);
+            Assert.Equal(2, callCount);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Visible_Set_GetReturnsExpected(bool value)
+        [InlineData(true, 3, 19)]
+        [InlineData(false, 19, 3)]
+        public void Visible_Set_GetReturnsExpected(bool value, int expectedOleStatus1, int expectedOleStatus2)
         {
-            var command = new MenuCommand(null, null) { Visible = value };
+            var command = new MenuCommand(null, null)
+            {
+                Visible = value
+            };
             Assert.Equal(value, command.Visible);
+            Assert.Equal(expectedOleStatus1, command.OleStatus);
+
+            // Set same.
+            command.Visible = value;
+            Assert.Equal(value, command.Visible);
+            Assert.Equal(expectedOleStatus1, command.OleStatus);
+
+            // Set different.
+            command.Visible = !value;
+            Assert.Equal(!value, command.Visible);
+            Assert.Equal(expectedOleStatus2, command.OleStatus);
+        }
+
+        [Fact]
+        public void Visible_SetWithCommandChanged_CallsHandler()
+        {
+            var command = new MenuCommand(null, null);
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(command, sender);
+                Assert.Same(EventArgs.Empty, e);
+                callCount++;
+            };
+            command.CommandChanged += handler;
+
+            // Set different.
+            command.Visible = false;
+            Assert.False(command.Visible);
+            Assert.Equal(1, callCount);
+
+            // Set same.
+            command.Visible = false;
+            Assert.False(command.Visible);
+            Assert.Equal(1, callCount);
+
+            // Set different.
+            command.Visible = true;
+            Assert.True(command.Visible);
+            Assert.Equal(2, callCount);
+
+            // Remove handler.
+            command.CommandChanged -= handler;
+            command.Visible = false;
+            Assert.False(command.Visible);
+            Assert.Equal(2, callCount);
+        }
+
+        public static IEnumerable<object[]> OnCommandChanged_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new EventArgs() };
+        }
+
+        [Theory]
+        [MemberData(nameof(OnCommandChanged_TestData))]
+        public void OnCommandChanged_Invoke_CallsCommandChanged(EventArgs eventArgs)
+        {
+            var command = new SubMenuCommand(null, null);
+            int callCount = 0;
+            EventHandler handler = (sender, e) =>
+            {
+                Assert.Same(command, sender);
+                Assert.Same(eventArgs, e);
+                callCount++;
+            };
+            command.CommandChanged += handler;
+
+            // Call with handler.
+            command.OnCommandChanged(eventArgs);
+            Assert.Equal(1, callCount);
+
+            // Remove handler.
+            command.CommandChanged -= handler;
+            command.OnCommandChanged(eventArgs);
+            Assert.Equal(1, callCount);
         }
 
         public static IEnumerable<object[]> ToString_TestData()
@@ -141,52 +362,12 @@ namespace System.ComponentModel.Design.Tests
             command.Invoke("arg");
         }
 
-        [Fact]
-        public void SetStatus_CommandChanged_Invokes()
-        {
-            int calledCommandChanged = 0;
-
-            var command = new MenuCommand(null, null);
-            command.CommandChanged += (sender, e) =>
-            {
-                calledCommandChanged++;
-
-                Assert.Same(command, sender);
-                Assert.Equal(EventArgs.Empty, e);
-            };
-
-            command.Checked = false;
-            Assert.Equal(0, calledCommandChanged);
-
-            command.Checked = true;
-            Assert.Equal(1, calledCommandChanged);
-
-            command.Enabled = true;
-            Assert.Equal(1, calledCommandChanged);
-
-            command.Enabled = false;
-            Assert.Equal(2, calledCommandChanged);
-
-            command.Visible = true;
-            Assert.Equal(2, calledCommandChanged);
-
-            command.Visible = false;
-            Assert.Equal(3, calledCommandChanged);
-
-            command.Supported = true;
-            Assert.Equal(3, calledCommandChanged);
-
-            command.Supported = false;
-            Assert.Equal(4, calledCommandChanged);
-        }
-
         private static object CalledEventSender { get; set; }
 
         private static void EventHandler(object sender, EventArgs e)
         {
             CalledEventSender = sender;
-
-            Assert.Equal(EventArgs.Empty, e);
+            Assert.Same(EventArgs.Empty, e);
         }
 
         private static void ThrowCanceledCheckoutException(object sender, EventArgs e)
@@ -197,6 +378,15 @@ namespace System.ComponentModel.Design.Tests
         private static void ThrowNonCanceledCheckoutException(object sender, EventArgs e)
         {
             throw new CheckoutException();
+        }
+
+        private class SubMenuCommand : MenuCommand
+        {
+            public SubMenuCommand(EventHandler handler, CommandID command) : base(handler, command)
+            {
+            }
+
+            public new void OnCommandChanged(EventArgs e) => base.OnCommandChanged(e);
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="TypeConverterAttributeTests.cs" />
     <Compile Include="TypeConverterTests.cs" />
     <Compile Include="TypeConverterTestBase.cs" />
+    <Compile Include="TypeDescriptionProviderTests.cs" />
     <Compile Include="TypeDescriptionProviderAttributeTests.cs" />
     <Compile Include="TypeDescriptorTests.cs" />
     <Compile Include="TypeDescriptorTests.netcoreapp.cs" Condition="'$(TargetsNetCoreApp)' == 'true'" />
@@ -157,6 +158,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="$(SystemComponentModelTypeConverterTestDataPackageVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\TestResx.resx">

--- a/src/System.ComponentModel.TypeConverter/tests/TypeDescriptionProviderTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeDescriptionProviderTests.cs
@@ -1,0 +1,794 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace System.ComponentModel.Tests
+{
+    public class TypeDescriptionProviderTests
+    {
+        public static IEnumerable<object[]> CreateInstance_WithoutParent_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new Mock<IServiceProvider>(MockBehavior.Strict).Object };
+        }
+
+        [Theory]
+        [MemberData(nameof(CreateInstance_WithoutParent_TestData))]
+        public void CreateInstance_InvokeWithoutParent_ReturnsExpected(IServiceProvider serviceProvider)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            Assert.Equal("aa", provider.CreateInstance(serviceProvider, typeof(string), new Type[] { typeof(char), typeof(int) }, new object[] { 'a', 2 }));
+
+            // Call again.
+            Assert.Equal("aa", provider.CreateInstance(serviceProvider, typeof(string), new Type[] { typeof(char), typeof(int) }, new object[] { 'a', 2 }));
+        }
+
+        public static IEnumerable<object[]> CreateInstance_WithParent_TestData()
+        {
+            foreach (object result in new object[] { null, new object() })
+            {
+                yield return new object[] { null, null, null, null, result };
+                yield return new object[] { new Mock<IServiceProvider>(MockBehavior.Strict).Object, typeof(string), new Type[] { typeof(char), typeof(int) }, new object[] { 'a', 2 }, result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CreateInstance_WithParent_TestData))]
+        public void CreateInstance_InvokeWithParent_ReturnsExpected(IServiceProvider serviceProvider, Type objectType, Type[] argTypes, object[] args, object result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.CreateInstance(serviceProvider, objectType, argTypes, args))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.CreateInstance(serviceProvider, objectType, argTypes, args));
+            mockParentProvider.Verify(p => p.CreateInstance(serviceProvider, objectType, argTypes, args), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.CreateInstance(serviceProvider, objectType, argTypes, args));
+            mockParentProvider.Verify(p => p.CreateInstance(serviceProvider, objectType, argTypes, args), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void CreateInstance_NullObjectType_ThrowsArgumentNullException()
+        {
+            var provider = new SubTypeDescriptionProvider();
+            AssertExtensions.Throws<ArgumentNullException>("objectType", () => provider.CreateInstance(null, null, null, null));
+        }
+
+        public static IEnumerable<object[]> GetCache_WithoutParent_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new object() };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCache_WithoutParent_TestData))]
+        public void GetCache_InvokeWithoutParent_ReturnsNull(object instance)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            Assert.Null(provider.GetCache(instance));
+
+            // Call again.
+            Assert.Null(provider.GetCache(instance));
+        }
+
+        public static IEnumerable<object[]> GetCache_WithParent_TestData()
+        {
+            foreach (IDictionary result in new IDictionary[] { null, new Dictionary<int, string>() })
+            {
+                yield return new object[] { null, result };
+                yield return new object[] { new object(), result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCache_WithParent_TestData))]
+        public void GetCache_InvokeWithParent_ReturnsExpected(object instance, IDictionary result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.GetCache(instance))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.GetCache(instance));
+            mockParentProvider.Verify(p => p.GetCache(instance), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetCache(instance));
+            mockParentProvider.Verify(p => p.GetCache(instance), Times.Exactly(2));
+        }
+
+        public static IEnumerable<object[]> GetExtendedTypeDescriptor_WithoutParent_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new object() };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetExtendedTypeDescriptor_WithoutParent_TestData))]
+        public void GetExtendedTypeDescriptor_InvokeWithoutParent_ReturnsExpected(object instance)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            CustomTypeDescriptor result1 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetExtendedTypeDescriptor(instance));
+            Assert.Empty(result1.GetProperties());
+
+            // Call again.
+            CustomTypeDescriptor result2 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetExtendedTypeDescriptor(instance));
+            Assert.Same(result1, result2);
+        }
+
+        public static IEnumerable<object[]> GetExtendedTypeDescriptor_WithParent_TestData()
+        {
+            foreach (ICustomTypeDescriptor result in new ICustomTypeDescriptor[] { null, new Mock<ICustomTypeDescriptor>(MockBehavior.Strict).Object })
+            {
+                yield return new object[] { null, result };
+                yield return new object[] { new object(), result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetExtendedTypeDescriptor_WithParent_TestData))]
+        public void GetExtendedTypeDescriptor_InvokeWithParent_ReturnsExpected(object instance, ICustomTypeDescriptor result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.GetExtendedTypeDescriptor(instance))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.GetExtendedTypeDescriptor(instance));
+            mockParentProvider.Verify(p => p.GetExtendedTypeDescriptor(instance), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetExtendedTypeDescriptor(instance));
+            mockParentProvider.Verify(p => p.GetExtendedTypeDescriptor(instance), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void GetExtenderProviders_InvokeWithoutParent_ReturnsEmpty()
+        {
+            var provider = new SubTypeDescriptionProvider();
+            Assert.Empty(provider.GetExtenderProviders(new object()));
+
+            // Call again.
+            Assert.Empty(provider.GetExtenderProviders(new object()));
+        }
+
+        public static IEnumerable<object[]> GetExtenderProviders_WithParent_TestData()
+        {
+            foreach (IExtenderProvider[] result in new IExtenderProvider[][] { null, new IExtenderProvider[] { new Mock<IExtenderProvider>(MockBehavior.Strict).Object } })
+            {
+                yield return new object[] { null, result };
+                yield return new object[] { new object(), result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetExtenderProviders_WithParent_TestData))]
+        public void GetExtenderProviders_InvokeWithParent_ReturnsExpected(object instance, IExtenderProvider[] result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Protected()
+                .Setup<IExtenderProvider[]>("GetExtenderProviders", instance ?? ItExpr.IsNull<object>())
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.GetExtenderProviders(instance));
+            mockParentProvider.Protected().Verify("GetExtenderProviders", Times.Once(), instance ?? ItExpr.IsNull<object>());
+
+            // Call again.
+            Assert.Same(result, provider.GetExtenderProviders(instance));
+            mockParentProvider.Protected().Verify("GetExtenderProviders", Times.Exactly(2), instance ?? ItExpr.IsNull<object>());
+        }
+
+        [Fact]
+        public void GetExtenderProviders_NullInstance_ThrowsArgumentNullException()
+        {
+            var provider = new SubTypeDescriptionProvider();
+            AssertExtensions.Throws<ArgumentNullException>("instance", () => provider.GetExtenderProviders(null));
+        }
+
+        public static IEnumerable<object[]> GetFullComponentName_WithoutParent_TestData()
+        {
+            yield return new object[] { new object() };
+            yield return new object[] { new Component() };
+            
+            var mockSite = new Mock<ISite>(MockBehavior.Strict);
+            mockSite
+                .Setup(s => s.Container)
+                .Returns<IContainer>(null);
+            mockSite
+                .Setup(s => s.Name)
+                .Returns("name");
+            yield return new object[] { new Component { Site = mockSite.Object } };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFullComponentName_WithoutParent_TestData))]
+        public void GetFullComponentName_InvokeWithoutParent_ReturnsNull(object component)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            Assert.Null(provider.GetFullComponentName(component));
+
+            // Call again.
+            Assert.Null(provider.GetFullComponentName(component));
+        }
+
+        public static IEnumerable<object[]> GetFullComponentName_InvokeWithCustomTypeDescriptor_TestData()
+        {
+            foreach (string result in new string[] { null, "name" })
+            {
+                yield return new object[] { new object(), result };
+                yield return new object[] { new Component(), result };
+                
+                var mockSite = new Mock<ISite>(MockBehavior.Strict);
+                mockSite
+                    .Setup(s => s.Container)
+                    .Returns<IContainer>(null);
+                mockSite
+                    .Setup(s => s.Name)
+                    .Returns("name");
+                yield return new object[] { new Component { Site = mockSite.Object }, result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFullComponentName_InvokeWithCustomTypeDescriptor_TestData))]
+        public void GetFullComponentName_InvokeWithCustomTypeDescriptor_ReturnsExpected(object component, string result)
+        {
+            var mockCustomTypeDescriptor = new Mock<ICustomTypeDescriptor>(MockBehavior.Strict);
+            mockCustomTypeDescriptor
+                .Setup(d => d.GetComponentName())
+                .Returns(result)
+                .Verifiable();
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider
+                .Setup(p => p.GetTypeDescriptor(component.GetType(), component))
+                .Returns(mockCustomTypeDescriptor.Object)
+                .Verifiable();
+            mockProvider
+                .Setup(p => p.GetFullComponentName(component))
+                .CallBase();
+            TypeDescriptionProvider provider = mockProvider.Object;
+            Assert.Same(result, provider.GetFullComponentName(component));
+            mockProvider.Verify(p => p.GetTypeDescriptor(component.GetType(), component), Times.Once());
+            mockCustomTypeDescriptor.Verify(d => d.GetComponentName(), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetFullComponentName(component));
+            mockProvider.Verify(p => p.GetTypeDescriptor(component.GetType(), component), Times.Exactly(2));
+            mockCustomTypeDescriptor.Verify(d => d.GetComponentName(), Times.Exactly(2));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFullComponentName_WithoutParent_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework throws NullReferenceException")]
+        public void GetFullComponentName_InvokeWithNullTypeDescriptor_ReturnsExpected(object component)
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider
+                .Setup(p => p.GetTypeDescriptor(component.GetType(), component))
+                .Returns<ICustomTypeDescriptor>(null)
+                .Verifiable();
+            mockProvider
+                .Setup(p => p.GetFullComponentName(component))
+                .CallBase();
+            TypeDescriptionProvider provider = mockProvider.Object;
+            Assert.Null(provider.GetFullComponentName(component));
+            mockProvider.Verify(p => p.GetTypeDescriptor(component.GetType(), component), Times.Once());
+
+            // Call again.
+            Assert.Null(provider.GetFullComponentName(component));
+            mockProvider.Verify(p => p.GetTypeDescriptor(component.GetType(), component), Times.Exactly(2));
+        }
+
+        public static IEnumerable<object[]> GetFullComponentName_WithParent_TestData()
+        {
+            foreach (string result in new string[] { null, "name" })
+            {
+                yield return new object[] { null, result };
+                yield return new object[] { new object(), result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetFullComponentName_WithParent_TestData))]
+        public void GetFullComponentName_InvokeWithParent_ReturnsExpected(object component, string result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.GetFullComponentName(component))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.GetFullComponentName(component));
+            mockParentProvider.Verify(p => p.GetFullComponentName(component), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetFullComponentName(component));
+            mockParentProvider.Verify(p => p.GetFullComponentName(component), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void GetFullComponentName_NullComponent_ReturnsNull()
+        {
+            var provider = new SubTypeDescriptionProvider();
+            AssertExtensions.Throws<ArgumentNullException>("instance", () => provider.GetFullComponentName(null));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(typeof(int))]
+        public void GetReflectionType_InvokeTypeWithoutParent_ReturnsExpected(Type objectType)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            Assert.Same(objectType, provider.GetReflectionType(objectType));
+
+            // Call again.
+            Assert.Same(objectType, provider.GetReflectionType(objectType));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(typeof(int))]
+        public void GetReflectionType_InvokeTypeWithoutParent_CallsTypeObjectOverload(Type objectType)
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider
+                .Setup(p => p.GetReflectionType(objectType, null))
+                .CallBase();
+            TypeDescriptionProvider provider = mockProvider.Object;
+            Assert.Same(objectType, provider.GetReflectionType(objectType));
+            mockProvider.Verify(p => p.GetReflectionType(objectType, null), Times.Once());
+
+            // Call again.
+            Assert.Same(objectType, provider.GetReflectionType(objectType));
+            mockProvider.Verify(p => p.GetReflectionType(objectType, null), Times.Exactly(2));
+        }
+
+        public static IEnumerable<object[]> GetReflectionType_TypeWithParent_TestData()
+        {
+            foreach (Type result in new Type[] { null, typeof(object) })
+            {
+                yield return new object[] { null, result };
+                yield return new object[] { typeof(object), result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetReflectionType_TypeWithParent_TestData))]
+        public void GetReflectionType_InvokeTypeWithParent_ReturnsExpected(Type objectType, Type result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.GetReflectionType(objectType, null))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.GetReflectionType(objectType));
+            mockParentProvider.Verify(p => p.GetReflectionType(objectType, null), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetReflectionType(objectType));
+            mockParentProvider.Verify(p => p.GetReflectionType(objectType, null), Times.Exactly(2));
+        }
+
+        [Theory]
+        [InlineData(1, typeof(int))]
+        public void GetReflectionType_InvokeObjectWithoutParent_ReturnsExpected(object instance, Type expected)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            Assert.Same(expected, provider.GetReflectionType(instance));
+
+            // Call again.
+            Assert.Same(expected, provider.GetReflectionType(instance));
+        }
+
+        [Theory]
+        [InlineData(1, typeof(int))]
+        public void GetReflectionType_InvokeTypeWithoutParent_CallsTypeObjectOverload(object instance, Type expected)
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider
+                .Setup(p => p.GetReflectionType(instance.GetType(), instance))
+                .CallBase();
+            TypeDescriptionProvider provider = mockProvider.Object;
+            Assert.Same(expected, provider.GetReflectionType(instance));
+            mockProvider.Verify(p => p.GetReflectionType(instance.GetType(), instance), Times.Once());
+
+            // Call again.
+            Assert.Same(expected, provider.GetReflectionType(instance));
+            mockProvider.Verify(p => p.GetReflectionType(instance.GetType(), instance), Times.Exactly(2));
+        }
+
+        [Theory]
+        [InlineData(1, null)]
+        [InlineData(1, typeof(object))]
+        public void GetReflectionType_InvokeObjectWithParent_ReturnsExpected(object instance, Type result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.GetReflectionType(instance.GetType(), instance))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.GetReflectionType(instance));
+            mockParentProvider.Verify(p => p.GetReflectionType(instance.GetType(), instance), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetReflectionType(instance));
+            mockParentProvider.Verify(p => p.GetReflectionType(instance.GetType(), instance), Times.Exactly(2));
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, 1)]
+        [InlineData(typeof(object), null)]
+        [InlineData(typeof(object), 1)]
+        public void GetReflectionType_InvokeTypeObjectWithoutParent_ReturnsExpected(Type objectType, object instance)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            Assert.Same(objectType, provider.GetReflectionType(objectType, instance));
+
+            // Call again.
+            Assert.Same(objectType, provider.GetReflectionType(objectType, instance));
+        }
+
+        public static IEnumerable<object[]> GetReflectionType_TypeObjectWithParent_TestData()
+        {
+            foreach (Type result in new Type[] { null, typeof(object) })
+            {
+                yield return new object[] { null, null, result };
+                yield return new object[] { typeof(int), null, result };
+                yield return new object[] { null, 1, result };
+                yield return new object[] { typeof(int), 1, result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetReflectionType_TypeObjectWithParent_TestData))]
+        public void GetReflectionType_InvokeTypeObjectWithParent_ReturnsExpected(Type objectType, object instance, Type result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.GetReflectionType(objectType, instance))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.GetReflectionType(objectType, instance));
+            mockParentProvider.Verify(p => p.GetReflectionType(objectType, instance), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetReflectionType(objectType, instance));
+            mockParentProvider.Verify(p => p.GetReflectionType(objectType, instance), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void GetReflectionType_NullInstance_ThrowsArgumentNullException()
+        {
+            var provider = new SubTypeDescriptionProvider();
+            AssertExtensions.Throws<ArgumentNullException>("instance", () => provider.GetReflectionType((object)null));
+        }
+
+        [Fact]
+        public void GetReflectionType_NullInstanceWithParent_ThrowsArgumentNullException()
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            AssertExtensions.Throws<ArgumentNullException>("instance", () => provider.GetReflectionType((object)null));
+        }
+
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(TypeDescriptionProviderTests))]
+        public void GetRuntimeType_InvokeWithoutParentSystemDefinedType_ReturnsSame(Type reflectionType)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            Assert.Same(reflectionType, provider.GetRuntimeType(reflectionType));
+
+            // Call again.
+            Assert.Same(reflectionType, provider.GetRuntimeType(reflectionType));
+        }
+        
+        [Theory]
+        [InlineData(null)]
+        [InlineData(typeof(int))]
+        public void GetRuntimeType_InvokeWithoutParentWithUserDefinedType_RetunsUnderlyingSystemType(Type result)
+        {
+            var mockType = new Mock<Type>(MockBehavior.Strict);
+            mockType
+                .Setup(t => t.UnderlyingSystemType)
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider();
+            Assert.Same(result, provider.GetRuntimeType(mockType.Object));
+            mockType.Verify(t => t.UnderlyingSystemType, Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetRuntimeType(mockType.Object));
+            mockType.Verify(t => t.UnderlyingSystemType, Times.Exactly(2));
+        }
+
+        public static IEnumerable<object[]> GetRuntimeType_WithParent_TestData()
+        {
+            foreach (Type result in new Type[] { null, typeof(int) })
+            {
+                yield return new object[] { null, result };
+                yield return new object[] { typeof(object), result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRuntimeType_WithParent_TestData))]
+        public void GetRuntimeType_InvokeWithParent_ReturnsExpected(Type reflectionType, Type result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.GetRuntimeType(reflectionType))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.GetRuntimeType(reflectionType));
+            mockParentProvider.Verify(p => p.GetRuntimeType(reflectionType), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetRuntimeType(reflectionType));
+            mockParentProvider.Verify(p => p.GetRuntimeType(reflectionType), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void GetRuntimeType_NullReflectionType_ThrowsArgumentNullException()
+        {
+            var provider = new SubTypeDescriptionProvider();
+            AssertExtensions.Throws<ArgumentNullException>("reflectionType", () => provider.GetRuntimeType(null));
+        }
+
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(typeof(int))]
+        public void GetTypeDescriptor_InvokeTypeWithoutParent_ReturnsExpected(Type objectType)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            CustomTypeDescriptor result1 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetTypeDescriptor(objectType));
+            Assert.Empty(result1.GetProperties());
+
+            // Call again.
+            CustomTypeDescriptor result2 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetTypeDescriptor(objectType));
+            Assert.Same(result1, result2);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(typeof(int))]
+        public void GetTypeDescriptor_InvokeTypeWithoutParent_CallsTypeObjectOverload(Type objectType)
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider
+                .Setup(p => p.GetTypeDescriptor(objectType, null))
+                .CallBase();
+            TypeDescriptionProvider provider = mockProvider.Object;
+            CustomTypeDescriptor result1 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetTypeDescriptor(objectType));
+            Assert.Empty(result1.GetProperties());
+            mockProvider.Verify(p => p.GetTypeDescriptor(objectType, null), Times.Once());
+
+            // Call again.
+            CustomTypeDescriptor result2 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetTypeDescriptor(objectType));
+            Assert.Same(result1, result2);
+            mockProvider.Verify(p => p.GetTypeDescriptor(objectType, null), Times.Exactly(2));
+        }
+
+        public static IEnumerable<object[]> GetTypeDescriptor_TypeWithParent_TestData()
+        {
+            foreach (ICustomTypeDescriptor result in new ICustomTypeDescriptor[] { null, new Mock<ICustomTypeDescriptor>(MockBehavior.Strict).Object })
+            {
+                yield return new object[] { null, result };
+                yield return new object[] { typeof(object), result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTypeDescriptor_TypeWithParent_TestData))]
+        public void GetTypeDescriptor_InvokeTypeWithParent_ReturnsExpected(Type objectType, ICustomTypeDescriptor result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.GetTypeDescriptor(objectType, null))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.GetTypeDescriptor(objectType));
+            mockParentProvider.Verify(p => p.GetTypeDescriptor(objectType, null), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetTypeDescriptor(objectType));
+            mockParentProvider.Verify(p => p.GetTypeDescriptor(objectType, null), Times.Exactly(2));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        public void GetTypeDescriptor_InvokeObjectWithoutParent_ReturnsExpected(object instance)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            CustomTypeDescriptor result1 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetTypeDescriptor(instance));
+            Assert.Empty(result1.GetProperties());
+
+            // Call again.
+            CustomTypeDescriptor result2 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetTypeDescriptor(instance));
+            Assert.Same(result1, result2);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        public void GetTypeDescriptor_InvokeTypeWithoutParent_CallsTypeObjectOverload(object instance)
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider
+                .Setup(p => p.GetTypeDescriptor(instance.GetType(), instance))
+                .CallBase();
+            TypeDescriptionProvider provider = mockProvider.Object;
+            CustomTypeDescriptor result1 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetTypeDescriptor(instance));
+            Assert.Empty(result1.GetProperties());
+            mockProvider.Verify(p => p.GetTypeDescriptor(instance.GetType(), instance), Times.Once());
+
+            // Call again.
+            CustomTypeDescriptor result2 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetTypeDescriptor(instance));
+            Assert.Same(result1, result2);
+            mockProvider.Verify(p => p.GetTypeDescriptor(instance.GetType(), instance), Times.Exactly(2));
+        }
+
+        public static IEnumerable<object[]> GetTypeDescriptor_ObjectWithParent_TestData()
+        {
+            foreach (ICustomTypeDescriptor result in new ICustomTypeDescriptor[] { null, new Mock<ICustomTypeDescriptor>(MockBehavior.Strict).Object })
+            {
+                yield return new object[] { 1, result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTypeDescriptor_ObjectWithParent_TestData))]
+        public void GetTypeDescriptor_InvokeObjectWithParent_ReturnsExpected(object instance, ICustomTypeDescriptor result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.GetTypeDescriptor(instance.GetType(), instance))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.GetTypeDescriptor(instance));
+            mockParentProvider.Verify(p => p.GetTypeDescriptor(instance.GetType(), instance), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetTypeDescriptor(instance));
+            mockParentProvider.Verify(p => p.GetTypeDescriptor(instance.GetType(), instance), Times.Exactly(2));
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, 1)]
+        [InlineData(typeof(object), null)]
+        [InlineData(typeof(object), 1)]
+        public void GetTypeDescriptor_InvokeTypeObjectWithoutParent_ReturnsExpected(Type objectType, object instance)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            CustomTypeDescriptor result1 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetTypeDescriptor(objectType, instance));
+            Assert.Empty(result1.GetProperties());
+
+            // Call again.
+            CustomTypeDescriptor result2 = Assert.IsAssignableFrom<CustomTypeDescriptor>(provider.GetTypeDescriptor(objectType, instance));
+            Assert.Same(result1, result2);
+        }
+
+        public static IEnumerable<object[]> GetTypeDescriptor_TypeObjectWithParent_TestData()
+        {
+            foreach (ICustomTypeDescriptor result in new ICustomTypeDescriptor[] { null, new Mock<ICustomTypeDescriptor>(MockBehavior.Strict).Object })
+            {
+                yield return new object[] { null, null, result };
+                yield return new object[] { typeof(int), null, result };
+                yield return new object[] { null, 1, result };
+                yield return new object[] { typeof(int), 1, result };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTypeDescriptor_TypeObjectWithParent_TestData))]
+        public void GetTypeDescriptor_InvokeTypeObjectWithParent_ReturnsExpected(Type objectType, object instance, ICustomTypeDescriptor result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.GetTypeDescriptor(objectType, instance))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Same(result, provider.GetTypeDescriptor(objectType, instance));
+            mockParentProvider.Verify(p => p.GetTypeDescriptor(objectType, instance), Times.Once());
+
+            // Call again.
+            Assert.Same(result, provider.GetTypeDescriptor(objectType, instance));
+            mockParentProvider.Verify(p => p.GetTypeDescriptor(objectType, instance), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void GetTypeDescriptor_NullInstance_ThrowsArgumentNullException()
+        {
+            var provider = new SubTypeDescriptionProvider();
+            AssertExtensions.Throws<ArgumentNullException>("instance", () => provider.GetTypeDescriptor((object)null));
+        }
+
+        [Fact]
+        public void GetTypeDescriptor_NullInstanceWithParent_ThrowsArgumentNullException()
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            AssertExtensions.Throws<ArgumentNullException>("instance", () => provider.GetTypeDescriptor((object)null));
+        }
+
+        [Theory]
+        [InlineData(typeof(int))]
+        public void IsSupportedType_InvokeWithoutParent_ReturnsTrue(Type type)
+        {
+            var provider = new SubTypeDescriptionProvider();
+            Assert.True(provider.IsSupportedType(type));
+
+            // Call again.
+            Assert.True(provider.IsSupportedType(type));
+        }
+
+        [Theory]
+        [InlineData(typeof(int), true)]
+        [InlineData(typeof(int), false)]
+        public void IsSupportedType_InvokeWithParent_ReturnsExpected(Type type, bool result)
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockParentProvider
+                .Setup(p => p.IsSupportedType(type))
+                .Returns(result)
+                .Verifiable();
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            Assert.Equal(result, provider.IsSupportedType(type));
+            mockParentProvider.Verify(p => p.IsSupportedType(type), Times.Once());
+
+            // Call again.
+            Assert.Equal(result, provider.IsSupportedType(type));
+            mockParentProvider.Verify(p => p.IsSupportedType(type), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void IsSupportedType_NullType_ThrowsArgumentNullException()
+        {
+            var provider = new SubTypeDescriptionProvider();
+            AssertExtensions.Throws<ArgumentNullException>("type", () => provider.IsSupportedType(null));
+        }
+
+        [Fact]
+        public void IsSupportedType_NullTypeWithParent_ThrowsArgumentNullException()
+        {
+            var mockParentProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            var provider = new SubTypeDescriptionProvider(mockParentProvider.Object);
+            AssertExtensions.Throws<ArgumentNullException>("type", () => provider.IsSupportedType(null));
+        }
+
+        private class SubTypeDescriptionProvider : TypeDescriptionProvider
+        {
+            public SubTypeDescriptionProvider() : base()
+            {
+            }
+            
+            public SubTypeDescriptionProvider(TypeDescriptionProvider parent) : base(parent)
+            {
+            }
+
+            public new IExtenderProvider[] GetExtenderProviders(object instance) => base.GetExtenderProviders(instance);
+        }
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeDescriptorTests.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Globalization;
+using Moq;
 using Xunit;
 
 namespace System.ComponentModel.Tests
@@ -12,23 +14,386 @@ namespace System.ComponentModel.Tests
     public partial class TypeDescriptorTests
     {
         [Fact]
-        public void AddAndRemoveProvider()
+        public void AddProvider_InvokeObject_GetProviderReturnsExpected()
         {
-            var provider = new InvocationRecordingTypeDescriptionProvider();
-            var component = new DescriptorTestComponent();
-            TypeDescriptor.AddProvider(provider, component);
+            var instance = new object();
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            mockProvider2
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>());
 
-            var retrievedProvider = TypeDescriptor.GetProvider(component);
-            retrievedProvider.GetCache(component);
+            TypeDescriptor.AddProvider(mockProvider1.Object, instance);
+            TypeDescriptionProvider actualProvider1 = TypeDescriptor.GetProvider(instance);
+            Assert.NotSame(actualProvider1, mockProvider1.Object);
+            actualProvider1.IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
 
-            Assert.True(provider.ReceivedCall);
+            // Add another.
+            TypeDescriptor.AddProvider(mockProvider2.Object, instance);
+            TypeDescriptionProvider actualProvider2 = TypeDescriptor.GetProvider(instance);
+            Assert.NotSame(actualProvider1, actualProvider2);
+            actualProvider2.IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+        }
 
-            provider.Reset();
-            TypeDescriptor.RemoveProvider(provider, component);
-            retrievedProvider = TypeDescriptor.GetProvider(component);
-            retrievedProvider.GetCache(component);
+        [Fact]
+        public void AddProvider_InvokeObjectMultipleTimes_Refreshes()
+        {
+            var instance = new object();
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>())
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>())
+                .Verifiable();
+            
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.ComponentChanged == instance)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.AddProvider(mockProvider1.Object, instance);
+                Assert.Equal(0, callCount);
+                mockProvider1.Verify(p => p.GetCache(instance), Times.Never());
+                mockProvider2.Verify(p => p.GetCache(instance), Times.Never());
 
-            Assert.False(provider.ReceivedCall);
+                // Add again.
+                TypeDescriptor.AddProvider(mockProvider1.Object, instance);
+                Assert.Equal(1, callCount);
+                mockProvider1.Verify(p => p.GetCache(instance), Times.Once());
+                mockProvider2.Verify(p => p.GetCache(instance), Times.Never());
+
+                // Add different.
+                TypeDescriptor.AddProvider(mockProvider2.Object, instance);
+                Assert.Equal(2, callCount);
+                mockProvider1.Verify(p => p.GetCache(instance), Times.Once());
+                mockProvider2.Verify(p => p.GetCache(instance), Times.Once());
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        [Fact]
+        public void AddProvider_InvokeType_GetProviderReturnsExpected()
+        {
+            Type type = typeof(AddProvider_InvokeType_GetProviderReturnsExpectedType);
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            mockProvider2
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>());
+
+            TypeDescriptor.AddProvider(mockProvider1.Object, type);
+            TypeDescriptionProvider actualProvider1 = TypeDescriptor.GetProvider(type);
+            Assert.NotSame(actualProvider1, mockProvider1.Object);
+            actualProvider1.IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+
+            // Add another.
+            TypeDescriptor.AddProvider(mockProvider2.Object, type);
+            TypeDescriptionProvider actualProvider2 = TypeDescriptor.GetProvider(type);
+            Assert.NotSame(actualProvider1, actualProvider2);
+            actualProvider2.IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+        }
+
+        private class AddProvider_InvokeType_GetProviderReturnsExpectedType { }
+
+
+        [Fact]
+        public void AddProvider_InvokeTypeMultipleTimes_Refreshes()
+        {
+            var type = typeof(AddProvider_InvokeTypeMultipleTimes_RefreshesType);
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>())
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>())
+                .Verifiable();
+            
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.TypeChanged == type)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.AddProvider(mockProvider1.Object, type);
+                Assert.Equal(1, callCount);
+                mockProvider1.Verify(p => p.GetCache(type), Times.Never());
+                mockProvider2.Verify(p => p.GetCache(type), Times.Never());
+
+                // Add again.
+                TypeDescriptor.AddProvider(mockProvider1.Object, type);
+                Assert.Equal(2, callCount);
+                mockProvider1.Verify(p => p.GetCache(type), Times.Never());
+                mockProvider2.Verify(p => p.GetCache(type), Times.Never());
+
+                // Add different.
+                TypeDescriptor.AddProvider(mockProvider2.Object, type);
+                Assert.Equal(3, callCount);
+                mockProvider1.Verify(p => p.GetCache(type), Times.Never());
+                mockProvider2.Verify(p => p.GetCache(type), Times.Never());
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        private class AddProvider_InvokeTypeMultipleTimes_RefreshesType { }
+
+        [Fact]
+        public void AddProvider_NullProvider_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("provider", () => TypeDescriptor.AddProvider(null, new object()));
+            Assert.Throws<ArgumentNullException>("provider", () => TypeDescriptor.AddProvider(null, typeof(int)));
+        }
+
+        [Fact]
+        public void AddProvider_NullInstance_ThrowsArgumentNullException()
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            Assert.Throws<ArgumentNullException>("instance", () => TypeDescriptor.AddProvider(mockProvider.Object, (object)null));
+        }
+
+        [Fact]
+        public void AddProvider_NullType_ThrowsArgumentNullException()
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            Assert.Throws<ArgumentNullException>("type", () => TypeDescriptor.AddProvider(mockProvider.Object, null));
+        }
+
+        [Fact]
+        public void AddProviderTransparent_InvokeObject_GetProviderReturnsExpected()
+        {
+            var instance = new object();
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            mockProvider2
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>());
+
+            TypeDescriptor.AddProviderTransparent(mockProvider1.Object, instance);
+            TypeDescriptionProvider actualProvider1 = TypeDescriptor.GetProvider(instance);
+            Assert.NotSame(actualProvider1, mockProvider1.Object);
+            actualProvider1.IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+
+            // Add another.
+            TypeDescriptor.AddProviderTransparent(mockProvider2.Object, instance);
+            TypeDescriptionProvider actualProvider2 = TypeDescriptor.GetProvider(instance);
+            Assert.NotSame(actualProvider1, actualProvider2);
+            actualProvider2.IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+        }
+
+        [Fact]
+        public void AddProviderTransparent_InvokeObjectMultipleTimes_Refreshes()
+        {
+            var instance = new object();
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>())
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>())
+                .Verifiable();
+            
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.ComponentChanged == instance)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.AddProviderTransparent(mockProvider1.Object, instance);
+                Assert.Equal(0, callCount);
+                mockProvider1.Verify(p => p.GetCache(instance), Times.Never());
+                mockProvider2.Verify(p => p.GetCache(instance), Times.Never());
+
+                // Add again.
+                TypeDescriptor.AddProviderTransparent(mockProvider1.Object, instance);
+                Assert.Equal(1, callCount);
+                mockProvider1.Verify(p => p.GetCache(instance), Times.Once());
+                mockProvider2.Verify(p => p.GetCache(instance), Times.Never());
+
+                // Add different.
+                TypeDescriptor.AddProviderTransparent(mockProvider2.Object, instance);
+                Assert.Equal(2, callCount);
+                mockProvider1.Verify(p => p.GetCache(instance), Times.Once());
+                mockProvider2.Verify(p => p.GetCache(instance), Times.Once());
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        [Fact]
+        public void AddProviderTransparent_InvokeType_GetProviderReturnsExpected()
+        {
+            Type type = typeof(AddProviderTransparent_InvokeType_GetProviderReturnsExpectedType);
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            mockProvider2
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>());
+
+            TypeDescriptor.AddProviderTransparent(mockProvider1.Object, type);
+            TypeDescriptionProvider actualProvider1 = TypeDescriptor.GetProvider(type);
+            Assert.NotSame(actualProvider1, mockProvider1.Object);
+            actualProvider1.IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+
+            // Add another.
+            TypeDescriptor.AddProviderTransparent(mockProvider2.Object, type);
+            TypeDescriptionProvider actualProvider2 = TypeDescriptor.GetProvider(type);
+            Assert.NotSame(actualProvider1, actualProvider2);
+            actualProvider2.IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+        }
+
+        private class AddProviderTransparent_InvokeType_GetProviderReturnsExpectedType { }
+
+        [Fact]
+        public void AddProviderTransparent_InvokeTypeMultipleTimes_Refreshes()
+        {
+            var type = typeof(AddProviderTransparent_InvokeTypeMultipleTimes_RefreshesType);
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>())
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>())
+                .Verifiable();
+            
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.TypeChanged == type)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.AddProviderTransparent(mockProvider1.Object, type);
+                Assert.Equal(1, callCount);
+                mockProvider1.Verify(p => p.GetCache(type), Times.Never());
+                mockProvider2.Verify(p => p.GetCache(type), Times.Never());
+
+                // Add again.
+                TypeDescriptor.AddProviderTransparent(mockProvider1.Object, type);
+                Assert.Equal(2, callCount);
+                mockProvider1.Verify(p => p.GetCache(type), Times.Never());
+                mockProvider2.Verify(p => p.GetCache(type), Times.Never());
+
+                // Add different.
+                TypeDescriptor.AddProviderTransparent(mockProvider2.Object, type);
+                Assert.Equal(3, callCount);
+                mockProvider1.Verify(p => p.GetCache(type), Times.Never());
+                mockProvider2.Verify(p => p.GetCache(type), Times.Never());
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        private class AddProviderTransparent_InvokeTypeMultipleTimes_RefreshesType { }
+
+        [Fact]
+        public void AddProviderTransparent_NullProvider_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("provider", () => TypeDescriptor.AddProviderTransparent(null, new object()));
+            Assert.Throws<ArgumentNullException>("provider", () => TypeDescriptor.AddProviderTransparent(null, typeof(int)));
+        }
+
+        [Fact]
+        public void AddProviderTransparent_NullInstance_ThrowsArgumentNullException()
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            Assert.Throws<ArgumentNullException>("instance", () => TypeDescriptor.AddProviderTransparent(mockProvider.Object, (object)null));
+        }
+
+        [Fact]
+        public void AddProviderTransparent_NullType_ThrowsArgumentNullException()
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            Assert.Throws<ArgumentNullException>("type", () => TypeDescriptor.AddProviderTransparent(mockProvider.Object, null));
         }
 
         [Fact]
@@ -170,6 +535,529 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
+        public void RemoveProvider_InvokeObject_RemovesProvider()
+        {
+            var instance = new object();
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>());
+            mockProvider1
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>());
+            mockProvider2
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider3 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider3
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>());
+            mockProvider3
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+
+            TypeDescriptor.AddProvider(mockProvider1.Object, instance);
+            TypeDescriptor.AddProvider(mockProvider2.Object, instance);
+            TypeDescriptor.AddProvider(mockProvider3.Object, instance);
+
+            // Remove middle.
+            TypeDescriptor.RemoveProvider(mockProvider2.Object, instance);
+            TypeDescriptor.GetProvider(instance).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+
+            // Remove end.
+            TypeDescriptor.RemoveProvider(mockProvider3.Object, instance);
+            TypeDescriptor.GetProvider(instance).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+
+            // Remove start.
+            TypeDescriptor.RemoveProvider(mockProvider1.Object, instance);
+            TypeDescriptor.GetProvider(instance).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+        }
+
+        [Fact]
+        public void RemoveProvider_InvokeObjectWithProviders_Refreshes()
+        {
+            var instance = new object();
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.ComponentChanged == instance)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.AddProvider(mockProvider1.Object, instance);
+                Assert.Equal(0, callCount);
+
+                TypeDescriptor.RemoveProvider(mockProvider1.Object, instance);
+                Assert.Equal(1, callCount);
+
+                // Remove again.
+                TypeDescriptor.RemoveProvider(mockProvider1.Object, instance);
+                Assert.Equal(2, callCount);
+
+                // Remove different.
+                TypeDescriptor.RemoveProvider(mockProvider2.Object, instance);
+                Assert.Equal(3, callCount);
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        [Fact]
+        public void RemoveProvider_InvokeObjectWithoutProviders_Refreshes()
+        {
+            var instance = new object();
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.ComponentChanged == instance)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.RemoveProvider(mockProvider.Object, instance);
+                Assert.Equal(1, callCount);
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        [Fact]
+        public void RemoveProvider_InvokeType_RemovesProvider()
+        {
+            Type type = typeof(RemoveProvider_InvokeType_RemovesProviderType);
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>());
+            mockProvider1
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>());
+            mockProvider2
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider3 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider3
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>());
+            mockProvider3
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+
+            TypeDescriptor.AddProvider(mockProvider1.Object, type);
+            TypeDescriptor.AddProvider(mockProvider2.Object, type);
+            TypeDescriptor.AddProvider(mockProvider3.Object, type);
+
+            // Remove middle.
+            TypeDescriptor.RemoveProvider(mockProvider2.Object, type);
+            TypeDescriptor.GetProvider(type).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+
+            // Remove end.
+            TypeDescriptor.RemoveProvider(mockProvider3.Object, type);
+            TypeDescriptor.GetProvider(type).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+
+            // Remove start.
+            TypeDescriptor.RemoveProvider(mockProvider1.Object, type);
+            TypeDescriptor.GetProvider(type).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+        }
+
+        private class RemoveProvider_InvokeType_RemovesProviderType { }
+
+        [Fact]
+        public void RemoveProvider_InvokeTypeWithProviders_Refreshes()
+        {
+            Type type = typeof(RemoveProvider_InvokeObjectWithProviders_RefreshesType);
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.TypeChanged == type)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.AddProvider(mockProvider1.Object, type);
+                Assert.Equal(1, callCount);
+
+                TypeDescriptor.RemoveProvider(mockProvider1.Object, type);
+                Assert.Equal(2, callCount);
+
+                // Remove again.
+                TypeDescriptor.RemoveProvider(mockProvider1.Object, type);
+                Assert.Equal(3, callCount);
+
+                // Remove different.
+                TypeDescriptor.RemoveProvider(mockProvider2.Object, type);
+                Assert.Equal(4, callCount);
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        private class RemoveProvider_InvokeObjectWithProviders_RefreshesType { }
+
+        [Fact]
+        public void RemoveProvider_InvokeTypeWithoutProviders_Refreshes()
+        {
+            Type type = typeof(RemoveProvider_InvokeTypeWithoutProviders_RefreshesType);
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.TypeChanged == type)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.RemoveProvider(mockProvider.Object, type);
+                Assert.Equal(1, callCount);
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        private class RemoveProvider_InvokeTypeWithoutProviders_RefreshesType { }
+
+        [Fact]
+        public void RemoveProvider_NullProvider_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("provider", () => TypeDescriptor.RemoveProvider(null, new object()));
+            Assert.Throws<ArgumentNullException>("provider", () => TypeDescriptor.RemoveProvider(null, typeof(int)));
+        }
+
+        [Fact]
+        public void RemoveProvider_NullInstance_ThrowsArgumentNullException()
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            Assert.Throws<ArgumentNullException>("instance", () => TypeDescriptor.RemoveProvider(mockProvider.Object, (object)null));
+        }
+
+        [Fact]
+        public void RemoveProvider_NullType_ThrowsArgumentNullException()
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            Assert.Throws<ArgumentNullException>("type", () => TypeDescriptor.RemoveProvider(mockProvider.Object, null));
+        }
+
+
+        [Fact]
+        public void RemoveProviderTransparent_InvokeObject_RemovesProvider()
+        {
+            var instance = new object();
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>());
+            mockProvider1
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>());
+            mockProvider2
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider3 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider3
+                .Setup(p => p.GetCache(instance))
+                .Returns(new Dictionary<int, string>());
+            mockProvider3
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+
+            TypeDescriptor.AddProvider(mockProvider1.Object, instance);
+            TypeDescriptor.AddProvider(mockProvider2.Object, instance);
+            TypeDescriptor.AddProvider(mockProvider3.Object, instance);
+
+            // Remove middle.
+            TypeDescriptor.RemoveProviderTransparent(mockProvider2.Object, instance);
+            TypeDescriptor.GetProvider(instance).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+
+            // Remove end.
+            TypeDescriptor.RemoveProviderTransparent(mockProvider3.Object, instance);
+            TypeDescriptor.GetProvider(instance).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+
+            // Remove start.
+            TypeDescriptor.RemoveProviderTransparent(mockProvider1.Object, instance);
+            TypeDescriptor.GetProvider(instance).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+        }
+
+        [Fact]
+        public void RemoveProviderTransparent_InvokeObjectWithProviders_Refreshes()
+        {
+            var instance = new object();
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.ComponentChanged == instance)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.AddProvider(mockProvider1.Object, instance);
+                Assert.Equal(0, callCount);
+
+                TypeDescriptor.RemoveProviderTransparent(mockProvider1.Object, instance);
+                Assert.Equal(1, callCount);
+
+                // Remove again.
+                TypeDescriptor.RemoveProviderTransparent(mockProvider1.Object, instance);
+                Assert.Equal(2, callCount);
+
+                // Remove different.
+                TypeDescriptor.RemoveProviderTransparent(mockProvider2.Object, instance);
+                Assert.Equal(3, callCount);
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        [Fact]
+        public void RemoveProviderTransparent_InvokeObjectWithoutProviders_Refreshes()
+        {
+            var instance = new object();
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.ComponentChanged == instance)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.RemoveProviderTransparent(mockProvider.Object, instance);
+                Assert.Equal(1, callCount);
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        [Fact]
+        public void RemoveProviderTransparent_InvokeType_RemovesProvider()
+        {
+            Type type = typeof(RemoveProviderTransparent_InvokeType_RemovesProviderType);
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider1
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>());
+            mockProvider1
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider2
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>());
+            mockProvider2
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+            var mockProvider3 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            mockProvider3
+                .Setup(p => p.GetCache(type))
+                .Returns(new Dictionary<int, string>());
+            mockProvider3
+                .Setup(p => p.IsSupportedType(typeof(int)))
+                .Returns(true)
+                .Verifiable();
+
+            TypeDescriptor.AddProvider(mockProvider1.Object, type);
+            TypeDescriptor.AddProvider(mockProvider2.Object, type);
+            TypeDescriptor.AddProvider(mockProvider3.Object, type);
+
+            // Remove middle.
+            TypeDescriptor.RemoveProviderTransparent(mockProvider2.Object, type);
+            TypeDescriptor.GetProvider(type).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+
+            // Remove end.
+            TypeDescriptor.RemoveProviderTransparent(mockProvider3.Object, type);
+            TypeDescriptor.GetProvider(type).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+
+            // Remove start.
+            TypeDescriptor.RemoveProviderTransparent(mockProvider1.Object, type);
+            TypeDescriptor.GetProvider(type).IsSupportedType(typeof(int));
+            mockProvider1.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+            mockProvider2.Verify(p => p.IsSupportedType(typeof(int)), Times.Never());
+            mockProvider3.Verify(p => p.IsSupportedType(typeof(int)), Times.Once());
+        }
+
+        private class RemoveProviderTransparent_InvokeType_RemovesProviderType { }
+
+        [Fact]
+        public void RemoveProviderTransparent_InvokeTypeWithProviders_Refreshes()
+        {
+            Type type = typeof(RemoveProviderTransparent_InvokeObjectWithProviders_RefreshesType);
+            var mockProvider1 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            var mockProvider2 = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.TypeChanged == type)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.AddProvider(mockProvider1.Object, type);
+                Assert.Equal(1, callCount);
+
+                TypeDescriptor.RemoveProviderTransparent(mockProvider1.Object, type);
+                Assert.Equal(2, callCount);
+
+                // Remove again.
+                TypeDescriptor.RemoveProviderTransparent(mockProvider1.Object, type);
+                Assert.Equal(3, callCount);
+
+                // Remove different.
+                TypeDescriptor.RemoveProviderTransparent(mockProvider2.Object, type);
+                Assert.Equal(4, callCount);
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        private class RemoveProviderTransparent_InvokeObjectWithProviders_RefreshesType { }
+
+        [Fact]
+        public void RemoveProviderTransparent_InvokeTypeWithoutProviders_Refreshes()
+        {
+            Type type = typeof(RemoveProviderTransparent_InvokeTypeWithoutProviders_RefreshesType);
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            int callCount = 0;
+            RefreshEventHandler handler = (e) =>
+            {
+                if (e.TypeChanged == type)
+                {
+                    callCount++;
+                }
+            };
+            TypeDescriptor.Refreshed += handler;
+            try
+            {
+                TypeDescriptor.RemoveProviderTransparent(mockProvider.Object, type);
+                Assert.Equal(1, callCount);
+            }
+            finally
+            {
+                TypeDescriptor.Refreshed -= handler;
+            }
+        }
+
+        private class RemoveProviderTransparent_InvokeTypeWithoutProviders_RefreshesType { }
+
+        [Fact]
+        public void RemoveProviderTransparent_NullProvider_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("provider", () => TypeDescriptor.RemoveProviderTransparent(null, new object()));
+            Assert.Throws<ArgumentNullException>("provider", () => TypeDescriptor.RemoveProviderTransparent(null, typeof(int)));
+        }
+
+        [Fact]
+        public void RemoveProviderTransparent_NullInstance_ThrowsArgumentNullException()
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            Assert.Throws<ArgumentNullException>("instance", () => TypeDescriptor.RemoveProviderTransparent(mockProvider.Object, (object)null));
+        }
+
+        [Fact]
+        public void RemoveProviderTransparent_NullType_ThrowsArgumentNullException()
+        {
+            var mockProvider = new Mock<TypeDescriptionProvider>(MockBehavior.Strict);
+            Assert.Throws<ArgumentNullException>("type", () => TypeDescriptor.RemoveProviderTransparent(mockProvider.Object, null));
+        }
+
+        [Fact]
         public void RemoveAssociationsRemovesAllAssociations()
         {
             var primaryObject = new DescriptorTestComponent();
@@ -210,71 +1098,46 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        public void DerivedPropertyAttribute() {
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework throws NullReferenceException")]
+        public void SortDescriptorArray_Invoke_ReturnsExpected()
+        {
+            var notADescriptor1 = new object();
+            var notADescriptor2 = new object();
+            var mockDescriptor1 = new Mock<EventDescriptor>(MockBehavior.Strict, "Name1", new Attribute[0]);
+            mockDescriptor1
+                .Setup(d => d.Name)
+                .Returns("Name1");
+            var mockDescriptor2 = new Mock<EventDescriptor>(MockBehavior.Strict, "Name2", new Attribute[0]);
+            mockDescriptor2
+                .Setup(d => d.Name)
+                .Returns("Name2");
+            var mockDescriptor3 = new Mock<EventDescriptor>(MockBehavior.Strict, "Name3", new Attribute[0]);
+            mockDescriptor3
+                .Setup(d => d.Name)
+                .Returns("Name3");
+            var infos = new object[] { null, mockDescriptor3.Object, notADescriptor2, mockDescriptor1.Object, mockDescriptor2.Object, null, notADescriptor1 };
+            TypeDescriptor.SortDescriptorArray(infos);
+            Assert.True(infos[0] == null || infos[0] == notADescriptor1 || infos[0] == notADescriptor2);
+            Assert.True(infos[1] == null || infos[1] == notADescriptor1 || infos[1] == notADescriptor2);
+            Assert.True(infos[2] == null || infos[2] == notADescriptor1 || infos[2] == notADescriptor2);
+            Assert.True(infos[3] == null || infos[3] == notADescriptor1 || infos[3] == notADescriptor2);
+            Assert.Same(mockDescriptor1.Object, infos[4]);
+            Assert.Same(mockDescriptor2.Object, infos[5]);
+            Assert.Same(mockDescriptor3.Object, infos[6]);
+        }
+
+        [Fact]
+        public void SortDescriptorArray_NullInfos_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("infos", () => TypeDescriptor.SortDescriptorArray(null));
+        }
+
+        [Fact]
+        public void DerivedPropertyAttribute()
+        {
             PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(FooBarDerived))["Value"];
             var descriptionAttribute = (DescriptionAttribute)property.Attributes[typeof(DescriptionAttribute)];
             Assert.Equal("Derived", descriptionAttribute.Description);
-        }
-
-        private class InvocationRecordingTypeDescriptionProvider : TypeDescriptionProvider
-        {
-            public bool ReceivedCall { get; private set; } = false;
-
-            public void Reset() => ReceivedCall = false;
-
-            public override object CreateInstance(IServiceProvider provider, Type objectType, Type[] argTypes, object[] args)
-            {
-                ReceivedCall = true;
-                return base.CreateInstance(provider, objectType, argTypes, args);
-            }
-
-            public override IDictionary GetCache(object instance)
-            {
-                ReceivedCall = true;
-                return base.GetCache(instance);
-            }
-
-            public override ICustomTypeDescriptor GetExtendedTypeDescriptor(object instance)
-            {
-                ReceivedCall = true;
-                return base.GetExtendedTypeDescriptor(instance);
-            }
-
-            public override string GetFullComponentName(object component)
-            {
-                ReceivedCall = true;
-                return base.GetFullComponentName(component);
-            }
-
-            public override Type GetReflectionType(Type objectType, object instance)
-            {
-                ReceivedCall = true;
-                return base.GetReflectionType(objectType, instance);
-            }
-
-            protected override IExtenderProvider[] GetExtenderProviders(object instance)
-            {
-                ReceivedCall = true;
-                return base.GetExtenderProviders(instance);
-            }
-
-            public override Type GetRuntimeType(Type reflectionType)
-            {
-                ReceivedCall = true;
-                return base.GetRuntimeType(reflectionType);
-            }
-
-            public override ICustomTypeDescriptor GetTypeDescriptor(Type objectType, object instance)
-            {
-                ReceivedCall = true;
-                return base.GetTypeDescriptor(objectType, instance);
-            }
-
-            public override bool IsSupportedType(Type type)
-            {
-                ReceivedCall = true;
-                return base.IsSupportedType(type);
-            }
         }
 
         class FooBarBase


### PR DESCRIPTION
Note: I opted to add a dependency to the `Moq` framework, following the precedent set in dotnet/winforms.

This is because we have lots of interfaces in System.ComponentModel that should be mocked to make sure
- We call the right thing the right number of times
- We don't call anything else
- We handle the right outputs of functions

Obviously this brings a dependency into corefx which may not be acceptable, so let me know what you think