### PR TITLE
Specify DateTimeKind.Utc in JSON tests to avoid ArgumentOutOfRangeException

### DIFF
--- a/src/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.WriteTests.cs
@@ -202,8 +202,8 @@ namespace System.Text.Json.Serialization.Tests
                     Id = i,
                     Abstract = new string('A', i * 2),
                     Title = new string('T', i),
-                    StartTime = new DateTime(i),
-                    EndTime = new DateTime(i * 10000),
+                    StartTime = new DateTime(i, DateTimeKind.Utc),
+                    EndTime = new DateTime(i * 10000, DateTimeKind.Utc),
                     TrackId = i,
                     Track = new Track()
                     {


### PR DESCRIPTION
Found this issue when testing #39541 which fixes #39067 

I saw that there was an implicit cast from `DateTime` to `DateTimeOffset` (without specifying `DateTimeKind`) in `System.Text.Json.Serialization.Tests.StreamTests.LargeJsonFile` tests. Specifying the `DateTimeKind` to UTC makes the tests pass.

Original exception before fix:
```
System.ArgumentOutOfRangeException : The UTC time represented when the offset is applied must be between year 0 and 10,000. (Parameter 'offset')]]
   at System.DateTimeOffset.ValidateDate(DateTime dateTime, TimeSpan offset) in /_/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs:line 967
   at System.DateTimeOffset..ctor(DateTime dateTime) in /_/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs:line 81
   at System.DateTimeOffset.op_Implicit(DateTime dateTime) in /_/src/System.Private.CoreLib/shared/System/DateTimeOffset.cs:line 998
   at System.Text.Json.Serialization.Tests.StreamTests.LargeJsonFile(Int32 bufferSize) in C:\Users\mb\src\gh\corefx\src\System.Text.Json\tests\Serialization\Stream.WriteTests.cs:line 200
--- End of stack trace from previous location where exception was thrown
```

//cc @layomia 