### PR TITLE
Font converter implementation made similar to netfx

### DIFF
--- a/src/System.Windows.Extensions/src/Resources/Strings.resx
+++ b/src/System.Windows.Extensions/src/Resources/Strings.resx
@@ -128,6 +128,9 @@
   <data name="none" xml:space="preserve">
     <value>(none)</value>
   </data>
+  <data name="InvalidArgumentValue" xml:space="preserve">
+    <value>Value of '{0}' is not valid for font size unit.</value>
+  </data>
   <data name="PlatformNotSupported_System_Windows_Extensions" xml:space="preserve">
     <value>System.Windows.Extensions types are not supported on this platform.</value>
   </data>

--- a/src/System.Windows.Extensions/src/Resources/Strings.resx
+++ b/src/System.Windows.Extensions/src/Resources/Strings.resx
@@ -125,6 +125,9 @@
   <data name="Enum_InvalidValue" xml:space="preserve">
     <value>Enumeration value '{0}' specified in condition mapping is not valid.</value>
   </data>
+  <data name="InvalidArgument" xml:space="preserve">
+    <value>The argument is invalid.</value>
+  </data>
   <data name="none" xml:space="preserve">
     <value>(none)</value>
   </data>

--- a/src/System.Windows.Extensions/src/Resources/Strings.resx
+++ b/src/System.Windows.Extensions/src/Resources/Strings.resx
@@ -125,9 +125,6 @@
   <data name="Enum_InvalidValue" xml:space="preserve">
     <value>Enumeration value '{0}' specified in condition mapping is not valid.</value>
   </data>
-  <data name="InvalidArgument" xml:space="preserve">
-    <value>The argument is invalid.</value>
-  </data>
   <data name="none" xml:space="preserve">
     <value>(none)</value>
   </data>

--- a/src/System.Windows.Extensions/src/System/Drawing/FontConverter.cs
+++ b/src/System.Windows.Extensions/src/System/Drawing/FontConverter.cs
@@ -14,7 +14,7 @@ namespace System.Drawing
 {
     public class FontConverter : TypeConverter
     {
-        private const string styleHdr = "style=";
+        private const string StyleHdr = "style=";
 
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
@@ -123,30 +123,30 @@ namespace System.Drawing
                 culture = CultureInfo.CurrentCulture;
             }
 
-            char sep = culture.TextInfo.ListSeparator[0]; // For vi-VN: ','
-            string f_name = font; // start with the assumption that only the font name was provided.
+            char separator = culture.TextInfo.ListSeparator[0]; // For vi-VN: ','
+            string fontName = font; // start with the assumption that only the font name was provided.
             string styleStr = null;
             string sizeStr = null;
-            float f_size = 8.25f;
-            FontStyle f_style = FontStyle.Regular;
+            float fontSize = 8.25f;
+            FontStyle fontStyle = FontStyle.Regular;
             GraphicsUnit units = GraphicsUnit.Point;
 
             // Get the index of the first separator (would indicate the end of the name in the string).
-            int nameIndex = font.IndexOf(sep);
+            int nameIndex = font.IndexOf(separator);
 
             if (nameIndex < 0)
             {
-                return new Font(f_name, f_size, f_style, units);
+                return new Font(fontName, fontSize, fontStyle, units);
             }
 
-            // some parameters are provided in addition to name.
-            f_name = font.Substring(0, nameIndex);
+            // Some parameters are provided in addition to name.
+            fontName = font.Substring(0, nameIndex);
 
             if (nameIndex < font.Length - 1)
             {
                 // Get the style index (if any). The size is a bit problematic because it can be formatted differently 
                 // depending on the culture, we'll parse it last.
-                int styleIndex = font.IndexOf(styleHdr, StringComparison.CurrentCultureIgnoreCase);
+                int styleIndex = font.IndexOf(StyleHdr, StringComparison.CurrentCultureIgnoreCase);
 
                 if (styleIndex != -1)
                 {
@@ -154,9 +154,9 @@ namespace System.Drawing
                     styleStr = font.Substring(styleIndex, font.Length - styleIndex);
 
                     // Expected style format ~ "style=Italic, Bold"
-                    if (!styleStr.StartsWith(styleHdr, StringComparison.CurrentCultureIgnoreCase))
+                    if (!styleStr.StartsWith(StyleHdr, StringComparison.CurrentCultureIgnoreCase))
                     {
-                        throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, font, $"name{sep} size[units[{sep} style=style1[{sep} style2{sep} ...]]]"));
+                        throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, font, $"name{separator} size[units[{separator} style=style1[{separator} style2{separator} ...]]]"), nameof(styleStr));
                     }
 
                     // Get the mid-substring containing the size information.
@@ -169,25 +169,25 @@ namespace System.Drawing
                 }
 
                 // Parse size.
