### PR TITLE
Improve Enumerable.Reverse() performance

### DIFF
--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -79,6 +79,7 @@
     <Compile Include="System\Linq\Iterator.cs" />
     <Compile Include="System\Linq\IIListProvider.cs" />
     <Compile Include="System\Linq\IPartition.cs" />
+    <Compile Include="System\Linq\IReverseProvider.cs" />
     <Compile Include="System\Linq\Join.cs" />
     <Compile Include="System\Linq\Last.cs" />
     <Compile Include="System\Linq\Lookup.cs" />

--- a/src/System.Linq/src/System/Linq/IReverseProvider.cs
+++ b/src/System.Linq/src/System/Linq/IReverseProvider.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Linq
+{
+    internal interface IReverseProvider<TElement> : IEnumerable<TElement>
+    {
+        IEnumerable<TElement> Reverse();
+    }
+}

--- a/src/System.Linq/src/System/Linq/Partition.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Partition.SpeedOpt.cs
@@ -17,7 +17,7 @@ namespace System.Linq
     /// Returning an instance of this type is useful to quickly handle scenarios where it is known
     /// that an operation will result in zero elements.
     /// </remarks>
-    internal sealed class EmptyPartition<TElement> : IPartition<TElement>, IEnumerator<TElement>
+    internal sealed class EmptyPartition<TElement> : IPartition<TElement>, IEnumerator<TElement>, IReverseProvider<TElement>
     {
         /// <summary>
         /// A cached, immutable instance of an empty enumerable.
@@ -49,6 +49,8 @@ namespace System.Linq
         {
             // Do nothing.
         }
+
+        public IEnumerable<TElement> Reverse() => this;
 
         public IPartition<TElement> Skip(int count) => this;
 
@@ -142,7 +144,7 @@ namespace System.Linq
         /// An iterator that yields the items of part of an <see cref="IList{TSource}"/>.
         /// </summary>
         /// <typeparam name="TSource">The type of the source list.</typeparam>
-        private sealed class ListPartition<TSource> : Iterator<TSource>, IPartition<TSource>
+        private sealed class ListPartition<TSource> : Iterator<TSource>, IPartition<TSource>, IReverseProvider<TSource>
         {
             private readonly IList<TSource> _source;
             private readonly int _minIndexInclusive;
@@ -180,6 +182,9 @@ namespace System.Linq
 
             public override IEnumerable<TResult> Select<TResult>(Func<TSource, TResult> selector) =>
                 new SelectListPartitionIterator<TSource, TResult>(_source, selector, _minIndexInclusive, _maxIndexInclusive);
+
+            public IEnumerable<TSource> Reverse() =>
+                new ReverseListPartition<TSource>(_source, _minIndexInclusive, _maxIndexInclusive);
 
             public IPartition<TSource> Skip(int count)
             {

--- a/src/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
@@ -49,7 +49,7 @@ namespace System.Linq
                 Debug.Assert(count > 0);
                 return count >= _source.Length
                     ? (IPartition<TSource>)this
-                    : new ReverseListPartition<TSource>(_source, _source.Length - count - 1, int.MaxValue);
+                    : new ReverseListPartition<TSource>(_source, _source.Length - count, int.MaxValue);
             }
 
             public TSource TryGetElementAt(int index, out bool found)
@@ -138,7 +138,7 @@ namespace System.Linq
                 Debug.Assert(count > 0);
                 return count >= _source.Length
                     ? (IPartition<TResult>)this
-                    : new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, _source.Length - count - 1, int.MaxValue);
+                    : new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, _source.Length - count, int.MaxValue);
             }
 
             public TResult TryGetElementAt(int index, out bool found)
@@ -200,13 +200,17 @@ namespace System.Linq
             public IPartition<TSource> Skip(int count)
             {
                 Debug.Assert(count > 0);
-                return new ReverseListPartition<TSource>(_source, 0, _source.Count - count - 1);
+                return count >= _source.Count
+                    ? EmptyPartition<TSource>.Instance
+                    : new ReverseListPartition<TSource>(_source, 0, _source.Count - count - 1);
             }
 
             public IPartition<TSource> Take(int count)
             {
                 Debug.Assert(count > 0);
-                return new ReverseListPartition<TSource>(_source, _source.Count - count - 1, int.MaxValue);
+                return count >= _source.Count
+                    ? (IPartition<TSource>)this
+                    : new ReverseListPartition<TSource>(_source, _source.Count - count, int.MaxValue);
             }
 
             public TSource TryGetElementAt(int index, out bool found)
@@ -300,13 +304,17 @@ namespace System.Linq
             public IPartition<TResult> Skip(int count)
             {
                 Debug.Assert(count > 0);
-                return new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, _source.Count - count - 1);
+                return count >= _source.Count
+                    ? EmptyPartition<TResult>.Instance
+                    : new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, _source.Count - count - 1);
             }
 
             public IPartition<TResult> Take(int count)
             {
                 Debug.Assert(count > 0);
-                return new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, _source.Count - count - 1, int.MaxValue);
+                return count >= _source.Count
+                    ? (IPartition<TResult>)this
+                    : new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, _source.Count - count, int.MaxValue);
             }
 
             public TResult TryGetElementAt(int index, out bool found)
@@ -379,13 +387,17 @@ namespace System.Linq
             public IPartition<TSource> Skip(int count)
             {
                 Debug.Assert(count > 0);
-                return new ReverseListPartition<TSource>(_source, 0, _source.Count - count - 1);
+                return count >= _source.Count
+                    ? EmptyPartition<TSource>.Instance
+                    : new ReverseListPartition<TSource>(_source, 0, _source.Count - count - 1);
             }
 
             public IPartition<TSource> Take(int count)
             {
                 Debug.Assert(count > 0);
-                return new ReverseListPartition<TSource>(_source, _source.Count - count - 1, int.MaxValue);
+                return count >= _source.Count
+                    ? (IPartition<TSource>)this
+                    : new ReverseListPartition<TSource>(_source, _source.Count - count, int.MaxValue);
             }
 
             public TSource TryGetElementAt(int index, out bool found)
@@ -479,13 +491,17 @@ namespace System.Linq
             public IPartition<TResult> Skip(int count)
             {
                 Debug.Assert(count > 0);
-                return new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, _source.Count - count - 1);
+                return count >= _source.Count
+                    ? EmptyPartition<TResult>.Instance
+                    : new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, _source.Count - count - 1);
             }
 
             public IPartition<TResult> Take(int count)
             {
                 Debug.Assert(count > 0);
-                return new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, _source.Count - count - 1, int.MaxValue);
+                return count >= _source.Count
+                    ? (IPartition<TResult>)this
+                    : new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, _source.Count - count, int.MaxValue);
             }
 
             public TResult TryGetElementAt(int index, out bool found)

