### PR TITLE
Update MatchCollection.cs

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/MatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/MatchCollection.cs
@@ -81,12 +81,13 @@ namespace System.Text.RegularExpressions
             }
         }
 
+
+        IEnumerator IEnumerable.GetEnumerator() => new Enumerator(this);
+        
         /// <summary>
         /// Provides an enumerator in the same order as Item[i].
         /// </summary>
-        public IEnumerator GetEnumerator() => new Enumerator(this);
-
-        IEnumerator<Match> IEnumerable<Match>.GetEnumerator() => new Enumerator(this);
+        public IEnumerator<Match> GetEnumerator() => new Enumerator(this);
 
         private Match GetMatch(int i)
         {


### PR DESCRIPTION
Take the following code as an example:

```cs
foreach (var match in Regex.Matches("hello, world!", @"[a-z]+"))
{
    Console.WriteLine(match.Value);
}
```
The output should be:
```
hello
world
```
but actually, it doesn't even compile. Why? Because `IEnumerable<Match>.GetEnumerator` is implemented explicitly while the non-generic version is not, hence, `var` infers `match` as `object` instead of `Match`. This fix would make the compiler to properly infer the type.