### PR TITLE
clean up HTTP2 protocol exception handling

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -484,7 +484,7 @@ namespace System.Net.Test.Common
             }
         }
 
-        private static int EncodeHeader(HttpHeaderData headerData, Span<byte> headerBlock)
+        public static int EncodeHeader(HttpHeaderData headerData, Span<byte> headerBlock)
         {
             // Always encode as literal, no indexing.
             int bytesGenerated = EncodeInteger(0, 0, 0b11110000, headerBlock);

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -444,14 +444,11 @@
   <data name="net_http_winhttp_error" xml:space="preserve">
     <value>Error {0} calling {1}, '{2}'.</value>
   </data>
-  <data name="net_http_http2_protocol_error" xml:space="preserve">
-    <value>The HTTP/2 request failed with protocol error '{0}' (0x{1}).</value>
+  <data name="net_http_http2_connection_error" xml:space="preserve">
+    <value>The HTTP/2 server sent invalid data on the connection. HTTP/2 error code '{0}' (0x{1}).</value>
   </data>
-  <data name="net_http_http2_protocol_error_text" xml:space="preserve">
-    <value>The HTTP/2 request failed with protocol error '{0}' ({1}).</value>
-  </data>
-  <data name="net_http_http2_protocol_state" xml:space="preserve">
-    <value>The HTTP/2 request encountered a protocol error, receiving '{0}' while in the state '{1}'.</value>
+  <data name="net_http_http2_stream_error" xml:space="preserve">
+    <value>The HTTP/2 server reset the stream. HTTP/2 error code '{0}' (0x{1}).</value>
   </data>
   <data name="net_MethodNotImplementedException" xml:space="preserve">
     <value>This method is not implemented by this class.</value>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -141,9 +141,11 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\EmptyReadStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\ExposedSocketNetworkStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2Connection.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Http2ConnectionException.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2ProtocolErrorCode.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2ProtocolException.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\Http2Stream.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\Http2StreamException.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpAuthenticatedConnectionHandler.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpBaseStream.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpConnection.cs" />

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2ConnectionException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2ConnectionException.cs
@@ -13,5 +13,7 @@ namespace System.Net.Http
             : base(SR.Format(SR.net_http_http2_connection_error, GetName(protocolError), ((int)protocolError).ToString("x")), protocolError)
         {
         }
+
+        private Http2ConnectionException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2ConnectionException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2ConnectionException.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Net.Http
+{
+    [Serializable]
+    internal sealed class Http2ConnectionException : Http2ProtocolException
+    {
+        public Http2ConnectionException(Http2ProtocolErrorCode protocolError)
+            : base(SR.Format(SR.net_http_http2_connection_error, GetName(protocolError), ((int)protocolError).ToString("x")), protocolError)
+        {
+        }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2ProtocolException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2ProtocolException.cs
@@ -15,7 +15,7 @@ namespace System.Net.Http
             ProtocolError = protocolError;
         }
 
-        private Http2ProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
+        protected Http2ProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
             ProtocolError = (Http2ProtocolErrorCode)info.GetInt32(nameof(ProtocolError));
         }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2ProtocolException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2ProtocolException.cs
@@ -2,24 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.Serialization;
 
 namespace System.Net.Http
 {
     [Serializable]
-    internal sealed class Http2ProtocolException : Exception
+    internal abstract class Http2ProtocolException : Exception
     {
-        public Http2ProtocolException(Http2ProtocolErrorCode protocolError)
-            : base(SR.Format(SR.net_http_http2_protocol_error, GetName(protocolError), ((int)protocolError).ToString("x")))
+        public Http2ProtocolException(string message, Http2ProtocolErrorCode protocolError)
+            : base(message)
         {
             ProtocolError = protocolError;
-        }
-
-        public Http2ProtocolException(string message)
-            : base(SR.Format(SR.net_http_http2_protocol_error_text, GetName(Http2ProtocolErrorCode.ProtocolError), message))
-        {
-            ProtocolError = Http2ProtocolErrorCode.ProtocolError;
         }
 
         private Http2ProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
@@ -35,14 +28,13 @@ namespace System.Net.Http
 
         internal Http2ProtocolErrorCode ProtocolError { get; }
 
-        private static string GetName(Http2ProtocolErrorCode code)
+        protected static string GetName(Http2ProtocolErrorCode code)
         {
             // These strings are the names used in the HTTP2 spec and should not be localized.
             switch (code)
             {
                 case Http2ProtocolErrorCode.NoError:
                     return "NO_ERROR";
-                default: // any unrecognized error code is treated as a protocol error
                 case Http2ProtocolErrorCode.ProtocolError:
                     return "PROTOCOL_ERROR";
                 case Http2ProtocolErrorCode.InternalError:
@@ -69,6 +61,8 @@ namespace System.Net.Http
                     return "INADEQUATE_SECURITY";
                 case Http2ProtocolErrorCode.Http11Required:
                     return "HTTP_1_1_REQUIRED";
+                default:
+                    return "(unknown error)";
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -231,7 +231,7 @@ namespace System.Net.Http
                         {
                             // Pseudo-headers are allowed only in header block
                             if (NetEventSource.IsEnabled) Trace($"Pseudo-header received in {_state} state.");
-                            throw new Http2ProtocolException(SR.net_http_invalid_response_pseudo_header_in_trailer);
+                            throw new HttpRequestException(SR.net_http_invalid_response_pseudo_header_in_trailer);
                         }
 
                         if (name.SequenceEqual(s_statusHeaderName))
@@ -239,7 +239,7 @@ namespace System.Net.Http
                             if (_state != StreamState.ExpectingStatus)
                             {
                                 if (NetEventSource.IsEnabled) Trace("Received extra status header.");
-                                throw new Http2ProtocolException(SR.Format(SR.net_http_invalid_response_status_code, "duplicate status"));
+                                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, "duplicate status"));
                             }
 
                             byte status1, status2, status3;
@@ -248,7 +248,7 @@ namespace System.Net.Http
                                 !IsDigit(status2 = value[1]) ||
                                 !IsDigit(status3 = value[2]))
                             {
-                                throw new Http2ProtocolException(SR.Format(SR.net_http_invalid_response_status_code, Encoding.ASCII.GetString(value)));
+                                throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, Encoding.ASCII.GetString(value)));
                             }
 
                             int statusValue = (100 * (status1 - '0') + 10 * (status2 - '0') + (status3 - '0'));