-                (string, string) unitTokens = ParseSizeTokens(sizeStr, sep);
+                (string size, string unit) unitTokens = ParseSizeTokens(sizeStr, separator);
 
-                if (unitTokens.Item1 != null)
+                if (unitTokens.size!= null)
                 {
                     try
                     {
-                        f_size = (float)TypeDescriptor.GetConverter(typeof(float)).ConvertFromString(context, culture, unitTokens.Item1);
+                        fontSize = (float)TypeDescriptor.GetConverter(typeof(float)).ConvertFromString(context, culture, unitTokens.size);
                     }
                     catch
                     {
                         // Exception from converter is too generic.
-                        throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, font, $"name{sep} size[units[{sep} style=style1[{sep} style2{sep} ...]]]"));
+                        throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, font, $"name{separator} size[units[{separator} style=style1[{separator} style2{separator} ...]]]"), nameof(sizeStr));
                     }
                 }
 
-                if (unitTokens.Item2 != null)
+                if (unitTokens.unit != null)
                 {
                     // ParseGraphicsUnits throws an ArgumentException if format is invalid.
-                    units = ParseGraphicsUnits(unitTokens.Item2);
+                    units = ParseGraphicsUnits(unitTokens.unit);
                 }
 
                 if (styleStr != null)
@@ -195,26 +195,26 @@ namespace System.Drawing
                     // Parse FontStyle                        
                     int eqIndex = styleStr.IndexOf("=");
                     styleStr = styleStr.Substring(eqIndex + 1);
-                    string[] styleTokens = styleStr.Split(sep);
+                    string[] styleTokens = styleStr.Split(separator);
 
                     for (int tokenCount = 0; tokenCount < styleTokens.Length; tokenCount++)
                     {
                         string styleText = styleTokens[tokenCount];
                         styleText = styleText.Trim();
 
-                        f_style |= (FontStyle)Enum.Parse(typeof(FontStyle), styleText, true);
+                        fontStyle |= (FontStyle)Enum.Parse(typeof(FontStyle), styleText, true);
 
                         // Enum.IsDefined doesn't do what we want on flags enums...
                         FontStyle validBits = FontStyle.Regular | FontStyle.Bold | FontStyle.Italic | FontStyle.Underline | FontStyle.Strikeout;
-                        if ((f_style | validBits) != validBits)
+                        if ((fontStyle | validBits) != validBits)
                         {
-                            throw new InvalidEnumArgumentException(nameof(styleStr), (int)f_style, typeof(FontStyle));
+                            throw new InvalidEnumArgumentException(nameof(styleStr), (int)fontStyle, typeof(FontStyle));
                         }
                     }
                 }
             }
 
-            return new Font(f_name, f_size, f_style, units);
+            return new Font(fontName, fontSize, fontStyle, units);
         }
 
         private (string, string) ParseSizeTokens(string text, char separator)
@@ -260,42 +260,42 @@ namespace System.Drawing
 
         private GraphicsUnit ParseGraphicsUnits(string units)
         {
-            GraphicsUnit f_unit;
+            GraphicsUnit fontSizeUnit;
             switch (units)
             {
                 case "display":
-                    f_unit = GraphicsUnit.Display;
+                    fontSizeUnit = GraphicsUnit.Display;
                     break;
 
                 case "doc":
-                    f_unit = GraphicsUnit.Document;
+                    fontSizeUnit = GraphicsUnit.Document;
                     break;
 
                 case "pt":
-                    f_unit = GraphicsUnit.Point;
+                    fontSizeUnit = GraphicsUnit.Point;
                     break;
 
                 case "in":
-                    f_unit = GraphicsUnit.Inch;
+                    fontSizeUnit = GraphicsUnit.Inch;
                     break;
 
                 case "mm":
-                    f_unit = GraphicsUnit.Millimeter;
+                    fontSizeUnit = GraphicsUnit.Millimeter;
                     break;
 
                 case "px":
-                    f_unit = GraphicsUnit.Pixel;
+                    fontSizeUnit = GraphicsUnit.Pixel;
                     break;
 
                 case "world":
-                    f_unit = GraphicsUnit.World;
+                    fontSizeUnit = GraphicsUnit.World;
                     break;
 
                 default:
-                    throw new ArgumentException(SR.InvalidArgument, nameof(units));
+                    throw new ArgumentException(null, nameof(units));
             }
 
-            return f_unit;
+            return fontSizeUnit;
         }
 
         public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)

