### PR TITLE
Improve LINQ predicate performance

### DIFF
--- a/src/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/System.Linq/src/System/Linq/AnyAll.cs
@@ -57,15 +57,9 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
-            foreach (TSource element in source)
-            {
-                if (predicate(element))
-                {
-                    return true;
-                }
-            }
+            source.TryGetFirst(predicate, out bool found);
 
-            return false;
+            return found;
         }
 
         public static bool All<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)

--- a/src/System.Linq/src/System/Linq/First.cs
+++ b/src/System.Linq/src/System/Linq/First.cs
@@ -107,8 +107,11 @@ namespace System.Linq
             }
             else if (source is List<TSource> list)
             {
-                foreach (TSource element in list)
+                TSource element;
+                for (int i = 0; i < list.Count; ++i)
                 {
+                    element = list[i];
+
                     if (predicate(element))
                     {
                         found = true;

--- a/src/System.Linq/src/System/Linq/First.cs
+++ b/src/System.Linq/src/System/Linq/First.cs
@@ -107,10 +107,9 @@ namespace System.Linq
             }
             else if (source is List<TSource> list)
             {
-                TSource element;
                 for (int i = 0; i < list.Count; ++i)
                 {
-                    element = list[i];
+                    TSource element = list[i];
 
                     if (predicate(element))
                     {

--- a/src/System.Linq/src/System/Linq/First.cs
+++ b/src/System.Linq/src/System/Linq/First.cs
@@ -94,12 +94,37 @@ namespace System.Linq
                 return ordered.TryGetFirst(predicate, out found);
             }
 
-            foreach (TSource element in source)
+            if (source is TSource[] array)
             {
-                if (predicate(element))
+                foreach (TSource element in array)
                 {
-                    found = true;
-                    return element;
+                    if (predicate(element))
+                    {
+                        found = true;
+                        return element;
+                    }
+                }
+            }
+            else if (source is List<TSource> list)
+            {
+                foreach (TSource element in list)
+                {
+                    if (predicate(element))
+                    {
+                        found = true;
+                        return element;
+                    }
+                }
+            }
+            else
+            {
+                foreach (TSource element in source)
+                {
+                    if (predicate(element))
+                    {
+                        found = true;
+                        return element;
+                    }
                 }
             }
 

--- a/src/System.Linq/src/System/Linq/Single.cs
+++ b/src/System.Linq/src/System/Linq/Single.cs
@@ -161,8 +161,11 @@ namespace System.Linq
             }
             else if (source is List<TSource> list)
             {
-                foreach (TSource element in list)
+                TSource element;
+                for (int i = 0; i < list.Count; ++i)
                 {
+                    element = list[i];
+
                     if (predicate(element))
                     {
                         if (found)

--- a/src/System.Linq/src/System/Linq/Single.cs
+++ b/src/System.Linq/src/System/Linq/Single.cs
@@ -45,7 +45,7 @@ namespace System.Linq
             }
 
             ThrowHelper.ThrowMoreThanOneElementException();
-            return default;
+            return default(TSource);
         }
 
         public static TSource Single<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
@@ -60,18 +60,9 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
-            var result = TryGetSingle(source, predicate, out bool found, out bool foundSingle);
-
-            if (!foundSingle)
-            {
-                ThrowHelper.ThrowMoreThanOneMatchException();
-                return default;
-            }
-
-            if (!found)
+            if (!TryGetSingle(source, predicate, out TSource result))
             {
                 ThrowHelper.ThrowNoMatchException();
-                return default;
             }
 
             return result;
@@ -129,19 +120,15 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
-            var result = TryGetSingle(source, predicate, out bool found, out bool foundSingle);
-
-            if (!foundSingle)
+            if (!TryGetSingle(source, predicate, out TSource result))
             {
-                ThrowHelper.ThrowMoreThanOneMatchException();
-
-                return default;
+                return default!;
             }
 
             return result;
         }
 
-        private static TSource TryGetSingle<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found, out bool foundSingle)
+        private static bool TryGetSingle<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out TSource result)
         {
             if (source == null)
             {
@@ -153,8 +140,8 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
-            TSource result = default!;
-            found = false;
+            result = default!;
+            bool found = false;
 
             if (source is TSource[] array)
             {
@@ -164,16 +151,13 @@ namespace System.Linq
                     {
                         if (found)
                         {
-                            foundSingle = false;
-                            return default!;
+                            ThrowHelper.ThrowMoreThanOneMatchException();
                         }
 
                         found = true;
                         result = element;
                     }
                 }
-
-                foundSingle = true;
             }
             else if (source is List<TSource> list)
             {
@@ -183,8 +167,7 @@ namespace System.Linq
                     {
                         if (found)
                         {
-                            foundSingle = false;
-                            return default!;
+                            ThrowHelper.ThrowMoreThanOneMatchException();
                         }
 
                         found = true;
@@ -200,8 +183,7 @@ namespace System.Linq
                     {
                         if (found)
                         {
-                            foundSingle = false;
-                            return default!;
+                            ThrowHelper.ThrowMoreThanOneMatchException();
                         }
 
                         found = true;
@@ -210,8 +192,7 @@ namespace System.Linq
                 }
             }
 
-            foundSingle = true;
-            return result;
+            return found;
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Single.cs
+++ b/src/System.Linq/src/System/Linq/Single.cs
@@ -50,16 +50,6 @@ namespace System.Linq
 
         public static TSource Single<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
-            if (predicate == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
-            }
-
             if (!TryGetSingle(source, predicate, out TSource result))
             {
                 ThrowHelper.ThrowNoMatchException();
@@ -110,20 +100,7 @@ namespace System.Linq
         [return: MaybeNull]
         public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
-            if (predicate == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
-            }
-
-            if (!TryGetSingle(source, predicate, out TSource result))
-            {
-                return default!;
-            }
+            TryGetSingle(source, predicate, out TSource result);
 
             return result;
         }
@@ -154,8 +131,8 @@ namespace System.Linq
                             ThrowHelper.ThrowMoreThanOneMatchException();
                         }
 
-                        found = true;
                         result = element;
+                        found = true;
                     }
                 }
             }
