### PR TITLE
Fix Ping.Send() to return correct PingReply status

### DIFF
--- a/src/Common/src/Interop/Windows/IpHlpApi/Interop.ICMP.cs
+++ b/src/Common/src/Interop/Windows/IpHlpApi/Interop.ICMP.cs
@@ -11,6 +11,8 @@ internal static partial class Interop
 {
     internal static partial class IpHlpApi
     {
+        internal const int IP_STATUS_BASE = 11000;
+
         // TODO: #3562 - Replace names with the ones from the Windows SDK.
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
@@ -89,6 +89,12 @@ namespace System.Net.NetworkInformation
                 if (!isAsync || error != Interop.IpHlpApi.ERROR_IO_PENDING)
                 {
                     Cleanup(isAsync);
+
+                    if (error != 0 && Enum.IsDefined(typeof(IPStatus), error))
+                    {
+                        return Task.FromResult(new PingReply(address, default, (IPStatus)error, default, Array.Empty<byte>()));
+                    }
+
                     throw new Win32Exception(error);
                 }
             }

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
@@ -90,12 +90,8 @@ namespace System.Net.NetworkInformation
                 {
                     Cleanup(isAsync);
 
-                    if (error != 0 && Enum.IsDefined(typeof(IPStatus), error))
-                    {
-                        return Task.FromResult(new PingReply(address, default, (IPStatus)error, default, Array.Empty<byte>()));
-                    }
-
-                    throw new Win32Exception(error);
+                    IPStatus status = GetStatusFromCode(error);
+                    return Task.FromResult(new PingReply(address, default, status, default, Array.Empty<byte>()));
                 }
             }
 
@@ -326,12 +322,25 @@ namespace System.Net.NetworkInformation
             }
         }
 
+        private static IPStatus GetStatusFromCode(int statusCode)
+        {
+            // Caveat lector: IcmpSendEcho2 doesn't allow us to know for sure if an error code
+            // is an IP Status code or a general win32 error code. This assumes everything under
+            // the base is a win32 error, and everything beyond is an IPStatus.
+            if (statusCode != 0 && statusCode < Interop.IpHlpApi.IP_STATUS_BASE)
+            {
+                throw new Win32Exception(statusCode);
+            }
+
+            return (IPStatus)statusCode;
+        }
+
         private static PingReply CreatePingReplyFromIcmpEchoReply(Interop.IpHlpApi.IcmpEchoReply reply)
         {
             const int DontFragmentFlag = 2;
 
             IPAddress address = new IPAddress(reply.address);
-            IPStatus ipStatus = (IPStatus)reply.status; // The icmpsendecho IP status codes.
+            IPStatus ipStatus = GetStatusFromCode((int)reply.status);
 
             long rtt;
             PingOptions options;
@@ -358,7 +367,7 @@ namespace System.Net.NetworkInformation
         private static PingReply CreatePingReplyFromIcmp6EchoReply(Interop.IpHlpApi.Icmp6EchoReply reply, IntPtr dataPtr, int sendSize)
         {
             IPAddress address = new IPAddress(reply.Address.Address, reply.Address.ScopeID);
-            IPStatus ipStatus = (IPStatus)reply.Status; // The icmpsendecho IP status codes.
+            IPStatus ipStatus = GetStatusFromCode((int)reply.Status);
 
             long rtt;
             byte[] buffer;

--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -842,7 +842,7 @@ namespace System.Net.NetworkInformation.Tests
         public void Ping_TimedOutSync_Success()
         {
             var sender = new Ping();
-            var reply = sender.Send("192.0.2.0");
+            PingReply reply = sender.Send("192.0.2.0");
             Assert.Equal(IPStatus.TimedOut, reply.Status);
         }
      }

--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -845,5 +845,14 @@ namespace System.Net.NetworkInformation.Tests
             PingReply reply = sender.Send(TestSettings.UnreachableAddress);
             Assert.Equal(IPStatus.TimedOut, reply.Status);
         }
-     }
+
+        [Fact]
+        [OuterLoop]
+        public async Task PingAsync_TimedOutSync_Success()
+        {
+            var sender = new Ping();
+            PingReply reply = await sender.SendPingAsync(TestSettings.UnreachableAddress);
+            Assert.Equal(IPStatus.TimedOut, reply.Status);
+        }
+    }
 }

--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -836,5 +836,14 @@ namespace System.Net.NetworkInformation.Tests
             pingReply = await ping.SendPingAsync(host, TestSettings.PingTimeout, TestSettings.PayloadAsBytesShort, options);
             Assert.NotEqual(IPStatus.Success, pingReply.Status);
         }
+
+        [Fact]
+        [OuterLoop]
+        public void Ping_TimedOutSync_Success()
+        {
+            var sender = new Ping();
+            var reply = sender.Send("192.0.2.0");
+            Assert.Equal(IPStatus.TimedOut, reply.Status);
+        }
      }
 }

--- a/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -842,7 +842,7 @@ namespace System.Net.NetworkInformation.Tests
         public void Ping_TimedOutSync_Success()
         {
             var sender = new Ping();
-            PingReply reply = sender.Send("192.0.2.0");
+            PingReply reply = sender.Send(TestSettings.UnreachableAddress);
             Assert.Equal(IPStatus.TimedOut, reply.Status);
         }
      }

--- a/src/System.Net.Ping/tests/FunctionalTests/TestSettings.cs
+++ b/src/System.Net.Ping/tests/FunctionalTests/TestSettings.cs
@@ -11,6 +11,7 @@ namespace System.Net.NetworkInformation.Tests
     internal static class TestSettings
     {
         public static readonly string LocalHost = "localhost";
+        public static readonly string UnreachableAddress = "192.0.2.0"; // TEST-NET-1
         public const int PingTimeout = 10 * 1000;
 
         public const string PayloadAsString = "'Post hoc ergo propter hoc'. 'After it, therefore because of it'. It means one thing follows the other, therefore it was caused by the other. But it's not always true. In fact it's hardly ever true.";


### PR DESCRIPTION
Resolves #38770. This fixes a behavior change between 2.x/3.0.

In 2.2, `Send()` will return a `PingReply` with e.g. `IPStatus.TimedOut` if a ping is not successful.
In 3.0, we updated `Send()` to have a truly sync implementation (previously wrapped async) but ended up throwing an incorrect exception rather than returning a `PingReply`.

This PR restores the behavior from 2.2.