### PR TITLE
Fixing small issue with reference assemblies not setting BaseIntermediateOutputPath

### DIFF
--- a/eng/ReferenceAssemblies.props
+++ b/eng/ReferenceAssemblies.props
@@ -1,15 +1,16 @@
 <Project>
   <PropertyGroup>
-    <IsReferenceAssembly Condition="'$(IsReferenceAssembly)'=='' AND ($(MSBuildProjectFullPath.Contains('\ref\')) OR $(MSBuildProjectFullPath.Contains('/ref/')))">true</IsReferenceAssembly>
+    <IsReferenceAssembly Condition="'$(IsReferenceAssembly)' == '' and ($(MSBuildProjectFullPath.Contains('\ref\')) or $(MSBuildProjectFullPath.Contains('/ref/')))">true</IsReferenceAssembly>
 
     <!-- Create a common root output directory for all reference assemblies -->
-    <ReferenceAssemblyOutputPath Condition="'$(ReferenceAssemblyOutputPath)' == ''">$(ArtifactsBinDir)ref/</ReferenceAssemblyOutputPath>
+    <ReferenceAssemblyOutputPath Condition="'$(ReferenceAssemblyOutputPath)' == ''">$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'ref'))</ReferenceAssemblyOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsReferenceAssembly)'=='true'">
-    <OutputPath>$([MSBuild]::NormalizeDirectory('$(ReferenceAssemblyOutputPath)', '$(MSBuildProjectName)', '$(Configuration)'))</OutputPath>
+  <PropertyGroup Condition="'$(IsReferenceAssembly)' == 'true'">
+    <BaseOutputPath>$([MSBuild]::NormalizeDirectory('$(ReferenceAssemblyOutputPath)', '$(MSBuildProjectName)'))</BaseOutputPath>
+    <OutputPath>$(BaseOutputPath)$(Configuration)</OutputPath>
     <BaseIntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'ref', '$(MSBuildProjectName)'))</BaseIntermediateOutputPath>
-    <IntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'ref', '$(MSBuildProjectName)', '$(Configuration)'))</IntermediateOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)</IntermediateOutputPath>
 
     <!-- disable warnings about unused fields -->
     <NoWarn>$(NoWarn);CS0169;CS0649;CS8618</NoWarn>
@@ -21,7 +22,7 @@
     <NoWarn>$(NoWarn);CS8625</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsReferenceAssembly)'=='true'">
+  <ItemGroup Condition="'$(IsReferenceAssembly)' == 'true'">
     <!-- All reference assemblies should have the 0x70 flag which prevents them from loading
          and the ReferenceAssemblyAttribute. -->
     <AssemblyInfoLines Include="[assembly:System.Runtime.CompilerServices.ReferenceAssembly]" />

--- a/eng/ReferenceAssemblies.props
+++ b/eng/ReferenceAssemblies.props
@@ -8,6 +8,7 @@
 
   <PropertyGroup Condition="'$(IsReferenceAssembly)'=='true'">
     <OutputPath>$([MSBuild]::NormalizeDirectory('$(ReferenceAssemblyOutputPath)', '$(MSBuildProjectName)', '$(Configuration)'))</OutputPath>
+    <BaseIntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'ref', '$(MSBuildProjectName)'))</BaseIntermediateOutputPath>
     <IntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'ref', '$(MSBuildProjectName)', '$(Configuration)'))</IntermediateOutputPath>
 
     <!-- disable warnings about unused fields -->


### PR DESCRIPTION
cc: @ViktorHofer @ericstj 

Eric and I found that there was a small bug causing restore re-running on incremental builds due to the project.assets.json file for the src\*.csproj having the same path as the ref\*.csproj. This meant that when you restored both the ref and src projects during a build, if you try re-running restore it wouldn't be a no-op since the assets file will be regenerated. This small change will ensure that ref\*.csproj assets.json files are unique.