### PR TITLE
Add tests for nullable metadata and unconditionally set nullablePublicOnly

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -256,7 +256,6 @@
     <!-- default to allowing all language features -->
     <LangVersion>latest</LangVersion>
     <LangVersion Condition="'$(Language)' == 'C#'">preview</LangVersion>
-    <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict;nullablePublicOnly</Features>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -257,7 +257,7 @@
     <LangVersion>latest</LangVersion>
     <LangVersion Condition="'$(Language)' == 'C#'">preview</LangVersion>
     <!-- Enables Strict mode for Roslyn compiler -->
-    <Features>strict</Features>
+    <Features>strict;nullablePublicOnly</Features>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Deterministic>true</Deterministic>
@@ -384,8 +384,6 @@
   <PropertyGroup>
     <!-- Clear the init locals flag on all src projects, except those in VB, where we can't use spans. -->
     <ILLinkClearInitLocals Condition="'$(IsSourceProject)' == 'true' and '$(Language)' != 'VB'">true</ILLinkClearInitLocals>
-
-    <Features Condition="'$(IsSourceProject)' == 'true' or '$(IsReferenceAssembly)' == 'true'">$(Features);nullablePublicOnly</Features>
   </PropertyGroup>
 
 </Project>

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="System\NotFiniteNumberExceptionTests.cs" />
     <Compile Include="System\NotImplementedExceptionTests.cs" />
     <Compile Include="System\NotSupportedExceptionTests.cs" />
+    <Compile Include="System\NullableMetadataTests.cs" />
     <Compile Include="System\NullableTests.cs" />
     <Compile Include="System\NullReferenceExceptionTests.cs" />
     <Compile Include="System\ObjectTests.cs" />

--- a/src/System.Runtime/tests/System/Attributes.cs
+++ b/src/System.Runtime/tests/System/Attributes.cs
@@ -207,6 +207,7 @@ namespace System.Tests
             Assert.Equal("System.Tests.MyCustomAttribute System.Tests.MyCustomAttribute", string.Join(" ", typeof(MultipleAttributes).GetCustomAttributes(inherit: true)));
         }
     }
+
     public static class GetCustomAttribute
     {
 
@@ -220,6 +221,7 @@ namespace System.Tests
             // [System.Diagnostics.DebuggableAttribute((Boolean)True, (Boolean)False)]
             Assert.Equal(4, customAttributes.Count);
         }
