### PR TITLE
Fix VS Test explorer SDK mismatch

### DIFF
--- a/external/runtime/runtime.depproj
+++ b/external/runtime/runtime.depproj
@@ -63,7 +63,7 @@
     <Exec Command="chmod +x $(TestHostRootPath)%(DotnetExe.Filename)%(DotnetExe.Extension)" Condition="'$(OS)' != 'Windows_NT'"/>
 
     <Copy SourceFiles="@(HostSdkFile)"
-          DestinationFolder="$(TestHostRootPath)sdk\$(ProductVersion)\%(RecursiveDir)"
+          DestinationFolder="$(TestHostRootPath)sdk\$(DotNetVersion)\%(RecursiveDir)"
           SkipUnchangedFiles="true"
           UseHardlinksIfPossible="$(UseHardlink)" />
   </Target>


### PR DESCRIPTION
Currently, since we introduced the SDK into global.json and the version we're using to produce the testhost's SDK is `ProductVersion` it creates an SDK with 3.0.0 version. So when trying to open a solution with `build.cmd -vs` you get the following error: 

> E:\repos\corefxCopy\corefx\src\System.Runtime\ref\System.Runtime.csproj : error  : The project file cannot be opened by the project system, because it is missing some critical imports or the referenced SDK cannot be found.
>
> Detailed Information:
Unable to locate the .NET Core SDK. Check that it is installed and that the version specified in global.json (if any) matches the installed version.

This fixes it to use the version defined in global.json and match the SDK version.

cc: @scalablecory 