### PR TITLE
Fix and re-enable Http2_FlowControl_ClientDoesNotExceedWindows 

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1163,7 +1163,6 @@ namespace System.Net.Http.Functional.Tests
             return bytesReceived;
         }
 
-        [ActiveIssue(38799)]
         [OuterLoop("Uses Task.Delay")]
         [ConditionalFact(nameof(SupportsAlpn))]
         public async Task Http2_FlowControl_ClientDoesNotExceedWindows()
@@ -1171,7 +1170,7 @@ namespace System.Net.Http.Functional.Tests
             const int InitialWindowSize = 65535;
             const int ContentSize = 100_000;
 
-            var content = new ByteArrayContent(TestHelper.GenerateRandomContent(ContentSize));
+            var content = new ByteAtATimeContent(ContentSize);
 
             using (var server = Http2LoopbackServer.CreateServer())
             using (HttpClient client = CreateHttpClient())


### PR DESCRIPTION
Use `ByteAtATimeContent` for compat with recent buffering change.
Clear `ActiveIssue` as original failure in #38799 could not be reproduced.

Resolves #38799.