### PR TITLE
Use Uri.OriginalString when serializing

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUri.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterUri.cs
@@ -8,7 +8,6 @@ namespace System.Text.Json.Serialization.Converters
     {
         public override Uri Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            // TODO: use reader.GetUri() when https://github.com/dotnet/corefx/issues/38647 is implemented.
             string uriString = reader.GetString();
             if (Uri.TryCreate(uriString, UriKind.RelativeOrAbsolute, out Uri value))
             {
@@ -21,8 +20,7 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, Uri value, JsonSerializerOptions options)
         {
-            // TODO: remove preprocessing when https://github.com/dotnet/corefx/issues/38647 is implemented.
-            writer.WriteStringValue(value.ToString());
+            writer.WriteStringValue(value.OriginalString);
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/ReadScenarioTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ReadScenarioTests.cs
@@ -8,14 +8,18 @@ using Xunit;
 namespace System.Text.Json.Tests.Serialization
 {
     /// <summary>
-    /// Catch-all location for general user reported scenarios that aren't specific to one serialization feature.
+    /// Catch-all location for combined read scenarios (user reported and otherwise) that aren't
+    /// specific to one serialization feature.
     /// </summary>
-    public class UserReports
+    public class ReadScenarioTests
     {
         [Fact]
-        public void Issue38568()
+        public void StringEnumUriAndCustomDateTimeConverter()
         {
-            // https://github.com/dotnet/corefx/issues/38568
+            // Validating a scenario reported with https://github.com/dotnet/corefx/issues/38568.
+            // Our DateTime parsing is ISO 8601 strict, more flexible parsing is possible by
+            // writing a simple converter. String based enum parsing is handled by registering
+            // a custom built-in parser (JsonStringEnumConverter). Uri is handled implicitly.
 
             string json =
                 @"{" +

--- a/src/System.Text.Json/tests/Serialization/UserReports.cs
+++ b/src/System.Text.Json/tests/Serialization/UserReports.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace System.Text.Json.Tests.Serialization
+{
+    /// <summary>
+    /// Catch-all location for general user reported scenarios that aren't specific to one serialization feature.
+    /// </summary>
+    public class UserReports
+    {
+        [Fact]
+        public void Issue38568()
+        {
+            // https://github.com/dotnet/corefx/issues/38568
+
+            string json =
+                @"{" +
+                    @"""picture"": ""http://placehold.it/32x32""," +
+                    @"""eyeColor"": ""Brown""," +
+                    @"""registered"": ""2015-05-30T01:50:21 -01:00""" +
+                @"}";
+
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                Converters =
+                {
+                    new JsonStringEnumConverter(),
+                    new Types38568.MyDateTimeConverter()
+                }
+            };
+
+            Types38568.Model model = JsonSerializer.Deserialize<Types38568.Model>(json, options);
+            Assert.Equal(Types38568.Color.Brown, model.EyeColor);
+            Assert.Equal(@"http://placehold.it/32x32", model.Picture.OriginalString);
+            Assert.Equal(DateTime.Parse("2015-05-30T01:50:21 -01:00"), model.Registered);
+        }
+
+        public class Types38568
+        {
+            // The built-in DateTime parser is stricter than DateTime.Parse.
+            public class MyDateTimeConverter : JsonConverter<DateTime>
+            {
+                public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                    => DateTime.Parse(reader.GetString());
+
+                public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+                    => writer.WriteStringValue(value.ToString("O"));
+            }
+
+            public sealed class Model
+            {
+                public Color EyeColor { get; set; }
+                public Uri Picture { get; set; }
+                public DateTime Registered { get; set; }
+            }
+
+            public enum Color
+            {
+                Blue,
+                Green,
+                Brown
+            }
+        }
+    }
+}

--- a/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.ReadTests.cs
@@ -291,9 +291,15 @@ namespace System.Text.Json.Serialization.Tests
         {
             Uri uri = JsonSerializer.Deserialize<Uri>(@"""https://domain/path""");
             Assert.Equal("https:\u002f\u002fdomain\u002fpath", uri.ToString());
+            Assert.Equal("https://domain/path", uri.OriginalString);
+
+            uri = JsonSerializer.Deserialize<Uri>(@"""https:\u002f\u002fdomain\u002fpath""");
+            Assert.Equal("https:\u002f\u002fdomain\u002fpath", uri.ToString());
+            Assert.Equal("https://domain/path", uri.OriginalString);
 
             uri = JsonSerializer.Deserialize<Uri>(@"""~/path""");
             Assert.Equal("~/path", uri.ToString());
+            Assert.Equal("~/path", uri.OriginalString);
         }
 
         private static int SingleToInt32Bits(float value)

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
@@ -63,9 +63,20 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal(@"""~\u002fpath""", JsonSerializer.Serialize(uri));
             }
 
+            // The next two scenarios validate that we're NOT using Uri.ToString() for serializing Uri. The serializer
+            // will escape backslashes and ampersands, but otherwise should be the same as the output of Uri.OriginalString.
+
             {
+                // ToString would collapse the relative segment
                 Uri uri = new Uri("http://a/b/../c");
                 Assert.Equal(@"""http:\u002f\u002fa\u002fb\u002f..\u002fc""", JsonSerializer.Serialize(uri));
+            }
+
+            {
+                // "%20" gets turned into a space by Uri.ToString()
+                // https://coding.abel.nu/2014/10/beware-of-uri-tostring/
+                Uri uri = new Uri("http://localhost?p1=Value&p2=A%20B%26p3%3DFooled!");
+                Assert.Equal(@"""http:\u002f\u002flocalhost?p1=Value\u0026p2=A%20B%26p3%3DFooled!""", JsonSerializer.Serialize(uri));
             }
         }
     }

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
@@ -62,6 +62,11 @@ namespace System.Text.Json.Serialization.Tests
                 Uri.TryCreate("~/path", UriKind.RelativeOrAbsolute, out Uri uri);
                 Assert.Equal(@"""~\u002fpath""", JsonSerializer.Serialize(uri));
             }
