### PR TITLE
JsonElement null support and serialize ext data without ext prop name

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -295,9 +296,6 @@
   </data>
   <data name="ZeroDepthAtEnd" xml:space="preserve">
     <value>Expected depth to be zero at the end of the JSON payload. There is an open JSON object or array that should be closed.</value>
-  </data>
-  <data name="DeserializeCannotBeNull" xml:space="preserve">
-    <value>The JSON value cannot be null.</value>
   </data>
   <data name="DeserializeDataRemaining" xml:space="preserve">
     <value>The provided data of length {0} has remaining bytes {1}.</value>

--- a/src/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/System.Text.Json/src/System.Text.Json.csproj
@@ -24,6 +24,7 @@
     <Compile Include="System\Text\Json\JsonHelpers.Date.cs" />
     <Compile Include="System\Text\Json\JsonTokenType.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\EnumConverterOptions.cs" />
+    <Compile Include="System\Text\Json\Serialization\ExtensionDataWriteStatus.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonStringEnumConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonDefaultNamingPolicy.cs" />
     <Compile Include="System\Text\Json\ThrowHelper.cs" />

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ExtensionDataWriteStatus.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ExtensionDataWriteStatus.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.Json.Serialization
+{
+    internal enum ExtensionDataWriteStatus : byte
+    {
+        NotStarted = 0,
+        Writing = 1,
+        Finished = 2
+    }
+}

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -116,10 +116,14 @@ namespace System.Text.Json
                             }
                         }
 
+                        if (DetermineExtensionDataProperty(cache))
+                        {
+                            // Remove from cache since it is handled independently.
+                            cache.Remove(DataExtensionProperty.NameAsString);
+                        }
+
                         // Set as a unit to avoid concurrency issues.
                         PropertyCache = cache;
-
-                        DetermineExtensionDataProperty();
                     }
                     break;
                 case ClassType.Enumerable:
@@ -165,9 +169,9 @@ namespace System.Text.Json
             }
         }
 
-        private void DetermineExtensionDataProperty()
+        private bool DetermineExtensionDataProperty(Dictionary<string, JsonPropertyInfo> cache)
         {
-            JsonPropertyInfo jsonPropertyInfo = GetPropertyThatHasAttribute(typeof(JsonExtensionDataAttribute));
+            JsonPropertyInfo jsonPropertyInfo = GetPropertyThatHasAttribute(typeof(JsonExtensionDataAttribute), cache);
             if (jsonPropertyInfo != null)
             {
                 Type declaredPropertyType = jsonPropertyInfo.DeclaredPropertyType;
@@ -178,16 +182,17 @@ namespace System.Text.Json
                 }
 
                 DataExtensionProperty = jsonPropertyInfo;
+                return true;
             }
+
+            return false;
         }
 
