### PR TITLE
Disable two Task GC tests for UWP

### DIFF
--- a/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
+++ b/src/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
@@ -521,6 +521,7 @@ namespace System.Threading.Tasks.Tests
             TaskScheduler.UnobservedTaskException -= handler;
         }
 
+        [ActiveIssue(39155, TargetFrameworkMonikers.Uap)]
         [Fact]
         public static async Task AsyncMethodsDropsStateMachineAndExecutionContextUponCompletion()
         {

--- a/src/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
+++ b/src/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
@@ -30,6 +30,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
+        [ActiveIssue(39155, TargetFrameworkMonikers.Uap)]
         [Fact]
         public static async Task TaskDropsExecutionContextUponCompletion()
         {


### PR DESCRIPTION
They're sporadically failing in CI.
cc: @tarekgh, @kouvel