### PR TITLE
checking if empty string is an installed font

### DIFF
--- a/src/System.Windows.Extensions/tests/Configurations.props
+++ b/src/System.Windows.Extensions/tests/Configurations.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <BuildConfigurations>
       netcoreapp-Windows_NT;
-      netfx-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
+++ b/src/System.Windows.Extensions/tests/System.Windows.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{AC1A1515-70D8-42E4-9B19-A72F739E974C}</ProjectGuid>
-    <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release</Configurations>
+    <Configurations>netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;</Configurations>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="X509Certificate2UITests.cs" />

--- a/src/System.Windows.Extensions/tests/System/Drawing/FontConverterTests.cs
+++ b/src/System.Windows.Extensions/tests/System/Drawing/FontConverterTests.cs
@@ -99,34 +99,34 @@ namespace System.ComponentModel.TypeConverterTests
                 { $"Arial{s_Separator} 10{s_Separator}", "Arial", 10f, GraphicsUnit.Point, FontStyle.Regular },
                 { $"Arial{s_Separator}", "Arial", 8.25f, GraphicsUnit.Point, FontStyle.Regular },
                 { $"Arial{s_Separator} 10{s_Separator} style=12", "Arial", 10f, GraphicsUnit.Point, FontStyle.Underline | FontStyle.Strikeout },
+                { $"Courier New{s_Separator} Style=Bold", "Courier New", 8.25f, GraphicsUnit.Point, FontStyle.Bold }, // FullFramework style keyword is case sensitive.
+                { $"11px{s_Separator} Style=Bold", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Bold}
             };
 
-            if (!PlatformDetection.IsFullFramework)
+            // FullFramework disregards all arguments if the font name is an empty string.
+            // Empty string is not an installed font on Windows 7, windows 8 and some versions of windows 10.
+            if (EmptyFontPresent)
             {
-                // FullFramework style keyword is case sensitive.
-                data.Add($"Courier New{s_Separator} Style=Bold", "Courier New", 8.25f, GraphicsUnit.Point, FontStyle.Bold);
-                data.Add($"11px{s_Separator} Style=Bold", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Bold);
-
-                // empty string is not an installed font on Windows 7, windows 8 and some versions of windows 10.
-                if (EmptyFontPresent)
-                {
-                    data.Add($"{s_Separator} 10{s_Separator} style=bold", "", 10f, GraphicsUnit.Point, FontStyle.Bold);
-                }
-                else
-                {
-                    data.Add($"{s_Separator} 10{s_Separator} style=bold", "Microsoft Sans Serif", 10f, GraphicsUnit.Point, FontStyle.Bold);
-                }
+                data.Add($"{s_Separator} 10{s_Separator} style=bold", "", 10f, GraphicsUnit.Point, FontStyle.Bold);
             }
             else
             {
-                // FullFramework disregards all arguments if the font name is an empty string.
-                data.Add($"{s_Separator} 10{s_Separator} style=bold", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Regular);
+                data.Add($"{s_Separator} 10{s_Separator} style=bold", "Microsoft Sans Serif", 10f, GraphicsUnit.Point, FontStyle.Bold);
             }
 
             return data;
         }
 
-        private static bool EmptyFontPresent => new InstalledFontCollection().Families.Select(t => t.Name).Contains(string.Empty);
+        private static bool EmptyFontPresent
+        {
+            get
+            {
+                using (var installedFonts = new InstalledFontCollection())
+                {
+                    return installedFonts.Families.Select(t => t.Name).Contains(string.Empty);
+                }
+            }
+        }
 
         public static TheoryData<string, string, string> ArgumentExceptionFontConverterData() => new TheoryData<string, string, string>()
         {

--- a/src/System.Windows.Extensions/tests/System/Drawing/FontConverterTests.cs
+++ b/src/System.Windows.Extensions/tests/System/Drawing/FontConverterTests.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Drawing;
+using System.Drawing.Text;
 using System.Globalization;
+using System.Linq;
 using Xunit;
 using static System.Drawing.FontConverter;
 
@@ -105,15 +107,26 @@ namespace System.ComponentModel.TypeConverterTests
                 data.Add($"Courier New{s_Separator} Style=Bold", "Courier New", 8.25f, GraphicsUnit.Point, FontStyle.Bold);
                 data.Add($"11px{s_Separator} Style=Bold", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Bold);
 
-                // FullFramework disregards all arguments if the font name is an empty string.
-                if (PlatformDetection.IsWindows10Version1607OrGreater)
+                // empty string is not an installed font on Windows 7, windows 8 and some versions of windows 10.
+                if (EmptyFontPresent)
                 {
-                    data.Add($"{s_Separator} 10{s_Separator} style=bold", "", 10f, GraphicsUnit.Point, FontStyle.Bold); // empty string is not a installed font on Windows 7 and windows 8.
+                    data.Add($"{s_Separator} 10{s_Separator} style=bold", "", 10f, GraphicsUnit.Point, FontStyle.Bold);
                 }
+                else
+                {
+                    data.Add($"{s_Separator} 10{s_Separator} style=bold", "Microsoft Sans Serif", 10f, GraphicsUnit.Point, FontStyle.Bold);
+                }
+            }
+            else
+            {
+                // FullFramework disregards all arguments if the font name is an empty string.
+                data.Add($"{s_Separator} 10{s_Separator} style=bold", "Microsoft Sans Serif", 8.25f, GraphicsUnit.Point, FontStyle.Regular);
             }
 
             return data;
         }
+
+        private static bool EmptyFontPresent => new InstalledFontCollection().Families.Select(t => t.Name).Contains(string.Empty);
 
         public static TheoryData<string, string, string> ArgumentExceptionFontConverterData() => new TheoryData<string, string, string>()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/39223

I added the check in the tests to check if the empty string font is installed on system or not.
I also added the test for the behavior on full framework