### PR TITLE
Add RHEL 8.1 runtime id to the runtime id graph

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -2331,6 +2331,32 @@
     "any",
     "base"
   ],
+  "rhel.8.1": [
+    "rhel.8.1",
+    "rhel.8.0",
+    "rhel.8",
+    "rhel",
+    "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "rhel.8.1-x64": [
+    "rhel.8.1-x64",
+    "rhel.8.1",
+    "rhel.8.0-x64",
+    "rhel.8.0",
+    "rhel.8-x64",
+    "rhel.8",
+    "rhel-x64",
+    "rhel",
+    "linux-x64",
+    "linux",
+    "unix-x64",
+    "unix",
+    "any",
+    "base"
+  ],
   "sles": [
     "sles",
     "linux",

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -1060,6 +1060,17 @@
         "rhel.8-x64"
       ]
     },
+    "rhel.8.1": {
+      "#import": [
+        "rhel.8.0"
+      ]
+    },
+    "rhel.8.1-x64": {
+      "#import": [
+        "rhel.8.1",
+        "rhel.8.0-x64"
+      ]
+    },
     "sles": {
       "#import": [
         "linux"

--- a/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -116,7 +116,7 @@
     <RuntimeGroup Include="rhel">
       <Parent>linux</Parent>
       <Architectures>x64</Architectures>
-      <Versions>8;8.0</Versions>
+      <Versions>8;8.0;8.1</Versions>
     </RuntimeGroup>
 
     <RuntimeGroup Include="sles">


### PR DESCRIPTION
RHEL 8.1 is expected to release around 6 months after RHEL 8.0. That would put it around Nov 2019. If it follows the RHEL 7 tradition, it should get identified as 'rhel.8.1`.