### PR TITLE
correct sending RST when request body fails

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -139,12 +139,11 @@ namespace System.Net.Http
                 {
                     if (NetEventSource.IsEnabled) Trace($"Failed to send request body: {e}");
 
-                    // Try to notify server if we did not finish sending request body.
-                    IgnoreExceptions(_connection.SendRstStreamAsync(_streamId, Http2ProtocolErrorCode.Cancel));
-
                     // if we decided abandon sending request and we get ObjectDisposed as result of it, just eat exception.
                     if (!_shouldSendRequestBody && (e is ObjectDisposedException || e.InnerException is ObjectDisposedException))
                     {
+                        // Try to notify server if we did not finish sending request body.
+                        IgnoreExceptions(_connection.SendRstStreamAsync(_streamId, Http2ProtocolErrorCode.Cancel));
                         return;
                     }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1581,7 +1581,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalTheory(nameof(SupportsAlpn))]
-        //[OuterLoop("Uses Task.Delay")]
+        [OuterLoop("Uses Task.Delay")]
         [InlineData(false)]
         [InlineData(true)]
         public async Task Http2_PendingSend_SendsReset(bool waitForData)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1620,7 +1620,7 @@ namespace System.Net.Http.Functional.Tests
                         // Cancel client after receiving Headers or part of request body.
                         cts.Cancel();
                     }
-                    frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds)).ConfigureAwait(false);
+                    frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds));
                     Assert.NotNull(frame); // We should get Rst before closing connection.
                     Assert.Equal(0, (int)(frame.Flags & FrameFlags.EndStream));
                     frameCount++;
@@ -1635,7 +1635,7 @@ namespace System.Net.Http.Functional.Tests
                 // Wait for any lingering frames or extra reset frames.
                 try
                 {
-                    frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(1000)).ConfigureAwait(false);
+                    frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(1000));
                 }
                 catch (System.OperationCanceledException) { };
                 Assert.Null(frame);    // Make sure we do not get any frames after getting Rst.
@@ -1708,7 +1708,7 @@ namespace System.Net.Http.Functional.Tests
                 Frame frame;
                 do
                 {
-                    frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds)).ConfigureAwait(false);
+                    frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds));
                     Assert.NotNull(frame); // We should get Rst before closing connection.
                     Assert.Equal(0, (int)(frame.Flags & FrameFlags.EndStream));
                  } while (frame.Type != FrameType.RstStream);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1580,9 +1580,11 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalFact(nameof(SupportsAlpn))]
-        [OuterLoop("Uses Task.Delay")]
-        public async Task Http2_PendingSend_SendsReset()
+        [ConditionalTheory(nameof(SupportsAlpn))]
+        //[OuterLoop("Uses Task.Delay")]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Http2_PendingSend_SendsReset(bool waitForData)
         {
             var cts = new CancellationTokenSource();
 
@@ -1597,6 +1599,12 @@ namespace System.Net.Http.Functional.Tests
                     request.Content = new StreamContent(stream);
 
                     await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await client.SendAsync(request, cts.Token));
+
+                    // Send another request to verify that connection is still functional.
+                    request = new HttpRequestMessage(HttpMethod.Get, url);
+                    request.Version = new Version(2,0);
+
+                    await client.SendAsync(request);
                 }
             },
             async server =>
@@ -1604,19 +1612,35 @@ namespace System.Net.Http.Functional.Tests
                 Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
 
                 (int streamId, HttpRequestData requestData) = await connection.ReadAndParseRequestHeaderAsync(readBody : false);
-
-                // Cancel client after receiving Headers.
-                cts.Cancel();
+                int frameCount = 0;
                 Frame frame;
                 do
                 {
+                    if (frameCount == (waitForData ? 1 : 0)) {
+                        // Cancel client after receiving Headers or part of request body.
+                        cts.Cancel();
+                    }
                     frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds)).ConfigureAwait(false);
                     Assert.NotNull(frame); // We should get Rst before closing connection.
                     Assert.Equal(0, (int)(frame.Flags & FrameFlags.EndStream));
+                    frameCount++;
                  } while (frame.Type != FrameType.RstStream);
 
-                 frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds)).ConfigureAwait(false);
-                 Assert.Null(frame);    // Make sure we do not get any frames after getting RST.
+                 Assert.Equal(1, frame.StreamId);
+
+                frame = null;
+                (streamId, requestData) = await connection.ReadAndParseRequestHeaderAsync();
+                await connection.SendResponseHeadersAsync(streamId, endStream: false, HttpStatusCode.OK);
+                await connection.SendResponseBodyAsync(streamId, Encoding.ASCII.GetBytes($"Http2_PendingSend_SendsReset(waitForData: {waitForData})"), isFinal: false);
+                // Wait for any lingering frames or extra reset frames.
+                try
+                {
+                    frame = await connection.ReadFrameAsync(TimeSpan.FromMilliseconds(1000)).ConfigureAwait(false);
+                }
+                catch (System.OperationCanceledException) { };
+                Assert.Null(frame);    // Make sure we do not get any frames after getting Rst.
+                await connection.SendResponseBodyAsync(streamId, Encoding.ASCII.GetBytes("final"), isFinal: true);
+                await connection.WaitForConnectionShutdownAsync();
             });
         }
 
@@ -1651,6 +1675,7 @@ namespace System.Net.Http.Functional.Tests
                             }
                             catch (OperationCanceledException) { };
                         }
+
                         isCanceled = true;
                     }
                 }


### PR DESCRIPTION
When we cancel while sending RequestBody we could send multiple reset frames. This should be fixed now as well as I added new test to cover cases when cancel before and after body send starts. 

With new test, I verified that it fails before product fix. 
There was still some delay before second RST was sent so I added some delay to processing of second request to allow all tasks from first request to complete.  

fixes #38913 (test coverage) 
fixes #39016