### PR TITLE
Add more TypeConverter tests

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/DateTimeConverter.cs
@@ -83,7 +83,6 @@ namespace System.ComponentModel
             if (destinationType == typeof(string) && value is DateTime)
             {
                 DateTime dt = (DateTime)value;
-
                 if (dt == DateTime.MinValue)
                 {
                     return string.Empty;
@@ -94,10 +93,8 @@ namespace System.ComponentModel
                     culture = CultureInfo.CurrentCulture;
                 }
 
-                DateTimeFormatInfo formatInfo = null;
-                formatInfo = (DateTimeFormatInfo)culture.GetFormat(typeof(DateTimeFormatInfo));
+                DateTimeFormatInfo formatInfo = (DateTimeFormatInfo)culture.GetFormat(typeof(DateTimeFormatInfo));
 
-                string format;
                 if (culture == CultureInfo.InvariantCulture)
                 {
                     if (dt.TimeOfDay.TotalSeconds == 0)
@@ -109,6 +106,8 @@ namespace System.ComponentModel
                         return dt.ToString(culture);
                     }
                 }
+
+                string format;
                 if (dt.TimeOfDay.TotalSeconds == 0)
                 {
                     format = formatInfo.ShortDatePattern;
@@ -124,32 +123,18 @@ namespace System.ComponentModel
             if (destinationType == typeof(InstanceDescriptor) && value is DateTime)
             {
                 DateTime dt = (DateTime)value;
-
                 if (dt.Ticks == 0)
                 {
-                    // Special case for empty DateTime
-                    ConstructorInfo ctr = typeof(DateTime).GetConstructor(new Type[] { typeof(long) });
-
-                    if (ctr != null)
-                    {
-                        return new InstanceDescriptor(ctr, new object[] {
-                            dt.Ticks });
-                    }
+                    return new InstanceDescriptor(
+                        typeof(DateTime).GetConstructor(new Type[] { typeof(long) }),
+                        new object[] { dt.Ticks }
+                    );
                 }
 
-                ConstructorInfo ctor = typeof(DateTime).GetConstructor(new Type[]
-                    {
-                        typeof(int), typeof(int), typeof(int), typeof(int),
-                        typeof(int), typeof(int), typeof(int)
-                    });
-
-                if (ctor != null)
-                {
-                    return new InstanceDescriptor(ctor, new object[]
-                        {
-                            dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second, dt.Millisecond
-                        });
-                }
+                return new InstanceDescriptor(
+                    typeof(DateTime).GetConstructor(new Type[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) }),
+                    new object[] { dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second, dt.Millisecond }
+                );
             }
 
             return base.ConvertTo(context, culture, value, destinationType);

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TimeSpanConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TimeSpanConverter.cs
@@ -64,19 +64,14 @@ namespace System.ComponentModel
         /// </summary>
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            if (destinationType == null)
-            {
-                throw new ArgumentNullException(nameof(destinationType));
-            }
-
             if (destinationType == typeof(InstanceDescriptor) && value is TimeSpan)
             {
-                MethodInfo method = typeof(TimeSpan).GetMethod("Parse", new Type[] { typeof(string) });
-                if (method != null)
-                {
-                    return new InstanceDescriptor(method, new object[] { value.ToString() });
-                }
+                return new InstanceDescriptor(
+                    typeof(TimeSpan).GetMethod(nameof(TimeSpan.Parse), new Type[] { typeof(string) }),
+                    new object[] { value.ToString() }
+                );
             }
+
             return base.ConvertTo(context, culture, value, destinationType);
         }
     }

--- a/src/System.ComponentModel.TypeConverter/tests/DateTimeConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DateTimeConverterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;
 using System.Reflection;
