### PR TITLE
WaitIdAnyExitedNoHangNoWait: handle waitid returning 0 for no waitable children

### DIFF
--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -638,17 +638,22 @@ void SystemNative_SysLog(SysLogPriority priority, const char* message, const cha
 
 int32_t SystemNative_WaitIdAnyExitedNoHangNoWait()
 {
-    siginfo_t siginfo;
+    siginfo_t siginfo = { 0 };
     int32_t result;
     while (CheckInterrupted(result = waitid(P_ALL, 0, &siginfo, WEXITED | WNOHANG | WNOWAIT)));
-    if (result == -1 && errno == ECHILD)
+    if (result == 0)
+    {
+        // When there are no waitable children and WNOHANG is specified,
+        // waitid may return zero with si_pid unchanged.
+        assert(siginfo.si_pid == 0 ||        // no waitable child
+               siginfo.si_signo == SIGCHLD); // waitable child
+
+        result = siginfo.si_pid;
+    }
+    else if (errno == ECHILD)
     {
         // The calling process has no existing unwaited-for child processes.
         result = 0;
-    }
-    else if (result == 0 && siginfo.si_signo == SIGCHLD)
-    {
-        result = siginfo.si_pid;
     }
     return result;
 }

--- a/src/Native/Unix/System.Native/pal_process.c
+++ b/src/Native/Unix/System.Native/pal_process.c
@@ -638,7 +638,8 @@ void SystemNative_SysLog(SysLogPriority priority, const char* message, const cha
 
 int32_t SystemNative_WaitIdAnyExitedNoHangNoWait()
 {
-    siginfo_t siginfo = { 0 };
+    siginfo_t siginfo;
+    memset(&siginfo, 0, sizeof(siginfo));
     int32_t result;
     while (CheckInterrupted(result = waitid(P_ALL, 0, &siginfo, WEXITED | WNOHANG | WNOWAIT)));
     if (result == 0)


### PR DESCRIPTION
This may fix https://github.com/dotnet/corefx/issues/39060.

@stephentoub ptal