### PR TITLE
Added a fsw notify test to validate no event fires for a file with spaces on Windows

### DIFF
--- a/src/Common/src/CoreLib/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/CoreLib/System/IO/PathInternal.Windows.cs
@@ -401,7 +401,7 @@ namespace System.IO
         /// </summary>
         internal static bool IsEffectivelyEmpty(ReadOnlySpan<char> path)
         {
-            return (path.IsEmpty || path.IndexOf(' ') > -1);
+            return path.IsWhiteSpace();
         }
     }
 }

--- a/src/Common/src/CoreLib/System/IO/PathInternal.Windows.cs
+++ b/src/Common/src/CoreLib/System/IO/PathInternal.Windows.cs
@@ -401,15 +401,7 @@ namespace System.IO
         /// </summary>
         internal static bool IsEffectivelyEmpty(ReadOnlySpan<char> path)
         {
-            if (path.IsEmpty)
-                return true;
-
-            foreach (char c in path)
-            {
-                if (c != ' ')
-                    return false;
-            }
-            return true;
+            return (path.IsEmpty || path.IndexOf(' ') > -1);
         }
     }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.File.NotifyFilter.cs
@@ -252,6 +252,26 @@ namespace System.IO.Tests
         }
 
         /// <summary>
+        /// Tests that a filename with just a space does not raise a watcher changed event.
+        /// </summary>
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void FileSystemWatcher_File_NotifyFilter_FileWithSpaces()
+        {
+            using (var testDirectory = new TempDirectory(GetTestFilePath()))
+            using (var file = new TempFile(Path.Combine(testDirectory.Path, " ")))
+            using (var watcher = new FileSystemWatcher(testDirectory.Path, "*"))
+            {
+                NotifyFilters filter = NotifyFilters.LastWrite | NotifyFilters.FileName;
+                watcher.NotifyFilter = filter;
+
+                Action action = () => File.AppendAllText(file.Path, "longText!");
+                
+                ExpectNoEvent(watcher, WatcherChangeTypes.Changed, action, expectedPath: file.Path);
+            }
+        }
+
+        /// <summary>
         /// Tests the watcher behavior when two events - a Modification and a Creation - happen closely
         /// after each other.
         /// </summary>


### PR DESCRIPTION
I was working on the Mono fork where we need to enforce the netfx behavior (no spaces) across the board. Figured it would be useful upstream in the Windows form.