### PR TITLE
Fix nullable annotations for EventRegistrationTokenTable<T>

### DIFF
--- a/src/System.Runtime.InteropServices.WindowsRuntime/ref/System.Runtime.InteropServices.WindowsRuntime.cs
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/ref/System.Runtime.InteropServices.WindowsRuntime.cs
@@ -24,12 +24,11 @@ namespace System.Runtime.InteropServices.WindowsRuntime
     public sealed partial class EventRegistrationTokenTable<T> where T : class
     {
         public EventRegistrationTokenTable() { }
-        [System.Diagnostics.CodeAnalysis.MaybeNullAttribute]
-        public T InvocationList { get { throw null; } set { } }
-        public System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken AddEventHandler(T handler) { throw null; }
+        public T? InvocationList { get { throw null; } set { } }
+        public System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken AddEventHandler(T? handler) { throw null; }
         public static System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T> GetOrCreateEventRegistrationTokenTable(ref System.Runtime.InteropServices.WindowsRuntime.EventRegistrationTokenTable<T>? refEventTable) { throw null; }
         public void RemoveEventHandler(System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken token) { }
-        public void RemoveEventHandler(T handler) { }
+        public void RemoveEventHandler(T? handler) { }
     }
     public partial interface IActivationFactory
     {


### PR DESCRIPTION
Based on API Review feedback that it handles nulls correctly and the `T` is constraint to `class`, we should accept/return `T?`.

cc: @dotnet/nullablefc @jkotas 