### PR TITLE
Remove unnecessary "internal" from JsonConverterFactory ctor

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -466,7 +466,7 @@ namespace System.Text.Json.Serialization
     }
     public abstract partial class JsonConverterFactory : System.Text.Json.Serialization.JsonConverter
     {
-        protected internal JsonConverterFactory() { }
+        protected JsonConverterFactory() { }
         public abstract System.Text.Json.Serialization.JsonConverter CreateConverter(System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
     }
     public abstract partial class JsonConverter<T> : System.Text.Json.Serialization.JsonConverter

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -17,7 +17,7 @@ namespace System.Text.Json.Serialization
         /// <summary>
         /// When overidden, constructs a new <see cref="JsonConverterFactory"/> instance.
         /// </summary>
-        protected internal JsonConverterFactory() { }
+        protected JsonConverterFactory() { }
 
         internal JsonConverter GetConverterInternal(Type typeToConvert, JsonSerializerOptions options)
         {


### PR DESCRIPTION
The ctor is already `protected`, so it can already be accessed by any derived type.  The only benefit adding `internal` would provide is so that it could be called directly by something else in the assembly, but the type is `abstract`, so that doesn't make sense for a ctor.

https://github.com/dotnet/corefx/pull/39438#discussion_r303219365
cc: @steveharter, @JeremyKuhne 