### PR TITLE
improve Http2_PendingSend_SendsReset test.

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1502,8 +1502,7 @@ namespace System.Net.Http.Functional.Tests
                  } while (frame.Type != FrameType.RstStream);
 
                  frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds)).ConfigureAwait(false);
-                 // Make sure we do not get any frames after getting RST.
-                 Assert.Null(frame);
+                 Assert.Null(frame);    // Make sure we do not get any frames after getting RST.
             });
         }
 


### PR DESCRIPTION
This adds extra time to make test more resilient to timing.
Note, that this does not increase test duration in normal case.  We will try to cancel as soon as we get request headers and test will finish when we verify proper cancelation. 

fixes #38820

I also added check to verify that we get only one RST and nothing more. 

contributes to #38913 