--- a/src/System.Windows.Extensions/src/System/Drawing/FontConverter.cs
+++ b/src/System.Windows.Extensions/src/System/Drawing/FontConverter.cs
@@ -14,6 +14,8 @@ namespace System.Drawing
 {
     public class FontConverter : TypeConverter
     {
+        private const string styleHdr = "style=";
+
         public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
             return sourceType == typeof(string) ? true : base.CanConvertFrom(context, sourceType);
@@ -101,21 +103,16 @@ namespace System.Drawing
 
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            FontStyle f_style;
-            float f_size;
-            GraphicsUnit f_unit;
-            string font;
-            string units;
-            string[] fields;
-
             if (!(value is string))
             {
                 return base.ConvertFrom(context, culture, value);
             }
 
-            font = (string)value;
+            string font = (string)value;
             font = font.Trim();
 
+            // Expected string format: "name[, size[, units[, style=style1[, style2[...]]]]]"
+            // Example using 'vi-VN' culture: "Microsoft Sans Serif, 8,25pt, style=Italic, Bold"
             if (font.Length == 0)
             {
                 return null;
@@ -126,94 +123,179 @@ namespace System.Drawing
                 culture = CultureInfo.CurrentCulture;
             }
 
-            // Format is FontFamily, size[<units>[, style=1,2,3]]
-            // This is a bit tricky since the comma can be used for styles and fields
-            fields = font.Split(new char[] { culture.TextInfo.ListSeparator[0] });
-            if (fields.Length < 1)
+            char sep = culture.TextInfo.ListSeparator[0]; // For vi-VN: ','
+            string f_name = font; // start with the assumption that only the font name was provided.
+            string styleStr = null;
+            string sizeStr = null;
+            float f_size = 8.25f;
+            FontStyle f_style = FontStyle.Regular;
+            GraphicsUnit units = GraphicsUnit.Point;
+
+            // Get the index of the first separator (would indicate the end of the name in the string).
+            int nameIndex = font.IndexOf(sep);
+
+            if (nameIndex < 0)
             {
-                throw new ArgumentException("Failed to parse font format");
+                return new Font(f_name, f_size, f_style, units);
             }
 
-            font = fields[0];
-            f_size = 8f;
-            units = "px";
-            f_unit = GraphicsUnit.Pixel;
-            if (fields.Length > 1)
-            {   // We have a size
-                for (int i = 0; i < fields[1].Length; i++)
+            // some parameters are provided in addition to name.
+            f_name = font.Substring(0, nameIndex);
+
+            if (nameIndex < font.Length - 1)
+            {
+                // Get the style index (if any). The size is a bit problematic because it can be formatted differently 
+                // depending on the culture, we'll parse it last.
+                int styleIndex = font.IndexOf(styleHdr, StringComparison.CurrentCultureIgnoreCase);
+
+                if (styleIndex != -1)
                 {
-                    if (char.IsLetter(fields[1][i]))
+                    // style found.
+                    styleStr = font.Substring(styleIndex, font.Length - styleIndex);
+
+                    // Expected style format ~ "style=Italic, Bold"
+                    if (!styleStr.StartsWith(styleHdr, StringComparison.CurrentCultureIgnoreCase))
                     {
-                        f_size = (float)TypeDescriptor.GetConverter(typeof(float)).ConvertFromString(context, culture, fields[1].Substring(0, i));
-                        units = fields[1].Substring(i);
-                        break;
+                        throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, font, $"name{sep} size[units[{sep} style=style1[{sep} style2{sep} ...]]]"));
+                    }
+
+                    // Get the mid-substring containing the size information.
+                    sizeStr = font.Substring(nameIndex + 1, styleIndex - nameIndex - 1);
+                }
+                else
+                {
+                    // no style.
+                    sizeStr = font.Substring(nameIndex + 1);
+                }
+
+                // Parse size.
+                (string, string) unitTokens = ParseSizeTokens(sizeStr, sep);
+
+                if (unitTokens.Item1 != null)
+                {
+                    try
+                    {
+                        f_size = (float)TypeDescriptor.GetConverter(typeof(float)).ConvertFromString(context, culture, unitTokens.Item1);
+                    }
+                    catch
+                    {
+                        // Exception from converter is too generic.
+                        throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, font, $"name{sep} size[units[{sep} style=style1[{sep} style2{sep} ...]]]"));
                     }
                 }
-                switch (units)
+
+                if (unitTokens.Item2 != null)
                 {
-                    case "display":
-                        f_unit = GraphicsUnit.Display;
-                        break;
-
-                    case "doc":
-                        f_unit = GraphicsUnit.Document;
-                        break;
-
-                    case "pt":
-                        f_unit = GraphicsUnit.Point;
-                        break;
-
-                    case "in":
-                        f_unit = GraphicsUnit.Inch;
-                        break;
-
-                    case "mm":
-                        f_unit = GraphicsUnit.Millimeter;
-                        break;
-
-                    case "px":
-                        f_unit = GraphicsUnit.Pixel;
-                        break;
-
-                    case "world":
-                        f_unit = GraphicsUnit.World;
-                        break;
+                    // ParseGraphicsUnits throws an ArgumentException if format is invalid.
+                    units = ParseGraphicsUnits(unitTokens.Item2);
                 }
