### PR TITLE
Remove cancellation token from new System.Data CloseAsync()

### DIFF
--- a/src/System.Data.Common/ref/System.Data.Common.cs
+++ b/src/System.Data.Common/ref/System.Data.Common.cs
@@ -1916,7 +1916,7 @@ namespace System.Data.Common
         public abstract void ChangeDatabase(string databaseName);
         public virtual System.Threading.Tasks.Task ChangeDatabaseAsync(string databaseName, System.Threading.CancellationToken cancellationToken = default) { throw null; }
         public abstract void Close();
-        public virtual System.Threading.Tasks.Task CloseAsync(System.Threading.CancellationToken cancellationToken = default) { throw null; }
+        public virtual System.Threading.Tasks.Task CloseAsync() { throw null; }
         public System.Data.Common.DbCommand CreateCommand() { throw null; }
         protected abstract System.Data.Common.DbCommand CreateDbCommand();
         public virtual void EnlistTransaction(System.Transactions.Transaction transaction) { }
@@ -2062,7 +2062,7 @@ namespace System.Data.Common
         public abstract int RecordsAffected { get; }
         public virtual int VisibleFieldCount { get { throw null; } }
         public virtual void Close() { }
-        public virtual System.Threading.Tasks.Task CloseAsync(System.Threading.CancellationToken cancellationToken = default) { throw null; }
+        public virtual System.Threading.Tasks.Task CloseAsync() { throw null; }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public void Dispose() { }
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }

--- a/src/System.Data.Common/src/System/Data/Common/DbConnection.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbConnection.cs
@@ -88,13 +88,8 @@ namespace System.Data.Common
 
         public abstract void Close();
 
-        public virtual Task CloseAsync(CancellationToken cancellationToken = default)
+        public virtual Task CloseAsync()
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled(cancellationToken);
-            }
-
             try
             {
                 Close();

--- a/src/System.Data.Common/src/System/Data/Common/DbDataReader.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbDataReader.cs
@@ -32,13 +32,8 @@ namespace System.Data.Common
 
         public virtual void Close() { }
 
-        public virtual Task CloseAsync(CancellationToken cancellationToken = default)
+        public virtual Task CloseAsync()
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled(cancellationToken);
-            }
-
             try
             {
                 Close();


### PR DESCRIPTION
Affects DbDataReader and DbConnection, since these APIs are very likely to be used for cleanup only, in which case a cancellation token is an anti-pattern (similar to why DisposeAsync doesn't accept one).

/cc @stephentoub @terrajobst @divega @ajcvickers 

See discussion here: https://github.com/dotnet/standard/pull/1283#pullrequestreview-255383035 (I propose to keep conversation in that issue)

Fixes #39060