### PR TITLE
Change CreateProcessLong test helper to use 5m rather than 30s sleep

### DIFF
--- a/src/System.Diagnostics.Process/tests/RemotelyInvokable.cs
+++ b/src/System.Diagnostics.Process/tests/RemotelyInvokable.cs
@@ -20,7 +20,7 @@ namespace System.Diagnostics.Tests
     internal static class RemotelyInvokable
     {
         public static readonly int SuccessExitCode = 42;
-        public const int WaitInMS = 30 * 1000;
+        public const int WaitInMS = 5 * 60 * 1000;
         public const string TestConsoleApp = "System.Diagnostics.Process.Tests";
         public static event EventHandler ClosedEvent;
 


### PR DESCRIPTION
The ProcessTestBase.CreateProcessLong helper function is used in situations where we effectively want an infinitely running process, which we then terminate when the test creating it completes.  But we also don't want the process to live in forever if something goes wrong with killing it, such as if the parent hangs or is itself terminated.  So we instead have it sleep for a "long" period of time, currently 30s.  However, in stress runs, that may not be long enough.  This bumps it to 5m.

If this ends up being insufficient, we can come up with another scheme.

cc: @CarolEidt, @wtgodbe, @krwq
https://github.com/dotnet/coreclr/issues/25191