### PR TITLE
Ensure that CancellationToken is propagated to built-in request content types

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -1394,7 +1394,11 @@ namespace System.Net.Http
             {
                 await state.RequestMessage.Content.CopyToAsync(
                     requestStream,
-                    state.TransportContext).ConfigureAwait(false);
+                    state.TransportContext
+#if HTTP_DLL
+                    , state.CancellationToken
+#endif
+                    ).ConfigureAwait(false);
                 await requestStream.EndUploadAsync(state.CancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.Net.Http
@@ -50,11 +51,17 @@ namespace System.Net.Http
             SetBuffer(_content, _offset, _count);
         }
 
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
-        {
-            Debug.Assert(stream != null);
-            return stream.WriteAsync(_content, _offset, _count);
-        }
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context) =>
+            SerializeToStreamAsyncCore(stream, default);
+
+        internal override Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken) =>
+            // Only skip the original protected virtual SerializeToStreamAsync if this
+            // isn't a derived type that may have overridden the behavior.
+            GetType() == typeof(ByteArrayContent) ? SerializeToStreamAsyncCore(stream, cancellationToken) :
+            base.SerializeToStreamAsync(stream, context, cancellationToken);
+
+        private protected Task SerializeToStreamAsyncCore(Stream stream, CancellationToken cancellationToken) =>
+            stream.WriteAsync(_content, _offset, _count, cancellationToken);
 
         protected internal override bool TryComputeLength(out long length)
         {

--- a/src/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
@@ -3,10 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
@@ -51,6 +52,12 @@ namespace System.Net.Http
             // Escape spaces as '+'.
             return Uri.EscapeDataString(data).Replace("%20", "+");
         }
+
+        internal override Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken) =>
+            // Only skip the original protected virtual SerializeToStreamAsync if this
+            // isn't a derived type that may have overridden the behavior.
+            GetType() == typeof(FormUrlEncodedContent) ? SerializeToStreamAsyncCore(stream, cancellationToken) :
+            base.SerializeToStreamAsync(stream, context, cancellationToken);
 
         internal override Stream TryCreateContentReadStream() =>
             GetType() == typeof(FormUrlEncodedContent) ? CreateMemoryStreamForByteArray() : // type check ensures we use possible derived type's CreateContentReadStreamAsync override

--- a/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -169,13 +169,22 @@ namespace System.Net.Http
         // write "--" + boundary + "--"
         // Can't be canceled directly by the user.  If the overall request is canceled 
         // then the stream will be closed an exception thrown.
-        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context) =>
+            SerializeToStreamAsyncCore(stream, context, default);
+
+        internal override Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken) =>
+            // Only skip the original protected virtual SerializeToStreamAsync if this
+            // isn't a derived type that may have overridden the behavior.
+            GetType() == typeof(MultipartContent) ? SerializeToStreamAsyncCore(stream, context, cancellationToken) :
+            base.SerializeToStreamAsync(stream, context, cancellationToken);
+
+        private protected async Task SerializeToStreamAsyncCore(Stream stream, TransportContext context, CancellationToken cancellationToken)
         {
             Debug.Assert(stream != null);
             try
             {
                 // Write start boundary.
-                await EncodeStringToStreamAsync(stream, "--" + _boundary + CrLf).ConfigureAwait(false);
+                await EncodeStringToStreamAsync(stream, "--" + _boundary + CrLf, cancellationToken).ConfigureAwait(false);
 
                 // Write each nested content.
                 var output = new StringBuilder();
@@ -183,12 +192,12 @@ namespace System.Net.Http
                 {
                     // Write divider, headers, and content.
                     HttpContent content = _nestedContent[contentIndex];
-                    await EncodeStringToStreamAsync(stream, SerializeHeadersToString(output, contentIndex, content)).ConfigureAwait(false);
-                    await content.CopyToAsync(stream).ConfigureAwait(false);
+                    await EncodeStringToStreamAsync(stream, SerializeHeadersToString(output, contentIndex, content), cancellationToken).ConfigureAwait(false);
+                    await content.CopyToAsync(stream, context, cancellationToken).ConfigureAwait(false);
                 }
 
                 // Write footer boundary.
-                await EncodeStringToStreamAsync(stream, CrLf + "--" + _boundary + "--" + CrLf).ConfigureAwait(false);
+                await EncodeStringToStreamAsync(stream, CrLf + "--" + _boundary + "--" + CrLf, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -271,10 +280,10 @@ namespace System.Net.Http
             return scratch.ToString();
         }
 
-        private static ValueTask EncodeStringToStreamAsync(Stream stream, string input)
+        private static ValueTask EncodeStringToStreamAsync(Stream stream, string input, CancellationToken cancellationToken)
         {
             byte[] buffer = HttpRuleParser.DefaultHttpEncoding.GetBytes(input);
-            return stream.WriteAsync(new ReadOnlyMemory<byte>(buffer));
+            return stream.WriteAsync(new ReadOnlyMemory<byte>(buffer), cancellationToken);
         }
 
         private static Stream EncodeStringToNewStream(string input)

--- a/src/System.Net.Http/src/System/Net/Http/MultipartFormDataContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MultipartFormDataContent.cs
@@ -3,7 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
@@ -84,5 +87,11 @@ namespace System.Net.Http
             }
             base.Add(content);
         }
