### PR TITLE
Add reflection root for DataTableMappingConverter

### DIFF
--- a/src/System.Data.Common/src/ILLinkTrim.xml
+++ b/src/System.Data.Common/src/ILLinkTrim.xml
@@ -32,5 +32,9 @@
       <!-- Instantiated via reflection -->
       <method name=".ctor" />
     </type>
+    <type fullname="System.Data.Common.DataTableMapping/DataTableMappingConverter">
+      <!-- Instantiated via reflection -->
+      <method name=".ctor" />
+    </type>
   </assembly>
 </linker>


### PR DESCRIPTION
Used via TypeConverterAttribute.
Caught while investigating linker diffs.

Separating this out from https://github.com/dotnet/corefx/pull/39287