### PR TITLE
Http2LoopbackConnection: Wait for pending ACK before setting up for new ignored settings frames

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -191,16 +191,18 @@ namespace System.Net.Test.Common
             return (oldSocket, oldStream);
         }
 
-        public async Task ExpectSettingsAckAsync(TimeSpan timeout)
+        // Set up loopback server to silently ignore the next inbound settings ack frame.
+        // If there already is a pending ack frame, wait until it has been read.
+        public async Task ExpectSettingsAckAsync(int timeoutMs = 5000)
         {
             // The timing of when we receive the settings ack is not guaranteed.
             // To simplify frame processing, just record that we are expecting one,
             // and then filter it out in ReadFrameAsync above.
 
-            // In case of a pending settings ack, wait for it or time out
             Task currentTask = _ignoredSettingsAckPromise?.Task;
             if (currentTask != null)
             {
+                var timeout = TimeSpan.FromMilliseconds(timeoutMs);
                 await currentTask.TimeoutAfter(timeout);
             }
 

--- a/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -125,7 +125,7 @@ namespace System.Net.Test.Common
             await connection.WriteFrameAsync(settingsAck).ConfigureAwait(false);
 
             // The client will send us a SETTINGS ACK eventually, but not necessarily right away.
-            connection.ExpectSettingsAck();
+            await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
 
             return (connection, clientSettingsFrame);
         }

--- a/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackServer.cs
@@ -125,7 +125,7 @@ namespace System.Net.Test.Common
             await connection.WriteFrameAsync(settingsAck).ConfigureAwait(false);
 
             // The client will send us a SETTINGS ACK eventually, but not necessarily right away.
-            await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
+            await connection.ExpectSettingsAckAsync();
 
             return (connection, clientSettingsFrame);
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -306,7 +306,7 @@ namespace System.Net.Http.Functional.Tests
                 (int streamId1, HttpRequestData requestData1) = await connection.ReadAndParseRequestHeaderAsync(readBody: true);
 
                 // Send SETTINGS frame to change stream limit to 0, allowing us to send a REFUSED_STREAM error due to the new limit
-                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
+                await connection.ExpectSettingsAckAsync();
                 Frame frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 0 });
                 await connection.WriteFrameAsync(frame);
 
@@ -317,7 +317,7 @@ namespace System.Net.Http.Functional.Tests
                 await connection.PingPong();
 
                 // Send SETTINGS frame to change stream limit to 1, allowing the request to now be processed
-                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
+                await connection.ExpectSettingsAckAsync();
                 frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 1 });
                 await connection.WriteFrameAsync(frame);
 
@@ -344,7 +344,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(Content, Encoding.UTF8.GetString(requestData1.Body));
 
                 // Send SETTINGS frame to change stream limit to 0, allowing us to send a REFUSED_STREAM error due to the new limit
-                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
+                await connection.ExpectSettingsAckAsync();
                 Frame frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 0 });
                 await connection.WriteFrameAsync(frame);
 
@@ -355,7 +355,7 @@ namespace System.Net.Http.Functional.Tests
                 await connection.PingPong();
 
                 // Send SETTINGS frame to change stream limit to 1, allowing the request to now be processed
-                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
+                await connection.ExpectSettingsAckAsync();
                 frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 1 });
                 await connection.WriteFrameAsync(frame);
 
@@ -1296,7 +1296,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(readFrameTask.IsCompleted);
 
                 // Change SETTINGS_INITIAL_WINDOW_SIZE to 0. This will make the client's credit go negative.
-                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
+                await connection.ExpectSettingsAckAsync();
                 await connection.WriteFrameAsync(new SettingsFrame(new SettingsEntry { SettingId = SettingId.InitialWindowSize, Value = 0 }));
 
                 await Task.Delay(500);
@@ -1309,7 +1309,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(readFrameTask.IsCompleted);
 
                 // Change SETTINGS_INITIAL_WINDOW_SIZE to 1. Client credit will still be negative.
-                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
+                await connection.ExpectSettingsAckAsync();
                 await connection.WriteFrameAsync(new SettingsFrame(new SettingsEntry { SettingId = SettingId.InitialWindowSize, Value = 1 }));
 
                 await Task.Delay(500);
@@ -1336,7 +1336,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(readFrameTask.IsCompleted);
 
                 // Increase SETTINGS_INITIAL_WINDOW_SIZE to 2, so client can now send a single byte.
-                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
+                await connection.ExpectSettingsAckAsync();
                 await connection.WriteFrameAsync(new SettingsFrame(new SettingsEntry { SettingId = SettingId.InitialWindowSize, Value = 2 }));
 
                 frame = await readFrameTask;
@@ -1351,7 +1351,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(readFrameTask.IsCompleted);
 
                 // Increase SETTINGS_INITIAL_WINDOW_SIZE to be enough that the client can send the rest of the content.