@@ -173,8 +150,8 @@ namespace System.Linq
                             ThrowHelper.ThrowMoreThanOneMatchException();
                         }
 
-                        found = true;
                         result = element;
+                        found = true;
                     }
                 }
             }
@@ -189,8 +166,8 @@ namespace System.Linq
                             ThrowHelper.ThrowMoreThanOneMatchException();
                         }
 
-                        found = true;
                         result = element;
+                        found = true;
                     }
                 }
             }

--- a/src/System.Linq/src/System/Linq/Single.cs
+++ b/src/System.Linq/src/System/Linq/Single.cs
@@ -138,10 +138,9 @@ namespace System.Linq
             }
             else if (source is List<TSource> list)
             {
-                TSource element;
                 for (int i = 0; i < list.Count; ++i)
                 {
-                    element = list[i];
+                    TSource element = list[i];
 
                     if (predicate(element))
                     {


### PR DESCRIPTION
Fixes #13696 and #39148 

This PR adds type checks and code paths for List<T> and T[] to `First(predicate)`, `FirstOrDefault(predicate)`, `Single(predicate)` and `SingleOrDefault(predicate)`.

`Any(predicate)` now uses the `TryGetFirst` method, I thought this might be better than doing the same type checks in there as well.

Things that might need some fixing still:
- ~~TryGetSingle has a `out bool found` and `out bool foundSingle` because I didn't think that throwing an exception from a method prefixed with 'Try' would be acceptable.~~ Fixed.
- ~~Might need to separate things with a `SpeedOpt` or `SizeOpt` implementation as well~~ This appears to be about memory usage, and not code size (?).

Benchmarks are submitted to dotnet/performance [here](https://github.com/dotnet/performance/pull/611).
