### PR TITLE
Increase wait timeout and add extra logs for Pipe Deadlock tests

### DIFF
--- a/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
@@ -47,8 +47,8 @@ namespace System.IO.Pipelines.Tests
                     buffer.FlushAsync(cts2.Token);
                 });
 
-            bool completed = Task.WhenAll(cancellationTask, blockingTask).Wait(TimeSpan.FromSeconds(10));
-            Assert.True(completed);
+            bool completed = Task.WhenAll(cancellationTask, blockingTask).Wait(TimeSpan.FromSeconds(30));
+            Assert.True(completed, $"Flush tasks are not completed. CancellationTask: {cancellationTask.Status.ToString()} BlockingTask: {blockingTask.Status.ToString()}");
         }
 
         [Fact]

--- a/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
@@ -26,7 +26,7 @@ namespace System.IO.Pipelines.Tests
             ValueTaskAwaiter<FlushResult> awaiter = buffer.FlushAsync(cts.Token).GetAwaiter();
             awaiter.OnCompleted(
                 () => {
-                    // We are on cancellation thread and need to wait untill another FlushAsync call
+                    // We are on cancellation thread and need to wait until another FlushAsync call
                     // takes pipe state lock
                     e.Wait();
 
@@ -37,7 +37,7 @@ namespace System.IO.Pipelines.Tests
                     buffer.FlushAsync();
                 });
 
-            // Start a thread that would run cancellation calbacks
+            // Start a thread that would run cancellation callbacks
             Task cancellationTask = Task.Run(() => cts.Cancel());
             // Start a thread that would call FlushAsync with different token
             // and block on _cancellationTokenRegistration.Dispose

--- a/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
@@ -48,7 +48,7 @@ namespace System.IO.Pipelines.Tests
                 });
 
             bool completed = Task.WhenAll(cancellationTask, blockingTask).Wait(TimeSpan.FromSeconds(30));
-            Assert.True(completed, $"Flush tasks are not completed. CancellationTask: {cancellationTask.Status.ToString()} BlockingTask: {blockingTask.Status.ToString()}");
+            Assert.True(completed, $"Flush tasks are not completed. CancellationTask: {cancellationTask.Status} BlockingTask: {blockingTask.Status.ToString()}");
         }
 
         [Fact]

--- a/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/FlushAsyncCancellationTests.cs
@@ -48,7 +48,7 @@ namespace System.IO.Pipelines.Tests
                 });
 
             bool completed = Task.WhenAll(cancellationTask, blockingTask).Wait(TimeSpan.FromSeconds(30));
-            Assert.True(completed, $"Flush tasks are not completed. CancellationTask: {cancellationTask.Status} BlockingTask: {blockingTask.Status.ToString()}");
+            Assert.True(completed, $"Flush tasks are not completed. CancellationTask: {cancellationTask.Status} BlockingTask: {blockingTask.Status}");
         }
 
         [Fact]

--- a/src/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
@@ -136,7 +136,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public void FlushAsyncCancellationDeadlock()
+        public void ReadAsyncCancellationDeadlock()
         {
             var cts = new CancellationTokenSource();
             var cts2 = new CancellationTokenSource();
@@ -145,7 +145,7 @@ namespace System.IO.Pipelines.Tests
             ValueTaskAwaiter<ReadResult> awaiter = Pipe.Reader.ReadAsync(cts.Token).GetAwaiter();
             awaiter.OnCompleted(
                 () => {
-                    // We are on cancellation thread and need to wait untill another ReadAsync call
+                    // We are on cancellation thread and need to wait until another ReadAsync call
                     // takes pipe state lock
                     e.Wait();
                     // Make sure we had enough time to reach _cancellationTokenRegistration.Dispose
@@ -154,7 +154,7 @@ namespace System.IO.Pipelines.Tests
                     Pipe.Reader.ReadAsync();
                 });
 
-            // Start a thread that would run cancellation calbacks
+            // Start a thread that would run cancellation callbacks
             Task cancellationTask = Task.Run(() => cts.Cancel());
             // Start a thread that would call ReadAsync with different token
             // and block on _cancellationTokenRegistration.Dispose
@@ -164,8 +164,8 @@ namespace System.IO.Pipelines.Tests
                     Pipe.Reader.ReadAsync(cts2.Token);
                 });
 
-            bool completed = Task.WhenAll(cancellationTask, blockingTask).Wait(TimeSpan.FromSeconds(10));
-            Assert.True(completed);
+            bool completed = Task.WhenAll(cancellationTask, blockingTask).Wait(TimeSpan.FromSeconds(30));
+            Assert.True(completed, $"Read tasks are not completed. CancellationTask: {cancellationTask.Status.ToString()} BlockingTask: {blockingTask.Status.ToString()}");
         }
 
         [Fact]

--- a/src/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
@@ -165,7 +165,7 @@ namespace System.IO.Pipelines.Tests
                 });
 
             bool completed = Task.WhenAll(cancellationTask, blockingTask).Wait(TimeSpan.FromSeconds(30));
-            Assert.True(completed, $"Read tasks are not completed. CancellationTask: {cancellationTask.Status} BlockingTask: {blockingTask.Status.ToString()}");
+            Assert.True(completed, $"Read tasks are not completed. CancellationTask: {cancellationTask.Status} BlockingTask: {blockingTask.Status}");
         }
 
         [Fact]

--- a/src/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
+++ b/src/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
@@ -165,7 +165,7 @@ namespace System.IO.Pipelines.Tests
                 });
 
             bool completed = Task.WhenAll(cancellationTask, blockingTask).Wait(TimeSpan.FromSeconds(30));
-            Assert.True(completed, $"Read tasks are not completed. CancellationTask: {cancellationTask.Status.ToString()} BlockingTask: {blockingTask.Status.ToString()}");
+            Assert.True(completed, $"Read tasks are not completed. CancellationTask: {cancellationTask.Status} BlockingTask: {blockingTask.Status.ToString()}");
         }
 
         [Fact]


### PR DESCRIPTION
Part of https://github.com/dotnet/corefx/issues/38156. I don't know whether it's a bad test or there is a legitimate issue. As mentioned in the thread, I'm going to increase the wait timeout and make the exception contain info about which thread didn't finish.