-        private JsonPropertyInfo GetPropertyThatHasAttribute(Type attributeType)
+        private JsonPropertyInfo GetPropertyThatHasAttribute(Type attributeType, Dictionary<string, JsonPropertyInfo> cache)
         {
-            Debug.Assert(PropertyCache != null);
-
             JsonPropertyInfo property = null;
 
-            foreach (JsonPropertyInfo jsonPropertyInfo in PropertyCache.Values)
+            foreach (JsonPropertyInfo jsonPropertyInfo in cache.Values)
             {
                 Attribute attribute = jsonPropertyInfo.PropertyInfo.GetCustomAttribute(attributeType);
                 if (attribute != null)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -171,7 +171,7 @@ namespace System.Text.Json
 
         private bool DetermineExtensionDataProperty(Dictionary<string, JsonPropertyInfo> cache)
         {
-            JsonPropertyInfo jsonPropertyInfo = GetPropertyThatHasAttribute(typeof(JsonExtensionDataAttribute), cache);
+            JsonPropertyInfo jsonPropertyInfo = GetPropertyWithUniqueAttribute(typeof(JsonExtensionDataAttribute), cache);
             if (jsonPropertyInfo != null)
             {
                 Type declaredPropertyType = jsonPropertyInfo.DeclaredPropertyType;
@@ -188,7 +188,7 @@ namespace System.Text.Json
             return false;
         }
 
-        private JsonPropertyInfo GetPropertyThatHasAttribute(Type attributeType, Dictionary<string, JsonPropertyInfo> cache)
+        private JsonPropertyInfo GetPropertyWithUniqueAttribute(Type attributeType, Dictionary<string, JsonPropertyInfo> cache)
         {
             JsonPropertyInfo property = null;
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonExtensionDataAttribute.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonExtensionDataAttribute.cs
@@ -11,11 +11,11 @@ namespace System.Text.Json.Serialization
     /// <remarks>
     /// The TKey value must be <see cref="string"/> and TValue must be <see cref="JsonElement"/> or <see cref="object"/>.
     /// 
-    /// During deserializing, when using <see cref="object"/> a "null" JSON value is treated as a null object reference, and when using
-    /// <see cref="JsonElement"/> "null" is treated as a JsonElement with <see cref="JsonElement.ValueKind"/> set to <see cref="JsonValueKind.Null"/>.
+    /// During deserializing, when using <see cref="object"/> a "null" JSON value is treated as a <c>null</c> object reference, and when using
+    /// <see cref="JsonElement"/> a "null" is treated as a JsonElement with <see cref="JsonElement.ValueKind"/> set to <see cref="JsonValueKind.Null"/>.
     /// 
-    /// During serializing, the name of the extension data property is not included in the JSON; the properties are serialized as if
-    /// they were not missing.
+    /// During serializing, the name of the extension data property is not included in the JSON;
+    /// the data contained within the extension data is serialized as properties of the JSON object.
     /// 
     /// If there is more than one extension property on a type, or it the property is not of the correct type,
     /// an <see cref="InvalidOperationException"/> is thrown during the first serialization or deserialization of that type.

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonExtensionDataAttribute.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonExtensionDataAttribute.cs
@@ -10,6 +10,13 @@ namespace System.Text.Json.Serialization
     /// </summary>
     /// <remarks>
     /// The TKey value must be <see cref="string"/> and TValue must be <see cref="JsonElement"/> or <see cref="object"/>.
+    /// 
+    /// During deserializing, when using <see cref="object"/> a "null" JSON value is treated as a null object reference, and when using
+    /// <see cref="JsonElement"/> "null" is treated as a JsonElement with <see cref="JsonElement.ValueKind"/> set to <see cref="JsonValueKind.Null"/>.
+    /// 
+    /// During serializing, the name of the extension data property is not included in the JSON; the properties are serialized as if
+    /// they were not missing.
+    /// 
     /// If there is more than one extension property on a type, or it the property is not of the correct type,
     /// an <see cref="InvalidOperationException"/> is thrown during the first serialization or deserialization of that type.
     /// </remarks>

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -38,6 +38,7 @@ namespace System.Text.Json
         {
             other.EscapedName = EscapedName;
             other.Name = Name;
+            other.NameAsString = NameAsString;
             other.PropertyNameKey = PropertyNameKey;
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleArray.cs
@@ -51,13 +51,9 @@ namespace System.Text.Json
 
                 state.Push();
                 state.Current.Initialize(elementType, options);
-                state.Current.CollectionPropertyInitialized = true;
-            }
-            else
-            {
-                state.Current.CollectionPropertyInitialized = true;
             }
 
+            state.Current.CollectionPropertyInitialized = true;
             jsonPropertyInfo = state.Current.JsonPropertyInfo;
 
             if (state.Current.JsonClassInfo.ClassType == ClassType.Value)
@@ -122,7 +118,7 @@ namespace System.Text.Json
             else if (state.Current.IsEnumerableProperty)
             {
                 // We added the items to the list already.
-                state.Current.ResetProperty();
+                state.Current.EndProperty();
                 return false;
             }
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -53,6 +53,7 @@ namespace System.Text.Json
                     }
                     state.Current.ReturnValue = classInfo.CreateObject();
                 }
+
                 return;
             }
 
@@ -90,14 +91,14 @@ namespace System.Text.Json
             if (state.Current.IsDictionaryProperty)
             {
                 // We added the items to the dictionary already.
-                state.Current.ResetProperty();
+                state.Current.EndProperty();
             }
             else if (state.Current.IsIDictionaryConstructibleProperty)
             {
                 Debug.Assert(state.Current.TempDictionaryValues != null);
                 JsonDictionaryConverter converter = state.Current.JsonPropertyInfo.DictionaryConverter;
                 state.Current.JsonPropertyInfo.SetValueAsObject(state.Current.ReturnValue, converter.CreateFromDictionary(ref state, state.Current.TempDictionaryValues, options));
-                state.Current.ResetProperty();
+                state.Current.EndProperty();
             }
             else
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -34,10 +34,9 @@ namespace System.Text.Json
 
             if (state.Current.IsCollectionForProperty)
             {
-                bool addElement = state.Current.CollectionPropertyInitialized;
-
-                if (addElement)
+                if (state.Current.CollectionPropertyInitialized)
                 {
+                    // Add the element.
                     AddNullToCollection(jsonPropertyInfo, ref reader, ref state);
                 }
                 else

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleNull.cs
@@ -8,44 +8,55 @@ namespace System.Text.Json
 {
     public static partial class JsonSerializer
     {
-        private static bool HandleNull(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
+        private static bool HandleNull(ref Utf8JsonReader reader, ref ReadStack state)
         {
             if (state.Current.SkipProperty)
             {
                 return false;
             }
 
-            // If null is read at the top level and the type is nullable, then the root is "null" so just return.
-            if (reader.CurrentDepth == 0 && (state.Current.JsonPropertyInfo == null || state.Current.JsonPropertyInfo.CanBeNull))
+            JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
+
+            if (jsonPropertyInfo == null || (reader.CurrentDepth == 0 && jsonPropertyInfo.CanBeNull))
             {
                 Debug.Assert(state.IsLastFrame);
                 Debug.Assert(state.Current.ReturnValue == null);
                 return true;
             }
 
-            JsonPropertyInfo propertyInfo = state.Current.JsonPropertyInfo;
-            if (!propertyInfo.CanBeNull)
-            {
-                ThrowHelper.ThrowJsonException_DeserializeCannotBeNull(reader, state.JsonPath);
-            }
+            Debug.Assert(jsonPropertyInfo != null);
 
-            if (state.Current.IsEnumerable || state.Current.IsDictionary || state.Current.IsIDictionaryConstructible)
+            if (state.Current.IsCollectionForClass)
             {
-                ApplyObjectToEnumerable(null, ref state, ref reader);
+                AddNullToCollection(jsonPropertyInfo, ref reader, ref state);
                 return false;
             }
 
-            if (state.Current.IsEnumerableProperty || state.Current.IsDictionaryProperty || state.Current.IsIDictionaryConstructibleProperty)
+            if (state.Current.IsCollectionForProperty)
             {
-                bool setPropertyToNull = !state.Current.CollectionPropertyInitialized;
-                ApplyObjectToEnumerable(null, ref state, ref reader, setPropertyDirectly: setPropertyToNull);
+                bool addElement = state.Current.CollectionPropertyInitialized;
 
-                if (setPropertyToNull)
+                if (addElement)
                 {
-                    // The property itself was set to null, in which case we should
-                    // reset so that `Is*Property` no longer returns true
-                    state.Current.ResetProperty();
+                    AddNullToCollection(jsonPropertyInfo, ref reader, ref state);
                 }
+                else
+                {
+                    // Set the property to null.
+                    ApplyObjectToEnumerable(null, ref state, ref reader, setPropertyDirectly: true);
+
+                    // Reset so that `Is*Property` no longer returns true
+                    state.Current.EndProperty();
+                }
+
+                return false;
+            }
+
+            if (!jsonPropertyInfo.CanBeNull)
+            {
+                // Allow a value type converter to return a null value representation, such as JsonElement.
+                // Most likely this will throw JsonException.
+                jsonPropertyInfo.Read(JsonTokenType.Null, ref state, ref reader);
                 return false;
             }
 
@@ -55,12 +66,31 @@ namespace System.Text.Json
                 return true;
             }
 
-            if (!propertyInfo.IgnoreNullValues)
+            if (!jsonPropertyInfo.IgnoreNullValues)
             {
                 state.Current.JsonPropertyInfo.SetValueAsObject(state.Current.ReturnValue, value : null);
             }
 
             return false;
+        }
+
+        private static void AddNullToCollection(JsonPropertyInfo jsonPropertyInfo, ref Utf8JsonReader reader, ref ReadStack state)
+        {
+            JsonPropertyInfo elementPropertyInfo = jsonPropertyInfo.ElementClassInfo.PolicyProperty;
+
+            // if elementPropertyInfo == null then this element doesn't need a converter (an object).
+
+            if (elementPropertyInfo?.CanBeNull == false)
+            {
+                // Allow a value type converter to return a null value representation.
+                // Most likely this will throw JsonException unless the converter has special logic (like converter for JsonElement).
+                elementPropertyInfo.ReadEnumerable(JsonTokenType.Null, ref state, ref reader);
+            }
+            else
+            {
+                // Assume collection types are reference types and can have null assigned.
+                ApplyObjectToEnumerable(null, ref state, ref reader);
+            }
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -23,47 +23,32 @@ namespace System.Text.Json
             Debug.Assert(state.Current.ReturnValue != default || state.Current.TempDictionaryValues != default);
             Debug.Assert(state.Current.JsonClassInfo != default);
 
-            if (state.Current.IsProcessingDictionary || state.Current.IsProcessingIDictionaryConstructible)
+            if ((state.Current.IsProcessingDictionary || state.Current.IsProcessingIDictionaryConstructible) &&
+                state.Current.JsonClassInfo.DataExtensionProperty != state.Current.JsonPropertyInfo)
             {
-                if (ReferenceEquals(state.Current.JsonClassInfo.DataExtensionProperty, state.Current.JsonPropertyInfo))
+                string keyName = reader.GetString();
+
+                if (options.DictionaryKeyPolicy != null)
                 {
-                    ReadOnlySpan<byte> propertyName = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
-
-                    // todo: use a cleaner call to get the unescaped string once https://github.com/dotnet/corefx/issues/35386 is implemented.
-                    if (reader._stringHasEscaping)
-                    {
-                        int idx = propertyName.IndexOf(JsonConstants.BackSlash);
-                        Debug.Assert(idx != -1);
-                        propertyName = GetUnescapedString(propertyName, idx);
-                    }
-
-                    ProcessMissingProperty(propertyName, options, ref reader, ref state);
+                    keyName = options.DictionaryKeyPolicy.ConvertName(keyName);
                 }
-                else
+
+                if (state.Current.IsDictionary || state.Current.IsIDictionaryConstructible)
                 {
-                    string keyName = reader.GetString();
-                    if (options.DictionaryKeyPolicy != null)
-                    {
-                        keyName = options.DictionaryKeyPolicy.ConvertName(keyName);
-                    }
-
-                    if (state.Current.IsDictionary || state.Current.IsIDictionaryConstructible)
-                    {
-                        state.Current.JsonPropertyInfo = state.Current.JsonClassInfo.PolicyProperty;
-                    }
-
-                    Debug.Assert(
-                        state.Current.IsDictionary ||
-                        (state.Current.IsDictionaryProperty && state.Current.JsonPropertyInfo != null) ||
-                        state.Current.IsIDictionaryConstructible ||
-                        (state.Current.IsIDictionaryConstructibleProperty && state.Current.JsonPropertyInfo != null));
-
-                    state.Current.KeyName = keyName;
+                    state.Current.JsonPropertyInfo = state.Current.JsonClassInfo.PolicyProperty;
                 }
+
+                Debug.Assert(
+                    state.Current.IsDictionary ||
+                    (state.Current.IsDictionaryProperty && state.Current.JsonPropertyInfo != null) ||
+                    state.Current.IsIDictionaryConstructible ||
+                    (state.Current.IsIDictionaryConstructibleProperty && state.Current.JsonPropertyInfo != null));
+
+                state.Current.KeyName = keyName;
             }
             else
             {
-                state.Current.ResetProperty();
+                state.Current.EndProperty();
 
                 ReadOnlySpan<byte> propertyName = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan;
                 if (reader._stringHasEscaping)
@@ -73,27 +58,35 @@ namespace System.Text.Json
                     propertyName = GetUnescapedString(propertyName, idx);
                 }
 
-                state.Current.JsonPropertyInfo = state.Current.JsonClassInfo.GetProperty(propertyName, ref state.Current);
-                if (state.Current.JsonPropertyInfo == null)
+                JsonPropertyInfo jsonPropertyInfo = state.Current.JsonClassInfo.GetProperty(propertyName, ref state.Current);
+                if (jsonPropertyInfo == null)
                 {
-                    if (state.Current.JsonClassInfo.DataExtensionProperty == null)
+                    JsonPropertyInfo dataExtProperty = state.Current.JsonClassInfo.DataExtensionProperty;
+                    if (dataExtProperty == null)
                     {
                         state.Current.JsonPropertyInfo = JsonPropertyInfo.s_missingProperty;
                     }
                     else
                     {
-                        ProcessMissingProperty(propertyName, options, ref reader, ref state);
+                        state.Current.JsonPropertyInfo = dataExtProperty;
+                        state.Current.JsonPropertyName = propertyName.ToArray();
+                        state.Current.KeyName = JsonHelpers.Utf8GetString(propertyName);
+                        state.Current.CollectionPropertyInitialized = true;
+
+                        CreateDataExtensionProperty(dataExtProperty, ref state);
                     }
                 }
                 else
                 {
                     // Support JsonException.Path.
                     Debug.Assert(
-                        state.Current.JsonPropertyInfo.JsonPropertyName == null ||
+                        jsonPropertyInfo.JsonPropertyName == null ||
                         options.PropertyNameCaseInsensitive ||
-                        propertyName.SequenceEqual(state.Current.JsonPropertyInfo.JsonPropertyName));
+                        propertyName.SequenceEqual(jsonPropertyInfo.JsonPropertyName));
 
-                    if (state.Current.JsonPropertyInfo.JsonPropertyName == null)
+                    state.Current.JsonPropertyInfo = jsonPropertyInfo;
+
+                    if (jsonPropertyInfo.JsonPropertyName == null)
                     {
                         byte[] propertyNameArray = propertyName.ToArray();
                         if (options.PropertyNameCaseInsensitive)
@@ -114,17 +107,10 @@ namespace System.Text.Json
             }
         }
 
-        private static void ProcessMissingProperty(
-            ReadOnlySpan<byte> unescapedPropertyName,
-            JsonSerializerOptions options,
-            ref Utf8JsonReader reader,
+        private static void CreateDataExtensionProperty(
+            JsonPropertyInfo jsonPropertyInfo,
             ref ReadStack state)
         {
-            // Remember the property name to support Path.
-            state.Current.JsonPropertyName = unescapedPropertyName.ToArray();
-
-            JsonPropertyInfo jsonPropertyInfo = state.Current.JsonClassInfo.DataExtensionProperty;
-
             Debug.Assert(jsonPropertyInfo != null);
             Debug.Assert(state.Current.ReturnValue != null);
 
@@ -143,17 +129,7 @@ namespace System.Text.Json
                 jsonPropertyInfo.SetValueAsObject(state.Current.ReturnValue, extensionData);
             }
 
-            JsonElement jsonElement;
-            using (JsonDocument jsonDocument = JsonDocument.ParseValue(ref reader))
-            {
-                jsonElement = jsonDocument.RootElement.Clone();
-            }
-
-            string keyName = JsonHelpers.Utf8GetString(unescapedPropertyName);
-
-            // Currently we don't apply any naming policy. If we do, we'd have to pass it onto the JsonDocument.
-
-            extensionData.Add(keyName, jsonElement);
+            // We don't add the value to the dictionary here because we need to support the read-ahead functionality for Streams.
         }
     }
 }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.cs
@@ -60,7 +60,7 @@ namespace System.Text.Json
                             readStack.Push();
                             readStack.Current.Drain = true;
                         }
-                        else if (readStack.Current.IsProcessingValue(tokenType))
+                        else if (readStack.Current.IsProcessingValue())
                         {
                             if (!HandleObjectAsValue(tokenType, options, ref reader, ref readStack, ref initialState, initialBytesConsumed))
                             {
@@ -94,7 +94,7 @@ namespace System.Text.Json
                     }
                     else if (tokenType == JsonTokenType.StartArray)
                     {
-                        if (!readStack.Current.IsProcessingValue(tokenType))
+                        if (!readStack.Current.IsProcessingValue())
                         {
                             HandleStartArray(options, ref reader, ref readStack);
                         }
@@ -110,7 +110,7 @@ namespace System.Text.Json
                     }
                     else if (tokenType == JsonTokenType.Null)
                     {
-                        HandleNull(ref reader, ref readStack, options);
+                        HandleNull(ref reader, ref readStack);
                     }
                 }
             }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -43,7 +43,10 @@ namespace System.Text.Json
                     state.Current.CollectionEnumerator = enumerable.GetEnumerator();
                 }
 
