### PR TITLE
Update branding in master to 5.0

### DIFF
--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -23,7 +23,7 @@
     <SkipBaseLineCheck>true</SkipBaseLineCheck>
 
     <!-- by default all packages will use the same version which revs with respect to product version -->
-    <PackageVersion Condition="'$(PackageVersion)' == ''">4.6.0</PackageVersion>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">5.0.0</PackageVersion>
     <!-- major.minor.release version of the platforms package we're currently building
          Pre-release will be appended during build -->
     <PlatformPackageVersion>$(ProductVersion)</PlatformPackageVersion>

--- a/eng/Packaging.props
+++ b/eng/Packaging.props
@@ -29,6 +29,7 @@
     <PlatformPackageVersion>$(ProductVersion)</PlatformPackageVersion>
     <SkipValidatePackageTargetFramework>true</SkipValidatePackageTargetFramework>
     <SkipGenerationCheck>true</SkipGenerationCheck>
+    <SkipIndexCheck>true</SkipIndexCheck>
   </PropertyGroup>
 
   <Import Condition="Exists('../pkg/baseline/baseline.props') AND '$(MSBuildProjectExtension)' == '.pkgproj'" Project="../pkg/baseline/baseline.props" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,13 +1,12 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET Core product branding version -->
-    <ProductVersion>3.0.0</ProductVersion>
-    <!-- We need to move to 4.7 as part of our versioning change when we switch to arcade to avoid downgrading versions -->
-    <MajorVersion>4</MajorVersion>
-    <MinorVersion>7</MinorVersion>
+    <ProductVersion>5.0.0</ProductVersion>
+    <MajorVersion>5</MajorVersion>
+    <MinorVersion>0</MinorVersion>
     <!-- Always use shipping version instead of dummy version -->
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
-    <PreReleaseVersionLabel>preview8</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview0</PreReleaseVersionLabel>
     <!-- Opt-in repo features -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,7 @@
     <MinorVersion>0</MinorVersion>
     <!-- Always use shipping version instead of dummy version -->
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
-    <PreReleaseVersionLabel>preview0</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>alpha1</PreReleaseVersionLabel>
     <!-- Opt-in repo features -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>

--- a/pkg/Microsoft.NETCore.Platforms.Future/Microsoft.NETCore.Platforms.Future.pkgproj
+++ b/pkg/Microsoft.NETCore.Platforms.Future/Microsoft.NETCore.Platforms.Future.pkgproj
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>3.0.0</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>

--- a/pkg/Microsoft.NETCore.Platforms.Future/Microsoft.NETCore.Platforms.Future.pkgproj
+++ b/pkg/Microsoft.NETCore.Platforms.Future/Microsoft.NETCore.Platforms.Future.pkgproj
@@ -1,7 +1,6 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>3.0.0</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>

--- a/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
+++ b/pkg/Microsoft.NETCore.Targets/Microsoft.NETCore.Targets.pkgproj
@@ -1,7 +1,6 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -1,7 +1,6 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
     <TargetFrameworkName>uap</TargetFrameworkName>
     <TargetFrameworkVersion>$(UAPvNextVersion)</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>

--- a/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
+++ b/pkg/Microsoft.Private.CoreFx.UAP/Microsoft.Private.CoreFx.UAP.pkgproj
@@ -1,7 +1,7 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>4.7.0</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
     <TargetFrameworkName>uap</TargetFrameworkName>
     <TargetFrameworkVersion>$(UAPvNextVersion)</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -2597,7 +2597,7 @@
         "4.5.2",
         "4.5.3"
       ],
-      "BaselineVersion": "5.0.0",
+      "BaselineVersion": "4.5.3",
       "InboxOn": {
         "netcoreapp2.1": "4.1.0.0",
         "netcoreapp3.0": "4.2.0.0",
@@ -4028,7 +4028,7 @@
         "4.0.0",
         "4.3.0"
       ],
-      "BaselineVersion": "5.0.0",
+      "BaselineVersion": "4.3.0",
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.0",
         "netcoreapp2.1": "4.0.3.0",
