### PR TITLE
Make System.Resources.Extensions use old System.Memory

### DIFF
--- a/eng/Tools.props
+++ b/eng/Tools.props
@@ -46,6 +46,9 @@
 
     <!-- UWP test tools -->
     <PackageReference Include="Microsoft.DotNet.UAP.TestTools" Version="$(MicrosoftDotNetUapTestToolsPackageVersion)" Condition="$(TargetGroup.StartsWith('uap'))" PrivateAssets="all" IsImplicitlyDefined="true" />
+    
+    <!-- Restore old System.Memory to use for VS compatibility -->
+    <PackageReference Include="System.Memory" Version="4.5.2" ExcludeAssets="All" />
   </ItemGroup>
 
   <UsingTask TaskName="Microsoft.DotNet.Arcade.Sdk.SaveItems" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2589,7 +2589,7 @@
         "4.5.2",
         "4.5.3"
       ],
-      "BaselineVersion": "4.5.3",
+      "BaselineVersion": "4.5.2",
       "InboxOn": {
         "netcoreapp2.1": "4.1.0.0",
         "netcoreapp3.0": "4.2.0.0",

--- a/src/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -25,6 +25,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Memory" />
+    <Reference Condition="'$(DotNetBuildFromSource)' == 'true'" Include="System.Memory" />
+    <!-- Visual studio needs to be able to load this assembly and cannot upgrade the version of System.Memory used -->
+    <Reference Condition="'$(DotNetBuildFromSource)' != 'true'" Include="$(NuGetPackageRoot)System.Memory\4.5.2\lib\netstandard2.0\System.Memory.dll" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
System.Resources.Extensions needs to be loaded by Visual Studio and currently
VS is still using an older copy of System.Memory and cannot upgrade.

