### PR TITLE
Stop using EDI.Throw for shared exception objects in HTTP/2

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1049,7 +1049,7 @@ namespace System.Net.Http
                 // The user should never see this exception.  Same logic lives in AddStream.
                 if (_abortException != null)
                 {
-                    ExceptionDispatchInfo.Throw(_abortException);
+                    throw new HttpRequestException(SR.net_http_client_execution_error, _abortException);
                 }
 
                 throw CreateRetryException();
@@ -1588,13 +1588,13 @@ namespace System.Net.Http
                     if (_abortException != null)
                     {
                         // Aborted because protocol error or IO.
-                        throw new ObjectDisposedException(nameof(Http2Connection));
+                        throw new ObjectDisposedException(nameof(Http2Connection), _abortException);
                     }
 
                     // We run out of IDs or we have race condition between receiving GOAWAY and processing requests.
                     // Throw a retryable request exception. This will cause retry logic to kick in
                     // and perform another connection attempt. The user should never see this exception.
-                    throw HttpConnectionBase.CreateRetryException();
+                    throw CreateRetryException();
                 }
 
                 int streamId = _nextStream;

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -903,9 +903,9 @@ namespace System.Net.Http
                     }
 
                     // TODO: until #9071 is fixed
-                    if (http2Stream._abortException is OperationCanceledException)
+                    if (http2Stream._abortException is OperationCanceledException oce)
                     {
-                        ExceptionDispatchInfo.Throw(http2Stream._abortException);
+                        throw new OperationCanceledException(oce.Message, oce, oce.CancellationToken);
                     }
 
                     return new ValueTask(http2Stream.SendDataAsync(buffer, cancellationToken));


### PR DESCRIPTION
Contributes to https://github.com/dotnet/corefx/issues/38911.  Avoids corrupting a stack trace by having multiple unrelated stacks merged together.
cc: @geoffkizer 

(This doesn't address the question asked in https://github.com/dotnet/corefx/issues/38911#issuecomment-507890180.)