--- a/src/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
@@ -4,12 +4,530 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using static System.Linq.Utilities;
 
 namespace System.Linq
 {
     public static partial class Enumerable
     {
-        private sealed partial class ReverseIterator<TSource> : IIListProvider<TSource>
+        private sealed partial class ReverseArrayIterator<TSource> : IPartition<TSource>
+        {
+            public TSource[] ToArray()
+            {
+                // See assert in constructor.
+                // Since _source should never be empty, we don't check for 0/return Array.Empty.
+                Debug.Assert(_source.Length > 0);
+
+                var results = (TSource[])_source.Clone();
+                Array.Reverse(results);
+                return results;
+            }
+
+            public List<TSource> ToList()
+            {
+                var results = new List<TSource>(_source);
+                results.Reverse();
+                return results;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return _source.Length;
+            }
+
+            public IPartition<TSource> Skip(int count)
+            {
+                Debug.Assert(count > 0);
+                return count >= _source.Length
+                    ? EmptyPartition<TSource>.Instance
+                    : new ReverseListPartition<TSource>(_source, 0, _source.Length - count - 1);
+            }
+
+            public IPartition<TSource> Take(int count)
+            {
+                Debug.Assert(count > 0);
+                return count >= _source.Length
+                    ? (IPartition<TSource>)this
+                    : new ReverseListPartition<TSource>(_source, _source.Length - count - 1, int.MaxValue);
+            }
+
+            public TSource TryGetElementAt(int index, out bool found)
+            {
+                if ((uint)index < (uint)_source.Length)
+                {
+                    found = true;
+                    return _source[_source.Length - index - 1];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetFirst(out bool found)
+            {
+                Debug.Assert(_source.Length > 0); // See assert in constructor
+
+                found = true;
+                return _source[_source.Length - 1];
+            }
+
+            public TSource TryGetLast(out bool found)
+            {
+                Debug.Assert(_source.Length > 0); // See assert in constructor
+
+                found = true;
+                return _source[0];
+            }
+        }
+
+        private sealed partial class ReverseSelectArrayIterator<TSource, TResult> : IPartition<TResult>
+        {
+            public TResult[] ToArray()
+            {
+                // See assert in constructor.
+                // Since _source should never be empty, we don't check for 0/return Array.Empty.
+                Debug.Assert(_source.Length > 0);
+
+                var results = new TResult[_source.Length];
+                for (int i = 0, j = results.Length - 1; i < results.Length; i++, j--)
+                {
+                    results[i] = _selector(_source[j]);
+                }
+
+                return results;
+            }
+
+            public List<TResult> ToList()
+            {
+                var results = new List<TResult>(_source.Length);
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    results.Add(_selector(_source[i]));
+                }
+
+                return results;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
+                if (!onlyIfCheap)
+                {
+                    for (int i = _source.Length - 1; i >= 0; i--)
+                    {
+                        _selector(_source[i]);
+                    }
+                }
+
+                return _source.Length;
+            }
+
+            public IPartition<TResult> Skip(int count)
+            {
+                Debug.Assert(count > 0);
+                return count >= _source.Length
+                    ? EmptyPartition<TResult>.Instance
+                    : new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, _source.Length - count - 1);
+            }
+
+            public IPartition<TResult> Take(int count)
+            {
+                Debug.Assert(count > 0);
+                return count >= _source.Length
+                    ? (IPartition<TResult>)this
+                    : new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, _source.Length - count - 1, int.MaxValue);
+            }
+
+            public TResult TryGetElementAt(int index, out bool found)
+            {
+                if ((uint)index < (uint)_source.Length)
+                {
+                    found = true;
+                    return _selector(_source[_source.Length - index - 1]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetFirst(out bool found)
+            {
+                Debug.Assert(_source.Length > 0); // See assert in constructor
+
+                found = true;
+                return _selector(_source[_source.Length - 1]);
+            }
+
+            public TResult TryGetLast(out bool found)
+            {
+                Debug.Assert(_source.Length > 0); // See assert in constructor
+
+                found = true;
+                return _selector(_source[0]);
+            }
+        }
+
+        private sealed partial class ReverseListIterator<TSource> : IPartition<TSource>
+        {
+            public TSource[] ToArray()
+            {
+                int count = _source.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<TSource>();
+                }
+
+                var results = _source.ToArray();
+                Array.Reverse(results);
+                return results;
+            }
+
+            public List<TSource> ToList()
+            {
+                var results = new List<TSource>(_source);
+                results.Reverse();
+                return results;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return _source.Count;
+            }
+
+            public IPartition<TSource> Skip(int count)
+            {
+                Debug.Assert(count > 0);
+                return new ReverseListPartition<TSource>(_source, 0, _source.Count - count - 1);
+            }
+
+            public IPartition<TSource> Take(int count)
+            {
+                Debug.Assert(count > 0);
+                return new ReverseListPartition<TSource>(_source, _source.Count - count - 1, int.MaxValue);
+            }
+
+            public TSource TryGetElementAt(int index, out bool found)
+            {
+                int count = _source.Count;
+                if ((uint)index < (uint)count)
+                {
+                    found = true;
+                    return _source[count - index - 1];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetFirst(out bool found)
+            {
+                int len = _source.Count;
+                if (len != 0)
+                {
+                    found = true;
+                    return _source[len - 1];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetLast(out bool found)
+            {
+                if (_source.Count != 0)
+                {
+                    found = true;
+                    return _source[0];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+        }
+
+        private sealed partial class ReverseSelectListIterator<TSource, TResult> : IPartition<TResult>
+        {
+            public TResult[] ToArray()
+            {
+                int count = _source.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<TResult>();
+                }
+
+                var results = new TResult[count];
+                for (int i = 0, j = results.Length - 1; i < results.Length; i++, j--)
+                {
+                    results[i] = _selector(_source[j]);
+                }
+
+                return results;
+            }
+
+            public List<TResult> ToList()
+            {
+                int count = _source.Count;
+                var results = new List<TResult>(count);
+                for (int i = count - 1; i >= 0; i--)
+                {
+                    results.Add(_selector(_source[i]));
+                }
+
+                return results;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
+                int count = _source.Count;
+
+                if (!onlyIfCheap)
+                {
+                    for (int i = count - 1; i >= 0; i--)
+                    {
+                        _selector(_source[i]);
+                    }
+                }
+
+                return count;
+            }
+
+            public IPartition<TResult> Skip(int count)
+            {
+                Debug.Assert(count > 0);
+                return new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, _source.Count - count - 1);
+            }
+
+            public IPartition<TResult> Take(int count)
+            {
+                Debug.Assert(count > 0);
+                return new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, _source.Count - count - 1, int.MaxValue);
+            }
+
+            public TResult TryGetElementAt(int index, out bool found)
+            {
+                int count = _source.Count;
+                if ((uint)index < (uint)count)
+                {
+                    found = true;
+                    return _selector(_source[count - index - 1]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetFirst(out bool found)
+            {
+                int len = _source.Count;
+                if (len != 0)
+                {
+                    found = true;
+                    return _selector(_source[len - 1]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetLast(out bool found)
+            {
+                if (_source.Count != 0)
+                {
+                    found = true;
+                    return _selector(_source[0]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+        }
+
+        private sealed partial class ReverseIListIterator<TSource> : IPartition<TSource>
+        {
+            public TSource[] ToArray()
+            {
+                int count = _source.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<TSource>();
+                }
+
+                var results = new TSource[count];
+                _source.CopyTo(results, 0);
+                Array.Reverse(results);
+                return results;
+            }
+
+            public List<TSource> ToList()
+            {
+                var results = new List<TSource>(_source);
+                results.Reverse();
+                return results;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return _source.Count;
+            }
+
+            public IPartition<TSource> Skip(int count)
+            {
+                Debug.Assert(count > 0);
+                return new ReverseListPartition<TSource>(_source, 0, _source.Count - count - 1);
+            }
+
+            public IPartition<TSource> Take(int count)
+            {
+                Debug.Assert(count > 0);
+                return new ReverseListPartition<TSource>(_source, _source.Count - count - 1, int.MaxValue);
+            }
+
+            public TSource TryGetElementAt(int index, out bool found)
+            {
+                int count = _source.Count;
+                if ((uint)index < (uint)count)
+                {
+                    found = true;
+                    return _source[count - index - 1];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetFirst(out bool found)
+            {
+                int len = _source.Count;
+                if (len != 0)
+                {
+                    found = true;
+                    return _source[len - 1];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetLast(out bool found)
+            {
+                if (_source.Count != 0)
+                {
+                    found = true;
+                    return _source[0];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+        }
+
+        private sealed partial class ReverseSelectIListIterator<TSource, TResult> : IPartition<TResult>
+        {
+            public TResult[] ToArray()
+            {
+                int count = _source.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<TResult>();
+                }
+
+                var results = new TResult[count];
+                for (int i = 0, j = results.Length - 1; i < results.Length; i++, j--)
+                {
+                    results[i] = _selector(_source[j]);
+                }
+
+                return results;
+            }
+
+            public List<TResult> ToList()
+            {
+                int count = _source.Count;
+                var results = new List<TResult>(count);
+                for (int i = count - 1; i >= 0; i--)
+                {
+                    results.Add(_selector(_source[i]));
+                }
+
+                return results;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
+                int count = _source.Count;
+
+                if (!onlyIfCheap)
+                {
+                    for (int i = count - 1; i >= 0; i--)
+                    {
+                        _selector(_source[i]);
+                    }
+                }
+
+                return count;
+            }
+
+            public IPartition<TResult> Skip(int count)
+            {
+                Debug.Assert(count > 0);
+                return new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, _source.Count - count - 1);
+            }
+
+            public IPartition<TResult> Take(int count)
+            {
+                Debug.Assert(count > 0);
+                return new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, _source.Count - count - 1, int.MaxValue);
+            }
+
+            public TResult TryGetElementAt(int index, out bool found)
+            {
+                int count = _source.Count;
+                if ((uint)index < (uint)count)
+                {
+                    found = true;
+                    return _selector(_source[count - index - 1]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetFirst(out bool found)
+            {
+                int len = _source.Count;
+                if (len != 0)
+                {
+                    found = true;
+                    return _selector(_source[len - 1]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetLast(out bool found)
+            {
+                if (_source.Count != 0)
+                {
+                    found = true;
+                    return _selector(_source[0]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+        }
+
+        private sealed partial class ReverseEnumerableIterator<TSource> : IIListProvider<TSource>
         {
             public TSource[] ToArray()
             {
@@ -46,6 +564,320 @@ namespace System.Linq
                 }
 
                 return _source.Count();
+            }
+        }
+
+        private sealed class ReverseListPartition<TSource> : Iterator<TSource>, IPartition<TSource>, IReverseProvider<TSource>
+        {
+            private readonly IList<TSource> _source;
+            private readonly int _minIndexInclusive;
+            private readonly int _maxIndexInclusive;
+
+            public ReverseListPartition(IList<TSource> source, int minIndexInclusive, int maxIndexInclusive)
+            {
+                Debug.Assert(source != null);
+                Debug.Assert(minIndexInclusive >= 0);
+                Debug.Assert(minIndexInclusive <= maxIndexInclusive);
+                _source = source;
+                _minIndexInclusive = minIndexInclusive;
+                _maxIndexInclusive = maxIndexInclusive;
+            }
+
+            public override Iterator<TSource> Clone() =>
+                new ReverseListPartition<TSource>(_source, _minIndexInclusive, _maxIndexInclusive);
+
+            public override bool MoveNext()
+            {
+                // _state - 1 represents the zero-based index into the list.
+                // Having a separate field for the index would be more readable. However, we save it
+                // into _state with a bias to minimize field size of the iterator.
+                int index = _state - 1;
+                int count = _source.Count;
+                if (unchecked((uint)index <= (uint)(_maxIndexInclusive - _minIndexInclusive) && index < count - _minIndexInclusive))
+                {
+                    _current = _source[Math.Min(count - 1, _maxIndexInclusive) - index];
+                    ++_state;
+                    return true;
+                }
+
+                Dispose();
+                return false;
+            }
+
+            public override IEnumerable<TResult> Select<TResult>(Func<TSource, TResult> selector) =>
+                new ReverseSelectListPartitionIterator<TSource, TResult>(_source, selector, _minIndexInclusive, _maxIndexInclusive);
+
+            public IEnumerable<TSource> Reverse() =>
+                new ListPartition<TSource>(_source, _minIndexInclusive, _maxIndexInclusive);
+
+            public TSource[] ToArray()
+            {
+                int count = Count;
+                if (count == 0)
+                {
+                    return Array.Empty<TSource>();
+                }
+
+                TSource[] array = new TSource[count];
+                for (int i = 0, curIdx = Math.Min(_source.Count - 1, _maxIndexInclusive); i != array.Length; ++i, --curIdx)
+                {
+                    array[i] = _source[curIdx];
+                }
+
+                return array;
+            }
+
+            public List<TSource> ToList()
+            {
+                int count = Count;
+                if (count == 0)
+                {
+                    return new List<TSource>();
+                }
+
+                List<TSource> list = new List<TSource>(count);
+                int end = _minIndexInclusive - 1;
+                for (int i = Math.Min(_source.Count - 1, _maxIndexInclusive); i != end; --i)
+                {
+                    list.Add(_source[i]);
+                }
+
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap) => Count;
+
+            public IPartition<TSource> Skip(int count)
+            {
+                Debug.Assert(count > 0);
+                int maxIndex = Math.Min(_source.Count - 1, _maxIndexInclusive) - count;
+                return maxIndex < _minIndexInclusive ? EmptyPartition<TSource>.Instance : new ReverseListPartition<TSource>(_source, _minIndexInclusive, maxIndex);
+            }
+
+            public IPartition<TSource> Take(int count)
+            {
+                Debug.Assert(count > 0);
+                int minIndex = Math.Min(_source.Count - 1, _maxIndexInclusive) - count + 1;
+                return minIndex <= _minIndexInclusive ? this : new ReverseListPartition<TSource>(_source, minIndex, _maxIndexInclusive);
+            }
+
+            public TSource TryGetElementAt(int index, out bool found)
+            {
+                int count = _source.Count;
+                if ((uint)index <= (uint)(_maxIndexInclusive - _minIndexInclusive) && index < count - _minIndexInclusive)
+                {
+                    found = true;
+                    return _source[Math.Min(count - 1, _maxIndexInclusive) - index];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetFirst(out bool found)
+            {
+                int lastIndex = _source.Count - 1;
+                if (lastIndex >= _minIndexInclusive)
+                {
+                    found = true;
+                    return _source[Math.Min(lastIndex, _maxIndexInclusive)];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetLast(out bool found)
+            {
+                if (_source.Count > _minIndexInclusive)
+                {
+                    found = true;
+                    return _source[_minIndexInclusive];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            private int Count
+            {
+                get
+                {
+                    int count = _source.Count;
+                    if (count <= _minIndexInclusive)
+                    {
+                        return 0;
+                    }
+
+                    return Math.Min(count - 1, _maxIndexInclusive) - _minIndexInclusive + 1;
+                }
+            }
+        }
+
+        private sealed class ReverseSelectListPartitionIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>, IReverseProvider<TResult>
+        {
+            private readonly IList<TSource> _source;
+            private readonly Func<TSource, TResult> _selector;
+            private readonly int _minIndexInclusive;
+            private readonly int _maxIndexInclusive;
+
+            public ReverseSelectListPartitionIterator(IList<TSource> source, Func<TSource, TResult> selector, int minIndexInclusive, int maxIndexInclusive)
+            {
+                Debug.Assert(source != null);
+                Debug.Assert(selector != null);
+                Debug.Assert(minIndexInclusive >= 0);
+                Debug.Assert(minIndexInclusive <= maxIndexInclusive);
+                _source = source;
+                _selector = selector;
+                _minIndexInclusive = minIndexInclusive;
+                _maxIndexInclusive = maxIndexInclusive;
+            }
+
+            public override Iterator<TResult> Clone() =>
+                new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, _minIndexInclusive, _maxIndexInclusive);
+
+            public override bool MoveNext()
+            {
+                // _state - 1 represents the zero-based index into the list.
+                // Having a separate field for the index would be more readable. However, we save it
+                // into _state with a bias to minimize field size of the iterator.
+                int index = _state - 1;
+                int count = _source.Count;
+                if (unchecked((uint)index <= (uint)(_maxIndexInclusive - _minIndexInclusive) && index < count - _minIndexInclusive))
+                {
+                    _current = _selector(_source[Math.Min(count - 1, _maxIndexInclusive) - index]);
+                    ++_state;
+                    return true;
+                }
+
+                Dispose();
+                return false;
+            }
+
+            public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
+                new ReverseSelectListPartitionIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector), _minIndexInclusive, _maxIndexInclusive);
+
+            public IEnumerable<TResult> Reverse() =>
+                new SelectListPartitionIterator<TSource, TResult>(_source, _selector, _minIndexInclusive, _maxIndexInclusive);
+
+            public TResult[] ToArray()
+            {
+                int count = Count;
+                if (count == 0)
+                {
+                    return Array.Empty<TResult>();
+                }
+
+                TResult[] array = new TResult[count];
+                for (int i = 0, curIdx = Math.Min(_source.Count - 1, _maxIndexInclusive); i != array.Length; ++i, --curIdx)
+                {
+                    array[i] = _selector(_source[curIdx]);
+                }
+
+                return array;
+            }
+
+            public List<TResult> ToList()
+            {
+                int count = Count;
+                if (count == 0)
+                {
+                    return new List<TResult>();
+                }
+
+                List<TResult> list = new List<TResult>(count);
+                int end = _minIndexInclusive - 1;
+                for (int i = Math.Min(_source.Count - 1, _maxIndexInclusive); i != end; --i)
+                {
+                    list.Add(_selector(_source[i]));
+                }
+
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
+                int count = Count;
+
+                if (!onlyIfCheap)
+                {
+                    int end = _minIndexInclusive - 1;
+                    for (int i = Math.Min(_source.Count - 1, _maxIndexInclusive); i != end; --i)
+                    {
+                        _selector(_source[i]);
+                    }
+                }
+
+                return count;
+            }
+
+            public IPartition<TResult> Skip(int count)
+            {
+                Debug.Assert(count > 0);
+                int maxIndex = Math.Min(_source.Count - 1, _maxIndexInclusive) - count;
+                return maxIndex < _minIndexInclusive ? EmptyPartition<TResult>.Instance : new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, _minIndexInclusive, maxIndex);
+            }
+
+            public IPartition<TResult> Take(int count)
+            {
+                Debug.Assert(count > 0);
+                int minIndex = Math.Min(_source.Count - 1, _maxIndexInclusive) - count + 1;
+                return minIndex <= _minIndexInclusive ? this : new ReverseSelectListPartitionIterator<TSource, TResult>(_source, _selector, minIndex, _maxIndexInclusive);
+            }
+
+            public TResult TryGetElementAt(int index, out bool found)
+            {
+                int count = _source.Count;
+                if ((uint)index <= (uint)(_maxIndexInclusive - _minIndexInclusive) && index < count - _minIndexInclusive)
+                {
+                    found = true;
+                    return _selector(_source[Math.Min(count - 1, _maxIndexInclusive) - index]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetFirst(out bool found)
+            {
+                int lastIndex = _source.Count - 1;
+                if (lastIndex >= _minIndexInclusive)
+                {
+                    found = true;
+                    return _selector(_source[Math.Min(lastIndex, _maxIndexInclusive)]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetLast(out bool found)
+            {
+                if (_source.Count > _minIndexInclusive)
+                {
+                    found = true;
+                    return _selector(_source[_minIndexInclusive]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            private int Count
+            {
+                get
+                {
+                    int count = _source.Count;
+                    if (count <= _minIndexInclusive)
+                    {
+                        return 0;
+                    }
+
+                    return Math.Min(count - 1, _maxIndexInclusive) - _minIndexInclusive + 1;
+                }
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
@@ -583,7 +583,7 @@ namespace System.Linq
             }
         }
 
-        private sealed class ReverseListPartition<TSource> : Iterator<TSource>, IPartition<TSource>, IReverseProvider<TSource>
+        private sealed class ReverseListPartition<TSource> : Iterator<TSource>, IPartition<TSource>
         {
             private readonly IList<TSource> _source;
             private readonly int _minIndexInclusive;
@@ -622,9 +622,6 @@ namespace System.Linq
 
             public override IEnumerable<TResult> Select<TResult>(Func<TSource, TResult> selector) =>
                 new ReverseSelectListPartitionIterator<TSource, TResult>(_source, selector, _minIndexInclusive, _maxIndexInclusive);
-
-            public IEnumerable<TSource> Reverse() =>
-                new ListPartition<TSource>(_source, _minIndexInclusive, _maxIndexInclusive);
 
             public TSource[] ToArray()
             {
@@ -730,7 +727,7 @@ namespace System.Linq
             }
         }
 
-        private sealed class ReverseSelectListPartitionIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>, IReverseProvider<TResult>
+        private sealed class ReverseSelectListPartitionIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
         {
             private readonly IList<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -772,9 +769,6 @@ namespace System.Linq
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
                 new ReverseSelectListPartitionIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector), _minIndexInclusive, _maxIndexInclusive);
-
-            public IEnumerable<TResult> Reverse() =>
-                new SelectListPartitionIterator<TSource, TResult>(_source, _selector, _minIndexInclusive, _maxIndexInclusive);
 
             public TResult[] ToArray()
             {

--- a/src/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
@@ -880,5 +880,249 @@ namespace System.Linq
                 }
             }
         }
+
+        internal sealed partial class ReverseWhereArrayIterator<TSource> : IIListProvider<TSource>
+        {
+            public TSource[] ToArray()
+            {
+                var builder = new LargeArrayBuilder<TSource>(_source.Length);
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        builder.Add(item);
+                    }
+                }
+
+                return builder.ToArray();
+            }
+
+            public List<TSource> ToList()
+            {
+                var list = new List<TSource>();
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        list.Add(item);
+                    }
+                }
+
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
+
+                int count = 0;
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        checked
+                        {
+                            count++;
+                        }
+                    }
+                }
+
+                return count;
+            }
+        }
+
+        private sealed partial class ReverseWhereListIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
+        {
+            public TSource[] ToArray()
+            {
+                var builder = new LargeArrayBuilder<TSource>(_source.Count);
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        builder.Add(item);
+                    }
+                }
+
+                return builder.ToArray();
+            }
+
+            public List<TSource> ToList()
+            {
+                var list = new List<TSource>();
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        list.Add(item);
+                    }
+                }
+
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
+
+                int count = 0;
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        checked
+                        {
+                            count++;
+                        }
+                    }
+                }
+
+                return count;
+            }
+        }
+
+        private sealed partial class ReverseWhereSelectArrayIterator<TSource, TResult> : IIListProvider<TResult>
+        {
+            public TResult[] ToArray()
+            {
+                var builder = new LargeArrayBuilder<TResult>(_source.Length);
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        builder.Add(_selector(item));
+                    }
+                }
+
+                return builder.ToArray();
+            }
+
+            public List<TResult> ToList()
+            {
+                var list = new List<TResult>();
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        list.Add(_selector(item));
+                    }
+                }
+
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
+
+                int count = 0;
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        _selector(item);
+                        checked
+                        {
+                            count++;
+                        }
+                    }
+                }
+
+                return count;
+            }
+        }
+
+        private sealed partial class ReverseWhereSelectListIterator<TSource, TResult> : IIListProvider<TResult>
+        {
+            public TResult[] ToArray()
+            {
+                var builder = new LargeArrayBuilder<TResult>(_source.Count);
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        builder.Add(_selector(item));
+                    }
+                }
+
+                return builder.ToArray();
+            }
+
+            public List<TResult> ToList()
+            {
+                var list = new List<TResult>();
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        list.Add(_selector(item));
+                    }
+                }
+
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
+
+                int count = 0;
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        _selector(item);
+                        checked
+                        {
+                            count++;
+                        }
+                    }
+                }
+
+                return count;
+            }
+        }
     }
 }

--- a/src/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
@@ -81,6 +81,211 @@ namespace System.Linq
             }
         }
 
+        private sealed partial class ReverseListIterator<TSource> : IPartition<TSource>
+        {
+            public TSource[] ToArray()
+            {
+                int count = _source.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<TSource>();
+                }
+
+                var results = _source.ToArray();
+                Array.Reverse(results);
+                return results;
+            }
+
+            public List<TSource> ToList()
+            {
+                var results = new List<TSource>(_source);
+                results.Reverse();
+                return results;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return _source.Count;
+            }
+
+            public IPartition<TSource> Skip(int count)
+            {
+                Debug.Assert(count > 0);
+                return count >= _source.Count
+                    ? EmptyPartition<TSource>.Instance
+                    : new ReverseListPartition<TSource>(_source, 0, _source.Count - count - 1);
+            }
+
+            public IPartition<TSource> Take(int count)
+            {
+                Debug.Assert(count > 0);
+                return count >= _source.Count
+                    ? (IPartition<TSource>)this
+                    : new ReverseListPartition<TSource>(_source, _source.Count - count, int.MaxValue);
+            }
+
+            public TSource TryGetElementAt(int index, out bool found)
+            {
+                int count = _source.Count;
+                if ((uint)index < (uint)count)
+                {
+                    found = true;
+                    return _source[count - index - 1];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetFirst(out bool found)
+            {
+                int len = _source.Count;
+                if (len != 0)
+                {
+                    found = true;
+                    return _source[len - 1];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetLast(out bool found)
+            {
+                if (_source.Count != 0)
+                {
+                    found = true;
+                    return _source[0];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+        }
+
+        private sealed partial class ReverseIListIterator<TSource> : IPartition<TSource>
+        {
+            public TSource[] ToArray()
+            {
+                int count = _source.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<TSource>();
+                }
+
+                var results = new TSource[count];
+                _source.CopyTo(results, 0);
+                Array.Reverse(results);
+                return results;
+            }
+
+            public List<TSource> ToList()
+            {
+                var results = new List<TSource>(_source);
+                results.Reverse();
+                return results;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return _source.Count;
+            }
+
+            public IPartition<TSource> Skip(int count)
+            {
+                Debug.Assert(count > 0);
+                return count >= _source.Count
+                    ? EmptyPartition<TSource>.Instance
+                    : new ReverseListPartition<TSource>(_source, 0, _source.Count - count - 1);
+            }
+
+            public IPartition<TSource> Take(int count)
+            {
+                Debug.Assert(count > 0);
+                return count >= _source.Count
+                    ? (IPartition<TSource>)this
+                    : new ReverseListPartition<TSource>(_source, _source.Count - count, int.MaxValue);
+            }
+
+            public TSource TryGetElementAt(int index, out bool found)
+            {
+                int count = _source.Count;
+                if ((uint)index < (uint)count)
+                {
+                    found = true;
+                    return _source[count - index - 1];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetFirst(out bool found)
+            {
+                int len = _source.Count;
+                if (len != 0)
+                {
+                    found = true;
+                    return _source[len - 1];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+
+            public TSource TryGetLast(out bool found)
+            {
+                if (_source.Count != 0)
+                {
+                    found = true;
+                    return _source[0];
+                }
+
+                found = false;
+                return default(TSource);
+            }
+        }
+
+        private sealed partial class ReverseEnumerableIterator<TSource> : IIListProvider<TSource>
+        {
+            public TSource[] ToArray()
+            {
+                TSource[] array = _source.ToArray();
+                Array.Reverse(array);
+                return array;
+            }
+
+            public List<TSource> ToList()
+            {
+                List<TSource> list = _source.ToList();
+                list.Reverse();
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                if (onlyIfCheap)
+                {
+                    switch (_source)
+                    {
+                        case IIListProvider<TSource> listProv:
+                            return listProv.GetCount(onlyIfCheap: true);
+
+                        case ICollection<TSource> colT:
+                            return colT.Count;
+
+                        case ICollection col:
+                            return col.Count;
+
+                        default:
+                            return -1;
+                    }
+                }
+
+                return _source.Count();
+            }
+        }
+
         private sealed partial class ReverseSelectArrayIterator<TSource, TResult> : IPartition<TResult>
         {
             public TResult[] ToArray()
@@ -167,88 +372,6 @@ namespace System.Linq
 
                 found = true;
                 return _selector(_source[0]);
-            }
-        }
-
-        private sealed partial class ReverseListIterator<TSource> : IPartition<TSource>
-        {
-            public TSource[] ToArray()
-            {
-                int count = _source.Count;
-                if (count == 0)
-                {
-                    return Array.Empty<TSource>();
-                }
-
-                var results = _source.ToArray();
-                Array.Reverse(results);
-                return results;
-            }
-
-            public List<TSource> ToList()
-            {
-                var results = new List<TSource>(_source);
-                results.Reverse();
-                return results;
-            }
-
-            public int GetCount(bool onlyIfCheap)
-            {
-                return _source.Count;
-            }
-
-            public IPartition<TSource> Skip(int count)
-            {
-                Debug.Assert(count > 0);
-                return count >= _source.Count
-                    ? EmptyPartition<TSource>.Instance
-                    : new ReverseListPartition<TSource>(_source, 0, _source.Count - count - 1);
-            }
-
-            public IPartition<TSource> Take(int count)
-            {
-                Debug.Assert(count > 0);
-                return count >= _source.Count
-                    ? (IPartition<TSource>)this
-                    : new ReverseListPartition<TSource>(_source, _source.Count - count, int.MaxValue);
-            }
-
-            public TSource TryGetElementAt(int index, out bool found)
-            {
-                int count = _source.Count;
-                if ((uint)index < (uint)count)
-                {
-                    found = true;
-                    return _source[count - index - 1];
-                }
-
-                found = false;
-                return default(TSource);
-            }
-
-            public TSource TryGetFirst(out bool found)
-            {
-                int len = _source.Count;
-                if (len != 0)
-                {
-                    found = true;
-                    return _source[len - 1];
-                }
-
-                found = false;
-                return default(TSource);
-            }
-
-            public TSource TryGetLast(out bool found)
-            {
-                if (_source.Count != 0)
-                {
-                    found = true;
-                    return _source[0];
-                }
-
-                found = false;
-                return default(TSource);
             }
         }
 
@@ -356,89 +479,6 @@ namespace System.Linq
             }
         }
 
-        private sealed partial class ReverseIListIterator<TSource> : IPartition<TSource>
-        {
-            public TSource[] ToArray()
-            {
-                int count = _source.Count;
-                if (count == 0)
-                {
-                    return Array.Empty<TSource>();
-                }
-
-                var results = new TSource[count];
-                _source.CopyTo(results, 0);
-                Array.Reverse(results);
-                return results;
-            }
-
-            public List<TSource> ToList()
-            {
-                var results = new List<TSource>(_source);
-                results.Reverse();
-                return results;
-            }
-
-            public int GetCount(bool onlyIfCheap)
-            {
-                return _source.Count;
-            }
-
-            public IPartition<TSource> Skip(int count)
-            {
-                Debug.Assert(count > 0);
-                return count >= _source.Count
-                    ? EmptyPartition<TSource>.Instance
-                    : new ReverseListPartition<TSource>(_source, 0, _source.Count - count - 1);
-            }
-
-            public IPartition<TSource> Take(int count)
-            {
-                Debug.Assert(count > 0);
-                return count >= _source.Count
-                    ? (IPartition<TSource>)this
-                    : new ReverseListPartition<TSource>(_source, _source.Count - count, int.MaxValue);
-            }
-
-            public TSource TryGetElementAt(int index, out bool found)
-            {
-                int count = _source.Count;
-                if ((uint)index < (uint)count)
-                {
-                    found = true;
-                    return _source[count - index - 1];
-                }
-
-                found = false;
-                return default(TSource);
-            }
-
-            public TSource TryGetFirst(out bool found)
-            {
-                int len = _source.Count;
-                if (len != 0)
-                {
-                    found = true;
-                    return _source[len - 1];
-                }
-
-                found = false;
-                return default(TSource);
-            }
-
-            public TSource TryGetLast(out bool found)
-            {
-                if (_source.Count != 0)
-                {
-                    found = true;
-                    return _source[0];
-                }
-
-                found = false;
-                return default(TSource);
-            }
-        }
-
         private sealed partial class ReverseSelectIListIterator<TSource, TResult> : IPartition<TResult>
         {
             public TResult[] ToArray()
@@ -543,19 +583,37 @@ namespace System.Linq
             }
         }
 
-        private sealed partial class ReverseEnumerableIterator<TSource> : IIListProvider<TSource>
+        private sealed partial class ReverseWhereArrayIterator<TSource> : IIListProvider<TSource>
         {
             public TSource[] ToArray()
             {
-                TSource[] array = _source.ToArray();
-                Array.Reverse(array);
-                return array;
+                var builder = new LargeArrayBuilder<TSource>(_source.Length);
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        builder.Add(item);
+                    }
+                }
+
+                return builder.ToArray();
             }
 
             public List<TSource> ToList()
             {
-                List<TSource> list = _source.ToList();
-                list.Reverse();
+                var list = new List<TSource>();
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        list.Add(item);
+                    }
+                }
+
                 return list;
             }
 
@@ -563,23 +621,209 @@ namespace System.Linq
             {
                 if (onlyIfCheap)
                 {
-                    switch (_source)
+                    return -1;
+                }
+
+                int count = 0;
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
                     {
-                        case IIListProvider<TSource> listProv:
-                            return listProv.GetCount(onlyIfCheap: true);
-
-                        case ICollection<TSource> colT:
-                            return colT.Count;
-
-                        case ICollection col:
-                            return col.Count;
-
-                        default:
-                            return -1;
+                        checked
+                        {
+                            count++;
+                        }
                     }
                 }
 
-                return _source.Count();
+                return count;
+            }
+        }
+
+        private sealed partial class ReverseWhereListIterator<TSource> : IIListProvider<TSource>
+        {
+            public TSource[] ToArray()
+            {
+                var builder = new LargeArrayBuilder<TSource>(_source.Count);
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        builder.Add(item);
+                    }
+                }
+
+                return builder.ToArray();
+            }
+
+            public List<TSource> ToList()
+            {
+                var list = new List<TSource>();
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        list.Add(item);
+                    }
+                }
+
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
+
+                int count = 0;
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        checked
+                        {
+                            count++;
+                        }
+                    }
+                }
+
+                return count;
+            }
+        }
+
+        private sealed partial class ReverseWhereSelectArrayIterator<TSource, TResult> : IIListProvider<TResult>
+        {
+            public TResult[] ToArray()
+            {
+                var builder = new LargeArrayBuilder<TResult>(_source.Length);
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        builder.Add(_selector(item));
+                    }
+                }
+
+                return builder.ToArray();
+            }
+
+            public List<TResult> ToList()
+            {
+                var list = new List<TResult>();
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        list.Add(_selector(item));
+                    }
+                }
+
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
+
+                int count = 0;
+
+                for (int i = _source.Length - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        _selector(item);
+                        checked
+                        {
+                            count++;
+                        }
+                    }
+                }
+
+                return count;
+            }
+        }
+
+        private sealed partial class ReverseWhereSelectListIterator<TSource, TResult> : IIListProvider<TResult>
+        {
+            public TResult[] ToArray()
+            {
+                var builder = new LargeArrayBuilder<TResult>(_source.Count);
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        builder.Add(_selector(item));
+                    }
+                }
+
+                return builder.ToArray();
+            }
+
+            public List<TResult> ToList()
+            {
+                var list = new List<TResult>();
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        list.Add(_selector(item));
+                    }
+                }
+
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
+
+                int count = 0;
+
+                for (int i = _source.Count - 1; i >= 0; i--)
+                {
+                    TSource item = _source[i];
+                    if (_predicate(item))
+                    {
+                        _selector(item);
+                        checked
+                        {
+                            count++;
+                        }
+                    }
+                }
+
+                return count;
             }
         }
 
