### PR TITLE
Added CompleteAsync to PipeReader and PipeWriter

### DIFF
--- a/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
+++ b/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
@@ -29,7 +29,7 @@ namespace System.IO.Pipelines
     }
     public partial class PipeOptions
     {
-        public PipeOptions(System.Buffers.MemoryPool<byte> pool = null, System.IO.Pipelines.PipeScheduler readerScheduler = null, System.IO.Pipelines.PipeScheduler writerScheduler = null, long pauseWriterThreshold = -1, long resumeWriterThreshold = -1, int minimumSegmentSize = -1, bool useSynchronizationContext = true) { }
+        public PipeOptions(System.Buffers.MemoryPool<byte> pool = null, System.IO.Pipelines.PipeScheduler readerScheduler = null, System.IO.Pipelines.PipeScheduler writerScheduler = null, long pauseWriterThreshold = (long)-1, long resumeWriterThreshold = (long)-1, int minimumSegmentSize = -1, bool useSynchronizationContext = true) { }
         public static System.IO.Pipelines.PipeOptions Default { get { throw null; } }
         public int MinimumSegmentSize { get { throw null; } }
         public long PauseWriterThreshold { get { throw null; } }
@@ -47,6 +47,7 @@ namespace System.IO.Pipelines
         public virtual System.IO.Stream AsStream(bool leaveOpen = false) { throw null; }
         public abstract void CancelPendingRead();
         public abstract void Complete(System.Exception exception = null);
+        public virtual System.Threading.Tasks.ValueTask CompleteAsync(System.Exception exception = null) { throw null; }
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Pipelines.PipeWriter destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public virtual System.Threading.Tasks.Task CopyToAsync(System.IO.Stream destination, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.IO.Pipelines.PipeReader Create(System.IO.Stream stream, System.IO.Pipelines.StreamPipeReaderOptions readerOptions = null) { throw null; }
@@ -68,6 +69,7 @@ namespace System.IO.Pipelines
         public virtual System.IO.Stream AsStream(bool leaveOpen = false) { throw null; }
         public abstract void CancelPendingFlush();
         public abstract void Complete(System.Exception exception = null);
+        public virtual System.Threading.Tasks.ValueTask CompleteAsync(System.Exception exception = null) { throw null; }
         protected internal virtual System.Threading.Tasks.Task CopyFromAsync(System.IO.Stream source, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.IO.Pipelines.PipeWriter Create(System.IO.Stream stream, System.IO.Pipelines.StreamPipeWriterOptions writerOptions = null) { throw null; }
         public abstract System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult> FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -93,15 +95,15 @@ namespace System.IO.Pipelines
     {
         public StreamPipeReaderOptions(System.Buffers.MemoryPool<byte> pool = null, int bufferSize = -1, int minimumReadSize = -1, bool leaveOpen = false) { }
         public int BufferSize { get { throw null; } }
+        public bool LeaveOpen { get { throw null; } }
         public int MinimumReadSize { get { throw null; } }
         public System.Buffers.MemoryPool<byte> Pool { get { throw null; } }
-        public bool LeaveOpen { get { throw null; } }
     }
     public partial class StreamPipeWriterOptions
     {
         public StreamPipeWriterOptions(System.Buffers.MemoryPool<byte> pool = null, int minimumBufferSize = -1, bool leaveOpen = false) { }
+        public bool LeaveOpen { get { throw null; } }
         public int MinimumBufferSize { get { throw null; } }
         public System.Buffers.MemoryPool<byte> Pool { get { throw null; } }
-        public bool LeaveOpen { get { throw null; } }
     }
 }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -75,15 +75,26 @@ namespace System.IO.Pipelines
         public abstract void CancelPendingRead();
 
         /// <summary>
-        /// Signal to the producer that the consumer is done reading.
+        /// Marks the <see cref="PipeReader"/> as being complete, meaning no more data will be read from it.
         /// </summary>
-        /// <param name="exception">Optional <see cref="Exception"/> indicating a failure that's causing the pipeline to complete.</param>
+        /// <param name="exception">Optional <see cref="Exception"/> indicating a failure that's causing the reader to complete.</param>
         public abstract void Complete(Exception exception = null);
+
+        /// <summary>
+        /// Marks the <see cref="PipeReader"/> as being complete, meaning no more data will be read from it.
+        /// </summary>
+        /// <param name="exception">Optional <see cref="Exception"/> indicating a failure that's causing the reader to complete.</param>
+        public virtual ValueTask CompleteAsync(Exception exception = null)
+        {
+            Complete(exception);
+            return default;
+        }
 
         /// <summary>
         /// Registers a callback that gets executed when the <see cref="PipeWriter"/> side of the pipe is completed
         /// </summary>
         public abstract void OnWriterCompleted(Action<Exception, object> callback, object state);
+
 
         /// <summary>
         /// Creates a <see cref="PipeReader"/> wrapping the specified <see cref="Stream"/>.

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -86,8 +86,15 @@ namespace System.IO.Pipelines
         /// <param name="exception">Optional <see cref="Exception"/> indicating a failure that's causing the reader to complete.</param>
         public virtual ValueTask CompleteAsync(Exception exception = null)
         {
-            Complete(exception);
-            return default;
+            try
+            {
+                Complete(exception);
+                return default;
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask(Task.FromException(ex));
+            }
         }
 
         /// <summary>

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriter.cs
@@ -16,10 +16,20 @@ namespace System.IO.Pipelines
         private PipeWriterStream _stream;
 
         /// <summary>
-        /// Marks the <see cref="PipeWriter"/> as being complete, meaning no more items will be written to it.
+        /// Marks the <see cref="PipeWriter"/> as being complete, meaning no more data will be written to it.
         /// </summary>
         /// <param name="exception">Optional <see cref="Exception"/> indicating a failure that's causing the pipeline to complete.</param>
         public abstract void Complete(Exception exception = null);
+
+        /// <summary>
+        /// Marks the <see cref="PipeWriter"/> as being complete, meaning no more data will be written to it.
+        /// </summary>
+        /// <param name="exception">Optional <see cref="Exception"/> indicating a failure that's causing the pipeline to complete.</param>
+        public virtual ValueTask CompleteAsync(Exception exception = null)
+        {
+            Complete(exception);
+            return default;
+        }
 
         /// <summary>
         /// Cancel the pending <see cref="FlushAsync"/> operation. If there is none, cancels next <see cref="FlushAsync"/> operation, without completing the <see cref="PipeWriter"/>.

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriter.cs
@@ -27,8 +27,15 @@ namespace System.IO.Pipelines
         /// <param name="exception">Optional <see cref="Exception"/> indicating a failure that's causing the pipeline to complete.</param>
         public virtual ValueTask CompleteAsync(Exception exception = null)
         {
-            Complete(exception);
-            return default;
+            try
+            {
+                Complete(exception);
+                return default;
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask(Task.FromException(ex));
+            }
         }
 
         /// <summary>

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -239,7 +239,11 @@ namespace System.IO.Pipelines
 
             if (!_leaveOpen)
             {
+#if netcoreapp
                 await InnerStream.DisposeAsync().ConfigureAwait(false);
+#else
+                InnerStream.Dispose();
+#endif
             }
         }
 

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -359,7 +359,11 @@ namespace System.IO.Pipelines
 
                 if (returnSegment.Length > 0)
                 {
+#if netcoreapp
                     InnerStream.Write(returnSegment.Memory.Span);
+#else
+                    InnerStream.Write(returnSegment.Memory);
+#endif
                 }
 
                 returnSegment.ResetMemory();

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -278,7 +278,7 @@ namespace System.IO.Pipelines
                 reg = cancellationToken.UnsafeRegister(state => ((StreamPipeWriter)state).Cancel(), this);
             }
 