-            }
 
-            f_style = FontStyle.Regular;
-            if (fields.Length > 2)
-            {   // We have style
-                string compare;
-
-                for (int i = 2; i < fields.Length; i++)
+                if (styleStr != null)
                 {
-                    compare = fields[i];
+                    // Parse FontStyle                        
+                    int eqIndex = styleStr.IndexOf("=");
+                    styleStr = styleStr.Substring(eqIndex + 1);
+                    string[] styleTokens = styleStr.Split(sep);
 
-                    if (compare.IndexOf("Regular") != -1)
+                    for (int tokenCount = 0; tokenCount < styleTokens.Length; tokenCount++)
                     {
-                        f_style |= FontStyle.Regular;
-                    }
-                    if (compare.IndexOf("Bold") != -1)
-                    {
-                        f_style |= FontStyle.Bold;
-                    }
-                    if (compare.IndexOf("Italic") != -1)
-                    {
-                        f_style |= FontStyle.Italic;
-                    }
-                    if (compare.IndexOf("Strikeout") != -1)
-                    {
-                        f_style |= FontStyle.Strikeout;
-                    }
-                    if (compare.IndexOf("Underline") != -1)
-                    {
-                        f_style |= FontStyle.Underline;
+                        string styleText = styleTokens[tokenCount];
+                        styleText = styleText.Trim();
+
+                        f_style |= (FontStyle)Enum.Parse(typeof(FontStyle), styleText, true);
+
+                        // Enum.IsDefined doesn't do what we want on flags enums...
+                        FontStyle validBits = FontStyle.Regular | FontStyle.Bold | FontStyle.Italic | FontStyle.Underline | FontStyle.Strikeout;
+                        if ((f_style | validBits) != validBits)
+                        {
+                            throw new InvalidEnumArgumentException(nameof(styleStr), (int)f_style, typeof(FontStyle));
+                        }
                     }
                 }
             }
 
-            return new Font(font, f_size, f_style, f_unit);
+            return new Font(f_name, f_size, f_style, units);
+        }
+
+        private (string, string) ParseSizeTokens(string text, char separator)
+        {
+            string size = null;
+            string units = null;
+
+            text = text.Trim();
+
+            int length = text.Length;
+            int splitPoint;
+
+            if (length > 0)
+            {
+                // text is expected to have a format like " 8,25pt, ". Leading and trailing spaces (trimmed above), 
+                // last comma, unit and decimal value may not appear.  We need to make it ####.##CC
+                for (splitPoint = 0; splitPoint < length; splitPoint++)
+                {
+                    if (char.IsLetter(text[splitPoint]))
+                    {
+                        break;
+                    }
+                }
+
+                char[] trimChars = new char[] { separator, ' ' };
+
+                if (splitPoint > 0)
+                {
+                    size = text.Substring(0, splitPoint);
+                    // Trimming spaces between size and units.
+                    size = size.Trim(trimChars);
+                }
+
+                if (splitPoint < length)
+                {
+                    units = text.Substring(splitPoint);
+                    units = units.TrimEnd(trimChars);
+                }
+            }
+
+            return (size, units);
+        }
+
+        private GraphicsUnit ParseGraphicsUnits(string units)
+        {
+            GraphicsUnit f_unit;
+            switch (units)
+            {
+                case "display":
+                    f_unit = GraphicsUnit.Display;
+                    break;
+
+                case "doc":
+                    f_unit = GraphicsUnit.Document;
+                    break;
+
+                case "pt":
+                    f_unit = GraphicsUnit.Point;
+                    break;
+
+                case "in":
+                    f_unit = GraphicsUnit.Inch;
+                    break;
+
+                case "mm":
+                    f_unit = GraphicsUnit.Millimeter;
+                    break;
+
+                case "px":
+                    f_unit = GraphicsUnit.Pixel;
+                    break;
+
+                case "world":
+                    f_unit = GraphicsUnit.World;
+                    break;
+
+                default:
+                    throw new ArgumentException(SR.InvalidArgument, nameof(units));
+            }
+
+            return f_unit;
         }
 
         public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)
@@ -391,7 +473,15 @@ namespace System.Drawing
 
             public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
             {
-                return base.GetStandardValues(context);
+                // display graphic unit is not supported.
+                if (Values == null)
+                {
+                    base.GetStandardValues(context); // sets "values"
+                    ArrayList filteredValues = new ArrayList(Values);
+                    filteredValues.Remove(GraphicsUnit.Display);
+                    Values = new StandardValuesCollection(filteredValues);
+                }
+                return Values;
             }
         }
     }

