### PR TITLE
Fix a race in buffer usage of Http2Connection.ProcessPingFrame

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -583,6 +583,7 @@ namespace System.Net.Http
             // Don't wait for completion, which could happen asynchronously.
             LogExceptions(SendPingAckAsync(_incomingBuffer.ActiveMemory.Slice(0, FrameHeader.PingLength)));
 
+            // SendPingAckAsync copies the buffer for us, so it is safe to not wait for completion.
             _incomingBuffer.Discard(frameHeader.Length);
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -581,7 +581,8 @@ namespace System.Net.Http
 
             // Send PING ACK
             // Don't wait for completion, which could happen asynchronously.
-            LogExceptions(SendPingAckAsync(_incomingBuffer.ActiveMemory.Slice(0, FrameHeader.PingLength)));
+            byte[] pingContent = _incomingBuffer.ActiveMemory.Slice(0, FrameHeader.PingLength).ToArray();
+            LogExceptions(SendPingAckAsync(pingContent));
 
             _incomingBuffer.Discard(frameHeader.Length);
         }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -792,7 +792,7 @@ namespace System.Net.Http
         {
             Debug.Assert(pingContent.Length == FrameHeader.PingLength);
 
-            // copy pingContent before we go async so the caller can
+            // Copy pingContent before we go async so the caller can
             // discard their buffer without waiting for us to complete.
             long pingContentLong = BitConverter.ToInt64(pingContent.Span);
 


### PR DESCRIPTION
Incoming buffer might be reused before we've sent it. Resolve #38788.