### PR TITLE
Fix HTTP2 duplex communication with Expect: 100-continue

### DIFF
--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -522,4 +522,7 @@
   <data name="net_http_hpack_bad_integer" xml:space="preserve">
     <value>HPACK integer exceeds limits or has an overlong encoding.</value>
   </data>
+  <data name="net_http_disposed_while_in_use" xml:space="preserve">
+    <value>The object was disposed while operations were in progress.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -157,6 +157,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpContentReadStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpContentStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpContentWriteStream.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\IHttpTrace.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SocketsHttpHandler.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\RawConnectionStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\RedirectHandler.cs" />

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CreditManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CreditManager.cs
@@ -11,21 +11,21 @@ namespace System.Net.Http
 {
     internal sealed class CreditManager : IDisposable
     {
-        private struct Waiter
-        {
-            public int Amount;
-            public TaskCompletionSourceWithCancellation<int> TaskCompletionSource;
-        }
-
+        private readonly IHttpTrace _owner;
+        private readonly string _name;
         private int _current;
         private Queue<Waiter> _waiters;
         private bool _disposed;
 
-        public CreditManager(int initialCredit)
+        public CreditManager(IHttpTrace owner, string name, int initialCredit)
         {
+            Debug.Assert(owner != null);
+            Debug.Assert(!string.IsNullOrWhiteSpace(name));
+
+            if (NetEventSource.IsEnabled) owner.Trace($"{name}. {nameof(initialCredit)}={initialCredit}");
+            _owner = owner;
+            _name = name;
             _current = initialCredit;
-            _waiters = null;
-            _disposed = false;
         }
 
         private object SyncObject
@@ -44,7 +44,7 @@ namespace System.Net.Http
             {
                 if (_disposed)
                 {
-                    throw new ObjectDisposedException(nameof(CreditManager));
+                    throw CreateObjectDisposedException(forActiveWaiter: false);
                 }
 
                 if (_current > 0)
@@ -52,25 +52,19 @@ namespace System.Net.Http
                     Debug.Assert(_waiters == null || _waiters.Count == 0, "Shouldn't have waiters when credit is available");
 
                     int granted = Math.Min(amount, _current);
+                    if (NetEventSource.IsEnabled) _owner.Trace($"{_name}. requested={amount}, current={_current}, granted={granted}");
                     _current -= granted;
                     return new ValueTask<int>(granted);
                 }
 
-                // Uses RunContinuationsAsynchronously internally.
-                var tcs = new TaskCompletionSourceWithCancellation<int>();
+                if (NetEventSource.IsEnabled) _owner.Trace($"{_name}. requested={amount}, no credit available.");
 
-                if (_waiters == null)
-                {
-                    _waiters = new Queue<Waiter>();
-                }
-
-                Waiter waiter = new Waiter { Amount = amount, TaskCompletionSource = tcs };
-
-                _waiters.Enqueue(waiter);
+                var waiter = new Waiter { Amount = amount };
+                (_waiters ??= new Queue<Waiter>()).Enqueue(waiter);
 
                 return new ValueTask<int>(cancellationToken.CanBeCanceled ?
-                                          tcs.WaitWithCancellationAsync(cancellationToken) :
-                                          tcs.Task);
+                                          waiter.WaitWithCancellationAsync(cancellationToken) :
+                                          waiter.Task);
             }
         }
 