+
         [Fact]
         public static void PositiveTest1()
         {

--- a/src/System.Runtime/tests/System/NullableMetadataTests.cs
+++ b/src/System.Runtime/tests/System/NullableMetadataTests.cs
@@ -1,27 +1,128 @@
-﻿
+﻿using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Xunit;
 
 namespace System.Runtime.Tests
 {
-    public class NullableMetadataTests
+    public static class NullableMetadataTests
     {
-        private const string NullableAttributeFullName = "System.Diagnostics.CompilerServices.NullableAttribute";
-        private const string NullableContextAttributeFullName = "System.Diagnostics.CompilerServices.NullableContextAttribute";
-        private const string NullablePublicOnlyAttributeFullName = "System.Diagnostics.CompilerServices.NullablePublicOnlyAttribute";
+        private const string NullableAttributeFullName = "System.Runtime.CompilerServices.NullableAttribute";
+        private const string NullableContextAttributeFullName = "System.Runtime.CompilerServices.NullableContextAttribute";
+        private const string NullablePublicOnlyAttributeFullName = "System.Runtime.CompilerServices.NullablePublicOnlyAttribute";
 
-        [Fact]
-        public static void NullableAttributesOnPublicApiOnly()
+        private static IEnumerable<CustomAttributeData> GetNullableAttributes(this IEnumerable<CustomAttributeData> attributes) =>
+            attributes.Where(attribute => attribute.AttributeType.FullName.Equals(NullableAttributeFullName) ||
+                                          attribute.AttributeType.FullName.Equals(NullableContextAttributeFullName));
+
+        private static CustomAttributeData GetNullablePublicOnlyAttribute(this IEnumerable<CustomAttributeData> attributes) =>
+            attributes.Where(attribute => attribute.AttributeType.FullName.Equals(NullablePublicOnlyAttributeFullName)).FirstOrDefault();
+
+        private static bool IsProtected(this MemberInfo info)
         {
-            MemberInfo[] internalMembers = typeof(string).GetMembers(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+            if (info is MethodBase methodBase)
+            {
+                return methodBase.IsFamily || methodBase.IsFamilyOrAssembly;
+            }
+            else if (info is FieldInfo fieldInfo)
+            {
+                return fieldInfo.IsFamily || fieldInfo.IsFamilyOrAssembly;
+            }
+            else if (info is PropertyInfo propertyInfo)
+            {
+                return (propertyInfo.GetMethod != null && (propertyInfo.GetMethod.IsFamily || propertyInfo.GetMethod.IsFamilyOrAssembly)) ||
+                       (propertyInfo.SetMethod != null && (propertyInfo.SetMethod.IsFamily || propertyInfo.SetMethod.IsFamilyOrAssembly));
+            }
+            else if (info is TypeInfo typeInfo)
+            {
+                return typeInfo.IsNestedFamily || typeInfo.IsNestedFamORAssem;
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<object[]> NullableMetadataTypesTestData()
+        {
+            yield return new object[] { typeof(string) };
+            yield return new object[] { typeof(Dictionary<,>) };
+            yield return new object[] { typeof(Uri) };
+            yield return new object[] { typeof(ConcurrentDictionary<,>) };
+            yield return new object[] { typeof(ArrayPool<>) };
+        }
+
+        [Theory]
+        [MemberData(nameof(NullableMetadataTypesTestData))]
+        public static void NullableAttributesOnPublicApiOnly(Type type)
+        {
+            MemberInfo[] internalMembers = type.GetMembers(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
 
             foreach (MemberInfo internalMember in internalMembers)
             {
-                Assert.Empty(internalMember.GetCustomAttributes().Where(a =>
-                    a.GetType().FullName.Equals(NullableAttributeFullName) ||
-                    a.GetType().FullName.Equals(NullableContextAttributeFullName)));
+                // When using BindingFlags.NonPublic protected members are included and those are expected
+                // to have Nullable attributes.
+                if (internalMember.IsProtected() || internalMember is PropertyInfo) // TODO-NULLABLE: validate properties (https://github.com/dotnet/roslyn/issues/37161)
+                    continue;
+
+                Assert.Empty(internalMember.CustomAttributes.GetNullableAttributes());
+
+                if (internalMember is MethodInfo methodInfo)
+                {
+                    Assert.Empty(methodInfo.ReturnParameter.CustomAttributes.GetNullableAttributes());
+
+                    foreach (ParameterInfo param in methodInfo.GetParameters())
+                    {
+                        Assert.Empty(param.CustomAttributes.GetNullableAttributes());
+                    }
+                }
             }
+
+            Assert.True(type.CustomAttributes.GetNullableAttributes().Any());
+
+            bool foundAtLeastOneNullableAttribute = type.CustomAttributes.Where(a => a.AttributeType.Name.Equals(NullableContextAttributeFullName)).Any();
+            
+            // If there is a NullableContextAttribute there is no guarantee that its members will have
+            // nullable attributes, if a class declare all reference types with the same nullability
+            // none will contain an attribute and will take the type's NullableContextAttribute value.
+            if (!foundAtLeastOneNullableAttribute)
+            {
+                MemberInfo[] publicMembers = type.GetMembers(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
+                foreach (MemberInfo publicMember in publicMembers)
+                {
+                    if (publicMember.CustomAttributes.GetNullableAttributes().Any())
+                    {
+                        foundAtLeastOneNullableAttribute = true;
+                        break;
+                    }
+
+                    if (publicMember is MethodInfo methodInfo)
+                    {
+                        if (methodInfo.ReturnParameter.CustomAttributes.GetNullableAttributes().Any())
+                        {
+                            foundAtLeastOneNullableAttribute = true;
+                            break;
+                        }
+                    }
+
+                    if (publicMember is MethodBase methodBase)
+                    {
+                        foreach (ParameterInfo param in methodBase.GetParameters())
+                        {
+                            if (param.CustomAttributes.GetNullableAttributes().Any())
+                            {
+                                foundAtLeastOneNullableAttribute = true;
+                                break;
+                            }
+                        }
+
+                        if (foundAtLeastOneNullableAttribute)
+                            break;
+                    }
+                }
+            }
+
+            Assert.True(foundAtLeastOneNullableAttribute);
         }
 
         [Fact]
@@ -38,8 +139,17 @@ namespace System.Runtime.Tests
         {
             Assembly assembly = Assembly.Load("mscorlib");
             Module module = assembly.Modules.First();
-            Assert.Empty(module.CustomAttributes.Where(a =>
-                a.GetType().FullName.Equals(NullablePublicOnlyAttributeFullName)));
+            Assert.Null(module.CustomAttributes.GetNullablePublicOnlyAttribute());
+        }
+
+        [Theory]
+        [MemberData(nameof(NullableMetadataTypesTestData))]
+        public static void NullablePublicOnlyAttributePresent(Type type)
+        {
+            CustomAttributeData nullablePublicOnlyAttribute = type.Module.CustomAttributes.GetNullablePublicOnlyAttribute();
+            Assert.NotNull(nullablePublicOnlyAttribute);
+
+            Assert.False((bool)nullablePublicOnlyAttribute.ConstructorArguments.First().Value);
         }
     }
 }

--- a/src/System.Runtime/tests/System/NullableMetadataTests.cs
+++ b/src/System.Runtime/tests/System/NullableMetadataTests.cs
@@ -18,7 +18,9 @@ namespace System.Runtime.Tests
 
             foreach (MemberInfo internalMember in internalMembers)
             {
-                Assert.Empty(internalMember.GetCustomAttributes().Where(a => NullableAttributesFilter(a)));
+                Assert.Empty(internalMember.GetCustomAttributes().Where(a =>
+                    a.GetType().FullName.Equals(NullableAttributeFullName) ||
+                    a.GetType().FullName.Equals(NullableContextAttributeFullName)));
             }
         }
 
@@ -36,12 +38,8 @@ namespace System.Runtime.Tests
         {
             Assembly assembly = Assembly.Load("mscorlib");
             Module module = assembly.Modules.First();
-            Assert.Empty(module.CustomAttributes.Where(a => a.GetType().FullName.Equals(NullablePublicOnlyAttributeFullName)));
-        }
-
-        private static bool NullableAttributesFilter(Attribute attribute)
-        {
-            return attribute.GetType().FullName.Equals(NullableAttributeFullName) || attribute.GetType().FullName.Equals(NullableContextAttributeFullName);
+            Assert.Empty(module.CustomAttributes.Where(a =>
+                a.GetType().FullName.Equals(NullablePublicOnlyAttributeFullName)));
         }
     }
 }

--- a/src/System.Runtime/tests/System/NullableMetadataTests.cs
+++ b/src/System.Runtime/tests/System/NullableMetadataTests.cs
@@ -1,0 +1,47 @@
+﻿
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace System.Runtime.Tests
+{
+    public class NullableMetadataTests
+    {
+        private const string NullableAttributeFullName = "System.Diagnostics.CompilerServices.NullableAttribute";
+        private const string NullableContextAttributeFullName = "System.Diagnostics.CompilerServices.NullableContextAttribute";
+        private const string NullablePublicOnlyAttributeFullName = "System.Diagnostics.CompilerServices.NullablePublicOnlyAttribute";
+
+        [Fact]
+        public static void NullableAttributesOnPublicApiOnly()
+        {
+            MemberInfo[] internalMembers = typeof(string).GetMembers(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+
+            foreach (MemberInfo internalMember in internalMembers)
+            {
+                Assert.Empty(internalMember.GetCustomAttributes().Where(a => NullableAttributesFilter(a)));
+            }
+        }
+
+        [Fact]
+        public static void ShimsHaveOnlyTypeForwards()
+        {
+            Assembly assembly = Assembly.Load("mscorlib");
+
+            Assert.Empty(assembly.GetTypes());
+            Assert.NotEmpty(assembly.GetForwardedTypes());
+        }
+
+        [Fact]
+        public static void ShimsDontHaveNullablePublicOnlyAttribute()
+        {
+            Assembly assembly = Assembly.Load("mscorlib");
+            Module module = assembly.Modules.First();
+            Assert.Empty(module.CustomAttributes.Where(a => a.GetType().FullName.Equals(NullablePublicOnlyAttributeFullName)));
+        }
+
+        private static bool NullableAttributesFilter(Attribute attribute)
+        {
+            return attribute.GetType().FullName.Equals(NullableAttributeFullName) || attribute.GetType().FullName.Equals(NullableContextAttributeFullName);
+        }
+    }
+}


### PR DESCRIPTION
This consumes the new compiler which now only emits the `NullablePublicOnlyAttribute` into the module only if it is actually needed and I also added tests to make sure the facades doesn't have any type definitions nor this attribute, plus tests to make sure that internal APIs doesn't get nullable attributes.

Fixes: #39175 

cc: @stephentoub @ericstj @ViktorHofer 