### PR TITLE
Move XamlAccessLevel to System.Windows.Extensions.dll

### DIFF
--- a/src/System.Security.Permissions/ref/System.Security.Permissions.Forwards.cs
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.Forwards.cs
@@ -18,3 +18,4 @@
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.PermissionSet))]
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Permissions.PermissionState))]
 #endif
+

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -2091,33 +2091,4 @@ namespace System.Web
         Unrestricted = 600,
     }
 }
-namespace System.Xaml.Permissions
-{
-    public partial class XamlAccessLevel
-    {
-        internal XamlAccessLevel() { }
-        public System.Reflection.AssemblyName AssemblyAccessToAssemblyName { get { throw null; } }
-        public string PrivateAccessToTypeName { get { throw null; } }
-        public static System.Xaml.Permissions.XamlAccessLevel AssemblyAccessTo(System.Reflection.Assembly assembly) { throw null; }
-        public static System.Xaml.Permissions.XamlAccessLevel AssemblyAccessTo(System.Reflection.AssemblyName assemblyName) { throw null; }
-        public static System.Xaml.Permissions.XamlAccessLevel PrivateAccessTo(string assemblyQualifiedTypeName) { throw null; }
-        public static System.Xaml.Permissions.XamlAccessLevel PrivateAccessTo(System.Type type) { throw null; }
-    }
-    public sealed partial class XamlLoadPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
-    {
-        public XamlLoadPermission(System.Collections.Generic.IEnumerable<System.Xaml.Permissions.XamlAccessLevel> allowedAccess) { }
-        public XamlLoadPermission(System.Security.Permissions.PermissionState state) { }
-        public XamlLoadPermission(System.Xaml.Permissions.XamlAccessLevel allowedAccess) { }
-        public System.Collections.Generic.IList<System.Xaml.Permissions.XamlAccessLevel> AllowedAccess { get { throw null; } }
-        public override System.Security.IPermission Copy() { throw null; }
-        public override bool Equals(object obj) { throw null; }
-        public override void FromXml(System.Security.SecurityElement elem) { }
-        public override int GetHashCode() { throw null; }
-        public bool Includes(System.Xaml.Permissions.XamlAccessLevel requestedAccess) { throw null; }
-        public override System.Security.IPermission Intersect(System.Security.IPermission target) { throw null; }
-        public override bool IsSubsetOf(System.Security.IPermission target) { throw null; }
-        public bool IsUnrestricted() { throw null; }
-        public override System.Security.SecurityElement ToXml() { throw null; }
-        public override System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
-    }
-}
+

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{07CAF142-B259-418E-86EF-C4BD8B50253E}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
@@ -8,6 +8,9 @@
     <Compile Include="System.Security.Permissions.cs" />
     <Compile Include="System.Security.Permissions.Forwards.cs" />
     <SuppressPackageTargetFrameworkCompatibility Include="$(UAPvNextTFM)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Compile Include="System.Security.Permissions.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsNetFx)' == 'true'">
     <Reference Include="mscorlib" />
@@ -38,5 +41,8 @@
     <ProjectReference Include="..\..\System.Security.Cryptography.X509Certificates\ref\System.Security.Cryptography.X509Certificates.csproj" />
     <ProjectReference Include="..\..\System.Text.RegularExpressions\ref\System.Text.RegularExpressions.csproj" />
     <ProjectReference Include="..\..\System.Threading\ref\System.Threading.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <ProjectReference Include="..\..\System.Windows.Extensions\ref\System.Windows.Extensions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/System.Security.Permissions/ref/System.Security.Permissions.netcoreapp.cs