-            if (_bytesBuffered > 0)
+            if (_tailBytesBuffered > 0)
             {
                 // Update any buffered data
                 _tail.End += _tailBytesBuffered;
@@ -344,7 +344,7 @@ namespace System.IO.Pipelines
         {
             // Write all completed segments and whatever remains in the current segment
             // and flush the result.
-            if (_bytesBuffered > 0)
+            if (_tailBytesBuffered > 0)
             {
                 // Update any buffered data
                 _tail.End += _tailBytesBuffered;

--- a/src/System.IO.Pipelines/tests/Infrastructure/CancelledWritesStream.cs
+++ b/src/System.IO.Pipelines/tests/Infrastructure/CancelledWritesStream.cs
@@ -15,7 +15,6 @@ namespace System.IO.Pipelines.Tests
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            throw new NotImplementedException();
         }
 
         public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)

--- a/src/System.IO.Pipelines/tests/Infrastructure/ThrowAfterNWritesStream.cs
+++ b/src/System.IO.Pipelines/tests/Infrastructure/ThrowAfterNWritesStream.cs
@@ -21,7 +21,6 @@ namespace System.IO.Pipelines.Tests
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            throw new InvalidOperationException();
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)

--- a/src/System.IO.Pipelines/tests/Infrastructure/WriteOnlyStream.cs
+++ b/src/System.IO.Pipelines/tests/Infrastructure/WriteOnlyStream.cs
@@ -18,7 +18,6 @@ namespace System.IO.Pipelines.Tests
 
         public override void Flush()
         {
-            throw new InvalidOperationException();
         }
 
         public override int Read(byte[] buffer, int offset, int count)

