### PR TITLE
Http2Connection: Wrap InvalidOperationExceptions

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1595,7 +1595,8 @@ namespace System.Net.Http
 
                 if (e is IOException ||
                     e is ObjectDisposedException ||
-                    e is Http2ProtocolException)
+                    e is Http2ProtocolException ||
+                    e is InvalidOperationException)
                 {
                     replacementException = new HttpRequestException(SR.net_http_client_execution_error, _abortException ?? e);
                 }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1802,11 +1802,7 @@ namespace System.Net.Http.Functional.Tests
                     Assert.IsType<InvalidOperationException>(exn.InnerException);
                 }
             },
-            async server =>
-            {
-                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
-                await connection.WaitForConnectionShutdownAsync();
-            });
+            async server => await server.EstablishConnectionAsync());
         }
 
         [ConditionalFact(nameof(SupportsAlpn))]
@@ -1828,11 +1824,7 @@ namespace System.Net.Http.Functional.Tests
                     await Assert.ThrowsAnyAsync<CustomException>(async () => await client.SendAsync(request));
                 }
             },
-            async server =>
-            {
-                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
-                await connection.WaitForConnectionShutdownAsync();
-            });
+            async server => await server.EstablishConnectionAsync());
         }
 
         private class CustomException : Exception { }

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -139,6 +139,7 @@
     <Compile Include="SyncBlockingContent.cs" />
     <Compile Include="TestHelper.cs" />
     <Compile Include="DefaultCredentialsTest.cs" />
+    <Compile Include="ThrowingContent.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <Compile Include="CustomContent.netcore.cs" />

--- a/src/System.Net.Http/tests/FunctionalTests/ThrowingContent.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ThrowingContent.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Net.Http.Functional.Tests
+{
+    /// <summary>HttpContent that mocks exceptions on serialization.</summary>
+    public class ThrowingContent : HttpContent
+    {
+        private readonly Func<Exception> _exnFactory;
+        private readonly int _length;
+
+        public ThrowingContent(Func<Exception> exnFactory, int length = 10)
+        {
+            _exnFactory = exnFactory;
+            _length = length;
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            throw _exnFactory();
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _length;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
To achieve parity with the v1.1 implementation. Fixes #39295.

Also added a couple of functional tests that validate the behaviour.