### PR TITLE
Increase connect timeout for Functional Tests

### DIFF
--- a/src/System.Data.SqlClient/tests/FunctionalTests/TestTdsServer.cs
+++ b/src/System.Data.SqlClient/tests/FunctionalTests/TestTdsServer.cs
@@ -43,7 +43,7 @@ namespace System.Data.SqlClient.Tests
             server._endpoint.Start();
 
             int port = server._endpoint.ServerEndPoint.Port;
-            server.connectionStringBuilder = new SqlConnectionStringBuilder() { DataSource = "localhost," + port, ConnectTimeout = 5, Encrypt = false };
+            server.connectionStringBuilder = new SqlConnectionStringBuilder() { DataSource = "localhost," + port, ConnectTimeout = 30, Encrypt = false };
             server.ConnectionString = server.connectionStringBuilder.ConnectionString;
             return server;
         }


### PR DESCRIPTION
Fix for issue [#37695](https://github.com/dotnet/corefx/issues/37695) by increasing the connect timeout to 30 seconds.