### PR TITLE
Add WriteTo API on JsonDocument and JsonProperty

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -95,11 +95,7 @@ namespace System.Text.Json
         public bool ValueEquals(System.ReadOnlySpan<byte> utf8Text) { throw null; }
         public bool ValueEquals(System.ReadOnlySpan<char> text) { throw null; }
         public bool ValueEquals(string text) { throw null; }
-        public void WriteProperty(System.ReadOnlySpan<byte> utf8PropertyName, System.Text.Json.Utf8JsonWriter writer) { }
-        public void WriteProperty(System.ReadOnlySpan<char> propertyName, System.Text.Json.Utf8JsonWriter writer) { }
-        public void WriteProperty(string propertyName, System.Text.Json.Utf8JsonWriter writer) { }
-        public void WriteProperty(System.Text.Json.JsonEncodedText propertyName, System.Text.Json.Utf8JsonWriter writer) { }
-        public void WriteValue(System.Text.Json.Utf8JsonWriter writer) { }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer) { }
         public partial struct ArrayEnumerator : System.Collections.Generic.IEnumerable<System.Text.Json.JsonElement>, System.Collections.Generic.IEnumerator<System.Text.Json.JsonElement>, System.Collections.IEnumerable, System.Collections.IEnumerator, System.IDisposable
         {
             private object _dummy;

--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -26,6 +26,7 @@ namespace System.Text.Json
         public static System.Threading.Tasks.Task<System.Text.Json.JsonDocument> ParseAsync(System.IO.Stream utf8Json, System.Text.Json.JsonDocumentOptions options = default(System.Text.Json.JsonDocumentOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Text.Json.JsonDocument ParseValue(ref System.Text.Json.Utf8JsonReader reader) { throw null; }
         public static bool TryParseValue(ref System.Text.Json.Utf8JsonReader reader, out System.Text.Json.JsonDocument document) { throw null; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer) { }
     }
     public partial struct JsonDocumentOptions
     {
@@ -163,6 +164,7 @@ namespace System.Text.Json
         public bool NameEquals(System.ReadOnlySpan<byte> utf8Text) { throw null; }
         public bool NameEquals(System.ReadOnlySpan<char> text) { throw null; }
         public bool NameEquals(string text) { throw null; }
+        public void WriteTo(System.Text.Json.Utf8JsonWriter writer) { }
         public override string ToString() { throw null; }
     }
     public partial struct JsonReaderOptions

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -757,129 +757,6 @@ namespace System.Text.Json
 
         internal void WriteElementTo(
             int index,
-            Utf8JsonWriter writer,
-            ReadOnlySpan<char> propertyName)
-        {
-            CheckNotDisposed();
-
-            DbRow row = _parsedData.Get(index);
-
-            switch (row.TokenType)
-            {
-                case JsonTokenType.StartObject:
-                    writer.WriteStartObject(propertyName);
-                    WriteComplexElement(index, writer);
-                    return;
-                case JsonTokenType.StartArray:
-                    writer.WriteStartArray(propertyName);
-                    WriteComplexElement(index, writer);
-                    return;
-                case JsonTokenType.String:
-                    WriteString(propertyName, row, writer);
-                    return;
-                case JsonTokenType.True:
-                    writer.WriteBoolean(propertyName, value: true);
-                    return;
-                case JsonTokenType.False:
-                    writer.WriteBoolean(propertyName, value: false);
-                    return;
-                case JsonTokenType.Null:
-                    writer.WriteNull(propertyName);
-                    return;
-                case JsonTokenType.Number:
-                    writer.WriteNumber(
-                        propertyName,
-                        _utf8Json.Slice(row.Location, row.SizeOrLength).Span);
-                    return;
-            }
-
-            Debug.Fail($"Unexpected encounter with JsonTokenType {row.TokenType}");
-        }
-
-        internal void WriteElementTo(
-            int index,
-            Utf8JsonWriter writer,
-            JsonEncodedText propertyName)
-        {
-            CheckNotDisposed();
-
-            DbRow row = _parsedData.Get(index);
-
-            switch (row.TokenType)
-            {
-                case JsonTokenType.StartObject:
-                    writer.WriteStartObject(propertyName);
-                    WriteComplexElement(index, writer);
-                    return;
-                case JsonTokenType.StartArray:
-                    writer.WriteStartArray(propertyName);
-                    WriteComplexElement(index, writer);
-                    return;
-                case JsonTokenType.String:
-                    WriteString(propertyName, row, writer);
-                    return;
-                case JsonTokenType.True:
-                    writer.WriteBoolean(propertyName, value: true);
-                    return;
-                case JsonTokenType.False:
-                    writer.WriteBoolean(propertyName, value: false);
-                    return;
-                case JsonTokenType.Null:
-                    writer.WriteNull(propertyName);
-                    return;
-                case JsonTokenType.Number:
-                    writer.WriteNumber(
-                        propertyName,
-                        _utf8Json.Slice(row.Location, row.SizeOrLength).Span);
-                    return;
-            }
-
-            Debug.Fail($"Unexpected encounter with JsonTokenType {row.TokenType}");
-        }
-
-        internal void WriteElementTo(
-            int index,
-            Utf8JsonWriter writer,
-            ReadOnlySpan<byte> propertyName)
-        {
-            CheckNotDisposed();
-
-            DbRow row = _parsedData.Get(index);
-
-            switch (row.TokenType)
-            {
-                case JsonTokenType.StartObject:
-                    writer.WriteStartObject(propertyName);
-                    WriteComplexElement(index, writer);
-                    return;
-                case JsonTokenType.StartArray:
-                    writer.WriteStartArray(propertyName);
-                    WriteComplexElement(index, writer);
-                    return;
-                case JsonTokenType.String:
-                    WriteString(propertyName, row, writer);
-                    return;
-                case JsonTokenType.True:
-                    writer.WriteBoolean(propertyName, value: true);
-                    return;
-                case JsonTokenType.False:
-                    writer.WriteBoolean(propertyName, value: false);
-                    return;
-                case JsonTokenType.Null:
-                    writer.WriteNull(propertyName);
-                    return;
-                case JsonTokenType.Number:
-                    writer.WriteNumber(
-                        propertyName,
-                        _utf8Json.Slice(row.Location, row.SizeOrLength).Span);
-                    return;
-            }
-
-            Debug.Fail($"Unexpected encounter with JsonTokenType {row.TokenType}");
-        }
-
-        internal void WriteElementTo(
-            int index,
             Utf8JsonWriter writer)
         {
             CheckNotDisposed();
@@ -1033,22 +910,6 @@ namespace System.Text.Json
             }
         }
 
-        private void WriteString(JsonEncodedText propertyName, in DbRow row, Utf8JsonWriter writer)
-        {
-            ArraySegment<byte> rented = default;
-
-            try
-            {
-                writer.WriteString(
-                    propertyName,
-                    UnescapeString(row, out rented));
-            }
-            finally
-            {
-                ClearAndReturn(rented);
-            }
-        }
-
         private void WriteString(ReadOnlySpan<byte> propertyName, in DbRow row, Utf8JsonWriter writer)
         {
             ArraySegment<byte> rented = default;
@@ -1062,23 +923,6 @@ namespace System.Text.Json
             finally
             {
                 ClearAndReturn(rented);
-            }
-        }
-
-        private void WriteString(ReadOnlySpan<char> propertyName, in DbRow row, Utf8JsonWriter writer)
-        {
-            ArraySegment<byte> rented = default;
-
-            try
-            {
-                writer.WriteString(
-                    propertyName,
-                    UnescapeString(row, out rented));
-            }
-            finally
-            {
-                ClearAndReturn(rented);
-
             }
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -80,7 +80,7 @@ namespace System.Text.Json
         /// </summary>
         /// <param name="writer"></param>
         /// <exception cref="ArgumentNullException">
-        ///   Parameter <paramref name="writer"/> of type <see cref="Utf8JsonWriter"/> should not be null.
+        ///   The <paramref name="writer"/> parameter is <see langword="null"/>.
         /// </exception>
         /// <exception cref="InvalidOperationException">
         ///   This <see cref="RootElement"/>'s <see cref="JsonElement.ValueKind"/> would result in an invalid JSON.

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -75,6 +75,21 @@ namespace System.Text.Json
             }
         }
 
