### PR TITLE
Address nits from other serialization PRs

### DIFF
--- a/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -419,7 +419,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ClassWithNoSetter()
         {
-            // We don't attempt to deserialize into collections without a setter.
+            // We replace the contents of this collection; we don't attempt to add items to the existing collection instance.
             string json = @"{""MyList"":[1,2]}";
             ClassWithPopulatedListAndNoSetter obj = JsonSerializer.Deserialize<ClassWithPopulatedListAndNoSetter>(json);
             Assert.Equal(1, obj.MyList.Count);
@@ -433,7 +433,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void ClassWithPopulatedList()
         {
-            // We don't attempt to deserialize into collections without a setter.
+            // We replace the contents of this collection; we don't attempt to add items to the existing collection instance.
             string json = @"{""MyList"":[2,3]}";
             ClassWithPopulatedListAndSetter obj = JsonSerializer.Deserialize<ClassWithPopulatedListAndSetter>(json);
             Assert.Equal(2, obj.MyList.Count);

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.KeyPolicy.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.KeyPolicy.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Runtime.Serialization;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests

--- a/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
+++ b/src/System.Text.Json/tests/Serialization/DictionaryTests.cs
@@ -5,7 +5,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests

--- a/src/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
@@ -191,9 +191,11 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData(16000)]
         public static async Task LargeJsonFile(int bufferSize)
         {
+            const int SessionResponseCount = 100;
+
             // Build up a large list to serialize.
             var list = new List<SessionResponse>();
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < SessionResponseCount; i++)
             {
                 SessionResponse response = new SessionResponse
                 {
@@ -238,7 +240,7 @@ namespace System.Text.Json.Serialization.Tests
             // Sync case.
             {
                 List<SessionResponse> deserializedList = JsonSerializer.Deserialize<List<SessionResponse>>(json, options);
-                Assert.Equal(100, deserializedList.Count);
+                Assert.Equal(SessionResponseCount, deserializedList.Count);
 
                 string jsonSerialized = JsonSerializer.Serialize(deserializedList, options);
                 Assert.Equal(json, jsonSerialized);
@@ -253,7 +255,7 @@ namespace System.Text.Json.Serialization.Tests
 
                 memoryStream.Position = 0;
                 List<SessionResponse> deserializedList = await JsonSerializer.DeserializeAsync<List<SessionResponse>>(memoryStream, options);
-                Assert.Equal(100, deserializedList.Count);
+                Assert.Equal(SessionResponseCount, deserializedList.Count);
             }
         }
     }


### PR DESCRIPTION
Remaining non-functional nits from
https://github.com/dotnet/corefx/commit/ef1ac63f264c6c1f170315c636da49b4bf421dd9
https://github.com/dotnet/corefx/commit/86b699192dd1a7d0ad3f8765f05e401056bdb6be
+ remove unnecessary using from namespace.