--- a/src/System.Windows.Extensions/tests/System/Drawing/FontConverterTests.cs
+++ b/src/System.Windows.Extensions/tests/System/Drawing/FontConverterTests.cs
@@ -4,6 +4,7 @@
 
 using System.Drawing;
 using Xunit;
+using static System.Drawing.FontConverter;
 
 namespace System.ComponentModel.TypeConverterTests
 {
@@ -32,6 +33,116 @@ namespace System.ComponentModel.TypeConverterTests
             FontConverter.FontNameConverter converter = new FontConverter.FontNameConverter();
             Assert.Throws<NotSupportedException>(() => converter.ConvertFrom(null));
             Assert.Throws<NotSupportedException>(() => converter.ConvertFrom(1));
+        }
+    }
+
+    public class FontConverterTest
+    {
+        [ConditionalTheory(Helpers.IsDrawingSupported)]
+        [MemberData(nameof(TestConvertFormData))]
+        public void TestConvertFrom(string input, string name, float size, GraphicsUnit units, FontStyle fontStyle)
+        {
+            FontConverter converter = new FontConverter();
+            Font font = (Font)converter.ConvertFrom(input);
+            Assert.Equal(name, font.Name);
+            Assert.Equal(size, font.Size);
+            Assert.Equal(units, font.Unit);
+            Assert.Equal(fontStyle, font.Style);
+        }
+
+        [ConditionalTheory(Helpers.IsDrawingSupported)]
+        [MemberData(nameof(ArgumentExceptionFontConverterData))]
+        public void InvalidInputThrowsArgumentException(string input)
+        {
+            FontConverter converter = new FontConverter();
+            Assert.Throws<ArgumentException>(() => converter.ConvertFrom(input));
+        }
+
+        [ConditionalTheory(Helpers.IsDrawingSupported)]
+        [MemberData(nameof(InvalidEnumArgumentExceptionFontConverterData))]
+        public void InvalidInputThrowsInvalidEnumArgumentException(string input)
+        {
+            FontConverter converter = new FontConverter();
+            Assert.Throws<InvalidEnumArgumentException>(() => converter.ConvertFrom(input));
+        }
+
+        [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void EmptyStringInput()
+        {
+            FontConverter converter = new FontConverter();
+            Font font = (Font)converter.ConvertFrom(string.Empty);
+            Assert.Null(font);
+        }
+
+        public static TheoryData<string, string, float, GraphicsUnit, FontStyle> TestConvertFormData()
+        {
+            var data = new TheoryData<string, string, float, GraphicsUnit, FontStyle>()
+            {
+                { "Courier New", "Courier New", 8.25f, GraphicsUnit.Point, FontStyle.Regular },
+                { "Courier New, 11", "Courier New", 11f, GraphicsUnit.Point, FontStyle.Regular },
+                { "Arial, 11px", "Arial", 11f, GraphicsUnit.Pixel, FontStyle.Regular },
+                { "Courier New, 11 px", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Regular },
+                { "Courier New, 11 px, style=Regular", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Regular },
+                { "Courier New, style=Bold", "Courier New", 8.25f, GraphicsUnit.Point, FontStyle.Bold },
+                { "Courier New, 11 px, style=Bold, Italic", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Bold | FontStyle.Italic },
+                { "Courier New, 11 px, style=Regular, Italic", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Regular | FontStyle.Italic },
+                { "Courier New, 11 px, style=Bold, Italic, Strikeout", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout },
+                { "Arial, 11 px, style=Bold, Italic, Strikeout", "Arial", 11f, GraphicsUnit.Pixel, FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout },
+                { "11px", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Regular },
+                { "Style=Bold", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Regular },
+                { "arIAL, 10, style=bold", "Arial", 10f, GraphicsUnit.Point, FontStyle.Bold },
+                { "Arial, 10,", "Arial", 10f, GraphicsUnit.Point, FontStyle.Regular },
+                { "Arial,", "Arial", 8.25f, GraphicsUnit.Point, FontStyle.Regular },
+                { "Arial, 10, style=12", "Arial", 10f, GraphicsUnit.Point, FontStyle.Underline | FontStyle.Strikeout },
+            };
+
+            if (!PlatformDetection.IsFullFramework)
+            {
+                // FullFramework style keyword is case sensitive.
+                data.Add("Courier New, Style=Bold", "Courier New", 8.25f, GraphicsUnit.Point, FontStyle.Bold);
+                data.Add("11px, Style=Bold", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Bold);
+
+                // FullFramework disregards all arguments if the font name is an empty string.
+                data.Add(", 10, style=bold", "", 10f, GraphicsUnit.Point, FontStyle.Bold);
+            }
+
+            return data;
+        }
+
+        public static TheoryData<string> ArgumentExceptionFontConverterData() => new TheoryData<string>()
+        {
+            { "Courier New, 11 px, type=Bold, Italic" },
+            { "Courier New, , Style=Bold" },
+            { "Courier New, 11, Style=" },
+            { "Courier New, 11, Style=RandomEnum" },
+            { "Arial, 10, style=bold," },
+            { "Arial, 10, style=null" },
+            { "Arial, 10, style=abc#" },
+            { "Arial, 10, style=##" },
+            { "Arial, 10display, style=bold" },
+            { "Arial, 10style, style=bold" },
+        };
+
+        public static TheoryData<string> InvalidEnumArgumentExceptionFontConverterData() => new TheoryData<string>()
+        {
+            { "Arial, 10, style=56" },
+            { "Arial, 10, style=-1" },
+        };
+    }
+
+    public class FontUnitConverterTest
+    {
+        [ConditionalFact(Helpers.IsDrawingSupported)]
+        public void GetStandardValuesTest()
+        {
+            FontUnitConverter converter = new FontUnitConverter();
+            var values = converter.GetStandardValues();
+            Assert.Equal(6, values.Count);
+
+            foreach (var item in values)
+            {
+                Assert.NotEqual(GraphicsUnit.Display, (GraphicsUnit)item);
+            }
         }
     }
 }

