### PR TITLE
Fix SocketsHttpHandler canceling request when response stream dropped

### DIFF
--- a/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -61,7 +61,7 @@ namespace System.Net.Test.Common
         public abstract Task SendResponseBodyAsync(byte[] data, bool isFinal = true, int requestId = 0);
 
         /// <summary>Waits for the client to signal cancellation.</summary>
-        public abstract Task WaitForCancellationAsync();
+        public abstract Task WaitForCancellationAsync(bool ignoreIncomingData = true, int requestId = 0);
 
         /// <summary>Helper function to make it easier to convert old test with strings.</summary>
         public async Task SendResponseBodyAsync(string data, bool isFinal = true, int requestId = 0)

--- a/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -48,17 +48,22 @@ namespace System.Net.Test.Common
     {
         public abstract void Dispose();
 
-        // Read request Headers and optionally request body as well.
+        /// <summary>Read request Headers and optionally request body as well.</summary>
         public abstract Task<HttpRequestData> ReadRequestDataAsync(bool readBody = true);
-        // Read complete request body if not done by ReadRequestData.
+        /// <summary>Read complete request body if not done by ReadRequestData.</summary>
         public abstract Task<Byte[]> ReadRequestBodyAsync();
 
-        // Sends Response back with provided statusCode, headers and content. Can be called multiple times on same response if isFinal was set to false before.
+        /// <summary>Sends Response back with provided statusCode, headers and content. Can be called multiple times on same response if isFinal was set to false before.</summary>
         public abstract Task SendResponseAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, string body = null, bool isFinal = true, int requestId = 0);
-        // Sends Response body after SendResponse was called with isFinal: false.
+        /// <summary>Sends response headers.</summary>
+        public abstract Task SendResponseHeadersAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, int requestId = 0);
+        /// <summary>Sends Response body after SendResponse was called with isFinal: false.</summary>
         public abstract Task SendResponseBodyAsync(byte[] data, bool isFinal = true, int requestId = 0);
 
-        // Helper function to make it easier to convert old test with strings.
+        /// <summary>Waits for the client to signal cancellation.</summary>
+        public abstract Task WaitForCancellationAsync();
+
+        /// <summary>Helper function to make it easier to convert old test with strings.</summary>
         public async Task SendResponseBodyAsync(string data, bool isFinal = true, int requestId = 0)
         {
             await SendResponseBodyAsync(String.IsNullOrEmpty(data) ? new byte[0] : Encoding.ASCII.GetBytes(data), isFinal, requestId);

--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -4,9 +4,9 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http.Functional.Tests;
 using System.Net.Security;
 using System.Net.Sockets;
-using System.Security.Authentication;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -716,10 +716,27 @@ namespace System.Net.Test.Common
             return SendResponseHeadersAsync(streamId, endStream : isFinal, statusCode, isTrailingHeader : false, endHeaders : endHeaders, headers);
         }
 
+        public override Task SendResponseHeadersAsync(HttpStatusCode statusCode = HttpStatusCode.OK, IList<HttpHeaderData> headers = null, int requestId = 0)
+        {
+            int streamId = requestId == 0 ? _lastStreamId : requestId;
+            return SendResponseHeadersAsync(streamId, endStream: false, statusCode, isTrailingHeader: false, endHeaders: true, headers);
+        }
+
         public override Task SendResponseBodyAsync(byte[] body, bool isFinal = true, int requestId = 0)
         {
             int streamId = requestId == 0 ? _lastStreamId : requestId;
             return SendResponseBodyAsync(streamId, body, isFinal);
+        }
+
+        public override async Task WaitForCancellationAsync()
+        {
+            Frame frame;
+            do
+            {
+                frame = await ReadFrameAsync(TimeSpan.FromMilliseconds(TestHelper.PassingTestTimeoutMilliseconds));
+                Assert.NotNull(frame); // We should get Rst before closing connection.
+                Assert.Equal(0, (int)(frame.Flags & FrameFlags.EndStream));
+            } while (frame.Type != FrameType.RstStream);
         }
     }
 }

--- a/src/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http.Functional.Tests;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
@@ -816,14 +815,23 @@ namespace System.Net.Test.Common
                 await SendResponseAsync(Encoding.UTF8.GetString(body)).ConfigureAwait(false);
             }
 
