### PR TITLE
Lookup OID if only friendly name is specified for ECCurve

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECCurve.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECCurve.cs
@@ -142,7 +142,21 @@ namespace System.Security.Cryptography
 
         private static ECCurve CreateFromValueAndName(string oidValue, string oidFriendlyName)
         {
-            return ECCurve.Create(new Oid(oidValue, oidFriendlyName));
+            Oid oid = null;
+
+            if (oidValue is null && oidFriendlyName is object)
+            {
+                try
+                {
+                    oid = Oid.FromFriendlyName(oidFriendlyName, OidGroup.All);
+                }
+                catch (CryptographicException)
+                {
+                }
+            }
+
+            oid ??= new Oid(oidValue, oidFriendlyName);
+            return ECCurve.Create(oid);
         }
 
         public bool IsPrime

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECCurve.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECCurve.cs
@@ -144,11 +144,11 @@ namespace System.Security.Cryptography
         {
             Oid oid = null;
 
-            if (oidValue is null && oidFriendlyName is object)
+            if (oidValue == null && oidFriendlyName != null)
             {
                 try
                 {
-                    oid = Oid.FromFriendlyName(oidFriendlyName, OidGroup.All);
+                    oid = Oid.FromFriendlyName(oidFriendlyName, OidGroup.PublicKeyAlgorithm);
                 }
                 catch (CryptographicException)
                 {

--- a/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
@@ -256,6 +256,25 @@ namespace System.Security.Cryptography.EcDsa.OpenSsl.Tests
             Assert.Equal(ECDSA_P256_OID_VALUE, param.Curve.Oid.Value);
         }
 
+        [Theory]
+        [InlineData("ECDSA_P521")]
+        [InlineData("ECDSA_P384")]
+        [InlineData("ECDSA_P256")]
+        public void LookupCurveByOidWindowsFriendlyName(string friendlyName)
+        {
+            ECDsaOpenSsl ec = new ECDsaOpenSsl(ECCurve.CreateFromFriendlyName(friendlyName));
+            ECParameters param = ec.ExportParameters(false);
+            param.Validate();
+        }
+
+        [Fact]
+        public void LookupCurveByOidWithInvalidThrowsPlatformNotSupported()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => {
+                new ECDsaOpenSsl(ECCurve.CreateFromFriendlyName("Invalid"));
+            });
+        }
+
         [Fact]
         public void LookupCurveByOidFriendlyName()
         {


### PR DESCRIPTION
Fixes #32323

When constructing an EC curve from the friendly name of an OID, the "Windows" friendly name lookup table was not used, so those friendly names would not work on Linux / macOS.

This resolves the OID's value from the friendly name first. If it fails, it continues as-it-was so that the original exception behavior of `PlatformNotSupportedException` is preserved.

This uses `OidGroup.All` so that Windows will use the cache to avoid hitting `FindOidInfo` when possible which comes with a penalty on Windows. The ECC implementation should still appropriately handle the scenario where a curve OID was created that is invalid.

/cc @bartonjs 