### PR TITLE
Make System.Runtime.Caching's implementation NETStandard based

### DIFF
--- a/src/System.Runtime.Caching/src/Configurations.props
+++ b/src/System.Runtime.Caching/src/Configurations.props
@@ -1,14 +1,8 @@
 ﻿<Project>
   <PropertyGroup>
-    <PackageConfigurations>
-      netstandard;
-      netcoreapp2.0-Windows_NT;
-      netcoreapp2.0-Unix;
-    </PackageConfigurations>
     <BuildConfigurations>
-      $(PackageConfigurations);
-      netcoreapp-Windows_NT;
-      netcoreapp-Unix;
+      netstandard;
+      netstandard-Windows_NT;
       _netfx;
     </BuildConfigurations>
   </PropertyGroup>

--- a/src/System.Runtime.Caching/src/System.Runtime.Caching.csproj
+++ b/src/System.Runtime.Caching/src/System.Runtime.Caching.csproj
@@ -5,10 +5,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Although we have a netstandard configuration, we know we are not currently UAP compatible-->
     <UWPCompatible>false</UWPCompatible>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetGroup)' == 'netstandard'">SR.PlatformNotSupported_Caching</GeneratePlatformNotSupportedAssemblyMessage>
-    <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netcoreapp2.0-Unix-Debug;netcoreapp2.0-Unix-Release;netcoreapp2.0-Windows_NT-Debug;netcoreapp2.0-Windows_NT-Release;netstandard-Debug;netstandard-Release</Configurations>
+    <Configurations>netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetGroup)' != 'netstandard'">
+  <ItemGroup>
     <Compile Include="System\Runtime\Caching\_shims.cs" />
     <Compile Include="System\Runtime\Caching\CacheEntryChangeMonitor.cs" />
     <Compile Include="System\Runtime\Caching\CacheEntryRemovedArguments.cs" />
@@ -66,37 +65,10 @@
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+  <ItemGroup Condition="'$(TargetsWindows)' != 'true'">
     <Compile Include="System\Runtime\Caching\PhysicalMemoryMonitor.Unix.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Win32.Primitives" />
-    <Reference Include="Microsoft.Win32.Registry" />
-    <Reference Include="System.Collections" />
-    <Reference Include="System.Collections.Specialized" />
-    <Reference Include="System.ComponentModel" />
-    <Reference Include="System.ComponentModel.Primitives" />
-    <Reference Include="System.ComponentModel.TypeConverter" />
     <Reference Include="System.Configuration.ConfigurationManager" />
-    <Reference Include="System.Diagnostics.Debug" />
-    <Reference Include="System.Diagnostics.Process" />
-    <Reference Include="System.Diagnostics.StackTrace" />
-    <Reference Include="System.Diagnostics.Tools" />
-    <Reference Include="System.Diagnostics.TraceSource" />
-    <Reference Include="System.IO" />
-    <Reference Include="System.IO.FileSystem" />
-    <Reference Include="System.IO.FileSystem.Watcher" />
-    <Reference Include="System.ObjectModel" />
-    <Reference Include="System.Resources.ResourceManager" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.Extensions" />
-    <Reference Include="System.Runtime.InteropServices" />
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
-    <Reference Include="System.Security.Principal.Windows" />
-    <Reference Include="System.Threading" />
-    <Reference Include="System.Threading.AccessControl" />
-    <Reference Include="System.Threading.Thread" />
-    <Reference Include="System.Threading.ThreadPool" />
-    <Reference Include="System.Threading.Timer" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #35319 

I chose to make the unix implementation behave as the default since it doesn't PInvoke.  You could further simplify the build of this library by removing the cross-compiling of the library and instead doing a runtime check for Windows.  This would make it more *normal* and easier to reason about.  CoreFx makes it easy (arguably) to cross-compile by runtime but that doesn't mean we should do it when a simple runtime check would suffice.