### PR TITLE
Remove dead remoting IUnimplemented code from TypeDescriptor

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/Resources/Strings.resx
+++ b/src/System.ComponentModel.TypeConverter/src/Resources/Strings.resx
@@ -114,9 +114,6 @@
   <data name="TypeDescriptorProviderError" xml:space="preserve">
     <value>The type description provider {0} has returned null from {1} which is illegal.</value>
   </data>
-  <data name="TypeDescriptorUnsupportedRemoteObject" xml:space="preserve">
-    <value>The object {0} is being remoted by a proxy that does not support interface discovery. This type of remoted object is not supported.</value>
-  </data>
   <data name="TypeDescriptorExpectedElementType" xml:space="preserve">
     <value>Expected types in the collection to be of type {0}.</value>
   </data>

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -905,12 +905,6 @@ namespace System.ComponentModel
                 throw new ArgumentException(nameof(component));
             }
 
-            if (component is IUnimplemented)
-            {
-                throw new NotSupportedException(SR.Format(SR.TypeDescriptorUnsupportedRemoteObject, component.GetType().FullName));
-            }
-
-
             ICustomTypeDescriptor desc = NodeFor(component).GetTypeDescriptor(component);
             ICustomTypeDescriptor d = component as ICustomTypeDescriptor;
             if (!noCustomTypeDesc && d != null)
@@ -2858,24 +2852,6 @@ namespace System.ComponentModel
                 return true;
             }
         }
-
-        /// <summary>
-        /// An unimplemented interface. What is this?  It is an interface that nobody ever
-        /// implements, of course? Where and why would it be used?  Why, to find cross-process
-        /// remoted objects, of course!  If a well-known object comes in from a cross process
-        /// connection, the remoting layer does contain enough type information to determine
-        /// if an object implements an interface. It assumes that if you are going to cast
-        /// an object to an interface that you know what you're doing, and allows the cast,
-        /// even for objects that DON'T actually implement the interface. The error here
-        /// is raised later when you make your first call on that interface pointer:  you
-        /// get a remoting exception.
-        ///
-        /// This is a big problem for code that does "is" and "as" checks to detect the
-        /// presence of an interface. We do that all over the place here, so we do a check
-        /// during parameter validation to see if an object implements IUnimplemented. If it
-        /// does, we know that what we really have is a lying remoting proxy, and we bail.
-        /// </summary>
-        private interface IUnimplemented { }
 
         /// <summary>
         /// This comparer compares member descriptors for sorting.


### PR DESCRIPTION
If I'm not mistaken, this is not relevant in .NET Core as we don't support remoting.

If I'm wrong, then I'll update the PR to update the comment to refer explicitly to .NET Core