@@ -283,7 +283,7 @@ namespace System.Net.Http
                         else
                         {
                             if (NetEventSource.IsEnabled) Trace($"Invalid response pseudo-header '{Encoding.ASCII.GetString(name)}'.");
-                            throw new Http2ProtocolException(SR.net_http_invalid_response);
+                            throw new HttpRequestException(SR.net_http_invalid_response);
                         }
                     }
                     else
@@ -297,13 +297,13 @@ namespace System.Net.Http
                         if (_state != StreamState.ExpectingHeaders && _state != StreamState.ExpectingTrailingHeaders)
                         {
                             if (NetEventSource.IsEnabled) Trace("Received header before status.");
-                            throw new Http2ProtocolException(SR.net_http_invalid_response);
+                            throw new HttpRequestException(SR.net_http_invalid_response);
                         }
 
                         if (!HeaderDescriptor.TryGet(name, out HeaderDescriptor descriptor))
                         {
                             // Invalid header name
-                            throw new Http2ProtocolException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
+                            throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_header_name, Encoding.ASCII.GetString(name)));
                         }
 
                         string headerValue = descriptor.GetHeaderValue(value);
@@ -337,7 +337,7 @@ namespace System.Net.Http
 
                     if (_state != StreamState.ExpectingStatus && _state != StreamState.ExpectingData)
                     {
-                        throw new Http2ProtocolException(SR.Format(SR.net_http_http2_protocol_state, "headers", _state));
+                        throw new Http2ConnectionException(Http2ProtocolErrorCode.ProtocolError);
                     }
 
                     if (_state == StreamState.ExpectingData)
@@ -359,7 +359,7 @@ namespace System.Net.Http
 
                     if (_state != StreamState.ExpectingHeaders && _state != StreamState.ExpectingTrailingHeaders && _state != StreamState.ExpectingIgnoredHeaders)
                     {
-                        throw new Http2ProtocolException(SR.Format(SR.net_http_http2_protocol_state, "headers", _state));
+                        throw new Http2ConnectionException(Http2ProtocolErrorCode.ProtocolError);
                     }
 
                     if (_state == StreamState.ExpectingHeaders)
@@ -370,8 +370,8 @@ namespace System.Net.Http
                     {
                         if (!endStream)
                         {
-                             if (NetEventSource.IsEnabled) Trace("Trailing headers received without endStream");
-                             throw new Http2ProtocolException(SR.net_http_invalid_response);
+                            if (NetEventSource.IsEnabled) Trace("Trailing headers received without endStream");
+                            throw new Http2ConnectionException(Http2ProtocolErrorCode.ProtocolError);
                         }
 
                         _state = StreamState.Complete;
@@ -381,7 +381,7 @@ namespace System.Net.Http
                         if (endStream)
                         {
                             // we should not get endStream while processing 1xx response.
-                            throw new Http2ProtocolException(SR.net_http_invalid_response);
+                            throw new Http2ConnectionException(Http2ProtocolErrorCode.ProtocolError);
                         }
 
                         _state = StreamState.ExpectingStatus;
@@ -420,13 +420,14 @@ namespace System.Net.Http
 
                     if (_state != StreamState.ExpectingData)
                     {
-                        throw new Http2ProtocolException(SR.Format(SR.net_http_http2_protocol_state, "data", _state));
+                        // Flow control messages are not valid in this state.
+                        throw new Http2ConnectionException(Http2ProtocolErrorCode.ProtocolError);
                     }
 
                     if (_responseBuffer.ActiveSpan.Length + buffer.Length > StreamWindowSize)
                     {
                         // Window size exceeded.
-                        throw new Http2ProtocolException(Http2ProtocolErrorCode.FlowControlError);
+                        throw new Http2ConnectionException(Http2ProtocolErrorCode.FlowControlError);
                     }
 
                     _responseBuffer.EnsureAvailableSpace(buffer.Length);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2StreamException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2StreamException.cs
@@ -13,5 +13,7 @@ namespace System.Net.Http
             : base(SR.Format(SR.net_http_http2_stream_error, GetName(protocolError), ((int)protocolError).ToString("x")), protocolError)
         {
         }
+
+        private Http2StreamException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2StreamException.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2StreamException.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Net.Http
+{
+    [Serializable]
+    internal sealed class Http2StreamException : Http2ProtocolException
+    {
+        public Http2StreamException(Http2ProtocolErrorCode protocolError)
+            : base(SR.Format(SR.net_http_http2_stream_error, GetName(protocolError), ((int)protocolError).ToString("x")), protocolError)
+        {
+        }
+    }
+}


### PR DESCRIPTION
(1) Distinguish between connection-level protocol exceptions and stream-level protocol exceptions
(2) Ensure that Http2ConnectionException is only used for actual connection errors; use HttpRequestException in other situations
(3) Fix a couple related test issues

Hopefully this helps with diagnosing issues in #38911 

@dotnet/ncl 