### PR TITLE
Allow copying/moving/replacing broken symlinks

### DIFF
--- a/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.Symlink.cs
+++ b/src/Common/src/CoreLib/Interop/Unix/System.Native/Interop.Symlink.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Symlink", SetLastError = true)]
+        internal static extern int Symlink(string target, string linkPath);
+    }
+}

--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -1471,3 +1471,8 @@ int32_t SystemNative_LChflagsCanSetHiddenFlag(void)
     return false;
 #endif
 }
+
+int32_t SystemNative_Symlink(const char* target, const char* linkPath)
+{
+    return symlink(target, linkPath);
+}

--- a/src/Native/Unix/System.Native/pal_io.h
+++ b/src/Native/Unix/System.Native/pal_io.h
@@ -734,3 +734,11 @@ DLLEXPORT int32_t SystemNative_LChflags(const char* path, uint32_t flags);
  * Returns true (non-zero) if supported, false (zero) if not.
  */
 DLLEXPORT int32_t SystemNative_LChflagsCanSetHiddenFlag(void);
+/**
+* Creates a symbolic link at "linkPath", pointing at "target".
+* "target" may or may not exist (dangling symbolic links are valid filesystem objects)
+* Returns 0 on success; otherwise, returns -1 and errno is set.
+*/
+DLLEXPORT int32_t SystemNative_Symlink(const char* target, const char* linkPath);
+
+END_EXTERN_C

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
+using System.Runtime.InteropServices;
 
 namespace System.IO.Tests
 {
@@ -46,6 +47,22 @@ namespace System.IO.Tests
             string testFile = GetTestFilePath();
             File.Create(testFile).Dispose();
             Assert.Throws<IOException>(() => Copy(testFile, testFile));
+        }
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int symlink(string target, string linkpath);
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void DanglingSymlinkCopy()
+        {
+            string dangling_symlink = GetTestFileName();
+            string missing_target = GetTestFileName();
+            string dangling_symlink_new_location = GetTestFileName();
+            Assert.False(File.Exists(missing_target));
+            Assert.Equal(0, symlink(missing_target, dangling_symlink));
+            Copy(dangling_symlink, dangling_symlink_new_location);
+            Assert.True(File.Exists(dangling_symlink_new_location)); // File.Exists returns true for dangling symlinks
         }
 
         [Fact]

--- a/src/System.IO.FileSystem/tests/File/Move.cs
+++ b/src/System.IO.FileSystem/tests/File/Move.cs
@@ -191,6 +191,22 @@ namespace System.IO.Tests
             Assert.False(File.Exists(testFileSource.FullName));
         }
 
+        [DllImport("libc", SetLastError = true)]
+        private static extern int symlink(string target, string linkpath);
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void DanglingSymlinkMove()
+        {
+            string dangling_symlink = GetTestFileName();
+            string missing_target = GetTestFileName();
+            string dangling_symlink_new_location = GetTestFileName();
+            Assert.False(File.Exists(missing_target));
+            Assert.Equal(0, symlink(missing_target, dangling_symlink));
+            Move(dangling_symlink, dangling_symlink_new_location);
+            Assert.True(File.Exists(dangling_symlink_new_location)); // File.Exists returns true for dangling symlinks
+        }
+
         [Fact]
         public void FileNameWithSignificantWhitespace()
         {


### PR DESCRIPTION
See https://github.com/mono/mono/issues/14971 for the motivation; while it is a regression only in Mono, dangling symlinks are valid filesystem objects that can be moved or copied. 