### PR TITLE
Line ending fixes for json tests

### DIFF
--- a/src/System.Text.Json/tests/JsonElementWriteTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWriteTests.cs
@@ -316,7 +316,7 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        //[InlineData(false)]
+        [InlineData(false)]
         [InlineData(true)]
         public static void WriteSimpleObject(bool indented)
         {
@@ -1177,8 +1177,7 @@ null,
                 target.WriteTo(writer);
                 writer.Flush();
 
-                AssertContents(indented ? expectedIndent : expectedMinimal, buffer);
-
+                JsonTestHelper.AssertContents(indented ? expectedIndent : expectedMinimal, buffer);
             }
         }
 
@@ -1243,13 +1242,6 @@ null,
                 target.WriteTo(writer);
                 writer.WriteEndObject();
                 writer.Flush();
-
-                if (indented && s_replaceNewlines)
-                {
-                    JsonTestHelper.AssertContents(
-                        expectedIndent.Replace(CompiledNewline, Environment.NewLine),
-                        buffer);
-                }
 
                 JsonTestHelper.AssertContents(indented ? expectedIndent : expectedMinimal, buffer);
             }
@@ -1333,7 +1325,8 @@ null,
                 using var writer = new Utf8JsonWriter(buffer, options);
 
                 writer.WriteStartObject();
-                target.WriteProperty(propertyName, writer);
+                writer.WritePropertyName(propertyName);
+                target.WriteTo(writer);
                 writer.WriteEndObject();
                 writer.Flush();
 

--- a/src/System.Text.Json/tests/JsonElementWriteTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWriteTests.cs
@@ -12,17 +12,11 @@ namespace System.Text.Json.Tests
 {
     public static class JsonElementWriteTests
     {
-        private const string CompiledNewline = @"
-";
-
         private static readonly JsonDocumentOptions s_options =
             new JsonDocumentOptions
             {
                 CommentHandling = JsonCommentHandling.Skip,
             };
-
-        private static readonly bool s_replaceNewlines =
-            !StringComparer.Ordinal.Equals(CompiledNewline, Environment.NewLine);
 
         [Fact]
         public static void CheckByPassingNullWriter()
@@ -310,19 +304,19 @@ namespace System.Text.Json.Tests
 6                       , 0
 
 
-, 1       ]",
+, 1       ]".NormalizeLineEndings(),
                 @"[
   2,
   4,
   6,
   0,
   1
-]",
+]".NormalizeLineEndings(),
                 "[2,4,6,0,1]");
         }
 
         [Theory]
-        [InlineData(false)]
+        //[InlineData(false)]
         [InlineData(true)]
         public static void WriteSimpleObject(bool indented)
         {
@@ -332,11 +326,11 @@ namespace System.Text.Json.Tests
 // Comments make everything more interesting.
             ""d"":
 2
-}",
+}".NormalizeLineEndings(),
                 @"{
   ""r"": 2,
   ""d"": 2
-}",
+}".NormalizeLineEndings(),
                 "{\"r\":2,\"d\":2}");
         }
 
@@ -347,7 +341,7 @@ namespace System.Text.Json.Tests
         {
             WriteComplexValue(
                 indented,
-                @"
+                (@"
 
 [
         ""Once upon a midnight dreary"",
@@ -374,7 +368,7 @@ null,
 
 ], ""more deep"": false },
 12 ], ""second property"": null }]
-",
+").NormalizeLineEndings(),
                 @"[
   ""Once upon a midnight dreary"",
   42,
@@ -413,7 +407,7 @@ null,
     ],
     ""second property"": null
   }
-]",
+]".NormalizeLineEndings(),
                 "[\"Once upon a midnight dreary\",42,1e400,3.141592653589793238462643383279," +
                     "false,true,null,\"Escaping is not required\"," +
                     "\"Some things get lost in the m\\u00eal\\u00e9e\",[2,3,5,7,11]," +
@@ -469,7 +463,7 @@ null,
       11
     ]
   }
