### PR TITLE
Don't recheck for attributes if the path is too long

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystem.Windows.cs
@@ -217,7 +217,8 @@ namespace System.IO
                         && errorCode != Interop.Errors.ERROR_INVALID_PARAMETER
                         && errorCode != Interop.Errors.ERROR_NETWORK_UNREACHABLE
                         && errorCode != Interop.Errors.ERROR_NETWORK_ACCESS_DENIED
-                        && errorCode != Interop.Errors.ERROR_INVALID_HANDLE  // eg from \\.\CON
+                        && errorCode != Interop.Errors.ERROR_INVALID_HANDLE         // eg from \\.\CON
+                        && errorCode != Interop.Errors.ERROR_FILENAME_EXCED_RANGE   // Path is too long
                         )
                     {
                         // Assert so we can track down other cases (if any) to add to our test suite


### PR DESCRIPTION
One of our existing tests hits this on some machines. There is no point in retrying if the path is too long and we don't want to add it to the assert either.

Fixes #39048