+        /// <summary>
+        ///  Write the document into the provided writer as a JSON value.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <exception cref="InvalidOperationException">
+        ///   This <see cref="RootElement"/>'s <see cref="JsonElement.ValueKind"/> would result in an invalid JSON.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The parent <see cref="JsonDocument"/> has been disposed.
+        /// </exception>
+        public void WriteTo(Utf8JsonWriter writer)
+        {
+            RootElement.WriteTo(writer);
+        }
+
         internal JsonTokenType GetJsonTokenType(int index)
         {
             CheckNotDisposed();

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -79,6 +79,9 @@ namespace System.Text.Json
         ///  Write the document into the provided writer as a JSON value.
         /// </summary>
         /// <param name="writer"></param>
+        /// <exception cref="ArgumentNullException">
+        ///   Parameter <paramref name="writer"/> of type <see cref="Utf8JsonWriter"/> should not be null.
+        /// </exception>
         /// <exception cref="InvalidOperationException">
         ///   This <see cref="RootElement"/>'s <see cref="JsonElement.ValueKind"/> would result in an invalid JSON.
         /// </exception>
@@ -87,6 +90,11 @@ namespace System.Text.Json
         /// </exception>
         public void WriteTo(Utf8JsonWriter writer)
         {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
             RootElement.WriteTo(writer);
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1273,7 +1273,7 @@ namespace System.Text.Json
         /// </summary>
         /// <param name="writer">The writer.</param>
         /// <exception cref="ArgumentNullException">
-        ///   Parameter <paramref name="writer"/> of type <see cref="Utf8JsonWriter"/> should not be null.
+        ///   The <paramref name="writer"/> parameter is <see langword="null"/>.
         /// </exception>
         /// <exception cref="InvalidOperationException">
         ///   This value's <see cref="ValueKind"/> is <see cref="JsonValueKind.Undefined"/>.

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1272,6 +1272,9 @@ namespace System.Text.Json
         ///   Write the element into the provided writer as a JSON value.
         /// </summary>
         /// <param name="writer">The writer.</param>
+        /// <exception cref="ArgumentNullException">
+        ///   Parameter <paramref name="writer"/> of type <see cref="Utf8JsonWriter"/> should not be null.
+        /// </exception>
         /// <exception cref="InvalidOperationException">
         ///   This value's <see cref="ValueKind"/> is <see cref="JsonValueKind.Undefined"/>.
         /// </exception>
@@ -1280,6 +1283,11 @@ namespace System.Text.Json
         /// </exception>
         public void WriteTo(Utf8JsonWriter writer)
         {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
             CheckValidInstance();
 
             _parent.WriteElementTo(_idx, writer);

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1269,76 +1269,6 @@ namespace System.Text.Json
         }
 
         /// <summary>
-        ///   Write the element into the provided writer as a named JSON object property.
-        /// </summary>
-        /// <param name="propertyName">The name for this value within the JSON object.</param>
-        /// <param name="writer">The writer.</param>
-        /// <exception cref="InvalidOperationException">
-        ///   This value's <see cref="ValueKind"/> is <see cref="JsonValueKind.Undefined"/>.
-        /// </exception>
-        /// <exception cref="ObjectDisposedException">
-        ///   The parent <see cref="JsonDocument"/> has been disposed.
-        /// </exception>
-        public void WriteProperty(string propertyName, Utf8JsonWriter writer)
-            => WriteProperty(propertyName.AsSpan(), writer);
-
-        /// <summary>
-        ///   Write the element into the provided writer as a named JSON object property.
-        /// </summary>
-        /// <param name="propertyName">The name for this value within the JSON object.</param>
-        /// <param name="writer">The writer.</param>
-        /// <exception cref="InvalidOperationException">
-        ///   This value's <see cref="ValueKind"/> is <see cref="JsonValueKind.Undefined"/>.
-        /// </exception>
-        /// <exception cref="ObjectDisposedException">
-        ///   The parent <see cref="JsonDocument"/> has been disposed.
-        /// </exception>
-        public void WriteProperty(ReadOnlySpan<char> propertyName, Utf8JsonWriter writer)
-        {
-            CheckValidInstance();
-
-            _parent.WriteElementTo(_idx, writer, propertyName);
-        }
-
-        /// <summary>
-        ///   Write the element into the provided writer as a named JSON object property.
-        /// </summary>
-        /// <param name="propertyName">The pre-encoded name for this value within the JSON object.</param>
-        /// <param name="writer">The writer.</param>
-        /// <exception cref="InvalidOperationException">
-        ///   This value's <see cref="ValueKind"/> is <see cref="JsonValueKind.Undefined"/>.
-        /// </exception>
-        /// <exception cref="ObjectDisposedException">
-        ///   The parent <see cref="JsonDocument"/> has been disposed.
-        /// </exception>
-        public void WriteProperty(JsonEncodedText propertyName, Utf8JsonWriter writer)
-        {
-            CheckValidInstance();
-
-            _parent.WriteElementTo(_idx, writer, propertyName);
-        }
-
-        /// <summary>
-        ///   Write the element into the provided writer as a named JSON object property.
-        /// </summary>
-        /// <param name="utf8PropertyName">
-        ///   The name for this value within the JSON object, as UTF-8 text.
-        /// </param>
-        /// <param name="writer">The writer.</param>
-        /// <exception cref="InvalidOperationException">
-        ///   This value's <see cref="ValueKind"/> is <see cref="JsonValueKind.Undefined"/>.
-        /// </exception>
-        /// <exception cref="ObjectDisposedException">
-        ///   The parent <see cref="JsonDocument"/> has been disposed.
-        /// </exception>
-        public void WriteProperty(ReadOnlySpan<byte> utf8PropertyName, Utf8JsonWriter writer)
-        {
-            CheckValidInstance();
-
-            _parent.WriteElementTo(_idx, writer, utf8PropertyName);
-        }
-
-        /// <summary>
         ///   Write the element into the provided writer as a JSON value.
         /// </summary>
         /// <param name="writer">The writer.</param>
@@ -1348,7 +1278,7 @@ namespace System.Text.Json
         /// <exception cref="ObjectDisposedException">
         ///   The parent <see cref="JsonDocument"/> has been disposed.
         /// </exception>
-        public void WriteValue(Utf8JsonWriter writer)
+        public void WriteTo(Utf8JsonWriter writer)
         {
             CheckValidInstance();
 
@@ -1451,11 +1381,11 @@ namespace System.Text.Json
                 case JsonTokenType.Number:
                 case JsonTokenType.StartArray:
                 case JsonTokenType.StartObject:
-                {
-                    // null parent should have hit the None case
-                    Debug.Assert(_parent != null);
-                    return _parent.GetRawValueAsString(_idx);
-                }
+                    {
+                        // null parent should have hit the None case
+                        Debug.Assert(_parent != null);
+                        return _parent.GetRawValueAsString(_idx);
+                    }
                 case JsonTokenType.String:
                     return GetString();
                 case JsonTokenType.Comment:

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
@@ -89,6 +89,25 @@ namespace System.Text.Json
         }
 
         /// <summary>
+        ///   Write the property into the provided writer as a named JSON object property.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        /// <exception cref="ArgumentException">
+        ///   This <see cref="Name"/>'s length is too large to be a JSON object property.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   This <see cref="Value"/>'s <see cref="JsonElement.ValueKind"/> would result in an invalid JSON.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The parent <see cref="JsonDocument"/> has been disposed.
+        /// </exception>>
+        public void WriteTo(Utf8JsonWriter writer)
+        {
+            writer.WritePropertyName(Name);
+            Value.WriteTo(writer);
+        }
+
+        /// <summary>
         ///   Provides a <see cref="string"/> representation of the property for
         ///   debugging purposes.
         /// </summary>

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
@@ -93,7 +93,7 @@ namespace System.Text.Json
         /// </summary>
         /// <param name="writer">The writer.</param>
         /// <exception cref="ArgumentNullException">
-        ///   Parameter <paramref name="writer"/> of type <see cref="Utf8JsonWriter"/> should not be null.
+        ///   The <paramref name="writer"/> parameter is <see langword="null"/>.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///   This <see cref="Name"/>'s length is too large to be a JSON object property.

--- a/src/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
@@ -92,6 +92,9 @@ namespace System.Text.Json
         ///   Write the property into the provided writer as a named JSON object property.
         /// </summary>
         /// <param name="writer">The writer.</param>
+        /// <exception cref="ArgumentNullException">
+        ///   Parameter <paramref name="writer"/> of type <see cref="Utf8JsonWriter"/> should not be null.
+        /// </exception>
         /// <exception cref="ArgumentException">
         ///   This <see cref="Name"/>'s length is too large to be a JSON object property.
         /// </exception>
@@ -103,6 +106,11 @@ namespace System.Text.Json
         /// </exception>>
         public void WriteTo(Utf8JsonWriter writer)
         {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
             writer.WritePropertyName(Name);
             Value.WriteTo(writer);
         }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterJsonElement.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonValueConverterJsonElement.cs
@@ -16,7 +16,7 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, JsonElement value, JsonSerializerOptions options)
         {
-            value.WriteValue(writer);
+            value.WriteTo(writer);
         }
     }
 }

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -1768,25 +1768,7 @@ namespace System.Text.Json.Tests
                 Assert.Throws<ObjectDisposedException>(() =>
                 {
                     Utf8JsonWriter writer = default;
-                    root.WriteValue(writer);
-                });
-
-                Assert.Throws<ObjectDisposedException>(() =>
-                {
-                    Utf8JsonWriter writer = default;
-                    root.WriteProperty(ReadOnlySpan<char>.Empty, writer);
-                });
-
-                Assert.Throws<ObjectDisposedException>(() =>
-                {
-                    Utf8JsonWriter writer = default;
-                    root.WriteProperty(ReadOnlySpan<byte>.Empty, writer);
-                });
-
-                Assert.Throws<ObjectDisposedException>(() =>
-                {
-                    Utf8JsonWriter writer = default;
-                    root.WriteProperty(JsonEncodedText.Encode(ReadOnlySpan<byte>.Empty), writer);
+                    root.WriteTo(writer);
                 });
             }
         }
