### PR TITLE
Change HttpStress app to highlight in red unchanged totals

### DIFF
--- a/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -537,6 +537,7 @@ public class Program
             // Spin up a thread dedicated to outputting stats for each defined interval
             new Thread(() =>
             {
+                long lastTotal = 0;
                 while (true)
                 {
                     Thread.Sleep(DisplayIntervalMilliseconds);
@@ -545,7 +546,14 @@ public class Program
                         Console.ForegroundColor = ConsoleColor.Cyan;
                         Console.Write("[" + DateTime.Now + "]");
                         Console.ResetColor();
+
+                        if (lastTotal == total)
+                        {
+                            Console.ForegroundColor = ConsoleColor.Red;
+                        }
+                        lastTotal = total;
                         Console.WriteLine(" Total: " + total.ToString("N0"));
+                        Console.ResetColor();
 
                         if (reuseAddressFailure > 0)
                         {


### PR DESCRIPTION
When no additional operations have completed since the last time status was output, highlight that in red.