### PR TITLE
Add two new HttpClient tests for a custom Transfer-Encoding.

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2355,7 +2355,7 @@ namespace System.Net.Http.Functional.Tests
                         Assert.Contains("Transfer-Encoding: chunked2", headers);
                         // Since we are using a custom (unknown) transfer encoding, the request body is sent as-is.
                         await connection.SendResponseAsync();
-                        var content = await connection.Reader.ReadToEndAsync();
+                        string content = await connection.ReadToEndAsync();
                         Assert.Equal(TestContent, content);
                     });
                 });

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1632,7 +1632,7 @@ namespace System.Net.Http.Functional.Tests
             await LoopbackServer.CreateClientAndServerAsync(
                 async url =>
                 {
-                    using (HttpClient client = new HttpClient())
+                    using (HttpClient client = CreateHttpClient())
                     {
                         // Since we are issuing a GET request, we do not need any Transfer-Encoding headers.
                         // It is still permissible to add them, though.
@@ -2339,7 +2339,7 @@ namespace System.Net.Http.Functional.Tests
             await LoopbackServer.CreateClientAndServerAsync(
                 async url =>
                 {
-                    using (HttpClient client = new HttpClient())
+                    using (HttpClient client = CreateHttpClient())
                     {
                         client.DefaultRequestHeaders.TransferEncoding.Add(new TransferCodingHeaderValue("chunked2"));
                         using (HttpResponseMessage response = await client.PostAsync(url, new StringContent(TestContent)))

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1628,6 +1628,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task GetAsync_CustomTransferEncoding_Success()
         {
+            const string TestContent = "Test String";
             await LoopbackServer.CreateClientAndServerAsync(
                 async url =>
                 {
@@ -1636,12 +1637,12 @@ namespace System.Net.Http.Functional.Tests
                         // Since we are issuing a GET request, we do not need any Transfer-Encoding headers.
                         // It is still permissible to add them, though.
                         client.DefaultRequestHeaders.TransferEncoding.Add(new TransferCodingHeaderValue("chunked2"));
-                        Assert.Equal("hello world", await client.GetStringAsync(url));
+                        Assert.Equal(TestContent, await client.GetStringAsync(url));
                     }
                 },
                 async server =>
                 {
-                    List<string> headers = await server.AcceptConnectionSendResponseAndCloseAsync(content: "hello world");
+                    List<string> headers = await server.AcceptConnectionSendResponseAndCloseAsync(content: TestContent);
                     Assert.Contains("Transfer-Encoding: chunked2", headers);
                 });
         }
@@ -2334,14 +2335,14 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task PostAsync_CustomTransferEncoding_Success()
         {
-            string data = "Test String";
+            const string TestContent = "Test String";
             await LoopbackServer.CreateClientAndServerAsync(
                 async url =>
                 {
                     using (HttpClient client = new HttpClient())
                     {
                         client.DefaultRequestHeaders.TransferEncoding.Add(new TransferCodingHeaderValue("chunked2"));
-                        using (HttpResponseMessage response = await client.PostAsync(url, new StringContent(data)))
+                        using (HttpResponseMessage response = await client.PostAsync(url, new StringContent(TestContent)))
                         {
                             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                         }
@@ -2355,7 +2356,7 @@ namespace System.Net.Http.Functional.Tests
                         // Since we are using a custom (unknown) transfer encoding, the request body is sent as-is.
                         await connection.SendResponseAsync();
                         var content = await connection.Reader.ReadToEndAsync();
-                        Assert.Equal(data, content);
+                        Assert.Equal(TestContent, content);
                     });
                 });
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1631,8 +1631,7 @@ namespace System.Net.Http.Functional.Tests
             await LoopbackServer.CreateClientAndServerAsync(
                 async url =>
                 {
-                    using (HttpClientHandler handler = CreateHttpClientHandler())
-                    using (var client = new HttpClient(handler))
+                    using (HttpClient client = new HttpClient())
                     {
                         // Since we are issuing a GET request, we do not need any Transfer-Encoding headers.
                         // It is still permissible to add them, though.
@@ -2339,8 +2338,7 @@ namespace System.Net.Http.Functional.Tests
             await LoopbackServer.CreateClientAndServerAsync(
                 async url =>
                 {
-                    using (HttpClientHandler handler = CreateHttpClientHandler())
-                    using (var client = new HttpClient(handler))
+                    using (HttpClient client = new HttpClient())
                     {
                         client.DefaultRequestHeaders.TransferEncoding.Add(new TransferCodingHeaderValue("chunked2"));
                         using (HttpResponseMessage response = await client.PostAsync(url, new StringContent(data)))

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1626,7 +1626,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public async Task GetAsync_CustomTransferEncoding()
+        public async Task GetAsync_CustomTransferEncoding_Success()
         {
             await LoopbackServer.CreateClientAndServerAsync(
                 async url =>
@@ -2332,7 +2332,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public async Task PostAsync_CustomTransferEncoding()
+        public async Task PostAsync_CustomTransferEncoding_Success()
         {
             string data = "Test String";
             await LoopbackServer.CreateClientAndServerAsync(


### PR DESCRIPTION
This ensures that you can add a custom TransferCodingHeaderValue such as for instance `chunked2`:

   client.DefaultRequestHeaders.TransferEncoding.Add(new TransferCodingHeaderValue("chunked2"));

While the Transfer-Encoding is not used when making a GET request, the current implementation still sends it as a custom HTTP header.