### PR TITLE
Scientific notation numbers with decimal separators support

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
@@ -140,7 +140,6 @@ namespace System.Text.Json
             // because it doesn't need to deal with "NeedsMoreData", or remembering the format.
             if (utf8FormattedNumber.IsEmpty)
             {
-                //ThrowHelper.ThrowArgumentException(nameof(utf8FormattedNumber), utf8FormattedNumber);
                 throw new ArgumentException(SR.RequiredDigitNotFoundEndOfData, nameof(utf8FormattedNumber));
             }
 
@@ -173,7 +172,7 @@ namespace System.Text.Json
                 return;
             }
 
-            //The non digit character inside the number
+            // The non digit character inside the number
             byte val = utf8FormattedNumber[i];
 
             if (val == '.')
@@ -190,7 +189,6 @@ namespace System.Text.Json
                     throw new ArgumentException(SR.RequiredDigitNotFoundEndOfData, nameof(utf8FormattedNumber));
                 }
             }
-
 
             if (i == utf8FormattedNumber.Length)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
@@ -140,6 +140,7 @@ namespace System.Text.Json
             // because it doesn't need to deal with "NeedsMoreData", or remembering the format.
             if (utf8FormattedNumber.IsEmpty)
             {
+                //ThrowHelper.ThrowArgumentException(nameof(utf8FormattedNumber), utf8FormattedNumber);
                 throw new ArgumentException(SR.RequiredDigitNotFoundEndOfData, nameof(utf8FormattedNumber));
             }
 
@@ -183,12 +184,13 @@ namespace System.Text.Json
                 {
                     i++;
                 }
+
+                if (utf8FormattedNumber.Length < i)
+                {
+                    throw new ArgumentException(SR.RequiredDigitNotFoundEndOfData, nameof(utf8FormattedNumber));
+                }
             }
 
-            if (utf8FormattedNumber.Length <= i)
-            {
-                throw new ArgumentException(SR.RequiredDigitNotFoundEndOfData, nameof(utf8FormattedNumber));
-            }
 
             if (i == utf8FormattedNumber.Length)
             {

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
@@ -185,17 +185,25 @@ namespace System.Text.Json
                 }
             }
 
+            if (utf8FormattedNumber.Length <= i)
+            {
+                throw new ArgumentException(SR.RequiredDigitNotFoundEndOfData, nameof(utf8FormattedNumber));
+            }
+
+            if (i == utf8FormattedNumber.Length)
+            {
+                return;
+            }
+
             val = utf8FormattedNumber[i];
 
             if (val == 'e' || val == 'E')
             {
                 i++;
 
-                if (i >= utf8FormattedNumber.Length)
+                if (utf8FormattedNumber.Length <= i)
                 {
-                    throw new ArgumentException(
-                        SR.RequiredDigitNotFoundEndOfData,
-                        nameof(utf8FormattedNumber));
+                    throw new ArgumentException(SR.RequiredDigitNotFoundEndOfData, nameof(utf8FormattedNumber));
                 }
 
                 val = utf8FormattedNumber[i];
@@ -212,11 +220,9 @@ namespace System.Text.Json
                     nameof(utf8FormattedNumber));
             }
 
-            if (i >= utf8FormattedNumber.Length)
+            if (utf8FormattedNumber.Length <= i)
             {
-                throw new ArgumentException(
-                    SR.RequiredDigitNotFoundEndOfData,
-                    nameof(utf8FormattedNumber));
+                throw new ArgumentException(SR.RequiredDigitNotFoundEndOfData, nameof(utf8FormattedNumber));
             }
 
             while (i < utf8FormattedNumber.Length && JsonHelpers.IsDigit(utf8FormattedNumber[i]))

--- a/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs
@@ -172,13 +172,22 @@ namespace System.Text.Json
                 return;
             }
 
+            //The non digit character inside the number
             byte val = utf8FormattedNumber[i];
 
             if (val == '.')
             {
                 i++;
+
+                while (i < utf8FormattedNumber.Length && JsonHelpers.IsDigit(utf8FormattedNumber[i]))
+                {
+                    i++;
+                }
             }
