### PR TITLE
enable request retry when receiving REFUSED_STREAM protocol error

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -643,7 +643,14 @@ namespace System.Net.Http
 
             _incomingBuffer.Discard(frameHeader.Length);
 
-            http2Stream.OnResponseAbort(new Http2ProtocolException(protocolError));
+            if (protocolError == Http2ProtocolErrorCode.RefusedStream)
+            {
+                http2Stream.OnRefused();
+            }
+            else
+            {
+                http2Stream.OnAbort(new Http2ProtocolException(protocolError));
+            }
 
             RemoveStream(http2Stream);
         }
@@ -1289,7 +1296,7 @@ namespace System.Net.Http
 
                     if (streamId > lastValidStream)
                     {
-                        kvp.Value.OnResponseAbort(abortException);
+                        kvp.Value.OnAbort(abortException);
 
                         _httpStreams.Remove(kvp.Value.StreamId);
                     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1049,7 +1049,7 @@ namespace System.Net.Http
                     ExceptionDispatchInfo.Throw(_abortException);
                 }
 
-                throw new HttpRequestException(null, null, allowRetry: true);
+                throw CreateRetryException();
             }
 
             Http2Stream http2Stream = null;
@@ -1571,7 +1571,7 @@ namespace System.Net.Http
                     // We run out of IDs or we have race condition between receiving GOAWAY and processing requests.
                     // Throw a retryable request exception. This will cause retry logic to kick in
                     // and perform another connection attempt. The user should never see this exception.
-                    throw new HttpRequestException(null, null, allowRetry: true);
+                    throw HttpConnectionBase.CreateRetryException();
                 }
 
                 int streamId = _nextStream;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -94,8 +94,6 @@ namespace System.Net.Http
 
                 _headerBudgetRemaining = connection._pool.Settings._maxResponseHeadersLength * 1024;
 
-                _canRetry = false;
-
                 if (NetEventSource.IsEnabled) Trace($"{request}, {nameof(initialWindowSize)}={initialWindowSize}");
             }
 
@@ -513,10 +511,7 @@ namespace System.Net.Http
                 {
                     if (_canRetry)
                     {
-                        // Throw a retryable request exception.
-                        // This will cause retry logic to kick in and perform another connection attempt.
-                        // The user should never see this exception. 
-                        throw new HttpRequestException(null, null, allowRetry: true);
+                        throw CreateRetryException();
                     }
 
                     throw new IOException(SR.net_http_request_aborted, _abortException);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -46,6 +46,16 @@ namespace System.Net.Http
             return expired;
         }
 
+        internal static HttpRequestException CreateRetryException()
+        {
+            // This is an exception that's thrown during request processing to indicate that the 
+            // attempt to send the request failed in such a manner that the server is guaranteed to not have 
+            // processed the request in any way, and thus the request can be retried.
+            // This will be caught in HttpConnectionPool.SendWithRetryAsync and the retry logic will kick in.
+            // The user should never see this exception. 
+            throw new HttpRequestException(null, null, allowRetry: true);
+        }
+
         internal static bool IsDigit(byte c) => (uint)(c - '0') <= '9' - '0';
 
         /// <summary>Awaits a task, ignoring any resulting exceptions.</summary>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -294,6 +294,80 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ConditionalFact(nameof(SupportsAlpn))]
+        public async Task GetAsync_StreamRefused_RequestIsRetried()
+        {
+            using (var server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                (_, Http2LoopbackConnection connection) = await EstablishConnectionAndProcessOneRequestAsync(client, server);
+
+                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
+                (int streamId1, HttpRequestData requestData1) = await connection.ReadAndParseRequestHeaderAsync(readBody: true);
+
+                // Send SETTINGS frame to change stream limit to 0, allowing us to send a REFUSED_STREAM error due to the new limit
+                connection.ExpectSettingsAck();
+                Frame frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 0 });
+                await connection.WriteFrameAsync(frame);
+
+                // Send a RST_STREAM with error = REFUSED_STREAM, indicating the request can be retried.
+                frame = new RstStreamFrame(FrameFlags.None, (int)ProtocolErrors.REFUSED_STREAM, streamId1);
+                await connection.WriteFrameAsync(frame);
+
+                await connection.PingPong();
+
+                // Send SETTINGS frame to change stream limit to 1, allowing the request to now be processed
+                connection.ExpectSettingsAck();
+                frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 1 });
+                await connection.WriteFrameAsync(frame);
+
+                // Process retried request
+                (int streamId2, HttpRequestData requestData2) = await connection.ReadAndParseRequestHeaderAsync(readBody: true);
+                await connection.SendDefaultResponseAsync(streamId2);
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsAlpn))]
+        public async Task PostAsync_StreamRefused_RequestIsRetried()
+        {
+            using (var server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                const string Content = "Hello world";
+
+                (_, Http2LoopbackConnection connection) = await EstablishConnectionAndProcessOneRequestAsync(client, server);
+
+                Task<HttpResponseMessage> sendTask = client.PostAsync(server.Address, new StringContent(Content));
+                (int streamId1, HttpRequestData requestData1) = await connection.ReadAndParseRequestHeaderAsync(readBody: true);
+                Assert.Equal(Content, Encoding.UTF8.GetString(requestData1.Body));
+
+                // Send SETTINGS frame to change stream limit to 0, allowing us to send a REFUSED_STREAM error due to the new limit
+                connection.ExpectSettingsAck();
+                Frame frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 0 });
+                await connection.WriteFrameAsync(frame);
+
+                // Send a RST_STREAM with error = REFUSED_STREAM, indicating the request can be retried.
+                frame = new RstStreamFrame(FrameFlags.None, (int)ProtocolErrors.REFUSED_STREAM, streamId1);
+                await connection.WriteFrameAsync(frame);
+
+                await connection.PingPong();
+
+                // Send SETTINGS frame to change stream limit to 1, allowing the request to now be processed
+                connection.ExpectSettingsAck();
+                frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 1 });
+                await connection.WriteFrameAsync(frame);
+
+                // Process retried request
+                (int streamId2, HttpRequestData requestData2) = await connection.ReadAndParseRequestHeaderAsync(readBody: true);
+                Assert.Equal(Content, Encoding.UTF8.GetString(requestData2.Body));
+                await connection.SendDefaultResponseAsync(streamId2);
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
         // This test is based on RFC 7540 section 6.1:
         // "If a DATA frame is received whose stream identifier field is 0x0, the recipient MUST
         // respond with a connection error (Section 5.4.1) of type PROTOCOL_ERROR."
@@ -720,6 +794,7 @@ namespace System.Net.Http.Functional.Tests
         public static IEnumerable<object[]> ValidAndInvalidProtocolErrors() =>
             Enum.GetValues(typeof(ProtocolErrors))
             .Cast<ProtocolErrors>()
+            .Where(e => e != ProtocolErrors.REFUSED_STREAM)     // REFUSED_STREAM allows retry instead of abort, so skip it
             .Concat(new[] { (ProtocolErrors)12345 })
             .Select(p => new object[] { p });
 


### PR DESCRIPTION
Fixes #39005 

The REFUSED_STREAM error code on RST_STREAM indicates that the stream has not been processed and should be retried. This is implemented by throwing a retryable HttpRequestException and using our existing retry logic.

@stephentoub Hopefully this fixes the REFUSED_STREAM errors you've seen...