+++ b/src/System.Security.Permissions/ref/System.Security.Permissions.netcoreapp.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+
+namespace System.Xaml.Permissions
+{
+    public sealed partial class XamlLoadPermission : System.Security.CodeAccessPermission, System.Security.Permissions.IUnrestrictedPermission
+    {
+        public XamlLoadPermission(System.Collections.Generic.IEnumerable<System.Xaml.Permissions.XamlAccessLevel> allowedAccess) { }
+        public XamlLoadPermission(System.Security.Permissions.PermissionState state) { }
+        public XamlLoadPermission(System.Xaml.Permissions.XamlAccessLevel allowedAccess) { }
+        public System.Collections.Generic.IList<System.Xaml.Permissions.XamlAccessLevel> AllowedAccess { get { throw null; } }
+        public override System.Security.IPermission Copy() { throw null; }
+        public override bool Equals(object obj) { throw null; }
+        public override void FromXml(System.Security.SecurityElement elem) { }
+        public override int GetHashCode() { throw null; }
+        public bool Includes(System.Xaml.Permissions.XamlAccessLevel requestedAccess) { throw null; }
+        public override System.Security.IPermission Intersect(System.Security.IPermission target) { throw null; }
+        public override bool IsSubsetOf(System.Security.IPermission target) { throw null; }
+        public bool IsUnrestricted() { throw null; }
+        public override System.Security.SecurityElement ToXml() { throw null; }
+        public override System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
+    }
+}

--- a/src/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{07390899-C8F6-4E83-A3A9-6867B8CB46A0}</ProjectGuid>
     <RootNamespace>System.Security.Permissions</RootNamespace>
@@ -178,7 +178,8 @@
     <Compile Include="System\Web\AspNetHostingPermission.cs" />
     <Compile Include="System\Web\AspNetHostingPermissionAttribute.cs" />
     <Compile Include="System\Web\AspNetHostingPermissionLevel.cs" />
-    <Compile Include="System\Xaml\Permissions\XamlAccessLevel.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="System\Xaml\Permissions\XamlLoadPermission.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
@@ -227,5 +228,8 @@
     <Reference Include="System.Text.RegularExpressions" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <Reference Include="System.Windows.Extensions" />
   </ItemGroup>
 </Project>

--- a/src/System.Security.Permissions/tests/PermissionTests.cs
+++ b/src/System.Security.Permissions/tests/PermissionTests.cs
@@ -7,7 +7,6 @@ using System.Configuration;
 using System.DirectoryServices;
 using System.Reflection;
 using System.Web;
-using System.Xaml.Permissions;
 
 namespace System.Security.Permissions.Tests
 {
@@ -442,26 +441,6 @@ namespace System.Security.Permissions.Tests
         {
             WebBrowserPermissionAttribute wpa = new WebBrowserPermissionAttribute(new Permissions.SecurityAction());
             IPermission ip = wpa.CreatePermission();
-        }
-
-        [Fact]
-        public static void XamlLoadPermissionCallMethods()
-        {
-            XamlAccessLevel accessLevel = XamlAccessLevel.AssemblyAccessTo(Assembly.GetExecutingAssembly().GetName());
-            XamlLoadPermission xp = new XamlLoadPermission(accessLevel);
-            XamlLoadPermission xp2 = new XamlLoadPermission(PermissionState.Unrestricted);
-            XamlLoadPermission xp3 = new XamlLoadPermission(Array.Empty<XamlAccessLevel>());
-            bool testbool = xp.IsUnrestricted();
-            IPermission ip = xp.Copy();
-            IPermission ip2 = xp.Intersect(ip);
-            IPermission ip3 = xp.Union(ip);
-            testbool = xp.IsSubsetOf(ip);
-            testbool = xp.Equals(new object());
-            testbool = xp.Includes(accessLevel);
-            int hash = xp.GetHashCode();
-            SecurityElement se = new SecurityElement("");
-            xp.FromXml(se);
-            se = xp.ToXml();
         }
 
         [Fact]

--- a/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
+++ b/src/System.Security.Permissions/tests/System.Security.Permissions.Tests.csproj
@@ -18,6 +18,8 @@
     <Compile Include="PrincipalPermissionTests.cs" />
     <Compile Include="SecurityElementTests.cs" />
     <Compile Include="TrustManagerContextTests.cs" />
-    <Compile Include="XamlAccessLevelTests.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp' And '$(TargetsWindows)' == 'true'">
+    <Compile Include="XamlLoadPermissionTests.cs"/>
   </ItemGroup>
 </Project>

--- a/src/System.Security.Permissions/tests/XamlLoadPermissionTests.cs
+++ b/src/System.Security.Permissions/tests/XamlLoadPermissionTests.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Configuration;
+using System.DirectoryServices;
+using System.Reflection;
+using System.Security;
+using System.Security.Permissions;
+using System.Web;
+using System.Xaml.Permissions;
+
+namespace System.Xaml.Permissions.Tests
+{
+    public class XamlLoadPermissionTests
+    {
+        [Fact]
+        public static void XamlLoadPermissionCallMethods()
+        {
+            XamlAccessLevel accessLevel = XamlAccessLevel.AssemblyAccessTo(Assembly.GetExecutingAssembly().GetName());
+            XamlLoadPermission xp = new XamlLoadPermission(accessLevel);
+            XamlLoadPermission xp2 = new XamlLoadPermission(PermissionState.Unrestricted);
+            XamlLoadPermission xp3 = new XamlLoadPermission(Array.Empty<XamlAccessLevel>());
+            bool testbool = xp.IsUnrestricted();
+            IPermission ip = xp.Copy();
+            IPermission ip2 = xp.Intersect(ip);
+            IPermission ip3 = xp.Union(ip);
+            testbool = xp.IsSubsetOf(ip);
+            testbool = xp.Equals(new object());
+            testbool = xp.Includes(accessLevel);
+            int hash = xp.GetHashCode();
+            SecurityElement se = new SecurityElement("");
+            xp.FromXml(se);
+            se = xp.ToXml();
+        }
+    }
+}

--- a/src/System.Windows.Extensions/ref/System.Windows.Extensions.cs
+++ b/src/System.Windows.Extensions/ref/System.Windows.Extensions.cs
@@ -133,3 +133,16 @@ namespace System.Security.Cryptography.X509Certificates
         MultiSelection = 1,
     }
 }
