### PR TITLE
Avoid loading resources for an SslStream exception never thrown

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -64,7 +64,7 @@ namespace System.Net.Security
         private object _queuedReadStateRequest;
 
         /// <summary>Set as the _exception when the instance is disposed.</summary>
-        private static readonly ExceptionDispatchInfo s_disposedSentinel = ExceptionDispatchInfo.Capture(new ObjectDisposedException(nameof(SslStream)));
+        private static readonly ExceptionDispatchInfo s_disposedSentinel = ExceptionDispatchInfo.Capture(new ObjectDisposedException(nameof(SslStream), (string)null));
 
         private void ThrowIfExceptional()
         {


### PR DESCRIPTION
SslStream's cctor creates an ObjectDisposedException it uses as a sentinel, but this instance is never actually thrown.  As such, we don't need to pay to load resources for it.

cc: @davidsh