### PR TITLE
Change StreamPipeReader/WriterOption buffer size to -1

### DIFF
--- a/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
+++ b/src/System.IO.Pipelines/ref/System.IO.Pipelines.cs
@@ -91,7 +91,7 @@ namespace System.IO.Pipelines
     }
     public partial class StreamPipeReaderOptions
     {
-        public StreamPipeReaderOptions(System.Buffers.MemoryPool<byte> pool = null, int bufferSize = 4096, int minimumReadSize = 1024, bool leaveOpen = false) { }
+        public StreamPipeReaderOptions(System.Buffers.MemoryPool<byte> pool = null, int bufferSize = -1, int minimumReadSize = 1024, bool leaveOpen = false) { }
         public int BufferSize { get { throw null; } }
         public int MinimumReadSize { get { throw null; } }
         public System.Buffers.MemoryPool<byte> Pool { get { throw null; } }
@@ -99,7 +99,7 @@ namespace System.IO.Pipelines
     }
     public partial class StreamPipeWriterOptions
     {
-        public StreamPipeWriterOptions(System.Buffers.MemoryPool<byte> pool = null, int minimumBufferSize = 4096, bool leaveOpen = false) { }
+        public StreamPipeWriterOptions(System.Buffers.MemoryPool<byte> pool = null, int minimumBufferSize = -1, bool leaveOpen = false) { }
         public int MinimumBufferSize { get { throw null; } }
         public System.Buffers.MemoryPool<byte> Pool { get { throw null; } }
         public bool LeaveOpen { get { throw null; } }

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReaderOptions.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReaderOptions.cs
@@ -22,23 +22,17 @@ namespace System.IO.Pipelines
         /// <summary>
         /// Creates a new instance of <see cref="StreamPipeReaderOptions"/>.
         /// </summary>
-        public StreamPipeReaderOptions(MemoryPool<byte> pool = null, int bufferSize = DefaultBufferSize, int minimumReadSize = DefaultMinimumReadSize, bool leaveOpen = false)
+        public StreamPipeReaderOptions(MemoryPool<byte> pool = null, int bufferSize = -1, int minimumReadSize = DefaultMinimumReadSize, bool leaveOpen = false)
         {
             Pool = pool ?? MemoryPool<byte>.Shared;
 
-            if (bufferSize <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(bufferSize));
-            }
+            BufferSize =
+                bufferSize == -1 ? DefaultBufferSize :
+                bufferSize <= 0 ? throw new ArgumentOutOfRangeException(nameof(bufferSize)) :
+                bufferSize;
 
-            BufferSize = bufferSize;
+            MinimumReadSize = minimumReadSize > 0 ? minimumReadSize : throw new ArgumentOutOfRangeException(nameof(minimumReadSize));
 
-            if (minimumReadSize <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(minimumReadSize));
-            }
-
-            MinimumReadSize = minimumReadSize;
             LeaveOpen = leaveOpen;
         }
 

--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriterOptions.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriterOptions.cs
@@ -21,16 +21,15 @@ namespace System.IO.Pipelines
         /// <summary>
         /// Creates a new instance of <see cref="StreamPipeWriterOptions"/>.
         /// </summary>
-        public StreamPipeWriterOptions(MemoryPool<byte> pool = null, int minimumBufferSize = DefaultMinimumBufferSize, bool leaveOpen = false)
+        public StreamPipeWriterOptions(MemoryPool<byte> pool = null, int minimumBufferSize = -1, bool leaveOpen = false)
         {
             Pool = pool ?? MemoryPool<byte>.Shared;
 
-            if (minimumBufferSize <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(minimumBufferSize));
-            }
+            MinimumBufferSize =
+                minimumBufferSize == -1 ? DefaultMinimumBufferSize :
+                minimumBufferSize <= 0 ? throw new ArgumentOutOfRangeException(nameof(minimumBufferSize)) :
+                minimumBufferSize;
 
-            MinimumBufferSize = minimumBufferSize;
             LeaveOpen = leaveOpen;
         }
 

--- a/src/System.IO.Pipelines/tests/StreamPipeReaderTests.cs
+++ b/src/System.IO.Pipelines/tests/StreamPipeReaderTests.cs
@@ -519,7 +519,7 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public void InvalidBufferSizeThrows()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new StreamPipeReaderOptions(bufferSize: -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new StreamPipeReaderOptions(bufferSize: -2));
             Assert.Throws<ArgumentOutOfRangeException>(() => new StreamPipeReaderOptions(bufferSize: 0));
         }
 
@@ -528,6 +528,29 @@ namespace System.IO.Pipelines.Tests
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new StreamPipeReaderOptions(minimumReadSize: -1));
             Assert.Throws<ArgumentOutOfRangeException>(() => new StreamPipeReaderOptions(minimumReadSize: 0));
+        }
+
+        [Fact]
+        public void StreamPipeReaderOptions_Ctor_Defaults()
+        {
+            var options = new StreamPipeReaderOptions();
+            Assert.Same(MemoryPool<byte>.Shared, options.Pool);
+            Assert.Equal(4096, options.BufferSize);
+            Assert.Equal(1024, options.MinimumReadSize);
+            Assert.False(options.LeaveOpen);
+        }
+
+        [Fact]
+        public void StreamPipeReaderOptions_Ctor_Roundtrip()
+        {
+            using (var pool = new TestMemoryPool())
+            {
+                var options = new StreamPipeReaderOptions(pool: pool, bufferSize: 1234, minimumReadSize: 5678, leaveOpen: true);
+                Assert.Same(pool, options.Pool);
+                Assert.Equal(1234, options.BufferSize);
+                Assert.Equal(5678, options.MinimumReadSize);
+                Assert.True(options.LeaveOpen);
+            }
         }
 
         [Fact]

--- a/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
+++ b/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
@@ -402,7 +402,28 @@ namespace System.IO.Pipelines.Tests
         public void InvalidMinimumBufferSize_ThrowsArgException()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new StreamPipeWriterOptions(minimumBufferSize: 0));
-            Assert.Throws<ArgumentOutOfRangeException>(() => new StreamPipeWriterOptions(minimumBufferSize: -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new StreamPipeWriterOptions(minimumBufferSize: -2));
+        }
+
+        [Fact]
+        public void StreamPipeWriterOptions_Ctor_Defaults()
+        {
+            var options = new StreamPipeWriterOptions();
+            Assert.Same(MemoryPool<byte>.Shared, options.Pool);
+            Assert.Equal(4096, options.MinimumBufferSize);
+            Assert.False(options.LeaveOpen);
+        }
+
+        [Fact]
+        public void StreamPipeWriterOptions_Ctor_Roundtrip()
+        {
+            using (var pool = new TestMemoryPool())
+            {
+                var options = new StreamPipeWriterOptions(pool: pool, minimumBufferSize: 1234, leaveOpen: true);
+                Assert.Same(pool, options.Pool);
+                Assert.Equal(1234, options.MinimumBufferSize);
+                Assert.True(options.LeaveOpen);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/37984.

The issue refers to also making a change to PipeOptions, but I'm not sure what argument it's referring to, so I didn't change anything.  minimumSegmentSize?

cc: @davidfowl, @tannergooding 