### PR TITLE
Fix exception messages for max response headers length

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -211,7 +211,7 @@ namespace System.Net.Http
                 _headerBudgetRemaining -= name.Length + value.Length;
                 if (_headerBudgetRemaining < 0)
                 {
-                    throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _connection._pool.Settings._maxResponseHeadersLength));
+                    throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _connection._pool.Settings._maxResponseHeadersLength * 1024L));
                 }
 
                 // TODO: ISSUE 31309: Optimize HPACK static table decoding

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1233,7 +1233,7 @@ namespace System.Net.Http
             {
                 if (_allowedReadLineBytes < buffer.Length)
                 {
-                    throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _pool.Settings._maxResponseHeadersLength));
+                    throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _pool.Settings._maxResponseHeadersLength * 1024L));
                 }
 
                 line = default;
@@ -1344,7 +1344,7 @@ namespace System.Net.Http
         {
             if (_allowedReadLineBytes < 0)
             {
-                throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _pool.Settings._maxResponseHeadersLength));
+                throw new HttpRequestException(SR.Format(SR.net_http_response_headers_exceeded_length, _pool.Settings._maxResponseHeadersLength * 1024L));
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -2034,7 +2034,8 @@ namespace System.Net.Http.Functional.Tests
                     handler.MaxResponseHeadersLength = 1;
 
                     using HttpClient client = CreateHttpClient(handler);
-                    await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(uri));
+                    Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(uri));
+                    Assert.Contains((handler.MaxResponseHeadersLength * 1024).ToString(), e.ToString());
                 },
                 async server =>
                 {
@@ -2062,7 +2063,8 @@ namespace System.Net.Http.Functional.Tests
                     handler.MaxResponseHeadersLength = 1;
 
                     using HttpClient client = CreateHttpClient(handler);
-                    await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(uri));
+                    Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(uri));
+                    Assert.Contains((handler.MaxResponseHeadersLength * 1024).ToString(), e.ToString());
                 },
                 async server =>
                 {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -90,8 +90,9 @@ namespace System.Net.Http.Functional.Tests
                             catch { }
                         });
 
-                        await Assert.ThrowsAsync<HttpRequestException>(() => getAsync);
+                        Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => getAsync);
                         cts.Cancel();
+                        Assert.Contains((handler.MaxResponseHeadersLength * 1024).ToString(), e.ToString());
                         await serverTask;
                     });
                 }
@@ -131,7 +132,8 @@ namespace System.Net.Http.Functional.Tests
                         }
                         else
                         {
-                            await Assert.ThrowsAsync<HttpRequestException>(() => getAsync);
+                            Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => getAsync);
+                            Assert.Contains((handler.MaxResponseHeadersLength * 1024).ToString(), e.ToString());
                             try { await serverTask; } catch { }
                         }
                     });


### PR DESCRIPTION
Some of the call sites use a value whose units is kbytes, but the exception message refers to bytes.

cc: @scalablecory, @davidsh