-            else if (val == 'e' || val == 'E')
+
+            val = utf8FormattedNumber[i];
+
+            if (val == 'e' || val == 'E')
             {
                 i++;
 

--- a/src/System.Text.Json/tests/JsonElementWriteTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWriteTests.cs
@@ -84,20 +84,19 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData("1e400", false)]
-        [InlineData("1e400", true)]
-        [InlineData("-1e400", false)]
-        [InlineData("-1e400", true)]
-        public static void WriteNumberTooLargeScientific(string value, bool indented)
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void WriteNumberTooLargeScientific(bool indented)
         {
             // This value is a reference "potential interoperability problem" from
             // https://tools.ietf.org/html/rfc7159#section-6
+            const string OneQuarticGoogol = "1e400";
 
             // This just validates we write the literal number 1e400 even though it is too
             // large to be represented by System.Double and would be converted to
             // PositiveInfinity instead (or throw if using double.Parse on frameworks
             // older than .NET Core 3.0).
-            WriteSimpleValue(indented, value);
+            WriteSimpleValue(indented, OneQuarticGoogol);
         }
 
         [Theory]

--- a/src/System.Text.Json/tests/JsonElementWriteTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWriteTests.cs
@@ -30,11 +30,39 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void WriteNumberScientific(bool indented)
+        [InlineData("1e6", false)]
+        [InlineData("1e6", true)]
+        [InlineData("1e+6", false)]
+        [InlineData("1e+6", true)]
+        [InlineData("1e-6", false)]
+        [InlineData("1e-6", true)]
+        [InlineData("-1e6", false)]
+        [InlineData("-1e6", true)]
+        [InlineData("-1e+6", true)]
+        [InlineData("-1e+6", true)]
+        [InlineData("-1e-6", false)]
+        [InlineData("-1e-6", true)]
+        public static void WriteNumberScientific(string value, bool indented)
         {
-            WriteSimpleValue(indented, "1e6");
+            WriteSimpleValue(indented, value);
+        }
+
+        [Theory]
+        [InlineData("5.012e-20", false)]
+        [InlineData("5.012e-20", true)]
+        [InlineData("5.012e20", false)]
+        [InlineData("5.012e20", true)]
+        [InlineData("5.012e+20", false)]
+        [InlineData("5.012e+20", true)]
+        [InlineData("-5.012e-20", false)]
+        [InlineData("-5.012e-20", true)]
+        [InlineData("-5.012e20", false)]
+        [InlineData("-5.012e20", true)]
+        [InlineData("-5.012e+20", false)]
+        [InlineData("-5.012e+20", true)]
+        public static void WriteNumberDecimalScientific(string value, bool indented)
+        {
+            WriteSimpleValue(indented, value);
         }
 
         [Theory]
@@ -56,19 +84,20 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public static void WriteNumberTooLargeScientific(bool indented)
+        [InlineData("1e400", false)]
+        [InlineData("1e400", true)]
+        [InlineData("-1e400", false)]
+        [InlineData("-1e400", true)]
+        public static void WriteNumberTooLargeScientific(string value, bool indented)
         {
             // This value is a reference "potential interoperability problem" from
             // https://tools.ietf.org/html/rfc7159#section-6
-            const string OneQuarticGoogol = "1e400";
 
             // This just validates we write the literal number 1e400 even though it is too
             // large to be represented by System.Double and would be converted to
             // PositiveInfinity instead (or throw if using double.Parse on frameworks
             // older than .NET Core 3.0).
-            WriteSimpleValue(indented, OneQuarticGoogol);
+            WriteSimpleValue(indented, value);
         }
 
         [Theory]

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -3747,6 +3747,13 @@ namespace System.Text.Json.Tests
             doubles[2] = double.MinValue;
             doubles[3] = 12.345e1;
             doubles[4] = -123.45e1;
+            doubles[5] = 6.022e-23;
+            doubles[6] = -6.022e-23;
+            doubles[7] = 1e200;
+            doubles[8] = -1e200;
+            doubles[9] = 1e-200;
+            doubles[10] = -1e-200;
+
             for (int i = 5; i < numberOfItems; i++)
             {
                 var value = random.NextDouble();

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -3747,12 +3747,6 @@ namespace System.Text.Json.Tests
             doubles[2] = double.MinValue;
             doubles[3] = 12.345e1;
             doubles[4] = -123.45e1;
-            doubles[5] = 6.022e-23;
-            doubles[6] = -6.022e-23;
-            doubles[7] = 1e200;
-            doubles[8] = -1e200;
-            doubles[9] = 1e-200;
-            doubles[10] = -1e-200;
 
             for (int i = 5; i < numberOfItems; i++)
             {


### PR DESCRIPTION
Writing Scientific notation numbers with decimal separators and exponent throwed an exception.
The decimal separator and the exponent separator were condition exclusive in the number validation

Fixes #39139.