### PR TITLE
Exclude built-in HttpContent types from duplex with SocketsHttpHandler's HTTP/2

### DIFF
--- a/src/Common/src/System/Net/Http/NoWriteNoSeekStreamContent.cs
+++ b/src/Common/src/System/Net/Http/NoWriteNoSeekStreamContent.cs
@@ -84,6 +84,8 @@ namespace System.Net.Http
 
 #if HTTP_DLL
         internal override Stream TryCreateContentReadStream() => _content;
+
+        internal override bool AllowDuplex => false;
 #endif
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
@@ -70,5 +70,7 @@ namespace System.Net.Http
             null;
 
         internal MemoryStream CreateMemoryStreamForByteArray() => new MemoryStream(_content, _offset, _count, writable: false);
+
+        internal override bool AllowDuplex => false;
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -322,6 +322,14 @@ namespace System.Net.Http
         internal virtual Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken) =>
             SerializeToStreamAsync(stream, context);
 
+        // TODO #38559: Expose something to enable this publicly.  For very specific HTTP/2 scenarios (e.g. gRPC), we need
+        // to be able to allow request content to continue sending after SendAsync has completed, which goes against the
+        // previous design of content, and which means that with some servers, even outside of desired scenarios we could
+        // end up unexpectedly having request content still sending even after the response completes, which could lead to
+        // spurious failures in unsuspecting client code.  To mitigate that, we prohibit duplex on all known HttpContent
+        // types, waiting for the request content to complete before completing the SendAsync task. 
+        internal virtual bool AllowDuplex => true;
+
         public Task CopyToAsync(Stream stream, TransportContext context) =>
             CopyToAsync(stream, context, CancellationToken.None);
 

--- a/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -282,6 +282,8 @@ namespace System.Net.Http
             return new MemoryStream(HttpRuleParser.DefaultHttpEncoding.GetBytes(input), writable: false);
         }
 
+        internal override bool AllowDuplex => false;
+
         protected internal override bool TryComputeLength(out long length)
         {
             int boundaryLength = GetEncodedLength(_boundary);

--- a/src/System.Net.Http/src/System/Net/Http/ReadOnlyMemoryContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/ReadOnlyMemoryContent.cs
@@ -41,5 +41,7 @@ namespace System.Net.Http
 
         internal override Stream TryCreateContentReadStream() =>
             new ReadOnlyMemoryStream(_content);
+
+        internal override bool AllowDuplex => false;
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
@@ -151,6 +151,8 @@ namespace System.Net.Http
                 return false;
             }
 
+            internal override bool AllowDuplex => false;
+
             protected override void Dispose(bool disposing)
             {
                 if (disposing)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionResponseContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionResponseContent.cs
@@ -60,6 +60,8 @@ namespace System.Net.Http
         internal sealed override Stream TryCreateContentReadStream() =>
             ConsumeStream();
 
+        internal override bool AllowDuplex => false;
+
         protected sealed override void Dispose(bool disposing)
         {
             if (disposing)

--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -94,6 +94,8 @@ namespace System.Net.Http
             GetType() == typeof(StreamContent) ? new ReadOnlyStream(_content) : // type check ensures we use possible derived type's CreateContentReadStreamAsync override
             null;
 
+        internal override bool AllowDuplex => false;
+
         private void PrepareContent()
         {
             if (_contentConsumed)

--- a/src/System.Net.Http/tests/FunctionalTests/CustomContent.netcore.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/CustomContent.netcore.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http.Functional.Tests
 {
-    internal partial class CustomContent : StreamContent
+    internal partial class CustomContent : HttpContent
     {
         internal class SlowTestStream : CustomStream
         {

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -180,7 +180,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory, MemberData(nameof(BasicAuthEchoServers))]
         public async Task PostRewindableContentUsingAuth_NoPreAuthenticate_Success(Uri serverUri)
         {
-            HttpContent content = CustomContent.Create(ExpectedContent, true);
+            HttpContent content = new StreamContent(new CustomContent.CustomStream(Encoding.UTF8.GetBytes(ExpectedContent), true));
             var credential = new NetworkCredential(UserName, Password);
             await PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, false);
         }
@@ -190,7 +190,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory, MemberData(nameof(BasicAuthEchoServers))]
         public async Task PostNonRewindableContentUsingAuth_NoPreAuthenticate_ThrowsHttpRequestException(Uri serverUri)
         {
-            HttpContent content = CustomContent.Create(ExpectedContent, false);
+            HttpContent content = new StreamContent(new CustomContent.CustomStream(Encoding.UTF8.GetBytes(ExpectedContent), false));
             var credential = new NetworkCredential(UserName, Password);
             await Assert.ThrowsAsync<HttpRequestException>(() => 
                 PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, preAuthenticate: false));
@@ -207,7 +207,7 @@ namespace System.Net.Http.Functional.Tests
                 return;
             }
 
-            HttpContent content = CustomContent.Create(ExpectedContent, false);
+            HttpContent content = new StreamContent(new CustomContent.CustomStream(Encoding.UTF8.GetBytes(ExpectedContent), false));
             var credential = new NetworkCredential(UserName, Password);
             await PostUsingAuthHelper(serverUri, ExpectedContent, content, credential, preAuthenticate: true);
         }


### PR DESCRIPTION
For 3.0:
- Adds an internal virtual AllowDuplex to HttpContent that defaults to true
- Override that on all of our HttpContent-derived types to return false
- SocketsHttpHandler's HTTP/2 implementation checks that, and if it returns false, awaits the sending of the request body as part of SendAsync.

Post-3.0, we'll revisit, likely with public surface area.

Contributes to https://github.com/dotnet/corefx/issues/38559 ("fixes" it for 3.0)
cc: @geoffkizer, @dotnet/ncl 