@@ -81,6 +75,8 @@ namespace System.Net.Http
 
             lock (SyncObject)
             {
+                if (NetEventSource.IsEnabled) _owner.Trace($"{_name}. {nameof(amount)}={amount}, current={_current}");
+
                 if (_disposed)
                 {
                     return;
@@ -100,7 +96,7 @@ namespace System.Net.Http
                         int granted = Math.Min(waiter.Amount, _current);
 
                         // Ensure that we grant credit only if the task has not been canceled.
-                        if (waiter.TaskCompletionSource.TrySetResult(granted))
+                        if (waiter.TrySetResult(granted))
                         {
                             _current -= granted;
                         }
@@ -124,10 +120,19 @@ namespace System.Net.Http
                 {
                     while (_waiters.TryDequeue(out Waiter waiter))
                     {
-                        waiter.TaskCompletionSource.TrySetException(new ObjectDisposedException(nameof(CreditManager)));
+                        waiter.TrySetException(CreateObjectDisposedException(forActiveWaiter: true));
                     }
                 }
             }
+        }
+
+        private ObjectDisposedException CreateObjectDisposedException(bool forActiveWaiter) => forActiveWaiter ?
+            new ObjectDisposedException($"{nameof(CreditManager)}:{_owner.GetType().Name}:{_name}", SR.net_http_disposed_while_in_use) :
+            new ObjectDisposedException($"{nameof(CreditManager)}:{_owner.GetType().Name}:{_name}");
+
+        private sealed class Waiter : TaskCompletionSourceWithCancellation<int>
+        {
+            public int Amount;
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -94,13 +94,15 @@ namespace System.Net.Http
 
             _writerLock = new SemaphoreSlim(1, 1);
             _headerSerializationLock = new SemaphoreSlim(1, 1);
-            _connectionWindow = new CreditManager(DefaultInitialWindowSize);
-            _concurrentStreams = new CreditManager(int.MaxValue);
+            _connectionWindow = new CreditManager(this, nameof(_connectionWindow), DefaultInitialWindowSize);
+            _concurrentStreams = new CreditManager(this, nameof(_concurrentStreams), int.MaxValue);
 
             _nextStream = 1;
             _initialWindowSize = DefaultInitialWindowSize;
             _maxConcurrentStreams = int.MaxValue;
             _pendingWindowUpdate = 0;
+
+            if (NetEventSource.IsEnabled) TraceConnection(stream);
         }
 
         private object SyncObject => _httpStreams;
@@ -145,6 +147,7 @@ namespace System.Net.Http
 
         private async Task EnsureIncomingBytesAsync(int minReadBytes)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(minReadBytes)}={minReadBytes}");
             if (_incomingBuffer.ActiveSpan.Length >= minReadBytes)
             {
                 return;
@@ -158,6 +161,7 @@ namespace System.Net.Http
 
         private async Task FlushOutgoingBytesAsync()
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(_outgoingBuffer.ActiveSpan.Length)}={_outgoingBuffer.ActiveSpan.Length}");
             Debug.Assert(_outgoingBuffer.ActiveSpan.Length > 0);
 
             try
@@ -177,6 +181,8 @@ namespace System.Net.Http
 
         private async ValueTask<FrameHeader> ReadFrameAsync(bool initialFrame = false)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(initialFrame)}={initialFrame}");
+
             // Read frame header
             await EnsureIncomingBytesAsync(FrameHeader.Size).ConfigureAwait(false);
             FrameHeader frameHeader = FrameHeader.ReadFrom(_incomingBuffer.ActiveSpan);
@@ -209,14 +215,16 @@ namespace System.Net.Http
                 {
                     throw new Http2ProtocolException(Http2ProtocolErrorCode.ProtocolError);
                 }
+                if (NetEventSource.IsEnabled) Trace($"Frame 0: {frameHeader}.");
 
                 // Process the initial SETTINGS frame. This will send an ACK.
                 ProcessSettingsFrame(frameHeader);
 
                 // Keep processing frames as they arrive.
-                while (true)
+                for (long frameNum = 1; ; frameNum++)
                 {
                     frameHeader = await ReadFrameAsync().ConfigureAwait(false);
+                    if (NetEventSource.IsEnabled) Trace($"Frame {frameNum}: {frameHeader}.");
 
                     switch (frameHeader.Type)
                     {
@@ -300,6 +308,7 @@ namespace System.Net.Http
 
         private async Task ProcessHeadersFrame(FrameHeader frameHeader)
         {
+            if (NetEventSource.IsEnabled) Trace($"{frameHeader}");
             Debug.Assert(frameHeader.Type == FrameType.Headers);
 
             bool endStream = frameHeader.EndStreamFlag;
@@ -499,6 +508,8 @@ namespace System.Net.Http
 
         private void ChangeMaxConcurrentStreams(uint newValue)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(newValue)}={newValue}");
+
             // The value is provided as a uint.
             // Limit this to int.MaxValue since the CreditManager implementation only supports singed values.
             // In practice, we should never reach this value.
@@ -511,6 +522,7 @@ namespace System.Net.Http
 
         private void ChangeInitialWindowSize(int newSize)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(newSize)}={newSize}");
             Debug.Assert(newSize >= 0);
 
             lock (SyncObject)
@@ -577,6 +589,7 @@ namespace System.Net.Http
             }
 
             int amount = BinaryPrimitives.ReadInt32BigEndian(_incomingBuffer.ActiveSpan) & 0x7FFFFFFF;