@@ -5425,7 +5425,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "5.0.0",
+      "BaselineVersion": "4.5.0",
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.0",
         "netcoreapp2.1": "4.0.3.0",

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -21,12 +21,14 @@
       }
     },
     "Microsoft.Bcl.AsyncInterfaces": {
+      "BaselineVersion": "1.1.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.0.0": "1.0.0"
       }
     },
     "Microsoft.Bcl.HashCode": {
+      "BaselineVersion": "1.1.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.0.0": "1.0.0"
@@ -115,6 +117,7 @@
       }
     },
     "Microsoft.Diagnostics.Tracing.EventSource.Redist": {
+      "BaselineVersion": "2.2.0",
       "StableVersions": [
         "2.0.0",
         "2.0.1"
@@ -152,7 +155,7 @@
         "2.1.4",
         "2.2.0"
       ],
-      "BaselineVersion": "3.0.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
     "Microsoft.NETCore.Targets": {
@@ -164,7 +167,7 @@
         "2.0.0",
         "2.1.0"
       ],
-      "BaselineVersion": "3.0.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
     "Microsoft.Phone": {
@@ -247,6 +250,7 @@
       }
     },
     "Microsoft.VisualBasic.Core": {
+      "BaselineVersion": "10.5.0",
       "InboxOn": {
         "netcoreapp3.0": "10.0.4.0",
         "uap10.0.16300": "10.0.4.0"
@@ -353,6 +357,7 @@
         "1.0.0",
         "2.0.0"
       ],
+      "BaselineVersion": "2.2.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "1.0.0.0": "1.0.0",
@@ -758,7 +763,7 @@
         "1.4.0",
         "1.5.0"
       ],
-      "BaselineVersion": "1.6.0",
+      "BaselineVersion": "1.7.0",
       "InboxOn": {
         "netcoreapp2.0": "1.2.2.0",
         "netcoreapp2.1": "1.2.3.0",
@@ -1050,7 +1055,7 @@
         "1.1.0",
         "1.2.0"
       ],
-      "BaselineVersion": "1.3.0",
+      "BaselineVersion": "1.4.0",
       "InboxOn": {}
     },
     "System.Composition.AttributedModel": {
@@ -1329,7 +1334,7 @@
         "4.6.0",
         "4.6.1"
       ],
-      "BaselineVersion": "4.7.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "net461": "4.1.0.0",
         "monoandroid10": "Any",
@@ -3168,7 +3173,7 @@
       "StableVersions": [
         "0.1.0"
       ],
-      "BaselineVersion": "0.2.0",
+      "BaselineVersion": "0.3.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "0.1.0.0": "0.1.0",
@@ -3529,7 +3534,7 @@
         "1.5.0",
         "1.6.0"
       ],
-      "BaselineVersion": "1.7.0",
+      "BaselineVersion": "1.8.0",
       "InboxOn": {
         "netcoreapp2.0": "1.4.2.0",
         "netcoreapp2.1": "1.4.3.0",
@@ -5229,7 +5234,7 @@
         "4.8.0",
         "4.9.0"
       ],
-      "BaselineVersion": "4.10.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.6.2.0",
         "netcoreapp2.1": "4.6.3.0",

--- a/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
+++ b/pkg/Microsoft.Private.PackageBaseline/packageIndex.json
@@ -73,7 +73,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.0.3.0",
         "netcoreapp2.1": "4.0.4.0",
@@ -127,6 +127,7 @@
       }
     },
     "Microsoft.IO.Redist": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.6.0"
@@ -294,7 +295,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -311,7 +312,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -325,7 +326,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.5.0",
@@ -513,11 +514,11 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
     "runtime.native.System.IO.Ports": {
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {}
     },
     "runtime.win7-x64.runtime.native.System.Data.SqlClient.sni": {
@@ -662,7 +663,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
@@ -875,7 +876,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.2.0.0",
         "netcoreapp2.1": "4.2.1.0",
@@ -908,7 +909,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "net45": "4.0.0.0",
         "monoandroid10": "Any",
@@ -924,6 +925,7 @@
       }
     },
     "System.ComponentModel.Composition.Registration": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "net45": "4.0.0.0"
       },
@@ -1138,7 +1140,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
@@ -1277,7 +1279,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.5.0",
@@ -1285,6 +1287,7 @@
       }
     },
     "System.Data.OleDb": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.6.0"
