### PR TITLE
Don't force flush for data packets in SocketsHttpHandler HTTP/2

### DIFF
--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -701,6 +701,7 @@
     <Reference Include="System.Text.RegularExpressions" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
+    <Reference Include="System.Threading.ThreadPool" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.Tasks.Extensions" />
     <Reference Include="System.Threading.Timer" />

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpBaseStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpBaseStream.cs
@@ -116,7 +116,7 @@ namespace System.Net.Http
             return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
         }
 
-        public override void Flush() { }
+        public override void Flush() => FlushAsync(default).GetAwaiter().GetResult();
 
         public override Task FlushAsync(CancellationToken cancellationToken) => NopAsync(cancellationToken);
 

--- a/src/System.Net.Http/tests/FunctionalTests/ByteAtATimeContent.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ByteAtATimeContent.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Threading.Tasks;
+
+namespace System.Net.Http.Functional.Tests
+{
+    internal sealed class ByteAtATimeContent : HttpContent
+    {
+        private readonly Task _waitToSend;
+        private readonly TaskCompletionSource<bool> _startedSend;
+        private readonly int _length;
+        private readonly int _millisecondDelayBetweenBytes;
+
+        public ByteAtATimeContent(int length) : this(length, Task.CompletedTask, new TaskCompletionSource<bool>(), millisecondDelayBetweenBytes: 0) { }
+
+        public ByteAtATimeContent(int length, Task waitToSend, TaskCompletionSource<bool> startedSend, int millisecondDelayBetweenBytes)
+        {
+            _length = length;
+            _waitToSend = waitToSend;
+            _startedSend = startedSend;
+            _millisecondDelayBetweenBytes = millisecondDelayBetweenBytes;
+        }
+
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            await _waitToSend;
+            _startedSend.SetResult(true);
+
+            var buffer = new byte[1];
+            for (int i = 0; i < _length; i++)
+            {
+                buffer[0] = (byte)i;
+                await stream.WriteAsync(buffer);
+                await stream.FlushAsync();
+                await Task.Delay(_millisecondDelayBetweenBytes);
+            }
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _length;
+            return true;
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -51,7 +51,7 @@ namespace System.Net.Http.Functional.Tests
                         var waitToSend = new TaskCompletionSource<bool>();
                         var contentSending = new TaskCompletionSource<bool>();
                         var req = new HttpRequestMessage(HttpMethod.Post, uri) { Version = VersionFromUseHttp2 };
-                        req.Content = new ByteAtATimeContent(int.MaxValue, waitToSend.Task, contentSending);
+                        req.Content = new ByteAtATimeContent(int.MaxValue, waitToSend.Task, contentSending, millisecondDelayBetweenBytes: 1);
                         req.Headers.TransferEncodingChunked = chunkedTransfer;
 
                         Task<HttpResponseMessage> resp = client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cts.Token);
@@ -465,39 +465,5 @@ namespace System.Net.Http.Functional.Tests
             from second in s_bools
             from third in s_bools
             select new object[] { first, second, third };
-
-        private sealed class ByteAtATimeContent : HttpContent
-        {
-            private readonly Task _waitToSend;
-            private readonly TaskCompletionSource<bool> _startedSend;
-            private readonly int _length;
-
-            public ByteAtATimeContent(int length, Task waitToSend, TaskCompletionSource<bool> startedSend)
-            {
-                _length = length;
-                _waitToSend = waitToSend;
-                _startedSend = startedSend;
-            }
-
-            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
-            {
-                await _waitToSend;
-                _startedSend.SetResult(true);
-
-                var buffer = new byte[1] { 42 };
-                for (int i = 0; i < _length; i++)
-                {
-                    await stream.WriteAsync(buffer);
-                    await stream.FlushAsync();
-                    await Task.Delay(1);
-                }
-            }
-
-            protected override bool TryComputeLength(out long length)
-            {
-                length = _length;
-                return true;
-            }
-        }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1255,9 +1255,9 @@ namespace System.Net.Http.Functional.Tests
         public async Task Http2_InitialWindowSize_ClientDoesNotExceedWindows()
         {
             const int DefaultInitialWindowSize = 65535;
-            const int ContentSize = 100_000;
+            const int ContentSize = DefaultInitialWindowSize + 1000;
 
-            var content = new ByteArrayContent(TestHelper.GenerateRandomContent(ContentSize));
+            var content = new ByteAtATimeContent(ContentSize);
 
             using (var server = Http2LoopbackServer.CreateServer())
             using (HttpClient client = CreateHttpClient())

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1504,7 +1504,7 @@ namespace System.Net.Http.Functional.Tests
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
 
-            var content = new ByteArrayContent(TestHelper.GenerateRandomContent(ContentSize));
+            var content = new ByteAtATimeContent(ContentSize);
 
             using (var server = Http2LoopbackServer.CreateServer())
             using (HttpClient client = CreateHttpClient(handler))

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="DelegatingHandlerTest.cs" />
     <Compile Include="FakeDiagnosticSourceListenerObserver.cs" />
     <Compile Include="FormUrlEncodedContentTest.cs" />
+    <Compile Include="ByteAtATimeContent.cs" />
     <Compile Include="HttpClientHandlerTest.Authentication.cs" />
     <Compile Include="HttpClientHandlerTest.AutoRedirect.cs" />
     <Compile Include="HttpClientHandlerTest.cs" />


### PR DESCRIPTION
Allow the write stream to request a flush via FlushAsync, but don't internally force a flush on each data packet.

Fixes https://github.com/dotnet/corefx/issues/39181
Fixes https://github.com/dotnet/corefx/issues/39234

cc: @geoffkizer, @wfurt, @scalablecory, @eiriktsarpalis, @davidsh