### PR TITLE
Change Span.Fill(0) call to Span.Clear() instead

### DIFF
--- a/src/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Windows/RequestContextBase.cs
@@ -123,7 +123,7 @@ namespace System.Net
             _backingBufferLength = size;
 
             // Zero out the contents of the buffer.
-            new Span<byte>(_backingBuffer.ToPointer(), size).Fill(0);
+            new Span<byte>(_backingBuffer.ToPointer(), size).Clear();
         }
     }
 }


### PR DESCRIPTION
Just some minor cleanup in `HttpListener`.