-                state.Current.WriteObjectOrArrayStart(ClassType.Dictionary, writer);
+                if (state.Current.ExtensionDataStatus != ExtensionDataWriteStatus.Writing)
+                {
+                    state.Current.WriteObjectOrArrayStart(ClassType.Dictionary, writer);
+                }
             }
 
             if (state.Current.CollectionEnumerator.MoveNext())
@@ -76,7 +79,14 @@ namespace System.Text.Json
             }
 
             // We are done enumerating.
-            writer.WriteEndObject();
+            if (state.Current.ExtensionDataStatus == ExtensionDataWriteStatus.Writing)
+            {
+                state.Current.ExtensionDataStatus = ExtensionDataWriteStatus.Finished;
+            }
+            else
+            {
+                writer.WriteEndObject();
+            }
 
             if (state.Current.PopStackOnEndCollection)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -175,7 +175,9 @@ namespace System.Text.Json
                 VerifyMutable();
 
                 if (value < 0)
+                {
                     throw ThrowHelper.GetArgumentOutOfRangeException_MaxDepthMustBePositive(nameof(value));
+                }
 
                 _maxDepth = value;
                 EffectiveMaxDepth = (value == 0 ? JsonReaderOptions.DefaultMaxDepth : value);

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -42,12 +42,6 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowJsonException_DeserializeCannotBeNull(in Utf8JsonReader reader, string path)
-        {
-            ThrowJsonException(SR.DeserializeCannotBeNull, in reader, path);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_DepthTooLarge(int currentDepth, in WriteStack writeStack, JsonSerializerOptions options)
         {
             var ex = new JsonException(SR.Format(SR.DepthTooLarge, currentDepth, options.EffectiveMaxDepth));

--- a/src/System.Text.Json/tests/NewtonsoftTests/JsonSerializerTests.cs
+++ b/src/System.Text.Json/tests/NewtonsoftTests/JsonSerializerTests.cs
@@ -26,7 +26,6 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
 using Xunit;
 
 namespace System.Text.Json.Tests
@@ -41,7 +40,7 @@ namespace System.Text.Json.Tests
         [Fact]
         public void DeserializeBoolean_Null()
         {
-            Assert.Throws<ArgumentNullException>(
+            Assert.Throws<JsonException>(
                 () => JsonSerializer.Deserialize<IList<bool>>(@"[null]"));
         }
 

--- a/src/System.Text.Json/tests/Serialization/CustomConverterTests.NullValueType.cs
+++ b/src/System.Text.Json/tests/Serialization/CustomConverterTests.NullValueType.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static partial class CustomConverterTests
+    {
+        /// <summary>
+        /// Allow a conversion of "null" to a 0 value.
+        /// </summary>
+        private class Int32NullConverter : JsonConverter<int>
+        {
+            public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                {
+                    return 0;
+                }
+
+                return reader.GetInt32();
+            }
+
+            public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+            {
+                writer.WriteNumberValue(value);
+            }
+        }
+
+        [Fact]
+        public static void ValueTypeConverterForNull()
+        {
+            // Baseline
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>("null"));
+            Assert.Equal(1, JsonSerializer.Deserialize<int>("1"));
+
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new Int32NullConverter());
+
+            Assert.Equal(0, JsonSerializer.Deserialize<int>("null", options));
+            Assert.Equal(1, JsonSerializer.Deserialize<int>("1", options));
+        }
+
+        [Fact]
+        public static void ValueTypeConverterForNullWithArray()
+        {
+            const string json = "[null, 1, null]";
+
+            // Baseline
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int[]>(json));
+
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new Int32NullConverter());
+
+            int[] arr = JsonSerializer.Deserialize<int[]>(json, options);
+            Assert.Equal(0, arr[0]);
+            Assert.Equal(1, arr[1]);
+            Assert.Equal(0, arr[2]);
+        }
+    }
+}

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -166,7 +166,7 @@ namespace System.Text.Json.Serialization.Tests
             public Dictionary<string, int> MyOverflow { get; set; }
         }
 
