### PR TITLE
Mark some tests with IsPreciseGcSupported condition

### DIFF
--- a/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
@@ -69,7 +69,7 @@ namespace System.Diagnostics.TraceSourceTests
             return new WeakReference(new TraceSource("TestTraceSource"));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public void PruneTest()
         {
             var strongTrace = new TraceSource("TestTraceSource");

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.indexer.regclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.indexer.regclass.cs
@@ -2268,7 +2268,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.indexer.regclas
             GC.KeepAlive(t);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void DynamicCSharpRunTest()
         {
             RequireLifetimesEnded();

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.genmethod.regclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.method.genmethod.regclass.cs
@@ -942,7 +942,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.method.genmetho
             GC.KeepAlive(t);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod());

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.regclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.operator.regclass.cs
@@ -1782,7 +1782,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclas
             GC.KeepAlive(t);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod());
@@ -3460,7 +3460,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.operate.regclas
             GC.KeepAlive(t);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod());

--- a/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.property.autoproperty.regclass.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Context/Conformance.dynamic.context.property.autoproperty.regclass.cs
@@ -519,7 +519,7 @@ namespace ManagedTests.DynamicCSharp.Conformance.dynamic.context.property.autopr
             GC.KeepAlive(t);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void DynamicCSharpRunTest()
         {
             Assert.Equal(0, MainMethod());

--- a/src/System.IO.FileSystem/tests/FileStream/Dispose.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/Dispose.cs
@@ -231,7 +231,7 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public void FinalizeFlushesWriteBuffer()
         {
             string fileName = GetTestFilePath();

--- a/src/System.Runtime/tests/System/GCTests.cs
+++ b/src/System.Runtime/tests/System/GCTests.cs
@@ -273,7 +273,7 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentNullException>("obj", () => GC.SuppressFinalize(null)); // Obj is null
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void ReRegisterForFinalize()
         {
             ReRegisterForFinalizeTest.Run();

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTableTests.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTableTests.cs
@@ -200,7 +200,7 @@ namespace System.Runtime.CompilerServices.Tests
             return new WeakReference(value);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void AddRemove_DropValue()
         {
             // Verify that the removed entry is not keeping the value alive

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTableTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTableTests.netcoreapp.cs
@@ -114,7 +114,7 @@ namespace System.Runtime.CompilerServices.Tests
             GC.KeepAlive(value1);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void GetEnumerator_CollectedItemsNotEnumerated()
         {
             var cwt = new ConditionalWeakTable<object, object>();

--- a/src/System.Runtime/tests/System/WeakReferenceTests.cs
+++ b/src/System.Runtime/tests/System/WeakReferenceTests.cs
@@ -26,7 +26,7 @@ namespace System.Tests
             return new WeakReference<object>(valueFactory(), trackResurrection);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void NonGeneric()
         {
             object o1 = new char[10];
@@ -75,7 +75,7 @@ namespace System.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void Generic()
         {
             object o1 = new char[10];


### PR DESCRIPTION
In order to ignore them on Mono, see https://github.com/dotnet/corefx/pull/37358#discussion_r280442394