@@ -10,97 +11,85 @@ using Xunit;
 
 namespace System.ComponentModel.Tests
 {
-    public class DateTimeConverterTests : ConverterTestBase
+    public class DateTimeConverterTests : TypeConverterTestBase
     {
-        private static TypeConverter s_converter = new DateTimeConverter();
-        private static DateTime s_testDate = new DateTime(1998, 12, 5);
+        public override TypeConverter Converter => new DateTimeConverter();
 
-        [Fact]
-        public static void CanConvertFrom_WithContext()
+        public override IEnumerable<ConvertTest> ConvertFromTestData()
         {
-            CanConvertFrom_WithContext(new object[2, 2]
-                {
-                    { typeof(string), true },
-                    { typeof(int), false }
-                },
-                DateTimeConverterTests.s_converter);
+            DateTime date = new DateTime(1998, 12, 5);
+            yield return ConvertTest.Valid("", DateTime.MinValue);
+            yield return ConvertTest.Valid("    ", DateTime.MinValue);
+            yield return ConvertTest.Valid(date.ToString(), date);
+            yield return ConvertTest.Valid(date.ToString(CultureInfo.InvariantCulture.DateTimeFormat), date, CultureInfo.InvariantCulture);
+            yield return ConvertTest.Valid(" " + date.ToString(CultureInfo.InvariantCulture.DateTimeFormat) + " ", date, CultureInfo.InvariantCulture);
+
+            yield return ConvertTest.Throws<FormatException>("invalid");
+
+            yield return ConvertTest.CantConvertFrom(new object());
+            yield return ConvertTest.CantConvertFrom(1);
         }
 
-        [Fact]
-        public static void ConvertFrom_WithContext()
+        public override IEnumerable<ConvertTest> ConvertToTestData()
         {
-            ConvertFrom_WithContext(new object[3, 3]
-                {
-                    { "  ", DateTime.MinValue, null },
-                    { DateTimeConverterTests.s_testDate.ToString(), DateTimeConverterTests.s_testDate, null },
-                    { DateTimeConverterTests.s_testDate.ToString(CultureInfo.InvariantCulture.DateTimeFormat), DateTimeConverterTests.s_testDate, CultureInfo.InvariantCulture }
-                },
-                DateTimeConverterTests.s_converter);
+            CultureInfo polandCulture = new CultureInfo("pl-PL");
+            DateTimeFormatInfo formatInfo = CultureInfo.CurrentCulture.DateTimeFormat;
+            DateTime date = new DateTime(1998, 12, 5);
+            yield return ConvertTest.Valid(date, date.ToString(formatInfo.ShortDatePattern));
+            yield return ConvertTest.Valid(date, date.ToString(polandCulture.DateTimeFormat.ShortDatePattern, polandCulture.DateTimeFormat))
+                .WithRemoteInvokeCulture(polandCulture);
+            yield return ConvertTest.Valid(date, "1998-12-05", CultureInfo.InvariantCulture)
+                .WithRemoteInvokeCulture(polandCulture);
+
+            DateTime dateWithTime = new DateTime(1998, 12, 5, 22, 30, 30);
+            yield return ConvertTest.Valid(dateWithTime, dateWithTime.ToString(formatInfo.ShortDatePattern + " " + formatInfo.ShortTimePattern));
+            yield return ConvertTest.Valid(dateWithTime, dateWithTime.ToString(polandCulture.DateTimeFormat.ShortDatePattern + " " + polandCulture.DateTimeFormat.ShortTimePattern, polandCulture.DateTimeFormat))
+                .WithRemoteInvokeCulture(polandCulture);
+            yield return ConvertTest.Valid(dateWithTime, "12/05/1998 22:30:30", CultureInfo.InvariantCulture)
+                .WithRemoteInvokeCulture(polandCulture);
+
+            yield return ConvertTest.Valid(DateTime.MinValue, string.Empty);
+
+            yield return ConvertTest.Valid(
+                new DateTime(),
+                new InstanceDescriptor(
+                    typeof(DateTime).GetConstructor(new Type[] { typeof(long) }),
+                    new object[] { (long)0 }
+                )
+            );
+            yield return ConvertTest.Valid(
+                date,
+                new InstanceDescriptor(
+                    typeof(DateTime).GetConstructor(new Type[] { typeof(int), typeof(int), typeof(int), typeof(int),  typeof(int), typeof(int), typeof(int) }),
+                    new object[] { 1998, 12, 5, 0, 0, 0, 0 }
+                )
+            );
+            yield return ConvertTest.Valid(
+                dateWithTime,
+                new InstanceDescriptor(
+                    typeof(DateTime).GetConstructor(new Type[] { typeof(int), typeof(int), typeof(int), typeof(int),  typeof(int), typeof(int), typeof(int) }),
+                    new object[] { 1998, 12, 5, 22, 30, 30, 0 }
+                )
+            );
+            yield return ConvertTest.Valid(
+                dateWithTime,
+                new InstanceDescriptor(
+                    typeof(DateTime).GetConstructor(new Type[] { typeof(int), typeof(int), typeof(int), typeof(int),  typeof(int), typeof(int), typeof(int) }),
+                    new object[] { 1998, 12, 5, 22, 30, 30, 0 }
+                ),
+                CultureInfo.InvariantCulture
+            );
+
+            yield return ConvertTest.CantConvertTo(new DateTime(), typeof(DateTime));
+            yield return ConvertTest.CantConvertTo(new DateTime(), typeof(int));
         }
 
-        [Fact]
-        public static void ConvertFrom_WithContext_Negative()
+        [Theory]
+        [InlineData(typeof(InstanceDescriptor))]
+        [InlineData(typeof(int))]
+        public void ConvertTo_InvalidValue_ThrowsNotSupportedException(Type destinationType)
         {
-            Assert.Throws<NotSupportedException>(
-                () => DateTimeConverterTests.s_converter.ConvertFrom(TypeConverterTests.s_context, null, 1));
-
-            Assert.Throws<FormatException>(
-                () => DateTimeConverterTests.s_converter.ConvertFrom(TypeConverterTests.s_context, null, "aaa"));
-        }
-
-        [Fact]
-        public static void CanConvertTo_WithContext()
-        {
-            CanConvertTo_WithContext(new object[3, 2]
-                {
-                    { typeof(string), true },
-                    { typeof(InstanceDescriptor), true },
-                    { typeof(int), false }
-                },
-                DateTimeConverterTests.s_converter);
-        }
-
-        [Fact]
-        public static void ConvertTo_WithContext()
-        {
-            RemoteExecutor.Invoke(() => {
-                CultureInfo.CurrentCulture = new CultureInfo("pl-PL");
-                DateTimeFormatInfo formatInfo = (DateTimeFormatInfo)CultureInfo.CurrentCulture.GetFormat(typeof(DateTimeFormatInfo));
-                string formatWithTime = formatInfo.ShortDatePattern + " " + formatInfo.ShortTimePattern;
-                string format = formatInfo.ShortDatePattern;
-                DateTime testDateAndTime = new DateTime(1998, 12, 5, 22, 30, 30);
-                ConstructorInfo ctor = typeof(DateTime).GetConstructor(new Type[]
-                    {
-                        typeof(int), typeof(int), typeof(int), typeof(int),
-                        typeof(int), typeof(int), typeof(int)
-                    });
-
-                InstanceDescriptor descriptor = new InstanceDescriptor(ctor, new object[]
-                    {
-                        testDateAndTime.Year, testDateAndTime.Month, testDateAndTime.Day, testDateAndTime.Hour, testDateAndTime.Minute, testDateAndTime.Second, testDateAndTime.Millisecond
-                    });
-
-                ConvertTo_WithContext(new object[5, 3]
-                    {
-                    { DateTimeConverterTests.s_testDate, DateTimeConverterTests.s_testDate.ToString(format, CultureInfo.CurrentCulture), null },
-                    { testDateAndTime, testDateAndTime.ToString(formatWithTime, CultureInfo.CurrentCulture), null },
-                    { DateTime.MinValue, string.Empty, null },
-                    { DateTimeConverterTests.s_testDate, "1998-12-05", CultureInfo.InvariantCulture },
-                    { testDateAndTime, "12/05/1998 22:30:30", CultureInfo.InvariantCulture }
-                    },
-                    DateTimeConverterTests.s_converter);
-
-                object describedInstanceNoCulture = s_converter.ConvertTo(TypeConverterTests.s_context, null, testDateAndTime, descriptor.GetType());
-                describedInstanceNoCulture = ((InstanceDescriptor)describedInstanceNoCulture).Invoke();
-
-                object describedInstanceCulture = s_converter.ConvertTo(TypeConverterTests.s_context, CultureInfo.InvariantCulture, testDateAndTime, descriptor.GetType());
-                describedInstanceCulture = ((InstanceDescriptor)describedInstanceCulture).Invoke();
-
-                Assert.Equal(testDateAndTime, describedInstanceNoCulture);
-                Assert.Equal(testDateAndTime, describedInstanceCulture);
-
-                return RemoteExecutor.SuccessExitCode;
-            }).Dispose();
+            Assert.Throws<NotSupportedException>(() => Converter.ConvertTo(new object(), destinationType));
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/GuidConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/GuidConverterTests.cs
@@ -10,80 +10,35 @@ using Xunit;
 
 namespace System.ComponentModel.Tests
 {
-    public class GuidConverterTests : ConverterTestBase
+    public class GuidConverterTests : TypeConverterTestBase
     {
-        [Theory]
-        [InlineData(typeof(string), true)]
-        [InlineData(typeof(InstanceDescriptor), true)]
-        [InlineData(typeof(Guid), false)]
-        [InlineData(null, false)]
-        public void CanConvertFrom_Invoke_ReturnsExpected(Type sourceType, bool expected)
+        public override TypeConverter Converter => new GuidConverter();
+
+        public override IEnumerable<ConvertTest> ConvertFromTestData()
         {
-            var converter = new GuidConverter();
-            Assert.Equal(expected, converter.CanConvertFrom(sourceType));
+            yield return ConvertTest.Valid(" {30da92c0-23e8-42a0-ae7c-734a0e5d2782}", new Guid(0x30da92c0, 0x23e8, 0x42a0, 0xae, 0x7c, 0x73, 0x4a, 0x0e, 0x5d, 0x27, 0x82));
+            yield return ConvertTest.Valid("{30da92c0-23e8-42a0-ae7c-734a0e5d2782}", new Guid(0x30da92c0, 0x23e8, 0x42a0, 0xae, 0x7c, 0x73, 0x4a, 0x0e, 0x5d, 0x27, 0x82));
+            yield return ConvertTest.Valid(" \t\r\n {30da92c0-23e8-42a0-ae7c-734a0e5d2782} \t\r\n ", new Guid(0x30da92c0, 0x23e8, 0x42a0, 0xae, 0x7c, 0x73, 0x4a, 0x0e, 0x5d, 0x27, 0x82));
+
+            yield return ConvertTest.Throws<FormatException>("");
+            yield return ConvertTest.Throws<FormatException>("invalid");
+            yield return ConvertTest.CantConvertFrom(1);
+            yield return ConvertTest.CantConvertFrom(new object());
         }
 
-        public static IEnumerable<object[]> ConvertFrom_TestData()
+        public override IEnumerable<ConvertTest> ConvertToTestData()
         {
-            yield return new object[] { " {30da92c0-23e8-42a0-ae7c-734a0e5d2782}", new Guid(0x30da92c0, 0x23e8, 0x42a0, 0xae, 0x7c, 0x73, 0x4a, 0x0e, 0x5d, 0x27, 0x82) };
-            yield return new object[] { "{30da92c0-23e8-42a0-ae7c-734a0e5d2782}", new Guid(0x30da92c0, 0x23e8, 0x42a0, 0xae, 0x7c, 0x73, 0x4a, 0x0e, 0x5d, 0x27, 0x82) };
-            yield return new object[] { " \t\r\n {30da92c0-23e8-42a0-ae7c-734a0e5d2782} \t\r\n ", new Guid(0x30da92c0, 0x23e8, 0x42a0, 0xae, 0x7c, 0x73, 0x4a, 0x0e, 0x5d, 0x27, 0x82) };
-        }
-
-        [Theory]
-        [MemberData(nameof(ConvertFrom_TestData))]
-        public void ConvertFrom_Invoke_ReturnsExpected(object value, object expected)
-        {
-            var converter = new GuidConverter();
-            Assert.Equal(expected, converter.ConvertFrom(value));
-        }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData("invalid")]
-        public void ConvertFrom_InvalidString_ThrowsFormatException(string value)
-        {
-            var converter = new GuidConverter();
-            Assert.Throws<FormatException>(() => converter.ConvertFrom(value));
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData(1)]
-        public void ConvertFrom_InvalidValue_ThrowsNotSupportedException(object value)
-        {
-            var converter = new GuidConverter();
-            Assert.Throws<NotSupportedException>(() => converter.ConvertFrom(value));
-        }
-
-        [Theory]
-        [InlineData(typeof(string), true)]
-        [InlineData(typeof(InstanceDescriptor), true)]
-        [InlineData(typeof(Guid), false)]
-        [InlineData(null, false)]
-        public void CanConvertTo_Invoke_ReturnsExpected(Type destinationType, bool expected)
-        {
-            var converter = new GuidConverter();
-            Assert.Equal(expected, converter.CanConvertTo(destinationType));
-        }
-
-        [Fact]
-        public void ConvertTo_String_ReturnsExpected()
-        {
-            var converter = new GuidConverter();
-            var value = new Guid(0x30da92c0, 0x23e8, 0x42a0, 0xae, 0x7c, 0x73, 0x4a, 0x0e, 0x5d, 0x27, 0x82);
-            Assert.Equal("30da92c0-23e8-42a0-ae7c-734a0e5d2782", converter.ConvertTo(value, typeof(string)));
-        }
-
-        [Fact]
-        public void ConvertTo_InstanceDescriptor_ReturnsExpected()
-        {
-            var converter = new GuidConverter();
-            var value = new Guid(0x30da92c0, 0x23e8, 0x42a0, 0xae, 0x7c, 0x73, 0x4a, 0x0e, 0x5d, 0x27, 0x82);
-            InstanceDescriptor descriptor = Assert.IsType<InstanceDescriptor>(converter.ConvertTo(value, typeof(InstanceDescriptor)));
-            ConstructorInfo constructor = Assert.IsAssignableFrom<ConstructorInfo>(descriptor.MemberInfo);
-            Assert.Equal(new Type[] { typeof(string) }, constructor.GetParameters().Select(p => p.ParameterType));
-            Assert.Equal(new object[] { "30da92c0-23e8-42a0-ae7c-734a0e5d2782" }, descriptor.Arguments);
+            const string GuidString = "30da92c0-23e8-42a0-ae7c-734a0e5d2782";
+            yield return ConvertTest.Valid(new Guid(0x30da92c0, 0x23e8, 0x42a0, 0xae, 0x7c, 0x73, 0x4a, 0x0e, 0x5d, 0x27, 0x82), GuidString);
+            yield return ConvertTest.Valid(
+                new Guid(0x30da92c0, 0x23e8, 0x42a0, 0xae, 0x7c, 0x73, 0x4a, 0x0e, 0x5d, 0x27, 0x82),
+                new InstanceDescriptor(
+                    typeof(Guid).GetConstructor(new Type[] { typeof(string) }),
+                    new object[] { GuidString }
+                )
+            );
+            yield return ConvertTest.CantConvertTo(new Guid(), typeof(Guid));
+            yield return ConvertTest.CantConvertTo(new Guid(), typeof(int));
         }
 
         [Theory]
@@ -91,8 +46,7 @@ namespace System.ComponentModel.Tests
         [InlineData(typeof(int))]
         public void ConvertTo_InvalidValue_ThrowsNotSupportedException(Type destinationType)
         {
-            var converter = new GuidConverter();
-            Assert.Throws<NotSupportedException>(() => converter.ConvertTo(new object(), destinationType));
+            Assert.Throws<NotSupportedException>(() => Converter.ConvertTo(new object(), destinationType));
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/ReferenceConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/ReferenceConverterTests.cs
@@ -40,104 +40,12 @@ namespace System.ComponentModel.Tests
 {
     public class ReferenceConverterTests : TypeConverterTestBase
     {
-        public class TestReferenceService : IReferenceService
-        {
-            private Dictionary<string, object> _references = new Dictionary<string, object>();
-
-            public void AddReference(string name, object reference)
-            {
-                _references[name ?? "(null)"] = reference;
-            }
-
-            public void ClearReferences() => _references.Clear();
-
-            public IComponent GetComponent(object reference) => null;
-
-            public string GetName(object reference)
-            {
-                foreach (KeyValuePair<string, object> entry in _references)
-                {
-                    if (entry.Value == reference)
-                    {
-                        return entry.Key == "(null)" ? null : entry.Key;
-                    }
-                }
-
-                return null;
-            }
-
-            public object GetReference(string name)
-            {
-                if (!_references.ContainsKey(name ?? "(null)"))
-                {
-                    return null;
-                }
-
-                return _references[name];
-            }
-
-            public object[] GetReferences()
-            {
-                object[] array = new object[_references.Values.Count];
-                _references.Values.CopyTo(array, 0);
-                return array;
-            }
-
-            public object[] GetReferences(Type baseType)
-            {
-                object[] references = GetReferences();
-
-                var filtered = new List<object>();
-                foreach (object reference in references)
-                {
-                    if (baseType.IsInstanceOfType(reference))
-                    {
-                        filtered.Add(reference);
-                    }
-                }
-
-                return filtered.ToArray();
-            }
-        }
-
-        public class TestTypeDescriptorContext : ITypeDescriptorContext
-        {
-            private IReferenceService _referenceService = null;
-
-            public TestTypeDescriptorContext() { }
-
-            public TestTypeDescriptorContext(IReferenceService referenceService)
-            {
-                _referenceService = referenceService;
-            }
-
-            public IContainer Container { get; set; }
-
-            public object Instance => null;
-            public PropertyDescriptor PropertyDescriptor => null;
-
-            public void OnComponentChanged() { }
-            public bool OnComponentChanging() => true;
-
-            public object GetService(Type serviceType)
-            {
-                if (serviceType == typeof(IReferenceService))
-                {
-                    return _referenceService;
-                }
-
-                return null;
-            }
-        }
-
-        private interface ITestInterface { }
-
-        private class TestComponent : Component { }
 
         public override TypeConverter Converter => new ReferenceConverter(typeof(ITestInterface));
 
         public override bool StandardValuesExclusive => true;
         public override bool StandardValuesSupported => true;
+        public override bool CanConvertToString => false;
 
         public override IEnumerable<ConvertTest> ConvertFromTestData()
         {
@@ -147,26 +55,63 @@ namespace System.ComponentModel.Tests
             yield return noContext;
 
             // No IReferenceService or IContainer.
-            yield return ConvertTest.Valid("", null);
+            yield return ConvertTest.Valid(string.Empty, null);
             yield return ConvertTest.Valid("   ", null);
             yield return ConvertTest.Valid("(none)", null).WithInvariantRemoteInvokeCulture();
             yield return ConvertTest.Valid("nothing", null);
 
             // IReferenceService.
-            var component = new TestComponent();
-            var referenceService = new TestReferenceService();
-            referenceService.AddReference("reference name", component);
-            var contextWithReferenceCollection = new TestTypeDescriptorContext(referenceService);
+            var nullReferenceServiceContext = new MockTypeDescriptorContext
+            {
+                GetServiceAction = (serviceType) =>
+                {
+                    Assert.Equal(typeof(IReferenceService), serviceType);
+                    return null;
+                }
+            };
+            yield return ConvertTest.Valid("reference name", null).WithContext(nullReferenceServiceContext);
 
-            yield return ConvertTest.Valid("reference name", component).WithContext(contextWithReferenceCollection);
-            yield return ConvertTest.Valid("no such reference", null).WithContext(contextWithReferenceCollection);
+            var invalidReferenceServiceContext = new MockTypeDescriptorContext
+            {
+                GetServiceAction = (serviceType) =>
+                {
+                    Assert.Equal(typeof(IReferenceService), serviceType);
+                    return new object();
+                }
+            };
+            yield return ConvertTest.Valid("reference name", null).WithContext(invalidReferenceServiceContext);
+
+            var component1 = new TestComponent();
+            var component2 = new TestComponent();
+            var nonComponent = new object();
+            var referenceService = new MockReferenceService();
+            referenceService.AddReference("reference name", component1);
+            referenceService.AddReference(string.Empty, component2);
+            referenceService.AddReference("non component", nonComponent);
+            var validReferenceServiceContext = new MockTypeDescriptorContext
+            {
+                GetServiceAction = (serviceType) =>
+                {
+                    Assert.Equal(typeof(IReferenceService), serviceType);
+                    return referenceService;
+                }
+            };
+            yield return ConvertTest.Valid("reference name", component1).WithContext(validReferenceServiceContext);
+            yield return ConvertTest.Valid("  reference name  ", component1).WithContext(validReferenceServiceContext);
+            yield return ConvertTest.Valid(string.Empty, component2).WithContext(validReferenceServiceContext);
+            yield return ConvertTest.Valid("non component", nonComponent).WithContext(validReferenceServiceContext);
+            yield return ConvertTest.Valid("no such reference", null).WithContext(validReferenceServiceContext);
 
             // IContainer.
+            var containerComponent1 = new TestComponent();
+            var containerComponent2 = new TestComponent();
             var container = new Container();
-            container.Add(component, "reference name");
-            var contextWithContainer = new TestTypeDescriptorContext { Container = container };
+            container.Add(containerComponent1, "reference name");
+            container.Add(containerComponent2, string.Empty);
+            var contextWithContainer = new MockTypeDescriptorContext { Container = container };
 
-            yield return ConvertTest.Valid("reference name", component).WithContext(contextWithContainer);
+            yield return ConvertTest.Valid("reference name", containerComponent1).WithContext(contextWithContainer);
+            yield return ConvertTest.Valid(string.Empty, containerComponent2).WithContext(contextWithContainer);
             yield return ConvertTest.Valid("no such reference", null).WithContext(contextWithContainer);
 
             yield return ConvertTest.CantConvertFrom(1);
@@ -175,27 +120,68 @@ namespace System.ComponentModel.Tests
 
         public override IEnumerable<ConvertTest> ConvertToTestData()
         {
-            var component = new TestComponent();
+            var component1 = new TestComponent();
+            var component2 = new TestComponent();
+            var component3 = new TestComponent();
+            var nonComponent = new object();
 
             // No Context.
-            yield return ConvertTest.Valid(null, "(none)").WithInvariantRemoteInvokeCulture();;
-            yield return ConvertTest.Valid(null, "(none)").WithContext(null).WithInvariantRemoteInvokeCulture();;
+            yield return ConvertTest.Valid(null, "(none)").WithInvariantRemoteInvokeCulture();
+            yield return ConvertTest.Valid(null, "(none)").WithContext(null).WithInvariantRemoteInvokeCulture();
             yield return ConvertTest.Valid(string.Empty, string.Empty).WithContext(null);
 
             // IReferenceCollection.
-            var referenceService = new TestReferenceService();
-            referenceService.AddReference("reference name", component);
-            var contextWithReferenceService = new TestTypeDescriptorContext(referenceService);
+            var nullReferenceServiceContext = new MockTypeDescriptorContext
+            {
+                GetServiceAction = (serviceType) =>
+                {
+                    Assert.Equal(typeof(IReferenceService), serviceType);
+                    return null;
+                }
+            };
+            yield return ConvertTest.Valid(component1, string.Empty).WithContext(nullReferenceServiceContext);
+            yield return ConvertTest.Valid(new Component(), string.Empty).WithContext(nullReferenceServiceContext);
 
-            yield return ConvertTest.Valid(component, "reference name").WithContext(contextWithReferenceService);
-            yield return ConvertTest.Valid(new Component(), string.Empty).WithContext(contextWithReferenceService);
+            var invalidReferenceServiceContext = new MockTypeDescriptorContext
+            {
+                GetServiceAction = (serviceType) =>
+                {
+                    Assert.Equal(typeof(IReferenceService), serviceType);
+                    return new object();
+                }
+            };
+            yield return ConvertTest.Valid(component1, string.Empty).WithContext(invalidReferenceServiceContext);
+            yield return ConvertTest.Valid(new Component(), string.Empty).WithContext(invalidReferenceServiceContext);
+
+            var referenceService = new MockReferenceService();
+            referenceService.AddReference("reference name", component1);
+            referenceService.AddReference(string.Empty, component2);
+            referenceService.AddReference(null, component3);
+            referenceService.AddReference("non component", nonComponent);
+            var validReferenceServiceContext = new MockTypeDescriptorContext
+            {
+                GetServiceAction = (serviceType) =>
+                {
+                    Assert.Equal(typeof(IReferenceService), serviceType);
+                    return referenceService;
+                }
+            };
+            yield return ConvertTest.Valid(component1, "reference name").WithContext(validReferenceServiceContext);
+            yield return ConvertTest.Valid(component2, string.Empty).WithContext(validReferenceServiceContext);
+            yield return ConvertTest.Valid(component3, string.Empty).WithContext(validReferenceServiceContext);
+            yield return ConvertTest.Valid(nonComponent, "non component").WithContext(validReferenceServiceContext);
+            yield return ConvertTest.Valid(new Component(), string.Empty).WithContext(validReferenceServiceContext);
 
             // IContainer.
+            var containerComponent1 = new TestComponent();
+            var containerComponent2 = new TestComponent();
             var container = new Container();
-            container.Add(component, "reference name");
-            var contextWithContainer = new TestTypeDescriptorContext { Container = container };
+            container.Add(containerComponent1, "reference name");
+            container.Add(containerComponent2, string.Empty);
+            var contextWithContainer = new MockTypeDescriptorContext { Container = container };
 
-            yield return ConvertTest.Valid(component, "reference name").WithContext(contextWithContainer);
+            yield return ConvertTest.Valid(containerComponent1, "reference name").WithContext(contextWithContainer);
+            yield return ConvertTest.Valid(containerComponent2, string.Empty).WithContext(contextWithContainer);
             yield return ConvertTest.Valid(new Component(), string.Empty).WithContext(contextWithContainer);
 
             yield return ConvertTest.CantConvertTo(1, typeof(int));
@@ -210,15 +196,99 @@ namespace System.ComponentModel.Tests
             var component2 = new TestComponent();
             var component3 = new Component();
 
-            var referenceService = new TestReferenceService();
+            var referenceService = new MockReferenceService();
+            referenceService.AddReference("reference name 1", component1);
+            referenceService.AddReference("reference name 2", component2);
+            referenceService.AddReference("reference name 3", component3);
+            referenceService.AddReference("reference name 4", component2);
+
+            int callCount = 0;
+            var context = new MockTypeDescriptorContext
+            {
+                GetServiceAction = (serviceType) =>
+                {
+                    callCount++;
+                    Assert.Equal(typeof(IReferenceService), serviceType);
+                    return referenceService;
+                }
+            };
+
+            TypeConverter.StandardValuesCollection values1 = converter.GetStandardValues(context);
+            Assert.Equal(1, callCount);
+            Assert.Equal(new object[] { component1, component2, component2, null }, values1.Cast<object>());
+
+            // Call again to test caching behavior.
+            TypeConverter.StandardValuesCollection values2 = converter.GetStandardValues(context);
+            Assert.Equal(2, callCount);
+            Assert.NotSame(values1, values2);
+        }
+
+        [Fact]
+        public void GetStandardValues_IReferenceServiceNullType_ReturnsExpected()
+        {
+            var converter = new ReferenceConverter(null);
+
+            var component1 = new TestComponent();
+            var component2 = new TestComponent();
+            var component3 = new Component();
+
+            var referenceService = new MockReferenceService();
             referenceService.AddReference("reference name 1", component1);
             referenceService.AddReference("reference name 2", component2);
             referenceService.AddReference("reference name 3", component3);
 
-            var context = new TestTypeDescriptorContext(referenceService);
+            int callCount = 0;
+            var context = new MockTypeDescriptorContext
+            {
+                GetServiceAction = (serviceType) =>
+                {
+                    callCount++;
+                    Assert.Equal(typeof(IReferenceService), serviceType);
+                    return referenceService;
+                }
+            };
 
-            TypeConverter.StandardValuesCollection values = converter.GetStandardValues(context);
-            Assert.Equal(new object[] { component1, component2, null }, values.Cast<object>());
+            TypeConverter.StandardValuesCollection values1 = converter.GetStandardValues(context);
+            Assert.Equal(1, callCount);
+            Assert.Equal(new object[] { null }, values1.Cast<object>());
+
+            // Call again to test caching behavior.
+            TypeConverter.StandardValuesCollection values2 = converter.GetStandardValues(context);
+            Assert.Equal(2, callCount);
+            Assert.NotSame(values1, values2);
+        }
+
+        public static IEnumerable<object[]> GetStandardValues_IReferenceServiceInvalid_TestData()
+        {
+            yield return new object[] { new MockReferenceService { References = null } };
+            yield return new object[] { new object() };
+            yield return new object[] { null };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetStandardValues_IReferenceServiceInvalid_TestData))]
+        public void GetStandardValues_IReferenceServiceInvalid_ReturnsExpected(object referenceService)
+        {
+            var converter = new ReferenceConverter(typeof(TestComponent));
+            int callCount = 0;
+            var context = new MockTypeDescriptorContext
+            {
+                GetServiceAction = (serviceType) =>
+                {
+                    callCount++;
+                    Assert.Equal(typeof(IReferenceService), serviceType);
+                    return referenceService;
+                }
+            };
+
+            TypeConverter.StandardValuesCollection values1 = converter.GetStandardValues(context);
+            Assert.Equal(1, callCount);
+            Assert.Equal(new object[] { null }, values1.Cast<object>());
+
+            // Call again to test caching behavior.
+            TypeConverter.StandardValuesCollection values2 = converter.GetStandardValues(context);
+            Assert.Equal(2, callCount);
+            Assert.NotSame(values1, values2);
         }
 
         [Fact]
@@ -230,16 +300,31 @@ namespace System.ComponentModel.Tests
             var component2 = new TestComponent();
             var component3 = new TestComponent();
 
-            var referenceService = new TestReferenceService();
+            var referenceService = new MockReferenceService();
             referenceService.AddReference("reference name 1", component1);
             referenceService.AddReference("reference name 2", component2);
             referenceService.AddReference("reference name 3", component3);
 
-            var context = new TestTypeDescriptorContext(referenceService);
+            int callCount = 0;
+            var context = new MockTypeDescriptorContext
+            {
+                GetServiceAction = (serviceType) =>
+                {
+                    callCount++;
+                    Assert.Equal(typeof(IReferenceService), serviceType);
+                    return referenceService;
+                }
+            };
 
-            TypeConverter.StandardValuesCollection values = converter.GetStandardValues(context);
-            Assert.Equal(new object[] { null }, values.Cast<object>());
-            Assert.Equal(new object[] { component2, component3 }, converter.Values);
+            TypeConverter.StandardValuesCollection values1 = converter.GetStandardValues(context);
+            Assert.Equal(1, callCount);
+            Assert.Equal(new object[] { null }, values1.Cast<object>());
+            Assert.Equal(new object[] { component2, component3 }, converter.DisallowedValues);
+
+            // Call again to test caching behavior.
+            TypeConverter.StandardValuesCollection values2 = converter.GetStandardValues(context);
+            Assert.Equal(2, callCount);
+            Assert.NotSame(values1, values2);
         }
 
         [Fact]
@@ -255,10 +340,37 @@ namespace System.ComponentModel.Tests
             container.Add(component3);
 
             var converter = new ReferenceConverter(typeof(TestComponent));
-            var context = new TestTypeDescriptorContext { Container = container };
+            var context = new MockTypeDescriptorContext { Container = container };
 
-            TypeConverter.StandardValuesCollection values = converter.GetStandardValues(context);
-            Assert.Equal(new object[] { component1, component2, null }, values.Cast<object>());
+            TypeConverter.StandardValuesCollection values1 = converter.GetStandardValues(context);
+            Assert.Equal(new object[] { component1, component2, null }, values1.Cast<object>());
+
+            // Call again to test caching behavior.
+            TypeConverter.StandardValuesCollection values2 = converter.GetStandardValues(context);
+            Assert.NotSame(values1, values2);
+        }
+
+        [Fact]
+        public void GetStandardValues_IContainerNullType_ReturnsExpected()
+        {
+            var component1 = new TestComponent();
+            var component2 = new TestComponent();
+            var component3 = new Component();
+
+            var container = new Container();
+            container.Add(component1);
+            container.Add(component2);
+            container.Add(component3);
+
+            var converter = new ReferenceConverter(null);
+            var context = new MockTypeDescriptorContext { Container = container };
+
+            TypeConverter.StandardValuesCollection values1 = converter.GetStandardValues(context);
+            Assert.Equal(new object[] { null }, values1.Cast<object>());
+
+            // Call again to test caching behavior.
+            TypeConverter.StandardValuesCollection values2 = converter.GetStandardValues(context);
+            Assert.NotSame(values1, values2);
         }
 
         [Fact]
@@ -274,11 +386,15 @@ namespace System.ComponentModel.Tests
             container.Add(component3);
 
             var converter = new SubReferenceConverter(typeof(TestComponent));
-            var context = new TestTypeDescriptorContext { Container = container };
+            var context = new MockTypeDescriptorContext { Container = container };
 
-            TypeConverter.StandardValuesCollection values = converter.GetStandardValues(context);
-            Assert.Equal(new object[] { null }, values.Cast<object>());
-            Assert.Equal(new object[] { component2, component3 }, converter.Values);
+            TypeConverter.StandardValuesCollection values1 = converter.GetStandardValues(context);
+            Assert.Equal(new object[] { null }, values1.Cast<object>());
+            Assert.Equal(new object[] { component2, component3 }, converter.DisallowedValues);
+
+            // Call again to test caching behavior.
+            TypeConverter.StandardValuesCollection values2 = converter.GetStandardValues(context);
+            Assert.NotSame(values1, values2);
         }
 
         [Fact]
@@ -292,23 +408,117 @@ namespace System.ComponentModel.Tests
         public void GetStandardValues_NoReferenceCollectionOrIContainer_ReturnsEmpty()
         {
             var converter = new ReferenceConverter(typeof(TestComponent));
-            var context = new TestTypeDescriptorContext();
+            var context = new MockTypeDescriptorContext();
 
-            TypeConverter.StandardValuesCollection values = converter.GetStandardValues(context);
-            Assert.Equal(new object[] { null }, values.Cast<object>());
+            TypeConverter.StandardValuesCollection values1 = converter.GetStandardValues(context);
+            Assert.Equal(new object[] { null }, values1.Cast<object>());
+
+            // Call again to test caching behavior.
+            TypeConverter.StandardValuesCollection values2 = converter.GetStandardValues(context);
+            Assert.NotSame(values1, values2);
         }
 
         private class SubReferenceConverter : ReferenceConverter
         {
             public SubReferenceConverter(Type type) : base(type) { }
 
-            public List<object> Values { get; } = new List<object>();
+            public List<object> DisallowedValues { get; } = new List<object>();
 
             protected override bool IsValueAllowed(ITypeDescriptorContext context, object value)
             {
-                Values.Add(value);
+                DisallowedValues.Add(value);
                 return false;
             }
+        }
+
+        public class MockTypeDescriptorContext : ITypeDescriptorContext
+        {
+            public Func<Type, object> GetServiceAction { get; set; }
+
+            public IContainer Container { get; set; }
+            public object Instance => null;
+            public PropertyDescriptor PropertyDescriptor => null;
+
+            public void OnComponentChanged()
+            {
+            }
+
+            public bool OnComponentChanging() => true;
+
+            public object GetService(Type serviceType) => GetServiceAction?.Invoke(serviceType);
+        }
+
+        public class MockReferenceService : IReferenceService
+        {
+            public Dictionary<string, object> References { get; set; } = new Dictionary<string, object>();
+
+            public void AddReference(string name, object reference)
+            {
+                References[name ?? "(null)"] = reference;
+            }
+
+            public void ClearReferences() => References.Clear();
+
+            public IComponent GetComponent(object reference) => null;
+
+            public string GetName(object reference)
+            {
+                foreach (KeyValuePair<string, object> entry in References)
+                {
+                    if (entry.Value == reference)
+                    {
+                        return entry.Key == "(null)" ? null : entry.Key;
+                    }
+                }
+
+                return null;
+            }
+
+            public object GetReference(string name)
+            {
+                if (!References.ContainsKey(name ?? "(null)"))
+                {
+                    return null;
+                }
+
+                return References[name];
+            }
+
+            public object[] GetReferences()
+            {
+                object[] array = new object[References.Values.Count];
+                References.Values.CopyTo(array, 0);
+                return array;
+            }
+
+            public object[] GetReferences(Type baseType)
+            {
+                if (References == null)
+                {
+                    return null;
+                }
+
+                object[] references = GetReferences();
+
+                var filtered = new List<object>();
+                foreach (object reference in references)
+                {
+                    if (baseType != null && baseType.IsInstanceOfType(reference))
+                    {
+                        filtered.Add(reference);
+                    }
+                }
+
+                return filtered.ToArray();
+            }
+        }
+
+        private interface ITestInterface
+        {
+        }
+
+        private class TestComponent : Component
+        {
         }
     }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/StringConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/StringConverterTests.cs
@@ -2,33 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.ComponentModel.Tests
 {
-    public class StringConverterTests : ConverterTestBase
+    public class StringConverterTests : TypeConverterTestBase
     {
-        private static StringConverter s_converter = new StringConverter();
+        public override TypeConverter Converter => new StringConverter();
 
-        [Fact]
-        public static void CanConvertFrom_WithContext()
-        {
-            CanConvertFrom_WithContext(new object[1, 2]
-                {
-                    { typeof(string), true }
-                },
-                StringConverterTests.s_converter);
-        }
+        public override bool CanConvertFromNull => true;
 
-        [Fact]
-        public static void ConvertFrom_WithContext()
+        public override IEnumerable<ConvertTest> ConvertFromTestData()
         {
-            ConvertFrom_WithContext(new object[2, 3]
-                {
-                    { "some string", "some string", null },
-                    { null, string.Empty, null }
-                },
-                StringConverterTests.s_converter);
+            yield return ConvertTest.Valid("string", "string");
+            yield return ConvertTest.Valid(string.Empty, string.Empty);
+            yield return ConvertTest.Valid(null, string.Empty);
+
+            yield return ConvertTest.CantConvertFrom(1);
+            yield return ConvertTest.CantConvertFrom(new object());
         }
     }
 }


### PR DESCRIPTION
- Enhance the test base to cover more behaviour that should be uniform across all converters
- Use in GuidConverter and DateTimeConverter
- Remove checks for if the `ctor` is null in DateTimeConverter when converting to an InstanceDescriptor as they should always exist