+
+        internal override Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken) =>
+            // Only skip the original protected virtual SerializeToStreamAsync if this
+            // isn't a derived type that may have overridden the behavior.
+            GetType() == typeof(MultipartFormDataContent) ? SerializeToStreamAsyncCore(stream, context, cancellationToken) :
+            base.SerializeToStreamAsync(stream, context, cancellationToken);
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -52,13 +52,25 @@ namespace System.Net.Http
             if (NetEventSource.IsEnabled) NetEventSource.Associate(this, content);
         }
 
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context) =>
+            SerializeToStreamAsyncCore(stream, default);
+
+        internal override Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken) =>
+            // Only skip the original protected virtual SerializeToStreamAsync if this
+            // isn't a derived type that may have overridden the behavior.
+            GetType() == typeof(StreamContent) ? SerializeToStreamAsyncCore(stream, cancellationToken) :
+            base.SerializeToStreamAsync(stream, context, cancellationToken);
+
+        private Task SerializeToStreamAsyncCore(Stream stream, CancellationToken cancellationToken)
         {
             Debug.Assert(stream != null);
-
             PrepareContent();
-            // If the stream can't be re-read, make sure that it gets disposed once it is consumed.
-            return StreamToStreamCopy.CopyAsync(_content, stream, _bufferSize, !_content.CanSeek);
+            return StreamToStreamCopy.CopyAsync(
+                _content,
+                stream,
+                _bufferSize,
+                !_content.CanSeek, // If the stream can't be re-read, make sure that it gets disposed once it is consumed.
+                cancellationToken);
         }
 
         protected internal override bool TryComputeLength(out long length)

--- a/src/System.Net.Http/src/System/Net/Http/StringContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StringContent.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.Net.Http
@@ -52,6 +53,12 @@ namespace System.Net.Http
 
             return encoding.GetBytes(content);
         }
+
+        internal override Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken) =>
+            // Only skip the original protected virtual SerializeToStreamAsync if this
+            // isn't a derived type that may have overridden the behavior.
+            GetType() == typeof(StringContent) ? SerializeToStreamAsyncCore(stream, cancellationToken) :
+            base.SerializeToStreamAsync(stream, context, cancellationToken);
 
         internal override Stream TryCreateContentReadStream() =>
             GetType() == typeof(StringContent) ? CreateMemoryStreamForByteArray() : // type check ensures we use possible derived type's CreateContentReadStreamAsync override

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -4,9 +4,10 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.IO;
+using System.Linq;
 using System.Net.Test.Common;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -399,6 +400,92 @@ namespace System.Net.Http.Functional.Tests
                     Task serverTask = server.HandleRequestAsync();
                     await clientCanceled.Task;
                 });
