### PR TITLE
Reduce JIT and type load overhead in WinForms startup

### DIFF
--- a/src/Common/src/System/Drawing/KnownColorTable.cs
+++ b/src/Common/src/System/Drawing/KnownColorTable.cs
@@ -60,13 +60,13 @@ namespace System.Drawing
             // SystemColors. In order to avoid a static dependency on SystemEvents since it is not available on all platforms 
             // and as such we don't want to bring it into the shared framework. We use the desktop identity for SystemEvents
             // since it is stable and will remain stable for compatibility whereas the core identity could change.
-            Type systemEventsType = Type.GetType("Microsoft.Win32.SystemEvents, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", throwOnError: false);
+            Type systemEventsType = Type.GetType("Microsoft.Win32.SystemEvents, Microsoft.Win32.SystemEvents", throwOnError: false);
             EventInfo upEventInfo = systemEventsType?.GetEvent("UserPreferenceChanging", BindingFlags.Public | BindingFlags.Static);
 
             if (upEventInfo != null)
             {
                 // Delegate TargetType
-                Type userPrefChangingDelegateType = Type.GetType("Microsoft.Win32.UserPreferenceChangingEventHandler, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", throwOnError: false);
+                Type userPrefChangingDelegateType = Type.GetType("Microsoft.Win32.UserPreferenceChangingEventHandler, Microsoft.Win32.SystemEvents", throwOnError: false);
                 Debug.Assert(userPrefChangingDelegateType != null);
 
                 if (userPrefChangingDelegateType != null)
@@ -83,9 +83,8 @@ namespace System.Drawing
                     }
 
                     // Retrieving getter of the category property of the UserPreferenceChangingEventArgs.
-                    Type argsType = Type.GetType("Microsoft.Win32.UserPreferenceChangingEventArgs, System, Version = 4.0.0.0, Culture = neutral, PublicKeyToken = b77a5c561934e089", throwOnError: false);
-                    PropertyInfo categoryProperty = argsType?.GetProperty("Category", BindingFlags.Instance | BindingFlags.Public);
-                    s_categoryGetter = categoryProperty?.GetGetMethod();
+                    Type argsType = Type.GetType("Microsoft.Win32.UserPreferenceChangingEventArgs, Microsoft.Win32.SystemEvents", throwOnError: false);
+                    s_categoryGetter = argsType?.GetMethod("get_Category", BindingFlags.Instance | BindingFlags.Public);
                     Debug.Assert(s_categoryGetter != null);
                 }
             }


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/37853#discussion_r300974699

The existing code was trading startup perf for throughput in a codepath that is unlikely to be executed commonly. The common scenario is that the `UserPreferencesChanging` event is not fired for the entire lifetime of the app (I left an app listening for this event running for an hour of normal work and never once was the event fired. I then changed system colors to force it and make sure it works).

To set up the high performance path, we have to load two unique `Func` instantiations and JIT two methods. It's likely the throughput optimization won't pay for itself in terms of CPU cycles even if someone does change quite a few settings.