### PR TITLE
Set sdk version in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,4 +1,7 @@
 {
+  "sdk": {
+    "version": "3.0.100-preview7-012630"
+  },
   "tools": {
     "dotnet": "3.0.100-preview7-012630"
   },


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/39336

We did not specify the SDK version in the global.json which would result in desktop msbuild picking the latest stable SDK and not actually the one that we depend on.

cc @davidsh 