### PR TITLE
S.S.C.Pkcs: Make static field initialization order deterministic

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Asn.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Asn.cs
@@ -26,6 +26,11 @@ namespace Internal.Cryptography.Pal.AnyOS
 
         public override byte[] DecodeOctetString(byte[] encodedOctets)
         {
+            return DecodeOctetStringCore(encodedOctets);
+        }
+
+        public static byte[] DecodeOctetStringCore(byte[] encodedOctets)
+        {
             // Read using BER because the CMS specification says the encoding is BER.
             AsnReader reader = new AsnReader(encodedOctets, AsnEncodingRules.BER);
 

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
@@ -13,8 +13,6 @@ namespace Internal.Cryptography.Pal.AnyOS
 {
     internal sealed partial class ManagedPkcsPal : PkcsPal
     {
-        internal new static readonly ManagedPkcsPal Instance = new ManagedPkcsPal();
-
         public override void AddCertsFromStoreForDecryption(X509Certificate2Collection certs)
         {
             certs.AddRange(PkcsHelpers.GetStoreCertificates(StoreName.My, StoreLocation.CurrentUser, openExistingOnly: false));

--- a/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/PkcsPal.AnyOS.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/PkcsPal.AnyOS.cs
@@ -8,6 +8,6 @@ namespace Internal.Cryptography
 {
     internal abstract partial class PkcsPal
     {
-        private static readonly PkcsPal s_instance = ManagedPkcsPal.Instance;
+        private static readonly PkcsPal s_instance = new ManagedPkcsPal();
     }
 }

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9LocalKeyId.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9LocalKeyId.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Security.Cryptography.Asn1;
-using Internal.Cryptography.Pal.AnyOS;
+using Internal.Cryptography;
 
 namespace System.Security.Cryptography.Pkcs
 {
@@ -48,7 +48,7 @@ namespace System.Security.Cryptography.Pkcs
                 return null;
             }
 
-            return ManagedPkcsPal.Instance.DecodeOctetString(rawData);
+            return PkcsPal.Instance.DecodeOctetString(rawData);
         }
     }
 }

--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9LocalKeyId.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9LocalKeyId.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Security.Cryptography.Asn1;
-using Internal.Cryptography;
+using Internal.Cryptography.Pal.AnyOS;
 
 namespace System.Security.Cryptography.Pkcs
 {
@@ -48,7 +48,7 @@ namespace System.Security.Cryptography.Pkcs
                 return null;
             }
 
-            return PkcsPal.Instance.DecodeOctetString(rawData);
+            return ManagedPkcsPal.DecodeOctetStringCore(rawData);
         }
     }
 }


### PR DESCRIPTION
Fixes issue on Mono runtime (https://github.com/mono/mono/issues/15238).

The reduce test case for the issue is the following:
```csharp
using System;

class Test
{
	internal abstract partial class PkcsPal
	{
		public static PkcsPal Instance => s_instance;
		private static readonly PkcsPal s_instance = ManagedPkcsPal.Instance;
	}

	internal sealed partial class ManagedPkcsPal : PkcsPal
	{
		internal new static readonly ManagedPkcsPal Instance = new ManagedPkcsPal();
	}

	public static void Main()
	{
		Console.WriteLine(ManagedPkcsPal.Instance == null); // should be False
		Console.WriteLine(PkcsPal.Instance == null); // should be False, it is True
	}
}
```

According to the ECMA specification the Mono `BeforeFieldInit` behavior is correct, as explained in https://github.com/mono/mono/issues/15238#issuecomment-504502193. The CoreCLR runtime is stricter and implements it as "right before static field access" (https://github.com/mono/mono/issues/15238#issuecomment-504510904).

The Mono runtime issue tracks progress for any potential fix for the underlying behavior difference. It was suggested that the static initialization cycle should also be broken in the CoreFX code (https://github.com/mono/mono/issues/15238#issuecomment-504512481) which is what this PR tries to do.

/cc @bartonjs @jkotas 