+
+            {
+                Uri uri = new Uri("http://a/b/../c");
+                Assert.Equal(@"""http:\u002f\u002fa\u002fb\u002f..\u002fc""", JsonSerializer.Serialize(uri));
+            }
         }
     }
 }

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -79,7 +79,7 @@
     <Compile Include="Serialization\TestClasses.SimpleTestClassWithSimpleObject.cs" />
     <Compile Include="Serialization\TestClasses.SimpleTestStruct.cs" />
     <Compile Include="Serialization\TestData.cs" />
-    <Compile Include="Serialization\UserReports.cs" />
+    <Compile Include="Serialization\ReadScenarioTests.cs" />
     <Compile Include="Serialization\Value.ReadTests.cs" />
     <Compile Include="Serialization\Value.ReadTests.GenericCollections.cs" />
     <Compile Include="Serialization\Value.ReadTests.ImmutableCollections.cs" />

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Serialization\TestClasses.SimpleTestClassWithSimpleObject.cs" />
     <Compile Include="Serialization\TestClasses.SimpleTestStruct.cs" />
     <Compile Include="Serialization\TestData.cs" />
+    <Compile Include="Serialization\UserReports.cs" />
     <Compile Include="Serialization\Value.ReadTests.cs" />
     <Compile Include="Serialization\Value.ReadTests.GenericCollections.cs" />
     <Compile Include="Serialization\Value.ReadTests.ImmutableCollections.cs" />


### PR DESCRIPTION
We want to be lossless if possible when round tripping (outside of escaping). To do so we need to write OriginalString instead of using ToString().

Removing pending issue reference as it was closed (we won't be adding a Uri parser to the reader).

Add user reported scenario. #38568