### PR TITLE
change CreateHttpClient handler to always enable HTTP2 via DefaultRequestVersion

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
@@ -4,12 +4,9 @@
 
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 using System.Net.Test.Common;
-
+using System.Reflection;
 using Xunit.Abstractions;
-using System.Collections.Generic;
-using System.Text;
 
 namespace System.Net.Http.Functional.Tests
 {
@@ -39,7 +36,13 @@ namespace System.Net.Http.Functional.Tests
         protected HttpClient CreateHttpClient(HttpMessageHandler handler)
         {
             var client = new HttpClient(handler);
-            SetDefaultRequestVersion(client, VersionFromUseHttp2);
+
+            // Always set the default request version to HTTP/2.
+            // The actual version used will be determined by the server (either loopback server or remote server).
+            // Note that if you create the HttpRequestMessage explicitly, you will need to set its Version explicitly
+            // because it defaults to 1.1.
+
+            SetDefaultRequestVersion(client, HttpVersion.Version20);
             return client;
         }
 


### PR DESCRIPTION
Fixes #39178 

Currently, a lot of remote server tests that are trying to test HTTP2 actually aren't using HTTP2, because the requests they create have Version=1.1.

Fix this by changing HttpClientHandlerTestBase.CreateHttpClient to always set HttpClient.DefaultRequestVersion to 2.0. This means we will always attempt to do HTTP2. Whether we actually do HTTP2 or not is determined by the server (loopback or remote).

Note that DefaultRequestVersion does not apply if you create the HttpRequestMessage yourself, so any tests that do this need to set Version=2.0 explicitly.

