### PR TITLE
Remove unused code from Linux crypto shim

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.GetIntegerBytes.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.GetIntegerBytes.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
 using System.Security.Cryptography.Asn1;
-using System.Text;
 
 using Microsoft.Win32.SafeHandles;
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
@@ -45,9 +45,6 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1BitStringFree")]
         internal static extern void Asn1BitStringFree(IntPtr o);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeAsn1OctetString")]
-        internal static extern SafeAsn1OctetStringHandle DecodeAsn1OctetString(byte[] buf, int len);
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1OctetStringNew")]
         internal static extern SafeAsn1OctetStringHandle Asn1OctetStringNew();
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.BIO.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.BIO.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
 using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -96,17 +96,6 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509RootStoreFile")]
         private static extern IntPtr GetX509RootStoreFile_private();
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetX509ChainVerifyTime")]
-        private static extern int SetX509ChainVerifyTime(
-            SafeX509StoreCtxHandle ctx,
-            int year,
-            int month,
-            int day,
-            int hour,
-            int minute,
-            int second,
-            [MarshalAs(UnmanagedType.Bool)] bool isDst);
-
         [DllImport(Libraries.CryptoNative)]
         private static extern int CryptoNative_X509StoreSetVerifyTime(
             SafeX509StoreHandle ctx,
@@ -145,28 +134,6 @@ internal static partial class Interop
         internal static byte[] GetX509PublicKeyParameterBytes(SafeX509Handle x509)
         {
             return GetDynamicBuffer((handle, buf, i) => GetX509PublicKeyParameterBytes(handle, buf, i), x509);
-        }
-
-        internal static void SetX509ChainVerifyTime(SafeX509StoreCtxHandle ctx, DateTime verifyTime)
-        {
-            // OpenSSL is going to convert our input time to universal, so we should be in Local or
-            // Unspecified (local-assumed).
-            Debug.Assert(verifyTime.Kind != DateTimeKind.Utc, "UTC verifyTime should have been normalized to Local");
-            
-            int succeeded = SetX509ChainVerifyTime(
-                ctx,
-                verifyTime.Year,
-                verifyTime.Month,
-                verifyTime.Day,
-                verifyTime.Hour,
-                verifyTime.Minute,
-                verifyTime.Second,
-                verifyTime.IsDaylightSavingTime());
-
-            if (succeeded != 1)
-            {
-                throw Interop.Crypto.CreateOpenSslCryptographicException();
-            }
         }
 
         internal static void X509StoreSetVerifyTime(SafeX509StoreHandle ctx, DateTime verifyTime)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Dsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Dsa.cs
@@ -12,9 +12,6 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaCreate")]
-        internal static extern SafeDsaHandle DsaCreate();
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DsaUpRef")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool DsaUpRef(IntPtr dsa);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
@@ -6,7 +6,6 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using System.Text;
 
 internal static partial class Interop
 {
@@ -14,9 +13,6 @@ internal static partial class Interop
     {
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrClearError")]
         internal static extern ulong ErrClearError();
-
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrGetError")]
-        internal static extern ulong ErrGetError();
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrGetErrorAlloc")]
         private static extern ulong ErrGetErrorAlloc([MarshalAs(UnmanagedType.Bool)] out bool isAllocFailure);

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -157,15 +156,6 @@ internal static partial class Interop
         internal static void EvpCipherSetGcmTag(SafeEvpCipherCtxHandle ctx, ReadOnlySpan<byte> tag)
         {
             if (!EvpCipherSetGcmTag(ctx, ref MemoryMarshal.GetReference(tag), tag.Length))
-            {
-                throw CreateOpenSslCryptographicException();
-            }
-        }
-
-        internal static void EvpCipherSetGcmTagLength(SafeEvpCipherCtxHandle ctx, int tagLength)
-        {
-            ref byte nullRef = ref MemoryMarshal.GetReference(Span<byte>.Empty);
-            if (!EvpCipherSetGcmTag(ctx, ref nullRef, tagLength))
             {
                 throw CreateOpenSslCryptographicException();
             }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.ImportExport.cs
@@ -12,9 +12,6 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyGetCurveType")]
-        internal static extern ECCurve.ECCurveType EcKeyGetCurveType(SafeEcKeyHandle key);
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByKeyParameters", CharSet = CharSet.Ansi)]
         private static extern int EcKeyCreateByKeyParameters(
             out SafeEcKeyHandle key,

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs7.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs7.cs
@@ -28,9 +28,6 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetPkcs7Certificates")]
         private static extern int GetPkcs7Certificates(SafePkcs7Handle p7, out SafeSharedX509StackHandle certs);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs7AddCertificate")]
-        internal static extern bool Pkcs7AddCertificate(SafePkcs7Handle p7, IntPtr x509);
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetPkcs7DerSize")]
         internal static extern int GetPkcs7DerSize(SafePkcs7Handle p7);
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SetProtocolOptions.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SetProtocolOptions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Win32.SafeHandles;
 using System;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -71,15 +71,6 @@ internal static partial class Interop
             return result;
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetSslConnectionInfo")]
-        internal static extern bool GetSslConnectionInfo(
-            SafeSslHandle ssl,
-            out int dataCipherAlg,
-            out int keyExchangeAlg,
-            out int dataHashAlg,
-            out int dataKeySize,
-            out int hashKeySize);
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslWrite")]
         internal static extern unsafe int SslWrite(SafeSslHandle ssl, byte* buf, int num);
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
 using System.Net.Security;
 using System.Runtime.InteropServices;
-using System.Security.Authentication;
-using System.Security.Authentication.ExtendedProtection;
 using System.Security.Cryptography;
 using Microsoft.Win32.SafeHandles;
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -86,9 +86,6 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool X509CheckPurpose(SafeX509Handle x, int id, int ca);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509CheckIssued")]
-        internal static extern int X509CheckIssued(SafeX509Handle issuer, SafeX509Handle subject);
-
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509IssuerNameHash")]
         internal static extern ulong X509IssuerNameHash(SafeX509Handle x);
 
@@ -144,10 +141,6 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreDestory")]
         internal static extern void X509StoreDestory(IntPtr v);
-
-        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreAddCert")]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool X509StoreAddCert(SafeX509StoreHandle ctx, SafeX509Handle x);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreAddCrl")]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Win32.SafeHandles;
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.c
@@ -877,7 +877,7 @@ void CryptoNative_RecursiveFreeX509Stack(STACK_OF(X509) * stack)
 
 /*
 Function:
-SetX509ChainVerifyTime
+SetX509StoreVerifyTime
 
 Used by System.Security.Cryptography.X509Certificates' OpenSslX509ChainProcessor to assign the
 verification time to the chain building.  The input is in LOCAL time, not UTC.
@@ -886,38 +886,6 @@ Return values:
 0 if ctx is NULL, if ctx has no X509_VERIFY_PARAM, or the date inputs don't produce a valid time_t;
 1 on success.
 */
-int32_t CryptoNative_SetX509ChainVerifyTime(X509_STORE_CTX* ctx,
-                                            int32_t year,
-                                            int32_t month,
-                                            int32_t day,
-                                            int32_t hour,
-                                            int32_t minute,
-                                            int32_t second,
-                                            int32_t isDst)
-{
-    if (!ctx)
-    {
-        return 0;
-    }
-
-    time_t verifyTime = MakeTimeT(year, month, day, hour, minute, second, isDst);
-
-    if (verifyTime == (time_t)-1)
-    {
-        return 0;
-    }
-
-    X509_VERIFY_PARAM* verifyParams = X509_STORE_CTX_get0_param(ctx);
-
-    if (!verifyParams)
-    {
-        return 0;
-    }
-
-    X509_VERIFY_PARAM_set_time(verifyParams, verifyTime);
-    return 1;
-}
-
 int32_t CryptoNative_X509StoreSetVerifyTime(X509_STORE* ctx,
                                             int32_t year,
                                             int32_t month,

--- a/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/openssl.h
@@ -47,15 +47,6 @@ DLLEXPORT X509* CryptoNative_GetX509StackField(STACK_OF(X509) * stack, int loc);
 
 DLLEXPORT void CryptoNative_RecursiveFreeX509Stack(STACK_OF(X509) * stack);
 
-DLLEXPORT int32_t CryptoNative_SetX509ChainVerifyTime(X509_STORE_CTX* ctx,
-                                                      int32_t year,
-                                                      int32_t month,
-                                                      int32_t day,
-                                                      int32_t hour,
-                                                      int32_t minute,
-                                                      int32_t second,
-                                                      int32_t isDst);
-
 DLLEXPORT int32_t CryptoNative_X509StoreSetVerifyTime(X509_STORE* ctx,
                                                       int32_t year,
                                                       int32_t month,

--- a/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -234,7 +234,6 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     LEGACY_FUNCTION(CRYPTO_num_locks) \
     LEGACY_FUNCTION(CRYPTO_set_locking_callback) \
     REQUIRED_FUNCTION(d2i_ASN1_BIT_STRING) \
-    REQUIRED_FUNCTION(d2i_ASN1_OCTET_STRING) \
     REQUIRED_FUNCTION(d2i_BASIC_CONSTRAINTS) \
     REQUIRED_FUNCTION(d2i_EXTENDED_KEY_USAGE) \
     REQUIRED_FUNCTION(d2i_OCSP_RESPONSE) \
@@ -497,7 +496,6 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     RENAMED_FUNCTION(TLS_method, SSLv23_method) \
     REQUIRED_FUNCTION(SSL_write) \
     FALLBACK_FUNCTION(X509_check_host) \
-    REQUIRED_FUNCTION(X509_check_issued) \
     REQUIRED_FUNCTION(X509_check_purpose) \
     REQUIRED_FUNCTION(X509_cmp_current_time) \
     REQUIRED_FUNCTION(X509_cmp_time) \
@@ -622,7 +620,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define CRYPTO_num_locks CRYPTO_num_locks_ptr
 #define CRYPTO_set_locking_callback CRYPTO_set_locking_callback_ptr
 #define d2i_ASN1_BIT_STRING d2i_ASN1_BIT_STRING_ptr
-#define d2i_ASN1_OCTET_STRING d2i_ASN1_OCTET_STRING_ptr
 #define d2i_BASIC_CONSTRAINTS d2i_BASIC_CONSTRAINTS_ptr
 #define d2i_EXTENDED_KEY_USAGE d2i_EXTENDED_KEY_USAGE_ptr
 #define d2i_OCSP_RESPONSE d2i_OCSP_RESPONSE_ptr
@@ -892,7 +889,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define SSL_write SSL_write_ptr
 #define TLS_method TLS_method_ptr
 #define X509_check_host X509_check_host_ptr
-#define X509_check_issued X509_check_issued_ptr
 #define X509_check_purpose X509_check_purpose_ptr
 #define X509_cmp_current_time X509_cmp_current_time_ptr
 #define X509_cmp_time X509_cmp_time_ptr

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.c
@@ -74,16 +74,6 @@ void CryptoNative_Asn1BitStringFree(ASN1_STRING* a)
     ASN1_BIT_STRING_free(a);
 }
 
-ASN1_OCTET_STRING* CryptoNative_DecodeAsn1OctetString(const uint8_t* buf, int32_t len)
-{
-    if (!buf || !len)
-    {
-        return NULL;
-    }
-
-    return d2i_ASN1_OCTET_STRING(NULL, &buf, len);
-}
-
 ASN1_OCTET_STRING* CryptoNative_Asn1OctetStringNew()
 {
     return ASN1_OCTET_STRING_new();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_asn1.h
@@ -66,11 +66,6 @@ Direct shim to ASN1_BIT_STRING_free.
 DLLEXPORT void CryptoNative_Asn1BitStringFree(ASN1_STRING* a);
 
 /*
-Shims the d2i_ASN1_OCTET_STRING method and makes it easier to invoke from managed code.
-*/
-DLLEXPORT ASN1_OCTET_STRING* CryptoNative_DecodeAsn1OctetString(const uint8_t* buf, int32_t len);
-
-/*
 Direct shim to ASN1_OCTET_STRING_new.
 */
 DLLEXPORT ASN1_OCTET_STRING* CryptoNative_Asn1OctetStringNew(void);

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_dsa.h
@@ -7,13 +7,6 @@
 #include "opensslshim.h"
 
 /*
-Shims the DSA_new method.
-
-Returns the new DSA instance.
-*/
-DLLEXPORT DSA* CryptoNative_DsaCreate(void);
-
-/*
 Shims the DSA_up_ref method.
 
 Returns 1 upon success, otherwise 0.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.c
@@ -37,7 +37,7 @@ static const EC_METHOD* CurveTypeToMethod(ECCurveType curveType)
     return NULL; //Edwards and others
 }
 
-ECCurveType CryptoNative_EcKeyGetCurveType(
+static ECCurveType EcKeyGetCurveType(
     const EC_KEY* key)
 {
     const EC_GROUP* group = EC_KEY_get0_group(key);
@@ -77,7 +77,7 @@ int32_t CryptoNative_GetECKeyParameters(
     BIGNUM *xBn = NULL;
     BIGNUM *yBn = NULL;
 
-    ECCurveType curveType = CryptoNative_EcKeyGetCurveType(key);
+    ECCurveType curveType = EcKeyGetCurveType(key);
     const EC_POINT* Q = EC_KEY_get0_public_key(key);
     const EC_GROUP* group = EC_KEY_get0_group(key);
     if (curveType == Unspecified || !Q || !group) 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_ecc_import_export.h
@@ -17,12 +17,6 @@ typedef enum
 
 
 /*
-Returns the ECCurveType given the key.
-*/
-DLLEXPORT ECCurveType CryptoNative_EcKeyGetCurveType(
-    const EC_KEY* key);
-
-/*
 Returns the ECC key parameters.
 */
 DLLEXPORT int32_t CryptoNative_GetECKeyParameters(

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_eckey.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_eckey.c
@@ -11,17 +11,11 @@ void CryptoNative_EcKeyDestroy(EC_KEY* r)
     EC_KEY_free(r);
 }
 
-// For backwards compatibility
-EC_KEY* CryptoNative_EcKeyCreateByCurveName(int32_t nid)
-{
-    return EC_KEY_new_by_curve_name(nid);
-}
-
 EC_KEY* CryptoNative_EcKeyCreateByOid(const char* oid)
 {
     // oid can be friendly name or value
     int nid = OBJ_txt2nid(oid);
-    return CryptoNative_EcKeyCreateByCurveName(nid);
+    return EC_KEY_new_by_curve_name(nid);
 }
 
 int32_t CryptoNative_EcKeyGenerateKey(EC_KEY* eckey)
@@ -54,23 +48,6 @@ int32_t CryptoNative_EcKeyGetSize(const EC_KEY* key, int32_t* keySize)
     *keySize = EC_GROUP_get_degree(group);
 
     return 1;
-}
-
-// For backwards compatibility
-int32_t CryptoNative_EcKeyGetCurveName(const EC_KEY* key)
-{
-    if (key == NULL)
-    {
-        return NID_undef;
-    }
-
-    const EC_GROUP* group = EC_KEY_get0_group(key);
-    if (group == NULL)
-    {
-        return NID_undef;
-    }
-
-    return EC_GROUP_get_curve_name(group);
 }
 
 int32_t CryptoNative_EcKeyGetCurveName2(const EC_KEY* key, int32_t* nidName)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_eckey.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_eckey.h
@@ -22,13 +22,6 @@ Shims the EC_KEY_new_by_curve_name method.
 
 Returns the new EC_KEY instance.
 */
-DLLEXPORT EC_KEY* CryptoNative_EcKeyCreateByCurveName(int32_t nid);
-
-/*
-Shims the EC_KEY_new_by_curve_name method.
-
-Returns the new EC_KEY instance.
-*/
 DLLEXPORT EC_KEY* CryptoNative_EcKeyCreateByOid(const char* oid);
 
 /*
@@ -51,11 +44,6 @@ Gets the key size in bits for the specified EC_KEY.
 Returns 1 upon success, otherwise 0.
 */
 DLLEXPORT int32_t CryptoNative_EcKeyGetSize(const EC_KEY* key, int32_t* keySize);
-
-/*
-Gets the NID of the curve name as an oid value for the specified EC_KEY.
-*/
-DLLEXPORT int32_t CryptoNative_EcKeyGetCurveName(const EC_KEY* key);
 
 /*
 Gets the NID of the curve name as an oid value for the specified EC_KEY.

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_err.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_err.c
@@ -10,11 +10,6 @@ void CryptoNative_ErrClearError()
     ERR_clear_error();
 }
 
-uint64_t CryptoNative_ErrGetError()
-{
-    return ERR_get_error();
-}
-
 uint64_t CryptoNative_ErrGetErrorAlloc(int32_t* isAllocFailure)
 {
     unsigned long err = ERR_get_error();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_err.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_err.h
@@ -12,11 +12,6 @@ Shims the ERR_clear_error method.
 DLLEXPORT void CryptoNative_ErrClearError(void);
 
 /*
-Shims the ERR_get_error method.
-*/
-DLLEXPORT uint64_t CryptoNative_ErrGetError(void);
-
-/*
 Shim to ERR_get_error which also returns whether the error
 was caused by an allocation failure.
 */

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.c
@@ -10,12 +10,6 @@
 #define KEEP_CURRENT_DIRECTION -1
 
 EVP_CIPHER_CTX*
-CryptoNative_EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char* iv, int32_t enc)
-{
-    return CryptoNative_EvpCipherCreate2(type, key, 0, 0, iv, enc);
-}
-
-EVP_CIPHER_CTX*
 CryptoNative_EvpCipherCreate2(const EVP_CIPHER* type, uint8_t* key, int32_t keyLength, int32_t effectiveKeyLength, unsigned char* iv, int32_t enc)
 {
     EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_evp_cipher.h
@@ -6,19 +6,6 @@
 #include "pal_compiler.h"
 #include "opensslshim.h"
 
-/*
-Creates and initializes an EVP_CIPHER_CTX with the given args.
-
-Implemented by:
-   1) allocating a new EVP_CIPHER_CTX
-   2) calling EVP_CIPHER_CTX_init on the new EVP_CIPHER_CTX
-   3) calling EVP_CipherInit_ex with the new EVP_CIPHER_CTX and the given args.
-
-Returns new EVP_CIPHER_CTX on success, nullptr on failure.
-*/
-DLLEXPORT EVP_CIPHER_CTX*
-CryptoNative_EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char* iv, int32_t enc);
-
 DLLEXPORT EVP_CIPHER_CTX*
 CryptoNative_EvpCipherCreate2(const EVP_CIPHER* type, uint8_t* key, int32_t keyLength, int32_t effectiveKeyLength, unsigned char* iv, int32_t enc);
 

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.c
@@ -133,11 +133,6 @@ int32_t CryptoNative_X509CheckPurpose(X509* x, int32_t id, int32_t ca)
     return X509_check_purpose(x, id, ca);
 }
 
-int32_t CryptoNative_X509CheckIssued(X509* issuer, X509* subject)
-{
-    return X509_check_issued(issuer, subject);
-}
-
 uint64_t CryptoNative_X509IssuerNameHash(X509* x)
 {
     return X509_issuer_name_hash(x);
@@ -192,22 +187,12 @@ ASN1_OCTET_STRING* CryptoNative_X509FindExtensionData(X509* x, int32_t nid)
     return X509_EXTENSION_get_data(ext);
 }
 
-X509_STORE* CryptoNative_X509StoreCreate()
-{
-    return X509_STORE_new();
-}
-
 void CryptoNative_X509StoreDestory(X509_STORE* v)
 {
     if (v != NULL)
     {
         X509_STORE_free(v);
     }
-}
-
-int32_t CryptoNative_X509StoreAddCert(X509_STORE* ctx, X509* x)
-{
-    return X509_STORE_add_cert(ctx, x);
 }
 
 int32_t CryptoNative_X509StoreAddCrl(X509_STORE* ctx, X509_CRL* x)

--- a/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/Unix/System.Security.Cryptography.Native/pal_x509.h
@@ -152,11 +152,6 @@ Shims the X509_check_purpose method.
 DLLEXPORT int32_t CryptoNative_X509CheckPurpose(X509* x, int32_t id, int32_t ca);
 
 /*
-Shims the X509_check_issued method.
-*/
-DLLEXPORT int32_t CryptoNative_X509CheckIssued(X509* issuer, X509* subject);
-
-/*
 Shims the X509_issuer_name_hash method.
 */
 DLLEXPORT uint64_t CryptoNative_X509IssuerNameHash(X509* x);
@@ -192,19 +187,9 @@ Returns the data portion of the first matched extension.
 DLLEXPORT ASN1_OCTET_STRING* CryptoNative_X509FindExtensionData(X509* x, int32_t nid);
 
 /*
-Shims the X509_STORE_new method.
-*/
-DLLEXPORT X509_STORE* CryptoNative_X509StoreCreate(void);
-
-/*
 Shims the X509_STORE_free method.
 */
 DLLEXPORT void CryptoNative_X509StoreDestory(X509_STORE* v);
-
-/*
-Shims the X509_STORE_add_cert method.
-*/
-DLLEXPORT int32_t CryptoNative_X509StoreAddCert(X509_STORE* ctx, X509* x);
 
 /*
 Shims the X509_STORE_add_crl method.


### PR DESCRIPTION
Remove unused code from the crypto shim so that we don't pay a maintenance cost on it going forward.

Some functions have just fallen out of use slowly, others were shifts that left the old version intact just-in-case.

* Pass 1: For each file in the cryptoshim Interop directory (from X509Certificates, Algorithms, Encoding, and System.Net.Security) delete any methods that are uncalled.
* Pass 2: Delete anything in the shim that was abandoned by pass 1
  * Be surprised at things like CryptoNative_DsaCreate, which had a DllImport and a .h declaration, but no body.
* Pass 3: grep DLLEXPORT *.h, delete anything that is not mapped to by a DllImport
* Pass 3: Delete any function pointers that get bound during the portable build load but are no longer used (by this change)

It was less removal than anticipated.  No audit was done that each function pointer that's bound is actually still used (other than the ones that had a usage reduced in this change); it felt less valuable per unit of time expended.