### PR TITLE
Replace collection instances on deserialize

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoCommon.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Converters;
 
 namespace System.Text.Json
 {
@@ -70,11 +69,6 @@ namespace System.Text.Json
 
                 Converter = (JsonConverter<TConverter>)value;
             }
-        }
-
-        public override void GetPolicies()
-        {
-            base.GetPolicies();
         }
 
         public override object GetValueAsObject(object obj)

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleDictionary.cs
@@ -70,10 +70,10 @@ namespace System.Text.Json
                 {
                     dictionaryClassInfo = options.GetOrAddClass(jsonPropertyInfo.DeclaredPropertyType);
                 }
+
                 state.Current.TempDictionaryValues = (IDictionary)dictionaryClassInfo.CreateConcreteDictionary();
             }
-            // Else if current property is already set (from a constructor, for example), leave as-is.
-            else if (jsonPropertyInfo.GetValueAsObject(state.Current.ReturnValue) == null)
+            else
             {
                 // Create the dictionary.
                 JsonClassInfo dictionaryClassInfo = jsonPropertyInfo.RuntimeClassInfo;
@@ -96,6 +96,11 @@ namespace System.Text.Json
 
         private static void HandleEndDictionary(JsonSerializerOptions options, ref Utf8JsonReader reader, ref ReadStack state)
         {
+            if (state.Current.SkipProperty)
+            {
+                return;
+            }
+
             if (state.Current.IsDictionaryProperty)
             {
                 // We added the items to the dictionary already.

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -135,7 +135,7 @@ namespace System.Text.Json
             KeyName = null;
         }
 
-        public static object CreateEnumerableValue(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
+        public static object CreateEnumerableValue(ref Utf8JsonReader reader, ref ReadStack state)
         {
             JsonPropertyInfo jsonPropertyInfo = state.Current.JsonPropertyInfo;
 
@@ -154,9 +154,14 @@ namespace System.Text.Json
 
                 state.Current.TempEnumerableValues = converterList;
 
+                // Clear the value if present to ensure we don't confuse tempEnumerableValues with the collection. 
+                if (!jsonPropertyInfo.IsPropertyPolicy)
+                {
+                    jsonPropertyInfo.SetValueAsObject(state.Current.ReturnValue, null);
+                }
+
                 return null;
             }
-
 
             Type propertyType = jsonPropertyInfo.RuntimePropertyType;
             if (typeof(IList).IsAssignableFrom(propertyType))

--- a/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -32,7 +32,9 @@ namespace System.Text.Json.Serialization.Tests
             var obj = new ClassWithNoSetter();
 
             string json = JsonSerializer.Serialize(obj, options);
-            Assert.Equal(@"{}", json);
+
+            // Collections are always serialized unless they have [JsonIgnore].
+            Assert.Equal(@"{""MyInts"":[1,2]}", json);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38435 the original issue with "Collection was of a fixed size" for pre-populated arrays.



In addition the semantics for how collections are materialized has changed:
- Pre-populated collections with a setter are replaced on deserialization.
- Pre-populated collections without a setter are ignored on deserialization.

Previously, pre-populated collections were appended to (when possible).

Replaces PR https://github.com/dotnet/corefx/pull/38797. cc @YohDeadfall 