--- a/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
+++ b/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
@@ -22,8 +22,43 @@ namespace System.IO.Pipelines.Tests
 
             Assert.Equal(0, stream.Length);
 
-            // This throws
             writer.Complete();
+        }
+
+        [Fact]
+        public void DataFlushedOnComplete()
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("Hello World");
+            var stream = new MemoryStream();
+            PipeWriter writer = PipeWriter.Create(stream, new StreamPipeWriterOptions(leaveOpen: true));
+
+            bytes.AsSpan().CopyTo(writer.GetSpan(bytes.Length));
+            writer.Advance(bytes.Length);
+
+            Assert.Equal(0, stream.Length);
+
+            writer.Complete();
+
+            Assert.Equal(bytes.Length, stream.Length);
+            Assert.Equal("Hello World", Encoding.ASCII.GetString(stream.ToArray()));
+        }
+
+        [Fact]
+        public async Task DataFlushedOnCompleteAsync()
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("Hello World");
+            var stream = new MemoryStream();
+            PipeWriter writer = PipeWriter.Create(stream, new StreamPipeWriterOptions(leaveOpen: true));
+
+            bytes.AsSpan().CopyTo(writer.GetSpan(bytes.Length));
+            writer.Advance(bytes.Length);
+
+            Assert.Equal(0, stream.Length);
+
+            await writer.CompleteAsync();
+
+            Assert.Equal(bytes.Length, stream.Length);
+            Assert.Equal("Hello World", Encoding.ASCII.GetString(stream.ToArray()));
         }
 
         [Fact]


### PR DESCRIPTION
- Since the introduction of PipeReader and PipeWriter wrappers over a Stream, we need the ability to asynchronously flush buffered data to the stream on complete. This can happen if GetMemory/Advance is called without calling FlushAsync and today that results in data truncation. This change introuduces a way to asynchronously complete a PipeReader or PipeWriter so that we can flush buffered data asynchronously and also dispose the underlying Stream asynchronously.
- Changed StreamPipeWriter to synchronously write and flush buffered data in Complete and asynchronously write and flush buffered data in CompleteAsync.
- Added some tests.
- The DefaultPipeReader and DefaultPipeWriter don't have this problem so they are using the default implementation (which delegates to the syncrhonous Complete).

Waiting for #39241 