@@ -1460,7 +1463,7 @@
         "4.5.0",
         "4.5.1"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.1",
         "netcoreapp2.1": "4.0.3.1",
@@ -1480,7 +1483,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.5.0",
@@ -1515,7 +1518,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "monoandroid10": "Any",
         "monotouch10": "Any",
@@ -1725,7 +1728,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "net45": "4.0.0.0"
       },
@@ -1737,7 +1740,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "net45": "4.0.0.0"
       },
@@ -1749,7 +1752,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "net45": "4.0.0.0"
       },
@@ -1770,7 +1773,7 @@
         "4.5.0",
         "4.5.1"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "monoandroid10": "Any",
         "monotouch10": "Any",
@@ -2141,7 +2144,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -2287,7 +2290,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -2304,7 +2307,7 @@
         "4.5.2",
         "4.5.3"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.5.0",
@@ -2352,7 +2355,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "uap10.0.16299": "4.0.1.0",
         "uap10.0.16300": "4.0.2.0"
@@ -2394,7 +2397,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "monoandroid10": "Any",
         "monotouch10": "Any",
@@ -2532,7 +2535,7 @@
         "4.0.1",
         "4.3.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.0.3.0",
         "net45": "4.0.0.0",
@@ -2569,7 +2572,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "net45": "4.0.0.0"
       },
@@ -2589,7 +2592,7 @@
         "4.5.2",
         "4.5.3"
       ],
-      "BaselineVersion": "4.5.3",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.1": "4.1.0.0",
         "netcoreapp3.0": "4.2.0.0",
@@ -2743,7 +2746,7 @@
         "4.5.3",
         "4.5.4"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -3131,7 +3134,7 @@
         "4.5.2",
         "4.5.3"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.5.0",
@@ -3212,7 +3215,7 @@
         "4.0.0",
         "4.3.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "uap10.0.16299": "4.0.4.0"
       },
@@ -3352,7 +3355,7 @@
         "4.0.0",
         "4.3.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "net45": "4.0.0.0",
         "portable46-net451+win81": "4.0.0.0",
@@ -3376,7 +3379,7 @@
         "4.5.1",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.0.3.0",
         "netcoreapp2.1": "4.0.4.0",
@@ -3405,7 +3408,7 @@
         "4.0.1",
         "4.3.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.1.0.0",
         "netcoreapp3.0": "4.1.1.0",
@@ -3546,6 +3549,7 @@
       }
     },
     "System.Reflection.MetadataLoadContext": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.6.0"
@@ -3600,7 +3604,7 @@
         "4.5.0",
         "4.5.1"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.1.2.0",
         "netcoreapp2.1": "4.1.3.0",
@@ -3624,6 +3628,7 @@
       }
     },
     "System.Resources.Extensions": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.6.0"
@@ -3767,7 +3772,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "net45": "4.0.0.0",
         "monoandroid10": "Any",
@@ -3788,7 +3793,7 @@
         "4.5.1",
         "4.5.2"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp3.0": "4.0.5.0",
         "uap10.0.16300": "4.0.5.0"
@@ -3969,7 +3974,7 @@
         "4.0.1",
         "4.3.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.0.3.0",
         "net45": "4.0.0.0",
@@ -4007,6 +4012,7 @@
       }
     },
     "System.Runtime.Intrinsics.Experimental": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.6.0"
@@ -4017,7 +4023,7 @@
         "4.0.0",
         "4.3.0"
       ],
-      "BaselineVersion": "4.3.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.0",
         "netcoreapp2.1": "4.0.3.0",
@@ -4262,7 +4268,7 @@
         "4.0.11",
         "4.3.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "net45": "4.0.0.0",
         "net451": "4.0.10.0",
@@ -4291,7 +4297,7 @@
         "4.0.0",
         "4.3.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "net45": "4.0.0.0",
         "portable46-win81+wpa81": "4.0.0.0",
@@ -4321,7 +4327,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "uap10.0.16299": "4.1.1.0"
       },
@@ -4392,7 +4398,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "monoandroid10": "Any",
         "monotouch10": "Any",
@@ -4469,7 +4475,7 @@
         "4.5.0",
         "4.5.1"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -4489,7 +4495,7 @@
         "4.5.1",
         "4.5.2"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -4533,7 +4539,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "monoandroid10": "Any",
         "monotouch10": "Any",
