### PR TITLE
Fix array size used by LookupOverflow json test

### DIFF
--- a/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
+++ b/src/System.Text.Json/tests/Utf8JsonReaderTests.ValueTextEquals.cs
@@ -628,12 +628,11 @@ namespace System.Text.Json.Tests
             Assert.False(json.ValueTextEquals(lookup));
         }
 
-        [ActiveIssue(38221)]
         [ConditionalFact(nameof(IsX64))]
         [OuterLoop]
         public static void LookupOverflow()
         {
-            char[] jsonString = new char[400_000_002];
+            char[] jsonString = new char[800_000_002];
 
             jsonString.AsSpan().Fill('a');
             jsonString[0] = '"';


### PR DESCRIPTION
#37911 fixed a 2x overstimation of the possible byte size of a converted UTF-16 string. The outerloop test that was validating the code wasn't updated to match.

fixes #38221