+        }
+
+        public static IEnumerable<object[]> PostAsync_Cancel_CancellationTokenPassedToContent_MemberData()
+        {
+            foreach (CancellationToken expectedToken in new[] { CancellationToken.None, new CancellationTokenSource().Token })
+            {
+                // StreamContent
+                {
+                    var actualToken = new StrongBox<CancellationToken>();
+                    bool called = false;
+                    var content = new StreamContent(new DelegateStream(
+                        canReadFunc: () => true,
+                        readAsyncFunc: (buffer, offset, count, cancellationToken) =>
+                        {
+                            actualToken.Value = cancellationToken;
+                            int result = called ? 0 : 1;
+                            called = true;
+                            return Task.FromResult(result);
+                        }
+                    ));
+                    yield return new object[] { content, expectedToken, actualToken };
+                }
+
+                // MultipartContent
+                {
+                    var actualToken = new StrongBox<CancellationToken>();
+                    bool called = false;
+                    var content = new MultipartContent();
+                    content.Add(new StreamContent(new DelegateStream(
+                        canReadFunc: () => true,
+                        canSeekFunc: () => true,
+                        lengthFunc: () => 1,
+                        positionGetFunc: () => 0,
+                        positionSetFunc: _ => {},
+                        readAsyncFunc: (buffer, offset, count, cancellationToken) =>
+                        {
+                            actualToken.Value = cancellationToken;
+                            int result = called ? 0 : 1;
+                            called = true;
+                            return Task.FromResult(result);
+                        }
+                    )));
+                    yield return new object[] { content, expectedToken, actualToken };
+                }
+
+                // MultipartFormDataContent
+                {
+                    var actualToken = new StrongBox<CancellationToken>();
+                    bool called = false;
+                    var content = new MultipartFormDataContent();
+                    content.Add(new StreamContent(new DelegateStream(
+                        canReadFunc: () => true,
+                        canSeekFunc: () => true,
+                        lengthFunc: () => 1,
+                        positionGetFunc: () => 0,
+                        positionSetFunc: _ => {},
+                        readAsyncFunc: (buffer, offset, count, cancellationToken) =>
+                        {
+                            actualToken.Value = cancellationToken;
+                            int result = called ? 0 : 1;
+                            called = true;
+                            return Task.FromResult(result);
+                        }
+                    )));
+                    yield return new object[] { content, expectedToken, actualToken };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(PostAsync_Cancel_CancellationTokenPassedToContent_MemberData))]
+        public async Task PostAsync_Cancel_CancellationTokenPassedToContent(HttpContent content, CancellationToken expectedToken, StrongBox<CancellationToken> actualToken)
+        {
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using (var invoker = new HttpMessageInvoker(CreateHttpClientHandler()))
+                    using (var req = new HttpRequestMessage(HttpMethod.Post, uri) { Content = content, Version = VersionFromUseHttp2 })
+                    using (HttpResponseMessage resp = await invoker.SendAsync(req, expectedToken))
+                    {
+                        Assert.Equal("Hello World", await resp.Content.ReadAsStringAsync());
+                    }
+                },
+                server => server.HandleRequestAsync(content: "Hello World"));
+
+            Assert.Equal(expectedToken, actualToken.Value);
         }
 
         private async Task ValidateClientCancellationAsync(Func<Task> clientBodyAsync)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Cancellation.cs
@@ -473,6 +473,12 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(PostAsync_Cancel_CancellationTokenPassedToContent_MemberData))]
         public async Task PostAsync_Cancel_CancellationTokenPassedToContent(HttpContent content, CancellationToken expectedToken, StrongBox<CancellationToken> actualToken)
         {
+            if (IsUapHandler)
+            {
+                // HttpHandlerToFilter doesn't flow the token into the request body.
+                return;
+            }
+
             await LoopbackServerFactory.CreateClientAndServerAsync(
                 async uri =>
                 {


### PR DESCRIPTION
We don't currently expose the overload that would allow CancellationToken to be accessed by HttpContent-derived types in general, but we can at least ensure that when using the built-in content types, the CancellationToken provided to SendAsync is appropriately threaded through.  We were doing this previously in only a few cases, where we knew that the previous overload wouldn't be overridden (namely internal types and sealed types), but we can enable the 90% scenario as well by doing a type check at run-time.

Fixes https://github.com/dotnet/corefx/issues/39467
cc: @geoffkizer, @davidsh, @scalablecory, @eiriktsarpalis, @wfurt 