--- a/src/System.Windows.Extensions/tests/System/Drawing/FontConverterTests.cs
+++ b/src/System.Windows.Extensions/tests/System/Drawing/FontConverterTests.cs
@@ -39,7 +39,7 @@ namespace System.ComponentModel.TypeConverterTests
 
     public class FontConverterTest
     {
-        public static char sep = CultureInfo.CurrentCulture.TextInfo.ListSeparator[0];
+        public static char s_Separator = CultureInfo.CurrentCulture.TextInfo.ListSeparator[0];
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(TestConvertFormData))]
@@ -55,18 +55,18 @@ namespace System.ComponentModel.TypeConverterTests
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ArgumentExceptionFontConverterData))]
-        public void InvalidInputThrowsArgumentException(string input)
+        public void InvalidInputThrowsArgumentException(string input, string paramName)
         {
             FontConverter converter = new FontConverter();
-            Assert.Throws<ArgumentException>(() => converter.ConvertFrom(input));
+            Assert.Throws<ArgumentException>(paramName, () => converter.ConvertFrom(input));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(InvalidEnumArgumentExceptionFontConverterData))]
-        public void InvalidInputThrowsInvalidEnumArgumentException(string input)
+        public void InvalidInputThrowsInvalidEnumArgumentException(string input, string paramName)
         {
             FontConverter converter = new FontConverter();
-            Assert.Throws<InvalidEnumArgumentException>(() => converter.ConvertFrom(input));
+            Assert.Throws<InvalidEnumArgumentException>(paramName, () => converter.ConvertFrom(input));
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -82,57 +82,57 @@ namespace System.ComponentModel.TypeConverterTests
             var data = new TheoryData<string, string, float, GraphicsUnit, FontStyle>()
             {
                 { $"Courier New", "Courier New", 8.25f, GraphicsUnit.Point, FontStyle.Regular },
-                { $"Courier New, 11", "Courier New", 11f, GraphicsUnit.Point, FontStyle.Regular },
-                { $"Arial{sep} 11px", "Arial", 11f, GraphicsUnit.Pixel, FontStyle.Regular },
-                { $"Courier New{sep} 11 px", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Regular },
-                { $"Courier New{sep} 11 px{sep} style=Regular", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Regular },
-                { $"Courier New{sep} style=Bold", "Courier New", 8.25f, GraphicsUnit.Point, FontStyle.Bold },
-                { $"Courier New{sep} 11 px{sep} style=Bold{sep} Italic", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Bold | FontStyle.Italic },
-                { $"Courier New{sep} 11 px{sep} style=Regular, Italic", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Regular | FontStyle.Italic },
-                { $"Courier New{sep} 11 px{sep} style=Bold{sep} Italic{sep} Strikeout", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout },
-                { $"Arial{sep} 11 px{sep} style=Bold, Italic, Strikeout", "Arial", 11f, GraphicsUnit.Pixel, FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout },
+                { $"Courier New{s_Separator} 11", "Courier New", 11f, GraphicsUnit.Point, FontStyle.Regular },
+                { $"Arial{s_Separator} 11px", "Arial", 11f, GraphicsUnit.Pixel, FontStyle.Regular },
+                { $"Courier New{s_Separator} 11 px", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Regular },
+                { $"Courier New{s_Separator} 11 px{s_Separator} style=Regular", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Regular },
+                { $"Courier New{s_Separator} style=Bold", "Courier New", 8.25f, GraphicsUnit.Point, FontStyle.Bold },
+                { $"Courier New{s_Separator} 11 px{s_Separator} style=Bold{s_Separator} Italic", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Bold | FontStyle.Italic },
+                { $"Courier New{s_Separator} 11 px{s_Separator} style=Regular, Italic", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Regular | FontStyle.Italic },
+                { $"Courier New{s_Separator} 11 px{s_Separator} style=Bold{s_Separator} Italic{s_Separator} Strikeout", "Courier New", 11f, GraphicsUnit.Pixel, FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout },
+                { $"Arial{s_Separator} 11 px{s_Separator} style=Bold, Italic, Strikeout", "Arial", 11f, GraphicsUnit.Pixel, FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout },
                 { $"11px", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Regular },
                 { $"Style=Bold", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Regular },
-                { $"arIAL{sep} 10{sep} style=bold", "Arial", 10f, GraphicsUnit.Point, FontStyle.Bold },
-                { $"Arial{sep} 10{sep}", "Arial", 10f, GraphicsUnit.Point, FontStyle.Regular },
-                { $"Arial{sep}", "Arial", 8.25f, GraphicsUnit.Point, FontStyle.Regular },
-                { $"Arial{sep} 10{sep} style=12", "Arial", 10f, GraphicsUnit.Point, FontStyle.Underline | FontStyle.Strikeout },
+                { $"arIAL{s_Separator} 10{s_Separator} style=bold", "Arial", 10f, GraphicsUnit.Point, FontStyle.Bold },
+                { $"Arial{s_Separator} 10{s_Separator}", "Arial", 10f, GraphicsUnit.Point, FontStyle.Regular },
+                { $"Arial{s_Separator}", "Arial", 8.25f, GraphicsUnit.Point, FontStyle.Regular },
+                { $"Arial{s_Separator} 10{s_Separator} style=12", "Arial", 10f, GraphicsUnit.Point, FontStyle.Underline | FontStyle.Strikeout },
             };
 
             if (!PlatformDetection.IsFullFramework)
             {
                 // FullFramework style keyword is case sensitive.
-                data.Add($"Courier New{sep} Style=Bold", "Courier New", 8.25f, GraphicsUnit.Point, FontStyle.Bold);
-                data.Add($"11px{sep} Style=Bold", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Bold);
+                data.Add($"Courier New{s_Separator} Style=Bold", "Courier New", 8.25f, GraphicsUnit.Point, FontStyle.Bold);
+                data.Add($"11px{s_Separator} Style=Bold", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Bold);
 
                 // FullFramework disregards all arguments if the font name is an empty string.
                 if (PlatformDetection.IsWindows10Version1607OrGreater)
                 {
-                    data.Add($"{sep} 10{sep} style=bold", "", 10f, GraphicsUnit.Point, FontStyle.Bold); // empty string is not a installed font on Windows 7 and windows 8.
+                    data.Add($"{s_Separator} 10{s_Separator} style=bold", "", 10f, GraphicsUnit.Point, FontStyle.Bold); // empty string is not a installed font on Windows 7 and windows 8.
                 }
             }
 
             return data;
         }
 
