### PR TITLE
Adjustments to cancellation on StreamPipeReader

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
@@ -220,7 +220,7 @@ namespace System.IO.Pipelines
                 _streamReadTask = ReadStreamAsync(cancellationToken);
 
                 // Completed the stream read inline because it was synchronous and there was no exception thrown
-                if (_streamReadTask.IsCompletedSuccessfully && _edi == null)
+                if (_streamReadTask.IsCompleted && _edi == null)
                 {
                     return new ValueTask<ReadResult>(GetReadResult());
                 }

--- a/src/System.IO.Pipelines/tests/StreamPipeReaderTests.cs
+++ b/src/System.IO.Pipelines/tests/StreamPipeReaderTests.cs
@@ -269,13 +269,16 @@ namespace System.IO.Pipelines.Tests
             PipeReader reader = PipeReader.Create(stream);
 
             ValueTask<ReadResult> task = reader.ReadAsync();
-
             reader.CancelPendingRead();
+            ReadResult readResult = await task;
+            Assert.True(readResult.IsCanceled);
+            reader.AdvanceTo(readResult.Buffer.End);
 
             stream.WaitForReadTask.TrySetResult(null);
 
-            ReadResult readResult = await task;
-            Assert.True(readResult.IsCanceled);
+            readResult = await reader.ReadAsync();
+            Assert.True(readResult.IsCompleted);
+
             reader.Complete();
         }
 


### PR DESCRIPTION
- Allow CancelPendingRead to yield the ReadAsync without cancelling the underlying Stream.ReadAsync.
- The biggest complication this introduces is calling Complete after CancelPendingRead when the underlying Stream.ReadAsync hasn't completed yet. We attempt to cancel the read using a token during the call to Complete in hopes that it'll end the call to ReadAsync.

This is driven by this behavior in Kestrel (https://github.com/aspnet/AspNetCore/issues/11804#issuecomment-508285740) which uses the pipe as an event loop and CancelPendingRead as a way to wake up the loop when no data is being sent. It's basically a synchronization primitive.

PS: I need to add some more tests, but wanted to get some eyes on it to make sure I'm not missing anything obvious.
I also need to handle dispatch to the sync context etc.