-}",
+}".NormalizeLineEndings(),
                 "{\"int\":42,\"quadratic googol\":1e400,\"precisePi\":3.141592653589793238462643383279," +
                     "\"lit0\":null,\"lit1\":false,\"lit2\":true,\"ascii\":\"pizza\",\"escaped\":\"pizza\"," +
                     "\"utf8\":\"p\\u00cdzza\",\"utf8ExtraEscape\":\"p\\u00cdzza\"," +
@@ -488,7 +482,7 @@ null,
                 "42",
                 @"{
   ""ectoplasm"": 42
-}",
+}".NormalizeLineEndings(),
                 "{\"ectoplasm\":42}");
         }
 
@@ -506,9 +500,9 @@ null,
                 indented,
                 propertyName,
                 "42",
-                @"{
+                (@"{
   ""\u00EA" + propertyName.Substring(1) + @""": 42
-}",
+}").NormalizeLineEndings(),
                 $"{{\"\\u00EA{propertyName.Substring(1)}\":42}}");
         }
 
@@ -523,7 +517,7 @@ null,
                 "1e6",
                 @"{
   ""m\u00eal\u00e9e"": 1e6
-}",
+}".NormalizeLineEndings(),
                 "{\"m\\u00eal\\u00e9e\":1e6}");
         }
 
@@ -573,7 +567,7 @@ null,
                 "3.141592653589793238462643383279",
                 @"{
   ""test property"": 3.141592653589793238462643383279
-}",
+}".NormalizeLineEndings(),
                 "{\"test property\":3.141592653589793238462643383279}");
         }
 
@@ -589,7 +583,7 @@ null,
                 "1e400",
                 @"{
   ""\u0643\u0628\u064A\u0631"": 1e400
-}",
+}".NormalizeLineEndings(),
                 "{\"\\u0643\\u0628\\u064A\\u0631\":1e400}");
         }
 
@@ -604,7 +598,7 @@ null,
                 "\"pizza\"",
                 @"{
   ""dinner"": ""pizza""
-}",
+}".NormalizeLineEndings(),
                 "{\"dinner\":\"pizza\"}");
         }
 
@@ -619,7 +613,7 @@ null,
                 "\"p\\u0069zza\"",
                 @"{
   ""dinner"": ""pizza""
-}",
+}".NormalizeLineEndings(),
                 "{\"dinner\":\"pizza\"}");
         }
 
@@ -634,7 +628,7 @@ null,
                 "\"p\u00CDzza\"",
                 @"{
   ""lunch"": ""p\u00cdzza""
-}",
+}".NormalizeLineEndings(),
                 "{\"lunch\":\"p\\u00cdzza\"}");
         }
 
@@ -649,7 +643,7 @@ null,
                 "\"p\u00CDz\\u007Aa\"",
                 @"{
   ""lunch"": ""p\u00cdzza""
-}",
+}".NormalizeLineEndings(),
                 "{\"lunch\":\"p\\u00cdzza\"}");
         }
 
@@ -664,7 +658,7 @@ null,
                 "true",
                 @"{
   "" boolean "": true
-}",
+}".NormalizeLineEndings(),
                 "{\" boolean \":true}");
         }
 
@@ -679,7 +673,7 @@ null,
                 "false",
                 @"{
   "" boolean "": false
-}",
+}".NormalizeLineEndings(),
                 "{\" boolean \":false}");
         }
 
@@ -694,7 +688,7 @@ null,
                 "null",
                 @"{
   ""someProp"": null
-}",
+}".NormalizeLineEndings(),
                 "{\"someProp\":null}");
         }
 
@@ -709,7 +703,7 @@ null,
                 "[        ]",
                 @"{
   ""arr"": []
-}",
+}".NormalizeLineEndings(),
                 "{\"arr\":[]}");
         }
 
@@ -724,7 +718,7 @@ null,
                 "{       }",
                 @"{
   ""obj"": {}
-}",
+}".NormalizeLineEndings(),
                 "{\"obj\":{}}");
         }
 
@@ -739,7 +733,7 @@ null,
                 "[   /* 5 */     ]",
                 @"{
   ""arr"": []
-}",
+}".NormalizeLineEndings(),
                 "{\"arr\":[]}");
         }
 
@@ -754,7 +748,7 @@ null,
                 "{ /* Technically empty */ }",
                 @"{
   ""obj"": {}