-        public static TheoryData<string> ArgumentExceptionFontConverterData() => new TheoryData<string>()
+        public static TheoryData<string, string> ArgumentExceptionFontConverterData() => new TheoryData<string, string>()
         {
-            { $"Courier New{sep} 11 px{sep} type=Bold{sep} Italic" },
-            { $"Courier New{sep} {sep} Style=Bold" },
-            { $"Courier New{sep} 11{sep} Style=" },
-            { $"Courier New{sep} 11{sep} Style=RandomEnum" },
-            { $"Arial{sep} 10{sep} style=bold{sep}" },
-            { $"Arial{sep} 10{sep} style=null" },
-            { $"Arial{sep} 10{sep} style=abc#" },
-            { $"Arial{sep} 10{sep} style=##" },
-            { $"Arial{sep} 10display{sep} style=bold" },
-            { $"Arial{sep} 10style{sep} style=bold" },
+            { $"Courier New{s_Separator} 11 px{s_Separator} type=Bold{s_Separator} Italic", "units" },
+            { $"Courier New{s_Separator} {s_Separator} Style=Bold", "sizeStr" },
+            { $"Courier New{s_Separator} 11{s_Separator} Style=", "value" },
+            { $"Courier New{s_Separator} 11{s_Separator} Style=RandomEnum", null },
+            { $"Arial{s_Separator} 10{s_Separator} style=bold{s_Separator}", "value" },
+            { $"Arial{s_Separator} 10{s_Separator} style=null", null },
+            { $"Arial{s_Separator} 10{s_Separator} style=abc#", null },
+            { $"Arial{s_Separator} 10{s_Separator} style=##", null },
+            { $"Arial{s_Separator} 10display{s_Separator} style=bold", null },
+            { $"Arial{s_Separator} 10style{s_Separator} style=bold", "units" },
         };
 
