### PR TITLE
Fix EventLog tests on latest Win10

### DIFF
--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -124,7 +124,6 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentException>(() => EventLog.GetEventLogs(""));
             EventLog[] eventLogCollection = EventLog.GetEventLogs();
             Assert.Contains(eventLogCollection, eventlog => eventlog.Log.Equals("Application"));
-            Assert.Contains(eventLogCollection, eventlog => eventlog.Log.Equals("Security"));
             Assert.Contains(eventLogCollection, eventlog => eventlog.Log.Equals("System"));
         }
 


### PR DESCRIPTION
The Security EventLog is ACLed for admin access only. Remove it from the set we look
for to make the test work in regular prompt.