### PR TITLE
Use nullablePublicOnly flag explicitly in source and ref assemblies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -258,7 +258,6 @@
     <LangVersion Condition="'$(Language)' == 'C#'">preview</LangVersion>
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict</Features>
-    <Features Condition="'$(IsTestProject)' != 'true'">$(Features);nullablePublicOnly</Features>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Deterministic>true</Deterministic>
@@ -380,6 +379,11 @@
   <PropertyGroup Condition="'$(IsSourceProject)' == 'true'">
     <!-- Set the documentation output file globally. -->
     <DocumentationFile Condition="'$(DocumentationFile)' == ''">$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsSourceProject)' == 'true' OR '$(IsReferenceAssembly)' == 'true'">
+    <Features Condition="'$(Features)' == ''">nullablePublicOnly</Features>
+    <Features Condition="'$(Features)' != ''">$(Features);nullablePublicOnly</Features>
   </PropertyGroup>
 
   <!-- Additional optimizations -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -363,7 +363,7 @@
 
   <PropertyGroup>
     <!-- F5 and debugging support for netcoreapp and netfx inside VS. -->
-    <EnableLaunchSettings Condition="'$(EnableLaunchSettings)' == ''AND '$(DotNetBuildFromSource)' != 'true'">true</EnableLaunchSettings>
+    <EnableLaunchSettings Condition="'$(EnableLaunchSettings)' == '' and '$(DotNetBuildFromSource)' != 'true'">true</EnableLaunchSettings>
   </PropertyGroup>
 
   <!-- Test properties for full build. -->
@@ -381,15 +381,12 @@
     <DocumentationFile Condition="'$(DocumentationFile)' == ''">$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsSourceProject)' == 'true' OR '$(IsReferenceAssembly)' == 'true'">
-    <Features Condition="'$(Features)' == ''">nullablePublicOnly</Features>
-    <Features Condition="'$(Features)' != ''">$(Features);nullablePublicOnly</Features>
-  </PropertyGroup>
-
   <!-- Additional optimizations -->
   <PropertyGroup>
     <!-- Clear the init locals flag on all src projects, except those in VB, where we can't use spans. -->
-    <ILLinkClearInitLocals Condition="'$(IsSourceProject)' == 'true' AND '$(Language)' != 'VB'">true</ILLinkClearInitLocals>
+    <ILLinkClearInitLocals Condition="'$(IsSourceProject)' == 'true' and '$(Language)' != 'VB'">true</ILLinkClearInitLocals>
+
+    <Features Condition="'$(IsSourceProject)' == 'true' or '$(IsReferenceAssembly)' == 'true'">$(Features);nullablePublicOnly</Features>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/coreclr/issues/25522

By adding the flag when `IsTestProject != true` it was passing down this flag for shim projects as well, which was causing the compiler to include some typedefs and attributes to the shims (mscorlib, etc).

cc: @stephentoub @sergiy-k @fadimounir 