### PR TITLE
Marking the test with outerloop attribute

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
@@ -167,7 +167,7 @@ namespace System.ServiceProcess.Tests
         }
 
         [Fact]
-        [OuterLoop]
+        [OuterLoop] // The test may fail on individual machines with more than one UI language.
         public static void SetDisplayName_GetServiceName()
         {
             var keyIsoDisplayName = new ServiceController(KeyIsoSvcName).DisplayName;

--- a/src/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/SafeServiceControllerTests.cs
@@ -167,6 +167,7 @@ namespace System.ServiceProcess.Tests
         }
 
         [Fact]
+        [OuterLoop]
         public static void SetDisplayName_GetServiceName()
         {
             var keyIsoDisplayName = new ServiceController(KeyIsoSvcName).DisplayName;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/39216

The test fails sometimes on non English locales. The bug seems to be in windows side and has been sent to os team.