@@ -888,250 +1132,6 @@ namespace System.Linq
 
                     return Math.Min(count - 1, _maxIndexInclusive) - _minIndexInclusive + 1;
                 }
-            }
-        }
-
-        internal sealed partial class ReverseWhereArrayIterator<TSource> : IIListProvider<TSource>
-        {
-            public TSource[] ToArray()
-            {
-                var builder = new LargeArrayBuilder<TSource>(_source.Length);
-
-                for (int i = _source.Length - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        builder.Add(item);
-                    }
-                }
-
-                return builder.ToArray();
-            }
-
-            public List<TSource> ToList()
-            {
-                var list = new List<TSource>();
-
-                for (int i = _source.Length - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        list.Add(item);
-                    }
-                }
-
-                return list;
-            }
-
-            public int GetCount(bool onlyIfCheap)
-            {
-                if (onlyIfCheap)
-                {
-                    return -1;
-                }
-
-                int count = 0;
-
-                for (int i = _source.Length - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        checked
-                        {
-                            count++;
-                        }
-                    }
-                }
-
-                return count;
-            }
-        }
-
-        private sealed partial class ReverseWhereListIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
-        {
-            public TSource[] ToArray()
-            {
-                var builder = new LargeArrayBuilder<TSource>(_source.Count);
-
-                for (int i = _source.Count - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        builder.Add(item);
-                    }
-                }
-
-                return builder.ToArray();
-            }
-
-            public List<TSource> ToList()
-            {
-                var list = new List<TSource>();
-
-                for (int i = _source.Count - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        list.Add(item);
-                    }
-                }
-
-                return list;
-            }
-
-            public int GetCount(bool onlyIfCheap)
-            {
-                if (onlyIfCheap)
-                {
-                    return -1;
-                }
-
-                int count = 0;
-
-                for (int i = _source.Count - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        checked
-                        {
-                            count++;
-                        }
-                    }
-                }
-
-                return count;
-            }
-        }
-
-        private sealed partial class ReverseWhereSelectArrayIterator<TSource, TResult> : IIListProvider<TResult>
-        {
-            public TResult[] ToArray()
-            {
-                var builder = new LargeArrayBuilder<TResult>(_source.Length);
-
-                for (int i = _source.Length - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        builder.Add(_selector(item));
-                    }
-                }
-
-                return builder.ToArray();
-            }
-
-            public List<TResult> ToList()
-            {
-                var list = new List<TResult>();
-
-                for (int i = _source.Length - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        list.Add(_selector(item));
-                    }
-                }
-
-                return list;
-            }
-
-            public int GetCount(bool onlyIfCheap)
-            {
-                // In case someone uses Count() to force evaluation of
-                // the selector, run it provided `onlyIfCheap` is false.
-
-                if (onlyIfCheap)
-                {
-                    return -1;
-                }
-
-                int count = 0;
-
-                for (int i = _source.Length - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        _selector(item);
-                        checked
-                        {
-                            count++;
-                        }
-                    }
-                }
-
-                return count;
-            }
-        }
-
-        private sealed partial class ReverseWhereSelectListIterator<TSource, TResult> : IIListProvider<TResult>
-        {
-            public TResult[] ToArray()
-            {
-                var builder = new LargeArrayBuilder<TResult>(_source.Count);
-
-                for (int i = _source.Count - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        builder.Add(_selector(item));
-                    }
-                }
-
-                return builder.ToArray();
-            }
-
-            public List<TResult> ToList()
-            {
-                var list = new List<TResult>();
-
-                for (int i = _source.Count - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        list.Add(_selector(item));
-                    }
-                }
-
-                return list;
-            }
-
-            public int GetCount(bool onlyIfCheap)
-            {
-                // In case someone uses Count() to force evaluation of
-                // the selector, run it provided `onlyIfCheap` is false.
-
-                if (onlyIfCheap)
-                {
-                    return -1;
-                }
-
-                int count = 0;
-
-                for (int i = _source.Count - 1; i >= 0; i--)
-                {
-                    TSource item = _source[i];
-                    if (_predicate(item))
-                    {
-                        _selector(item);
-                        checked
-                        {
-                            count++;
-                        }
-                    }
-                }
-
-                return count;
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.cs
@@ -42,7 +42,7 @@ namespace System.Linq
             return new ReverseEnumerableIterator<TSource>(source);
         }
 
