### PR TITLE
Speed up BitArray

### DIFF
--- a/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
+++ b/src/System.Collections/tests/BitArray/BitArray_OperatorsTests.cs
@@ -15,7 +15,7 @@ namespace System.Collections.Tests
 
         public static IEnumerable<object[]> Not_Operator_Data()
         {
-            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
+            foreach (int size in new[] { 0, 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 3, BitsPerInt32 * 4, BitsPerInt32 * 5, BitsPerInt32 * 6, BitsPerInt32 * 7, BitsPerInt32 * 8, BitsPerInt32 * 8 + BitsPerInt32 - 1, short.MaxValue })
             {
                 yield return new object[] { Enumerable.Repeat(true, size).ToArray() };
                 yield return new object[] { Enumerable.Repeat(false, size).ToArray() };
@@ -41,7 +41,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> And_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
+            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 3, BitsPerInt32 * 4, BitsPerInt32 * 5, BitsPerInt32 * 6, BitsPerInt32 * 7, BitsPerInt32 * 8, BitsPerInt32 * 8 + BitsPerInt32 - 1, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();
@@ -77,7 +77,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> Or_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
+            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 3, BitsPerInt32 * 4, BitsPerInt32 * 5, BitsPerInt32 * 6, BitsPerInt32 * 7, BitsPerInt32 * 8, BitsPerInt32 * 8 + BitsPerInt32 - 1, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();
@@ -113,7 +113,7 @@ namespace System.Collections.Tests
         public static IEnumerable<object[]> Xor_Operator_Data()
         {
             yield return new object[] { new bool[0], new bool[0], new bool[0] };
-            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, short.MaxValue })
+            foreach (int size in new[] { 1, BitsPerByte, BitsPerByte * 2, BitsPerInt32, BitsPerInt32 * 2, BitsPerInt32 * 3, BitsPerInt32 * 4, BitsPerInt32 * 5, BitsPerInt32 * 6, BitsPerInt32 * 7, BitsPerInt32 * 8, BitsPerInt32 * 8 + BitsPerInt32 - 1, short.MaxValue })
             {
                 bool[] allTrue = Enumerable.Repeat(true, size).ToArray();
                 bool[] allFalse = Enumerable.Repeat(false, size).ToArray();


### PR DESCRIPTION
1. Use AVX2, if available, for And/Or/Xor
2. Vectorize Not
3. Use Span<T>.Fill() for SetAll()
4. Add more test sizes to account for And/Or/Xor/Not loop unrolling cases