@@ -4580,7 +4586,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
@@ -4593,7 +4599,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.4.0",
@@ -4649,7 +4655,7 @@
         "4.5.0",
         "4.5.1"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "uap10.0.16299": "4.1.1.0"
       },
@@ -4826,7 +4832,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.5.0",
@@ -4874,7 +4880,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.1.0.0": "4.1.0",
@@ -4941,7 +4947,7 @@
         "4.5.0",
         "4.5.1"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "monoandroid10": "Any",
         "monotouch10": "Any",
@@ -5012,7 +5018,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp3.0": "4.0.4.0",
         "uap10.0.16300": "4.0.4.0"
@@ -5026,6 +5032,7 @@
       }
     },
     "System.Text.Json": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp3.0": "4.0.0.0",
         "uap10.0.16300": "4.0.0.0"
@@ -5128,7 +5135,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.0.0",
@@ -5142,7 +5149,7 @@
       "StableVersions": [
         "4.5.0"
       ],
-      "BaselineVersion": "4.6.0",
+      "BaselineVersion": "5.0.0",
         "InboxOn": {
           "netcoreapp3.0":  "4.0.1.0"
         },
@@ -5401,6 +5408,7 @@
       }
     },
     "System.Utf8String.Experimental": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.6.0"
@@ -5412,7 +5420,7 @@
         "4.4.0",
         "4.5.0"
       ],
-      "BaselineVersion": "4.5.0",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {
         "netcoreapp2.0": "4.0.2.0",
         "netcoreapp2.1": "4.0.3.0",
@@ -5558,6 +5566,7 @@
       }
     },
     "System.Windows.Extensions": {
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.0.0": "4.6.0"

--- a/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
       <!-- We use the PackageVersion property defined in Packaging.props for the Prerelease packages which are using it to be built -->
     <_PreReleasePackageVersion>$(PackageVersion)</_PreReleasePackageVersion>
-    <PackageVersion>3.0.0</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
     <ServiceModelVersion>4.5.3</ServiceModelVersion>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>
@@ -30,7 +30,7 @@
     <PrereleaseLibraryPackage Include="System.Data.OleDb" />
     <PrereleaseLibraryPackage Include="System.Data.SqlClient">
       <!-- SQL client defines its own version, higher than rest of master -->
-      <Version>4.7.0</Version>
+      <Version>5.0.0</Version>
     </PrereleaseLibraryPackage>
     <PrereleaseLibraryPackage Include="System.Drawing.Common" />
     <PrereleaseLibraryPackage Include="System.Diagnostics.EventLog" />

--- a/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -1,19 +1,16 @@
 ﻿<Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Directory.Build.props))\Directory.Build.props" />
   <PropertyGroup>
-      <!-- We use the PackageVersion property defined in Packaging.props for the Prerelease packages which are using it to be built -->
-    <_PreReleasePackageVersion>$(PackageVersion)</_PreReleasePackageVersion>
-    <PackageVersion>5.0.0</PackageVersion>
     <ServiceModelVersion>4.5.3</ServiceModelVersion>
     <!-- We don't need to harvest the stable packages to build this -->
     <HarvestStablePackage>false</HarvestStablePackage>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <PrereleaseLibraryPackage>
-      <Version>$(_PreReleasePackageVersion)</Version>
+      <Version>$(PackageVersion)</Version>
     </PrereleaseLibraryPackage>
     <NS21PrereleaseLibraryPackage>
-      <Version>$(_PreReleasePackageVersion)</Version>
+      <Version>$(PackageVersion)</Version>
     </NS21PrereleaseLibraryPackage>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -28,10 +25,7 @@
     <PrereleaseLibraryPackage Include="System.Configuration.ConfigurationManager" />
     <PrereleaseLibraryPackage Include="System.Data.Odbc" />
     <PrereleaseLibraryPackage Include="System.Data.OleDb" />
-    <PrereleaseLibraryPackage Include="System.Data.SqlClient">
-      <!-- SQL client defines its own version, higher than rest of master -->
-      <Version>5.0.0</Version>
-    </PrereleaseLibraryPackage>
+    <PrereleaseLibraryPackage Include="System.Data.SqlClient" />
     <PrereleaseLibraryPackage Include="System.Drawing.Common" />
     <PrereleaseLibraryPackage Include="System.Diagnostics.EventLog" />
     <PrereleaseLibraryPackage Include="System.Diagnostics.PerformanceCounter" />

