### PR TITLE
Don't apply dictionary key policy on extension data

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleDictionary.cs
@@ -143,7 +143,8 @@ namespace System.Text.Json
             }
             else
             {
-                if (options.DictionaryKeyPolicy != null)
+                if (options.DictionaryKeyPolicy != null && 
+                    current.ExtensionDataStatus != ExtensionDataWriteStatus.Writing) // We do not convert extension data.
                 {
                     key = options.DictionaryKeyPolicy.ConvertName(key);
 

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -152,9 +152,9 @@ namespace System.Text.Json
             }
 
             // Allow redirection for generic types or the enum converter.
-            if (converter is JsonConverterFactory binder)
+            if (converter is JsonConverterFactory factory)
             {
-                converter = binder.GetConverterInternal(typeToConvert);
+                converter = factory.GetConverterInternal(typeToConvert);
                 if (converter == null || converter.TypeToConvert == null)
                 {
                     throw new ArgumentNullException("typeToConvert");

--- a/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -100,7 +100,7 @@ namespace System.Text.Json.Serialization.Tests
 
                 obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(jsonWithProperty, options);
                 Assert.Equal(1, obj.MyOverflow["MyIntMissing"].GetInt32());
-                string json = JsonSerializer.Serialize(obj);
+                string json = JsonSerializer.Serialize(obj, options);
                 Assert.Contains(@"""MyIntMissing"":1", json);
             }
 
@@ -120,7 +120,7 @@ namespace System.Text.Json.Serialization.Tests
 
                 obj = JsonSerializer.Deserialize<ClassWithExtensionProperty>(jsonWithPropertyCamelCased, options);
                 Assert.Equal(1, obj.MyOverflow["myIntMissing"].GetInt32());
-                string json = JsonSerializer.Serialize(obj);
+                string json = JsonSerializer.Serialize(obj, options);
                 Assert.Contains(@"""myIntMissing"":1", json);
             }
         }


### PR DESCRIPTION
Addresses the TODO from PR https://github.com/dotnet/corefx/pull/39042 (which couldn't be done at the time due to timing).