-        private sealed partial class ReverseArrayIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
+        private sealed partial class ReverseArrayIterator<TSource> : Iterator<TSource>
         {
             private readonly TSource[] _source;
 
@@ -73,11 +73,9 @@ namespace System.Linq
 
             public override IEnumerable<TSource> Where(Func<TSource, bool> predicate) =>
                 new ReverseWhereArrayIterator<TSource>(_source, predicate);
-
-            public IEnumerable<TSource> Reverse() => _source;
         }
 
-        private sealed partial class ReverseSelectArrayIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
+        private sealed partial class ReverseSelectArrayIterator<TSource, TResult> : Iterator<TResult>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, TResult> _selector;
@@ -108,12 +106,9 @@ namespace System.Linq
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
                 new ReverseSelectArrayIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector));
-
-            public IEnumerable<TResult> Reverse() =>
-                new SelectArrayIterator<TSource, TResult>(_source, _selector);
         }
 
-        private sealed partial class ReverseListIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
+        private sealed partial class ReverseListIterator<TSource> : Iterator<TSource>
         {
             private readonly List<TSource> _source;
 
@@ -144,11 +139,9 @@ namespace System.Linq
 
             public override IEnumerable<TSource> Where(Func<TSource, bool> predicate) =>
                 new ReverseWhereListIterator<TSource>(_source, predicate);
-
-            public IEnumerable<TSource> Reverse() => _source;
         }
 