-        private class ClassWithTwoExtensionPropertys
+        private class ClassWithTwoExtensionProperties
         {
             [JsonExtensionData]
             public Dictionary<string, object> MyOverflow1 { get; set; }
@@ -183,7 +183,7 @@ namespace System.Text.Json.Serialization.Tests
             JsonSerializer.Deserialize<ClassWithExtensionPropertyAsObject>(@"{}");
 
             Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithInvalidExtensionProperty>(@"{}"));
-            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithTwoExtensionPropertys>(@"{}"));
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithTwoExtensionProperties>(@"{}"));
         }
 
         private class ClassWithIgnoredData

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -34,6 +34,9 @@ namespace System.Text.Json.Serialization.Tests
                 string json = JsonSerializer.Serialize(obj);
                 obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(json);
                 Verify();
+
+                // The json should not contain the dictionary name.
+                Assert.DoesNotContain(nameof(ClassWithExtensionProperty.MyOverflow), json);
             }
 
             void Verify()
@@ -126,7 +129,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void NullValuesIgnored()
         {
             const string json = @"{""MyNestedClass"":null}";
-            const string jsonMissing = @"{ ""MyNestedClassMissing"":null}";
+            const string jsonMissing = @"{""MyNestedClassMissing"":null}";
 
             {
                 // Baseline with no missing.
@@ -157,6 +160,21 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
+        private class ClassWithInvalidExtensionProperty
+        {
+            [JsonExtensionData]
+            public Dictionary<string, int> MyOverflow { get; set; }
+        }
+
+        private class ClassWithTwoExtensionPropertys
+        {
+            [JsonExtensionData]
+            public Dictionary<string, object> MyOverflow1 { get; set; }
+
+            [JsonExtensionData]
+            public Dictionary<string, object> MyOverflow2 { get; set; }
+        }
+
         [Fact]
         public static void InvalidExtensionPropertyFail()
         {
@@ -166,6 +184,15 @@ namespace System.Text.Json.Serialization.Tests
 
             Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithInvalidExtensionProperty>(@"{}"));
             Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWithTwoExtensionPropertys>(@"{}"));
+        }
+
+        private class ClassWithIgnoredData
+        {
+            [JsonExtensionData]
+            public Dictionary<string, object> MyOverflow { get; set; }
+
+            [JsonIgnore]
+            public int MyInt { get; set; }
         }
 
         [Fact]
