### PR TITLE
Propagate abort exceptions from CreditManager.Dispose

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1419,8 +1419,8 @@ namespace System.Net.Http
             // Do shutdown.
             _stream.Close();
 
-            _connectionWindow.Dispose();
-            _concurrentStreams.Dispose();
+            _connectionWindow.Dispose(_abortException);
+            _concurrentStreams.Dispose(_abortException);
         }
 
         public void Dispose()

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -722,7 +722,7 @@ namespace System.Net.Http
                     {
                         _disposed = true;
 
-                        _streamWindow.Dispose();
+                        _streamWindow.Dispose(_abortException);
                         _responseBuffer.Dispose();
 
                         // TODO: ISSUE 31310: If the stream is not complete, we should send RST_STREAM


### PR DESCRIPTION
Currently, if an abort occurs, it disposes of credit managers, and if there's a waiter on that credit manager, that waiter propagates an ObjectDisposedException.  It should instead propagate whatever exception resulted from the abort.

Fixes https://github.com/dotnet/corefx/issues/39511
cc: @geoffkizer, @scalablecory, @davidsh, @eiriktsarpalis, @wfurt 