### PR TITLE
Fix DateTimeOffsetConverterTests test

### DIFF
--- a/src/System.ComponentModel.TypeConverter/tests/TypeConverterTestBase.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeConverterTestBase.cs
@@ -187,7 +187,10 @@ namespace System.ComponentModel.Tests
             public CultureInfo RemoteInvokeCulture { get; set; }
 
             public bool CanConvert { get; set; }
-            
+
+            public override string ToString() => // for debugging / xunit test output
+                $"Source='{Source}', Type='{DestinationType}', Culture='{Culture?.Name ?? "(null)"}', RemoteCulture='{RemoteInvokeCulture?.Name ?? "(null)"}'";
+
             public static ConvertTest Valid(object source, object expected, CultureInfo culture = null)
             {
                 return new ConvertTest

--- a/src/System.ComponentModel.TypeConverter/tests/TypeConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeConverterTests.cs
@@ -71,23 +71,26 @@ namespace System.ComponentModel.Tests
         [Fact]
         public static void ConvertFrom_InstanceDescriptor()
         {
-            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
-            DateTime testDateAndTime = DateTime.UtcNow;
-            ConstructorInfo ctor = typeof(DateTime).GetConstructor(new Type[]
+            RemoteExecutor.Invoke(() =>
             {
-                typeof(int), typeof(int), typeof(int), typeof(int),
-                typeof(int), typeof(int), typeof(int)
-            });
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+                DateTime testDateAndTime = DateTime.UtcNow;
+                ConstructorInfo ctor = typeof(DateTime).GetConstructor(new Type[]
+                {
+                    typeof(int), typeof(int), typeof(int), typeof(int),
+                    typeof(int), typeof(int), typeof(int)
+                });
 
-            InstanceDescriptor descriptor = new InstanceDescriptor(ctor, new object[]
-            {
-                testDateAndTime.Year, testDateAndTime.Month, testDateAndTime.Day, testDateAndTime.Hour,
-                testDateAndTime.Minute, testDateAndTime.Second, testDateAndTime.Millisecond
-            });
+                InstanceDescriptor descriptor = new InstanceDescriptor(ctor, new object[]
+                {
+                    testDateAndTime.Year, testDateAndTime.Month, testDateAndTime.Day, testDateAndTime.Hour,
+                    testDateAndTime.Minute, testDateAndTime.Second, testDateAndTime.Millisecond
+                });
 
-            const string format = "dd MMM yyyy hh:mm";
-            object o = s_converter.ConvertFrom(descriptor);
-            Assert.Equal(testDateAndTime.ToString(format), ((DateTime)o).ToString(format));
+                const string format = "dd MMM yyyy hh:mm";
+                object o = s_converter.ConvertFrom(descriptor);
+                Assert.Equal(testDateAndTime.ToString(format), ((DateTime)o).ToString(format));
+            }).Dispose();
         }
 
         [Fact]


### PR DESCRIPTION
We're getting a sporadic failure in CI due from a DateTimeOffset TypeConverter test.  I believe the issue is that another test which changes the current culture to fr-FR runs before or concurrently and ends up affecting the test.  I've fixed that test to do the culture change in another process (as is done in every other such test), but just in case that doesn't fix it, I've also augmented the test helper class that represents a test case here to have a ToString that makes the xunit output more debuggable.

Fixes https://github.com/dotnet/corefx/issues/39084 (hopefully)

cc: @hughbe, @maryamariyan, @safern