### PR TITLE
Condition failing test on Nano

### DIFF
--- a/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
@@ -63,7 +63,7 @@ namespace System.Drawing.Printing.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(Helpers.IsDrawingSupported)]
         [ActiveIssue(20884, TestPlatforms.AnyUnix)]
         public void DefaultPageSettings_Null_ReturnsExpected()
         {


### PR DESCRIPTION
This test shouldn't run on Nano: https://dnceng.visualstudio.com/public/_build/results?buildId=260574&view=ms.vss-test-web.build-test-results-tab&runId=6972534&resultId=196737&paneView=debug