### PR TITLE
Fix expected range of MemoryLoadBytes in GetGCMemoryInfo test

### DIFF
--- a/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
+++ b/src/System.Runtime/tests/System/GCTests.netcoreapp.cs
@@ -63,11 +63,10 @@ namespace System.Tests
                     scenario = nameof(memoryInfo2.HighMemoryLoadThresholdBytes);
                     Assert.Equal(memoryInfo2.HighMemoryLoadThresholdBytes, memoryInfo1.HighMemoryLoadThresholdBytes);
 
-                    // TODO: the following test fails. Disabling now while figuring what  range of values is actually expected here.
-                    //       see: https://github.com/dotnet/corefx/issues/37378
-                    //
-                    //scenario = nameof(memoryInfo2.MemoryLoadBytes);
-                    //Assert.InRange(memoryInfo2.MemoryLoadBytes, memoryInfo1.MemoryLoadBytes, long.MaxValue);
+                    // Even though we have allocated, the overall load may decrease or increase depending what other processes are doing.
+                    // It cannot go above total available though.
+                    scenario = nameof(memoryInfo2.MemoryLoadBytes);
+                    Assert.InRange(memoryInfo2.MemoryLoadBytes, 1, memoryInfo1.TotalAvailableMemoryBytes);
 
                     scenario = nameof(memoryInfo2.TotalAvailableMemoryBytes);
                     Assert.Equal(memoryInfo2.TotalAvailableMemoryBytes, memoryInfo1.TotalAvailableMemoryBytes);


### PR DESCRIPTION
`MemoryLoadBytes` does not necessarily increase after allocating. 
Since it is an external metric, it also depends on what other processes are doing. It may sometimes go down even after allocating.

Fixes:#37378