@@ -180,9 +207,72 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ExtensionPropertyObjectValue_Empty()
         {
-            // Baseline
             ClassWithExtensionPropertyAlreadyInstantiated obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAlreadyInstantiated>(@"{}");
-            Assert.Equal(@"{""MyOverflow"":{}}", JsonSerializer.Serialize(obj));
+            Assert.Equal(@"{}", JsonSerializer.Serialize(obj));
+        }
+
+        [Fact]
+        public static void ExtensionPropertyObjectValue_SameAsExtensionPropertyName()
+        {
+            const string json = @"{""MyOverflow"":{""Key1"":""V""}}";
+
+            // Deserializing directly into the overflow is not supported by design.
+            ClassWithExtensionPropertyAsObject obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsObject>(json);
+
+            // The JSON is treated as normal overflow.
+            Assert.NotNull(obj.MyOverflow["MyOverflow"]);
+            Assert.Equal(json, JsonSerializer.Serialize(obj));
+        }
+
+        private class ClassWithExtensionPropertyAsObjectAndNameProperty
+        {
+            public string Name { get; set; }
+
+            [JsonExtensionData]
+            public Dictionary<string, object> MyOverflow { get; set; }
+        }
+
+        [Fact]
+        public static void ExtensionPropertyDuplicateNames()
+        {
+            var obj = new ClassWithExtensionPropertyAsObjectAndNameProperty();
+            obj.Name = "Name1";
+
+            obj.MyOverflow = new Dictionary<string, object>();
+            obj.MyOverflow["Name"] = "Name2";
+
+            string json = JsonSerializer.Serialize(obj);
+            Assert.Equal(@"{""Name"":""Name1"",""Name"":""Name2""}", json);
+
+            // The overflow value comes last in the JSOn so it overwrites the original value.
+            obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsObjectAndNameProperty>(json);
+            Assert.Equal("Name2", obj.Name);
+
+            // Since there was no overflow, this should be null.
+            Assert.Null(obj.MyOverflow);
+        }
+
+        [Fact]
+        public static void NullAsNullObjectOrJsonValueKindNull()
+        {
+            const string json = @"{""MissingProperty"":null}";
+
+            {
+                ClassWithExtensionPropertyAsObject obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsObject>(json);
+
+                // A null value maps to <object>, so the value is null.
+                object elem = obj.MyOverflow["MissingProperty"];
+                Assert.Null(elem);
+            }
+
+            {
+                ClassWithExtensionPropertyAsJsonElement obj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAsJsonElement>(json);
+
+                // Since JsonElement is a struct, it treats null as JsonValueKind.Null.
+                object elem = obj.MyOverflow["MissingProperty"];
+                Assert.IsType<JsonElement>(elem);
+                Assert.Equal(JsonValueKind.Null, ((JsonElement)elem).ValueKind);
+            }
         }
 
         [Fact]