@@ -1835,19 +1817,7 @@ namespace System.Text.Json.Tests
             Assert.Throws<InvalidOperationException>(() =>
             {
                 Utf8JsonWriter writer = default;
-                root.WriteValue(writer);
-            });
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                Utf8JsonWriter writer = default;
-                root.WriteProperty(ReadOnlySpan<char>.Empty, writer);
-            });
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                Utf8JsonWriter writer = default;
-                root.WriteProperty(ReadOnlySpan<byte>.Empty, writer);
+                root.WriteTo(writer);
             });
         }
 

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -1740,6 +1740,7 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void CheckUseAfterDispose()
         {
+            var buffer = new ArrayBufferWriter<byte>(1024);
             using (JsonDocument doc = JsonDocument.Parse("{\"First\":1}", default))
             {
                 JsonElement root = doc.RootElement;
@@ -1780,19 +1781,19 @@ namespace System.Text.Json.Tests
 
                 Assert.Throws<ObjectDisposedException>(() =>
                 {
-                    Utf8JsonWriter writer = default;
+                    Utf8JsonWriter writer = new Utf8JsonWriter(buffer);
                     root.WriteTo(writer);
                 });
 
                 Assert.Throws<ObjectDisposedException>(() =>
                 {
-                    Utf8JsonWriter writer = default;
+                    Utf8JsonWriter writer = new Utf8JsonWriter(buffer);
                     doc.WriteTo(writer);
                 });
 
                 Assert.Throws<ObjectDisposedException>(() =>
                 {
-                    Utf8JsonWriter writer = default;
+                    Utf8JsonWriter writer = new Utf8JsonWriter(buffer);
                     property.WriteTo(writer);
                 });
             }
@@ -1841,9 +1842,28 @@ namespace System.Text.Json.Tests
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                Utf8JsonWriter writer = default;
+                var buffer = new ArrayBufferWriter<byte>(1024);
+                Utf8JsonWriter writer = new Utf8JsonWriter(buffer);                
                 root.WriteTo(writer);
             });
