### PR TITLE
Add nuget.org feed to NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,6 +8,7 @@
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
We need all restore sources to be located in NuGet.config since internal feeds can only be restored from there. More details including next steps [here](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md)

Please let me know if there are any other feeds that I missed.