### PR TITLE
Compile InvocationExpression target if necessary

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Expressions.cs
@@ -181,7 +181,12 @@ namespace System.Linq.Expressions.Compiler
             }
 
             expr = node.Expression;
-            Debug.Assert(!typeof(LambdaExpression).IsAssignableFrom(expr.Type));
+            if (typeof(LambdaExpression).IsAssignableFrom(expr.Type))
+            {
+                // if the invoke target is a lambda expression tree, first compile it into a delegate
+                expr = Expression.Call(expr, expr.Type.GetMethod("Compile", Array.Empty<Type>()));
+            }
+
             EmitMethodCall(expr, expr.Type.GetInvokeMethod(), node, CompilationFlags.EmitAsNoTail | CompilationFlags.EmitExpressionStart);
         }
 

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -56,7 +56,6 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Theory, ClassData(typeof(CompilationTypes))]
-        [ActiveIssue(30471)]
         public void InvokeComputedLambda(bool useInterpreter)
         {
             ParameterExpression x = Expression.Parameter(typeof(int), "x");


### PR DESCRIPTION
Replaces code removed in https://github.com/dotnet/corefx/pull/18468.

Fixes https://github.com/dotnet/corefx/issues/30471