-        private sealed partial class ReverseSelectListIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
+        private sealed partial class ReverseSelectListIterator<TSource, TResult> : Iterator<TResult>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -179,12 +172,9 @@ namespace System.Linq
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
                 new ReverseSelectListIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector));
-
-            public IEnumerable<TResult> Reverse() =>
-                new SelectListIterator<TSource, TResult>(_source, _selector);
         }
 
-        private sealed partial class ReverseIListIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
+        private sealed partial class ReverseIListIterator<TSource> : Iterator<TSource>
         {
             private readonly IList<TSource> _source;
             private TSource[] _buffer;
@@ -247,11 +237,9 @@ namespace System.Linq
 
             public override IEnumerable<TResult> Select<TResult>(Func<TSource, TResult> selector) =>
                 new ReverseSelectIListIterator<TSource, TResult>(_source, selector);
-
-            public IEnumerable<TSource> Reverse() => _source;
         }
 
-        private sealed partial class ReverseSelectIListIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
+        private sealed partial class ReverseSelectIListIterator<TSource, TResult> : Iterator<TResult>
         {
             private readonly IList<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -317,16 +305,9 @@ namespace System.Linq
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
                 new ReverseSelectIListIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector));
-
-            public IEnumerable<TResult> Reverse() =>
-                new SelectIListIterator<TSource, TResult>(_source, _selector);
         }
 