-            public override async Task WaitForCancellationAsync()
+            public override async Task WaitForCancellationAsync(bool ignoreIncomingData = true, int requestId = 0)
             {
                 var buffer = new byte[1024];
-                try
+                while (true)
                 {
-                    while (await ReadAsync(buffer, 0, buffer.Length).TimeoutAfter(TestHelper.PassingTestTimeoutMilliseconds).ConfigureAwait(false) > 0);
+                    int bytesRead = await ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+
+                    if (!ignoreIncomingData)
+                    {
+                        Assert.Equal(0, bytesRead);
+                    }
+
+                    if (bytesRead == 0)
+                    {
+                        break;
+                    }
                 }
-                catch (IOException) { }
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1613,6 +1613,8 @@ namespace System.Net.Http
 
                 // Wait for the response headers to complete if they haven't already, propagating any exceptions.
                 await responseHeadersTask.ConfigureAwait(false);
+
+                return http2Stream.GetAndClearResponse();
             }
             catch (Exception e)
             {
@@ -1651,8 +1653,6 @@ namespace System.Net.Http
                 }
                 throw;
             }
-
-            return http2Stream.Response;
         }
 
         private Http2Stream AddStream(HttpRequestMessage request)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -320,7 +320,7 @@ namespace System.Net.Http
                         // if the header can't be added, we silently drop it.
                         if (_state == StreamState.ExpectingTrailingHeaders)
                         {
-                            _trailers ??= new List<KeyValuePair<HeaderDescriptor, string>>();
+                            Debug.Assert(_trailers != null);
                             _trailers.Add(KeyValuePair.Create(descriptor.HeaderType == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue));
                         }
                         else if (descriptor.HeaderType == HttpHeaderType.Content)
@@ -354,6 +354,7 @@ namespace System.Net.Http
                     if (_state == StreamState.ExpectingData)
                     {
                         _state = StreamState.ExpectingTrailingHeaders;
+                        _trailers ??= new List<KeyValuePair<HeaderDescriptor, string>>();
                     }
                 }
             }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http.Headers;
@@ -32,6 +33,8 @@ namespace System.Net.Http
             private readonly CreditManager _streamWindow;
             private readonly HttpRequestMessage _request;
             private HttpResponseMessage _response;
+            /// <summary>Stores any trailers received after returning the response content to the caller.</summary>
+            private List<KeyValuePair<HeaderDescriptor, string>> _trailers;
 
             private ArrayBuffer _responseBuffer; // mutable struct, do not make this readonly
             private int _pendingWindowUpdate;
@@ -100,8 +103,17 @@ namespace System.Net.Http
             private object SyncObject => _streamWindow;
 
             public int StreamId => _streamId;
-            public HttpRequestMessage Request => _request;
-            public HttpResponseMessage Response => _response;
+
+            public HttpResponseMessage GetAndClearResponse()
+            {
+                // Once SendAsync completes, the Http2Stream should no longer hold onto the response message.
+                // Since the Http2Stream is rooted by the Http2Connection dictionary, doing so would prevent
+                // the response stream from being collected and finalized if it were to be dropped without
+                // being disposed first.
+                HttpResponseMessage r = _response;
+                _response = null;
+                return r;
+            }
 
             public async Task SendRequestBodyAsync(CancellationToken cancellationToken)
             {
@@ -272,7 +284,7 @@ namespace System.Net.Http
                             {
                                 _state = StreamState.ExpectingHeaders;
                                 // If we tried 100-Continue and got rejected signal that we should not send request body.
-                                _shouldSendRequestBody = (int)Response.StatusCode < 300;
+                                _shouldSendRequestBody = (int)_response.StatusCode < 300;
                                 shouldSendRequestBodyWaiter?.TrySetResult(_shouldSendRequestBody);
                             }
                         }
@@ -308,14 +320,17 @@ namespace System.Net.Http
                         // if the header can't be added, we silently drop it.
                         if (_state == StreamState.ExpectingTrailingHeaders)
                         {
-                            _response.TrailingHeaders.TryAddWithoutValidation(descriptor.HeaderType == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue);
+                            _trailers ??= new List<KeyValuePair<HeaderDescriptor, string>>();
+                            _trailers.Add(KeyValuePair.Create(descriptor.HeaderType == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue));
                         }
                         else if (descriptor.HeaderType == HttpHeaderType.Content)
                         {
+                            Debug.Assert(_response != null);
                             _response.Content.Headers.TryAddWithoutValidation(descriptor, headerValue);
                         }
                         else
                         {
+                            Debug.Assert(_response != null);
                             _response.Headers.TryAddWithoutValidation(descriptor.HeaderType == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue);
                         }
                     }
@@ -538,9 +553,18 @@ namespace System.Net.Http
                 }
 
                 // Start to process the response body.
