### PR TITLE
Remove the WriteNullStringAsProperty test

### DIFF
--- a/src/System.Text.Json/tests/JsonElementWriteTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWriteTests.cs
@@ -385,21 +385,6 @@ null,
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public static void WriteNullStringAsProperty(bool indented)
-        {
-            WritePropertyValueBothForms(
-                indented,
-                null,
-                "\"\"",
-                @"{
-  """": """"
-}",
-                "{\"\":\"\"}");
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
         public static void WriteNumberAsProperty(bool indented)
         {
             WritePropertyValueBothForms(


### PR DESCRIPTION
The writer has standardized on not allowing null -> Empty coercion, and this
test no longer is needed since JsonElement doesn't have a WriteProperty method,
and a JsonProperty can't ever have a null property name.

Fixes #39451.