--- a/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
+++ b/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->
   </PropertyGroup>

--- a/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
+++ b/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <PackageVersion>5.0.0</PackageVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->
   </PropertyGroup>

--- a/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
+++ b/src/Microsoft.Bcl.AsyncInterfaces/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->

--- a/src/Microsoft.Bcl.HashCode/Directory.Build.props
+++ b/src/Microsoft.Bcl.HashCode/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->
   </PropertyGroup>

--- a/src/Microsoft.Bcl.HashCode/Directory.Build.props
+++ b/src/Microsoft.Bcl.HashCode/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <PackageVersion>5.0.0</PackageVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->
   </PropertyGroup>

--- a/src/Microsoft.Bcl.HashCode/Directory.Build.props
+++ b/src/Microsoft.Bcl.HashCode/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
+    <PackageVersion>1.1.0</PackageVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- This assembly should never be placed inbox as it is only for downlevel compatibility. -->

--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/Directory.Build.props
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <PackageVersion>5.0.0</PackageVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <AssemblyVersion>2.0.2.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/Directory.Build.props
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
+    <PackageVersion>2.2.0</PackageVersion>
     <AssemblyVersion>2.0.2.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/Directory.Build.props
+++ b/src/Microsoft.Diagnostics.Tracing.EventSource.Redist/Directory.Build.props
@@ -1,8 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>2.1.0</PackageVersion>
-    <AssemblyVersion>2.0.2.0</AssemblyVersion>
+    <PackageVersion>5.0.0</PackageVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualBasic.Core/Directory.Build.props
+++ b/src/Microsoft.VisualBasic.Core/Directory.Build.props
@@ -1,8 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>10.4.0</PackageVersion>
-    <AssemblyVersion>10.0.4.0</AssemblyVersion>
+    <PackageVersion>5.0.0</PackageVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/Microsoft.VisualBasic.Core/Directory.Build.props
+++ b/src/Microsoft.VisualBasic.Core/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>11.4.0</PackageVersion>
+    <PackageVersion>10.5.0</PackageVersion>
     <AssemblyVersion>10.0.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/Microsoft.VisualBasic.Core/Directory.Build.props
+++ b/src/Microsoft.VisualBasic.Core/Directory.Build.props
@@ -1,8 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <PackageVersion>11.4.0</PackageVersion>
+    <AssemblyVersion>10.0.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
+++ b/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
+    <PackageVersion>2.2.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion)</AssemblyFileVersion>

--- a/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
+++ b/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>2.1.0</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion)</AssemblyFileVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
+++ b/src/Microsoft.XmlSerializer.Generator/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageVersion>5.0.0</PackageVersion>
     <SkipValidatePackage>true</SkipValidatePackage>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion)</AssemblyFileVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/System.Collections.Immutable/Directory.Build.props
+++ b/src/System.Collections.Immutable/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
+    <PackageVersion>1.7.0</PackageVersion>
     <AssemblyVersion>1.2.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/System.Collections.Immutable/Directory.Build.props
+++ b/src/System.Collections.Immutable/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <PackageVersion>5.0.0</PackageVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <AssemblyVersion>1.2.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Collections.Immutable/Directory.Build.props
+++ b/src/System.Collections.Immutable/Directory.Build.props
@@ -1,8 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>1.6.0</PackageVersion>
-    <AssemblyVersion>1.2.4.0</AssemblyVersion>
+    <PackageVersion>5.0.0</PackageVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Composition/Directory.Build.props
+++ b/src/System.Composition/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
+    <PackageVersion>1.4.0</PackageVersion>
     <AssemblyVersion>1.0.34.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition/Directory.Build.props