-        /// <summary>
-        /// An iterator that yields the items of an <see cref="IEnumerable{TSource}"/> in reverse.
-        /// </summary>
-        /// <typeparam name="TSource">The type of the source enumerable.</typeparam>
-        private sealed partial class ReverseEnumerableIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
+        private sealed partial class ReverseEnumerableIterator<TSource> : Iterator<TSource>
         {
             private readonly IEnumerable<TSource> _source;
             private TSource[] _buffer;
@@ -386,11 +367,9 @@ namespace System.Linq
                 _buffer = null; // Just in case this ends up being long-lived, allow the memory to be reclaimed.
                 base.Dispose();
             }
-
-            public IEnumerable<TSource> Reverse() => _source;
         }
 
-        internal sealed partial class ReverseWhereArrayIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
+        internal sealed partial class ReverseWhereArrayIterator<TSource> : Iterator<TSource>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, bool> _predicate;
@@ -432,12 +411,9 @@ namespace System.Linq
 
             public override IEnumerable<TSource> Where(Func<TSource, bool> predicate) =>
                 new ReverseWhereArrayIterator<TSource>(_source, CombinePredicates(_predicate, predicate));
-
-            public IEnumerable<TSource> Reverse() =>
-                new WhereArrayIterator<TSource>(_source, _predicate);
         }
 
-        private sealed partial class ReverseWhereListIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
+        private sealed partial class ReverseWhereListIterator<TSource> : Iterator<TSource>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -480,12 +456,9 @@ namespace System.Linq
 
             public override IEnumerable<TSource> Where(Func<TSource, bool> predicate) =>
                 new ReverseWhereListIterator<TSource>(_source, CombinePredicates(_predicate, predicate));
-
-            public IEnumerable<TSource> Reverse() =>
-                new WhereListIterator<TSource>(_source, _predicate);
         }
 
-        private sealed partial class ReverseWhereSelectArrayIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
+        private sealed partial class ReverseWhereSelectArrayIterator<TSource, TResult> : Iterator<TResult>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, bool> _predicate;
@@ -527,12 +500,9 @@ namespace System.Linq
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
                 new ReverseWhereSelectArrayIterator<TSource, TResult2>(_source, _predicate, CombineSelectors(_selector, selector));
-
-            public IEnumerable<TResult> Reverse() =>
-                new WhereSelectArrayIterator<TSource, TResult>(_source, _predicate, _selector);
         }
 
-        private sealed partial class ReverseWhereSelectListIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
+        private sealed partial class ReverseWhereSelectListIterator<TSource, TResult> : Iterator<TResult>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -575,9 +545,6 @@ namespace System.Linq
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
                 new ReverseWhereSelectListIterator<TSource, TResult2>(_source, _predicate, CombineSelectors(_selector, selector));
