### PR TITLE
[release/2.1] Don't close connection for responses to NT auth using 100continue

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
@@ -57,6 +57,26 @@ namespace System.Net.Http
             return false;
         }
 
+        // Helper function to determine if response is part of session-based authentication challenge.
+        internal static bool IsSessionAuthenticationChallenge(HttpResponseMessage response)
+        {
+            if (response.StatusCode != HttpStatusCode.Unauthorized)
+            {
+                return false;
+            }
+
+            HttpHeaderValueCollection<AuthenticationHeaderValue> authenticationHeaderValues = GetResponseAuthenticationHeaderValues(response, isProxyAuth: false);
+            foreach (AuthenticationHeaderValue ahv in authenticationHeaderValues)
+            {
+                if (StringComparer.OrdinalIgnoreCase.Equals(NegotiateScheme, ahv.Scheme) || StringComparer.OrdinalIgnoreCase.Equals(NtlmScheme, ahv.Scheme))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private static bool TryGetValidAuthenticationChallengeForScheme(string scheme, AuthenticationType authenticationType, Uri uri, ICredentials credentials,
             HttpHeaderValueCollection<AuthenticationHeaderValue> authenticationHeaderValues, out AuthenticationChallenge challenge)
         {

--- a/src/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/NtAuthTests.cs
@@ -129,5 +129,29 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(expectedStatusCode, response.StatusCode);
             }
         }
+
+        [OuterLoop]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsNotWindowsNanoServer))]    // HttpListener doesn't support nt auth on non-Windows platforms
+        [InlineData(true, 1023)]
+        [InlineData(true, 1024)]
+        [InlineData(true, 1025)]
+        [InlineData(false, 1023)]
+        [InlineData(false, 1024)]
+        [InlineData(false, 1025)]
+        public async Task PostAsync_NtAuthServer_UseExpect100Header_Success(bool ntlm, int contentSize)
+        {
+            NtAuthServer server = ntlm ? _servers.NtlmServer : _servers.NegotiateServer;
+
+            var handler = new HttpClientHandler() { UseDefaultCredentials = true };
+            using (var client = new HttpClient(handler))
+            {
+                client.DefaultRequestHeaders.ExpectContinue = true;
+                var content = new StringContent(new string('A', contentSize));
+                using (HttpResponseMessage response = await client.PostAsync(server.BaseUrl, content))
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Port fix from PR #38744 (.NET Core 3.0) to release/2.1 LTS branch.

Fixes #30760