+++ b/src/System.Composition/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <PackageVersion>5.0.0</PackageVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <AssemblyVersion>1.0.34.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Composition/Directory.Build.props
+++ b/src/System.Composition/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>1.3.0</PackageVersion>
-    <AssemblyVersion>1.0.34.0</AssemblyVersion>
+    <PackageVersion>5.0.0</PackageVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Data.SqlClient/Directory.Build.props
+++ b/src/System.Data.SqlClient/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Must be kept in sync with pkg\Microsoft.Windows.Compatibility\Microsoft.Windows.Compatibility.pkgproj -->
     <PackageVersion>5.0.0</PackageVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.6.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsUAP>true</IsUAP>
   </PropertyGroup>

--- a/src/System.Data.SqlClient/Directory.Build.props
+++ b/src/System.Data.SqlClient/Directory.Build.props
@@ -1,8 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <!-- Must be kept in sync with pkg\Microsoft.Windows.Compatibility\Microsoft.Windows.Compatibility.pkgproj -->
-    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyVersion>4.6.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsUAP>true</IsUAP>

--- a/src/System.Data.SqlClient/Directory.Build.props
+++ b/src/System.Data.SqlClient/Directory.Build.props
@@ -2,8 +2,8 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <!-- Must be kept in sync with pkg\Microsoft.Windows.Compatibility\Microsoft.Windows.Compatibility.pkgproj -->
-    <PackageVersion>4.7.0</PackageVersion>
-    <AssemblyVersion>4.6.0.0</AssemblyVersion>
+    <PackageVersion>5.0.0</PackageVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsUAP>true</IsUAP>
   </PropertyGroup>

--- a/src/System.Numerics.Tensors/Directory.Build.props
+++ b/src/System.Numerics.Tensors/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
+    <PackageVersion>0.3.0</PackageVersion>
     <AssemblyVersion>0.2.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>

--- a/src/System.Numerics.Tensors/Directory.Build.props
+++ b/src/System.Numerics.Tensors/Directory.Build.props
@@ -1,8 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <PackageVersion>0.2.0</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Numerics.Tensors/Directory.Build.props
+++ b/src/System.Numerics.Tensors/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <PackageVersion>5.0.0</PackageVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
   </PropertyGroup>
 </Project>

--- a/src/System.Reflection.Metadata/Directory.Build.props
+++ b/src/System.Reflection.Metadata/Directory.Build.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
+    <PackageVersion>1.8.0</PackageVersion>
     <AssemblyVersion>1.4.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>

--- a/src/System.Reflection.Metadata/Directory.Build.props
+++ b/src/System.Reflection.Metadata/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <PackageVersion>5.0.0</PackageVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <AssemblyVersion>1.4.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Reflection.Metadata/Directory.Build.props
+++ b/src/System.Reflection.Metadata/Directory.Build.props
@@ -1,8 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>1.7.0</PackageVersion>
-    <AssemblyVersion>1.4.4.0</AssemblyVersion>
+    <PackageVersion>5.0.0</PackageVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Threading.Tasks.Dataflow/Directory.Build.props
+++ b/src/System.Threading.Tasks.Dataflow/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <PackageVersion>5.0.0</PackageVersion>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <AssemblyVersion>4.6.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Threading.Tasks.Dataflow/Directory.Build.props
+++ b/src/System.Threading.Tasks.Dataflow/Directory.Build.props
@@ -1,8 +1,8 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>4.10.0</PackageVersion>
-    <AssemblyVersion>4.6.4.0</AssemblyVersion>
+    <PackageVersion>5.0.0</PackageVersion>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>
     <IsUAP>true</IsUAP>

--- a/src/System.Threading.Tasks.Dataflow/Directory.Build.props
+++ b/src/System.Threading.Tasks.Dataflow/Directory.Build.props
@@ -1,7 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <PackageVersion>5.0.0</PackageVersion>
     <AssemblyVersion>4.6.4.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IsNETCoreApp>true</IsNETCoreApp>


### PR DESCRIPTION
Please don't merge this until 7/16, after noon PST

Updates branding to 5.0, as part of https://github.com/dotnet/corefx/issues/39489. This updates the following things to 5.0:

`ProductVersion`
`PackageVersion`s
`FileVersion`s

There are some seemingly special cases here, which I'll call out in the individual files. We'll still need to figure out what to do w/ AssemblyVersions, and if there's anywhere I missed for FileVersions (I believe I've got everything, but it's possible I missed something. I'm doing a local build which I'll inspect for weirdness.

@ericstj @safern @ViktorHofer @joperezr @danmosemsft PTAL