+            if (NetEventSource.IsEnabled) Trace($"{frameHeader}. {nameof(amount)}={amount}");
 
             Debug.Assert(amount >= 0);
             if (amount == 0)
@@ -652,6 +665,7 @@ namespace System.Net.Http
 
             int lastValidStream = (int)(BinaryPrimitives.ReadUInt32BigEndian(_incomingBuffer.ActiveSpan) & 0x7FFFFFFF);
             var errorCode = (Http2ProtocolErrorCode)BinaryPrimitives.ReadInt32BigEndian(_incomingBuffer.ActiveSpan.Slice(sizeof(int)));
+            if (NetEventSource.IsEnabled) Trace(frameHeader.StreamId, $"{nameof(lastValidStream)}={lastValidStream}, {nameof(errorCode)}={errorCode}");
 
             AbortStreams(lastValidStream, new Http2ProtocolException(errorCode));
 
@@ -660,6 +674,7 @@ namespace System.Net.Http
 
         private async ValueTask<Memory<byte>> StartWriteAsync(int writeBytes, CancellationToken cancellationToken = default)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(writeBytes)}={writeBytes}");
             await AcquireWriteLockAsync(cancellationToken).ConfigureAwait(false);
 
             try
@@ -701,6 +716,8 @@ namespace System.Net.Http
         // they want to release it.
         private void FinishWrite(bool mustFlush)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(mustFlush)}={mustFlush}");
+
             // We can't validate that we hold the semaphore, but we can at least validate that someone is
             // holding it.
             Debug.Assert(_writerLock.CurrentCount == 0);
@@ -746,6 +763,7 @@ namespace System.Net.Http
 
         private async Task SendSettingsAckAsync()
         {
+            if (NetEventSource.IsEnabled) Trace("");
             Memory<byte> writeBuffer = await StartWriteAsync(FrameHeader.Size).ConfigureAwait(false);
 
             FrameHeader frameHeader = new FrameHeader(0, FrameType.Settings, FrameFlags.Ack, 0);
@@ -756,6 +774,7 @@ namespace System.Net.Http
 
         private async Task SendPingAckAsync(ReadOnlyMemory<byte> pingContent)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(pingContent.Length)}={pingContent.Length}");
             Debug.Assert(pingContent.Length == FrameHeader.PingLength);
 
             Memory<byte> writeBuffer = await StartWriteAsync(FrameHeader.Size + FrameHeader.PingLength).ConfigureAwait(false);
@@ -771,6 +790,7 @@ namespace System.Net.Http
 
         private async Task SendRstStreamAsync(int streamId, Http2ProtocolErrorCode errorCode)
         {
+            if (NetEventSource.IsEnabled) Trace(streamId, $"{nameof(errorCode)}={errorCode}");
             Memory<byte> writeBuffer = await StartWriteAsync(FrameHeader.Size + FrameHeader.RstStreamLength).ConfigureAwait(false);
 
             FrameHeader frameHeader = new FrameHeader(FrameHeader.RstStreamLength, FrameType.RstStream, FrameFlags.None, streamId);
@@ -789,6 +809,8 @@ namespace System.Net.Http
 
         private void WriteIndexedHeader(int index)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(index)}={index}");
+
             int bytesWritten;
             while (!HPackEncoder.EncodeIndexedHeaderField(index, _headerBuffer.AvailableSpan, out bytesWritten))
             {
@@ -800,6 +822,8 @@ namespace System.Net.Http
 
         private void WriteIndexedHeader(int index, string value)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(index)}={index}, {nameof(value)}={value}");
