### PR TITLE
Fixing issue happenning on very large zip files

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -63,7 +63,7 @@
     <NewtonsoftJsonPackageVersion>12.0.1</NewtonsoftJsonPackageVersion>
     <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview5-27626-15</MicrosoftExtensionsDependencyModelPackageVersion>
     <!-- Test data -->
-    <SystemIOCompressionTestDataPackageVersion>1.0.13</SystemIOCompressionTestDataPackageVersion>
+    <SystemIOCompressionTestDataPackageVersion>1.0.14</SystemIOCompressionTestDataPackageVersion>
     <SystemIOPackagingTestDataPackageVersion>1.0.4</SystemIOPackagingTestDataPackageVersion>
     <SystemSecurityCryptographyX509CertificatesTestDataPackageVersion>1.0.7</SystemSecurityCryptographyX509CertificatesTestDataPackageVersion>
     <SystemNetTestDataPackageVersion>1.0.6</SystemNetTestDataPackageVersion>

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -117,7 +117,7 @@ namespace System.IO.Compression
                 {
                     if (_uncompressedSize > _currentInflatedCount)
                     {
-                        length = Math.Min(length, (int)(_uncompressedSize - _currentInflatedCount));
+                        length = (int)Math.Min(length, _uncompressedSize - _currentInflatedCount);
                         copied = _output.CopyTo(bytes, offset, length);
                         _currentInflatedCount += copied;
                     }

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Inflater.cs
@@ -95,7 +95,7 @@ namespace System.IO.Compression
                 {
                     if (_uncompressedSize > _currentInflatedCount)
                     {
-                        length = Math.Min(length, (int)(_uncompressedSize - _currentInflatedCount));
+                        length = (int)Math.Min(length, _uncompressedSize - _currentInflatedCount);
                         ReadOutput(bufPtr, length, out bytesRead);
                         _currentInflatedCount += bytesRead;
                     }

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -23,7 +23,7 @@ namespace System.IO.Compression
         private readonly int _diskNumberStart;
         private readonly ZipVersionMadeByPlatform _versionMadeByPlatform;
         private ZipVersionNeededValues _versionMadeBySpecification;
-        private ZipVersionNeededValues _versionToExtract;
+        internal ZipVersionNeededValues _versionToExtract;
         private BitFlagValues _generalPurposeBitFlag;
         private CompressionMethodValues _storedCompressionMethod;
         private DateTimeOffset _lastModified;

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -440,7 +440,7 @@ namespace System.IO.Compression
             if (reader.BaseStream.Length < reader.BaseStream.Position + OffsetToFilename)
                 return false;
 
-            uint minimumVersion = reader.ReadUInt16();
+            reader.BaseStream.Seek(2, SeekOrigin.Current); // skipping minimum version (using min version from central directory header)
             uint dataDescriptorBit = reader.ReadUInt16() & (uint)ZipArchiveEntry.BitFlagValues.DataDescriptor;
             reader.BaseStream.Seek(10, SeekOrigin.Current); // skipping bytes used for Compression method (2 bytes), last modification time and date (4 bytes) and CRC (4 bytes)
             long compressedSize = reader.ReadUInt32();
@@ -495,7 +495,7 @@ namespace System.IO.Compression
                     seekSize = 4;
                 }
 
-                bool is64bit = minimumVersion >= (uint)ZipVersionNeededValues.Zip64;
+                bool is64bit = entry._versionToExtract >= ZipVersionNeededValues.Zip64;
                 seekSize += (is64bit ? 8 : 4) * 2;   // if Zip64 read by 8 bytes else 4 bytes 2 times (compressed and uncompressed size)
 
                 if (reader.BaseStream.Length < reader.BaseStream.Position + seekSize)

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -495,7 +495,7 @@ namespace System.IO.Compression
                     seekSize = 4;
                 }
 
-                bool is64bit = minimumVersion > (uint)ZipVersionNeededValues.Zip64;
+                bool is64bit = minimumVersion >= (uint)ZipVersionNeededValues.Zip64;
                 seekSize += (is64bit ? 8 : 4) * 2;   // if Zip64 read by 8 bytes else 4 bytes 2 times (compressed and uncompressed size)
 
                 if (reader.BaseStream.Length < reader.BaseStream.Position + seekSize)

--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -315,16 +315,16 @@ namespace System.IO.Compression.Tests
             using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Read))
             {
                 ZipArchiveEntry e = archive.GetEntry("bigFile.bin");
+                
+                Assert.Equal(6_442_450_944, e.Length);
+                Assert.Equal(6_261_752, e.CompressedLength);
+
                 using (Stream source = e.Open())
                 {
                     byte[] buffer = new byte[s_bufferSize];
-                    int read;
-                    while ((read = source.Read(buffer, 0, buffer.Length)) != 0)
-                    {
-                        if (read == s_bufferSize)   // We don't want to inflate this large archive entirely
-                            break;                  // just making sure it read successfully
-                    }
-                    Assert.Equal(s_bufferSize, read);
+                    int read = source.Read(buffer, 0, buffer.Length);   // We don't want to inflate this large archive entirely
+                                                                        // just making sure it read successfully
+                    Assert.Equal(s_bufferSize, read);                   
                 }
             }
         }

--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -321,10 +321,10 @@ namespace System.IO.Compression.Tests
                     int read;
                     while ((read = source.Read(buffer, 0, buffer.Length)) != 0)
                     {
-                        if (read == s_bufferSize * 2) // We don't want to inflate this large archive entirely
-                            break;                    // just making sure it read successfully
+                        if (read == s_bufferSize)   // We don't want to inflate this large archive entirely
+                            break;                  // just making sure it read successfully
                     }
-                    Assert.Equal(s_bufferSize * 2, read);
+                    Assert.Equal(s_bufferSize, read);
                 }
             }
         }

--- a/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -312,23 +312,19 @@ namespace System.IO.Compression.Tests
         {
             MemoryStream stream = await LocalMemoryStream.readAppFileAsync(strange("veryLarge.zip"));
 
-            using (
-                ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Read))
+            using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Read))
             {
                 ZipArchiveEntry e = archive.GetEntry("bigFile.bin");
-                using (var ms = new MemoryStream())
                 using (Stream source = e.Open())
                 {
                     byte[] buffer = new byte[s_bufferSize];
                     int read;
-                    int count = 1;
                     while ((read = source.Read(buffer, 0, buffer.Length)) != 0)
                     {
-                        ms.Write(buffer, 0, read);
-                        if (count++ == 2)
-                            break;      // We don't want to inflate this large archive entirely
+                        if (read == s_bufferSize * 2) // We don't want to inflate this large archive entirely
+                            break;                    // just making sure it read successfully
                     }
-                    Assert.Equal(s_bufferSize * 2, ms.Length);
+                    Assert.Equal(s_bufferSize * 2, read);
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/39075. Had 2 bug here:
1. Issue with determining if the zip file is 64 bit zip or not
2. Casting long to int before comparing with int was very stupid mistake 

Didn't had a test with such big files and didn't added such test case because Compression Test data doesn't have big enough zip file for this kind of testing. As this failing test `System.IO.Packaging.Tests.VeryLargePart` reported in the issue is covering this uncovered scenario i think we are good.