-                ((HttpConnectionResponseContent)_response.Content).SetStream(emptyResponse ?
-                    EmptyReadStream.Instance :
-                    (Stream)new Http2ReadStream(this));
+                var responseContent = (HttpConnectionResponseContent)_response.Content;
+                if (emptyResponse)
+                {
+                    // If there are any trailers, copy them over to the response.  Normally this would be handled by
+                    // the response stream hitting EOF, but if there is no response body, we do it here.
+                    CopyTrailersToResponseMessage(_response);
+                    responseContent.SetStream(EmptyReadStream.Instance);
+                }
+                else
+                {
+                    responseContent.SetStream(new Http2ReadStream(this));
+                }
 
                 // Process Set-Cookie headers.
                 if (_connection._pool.Settings._useCookies)
@@ -603,7 +627,7 @@ namespace System.Net.Http
                 }
             }
 
-            public int ReadData(Span<byte> buffer, CancellationToken cancellationToken)
+            public int ReadData(Span<byte> buffer, HttpResponseMessage responseMessage)
             {
                 if (buffer.Length == 0)
                 {
@@ -615,8 +639,7 @@ namespace System.Net.Http
                 {
                     // Synchronously block waiting for data to be produced.
                     Debug.Assert(bytesRead == 0);
-                    GetWaiterTask(cancellationToken).AsTask().GetAwaiter().GetResult();
-                    CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
+                    GetWaiterTask(default).AsTask().GetAwaiter().GetResult();
                     (wait, bytesRead) = TryReadFromBuffer(buffer);
                     Debug.Assert(!wait);
                 }
@@ -624,13 +647,17 @@ namespace System.Net.Http
                 if (bytesRead != 0)
                 {
                     ExtendWindow(bytesRead);
-                    _connection.ExtendWindow(bytesRead);
+                }
+                else
+                {
+                    // We've hit EOF.  Pull in from the Http2Stream any trailers that were temporarily stored there.
+                    CopyTrailersToResponseMessage(responseMessage);
                 }
 
                 return bytesRead;
             }
 
-            public async ValueTask<int> ReadDataAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+            public async ValueTask<int> ReadDataAsync(Memory<byte> buffer, HttpResponseMessage responseMessage, CancellationToken cancellationToken)
             {
                 if (buffer.Length == 0)
                 {
@@ -650,8 +677,25 @@ namespace System.Net.Http
                 {
                     ExtendWindow(bytesRead);
                 }
+                else
+                {
+                    // We've hit EOF.  Pull in from the Http2Stream any trailers that were temporarily stored there.
+                    CopyTrailersToResponseMessage(responseMessage);
+                }
 
                 return bytesRead;
+            }
+
+            private void CopyTrailersToResponseMessage(HttpResponseMessage responseMessage)
+            {
+                if (_trailers != null && _trailers.Count > 0)
+                {
+                    foreach (KeyValuePair<HeaderDescriptor, string> trailer in _trailers)
+                    {
+                        responseMessage.TrailingHeaders.TryAddWithoutValidation(trailer.Key, trailer.Value);
+                    }
+                    _trailers.Clear();
+                }
             }
 
             private async Task SendDataAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
@@ -774,11 +818,27 @@ namespace System.Net.Http
             private sealed class Http2ReadStream : HttpBaseStream
             {
                 private Http2Stream _http2Stream;
+                private readonly HttpResponseMessage _responseMessage;
 
                 public Http2ReadStream(Http2Stream http2Stream)
                 {
                     Debug.Assert(http2Stream != null);
+                    Debug.Assert(http2Stream._response != null);
                     _http2Stream = http2Stream;
+                    _responseMessage = _http2Stream._response;
+                }
+
+                ~Http2ReadStream()
+                {
+                    if (NetEventSource.IsEnabled) _http2Stream?.Trace("");
+                    try
+                    {
+                        Dispose(disposing: false);
+                    }
+                    catch (Exception e)
+                    {
+                        if (NetEventSource.IsEnabled) _http2Stream?.Trace($"Error: {e}");
+                    }
                 }
 
                 protected override void Dispose(bool disposing)
@@ -789,16 +849,19 @@ namespace System.Net.Http
                         return;
                     }
 
-                    if (disposing)
-                    {
-                        if (http2Stream._state != StreamState.Aborted && http2Stream._state != StreamState.Complete)
-                        {
-                            // If we abort response stream before endOfStream, let server know.
-                            IgnoreExceptions(http2Stream._connection.SendRstStreamAsync(http2Stream._streamId, Http2ProtocolErrorCode.Cancel));
-                        }
+                    // Technically we shouldn't be doing the following work when disposing == false,
+                    // as the following work relies on other finalizable objects.  But given the HTTP/2
+                    // protocol, we have little choice: if someone drops the Http2ReadStream without
+                    // disposing of it, we need to a) signal to the server that the stream is being
+                    // canceled, and b) clean up the associated state in the Http2Connection.
 
-                        http2Stream.Dispose();
+                    if (http2Stream._state != StreamState.Aborted && http2Stream._state != StreamState.Complete)
+                    {
+                        // If we abort response stream before endOfStream, let server know.
+                        IgnoreExceptions(http2Stream._connection.SendRstStreamAsync(http2Stream._streamId, Http2ProtocolErrorCode.Cancel));
                     }
+
+                    http2Stream.Dispose();
 
                     base.Dispose(disposing);
                 }
@@ -814,7 +877,7 @@ namespace System.Net.Http
                         throw new IOException(SR.net_http_client_execution_error, http2Stream._abortException);
                     }
 
-                    return http2Stream.ReadData(destination, CancellationToken.None);
+                    return http2Stream.ReadData(destination, _responseMessage);
                 }
 
                 public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
