### PR TITLE
Request-in-flight GOAWAY test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -779,6 +779,48 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalFact(nameof(SupportsAlpn))]
+        public async Task GoAwayFrame_RequestInFlight_Finished()
+        {
+            using (await Watchdog.CreateAsync())
+            using (var server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address);
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+                int streamId = await connection.ReadRequestHeaderAsync();
+
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+
+                await connection.SendResponseBodyAsync(streamId, new byte[5] { 5, 4, 3, 2, 1 }, isFinal: false);
+                await connection.SendResponseBodyAsync(streamId, new byte[6] { 11, 10, 9, 8, 7, 6 }, isFinal: false);
+                // Signal that our request is the last thing which will be processed
+                await connection.SendGoAway(streamId);
+
+                // Make sure client received GOAWAY
+                await connection.PingPong();
+
+                await connection.SendResponseBodyAsync(streamId, new byte[4] { 15, 14, 13, 12 }, isFinal: false);
+                await connection.SendResponseBodyAsync(streamId, new byte[5] { 20, 19, 18, 17, 16 }, isFinal: true);
+
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                byte[] responseBody = await response.Content.ReadAsByteArrayAsync();
+
+                Assert.Equal(
+                    new byte[20]
+                    {
+                        5, 4, 3, 2, 1,
+                        11, 10, 9, 8, 7, 6,
+                        15, 14, 13, 12,
+                        20, 19, 18, 17, 16,
+                    },
+                    responseBody);
+
+                await connection.WaitForConnectionShutdownAsync();
+            }
+        }
+
+        [ConditionalFact(nameof(SupportsAlpn))]
         public async Task DataFrame_TooLong_ConnectionError()
         {
             using (var server = Http2LoopbackServer.CreateServer())


### PR DESCRIPTION
Fixes: https://github.com/dotnet/corefx/issues/34638

Most of the tests for that issue were already added in the previous PRs.

I wasn't sure how to test WINDOW_UPDATE and SETTINGS test mentioned in the issue but they don't seem super important considering PING is a very similar scenario and we already have that tested.