-                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
+                await connection.ExpectSettingsAckAsync();
                 await connection.WriteFrameAsync(new SettingsFrame(new SettingsEntry { SettingId = SettingId.InitialWindowSize, Value = ContentSize - (DefaultInitialWindowSize - 1) }));
 
                 frame = await readFrameTask;
@@ -1411,7 +1411,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(readFrameTask.IsCompleted);
 
                 // Change MaxConcurrentStreams again to allow a single request to come through.
-                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
+                await connection.ExpectSettingsAckAsync();
                 settingsFrame = new SettingsFrame(new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = 1 });
                 await connection.WriteFrameAsync(settingsFrame);
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -306,7 +306,7 @@ namespace System.Net.Http.Functional.Tests
                 (int streamId1, HttpRequestData requestData1) = await connection.ReadAndParseRequestHeaderAsync(readBody: true);
 
                 // Send SETTINGS frame to change stream limit to 0, allowing us to send a REFUSED_STREAM error due to the new limit
-                connection.ExpectSettingsAck();
+                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
                 Frame frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 0 });
                 await connection.WriteFrameAsync(frame);
 
@@ -317,7 +317,7 @@ namespace System.Net.Http.Functional.Tests
                 await connection.PingPong();
 
                 // Send SETTINGS frame to change stream limit to 1, allowing the request to now be processed
-                connection.ExpectSettingsAck();
+                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
                 frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 1 });
                 await connection.WriteFrameAsync(frame);
 
@@ -344,7 +344,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(Content, Encoding.UTF8.GetString(requestData1.Body));
 
                 // Send SETTINGS frame to change stream limit to 0, allowing us to send a REFUSED_STREAM error due to the new limit
-                connection.ExpectSettingsAck();
+                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
                 Frame frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 0 });
                 await connection.WriteFrameAsync(frame);
 
@@ -355,7 +355,7 @@ namespace System.Net.Http.Functional.Tests
                 await connection.PingPong();
 
                 // Send SETTINGS frame to change stream limit to 1, allowing the request to now be processed
-                connection.ExpectSettingsAck();
+                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
                 frame = new SettingsFrame(new SettingsEntry() { SettingId = SettingId.MaxConcurrentStreams, Value = 1 });
                 await connection.WriteFrameAsync(frame);
 
@@ -1296,7 +1296,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(readFrameTask.IsCompleted);
 
                 // Change SETTINGS_INITIAL_WINDOW_SIZE to 0. This will make the client's credit go negative.
-                connection.ExpectSettingsAck();
+                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
                 await connection.WriteFrameAsync(new SettingsFrame(new SettingsEntry { SettingId = SettingId.InitialWindowSize, Value = 0 }));
 
                 await Task.Delay(500);
@@ -1309,7 +1309,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(readFrameTask.IsCompleted);
 
                 // Change SETTINGS_INITIAL_WINDOW_SIZE to 1. Client credit will still be negative.
-                connection.ExpectSettingsAck();
+                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
                 await connection.WriteFrameAsync(new SettingsFrame(new SettingsEntry { SettingId = SettingId.InitialWindowSize, Value = 1 }));
 
                 await Task.Delay(500);
@@ -1336,7 +1336,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(readFrameTask.IsCompleted);
 
                 // Increase SETTINGS_INITIAL_WINDOW_SIZE to 2, so client can now send a single byte.
-                connection.ExpectSettingsAck();
+                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
                 await connection.WriteFrameAsync(new SettingsFrame(new SettingsEntry { SettingId = SettingId.InitialWindowSize, Value = 2 }));
 
                 frame = await readFrameTask;
@@ -1351,7 +1351,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(readFrameTask.IsCompleted);
 
                 // Increase SETTINGS_INITIAL_WINDOW_SIZE to be enough that the client can send the rest of the content.
-                connection.ExpectSettingsAck();
+                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
                 await connection.WriteFrameAsync(new SettingsFrame(new SettingsEntry { SettingId = SettingId.InitialWindowSize, Value = ContentSize - (DefaultInitialWindowSize - 1) }));
 
                 frame = await readFrameTask;
@@ -1411,7 +1411,7 @@ namespace System.Net.Http.Functional.Tests
                 Assert.False(readFrameTask.IsCompleted);
 
                 // Change MaxConcurrentStreams again to allow a single request to come through.
-                connection.ExpectSettingsAck();
+                await connection.ExpectSettingsAckAsync(TimeSpan.FromSeconds(30.0));
                 settingsFrame = new SettingsFrame(new SettingsEntry { SettingId = SettingId.MaxConcurrentStreams, Value = 1 });
                 await connection.WriteFrameAsync(settingsFrame);
 


### PR DESCRIPTION
Make the Http2LoopbackConnection.ExpectSettingsAck() method handle outstanding acks more gracefully. This should fix #39082.