### PR TITLE
Temporarily disable `MemoryLoadBytes` scenario in `GetGCMemoryInfo` test

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
@@ -64,6 +64,8 @@ namespace System.Tests
                     Assert.Equal(memoryInfo2.HighMemoryLoadThresholdBytes, memoryInfo1.HighMemoryLoadThresholdBytes);
 
                     // TODO: the following test fails. Disabling now while figuring what  range of values is actually expected here.
+                    //       see: https://github.com/dotnet/corefx/issues/37378
+                    //
                     //scenario = nameof(memoryInfo2.MemoryLoadBytes);
                     //Assert.InRange(memoryInfo2.MemoryLoadBytes, memoryInfo1.MemoryLoadBytes, long.MaxValue);
 

--- a/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
@@ -63,8 +63,9 @@ namespace System.Tests
                     scenario = nameof(memoryInfo2.HighMemoryLoadThresholdBytes);
                     Assert.Equal(memoryInfo2.HighMemoryLoadThresholdBytes, memoryInfo1.HighMemoryLoadThresholdBytes);
 
-                    scenario = nameof(memoryInfo2.MemoryLoadBytes);
-                    Assert.InRange(memoryInfo2.MemoryLoadBytes, memoryInfo1.MemoryLoadBytes, long.MaxValue);
+                    // TODO: the following test fails. Disabling now while figuring what  range of values is actually expected here.
+                    //scenario = nameof(memoryInfo2.MemoryLoadBytes);
+                    //Assert.InRange(memoryInfo2.MemoryLoadBytes, memoryInfo1.MemoryLoadBytes, long.MaxValue);
 
                     scenario = nameof(memoryInfo2.TotalAvailableMemoryBytes);
                     Assert.Equal(memoryInfo2.TotalAvailableMemoryBytes, memoryInfo1.TotalAvailableMemoryBytes);


### PR DESCRIPTION
related to https://github.com/dotnet/corefx/issues/37378