-
-            public IEnumerable<TResult> Reverse() =>
-                new WhereSelectListIterator<TSource, TResult>(_source, _predicate, _selector);
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using static System.Linq.Utilities;
 
 namespace System.Linq
 {
@@ -16,25 +17,179 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            return new ReverseIterator<TSource>(source);
+            if (source is IReverseProvider<TSource> reverse)
+            {
+                return reverse.Reverse();
+            }
+
+            if (source is IList<TSource> ilist)
+            {
+                if (source is TSource[] array)
+                {
+                    return array.Length == 0
+                        ? Empty<TSource>()
+                        : new ReverseArrayIterator<TSource>(array);
+                }
+
+                if (source is List<TSource> list)
+                {
+                    return new ReverseListIterator<TSource>(list);
+                }
+
+                return new ReverseIListIterator<TSource>(ilist);
+            }
+
+            return new ReverseEnumerableIterator<TSource>(source);
         }
 
-        /// <summary>
-        /// An iterator that yields the items of an <see cref="IEnumerable{TSource}"/> in reverse.
-        /// </summary>
-        /// <typeparam name="TSource">The type of the source enumerable.</typeparam>
-        private sealed partial class ReverseIterator<TSource> : Iterator<TSource>
+        private sealed partial class ReverseArrayIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
         {
-            private readonly IEnumerable<TSource> _source;
-            private TSource[] _buffer;
+            private readonly TSource[] _source;
 
-            public ReverseIterator(IEnumerable<TSource> source)
+            public ReverseArrayIterator(TSource[] source)
+            {
+                Debug.Assert(source != null);
+                Debug.Assert(source.Length > 0); // Caller should check this beforehand and return a cached result
+                _source = source;
+            }
+
+            public override Iterator<TSource> Clone() => new ReverseArrayIterator<TSource>(_source);
+
+            public override bool MoveNext()
+            {
+                if (_state < 1 | _state == _source.Length + 1)
+                {
+                    Dispose();
+                    return false;
+                }
+
+                int index = _source.Length - _state++;
+                _current = _source[index];
+                return true;
+            }
+
+            public override IEnumerable<TResult> Select<TResult>(Func<TSource, TResult> selector) =>
+                new ReverseSelectArrayIterator<TSource, TResult>(_source, selector);
+
+            public IEnumerable<TSource> Reverse() => _source;
+        }
+
+        private sealed partial class ReverseSelectArrayIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
+        {
+            private readonly TSource[] _source;
+            private readonly Func<TSource, TResult> _selector;
+
+            public ReverseSelectArrayIterator(TSource[] source, Func<TSource, TResult> selector)
+            {
+                Debug.Assert(source != null);
+                Debug.Assert(selector != null);
+                Debug.Assert(source.Length > 0); // Caller should check this beforehand and return a cached result
+                _source = source;
+                _selector = selector;
+            }
+
+            public override Iterator<TResult> Clone() => new ReverseSelectArrayIterator<TSource, TResult>(_source, _selector);
+
+            public override bool MoveNext()
+            {
+                if (_state < 1 | _state == _source.Length + 1)
+                {
+                    Dispose();
+                    return false;
+                }
+
+                int index = _source.Length - _state++;
+                _current = _selector(_source[index]);
+                return true;
+            }
+
+            public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
+                new ReverseSelectArrayIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector));
+
+            public IEnumerable<TResult> Reverse() =>
+                new SelectArrayIterator<TSource, TResult>(_source, _selector);
+        }
+
+        private sealed partial class ReverseListIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
+        {
+            private readonly List<TSource> _source;
+
+            public ReverseListIterator(List<TSource> source)
             {
                 Debug.Assert(source != null);
                 _source = source;
             }
 
-            public override Iterator<TSource> Clone() => new ReverseIterator<TSource>(_source);
+            public override Iterator<TSource> Clone() => new ReverseListIterator<TSource>(_source);
+
+            public override bool MoveNext()
+            {
+                int count = _source.Count;
+                if (_state < 1 | _state == count + 1)
+                {
+                    Dispose();
+                    return false;
+                }
+
+                int index = count - _state++;
+                _current = _source[index];
+                return true;
+            }
+
+            public override IEnumerable<TResult> Select<TResult>(Func<TSource, TResult> selector) =>
+                new ReverseSelectListIterator<TSource, TResult>(_source, selector);
+
+            public IEnumerable<TSource> Reverse() => _source;
+        }
+
+        private sealed partial class ReverseSelectListIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
+        {
+            private readonly List<TSource> _source;
+            private readonly Func<TSource, TResult> _selector;
+
+            public ReverseSelectListIterator(List<TSource> source, Func<TSource, TResult> selector)
+            {
+                Debug.Assert(source != null);
+                Debug.Assert(selector != null);
+                _source = source;
+                _selector = selector;
+            }
+
+            public override Iterator<TResult> Clone() => new ReverseSelectListIterator<TSource, TResult>(_source, _selector);
+
+            public override bool MoveNext()
+            {
+                int count = _source.Count;
+                if (_state < 1 | _state == count + 1)
+                {
+                    Dispose();
+                    return false;
+                }
+
+                int index = count - _state++;
+                _current = _selector(_source[index]);
+                return true;
+            }
+
+            public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
+                new ReverseSelectListIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector));
+
+            public IEnumerable<TResult> Reverse() =>
+                new SelectListIterator<TSource, TResult>(_source, _selector);
+        }
+
+        private sealed partial class ReverseIListIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
+        {
+            private readonly IList<TSource> _source;
+            private TSource[] _buffer;
+
+            public ReverseIListIterator(IList<TSource> source)
+            {
+                Debug.Assert(source != null);
+                _source = source;
+            }
+
+            public override Iterator<TSource> Clone() => new ReverseIListIterator<TSource>(_source);
 
             public override bool MoveNext()
             {
@@ -83,6 +238,150 @@ namespace System.Linq
                 _buffer = null; // Just in case this ends up being long-lived, allow the memory to be reclaimed.
                 base.Dispose();
             }
+
+            public override IEnumerable<TResult> Select<TResult>(Func<TSource, TResult> selector) =>
+                new ReverseSelectIListIterator<TSource, TResult>(_source, selector);
+
+            public IEnumerable<TSource> Reverse() => _source;
+        }
+
+        private sealed partial class ReverseSelectIListIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
+        {
+            private readonly IList<TSource> _source;
+            private readonly Func<TSource, TResult> _selector;
+            private TSource[] _buffer;
+
+            public ReverseSelectIListIterator(IList<TSource> source, Func<TSource, TResult> selector)
+            {
+                Debug.Assert(source != null);
+                Debug.Assert(selector != null);
+                _source = source;
+                _selector = selector;
+            }
+
+            public override Iterator<TResult> Clone() => new ReverseSelectIListIterator<TSource, TResult>(_source, _selector);
+
+            public override bool MoveNext()
+            {
+                if (_state - 2 <= -2)
+                {
+                    // Either someone called a method and cast us to IEnumerable without calling GetEnumerator,
+                    // or we were already disposed. In either case, iteration has ended, so return false.
+                    // A comparison is made against -2 instead of _state <= 0 because we want to handle cases where
+                    // the source is really large and adding the bias causes _state to overflow.
+                    Debug.Assert(_state == -1 || _state == 0);
+                    Dispose();
+                    return false;
+                }
+
+                switch (_state)
+                {
+                    case 1:
+                        // Iteration has just started. Capture the source into an array and set _state to 2 + the count.
+                        // Having an extra field for the count would be more readable, but we save it into _state with a
+                        // bias instead to minimize field size of the iterator.
+                        Buffer<TSource> buffer = new Buffer<TSource>(_source);
+                        _buffer = buffer._items;
+                        _state = buffer._count + 2;
+                        goto default;
+                    default:
+                        // At this stage, _state starts from 2 + the count. _state - 3 represents the current index into the
+                        // buffer. It is continuously decremented until it hits 2, which means that we've run out of items to
+                        // yield and should return false.
+                        int index = _state - 3;
+                        if (index != -1)
+                        {
+                            _current = _selector(_buffer[index]);
+                            --_state;
+                            return true;
+                        }
+
+                        break;
+                }
+
+                Dispose();
+                return false;
+            }
+
+            public override void Dispose()
+            {
+                _buffer = null; // Just in case this ends up being long-lived, allow the memory to be reclaimed.
+                base.Dispose();
+            }
+
+            public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
+                new ReverseSelectIListIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector));
+
+            public IEnumerable<TResult> Reverse() =>
+                new SelectIListIterator<TSource, TResult>(_source, _selector);
+        }
+
+        /// <summary>
+        /// An iterator that yields the items of an <see cref="IEnumerable{TSource}"/> in reverse.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the source enumerable.</typeparam>
+        private sealed partial class ReverseEnumerableIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
+        {
+            private readonly IEnumerable<TSource> _source;
+            private TSource[] _buffer;
+
+            public ReverseEnumerableIterator(IEnumerable<TSource> source)
+            {
+                Debug.Assert(source != null);
+                _source = source;
+            }
+
+            public override Iterator<TSource> Clone() => new ReverseEnumerableIterator<TSource>(_source);
+
+            public override bool MoveNext()
+            {
+                if (_state - 2 <= -2)
+                {
+                    // Either someone called a method and cast us to IEnumerable without calling GetEnumerator,
+                    // or we were already disposed. In either case, iteration has ended, so return false.
+                    // A comparison is made against -2 instead of _state <= 0 because we want to handle cases where
+                    // the source is really large and adding the bias causes _state to overflow.
+                    Debug.Assert(_state == -1 || _state == 0);
+                    Dispose();
+                    return false;
+                }
+
+                switch (_state)
+                {
+                    case 1:
+                        // Iteration has just started. Capture the source into an array and set _state to 2 + the count.
+                        // Having an extra field for the count would be more readable, but we save it into _state with a
+                        // bias instead to minimize field size of the iterator.
+                        Buffer<TSource> buffer = new Buffer<TSource>(_source);
+                        _buffer = buffer._items;
+                        _state = buffer._count + 2;
+                        goto default;
+                    default:
+                        // At this stage, _state starts from 2 + the count. _state - 3 represents the current index into the
+                        // buffer. It is continuously decremented until it hits 2, which means that we've run out of items to
+                        // yield and should return false.
+                        int index = _state - 3;
+                        if (index != -1)
+                        {
+                            _current = _buffer[index];
+                            --_state;
+                            return true;
+                        }
+
+                        break;
+                }
+
+                Dispose();
+                return false;
+            }
+
+            public override void Dispose()
+            {
+                _buffer = null; // Just in case this ends up being long-lived, allow the memory to be reclaimed.
+                base.Dispose();
+            }
+
+            public IEnumerable<TSource> Reverse() => _source;
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -154,7 +154,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source array.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
-        private sealed partial class SelectArrayIterator<TSource, TResult> : Iterator<TResult>
+        private sealed partial class SelectArrayIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, TResult> _selector;
@@ -185,6 +185,9 @@ namespace System.Linq
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
                 new SelectArrayIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector));