+namespace System.Xaml.Permissions
+{
+    public partial class XamlAccessLevel
+    {
+        internal XamlAccessLevel() { }
+        public System.Reflection.AssemblyName AssemblyAccessToAssemblyName { get { throw null; } }
+        public string PrivateAccessToTypeName { get { throw null; } }
+        public static System.Xaml.Permissions.XamlAccessLevel AssemblyAccessTo(System.Reflection.Assembly assembly) { throw null; }
+        public static System.Xaml.Permissions.XamlAccessLevel AssemblyAccessTo(System.Reflection.AssemblyName assemblyName) { throw null; }
+        public static System.Xaml.Permissions.XamlAccessLevel PrivateAccessTo(string assemblyQualifiedTypeName) { throw null; }
+        public static System.Xaml.Permissions.XamlAccessLevel PrivateAccessTo(System.Type type) { throw null; }
+    }
+}

--- a/src/System.Windows.Extensions/src/System.Windows.Extensions.csproj
+++ b/src/System.Windows.Extensions/src/System.Windows.Extensions.csproj
@@ -71,6 +71,7 @@
     <Compile Include="System\Media\SoundPlayer.cs" />
     <Compile Include="System\Media\SystemSound.cs" />
     <Compile Include="System\Media\SystemSounds.cs" />
+    <Compile Include="System\Xaml\Permissions\XamlAccessLevel.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Reference Include="System.Buffers" />

--- a/src/System.Windows.Extensions/src/System/Xaml/Permissions/XamlAccessLevel.cs
+++ b/src/System.Windows.Extensions/src/System/Xaml/Permissions/XamlAccessLevel.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
+++ b/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
@@ -6,6 +6,7 @@
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="X509Certificate2UITests.cs" />
     <Compile Include="X509Certificate2UIManualTests.cs" />
+    <Compile Include="XamlAccessLevelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Drawing\Helpers.cs">

--- a/src/System.Windows.Extensions/tests/XamlAccessLevelTests.cs
+++ b/src/System.Windows.Extensions/tests/XamlAccessLevelTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 


### PR DESCRIPTION
[Cherry picking `XamlAccessLevel` move to release/3.0] 

WPF needs continued access to XamlAccessLevel type. System.Xaml.Permissions.XamlLoadPermission also needs to use XamlAccessLevel.

WPF is trying to remove its references to System.Security.Permissions. In order to complete this work, XamlAccessLevel is being moved to System.Windows.Extensions.dll (while leaving XamlLoadPermission in System.Permission.dll as-is). This will allow WindowsDesktop.App to bundle System.Windows.Extensions.dll (but not carry System.Security.Permissions.dll).