-}",
+}".NormalizeLineEndings(),
                 "{\"obj\":{}}");
         }
 
@@ -775,7 +769,7 @@ null,
     0,
     1
   ]
-}",
+}".NormalizeLineEndings(),
                 "{\"valjean\":[2,4,6,0,1]}");
         }
 
@@ -791,13 +785,13 @@ null,
 // Comments make everything more interesting.
             ""d"":
 2
-}",
+}".NormalizeLineEndings(),
                 @"{
   ""bestMinorCharacter"": {
     ""r"": 2,
     ""d"": 2
   }
-}",
+}".NormalizeLineEndings(),
                 "{\"bestMinorCharacter\":{\"r\":2,\"d\":2}}");
         }
 
@@ -877,7 +871,7 @@ null,
       ""second property"": null
     }
   ]
-}",
+}".NormalizeLineEndings(),
 
                 "{\"data\":[\"Once upon a midnight dreary\",42,1e400,3.141592653589793238462643383279," +
                     "false,true,null,\"Escaping is not required\"," +
@@ -937,7 +931,7 @@ null,
       ]
     }
   }
-}",
+}".NormalizeLineEndings(),
                 "{\"data\":" +
                     "{\"int\":42,\"quadratic googol\":1e400,\"precisePi\":3.141592653589793238462643383279," +
                     "\"lit0\":null,\"lit1\":false,\"lit2\":true,\"ascii\":\"pizza\",\"escaped\":\"pizza\"," +
@@ -1175,7 +1169,7 @@ null,
 
                 var options = new JsonWriterOptions
                 {
-                    Indented = indented,
+                    Indented = indented
                 };
 
                 using var writer = new Utf8JsonWriter(buffer, options);
@@ -1183,14 +1177,8 @@ null,
                 target.WriteTo(writer);
                 writer.Flush();
 
-                if (indented && s_replaceNewlines)
-                {
-                    JsonTestHelper.AssertContents(
-                        expectedIndent.Replace(CompiledNewline, Environment.NewLine),
-                        buffer);
-                }
+                AssertContents(indented ? expectedIndent : expectedMinimal, buffer);
 
-                JsonTestHelper.AssertContents(indented ? expectedIndent : expectedMinimal, buffer);
             }
         }
 
@@ -1292,13 +1280,6 @@ null,
                 writer.WriteEndObject();
                 writer.Flush();
 
-                if (indented && s_replaceNewlines)
-                {
-                    JsonTestHelper.AssertContents(
-                        expectedIndent.Replace(CompiledNewline, Environment.NewLine),
-                        buffer);
-                }
-
                 JsonTestHelper.AssertContents(indented ? expectedIndent : expectedMinimal, buffer);
             }
         }
@@ -1328,13 +1309,6 @@ null,
                 writer.WriteEndObject();
                 writer.Flush();
 
-                if (indented && s_replaceNewlines)
-                {
-                    JsonTestHelper.AssertContents(
-                        expectedIndent.Replace(CompiledNewline, Environment.NewLine),
-                        buffer);
-                }
-
                 JsonTestHelper.AssertContents(indented ? expectedIndent : expectedMinimal, buffer);
             }
         }
@@ -1359,21 +1333,12 @@ null,
                 using var writer = new Utf8JsonWriter(buffer, options);
 
                 writer.WriteStartObject();
-                writer.WritePropertyName(propertyName);
-                target.WriteTo(writer);
+                target.WriteProperty(propertyName, writer);
                 writer.WriteEndObject();
                 writer.Flush();
-
-                if (indented && s_replaceNewlines)
-                {
-                    JsonTestHelper.AssertContents(
-                        expectedIndent.Replace(CompiledNewline, Environment.NewLine),
-                        buffer);
-                }
 
                 JsonTestHelper.AssertContents(indented ? expectedIndent : expectedMinimal, buffer);
             }
         }
-
     }
 }

--- a/src/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/System.Text.Json/tests/JsonTestHelper.cs
@@ -25,6 +25,12 @@ namespace System.Text.Json
         public const string SingleFormatString = "G9";
 #endif
 