+
             int bytesWritten;
             while (!HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexing(index, value, _headerBuffer.AvailableSpan, out bytesWritten))
             {
@@ -811,6 +835,8 @@ namespace System.Net.Http
 
         private void WriteLiteralHeader(string name, string[] values)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(name)}={name}, {nameof(values)}={string.Join(", ", values)}");
+
             int bytesWritten;
             while (!HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingNewName(name, values, HttpHeaderParser.DefaultSeparator, _headerBuffer.AvailableSpan, out bytesWritten))
             {
@@ -822,6 +848,8 @@ namespace System.Net.Http
 
         private void WriteLiteralHeaderValues(string[] values, string separator)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(values)}={string.Join(separator, values)}");
+
             int bytesWritten;
             while (!HPackEncoder.EncodeStringLiterals(values, separator, _headerBuffer.AvailableSpan, out bytesWritten))
             {
@@ -833,6 +861,8 @@ namespace System.Net.Http
 
         private void WriteLiteralHeaderValue(string value)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(value)}={value}");
+
             int bytesWritten;
             while (!HPackEncoder.EncodeStringLiteral(value, _headerBuffer.AvailableSpan, out bytesWritten))
             {
@@ -844,6 +874,8 @@ namespace System.Net.Http
 
         private void WriteBytes(ReadOnlySpan<byte> bytes)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(bytes.Length)}={bytes.Length}");
