### PR TITLE
Fix MaxResponseHeadersLength assert for value string

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.MaxResponseHeadersLength.cs
@@ -92,7 +92,10 @@ namespace System.Net.Http.Functional.Tests
 
                         Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => getAsync);
                         cts.Cancel();
-                        Assert.Contains((handler.MaxResponseHeadersLength * 1024).ToString(), e.ToString());
+                        if (UseSocketsHttpHandler)
+                        {
+                            Assert.Contains((handler.MaxResponseHeadersLength * 1024).ToString(), e.ToString());
+                        }
                         await serverTask;
                     });
                 }
@@ -133,7 +136,10 @@ namespace System.Net.Http.Functional.Tests
                         else
                         {
                             Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => getAsync);
-                            Assert.Contains((handler.MaxResponseHeadersLength * 1024).ToString(), e.ToString());
+                            if (UseSocketsHttpHandler)
+                            {
+                                Assert.Contains((handler.MaxResponseHeadersLength * 1024).ToString(), e.ToString());
+                            }
                             try { await serverTask; } catch { }
                         }
                     });


### PR DESCRIPTION
I'd fixed the assert message to contain the right value when MaxResponseHeadersLength was exceeded, but this error message isn't used for WinHttpHandler, and thus it doesn't contain the value.  Special-case the check for just SocketsHttpHandler.