### PR TITLE
Stop disposing of the proxy in HttpConnectionPoolManager.Dispose

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinInetProxyHelper.cs
@@ -13,10 +13,10 @@ namespace System.Net.Http
     // is not supported (i.e. before Win8.1/Win2K12R2) in the WinHttpOpen() function.
     internal class WinInetProxyHelper
     {
-        private bool _useProxy = false;
+        private const int RecentAutoDetectionInterval = 120_000; // 2 minutes in milliseconds.
+        private readonly bool _useProxy = false;
         private bool _autoDetectionFailed;
         private int _lastTimeAutoDetectionFailed; // Environment.TickCount units (milliseconds).
-        private const int _recentAutoDetectionInterval = 120_000; // 2 minutes in milliseconds.
 
         public WinInetProxyHelper()
         {
@@ -57,9 +57,9 @@ namespace System.Net.Http
             }
         }
 
-        public string AutoConfigUrl { get; private set; }
+        public string AutoConfigUrl { get; }
 
-        public bool AutoDetect { get; private set; }
+        public bool AutoDetect { get; }
 
         public bool AutoSettingsUsed => AutoDetect || !string.IsNullOrEmpty(AutoConfigUrl);
 
@@ -67,13 +67,13 @@ namespace System.Net.Http
 
         public bool ManualSettingsOnly => !AutoSettingsUsed && ManualSettingsUsed;
 
-        public string Proxy { get; private set; }
+        public string Proxy { get; }
 
-        public string ProxyBypass { get; private set; }
+        public string ProxyBypass { get; }
 
         public bool RecentAutoDetectionFailure =>
             _autoDetectionFailed &&
-            Environment.TickCount - _lastTimeAutoDetectionFailed <= _recentAutoDetectionInterval;
+            Environment.TickCount - _lastTimeAutoDetectionFailed <= RecentAutoDetectionInterval;
 
         public bool GetProxyForUrl(
             SafeWinHttpHandle sessionHandle,

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -308,11 +308,6 @@ namespace System.Net.Http
             {
                 pool.Value.Dispose();
             }
-
-            if (_proxy is IDisposable obj)
-            {
-                obj.Dispose();
-            }
         }
 
         /// <summary>Sets <see cref="_cleaningTimer"/> and <see cref="_timerIsRunning"/> based on the specified timeout.</summary>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Proxy.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Proxy.cs
@@ -22,6 +22,31 @@ namespace System.Net.Http.Functional.Tests
     {
         public HttpClientHandler_Proxy_Test(ITestOutputHelper output) : base(output) { }
 
+        [Fact]
+        public async Task Dispose_HandlerWithProxy_ProxyNotDisposed()
+        {
+            var proxy = new TrackDisposalProxy();
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
+            {
+                using (HttpClientHandler handler = CreateHttpClientHandler())
+                {
+                    handler.UseProxy = true;
+                    handler.Proxy = proxy;
+                    using (HttpClient client = CreateHttpClient(handler))
+                    {
+                        Assert.Equal("hello", await client.GetStringAsync(uri));
+                    }
+                }
+            }, async server =>
+            {
+                await server.HandleRequestAsync(content: "hello");
+            });
+
+            Assert.True(proxy.ProxyUsed);
+            Assert.False(proxy.Disposed);
+        }
+
         [ActiveIssue(32809)]
         [OuterLoop("Uses external server")]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
@@ -317,6 +342,25 @@ namespace System.Net.Http.Functional.Tests
                 yield return new object[] { new NetworkCredential("username", "password"), wrapCredsInCache };
                 yield return new object[] { new NetworkCredential("username", "password", "domain"), wrapCredsInCache };
             }
+        }
+
+        private sealed class TrackDisposalProxy : IWebProxy, IDisposable
+        {
+            public bool Disposed;
+            public bool ProxyUsed;
+
+            public void Dispose() => Disposed = true;
+            public Uri GetProxy(Uri destination)
+            {
+                ProxyUsed = true;
+                return null;
+            }
+            public bool IsBypassed(Uri host)
+            {
+                ProxyUsed = true;
+                return true;
+            }
+            public ICredentials Credentials { get => null; set { } }
         }
     }
 }


### PR DESCRIPTION
SocketsHttpHandler doesn't own the proxy its given; the lifetime of that proxy is up to the developer supplying it.  We may also end up using a global proxy instance if the developer hasn't explicitly supplied one.  However, SocketsHttpHandler's internal HttpConnectionPoolManager was disposing of this proxy instance on its disposal.  For proxies that implement IDisposable, as our global default proxy does, that can be very problematic; on Windows, our default proxy has a SafeHandle, and once its disposed, every subsequent request to the proxy will fail (an exception gets thrown and then internally eaten). The fix is simply to stop disposing a proxy instance we don't own.

While investigating this, I also made a few style tweaks to WinInetProxyHelper, removing private property setters, so as to better be able to see that certain values were readonly and never changed after construction.

Fixes https://github.com/dotnet/corefx/issues/38989
cc: @davidsh, @geoffkizer 