+
+            public IEnumerable<TResult> Reverse() =>
+                new ReverseSelectArrayIterator<TSource, TResult>(_source, _selector);
         }
 
         /// <summary>
@@ -192,7 +195,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source list.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
-        private sealed partial class SelectListIterator<TSource, TResult> : Iterator<TResult>
+        private sealed partial class SelectListIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -232,6 +235,9 @@ namespace System.Linq
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
                 new SelectListIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector));
+
+            public IEnumerable<TResult> Reverse() =>
+                new ReverseSelectListIterator<TSource, TResult>(_source, _selector);
         }
 
         /// <summary>
@@ -239,7 +245,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source list.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
-        private sealed partial class SelectIListIterator<TSource, TResult> : Iterator<TResult>
+        private sealed partial class SelectIListIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
         {
             private readonly IList<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -290,6 +296,9 @@ namespace System.Linq
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
                 new SelectIListIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector));
+
+            public IEnumerable<TResult> Reverse() =>
+                new ReverseSelectIListIterator<TSource, TResult>(_source, _selector);
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Where.cs
+++ b/src/System.Linq/src/System/Linq/Where.cs
@@ -142,7 +142,7 @@ namespace System.Linq
         /// An iterator that filters each item of a <see cref="T:TSource[]"/>.
         /// </summary>
         /// <typeparam name="TSource">The type of the source array.</typeparam>
-        internal sealed partial class WhereArrayIterator<TSource> : Iterator<TSource>
+        internal sealed partial class WhereArrayIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, bool> _predicate;
@@ -183,13 +183,16 @@ namespace System.Linq
 
             public override IEnumerable<TSource> Where(Func<TSource, bool> predicate) =>
                 new WhereArrayIterator<TSource>(_source, CombinePredicates(_predicate, predicate));
+
+            public IEnumerable<TSource> Reverse() =>
+                new ReverseWhereArrayIterator<TSource>(_source, _predicate);
         }
 
         /// <summary>
         /// An iterator that filters each item of a <see cref="List{TSource}"/>.
         /// </summary>
         /// <typeparam name="TSource">The type of the source list.</typeparam>
-        private sealed partial class WhereListIterator<TSource> : Iterator<TSource>
+        private sealed partial class WhereListIterator<TSource> : Iterator<TSource>, IReverseProvider<TSource>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -237,6 +240,9 @@ namespace System.Linq
 
             public override IEnumerable<TSource> Where(Func<TSource, bool> predicate) =>
                 new WhereListIterator<TSource>(_source, CombinePredicates(_predicate, predicate));
+
+            public IEnumerable<TSource> Reverse() =>
+                new ReverseWhereListIterator<TSource>(_source, _predicate);
         }
 
         /// <summary>
@@ -244,7 +250,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source array.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
-        private sealed partial class WhereSelectArrayIterator<TSource, TResult> : Iterator<TResult>
+        private sealed partial class WhereSelectArrayIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, bool> _predicate;
@@ -285,6 +291,9 @@ namespace System.Linq
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
                 new WhereSelectArrayIterator<TSource, TResult2>(_source, _predicate, CombineSelectors(_selector, selector));
+
+            public IEnumerable<TResult> Reverse() =>
+                new ReverseWhereSelectArrayIterator<TSource, TResult>(_source, _predicate, _selector);
         }
 
         /// <summary>
@@ -292,7 +301,7 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of the source list.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>
-        private sealed partial class WhereSelectListIterator<TSource, TResult> : Iterator<TResult>
+        private sealed partial class WhereSelectListIterator<TSource, TResult> : Iterator<TResult>, IReverseProvider<TResult>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -340,6 +349,9 @@ namespace System.Linq
 
             public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector) =>
                 new WhereSelectListIterator<TSource, TResult2>(_source, _predicate, CombineSelectors(_selector, selector));
+
+            public IEnumerable<TResult> Reverse() =>
+                new ReverseWhereSelectListIterator<TSource, TResult>(_source, _predicate, _selector);
         }
 
         /// <summary>


### PR DESCRIPTION
- In sequence reverse, if the sequence is IList, we can enumerate the sequence backwards to improve performance and reduce memory allocation.

- In IEnumerable.Reverse().Reverse() case, we can return the source sequence direct to improve performance.

Here is the performance test case.
``` C#
    [MemoryDiagnoser]
    public class ReversePerfTest
    {
        private int[] data;

        [Params(0, 10, 100, 1000)]
        public int COUNT;


        [GlobalSetup]
        public void Setup()
        {
            data = new int[COUNT];
            for (int i = 0; i < COUNT; i++)
            {
                data[i] = i;
            }
        }

        [Benchmark]
        public int[] ReversePerf()
        {
            return data.ReversePerf().Skip(5).Take(10).ToArray();
        }

        [Benchmark(Baseline = true)]
        public int[] Reverse()
        {
            return data.Reverse().Skip(5).Take(10).ToArray();
        }
    }
```

Here is the result.
``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.17134.765 (1803/April2018Update/Redstone4)
Intel Core i7-7500U CPU 2.70GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
Frequency=2835938 Hz, Resolution=352.6170 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3416.0
  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.7.3416.0


```
|      Method | COUNT |      Mean |      Error |     StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |------ |----------:|-----------:|-----------:|------:|-------:|------:|------:|----------:|
| **ReversePerf** |     **0** |  **68.00 ns** |  **0.9577 ns** |  **0.8489 ns** |  **0.45** | **0.0151** |     **-** |     **-** |      **32 B** |
|     Reverse |     0 | 150.68 ns |  2.9447 ns |  2.7544 ns |  1.00 | 0.0474 |     - |     - |     100 B |
|             |       |           |            |            |       |        |       |       |           |
| **ReversePerf** |    **10** | **107.81 ns** |  **1.8778 ns** |  **1.5680 ns** |  **0.28** | **0.0457** |     **-** |     **-** |      **96 B** |
|     Reverse |    10 | 390.91 ns |  7.5755 ns |  7.0861 ns |  1.00 | 0.1216 |     - |     - |     256 B |
|             |       |           |            |            |       |        |       |       |           |
| **ReversePerf** |   **100** | **130.14 ns** |  **2.9506 ns** |  **4.4163 ns** |  **0.26** | **0.0703** |     **-** |     **-** |     **148 B** |
|     Reverse |   100 | 508.18 ns | 10.0186 ns | 13.7136 ns |  1.00 | 0.3233 |     - |     - |     680 B |
|             |       |           |            |            |       |        |       |       |           |
| **ReversePerf** |  **1000** | **131.47 ns** |  **2.5980 ns** |  **2.5516 ns** |  **0.17** | **0.0703** |     **-** |     **-** |     **148 B** |
|     Reverse |  1000 | 768.03 ns | 15.0081 ns | 20.5433 ns |  1.00 | 2.0399 |     - |     - |    4280 B |