+        private const string CompiledNewline = @"
+";
+
+        private static readonly bool s_replaceNewlines =
+            !StringComparer.Ordinal.Equals(CompiledNewline, Environment.NewLine);
+
         public static string NewtonsoftReturnStringHelper(TextReader reader)
         {
             var sb = new StringBuilder();
@@ -771,5 +777,12 @@ namespace System.Text.Json
 
         public static string StripWhitespace(this string value)
             => s_stripWhitespace.Replace(value, string.Empty);
+
+        // Should be called only on compile-time strings
+        // This is needed due to the fact that git might normalize line endings when checking-out files
+        public static string NormalizeLineEndings(this string value)
+            => s_replaceNewlines ?
+            value.Replace(CompiledNewline, Environment.NewLine) :
+            value;
     }
 }

--- a/src/System.Text.Json/tests/NewtonsoftTests/CamelCaseTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/CamelCaseTests.cs
@@ -72,7 +72,7 @@ namespace System.Text.Json.Tests
   ""name"": ""Name!"",
   ""birthDate"": ""2000-11-20T23:55:44Z"",
   ""lastModified"": ""2000-11-20T23:55:44Z""
-}", json);
+}".NormalizeLineEndings(), json);
 
             Person deserializedPerson = JsonSerializer.Deserialize<Person>(json, s_camelCaseAndIndentedOption);
 
@@ -85,7 +85,7 @@ namespace System.Text.Json.Tests
   ""Name"": ""Name!"",
   ""BirthDate"": ""2000-11-20T23:55:44Z"",
   ""LastModified"": ""2000-11-20T23:55:44Z""
-}", json);
+}".NormalizeLineEndings(), json);
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace System.Text.Json.Tests
     ""Medium"",
     ""Large""
   ]
-}", json);
+}".NormalizeLineEndings(), json);
         }
     }
 }

--- a/src/System.Text.Json/tests/NewtonsoftTests/CustomObjectConverterTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/CustomObjectConverterTests.cs
@@ -61,7 +61,7 @@ namespace System.Text.Json.Tests
     ""Last"": 2147483647
   },
   ""NullDecimalRange"": null
-}", json);
+}".NormalizeLineEndings(), json);
         }
 
         [Fact]
@@ -122,7 +122,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(@"{
   ""ByteArray"": ""VGhpcyBpcyBzb21lIHRlc3QgZGF0YSEhIQ=="",
   ""NullByteArray"": null
-}", json);
+}".NormalizeLineEndings(), json);
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/NewtonsoftTests/EnumConverterTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/EnumConverterTests.cs
@@ -50,7 +50,7 @@ namespace System.Text.Json.Tests
   ""StoreColor"": 2,
   ""NullableStoreColor1"": 8,
   ""NullableStoreColor2"": null
-}", json);
+}".NormalizeLineEndings(), json);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace System.Text.Json.Tests
   ""StoreColor"": 1000,
   ""NullableStoreColor1"": 1000,
   ""NullableStoreColor2"": null
-}", json);
+}".NormalizeLineEndings(), json);
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace System.Text.Json.Tests
   ""StoreColor"": 10,
   ""NullableStoreColor1"": 0,
   ""NullableStoreColor2"": 11
-}", json);
+}".NormalizeLineEndings(), json);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(@"{
   ""Value1"": -2,
   ""Value2"": 6
-}", json);
+}".NormalizeLineEndings(), json);
         }
 
         [Fact]
@@ -120,7 +120,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(@"{
   ""Value1"": -1,
   ""Value2"": -2147483648
-}", json);
+}".NormalizeLineEndings(), json);
         }
 
         [Fact]
@@ -146,7 +146,7 @@ namespace System.Text.Json.Tests
   4,
   5,
   2147483647
-]", json1);
+]".NormalizeLineEndings(), json1);
 
             IList<Foo> foos = JsonSerializer.Deserialize<List<Foo>>(json1);
 
@@ -166,7 +166,7 @@ namespace System.Text.Json.Tests
   0,
   1,
   2
-]", json2);
+]".NormalizeLineEndings(), json2);
 
             IList<Bar> bars = JsonSerializer.Deserialize<List<Bar>>(json2);
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/38948

This makes it a bit less annoying to work with Json tests on Windows with line endings conversion enabled.

Currently getting around 35 failures after checking out