### PR TITLE
Fix VB string tests for non-english cultures

### DIFF
--- a/src/Microsoft.VisualBasic.Core/tests/StringsTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/StringsTests.cs
@@ -1046,6 +1046,6 @@ namespace Microsoft.VisualBasic.Tests
             { "abab", "ab", 3, 1 },
         };
 
-        private static bool IsEnUS() => System.Threading.Thread.CurrentThread.CurrentUICulture.Name == "en-US";
+        private static bool IsEnUS() => System.Threading.Thread.CurrentThread.CurrentCulture.Name == "en-US";
     }
 }


### PR DESCRIPTION
`Strings.Format` tests are failing on some machines, because `CurrentUICulture` can be en-US even if the `CurrentCulture` used for number formatting is not.

In my case
`CurrentCulture`: en-SI
`CurrentUICulture`: en-US
`Strings.Format(1.2, "")` => `1,2` instead of `1.2`