@@ -193,7 +283,17 @@ namespace System.Text.Json.Serialization.Tests
             obj.MyOverflow.Add("test", new object());
             obj.MyOverflow.Add("test1", 1);
 
-            Assert.Equal(@"{""MyOverflow"":{""test"":{},""test1"":1}}", JsonSerializer.Serialize(obj));
+            Assert.Equal(@"{""test"":{},""test1"":1}", JsonSerializer.Serialize(obj));
+        }
+
+        private class DummyObj
+        {
+            public string Prop { get; set; }
+        }
+
+        private struct DummyStruct
+        {
+            public string Prop { get; set; }
         }
 
         [Fact]
@@ -208,7 +308,8 @@ namespace System.Text.Json.Serialization.Tests
             obj.MyOverflow.Add("test4", new DummyStruct() { Prop = "StructProp" });
             obj.MyOverflow.Add("test5", new Dictionary<string, object>() { { "Key", "Value" }, { "Key1", "Value1" }, });
 
-            ClassWithExtensionPropertyAlreadyInstantiated roundTripObj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAlreadyInstantiated>(JsonSerializer.Serialize(obj));
+            string json = JsonSerializer.Serialize(obj);
+            ClassWithExtensionPropertyAlreadyInstantiated roundTripObj = JsonSerializer.Deserialize<ClassWithExtensionPropertyAlreadyInstantiated>(json);
 
             Assert.Equal(6, roundTripObj.MyOverflow.Count);
 