-        public static TheoryData<string> InvalidEnumArgumentExceptionFontConverterData() => new TheoryData<string>()
+        public static TheoryData<string, string> InvalidEnumArgumentExceptionFontConverterData() => new TheoryData<string, string>()
         {
-            { $"Arial{sep} 10{sep} style=56" },
-            { $"Arial{sep} 10{sep} style=-1" },
+            { $"Arial{s_Separator} 10{s_Separator} style=56", "styleStr" },
+            { $"Arial{s_Separator} 10{s_Separator} style=-1", "styleStr" },
         };
     }
 

--- a/src/System.Windows.Extensions/tests/System/Drawing/FontConverterTests.cs
+++ b/src/System.Windows.Extensions/tests/System/Drawing/FontConverterTests.cs
@@ -55,10 +55,10 @@ namespace System.ComponentModel.TypeConverterTests
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
         [MemberData(nameof(ArgumentExceptionFontConverterData))]
-        public void InvalidInputThrowsArgumentException(string input, string paramName)
+        public void InvalidInputThrowsArgumentException(string input, string paramName, string netfxParamName)
         {
             FontConverter converter = new FontConverter();
-            Assert.Throws<ArgumentException>(paramName, () => converter.ConvertFrom(input));
+            AssertExtensions.Throws<ArgumentException>(paramName, netfxParamName, () => converter.ConvertFrom(input));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -115,24 +115,24 @@ namespace System.ComponentModel.TypeConverterTests
             return data;
         }
 
-        public static TheoryData<string, string> ArgumentExceptionFontConverterData() => new TheoryData<string, string>()
+        public static TheoryData<string, string, string> ArgumentExceptionFontConverterData() => new TheoryData<string, string, string>()
         {
-            { $"Courier New{s_Separator} 11 px{s_Separator} type=Bold{s_Separator} Italic", "units" },
-            { $"Courier New{s_Separator} {s_Separator} Style=Bold", "sizeStr" },
-            { $"Courier New{s_Separator} 11{s_Separator} Style=", "value" },
-            { $"Courier New{s_Separator} 11{s_Separator} Style=RandomEnum", null },
-            { $"Arial{s_Separator} 10{s_Separator} style=bold{s_Separator}", "value" },
-            { $"Arial{s_Separator} 10{s_Separator} style=null", null },
-            { $"Arial{s_Separator} 10{s_Separator} style=abc#", null },
-            { $"Arial{s_Separator} 10{s_Separator} style=##", null },
-            { $"Arial{s_Separator} 10display{s_Separator} style=bold", null },
-            { $"Arial{s_Separator} 10style{s_Separator} style=bold", "units" },
+            { $"Courier New{s_Separator} 11 px{s_Separator} type=Bold{s_Separator} Italic", "units", null },
+            { $"Courier New{s_Separator} {s_Separator} Style=Bold", "sizeStr", null },
+            { $"Courier New{s_Separator} 11{s_Separator} Style=", "value", null },
+            { $"Courier New{s_Separator} 11{s_Separator} Style=RandomEnum", null, null },
+            { $"Arial{s_Separator} 10{s_Separator} style=bold{s_Separator}", "value", null },
+            { $"Arial{s_Separator} 10{s_Separator} style=null", null, null },
+            { $"Arial{s_Separator} 10{s_Separator} style=abc#", null, null },
+            { $"Arial{s_Separator} 10{s_Separator} style=##", null, null },
+            { $"Arial{s_Separator} 10display{s_Separator} style=bold", null, null },
+            { $"Arial{s_Separator} 10style{s_Separator} style=bold", "units", null },
         };
 
         public static TheoryData<string, string> InvalidEnumArgumentExceptionFontConverterData() => new TheoryData<string, string>()
         {
-            { $"Arial{s_Separator} 10{s_Separator} style=56", "styleStr" },
-            { $"Arial{s_Separator} 10{s_Separator} style=-1", "styleStr" },
+            { $"Arial{s_Separator} 10{s_Separator} style=56", "style" },
+            { $"Arial{s_Separator} 10{s_Separator} style=-1", "style" },
         };
     }
 


### PR DESCRIPTION
Fixes #38960 

The current implementation of System.Drawing.Converters is quite different from .NetFramework
The main difference is in Font Coverter eg

- Default units for input size is px on core vs pt on framework.

- .Net core doesnot support size without units.

- .Net Core doesnot have any restrictions on the input style string eg Name, size , anyRandomGarbageBold will be consider as bold style.

- If the name string is empty then it ignores all the other attributes, which is not the case now.

- Exceptions contains the paramName now

FontUnitConverter treats "Display" as a value in .net core while its not a value in .netFramework

The rest of the converters are almost similar. This PR all adds Tests for the fontConverter

It is technically a breaking change but I think we should go ahead and fix this behavior