+
             if (bytes.Length > _headerBuffer.AvailableLength)
             {
                 _headerBuffer.EnsureAvailableSpace(bytes.Length);
@@ -855,6 +887,8 @@ namespace System.Net.Http
 
         private void WriteHeaderCollection(HttpHeaders headers)
         {
+            if (NetEventSource.IsEnabled) Trace("");
+
             foreach (KeyValuePair<HeaderDescriptor, string[]> header in headers.GetHeaderDescriptorsAndValues())
             {
                 Debug.Assert(header.Value.Length > 0, "No values for header??");
@@ -911,6 +945,7 @@ namespace System.Net.Http
 
         private void WriteHeaders(HttpRequestMessage request)
         {
+            if (NetEventSource.IsEnabled) Trace("");
             Debug.Assert(_headerBuffer.ActiveMemory.Length == 0);
 
             // HTTP2 does not support Transfer-Encoding: chunked, so disable this on the request.
@@ -987,6 +1022,7 @@ namespace System.Net.Http
 
         private async ValueTask<Http2Stream> SendHeadersAsync(HttpRequestMessage request, CancellationToken cancellationToken, bool mustFlush = false)
         {
+            if (NetEventSource.IsEnabled) Trace("");
             try
             {
                 // Ensure we don't exceed the max concurrent streams setting.
@@ -1085,6 +1121,7 @@ namespace System.Net.Http
 
         private async Task SendStreamDataAsync(int streamId, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
+            if (NetEventSource.IsEnabled) Trace(streamId, $"{nameof(buffer.Length)}={buffer.Length}");
             ReadOnlyMemory<byte> remaining = buffer;
 
             while (remaining.Length > 0)
@@ -1125,6 +1162,7 @@ namespace System.Net.Http
 
         private async Task SendEndStreamAsync(int streamId)
         {
+            if (NetEventSource.IsEnabled) Trace(streamId, "");
             Memory<byte> writeBuffer = await StartWriteAsync(FrameHeader.Size).ConfigureAwait(false);
 
             FrameHeader frameHeader = new FrameHeader(0, FrameType.Data, FrameFlags.EndStream, streamId);
@@ -1135,6 +1173,7 @@ namespace System.Net.Http
 
         private async Task SendWindowUpdateAsync(int streamId, int amount)
         {
+            if (NetEventSource.IsEnabled) Trace(streamId, $"{nameof(amount)}={amount}");
             Debug.Assert(amount > 0);
 
             // We update both the connection-level and stream-level windows at the same time
@@ -1151,6 +1190,7 @@ namespace System.Net.Http
 
         private void ExtendWindow(int amount)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(amount)}={amount}");
             Debug.Assert(amount > 0);
 
             int windowUpdateSize;
@@ -1161,6 +1201,7 @@ namespace System.Net.Http
                 _pendingWindowUpdate += amount;
                 if (_pendingWindowUpdate < ConnectionWindowThreshold)
                 {
+                    if (NetEventSource.IsEnabled) Trace($"{nameof(_pendingWindowUpdate)} {_pendingWindowUpdate} < {ConnectionWindowThreshold}.");
                     return;
                 }
 
@@ -1173,6 +1214,7 @@ namespace System.Net.Http
 
         private void WriteFrameHeader(FrameHeader frameHeader)
         {
+            if (NetEventSource.IsEnabled) Trace($"{frameHeader}");
             Debug.Assert(_outgoingBuffer.AvailableMemory.Length >= FrameHeader.Size);
 
             frameHeader.WriteTo(_outgoingBuffer.AvailableSpan);
@@ -1228,6 +1270,8 @@ namespace System.Net.Http
 
         private void AbortStreams(int lastValidStream, Exception abortException)
         {
+            if (NetEventSource.IsEnabled) Trace($"{nameof(lastValidStream)}={lastValidStream}, {nameof(abortException)}={lastValidStream}={abortException}");
+
             bool shouldInvalidate = false;
             lock (SyncObject)
             {
@@ -1374,6 +1418,8 @@ namespace System.Net.Http
             }
 
             public void WriteTo(Memory<byte> buffer) => WriteTo(buffer.Span);
+
+            public override string ToString() => $"StreamId={StreamId}; Type={Type}; Flags={Flags}; Length={Length}"; // Description for diagnostic purposes
         }
 
         [Flags]
@@ -1406,61 +1452,57 @@ namespace System.Net.Http
 
         public sealed override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if (NetEventSource.IsEnabled) Trace($"{request}");
+
             Http2Stream http2Stream = null;
             try
             {
                 // Send headers
                 bool shouldExpectContinue = request.Content != null && request.HasHeaders && request.Headers.ExpectContinue == true;
-
                 http2Stream = await SendHeadersAsync(request, cancellationToken, mustFlush: shouldExpectContinue).ConfigureAwait(false);
-                if (shouldExpectContinue)
+
+                // Send request body, if any, and read response headers.
+                Task requestBodyTask = 
+                    request.Content == null ? Task.CompletedTask :
+                    shouldExpectContinue ? http2Stream.SendRequestBodyWithExpect100ContinueAsync(cancellationToken) :
+                    http2Stream.SendRequestBodyAsync(cancellationToken);
+                Task responseHeadersTask = http2Stream.ReadResponseHeadersAsync(cancellationToken);
+
+                // Wait for either task to complete.  The best and most common case is when the request body completes
+                // before the response headers, in which case we can fully process the sending of the request and then
+                // fully process the sending of the response.  WhenAny is not free, so we do a fast-path check to see
+                // if the request body completed synchronously, only progressing to do the WhenAny if it didn't. Then
+                // if the WhenAny completes and either the WhenAny indicated that the request body completed or
+                // both tasks completed, we can proceed to handle the request body as if it completed first.
+                if (requestBodyTask.IsCompleted ||
+                    requestBodyTask == await Task.WhenAny(requestBodyTask, responseHeadersTask).ConfigureAwait(false) ||
+                    requestBodyTask.IsCompleted)
                 {
-                    // Send header and wait a little bit to see if server sends 100, reject code or nothing.
-                    if (NetEventSource.IsEnabled) Trace($"Request content is not null, start processing 100-Continue.");
-                    await http2Stream.SendRequestBodyWithExpect100ContinueAsync(cancellationToken).ConfigureAwait(false);
+                    // The sending of the request body completed before receiving all of the request headers.
+                    // This is the common and desirable case.
+                    try
+                    {
+                        await requestBodyTask.ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        if (NetEventSource.IsEnabled) Trace($"Sending request content failed: {e}");
+                        LogExceptions(responseHeadersTask); // Observe exception (if any) on responseHeadersTask.
+                        throw;
+                    }
                 }
                 else
                 {
-                    // Send request body, if any, and read response headers.
-                    Task requestBodyTask = http2Stream.SendRequestBodyAsync(cancellationToken);
-                    Task responseHeadersTask = http2Stream.ReadResponseHeadersAsync(cancellationToken);
-
-                    // Wait for either task to complete.  The best and most common case is when the request body completes
-                    // before the response headers, in which case we can fully process the sending of the request and then
-                    // fully process the sending of the response.  WhenAny is not free, so we do a fast-path check to see
-                    // if the request body completed synchronously, only progressing to do the WhenAny if it didn't. Then
-                    // if the WhenAny completes and either the WhenAny indicated that the request body completed or
-                    // both tasks completed, we can proceed to handle the request body as if it completed first.
-                    if (requestBodyTask.IsCompleted ||
-                        requestBodyTask == await Task.WhenAny(requestBodyTask, responseHeadersTask).ConfigureAwait(false) ||
-                        requestBodyTask.IsCompleted)
-                    {
-                        // The sending of the request body completed before receiving all of the request headers.
-                        // This is the common and desirable case.
-                        try
-                        {
-                            await requestBodyTask.ConfigureAwait(false);
-                        }
-                        catch (Exception e)
-                        {
-                            if (NetEventSource.IsEnabled) Trace($"{nameof(http2Stream.SendRequestBodyAsync)} failed. {e}");
-                            LogExceptions(responseHeadersTask); // Observe exception (if any) on responseHeadersTask.
-                            throw;
-                        }
-                    }
-                    else
-                    {
-                        // We received the response headers but the request body hasn't yet finished; this most commonly happens
-                        // when the protocol is being used to enable duplex communication. If the connection is aborted or if we
-                        // get RST or GOAWAY from server, exception will be stored in stream._abortException and propagated up
-                        // to caller if possible while processing response, but make sure that we log any exceptions from this task
-                        // completing asynchronously).
-                        LogExceptions(requestBodyTask);
-                    }
-
-                    // Wait for the response headers to complete if they haven't already, propagating any exceptions.
-                    await responseHeadersTask.ConfigureAwait(false);
+                    // We received the response headers but the request body hasn't yet finished; this most commonly happens
+                    // when the protocol is being used to enable duplex communication. If the connection is aborted or if we
+                    // get RST or GOAWAY from server, exception will be stored in stream._abortException and propagated up
+                    // to caller if possible while processing response, but make sure that we log any exceptions from this task
+                    // completing asynchronously).
+                    LogExceptions(requestBodyTask);
                 }
+
+                // Wait for the response headers to complete if they haven't already, propagating any exceptions.
+                await responseHeadersTask.ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -1521,6 +1563,7 @@ namespace System.Net.Http
                 }
 
                 int streamId = _nextStream;
+                if (NetEventSource.IsEnabled) Trace(streamId, $"request={request}");
 
                 // Client-initiated streams are always odd-numbered, so increase by 2.
                 _nextStream += 2;
@@ -1535,6 +1578,7 @@ namespace System.Net.Http
 
         private void RemoveStream(Http2Stream http2Stream)
         {
+            if (NetEventSource.IsEnabled) Trace(http2Stream.StreamId, "");
             Debug.Assert(http2Stream != null);
 
             lock (SyncObject)
@@ -1585,13 +1629,16 @@ namespace System.Net.Http
 
         public sealed override string ToString() => $"{nameof(Http2Connection)}({_pool})"; // Description for diagnostic purposes
 
-        internal override void Trace(string message, [CallerMemberName] string memberName = null) =>
+        public override void Trace(string message, [CallerMemberName] string memberName = null) =>
+            Trace(0, message, memberName);
+
+        internal void Trace(int streamId, string message, [CallerMemberName] string memberName = null) =>
             NetEventSource.Log.HandlerMessage(
                 _pool?.GetHashCode() ?? 0,    // pool ID
                 GetHashCode(),                // connection ID
-                _stream?.GetHashCode() ?? 0,  // stream ID
+                streamId,                     // stream ID
                 memberName,                   // method name
-                ToString() + ": " + message); // message
+                message);                     // message
 
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -2,15 +2,36 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
+using System.Net.Security;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal abstract class HttpConnectionBase
+    internal abstract class HttpConnectionBase : IHttpTrace
     {
         public abstract Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken);
-        internal abstract void Trace(string message, string memberName = null);
+        public abstract void Trace(string message, [CallerMemberName] string memberName = null);
+
+        protected void TraceConnection(Stream stream)
+        {
+            if (stream is SslStream sslStream)
+            {
+                Trace(
+                    $"{this}. " +
+                    $"SslProtocol:{sslStream.SslProtocol}, NegotiatedApplicationProtocol:{sslStream.NegotiatedApplicationProtocol}, " +
+                    $"NegotiatedCipherSuite:{sslStream.NegotiatedCipherSuite}, CipherAlgorithm:{sslStream.CipherAlgorithm}, CipherStrength:{sslStream.CipherStrength}, " +
+                    $"HashAlgorithm:{sslStream.HashAlgorithm}, HashStrength:{sslStream.HashStrength}, " +
+                    $"KeyExchangeAlgorithm:{sslStream.KeyExchangeAlgorithm}, KeyExchangeStrength:{sslStream.KeyExchangeStrength}, " +
+                    $"LocalCertificate:{sslStream.LocalCertificate}, RemoteCertificate:{sslStream.RemoteCertificate}");
+            }
+            else
+            {
+                Trace($"{this}");
+            }
+        }
 
         private long CreationTickCount { get; } = Environment.TickCount64;
 
@@ -24,6 +45,8 @@ namespace System.Net.Http
             if (expired && NetEventSource.IsEnabled) Trace($"Connection no longer usable. Alive {TimeSpan.FromMilliseconds((nowTicks - CreationTickCount))} > {lifetime}.");
             return expired;
         }
+
+        internal static bool IsDigit(byte c) => (uint)(c - '0') <= '9' - '0';
 
         /// <summary>Awaits a task, ignoring any resulting exceptions.</summary>
         internal static void IgnoreExceptions(ValueTask<int> task)
@@ -64,6 +87,5 @@ namespace System.Net.Http
                 }
             }
         }
-
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -180,6 +180,8 @@ namespace System.Net.Http
             {
                 PreAuthCredentials = new CredentialCache();
             }
+
+            if (NetEventSource.IsEnabled) Trace($"{this}");
         }
 
         private static readonly List<SslApplicationProtocol> Http2ApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http2, SslApplicationProtocol.Http11 };
@@ -1043,7 +1045,7 @@ namespace System.Net.Http
                 0,                           // connection ID
                 0,                           // request ID
                 memberName,                  // method name
-                ToString() + ":" + message); // message
+                message);                    // message
 
         /// <summary>A cached idle connection and metadata about it.</summary>
         [StructLayout(LayoutKind.Auto)]

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/IHttpTrace.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/IHttpTrace.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Net.Http
+{
+    internal interface IHttpTrace
+    {
+        void Trace(string message, [CallerMemberName] string memberName = null);
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/TaskCompletionSourceWithCancellation.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/TaskCompletionSourceWithCancellation.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal sealed class TaskCompletionSourceWithCancellation<T> : TaskCompletionSource<T>
+    internal class TaskCompletionSourceWithCancellation<T> : TaskCompletionSource<T>
     {
         private CancellationToken _cancellationToken;
 


### PR DESCRIPTION
Duplex communication (allowing the request body to continue sending as the response body is processed) is currently broken with Expect: 100-continue: it's waiting for the request body to send before it'll return the stream for the response body to the caller.  The fix is to simplify the code, and minimize the special handling for Expect: 100-continue to just control if/when the request body is sent, rather than forking all of the logic around the handling of the request/response.

As part of diagnosing this, I added a lot more tracing, which I'm also including.

I also streamlined the CreditManager's wait list to make it slimmer.

Fixes https://github.com/dotnet/corefx/issues/38968
cc: @geoffkizer, @davidsh, @scalablecory, @wfurt