@@ -237,6 +338,14 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("Value1", ((JsonElement)roundTripObj.MyOverflow["test5"]).GetProperty("Key1").GetString());
         }
 
+        private class ClassWithReference
+        {
+            [JsonExtensionData]
+            public Dictionary<string, JsonElement> MyOverflow { get; set; }
+
+            public ClassWithExtensionProperty MyReference { get; set; }
+        }
+
         [Fact]
         public static void ObjectTree()
         {
@@ -254,6 +363,18 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(3, child.MyOverflow["MyIntMissingChild"].GetInt32());
         }
 
+        private class ClassWithInvalidExtensionPropertyStringString
+        {
+            [JsonExtensionData]
+            public Dictionary<string, string> MyOverflow { get; set; }
+        }
+
+        private class ClassWithInvalidExtensionPropertyObjectString
+        {
+            [JsonExtensionData]
+            public Dictionary<DummyObj, string> MyOverflow { get; set; }
+        }
+
         [Fact]
         public static void ExtensionProperty_InvalidDictionary()
         {
@@ -264,17 +385,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<NotSupportedException>(() => JsonSerializer.Serialize(obj2));
         }
 
-        public class DummyObj
-        {
-            public string Prop { get; set; }
-        }
-
-        public struct DummyStruct
-        {
-            public string Prop { get; set; }
-        }
-
-        public class ClassWithExtensionPropertyAlreadyInstantiated
+        private class ClassWithExtensionPropertyAlreadyInstantiated
         {
             public ClassWithExtensionPropertyAlreadyInstantiated()
             {
@@ -285,54 +396,16 @@ namespace System.Text.Json.Serialization.Tests
             public Dictionary<string, object> MyOverflow { get; set; }
         }
 
-        public class ClassWithExtensionPropertyAsObject
+        private class ClassWithExtensionPropertyAsObject
         {
             [JsonExtensionData]
             public Dictionary<string, object> MyOverflow { get; set; }
         }
 
-        public class ClassWithIgnoredData
-        {
-            [JsonExtensionData]
-            public Dictionary<string, object> MyOverflow { get; set; }
-
-            [JsonIgnore]
-            public int MyInt { get; set; }
-        }
-
-        public class ClassWithInvalidExtensionProperty
-        {
-            [JsonExtensionData]
-            public Dictionary<string, int> MyOverflow { get; set; }
-        }
-
-        public class ClassWithInvalidExtensionPropertyStringString
-        {
-            [JsonExtensionData]
-            public Dictionary<string, string> MyOverflow { get; set; }
-        }
-
-        public class ClassWithInvalidExtensionPropertyObjectString
-        {
-            [JsonExtensionData]
-            public Dictionary<DummyObj, string> MyOverflow { get; set; }
-        }
-
-        public class ClassWithTwoExtensionPropertys
-        {
-            [JsonExtensionData]
-            public Dictionary<string, object> MyOverflow1 { get; set; }
-
-            [JsonExtensionData]
-            public Dictionary<string, object> MyOverflow2 { get; set; }
-        }
-
-        public class ClassWithReference
+        private class ClassWithExtensionPropertyAsJsonElement
         {
             [JsonExtensionData]
             public Dictionary<string, JsonElement> MyOverflow { get; set; }
-
-            public ClassWithExtensionProperty MyReference { get; set; }
         }
     }
 }

