### PR TITLE
Add more options to HttpStress program

### DIFF
--- a/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -40,6 +40,7 @@ public class Program
         cmd.AddOption(new Option("-ops", "Indices of the operations to use") { Argument = new Argument<int[]>("space-delimited indices", null) });
         cmd.AddOption(new Option("-trace", "Enable Microsoft-System-Net-Http tracing.") { Argument = new Argument<string>("\"console\" or path") });
         cmd.AddOption(new Option("-aspnetlog", "Enable ASP.NET warning and error logging.") { Argument = new Argument<bool>("enable", false) });
+        cmd.AddOption(new Option("-listOps", "List available options.") { Argument = new Argument<bool>("enable", false) });
 
         ParseResult cmdline = cmd.Parse(args);
         if (cmdline.Errors.Count > 0)
@@ -58,17 +59,35 @@ public class Program
             cmdline.ValueForOption<Version>("-http"),
             cmdline.ValueForOption<int[]>("-ops"),
             cmdline.HasOption("-trace") ? cmdline.ValueForOption<string>("-trace") : null,
-            cmdline.ValueForOption<bool>("-aspnetlog"));
+            cmdline.ValueForOption<bool>("-aspnetlog"),
+            cmdline.ValueForOption<bool>("-listOps"));
     }
 
-    private static void Run(int concurrentRequests, int contentLength, Version httpVersion, int[] opIndices, string logPath, bool aspnetLog)
+    private static void Run(int concurrentRequests, int contentLength, Version httpVersion, int[] opIndices, string logPath, bool aspnetLog, bool listOps)
     {
         // Handle command-line arguments.
         EventListener listener =
             logPath == null ? null :
             new HttpEventListener(logPath != "console" ? new StreamWriter(logPath) { AutoFlush = true } : null);
+        if (listener == null)
+        {
+            // If no command-line requested logging, enable the user to press 'L' to enable logging to the console
+            // during execution, so that it can be done just-in-time when something goes awry.
+            new Thread(() =>
+            {
+                while (true)
+                {
+                    if (Console.ReadKey(intercept: true).Key == ConsoleKey.L)
+                    {
+                        listener = new HttpEventListener();
+                        break;
+                    }
+                }
+            }) { IsBackground = true }.Start();
+        }
 
         string content = string.Concat(Enumerable.Repeat("1234567890", contentLength / 10));
+        byte[] contentBytes = Encoding.ASCII.GetBytes(content);
         const int DisplayIntervalMilliseconds = 1000;
         const int HttpsPort = 5001;
         const string LocalhostName = "localhost";
@@ -183,7 +202,17 @@ public class Program
             ("POST Duplex",
             async client =>
             {
-                using (HttpResponseMessage m = await client.PostAsync(serverUri + "/duplex", new StringContent(content)))
+                using (HttpResponseMessage m = await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, serverUri + "/duplex") { Content = new StringContent(content), Version = httpVersion }, HttpCompletionOption.ResponseHeadersRead))
+                {
+                    ValidateResponse(m);
+                    return await m.Content.ReadAsStringAsync();
+                }
+            }),
+
+            ("POST Duplex Slow",
+            async client =>
+            {
+                using (HttpResponseMessage m = await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, serverUri + "/duplexSlow") { Content = new ByteAtATimeNoLengthContent(contentBytes), Version = httpVersion }, HttpCompletionOption.ResponseHeadersRead))
                 {
                     ValidateResponse(m);
                     return await m.Content.ReadAsStringAsync();
@@ -193,9 +222,8 @@ public class Program
             ("POST ExpectContinue",
             async client =>
             {
-                using (var req = new HttpRequestMessage(HttpMethod.Post, serverUri) { Version = httpVersion })
+                using (var req = new HttpRequestMessage(HttpMethod.Post, serverUri) { Content = new StringContent(content), Version = httpVersion })
                 {
-                    req.Content = new StringContent(content);
                     req.Headers.ExpectContinue = true;
                     using (HttpResponseMessage m = await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
                     {
@@ -226,7 +254,42 @@ public class Program
                     catch (OperationCanceledException) { return null; }
                 }
             }),
+
+            ("HEAD",
+            async client =>
+            {
+                using (HttpResponseMessage m = await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, serverUri) { Version = httpVersion }))
+                {
+                    ValidateResponse(m);
+                    if (m.Content.Headers.ContentLength != contentLength)
+                    {
+                        throw new Exception($"Expected {contentLength}, got {m.Content.Headers.ContentLength}");
+                    }
+                    string r = await m.Content.ReadAsStringAsync();
+                    return r.Length == 0 ? null : r;
+                }
+            }),
+
+            ("PUT",
+            async client =>
+            {
+                using (HttpResponseMessage m = await client.PutAsync(serverUri, new StringContent(content)))
+                {
+                    ValidateResponse(m);
+                    string r = await m.Content.ReadAsStringAsync();
+                    return r == "" ? content : throw new Exception("Got unexpected response: {r}");
+                }
+            }),
         };
+
+        if (listOps)
+        {
+            for (int i = 0; i < clientOperations.Length; i++)
+            {
+                Console.WriteLine($"{i} = {clientOperations[i].Item1}");
+            }
+            return;
+        }
 
         if (opIndices != null)
         {
@@ -274,6 +337,7 @@ public class Program
             // Set up how each request should be handled by the server.
             .Configure(app =>
             {
+                var head = new[] { "HEAD" };
                 app.UseRouting();
                 app.UseEndpoints(endpoints =>
                 {
@@ -320,6 +384,26 @@ public class Program
                     {
                         // Echos back the requested content in a full duplex manner.
                         await context.Request.Body.CopyToAsync(context.Response.Body);
+                    });
+                    endpoints.MapPost("/duplexSlow", async context =>
+                    {
+                        // Echos back the requested content in a full duplex manner, but one byte at a time.
+                        var buffer = new byte[1];
+                        while ((await context.Request.Body.ReadAsync(buffer)) != 0)
+                        {
+                            await context.Response.Body.WriteAsync(buffer);
+                        }
+                    });
+                    endpoints.MapMethods("/", head, context =>
+                    {
+                        // Just set the content length on the response.
+                        context.Response.Headers.ContentLength = contentLength;
+                        return Task.CompletedTask;
+                    });
+                    endpoints.MapPut("/", async context =>
+                    {
+                        // Read the full request but don't send back a response body.
+                        await context.Request.Body.CopyToAsync(Stream.Null);
                     });
                 });
             })
@@ -458,6 +542,28 @@ public class Program
         {
             length = 42;
             return true;
+        }
+    }
+
+    private sealed class ByteAtATimeNoLengthContent : HttpContent
+    {
+        private readonly byte[] _buffer;
+
+        public ByteAtATimeNoLengthContent(byte[] buffer) => _buffer = buffer;
+
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            for (int i = 0; i < _buffer.Length; i++)
+            {
+                await stream.WriteAsync(_buffer.AsMemory(i, 1));
+                await stream.FlushAsync();
+            }
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
         }
     }
 


### PR DESCRIPTION
- "listOps" option, to see what numbers correspond to which client operations
- New client operation for HEAD
- New client operation for PUT
- New client operation for POST duplex, but that dribbles a byte at a time
- Fixed POST duplex to use ResponseHeadersRead
- Enable HTTP logging to be started to the console during a run