### PR TITLE
Add arm64 runtime ids for Fedora and RHEL 8

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -587,6 +587,16 @@
     "any",
     "base"
   ],
+  "fedora-arm64": [
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
   "fedora-x64": [
     "fedora-x64",
     "fedora",
@@ -601,6 +611,18 @@
     "fedora.23",
     "fedora",
     "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.23-arm64": [
+    "fedora.23-arm64",
+    "fedora.23",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
     "unix",
     "any",
     "base"
@@ -625,6 +647,18 @@
     "any",
     "base"
   ],
+  "fedora.24-arm64": [
+    "fedora.24-arm64",
+    "fedora.24",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
   "fedora.24-x64": [
     "fedora.24-x64",
     "fedora.24",
@@ -641,6 +675,18 @@
     "fedora.25",
     "fedora",
     "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.25-arm64": [
+    "fedora.25-arm64",
+    "fedora.25",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
     "unix",
     "any",
     "base"
@@ -665,6 +711,18 @@
     "any",
     "base"
   ],
+  "fedora.26-arm64": [
+    "fedora.26-arm64",
+    "fedora.26",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
   "fedora.26-x64": [
     "fedora.26-x64",
     "fedora.26",
@@ -681,6 +739,18 @@
     "fedora.27",
     "fedora",
     "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.27-arm64": [
+    "fedora.27-arm64",
+    "fedora.27",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
     "unix",
     "any",
     "base"
@@ -705,6 +775,18 @@
     "any",
     "base"
   ],
+  "fedora.28-arm64": [
+    "fedora.28-arm64",
+    "fedora.28",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
   "fedora.28-x64": [
     "fedora.28-x64",
     "fedora.28",
@@ -721,6 +803,18 @@
     "fedora.29",
     "fedora",
     "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.29-arm64": [
+    "fedora.29-arm64",
+    "fedora.29",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
     "unix",
     "any",
     "base"
@@ -745,6 +839,18 @@
     "any",
     "base"
   ],
+  "fedora.30-arm64": [
+    "fedora.30-arm64",
+    "fedora.30",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
   "fedora.30-x64": [
     "fedora.30-x64",
     "fedora.30",
@@ -761,6 +867,18 @@
     "fedora.31",
     "fedora",
     "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "fedora.31-arm64": [
+    "fedora.31-arm64",
+    "fedora.31",
+    "fedora-arm64",
+    "fedora",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
     "unix",
     "any",
     "base"
@@ -2116,6 +2234,16 @@
     "any",
     "base"
   ],
+  "rhel-arm64": [
+    "rhel-arm64",
+    "rhel",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
   "rhel-x64": [
     "rhel-x64",
     "rhel",
@@ -2398,6 +2526,18 @@
     "any",
     "base"
   ],
+  "rhel.8-arm64": [
+    "rhel.8-arm64",
+    "rhel.8",
+    "rhel-arm64",
+    "rhel",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
   "rhel.8-x64": [
     "rhel.8-x64",
     "rhel.8",
@@ -2415,6 +2555,20 @@
     "rhel.8",
     "rhel",
     "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "rhel.8.0-arm64": [
+    "rhel.8.0-arm64",
+    "rhel.8.0",
+    "rhel.8-arm64",
+    "rhel.8",
+    "rhel-arm64",
+    "rhel",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
     "unix",
     "any",
     "base"
@@ -2439,6 +2593,22 @@
     "rhel.8",
     "rhel",
     "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "rhel.8.1-arm64": [
+    "rhel.8.1-arm64",
+    "rhel.8.1",
+    "rhel.8.0-arm64",
+    "rhel.8.0",
+    "rhel.8-arm64",
+    "rhel.8",
+    "rhel-arm64",
+    "rhel",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
     "unix",
     "any",
     "base"

--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -293,6 +293,12 @@
         "linux"
       ]
     },
+    "fedora-arm64": {
+      "#import": [
+        "fedora",
+        "linux-arm64"
+      ]
+    },
     "fedora-x64": {
       "#import": [
         "fedora",
@@ -302,6 +308,12 @@
     "fedora.23": {
       "#import": [
         "fedora"
+      ]
+    },
+    "fedora.23-arm64": {
+      "#import": [
+        "fedora.23",
+        "fedora-arm64"
       ]
     },
     "fedora.23-x64": {
@@ -315,6 +327,12 @@
         "fedora"
       ]
     },
+    "fedora.24-arm64": {
+      "#import": [
+        "fedora.24",
+        "fedora-arm64"
+      ]
+    },
     "fedora.24-x64": {
       "#import": [
         "fedora.24",
@@ -324,6 +342,12 @@
     "fedora.25": {
       "#import": [
         "fedora"
+      ]
+    },
+    "fedora.25-arm64": {
+      "#import": [
+        "fedora.25",
+        "fedora-arm64"
       ]
     },
     "fedora.25-x64": {
@@ -337,6 +361,12 @@
         "fedora"
       ]
     },
+    "fedora.26-arm64": {
+      "#import": [
+        "fedora.26",
+        "fedora-arm64"
+      ]
+    },
     "fedora.26-x64": {
       "#import": [
         "fedora.26",
@@ -346,6 +376,12 @@
     "fedora.27": {
       "#import": [
         "fedora"
+      ]
+    },
+    "fedora.27-arm64": {
+      "#import": [
+        "fedora.27",
+        "fedora-arm64"
       ]
     },
     "fedora.27-x64": {
@@ -359,6 +395,12 @@
         "fedora"
       ]
     },
+    "fedora.28-arm64": {
+      "#import": [
+        "fedora.28",
+        "fedora-arm64"
+      ]
+    },
     "fedora.28-x64": {
       "#import": [
         "fedora.28",
@@ -368,6 +410,12 @@
     "fedora.29": {
       "#import": [
         "fedora"
+      ]
+    },
+    "fedora.29-arm64": {
+      "#import": [
+        "fedora.29",
+        "fedora-arm64"
       ]
     },
     "fedora.29-x64": {
@@ -381,6 +429,12 @@
         "fedora"
       ]
     },
+    "fedora.30-arm64": {
+      "#import": [
+        "fedora.30",
+        "fedora-arm64"
+      ]
+    },
     "fedora.30-x64": {
       "#import": [
         "fedora.30",
@@ -390,6 +444,12 @@
     "fedora.31": {
       "#import": [
         "fedora"
+      ]
+    },
+    "fedora.31-arm64": {
+      "#import": [
+        "fedora.31",
+        "fedora-arm64"
       ]
     },
     "fedora.31-x64": {
@@ -966,6 +1026,12 @@
         "linux"
       ]
     },
+    "rhel-arm64": {
+      "#import": [
+        "rhel",
+        "linux-arm64"
+      ]
+    },
     "rhel-x64": {
       "#import": [
         "rhel",
@@ -1076,6 +1142,12 @@
         "rhel"
       ]
     },
+    "rhel.8-arm64": {
+      "#import": [
+        "rhel.8",
+        "rhel-arm64"
+      ]
+    },
     "rhel.8-x64": {
       "#import": [
         "rhel.8",
@@ -1087,6 +1159,12 @@
         "rhel.8"
       ]
     },
+    "rhel.8.0-arm64": {
+      "#import": [
+        "rhel.8.0",
+        "rhel.8-arm64"
+      ]
+    },
     "rhel.8.0-x64": {
       "#import": [
         "rhel.8.0",
@@ -1096,6 +1174,12 @@
     "rhel.8.1": {
       "#import": [
         "rhel.8.0"
+      ]
+    },
+    "rhel.8.1-arm64": {
+      "#import": [
+        "rhel.8.1",
+        "rhel.8.0-arm64"
       ]
     },
     "rhel.8.1-x64": {

--- a/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -41,7 +41,7 @@
 
     <RuntimeGroup Include="fedora">
       <Parent>linux</Parent>
-      <Architectures>x64</Architectures>
+      <Architectures>x64;arm64</Architectures>
       <Versions>23;24;25;26;27;28;29;30;31</Versions>
       <TreatVersionsAsCompatible>false</TreatVersionsAsCompatible>
     </RuntimeGroup>
@@ -115,7 +115,7 @@
     </RuntimeGroup>
     <RuntimeGroup Include="rhel">
       <Parent>linux</Parent>
-      <Architectures>x64</Architectures>
+      <Architectures>x64;arm64</Architectures>
       <Versions>8;8.0;8.1</Versions>
     </RuntimeGroup>
 


### PR DESCRIPTION
Both Fedora and RHEL 8 have arm64 (aka aarch64) among the primary/main
architectures they support.

Fedora includes aarch64 as a "Primary Architecture":
https://fedoraproject.org/wiki/Architectures#Primary_Architectures

RHEL 8 lists aarch64 right next to x86_64 in the developer download site:
https://developers.redhat.com/products/rhel/download