--- a/src/System.Text.Json/tests/Serialization/JsonElementTests.cs
+++ b/src/System.Text.Json/tests/Serialization/JsonElementTests.cs
@@ -34,7 +34,7 @@ namespace System.Text.Json.Serialization.Tests
             public JsonElement String { get; set; }
             public JsonElement Array { get; set; }
             public JsonElement Object { get; set; }
-            // public JsonElement Null { get; set; }
+            public JsonElement Null { get; set; }
 
             public static readonly string s_json =
                 @"{" +
@@ -43,9 +43,8 @@ namespace System.Text.Json.Serialization.Tests
                     @"""False"" : false," +
                     @"""String"" : ""Hello""," +
                     @"""Array"" : [2, false, true, ""Goodbye""]," +
-                    @"""Object"" : {}" +
-                    // TODO: Null doesn't work yet (but probably should? object gets null in this case)
-                    //@"""Null"" : null" +
+                    @"""Object"" : {}," +
+                    @"""Null"" : null" +
                 @"}";
 
             public static readonly byte[] s_data = Encoding.UTF8.GetBytes(s_json);
@@ -58,7 +57,7 @@ namespace System.Text.Json.Serialization.Tests
                 String = JsonDocument.Parse(@"""Hello""").RootElement.Clone();
                 Array = JsonDocument.Parse(@"[2, false, true, ""Goodbye""]").RootElement.Clone();
                 Object = JsonDocument.Parse(@"{}").RootElement.Clone();
-                // Null = JsonDocument.Parse(@"null").RootElement.Clone();
+                Null = JsonDocument.Parse(@"null").RootElement.Clone();
             }
 
             public void Verify()
@@ -83,8 +82,8 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal("Goodbye", elements[3].ToString());
                 Assert.Equal(JsonValueKind.Object, Object.ValueKind);
                 Assert.Equal("{}", Object.ToString());
-                //Assert.Equal(JsonValueKind.Null, Null.ValueKind);
-                //Assert.Equal("Null", Null.ToString());
+                Assert.Equal(JsonValueKind.Null, Null.ValueKind);
+                Assert.Equal("", Null.ToString()); // JsonElement returns empty string for null.
             }
         }
 
@@ -114,10 +113,9 @@ namespace System.Text.Json.Serialization.Tests
                         @"1, " +
                         @"true, " +
                         @"false, " +
-                        @"""Hello""" +
-                        // TODO: Nested complex objects aren't handled by the collection code yet.
-                        // @"[2, false, true, ""Goodbye""], " +
-                        // @"{}" +
+                        @"""Hello""," +
+                        @"[2, false, true, ""Goodbye""]," +
+                        @"{}" +
                     @"]" +
                 @"}";
 

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Serialization\CustomConverterTests.Exceptions.cs" />
     <Compile Include="Serialization\CustomConverterTests.Int32.cs" />
     <Compile Include="Serialization\CustomConverterTests.List.cs" />
+    <Compile Include="Serialization\CustomConverterTests.NullValueType.cs" />
     <Compile Include="Serialization\CustomConverterTests.Object.cs" />
     <Compile Include="Serialization\CustomConverterTests.Point.cs" />
     <Compile Include="Serialization\CustomConverterTests.Polymorphic.cs" />


### PR DESCRIPTION
Change the semantics of extension data so that extension data JSON is not nested under the property name containing the extension data; instead the JSON appears as if the property was not missing.

Fixes https://github.com/dotnet/corefx/issues/38769

Also fixed:
- A `JsonElement` can be deserialized from a "null" literal. A `JsonElement` is a struct, so internally its `ValueKind` property will be `JsonValueKind.Null`. Previous tests that were commented out are now active.
  - The generalized support is that it is now possible to have a struct handle `TokenType.Null`. A test was added for an Int32 converter to treat "null" as a value of 0.
- Extension data will now always work with read-ahead functionality used with Streams. Tests were added.

TODO: sync with this [PR ](https://github.com/dotnet/corefx/pull/39032)to ensure the dictionary naming policy or property naming policy doesn't change the property names in the extension data.