### PR TITLE
Re-add removed Packaging.props lines related to IntelliSense packages

### DIFF
--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -12,9 +12,8 @@
     <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>
     <NativePackagePath>$(MSBuildThisFileDirectory)src/Native/pkg</NativePackagePath>
 
-    <XmlDocPackage>Microsoft.Private.Intellisense</XmlDocPackage>
-    <XmlDocPackageVersion>3.0.0-preview3-190305-0</XmlDocPackageVersion>
-    <XmlDocFileRoot>$(NuGetPackageRoot)$(XmlDocPackage.ToLowerInvariant())/$(XmlDocPackageVersion)/xmldocs/netcoreapp</XmlDocFileRoot>
+    <!-- Used by PackageLibs.targets -->
+    <XmlDocFileRoot>$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackageId)/$(MicrosoftPrivateIntellisensePackageVersion)/xmldocs/netcoreapp</XmlDocFileRoot>
 
     <!-- By default the packaging targets will package desktop facades as ref,
          but we don't use this as we now build partial-reference-facades. -->

--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -12,6 +12,10 @@
     <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>
     <NativePackagePath>$(MSBuildThisFileDirectory)src/Native/pkg</NativePackagePath>
 
+    <XmlDocPackage>Microsoft.Private.Intellisense</XmlDocPackage>
+    <XmlDocPackageVersion>3.0.0-preview3-190305-0</XmlDocPackageVersion>
+    <XmlDocFileRoot>$(NuGetPackageRoot)$(XmlDocPackage.ToLowerInvariant())/$(XmlDocPackageVersion)/xmldocs/netcoreapp</XmlDocFileRoot>
+
     <!-- By default the packaging targets will package desktop facades as ref,
          but we don't use this as we now build partial-reference-facades. -->
     <PackageDesktopAsRef>false</PackageDesktopAsRef>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,6 +25,7 @@
     <WindowsCoreFxOptimizationDataPackageId>optimization.windows_nt-x64.ibc.corefx</WindowsCoreFxOptimizationDataPackageId>
     <LinuxCoreFxOptimizationDataPackageId>optimization.linux-x64.ibc.corefx</LinuxCoreFxOptimizationDataPackageId>
     <MicrosoftDotNetUapTestToolsPackageId>microsoft.dotnet.uap.testtools</MicrosoftDotNetUapTestToolsPackageId>
+    <MicrosoftPrivateIntellisensePackageId>microsoft.private.intellisense</MicrosoftPrivateIntellisensePackageId>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Arcade dependencies -->

--- a/eng/restore/docs.targets
+++ b/eng/restore/docs.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="microsoft.private.intellisense" Version="$(MicrosoftPrivateIntellisensePackageVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="$(MicrosoftPrivateIntellisensePackageId)" Version="$(MicrosoftPrivateIntellisensePackageVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <!-- the intellisense package doesn't use nuget conventions so we need to select manually -->
@@ -9,7 +9,7 @@
           AfterTargets="Restore">
 
     <ItemGroup>
-      <DocFile Include="$(NuGetPackageRoot)microsoft.private.intellisense/$(MicrosoftPrivateIntellisensePackageVersion)/xmldocs/netcoreapp/**/*.xml"/>
+      <DocFile Include="$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackageId)/$(MicrosoftPrivateIntellisensePackageVersion)/xmldocs/netcoreapp/**/*.xml"/>
       <DocFile>
         <!-- trim off slash since it differs by platform and we need to do a string compare -->
         <LCID>$([System.String]::new('%(RecursiveDir)').TrimEnd('\/'))</LCID>


### PR DESCRIPTION
Back in Preview 6, the build process was properly placing the nuget intellisense xml files next to the built dlls, but [a recent change](https://github.com/dotnet/corefx/commit/c4c1985531cc1f25c805bbc4801b85c98e0dfee0#diff-ba98fbb097dbdca16daf37fed8c21357) removed the lines in Packaging.props necessary for this task.