@@ -835,7 +898,7 @@ namespace System.Net.Http
                         return new ValueTask<int>(Task.FromCanceled<int>(cancellationToken));
                     }
 
-                    return http2Stream.ReadDataAsync(destination, cancellationToken);
+                    return http2Stream.ReadDataAsync(destination, _responseMessage, cancellationToken);
                 }
 
                 public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException(SR.net_http_content_readonly_stream);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
@@ -26,7 +26,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
-        public async Task PendingReceive_ResponseDropped_SendsReset()
+        public async Task IncompleteResponseStream_ResponseDropped_CancelsRequestToServer()
         {
             using (HttpClient client = CreateHttpClient())
             {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Finalization.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Test.Common;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public abstract class HttpClientHandler_Finalization_Test : HttpClientHandlerTestBase
+    {
+        public HttpClientHandler_Finalization_Test(ITestOutputHelper output) : base(output) { }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Task GetAndDropResponse(HttpClient client, Uri url)
+        {
+            return Task.Run(async () =>
+            {
+                // Get the response stream, but don't dispose it or return it. Just drop it.
+                await client.GetStreamAsync(url);
+            });
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+        public async Task PendingReceive_ResponseDropped_SendsReset()
+        {
+            using (HttpClient client = CreateHttpClient())
+            {
+                bool stopGCs = false;
+                await LoopbackServerFactory.CreateClientAndServerAsync(async url =>
+                {
+                    await GetAndDropResponse(client, url);
+
+                    while (!Volatile.Read(ref stopGCs))
+                    {
+                        await Task.Delay(10);
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                    }
+                },
+                server => server.AcceptConnectionAsync(async connection =>
+                {
+                    try
+                    {
+                        HttpRequestData data = await connection.ReadRequestDataAsync(readBody: false);
+                        await connection.SendResponseHeadersAsync(headers: new HttpHeaderData[] { new HttpHeaderData("SomeHeaderName", "AndValue") });
+                        await connection.WaitForCancellationAsync();
+                    }
+                    finally
+                    {
+                        Volatile.Write(ref stopGCs, true);
+                    }
+                }));
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -152,6 +152,19 @@ namespace System.Net.Http.Functional.Tests
         protected override bool UseSocketsHttpHandler => true;
     }
 
+    public sealed class SocketsHttpHandler_HttpClientHandler_Finalization_Http11_Test : HttpClientHandler_Finalization_Test
+    {
+        public SocketsHttpHandler_HttpClientHandler_Finalization_Http11_Test(ITestOutputHelper output) : base(output) { }
+        protected override bool UseSocketsHttpHandler => true;
+    }
+
+    public sealed class SocketsHttpHandler_HttpClientHandler_Finalization_Http2_Test : HttpClientHandler_Finalization_Test
+    {
+        public SocketsHttpHandler_HttpClientHandler_Finalization_Http2_Test(ITestOutputHelper output) : base(output) { }
+        protected override bool UseSocketsHttpHandler => true;
+        protected override bool UseHttp2 => true;
+    }
+
     public sealed class SocketsHttpHandler_HttpClientHandler_MaxConnectionsPerServer_Test : HttpClientHandler_MaxConnectionsPerServer_Test
     {
         protected override bool UseSocketsHttpHandler => true;

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -94,17 +94,20 @@
     <Compile Include="FakeDiagnosticSourceListenerObserver.cs" />
     <Compile Include="FormUrlEncodedContentTest.cs" />
     <Compile Include="ByteAtATimeContent.cs" />
+    <Compile Include="HttpClientHandlerTest.cs" />
+    <Compile Include="HttpClientHandlerTest.Asynchrony.cs" />
     <Compile Include="HttpClientHandlerTest.Authentication.cs" />
     <Compile Include="HttpClientHandlerTest.AutoRedirect.cs" />
-    <Compile Include="HttpClientHandlerTest.cs" />
     <Compile Include="HttpClientHandlerTest.Cancellation.cs" />
     <Compile Include="HttpClientHandlerTest.ClientCertificates.cs" />
-    <Compile Include="HttpClientHandlerTest.Asynchrony.cs" />
+    <Compile Include="HttpClientHandlerTest.Cookies.cs" />
     <Compile Include="HttpClientHandlerTest.DefaultProxyCredentials.cs" />
-    <Compile Include="HttpClientHandlerTest.Proxy.cs" />
-    <Compile Include="HttpClientHandlerTest.ResponseDrain.cs" />
+    <Compile Include="HttpClientHandlerTest.Finalization.cs" />
+    <Compile Include="HttpClientHandlerTest.Headers.cs" />
     <Compile Include="HttpClientHandlerTest.MaxConnectionsPerServer.cs" />
     <Compile Include="HttpClientHandlerTest.MaxResponseHeadersLength.cs" />
+    <Compile Include="HttpClientHandlerTest.Proxy.cs" />
+    <Compile Include="HttpClientHandlerTest.ResponseDrain.cs" />
     <Compile Include="HttpClientHandlerTest.ServerCertificates.cs" />
     <Compile Include="HttpClientHandlerTest.ServerCertificates.Unix.cs" Condition="'$(TargetsUnix)' == 'true'" />
     <Compile Include="HttpClientHandlerTest.ServerCertificates.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
@@ -119,8 +122,6 @@
     <Compile Include="HttpContentTest.cs" />
     <Compile Include="HttpMessageInvokerTest.cs" />
     <Compile Include="HttpMethodTest.cs" />
-    <Compile Include="HttpClientHandlerTest.Cookies.cs" />
-    <Compile Include="HttpClientHandlerTest.Headers.cs" />
     <Compile Include="HttpRetryProtocolTests.cs" />
     <Compile Include="IdnaProtocolTests.cs" />
     <Compile Include="HttpProtocolTests.cs" />


### PR DESCRIPTION
Good code using HttpClient should Dispose of the HttpResponseMessage and/or response Stream when its done with it.  However, if code fails to do so, we still want to ensure that we don't leak connections/requests to the server or leak resources on the client.  If the response isn't disposed but the code reads all the way to the end of it, then internally things are cleaned up.  But if the response isn't disposed and hasn't read to the end, for both HTTP/1.1 and HTTP/2, we have some issues.

For HTTP/1.1, we rely on the Socket's finalization to close the associated connection.  However, we use a cache of SocketAsyncEventArgs instances to handle creating connections, and it turns out that these SocketAsyncEventArgs instances are keeping around a reference to the last created Socket.  If the SAEA is reused for another connection, then there's no issue, but until it is, it maintains several references to the socket: in ConnectSocket, in _currentSocket, in _multipleConnect, and then further within another SAEA instance that the _multipleConnect itself is creating for some reason.  We should go through and clean all that up in SAEA, but for now, this just removes the SAEA cache.

For HTTP/2, nothing was cleaning up in this case.  To handle it, we:
1. Make the response stream finalizable, such that when finalized it behaves as if Dispose were called.
2. When SendAsync completes, we remove the strong reference from the Http2Stream to the response message, such that the response (and in turn the response stream) doesn't get rooted by the Http2Connection storing the Http2Stream in its dictionary).
3. The only reason that reference was still needed was to support trailing headers.  So we create a lazily-allocated list on the Http2Stream for storing trailers if any should arrive, and then when the response body completes, the response stream pulls those headers in from the temporary collection into the response that it then has a reference to.  This also helps to avoid a race condition where consuming code erroneously accesses TrailingHeaders before the request has completed, in which case we previously could have been trying to write to the collection while user code was reading from it; with this change, that mutation happens as part of a call the consumer makes.

cc: @geoffkizer, @davidsh, @wfurt, @scalablecory, @eiriktsarpalis 
Fixes https://github.com/dotnet/corefx/issues/39470
Fixes https://github.com/dotnet/corefx/issues/39427
Fixes https://github.com/dotnet/corefx/issues/39420
Related to https://github.com/dotnet/corefx/issues/39466
Related to https://github.com/dotnet/corefx/issues/39461 (this doesn't fix that but will be impacted by it)