+        }
+
+        [Fact]
+        public static void CheckByPassingNullWriter()
+        {
+            using (JsonDocument doc = JsonDocument.Parse("{\"First\":1}", default))
+            {
+                var expectedErrorMessage = @"Value cannot be null. (Parameter 'writer')";
+                AssertExtensions.Throws<ArgumentNullException>(() => doc.WriteTo(null), expectedErrorMessage);
+
+                JsonElement root = doc.RootElement;
+                AssertExtensions.Throws<ArgumentNullException>(() => root.WriteTo(null), expectedErrorMessage);
+
+                foreach (JsonProperty property in root.EnumerateObject())
+                {
+                    AssertExtensions.Throws<ArgumentNullException>(() => property.WriteTo(null), expectedErrorMessage);
+                }
+            }
         }
 
         [Fact]

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -28,18 +28,6 @@ namespace System.Text.Json.Tests
         private static readonly Dictionary<TestCaseType, string> s_compactJson =
             new Dictionary<TestCaseType, string>();
 
-        private const string CompiledNewline = @"
-";
-
-        private static readonly JsonDocumentOptions s_options =
-            new JsonDocumentOptions
-            {
-                CommentHandling = JsonCommentHandling.Skip,
-            };
-
-        private static readonly bool s_replaceNewlines =
-            !StringComparer.Ordinal.Equals(CompiledNewline, Environment.NewLine);
-
         public static IEnumerable<object[]> BadBOMCases { get; } =
             new object[][]
             {
@@ -1851,18 +1839,9 @@ namespace System.Text.Json.Tests
         [Fact]
         public static void CheckByPassingNullWriter()
         {
-            using (JsonDocument doc = JsonDocument.Parse("{\"First\":1}", default))
+            using (JsonDocument doc = JsonDocument.Parse("true", default))
             {
-                var expectedErrorMessage = @"Value cannot be null. (Parameter 'writer')";
-                AssertExtensions.Throws<ArgumentNullException>(() => doc.WriteTo(null), expectedErrorMessage);
-
-                JsonElement root = doc.RootElement;
-                AssertExtensions.Throws<ArgumentNullException>(() => root.WriteTo(null), expectedErrorMessage);
-
-                foreach (JsonProperty property in root.EnumerateObject())
-                {
-                    AssertExtensions.Throws<ArgumentNullException>(() => property.WriteTo(null), expectedErrorMessage);
-                }
+                AssertExtensions.Throws<ArgumentNullException>("writer", () => doc.WriteTo(null));
             }
         }
 
@@ -3714,13 +3693,7 @@ namespace System.Text.Json.Tests
             var expectedNonIndentedJson = $"[{OneQuarticGoogol}]";
             using (JsonDocument doc = JsonDocument.Parse($"[ {OneQuarticGoogol} ]"))
             {
-                var options = new JsonWriterOptions
-                {
-                    Indented = false,
-                };
-
-                var writer = new Utf8JsonWriter(buffer, options);
-
+                var writer = new Utf8JsonWriter(buffer, default);
                 doc.WriteTo(writer);
                 writer.Flush();
 

--- a/src/System.Text.Json/tests/JsonElementWriteTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWriteTests.cs
@@ -21,6 +21,16 @@ namespace System.Text.Json.Tests
         private static readonly bool s_replaceNewlines =
             !StringComparer.Ordinal.Equals(CompiledNewline, Environment.NewLine);
 
+        [Fact]
+        public static void CheckByPassingNullWriter()
+        {
+            using (JsonDocument doc = JsonDocument.Parse("true", default))
+            {
+                JsonElement root = doc.RootElement;
+                AssertExtensions.Throws<ArgumentNullException>("writer", () => root.WriteTo(null));
+            }
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -903,33 +913,10 @@ null,
                 {
                     foreach (JsonElement val in root.EnumerateArray())
                     {
-                        JsonTestHelper.AssertThrows<InvalidOperationException>(
-                            ref writer,
-                            (ref Utf8JsonWriter w) =>
-                            {
-                                w.WritePropertyName(CharLabel);
-                            });
-
-                        JsonTestHelper.AssertThrows<InvalidOperationException>(
-                            ref writer,
-                            (ref Utf8JsonWriter w) =>
-                            {
-                                w.WritePropertyName(CharLabel.AsSpan());
-                            });
-
-                        JsonTestHelper.AssertThrows<InvalidOperationException>(
-                            ref writer,
-                            (ref Utf8JsonWriter w) =>
-                            {
-                                w.WritePropertyName(byteUtf8);
-                            });
-
-                        JsonTestHelper.AssertThrows<InvalidOperationException>(
-                            ref writer,
-                            (ref Utf8JsonWriter w) =>
-                            {
-                                w.WritePropertyName(JsonEncodedText.Encode(CharLabel));
-                            });
+                        Assert.Throws<InvalidOperationException>(() => writer.WritePropertyName(CharLabel));
+                        Assert.Throws<InvalidOperationException>(() => writer.WritePropertyName(CharLabel.AsSpan()));
+                        Assert.Throws<InvalidOperationException>(() => writer.WritePropertyName(byteUtf8));
+                        Assert.Throws<InvalidOperationException>(() => writer.WritePropertyName(JsonEncodedText.Encode(CharLabel)));
                     }
 
                     writer.Flush();
@@ -974,9 +961,7 @@ null,
                 {
                     foreach (JsonElement val in root.EnumerateArray())
                     {
-                        JsonTestHelper.AssertThrows<InvalidOperationException>(
-                            ref writer,
-                            (ref Utf8JsonWriter w) => val.WriteTo(w));
+                        Assert.Throws<InvalidOperationException>(() => val.WriteTo(writer));
                     }
 
                     writer.WriteEndObject();

--- a/src/System.Text.Json/tests/JsonElementWriteTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWriteTests.cs
@@ -844,7 +844,7 @@ null,
             using (JsonDocument doc = JsonDocument.Parse(jsonIn, optionsCopy))
             {
                 var writer = new Utf8JsonWriter(buffer);
-                doc.RootElement.WriteValue(writer);
+                doc.RootElement.WriteTo(writer);
                 writer.Flush();
 
                 ReadOnlySpan<byte> formatted = buffer.WrittenSpan;
@@ -877,10 +877,14 @@ null,
                 {
                     foreach (JsonElement val in root.EnumerateArray())
                     {
-                        val.WriteProperty(CharLabel, writer);
-                        val.WriteProperty(CharLabel.AsSpan(), writer);
-                        val.WriteProperty(byteUtf8, writer);
-                        val.WriteProperty(JsonEncodedText.Encode(CharLabel), writer);
+                        writer.WritePropertyName(CharLabel);
+                        val.WriteTo(writer);
+                        writer.WritePropertyName(CharLabel.AsSpan());
+                        val.WriteTo(writer);
+                        writer.WritePropertyName(byteUtf8);
+                        val.WriteTo(writer);
+                        writer.WritePropertyName(JsonEncodedText.Encode(CharLabel));
+                        val.WriteTo(writer);
                     }
 
                     writer.Flush();
@@ -901,19 +905,31 @@ null,
                     {
                         JsonTestHelper.AssertThrows<InvalidOperationException>(
                             ref writer,
-                            (ref Utf8JsonWriter w) => val.WriteProperty(CharLabel, w));
+                            (ref Utf8JsonWriter w) =>
+                            {
+                                w.WritePropertyName(CharLabel);
+                            });
 
                         JsonTestHelper.AssertThrows<InvalidOperationException>(
                             ref writer,
-                            (ref Utf8JsonWriter w) => val.WriteProperty(CharLabel.AsSpan(), w));
+                            (ref Utf8JsonWriter w) =>
+                            {
+                                w.WritePropertyName(CharLabel.AsSpan());
+                            });
 
                         JsonTestHelper.AssertThrows<InvalidOperationException>(
                             ref writer,
-                            (ref Utf8JsonWriter w) => val.WriteProperty(byteUtf8, w));
+                            (ref Utf8JsonWriter w) =>
+                            {
+                                w.WritePropertyName(byteUtf8);
+                            });
 
                         JsonTestHelper.AssertThrows<InvalidOperationException>(
                             ref writer,
-                            (ref Utf8JsonWriter w) => val.WriteProperty(JsonEncodedText.Encode(CharLabel), w));
+                            (ref Utf8JsonWriter w) =>
+                            {
+                                w.WritePropertyName(JsonEncodedText.Encode(CharLabel));
+                            });
                     }
 
                     writer.Flush();
@@ -944,7 +960,7 @@ null,
                 {
                     foreach (JsonElement val in root.EnumerateArray())
                     {
-                        val.WriteValue(writer);
+                        val.WriteTo(writer);
                     }
 
                     writer.WriteEndObject();
@@ -960,7 +976,7 @@ null,
                     {
                         JsonTestHelper.AssertThrows<InvalidOperationException>(
                             ref writer,
-                            (ref Utf8JsonWriter w) => val.WriteValue(w));
+                            (ref Utf8JsonWriter w) => val.WriteTo(w));
                     }
 
                     writer.WriteEndObject();
@@ -985,7 +1001,7 @@ null,
 
                 var writer = new Utf8JsonWriter(buffer, options);
 
-                target.WriteValue(writer);
+                target.WriteTo(writer);
                 writer.Flush();
 
                 AssertContents(jsonOut ?? jsonIn, buffer);
@@ -1010,7 +1026,7 @@ null,
 
                 var writer = new Utf8JsonWriter(buffer, options);
 
-                target.WriteValue(writer);
+                target.WriteTo(writer);
                 writer.Flush();
 
                 if (indented && s_replaceNewlines)
@@ -1081,7 +1097,8 @@ null,
                 var writer = new Utf8JsonWriter(buffer, options);
 
                 writer.WriteStartObject();
-                target.WriteProperty(propertyName, writer);
+                writer.WritePropertyName(propertyName);
+                target.WriteTo(writer);
                 writer.WriteEndObject();
                 writer.Flush();
 
@@ -1116,7 +1133,8 @@ null,
                 var writer = new Utf8JsonWriter(buffer, options);
 
                 writer.WriteStartObject();
-                target.WriteProperty(propertyName, writer);
+                writer.WritePropertyName(propertyName);
+                target.WriteTo(writer);
                 writer.WriteEndObject();
                 writer.Flush();
 
@@ -1151,7 +1169,8 @@ null,
                 var writer = new Utf8JsonWriter(buffer, options);
 
                 writer.WriteStartObject();
-                target.WriteProperty(propertyName, writer);
+                writer.WritePropertyName(propertyName);
+                target.WriteTo(writer);
                 writer.WriteEndObject();
                 writer.Flush();
 
@@ -1186,7 +1205,8 @@ null,
                 var writer = new Utf8JsonWriter(buffer, options);
 
                 writer.WriteStartObject();
-                target.WriteProperty(propertyName, writer);
+                writer.WritePropertyName(propertyName);
+                target.WriteTo(writer);
                 writer.WriteEndObject();
                 writer.Flush();
 

--- a/src/System.Text.Json/tests/JsonPropertyTests.cs
+++ b/src/System.Text.Json/tests/JsonPropertyTests.cs
@@ -3,23 +3,25 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
-using System.Collections;
-using System.Globalization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System.Collections.Generic;
-using System.IO;
-using Xunit;
-using System.Buffers.Text;
-using System.IO.Tests;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
+using Xunit;
 
 namespace System.Text.Json.Tests
 {
     public static class JsonPropertyTests
     {
+
+        [Fact]
+        public static void CheckByPassingNullWriter()
+        {
+            using (JsonDocument doc = JsonDocument.Parse("{\"First\":1}", default))
+            {
+                foreach (JsonProperty property in doc.RootElement.EnumerateObject())
+                {
+                    AssertExtensions.Throws<ArgumentNullException>("writer", () => property.WriteTo(null));
+                }
+            }
+        }
 
         [Theory]
         [InlineData(false)]

--- a/src/System.Text.Json/tests/JsonPropertyTests.cs
+++ b/src/System.Text.Json/tests/JsonPropertyTests.cs
@@ -20,34 +20,6 @@ namespace System.Text.Json.Tests
 {
     public static class JsonPropertyTests
     {
-        private const string CompiledNewline = @"
-";
-
-        private static readonly JsonDocumentOptions s_options =
-            new JsonDocumentOptions
-            {
-                CommentHandling = JsonCommentHandling.Skip,
-            };
-
-        private static readonly bool s_replaceNewlines =
-            !StringComparer.Ordinal.Equals(CompiledNewline, Environment.NewLine);
-
-        [Fact]
-        public static void CheckUseAfterDispose()
-        {
-            using (JsonDocument doc = JsonDocument.Parse("{\"First\":1}", default))
-            {
-                JsonElement root = doc.RootElement;
-                JsonProperty property = root.EnumerateObject().First();
-                doc.Dispose();
-
-                Assert.Throws<ObjectDisposedException>(() =>
-                {
-                    Utf8JsonWriter writer = default;
-                    property.WriteTo(writer);
-                });
-            }
-        }
 
         [Theory]
         [InlineData(false)]
@@ -87,118 +59,13 @@ namespace System.Text.Json.Tests
             }
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void WriteEmptyObject(bool indented)
-        {
-            WriteValue(
-                indented,
-                "{     }",
-                "{}",
-                "{}");
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void WriteEmptyCommentedObject(bool indented)
-        {
-            WriteValue(
-                indented,
-                "{ /* Technically empty */ }",
-                "{}",
-                "{}");
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void WriteSimpleObject(bool indented)
-        {
-            WriteValue(
-                indented,
-                @"{ ""r""   : 2,
-// Comments make everything more interesting.
-            ""d"":
-2
-}",
-                @"{
-  ""r"": 2,
-  ""d"": 2
-}",
-                "{\"r\":2,\"d\":2}");
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void WriteEverythingObject(bool indented)
-        {
-            WriteValue(
-                indented,
-                "{" +
-                    "\"int\": 42," +
-                    "\"quadratic googol\": 1e400," +
-                    "\"precisePi\": 3.141592653589793238462643383279," +
-                    "\"lit0\": null,\"lit1\":  false,/*guess next*/\"lit2\": true," +
-                    "\"ascii\": \"pizza\"," +
-                    "\"escaped\": \"p\\u0069zza\"," +
-                    "\"utf8\": \"p\u00CDzza\"," +
-                    "\"utf8ExtraEscape\": \"p\u00CDz\\u007Aa\"," +
-                    "\"arr\": [\"hello\", \"sa\\u0069lor\", 21, \"blackjack!\" ]," +
-                    "\"obj\": {" +
-                        "\"arr\": [ 1, 3, 5, 7, /*9,*/ 11] " +
-                    "}}",
-                @"{
-  ""int"": 42,
-  ""quadratic googol"": 1e400,
-  ""precisePi"": 3.141592653589793238462643383279,
-  ""lit0"": null,
-  ""lit1"": false,
-  ""lit2"": true,
-  ""ascii"": ""pizza"",
-  ""escaped"": ""pizza"",
-  ""utf8"": ""p\u00cdzza"",
-  ""utf8ExtraEscape"": ""p\u00cdzza"",
-  ""arr"": [
-    ""hello"",
-    ""sailor"",
-    21,
-    ""blackjack!""
-  ],
-  ""obj"": {
-    ""arr"": [
-      1,
-      3,
-      5,
-      7,
-      11
-    ]
-  }
-}",
-                "{\"int\":42,\"quadratic googol\":1e400,\"precisePi\":3.141592653589793238462643383279," +
-                    "\"lit0\":null,\"lit1\":false,\"lit2\":true,\"ascii\":\"pizza\",\"escaped\":\"pizza\"," +
-                    "\"utf8\":\"p\\u00cdzza\",\"utf8ExtraEscape\":\"p\\u00cdzza\"," +
-                    "\"arr\":[\"hello\",\"sailor\",21,\"blackjack!\"]," +
-                    "\"obj\":{\"arr\":[1,3,5,7,11]}}");
-        }
-
-        private static void WriteValue(
-            bool indented,
-            string jsonIn,
-            string expectedIndent,
-            string expectedMinimal)
+        [Fact]
+        public static void WriteSimpleObject()
         {
             var buffer = new ArrayBufferWriter<byte>(1024);
-            using (JsonDocument doc = JsonDocument.Parse(jsonIn, s_options))
+            using (JsonDocument doc = JsonDocument.Parse("{\"First\":1, \"Number\":1e400}"))
             {
-                var options = new JsonWriterOptions
-                {
-                    Indented = indented,
-                };
-
-                var writer = new Utf8JsonWriter(buffer, options);
+                var writer = new Utf8JsonWriter(buffer);
                 writer.WriteStartObject();
                 foreach (JsonProperty prop in doc.RootElement.EnumerateObject())
                 {
@@ -207,14 +74,7 @@ namespace System.Text.Json.Tests
                 writer.WriteEndObject();
                 writer.Flush();
 
-                if (indented && s_replaceNewlines)
-                {
-                    AssertContents(
-                        expectedIndent.Replace(CompiledNewline, Environment.NewLine),
-                        buffer);
-                }
-
-                AssertContents(indented ? expectedIndent : expectedMinimal, buffer);
+                AssertContents("{\"First\":1,\"Number\":1e400}", buffer);
             }
         }
 

--- a/src/System.Text.Json/tests/JsonPropertyTests.cs
+++ b/src/System.Text.Json/tests/JsonPropertyTests.cs
@@ -1,0 +1,289 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Collections;
+using System.Globalization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using System.Buffers.Text;
+using System.IO.Tests;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace System.Text.Json.Tests
+{
+    public static class JsonPropertyTests
+    {
+        private const string CompiledNewline = @"
+";
+
+        private static readonly JsonDocumentOptions s_options =
+            new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+            };
+
+        private static readonly bool s_replaceNewlines =
+            !StringComparer.Ordinal.Equals(CompiledNewline, Environment.NewLine);
+
+        [Fact]
+        public static void CheckUseAfterDispose()
+        {
+            using (JsonDocument doc = JsonDocument.Parse("{\"First\":1}", default))
+            {
+                JsonElement root = doc.RootElement;
+                JsonProperty property = root.EnumerateObject().First();
+                doc.Dispose();
+
+                Assert.Throws<ObjectDisposedException>(() =>
+                {
+                    Utf8JsonWriter writer = default;
+                    property.WriteTo(writer);
+                });
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void WriteObjectValidations(bool skipValidation)
+        {
+            var buffer = new ArrayBufferWriter<byte>(1024);
+            using (JsonDocument doc = JsonDocument.Parse("{\"First\":1}", default))
+            {
+                JsonElement root = doc.RootElement;
+                var options = new JsonWriterOptions
+                {
+                    SkipValidation = skipValidation,
+                };
+                var writer = new Utf8JsonWriter(buffer, options);
+                if (skipValidation)
+                {
+                    foreach (JsonProperty property in root.EnumerateObject())
+                    {
+                        property.WriteTo(writer);
+                    }
+                    writer.Flush();
+                    AssertContents("\"First\":1", buffer);
+                }
+                else
+                {
+                    foreach (JsonProperty property in root.EnumerateObject())
+                    {
+                        Assert.Throws<InvalidOperationException>(() =>
+                        {
+                            property.WriteTo(writer);
+                        });
+                    }
+                    writer.Flush();
+                    AssertContents("", buffer);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void WriteEmptyObject(bool indented)
+        {
+            WriteValue(
+                indented,
+                "{     }",
+                "{}",
+                "{}");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void WriteEmptyCommentedObject(bool indented)
+        {
+            WriteValue(
+                indented,
+                "{ /* Technically empty */ }",
+                "{}",
+                "{}");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void WriteSimpleObject(bool indented)
+        {
+            WriteValue(
+                indented,
+                @"{ ""r""   : 2,
+// Comments make everything more interesting.
+            ""d"":
+2
+}",
+                @"{
+  ""r"": 2,
+  ""d"": 2
+}",
+                "{\"r\":2,\"d\":2}");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void WriteEverythingObject(bool indented)
+        {
+            WriteValue(
+                indented,
+                "{" +
+                    "\"int\": 42," +
+                    "\"quadratic googol\": 1e400," +
+                    "\"precisePi\": 3.141592653589793238462643383279," +
+                    "\"lit0\": null,\"lit1\":  false,/*guess next*/\"lit2\": true," +
+                    "\"ascii\": \"pizza\"," +
+                    "\"escaped\": \"p\\u0069zza\"," +
+                    "\"utf8\": \"p\u00CDzza\"," +
+                    "\"utf8ExtraEscape\": \"p\u00CDz\\u007Aa\"," +
+                    "\"arr\": [\"hello\", \"sa\\u0069lor\", 21, \"blackjack!\" ]," +
+                    "\"obj\": {" +
+                        "\"arr\": [ 1, 3, 5, 7, /*9,*/ 11] " +
+                    "}}",
+                @"{
+  ""int"": 42,
+  ""quadratic googol"": 1e400,
+  ""precisePi"": 3.141592653589793238462643383279,
+  ""lit0"": null,
+  ""lit1"": false,
+  ""lit2"": true,
+  ""ascii"": ""pizza"",
+  ""escaped"": ""pizza"",
+  ""utf8"": ""p\u00cdzza"",
+  ""utf8ExtraEscape"": ""p\u00cdzza"",
+  ""arr"": [
+    ""hello"",
+    ""sailor"",
+    21,
+    ""blackjack!""
+  ],
+  ""obj"": {
+    ""arr"": [
+      1,
+      3,
+      5,
+      7,
+      11
+    ]
+  }
+}",
+                "{\"int\":42,\"quadratic googol\":1e400,\"precisePi\":3.141592653589793238462643383279," +
+                    "\"lit0\":null,\"lit1\":false,\"lit2\":true,\"ascii\":\"pizza\",\"escaped\":\"pizza\"," +
+                    "\"utf8\":\"p\\u00cdzza\",\"utf8ExtraEscape\":\"p\\u00cdzza\"," +
+                    "\"arr\":[\"hello\",\"sailor\",21,\"blackjack!\"]," +
+                    "\"obj\":{\"arr\":[1,3,5,7,11]}}");
+        }
+
+        private static void WriteValue(
+            bool indented,
+            string jsonIn,
+            string expectedIndent,
+            string expectedMinimal)
+        {
+            var buffer = new ArrayBufferWriter<byte>(1024);
+            using (JsonDocument doc = JsonDocument.Parse(jsonIn, s_options))
+            {
+                var options = new JsonWriterOptions
+                {
+                    Indented = indented,
+                };
+
+                var writer = new Utf8JsonWriter(buffer, options);
+                writer.WriteStartObject();
+                foreach (JsonProperty prop in doc.RootElement.EnumerateObject())
+                {
+                    prop.WriteTo(writer);
+                }
+                writer.WriteEndObject();
+                writer.Flush();
+
+                if (indented && s_replaceNewlines)
+                {
+                    AssertContents(
+                        expectedIndent.Replace(CompiledNewline, Environment.NewLine),
+                        buffer);
+                }
+
+                AssertContents(indented ? expectedIndent : expectedMinimal, buffer);
+            }
+        }
+
+        private static void AssertContents(string expectedValue, ArrayBufferWriter<byte> buffer)
+        {
+            Assert.Equal(
+                expectedValue,
+                Encoding.UTF8.GetString(
+                    buffer.WrittenSpan
+#if netfx
+                        .ToArray()
+#endif
+                    ));
+        }
+
+        [Theory]
+        [InlineData("hello")]
+        [InlineData("")]
+        [InlineData(null)]
+        public static void NameEquals_InvalidInstance_Throws(string text)
+        {
+            const string ErrorMessage = "Operation is not valid due to the current state of the object.";
+            JsonProperty prop = default;
+            AssertExtensions.Throws<InvalidOperationException>(() => prop.NameEquals(text), ErrorMessage);
+            AssertExtensions.Throws<InvalidOperationException>(() => prop.NameEquals(text.AsSpan()), ErrorMessage);
+            byte[] expectedGetBytes = text == null ? null : Encoding.UTF8.GetBytes(text);
+            AssertExtensions.Throws<InvalidOperationException>(() => prop.NameEquals(expectedGetBytes), ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("conne\\u0063tionId", "connectionId")]
+        [InlineData("connectionId", "connectionId")]
+        [InlineData("123", "123")]
+        [InlineData("My name is \\\"Ahson\\\"", "My name is \"Ahson\"")]
+        public static void NameEquals_UseGoodMatches_True(string propertyName, string otherText)
+        {
+            string jsonString = $"{{ \"{propertyName}\" : \"itsValue\" }}";
+            using (JsonDocument doc = JsonDocument.Parse(jsonString))
+            {
+                JsonElement jElement = doc.RootElement;
+                JsonProperty property = jElement.EnumerateObject().First();
+                byte[] expectedGetBytes = Encoding.UTF8.GetBytes(otherText);
+                Assert.True(property.NameEquals(otherText));
+                Assert.True(property.NameEquals(otherText.AsSpan()));
+                Assert.True(property.NameEquals(expectedGetBytes));
+            }
+        }
+
+        [Fact]
+        public static void NameEquals_GivenPropertyAndValue_TrueForPropertyName()
+        {
+            string jsonString = $"{{ \"aPropertyName\" : \"itsValue\" }}";
+            using (JsonDocument doc = JsonDocument.Parse(jsonString))
+            {
+                JsonElement jElement = doc.RootElement;
+                JsonProperty property = jElement.EnumerateObject().First();
+
+                string text = "aPropertyName";
+                byte[] expectedGetBytes = Encoding.UTF8.GetBytes(text);
+                Assert.True(property.NameEquals(text));
+                Assert.True(property.NameEquals(text.AsSpan()));
+                Assert.True(property.NameEquals(expectedGetBytes));
+
+                text = "itsValue";
+                expectedGetBytes = Encoding.UTF8.GetBytes(text);
+                Assert.False(property.NameEquals(text));
+                Assert.False(property.NameEquals(text.AsSpan()));
+                Assert.False(property.NameEquals(expectedGetBytes));
+            }
+        }
+    }
+}

--- a/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -21,6 +21,7 @@
     <Compile Include="JsonEncodedTextTests.cs" />
     <Compile Include="JsonGuidTestData.cs" />
     <Compile Include="JsonNumberTestData.cs" />
+    <Compile Include="JsonPropertyTests.cs" />
     <Compile Include="JsonReaderStateAndOptionsTests.cs" />
     <Compile Include="JsonTestHelper.cs" />
     <Compile Include="JsonWriterOptionsTests.cs" />


### PR DESCRIPTION
Fixes #39037 

Changes:

1. `WriteProperty` API in `JsonElement` is removed.
2. `WriteValue` API in `JsonElement` is renamed as `WriteTo`.
3. `WriteTo` API is added in `JsonDocument` and `JsonProperty`.

For unit tests, I referred previously available unit test methods for `JsonDocument` and `JsonProperty` new API `WriteTo`.

Thanks for all the help @bartonjs and @ahsonkhan . I have done as we discussed. Let me know if I missed anything.

