### PR TITLE
Add sdk roll.forward policy in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "3.0.100-preview7-012630"
+    "version": "3.0.100-preview7-012630",
+    "rollforward": "major"
   },
   "tools": {
     "dotnet": "3.0.100-preview7-012630"


### PR DESCRIPTION
I just noticed that the added sdk version forces everyone now to install that sdk version. Newer versions beyond the patch level aren't valid with the default roll-forward policy. Setting to major to not restrict any newer sdk version.

The change was merged two days ago: https://github.com/dotnet/core-setup/pull/6953. Ideally we would also update the sdk but I'm hesitant to force every dev in corefx to download the very latest nightly build.