### PR TITLE
Make all events nullable

### DIFF
--- a/src/System.Diagnostics.Contracts/ref/System.Diagnostics.Contracts.cs
+++ b/src/System.Diagnostics.Contracts/ref/System.Diagnostics.Contracts.cs
@@ -9,7 +9,7 @@ namespace System.Diagnostics.Contracts
 {
     public static partial class Contract
     {
-        public static event System.EventHandler<System.Diagnostics.Contracts.ContractFailedEventArgs> ContractFailed { add { } remove { } }
+        public static event System.EventHandler<System.Diagnostics.Contracts.ContractFailedEventArgs>? ContractFailed { add { } remove { } }
         [System.Diagnostics.ConditionalAttribute("CONTRACTS_FULL")]
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
         public static void Assert([System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute(false)] bool condition) { }

--- a/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
+++ b/src/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
@@ -112,8 +112,8 @@ namespace System.Diagnostics.Tracing
     public abstract partial class EventListener : System.IDisposable
     {
         protected EventListener() { }
-        public event System.EventHandler<System.Diagnostics.Tracing.EventSourceCreatedEventArgs> EventSourceCreated { add { } remove { } }
-        public event System.EventHandler<System.Diagnostics.Tracing.EventWrittenEventArgs> EventWritten { add { } remove { } }
+        public event System.EventHandler<System.Diagnostics.Tracing.EventSourceCreatedEventArgs>? EventSourceCreated { add { } remove { } }
+        public event System.EventHandler<System.Diagnostics.Tracing.EventWrittenEventArgs>? EventWritten { add { } remove { } }
         public void DisableEvents(System.Diagnostics.Tracing.EventSource eventSource) { }
         public virtual void Dispose() { }
         public void EnableEvents(System.Diagnostics.Tracing.EventSource eventSource, System.Diagnostics.Tracing.EventLevel level) { }
@@ -160,7 +160,7 @@ namespace System.Diagnostics.Tracing
         public System.Guid Guid { get { throw null; } }
         public string Name { get { throw null; } }
         public System.Diagnostics.Tracing.EventSourceSettings Settings { get { throw null; } }
-        public event System.EventHandler<System.Diagnostics.Tracing.EventCommandEventArgs> EventCommandExecuted { add { } remove { } }
+        public event System.EventHandler<System.Diagnostics.Tracing.EventCommandEventArgs>? EventCommandExecuted { add { } remove { } }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         ~EventSource() { }

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -26,15 +26,15 @@ namespace System
         public string? RelativeSearchPath { get { throw null; } }
         public System.AppDomainSetup SetupInformation { get { throw null; } }
         public bool ShadowCopyFiles { get { throw null; } }
-        public event System.AssemblyLoadEventHandler AssemblyLoad { add { } remove { } }
-        public event System.ResolveEventHandler AssemblyResolve { add { } remove { } }
-        public event System.EventHandler DomainUnload { add { } remove { } }
-        public event System.EventHandler<System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs> FirstChanceException { add { } remove { } }
-        public event System.EventHandler ProcessExit { add { } remove { } }
-        public event System.ResolveEventHandler ReflectionOnlyAssemblyResolve { add { } remove { } }
-        public event System.ResolveEventHandler ResourceResolve { add { } remove { } }
-        public event System.ResolveEventHandler TypeResolve { add { } remove { } }
-        public event System.UnhandledExceptionEventHandler UnhandledException { add { } remove { } }
+        public event System.AssemblyLoadEventHandler? AssemblyLoad { add { } remove { } }
+        public event System.ResolveEventHandler? AssemblyResolve { add { } remove { } }
+        public event System.EventHandler? DomainUnload { add { } remove { } }
+        public event System.EventHandler<System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs>? FirstChanceException { add { } remove { } }
+        public event System.EventHandler? ProcessExit { add { } remove { } }
+        public event System.ResolveEventHandler? ReflectionOnlyAssemblyResolve { add { } remove { } }
+        public event System.ResolveEventHandler? ResourceResolve { add { } remove { } }
+        public event System.ResolveEventHandler? TypeResolve { add { } remove { } }
+        public event System.UnhandledExceptionEventHandler? UnhandledException { add { } remove { } }
         [System.ObsoleteAttribute("AppDomain.AppendPrivatePath has been deprecated. Please investigate the use of AppDomainSetup.PrivateBinPath instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public void AppendPrivatePath(string? path) { }
         public string ApplyPolicy(string assemblyName) { throw null; }
@@ -969,7 +969,7 @@ namespace System
     {
         public Progress() { }
         public Progress(System.Action<T> handler) { }
-        public event System.EventHandler<T> ProgressChanged { add { } remove { } }
+        public event System.EventHandler<T>? ProgressChanged { add { } remove { } }
         protected virtual void OnReport(T value) { }
         void System.IProgress<T>.Report(T value) { }
     }

--- a/src/System.Runtime.Loader/ref/System.Runtime.Loader.cs
+++ b/src/System.Runtime.Loader/ref/System.Runtime.Loader.cs
@@ -32,9 +32,9 @@ namespace System.Runtime.Loader
         public static System.Runtime.Loader.AssemblyLoadContext Default { get { throw null; } }
         public bool IsCollectible { get { throw null; } }
         public string? Name { get { throw null; } }
-        public event System.Func<System.Runtime.Loader.AssemblyLoadContext, System.Reflection.AssemblyName, System.Reflection.Assembly?> Resolving { add { } remove { } }
-        public event System.Func<System.Reflection.Assembly, string, System.IntPtr> ResolvingUnmanagedDll { add { } remove { } }
-        public event System.Action<System.Runtime.Loader.AssemblyLoadContext> Unloading { add { } remove { } }
+        public event System.Func<System.Runtime.Loader.AssemblyLoadContext, System.Reflection.AssemblyName, System.Reflection.Assembly?>? Resolving { add { } remove { } }
+        public event System.Func<System.Reflection.Assembly, string, System.IntPtr>? ResolvingUnmanagedDll { add { } remove { } }
+        public event System.Action<System.Runtime.Loader.AssemblyLoadContext>? Unloading { add { } remove { } }
         public System.Runtime.Loader.AssemblyLoadContext.ContextualReflectionScope EnterContextualReflection() { throw null; }
         public static System.Runtime.Loader.AssemblyLoadContext.ContextualReflectionScope EnterContextualReflection(System.Reflection.Assembly? activating) { throw null; }
         ~AssemblyLoadContext() { }

--- a/src/System.Runtime/ref/System.Runtime.cs
+++ b/src/System.Runtime/ref/System.Runtime.cs
@@ -1191,7 +1191,7 @@ namespace System
         public virtual string? Source { get { throw null; } set { } }
         public virtual string? StackTrace { get { throw null; } }
         public System.Reflection.MethodBase? TargetSite { get { throw null; } }
-        protected event System.EventHandler<System.Runtime.Serialization.SafeSerializationEventArgs> SerializeObjectState { add { } remove { } }
+        protected event System.EventHandler<System.Runtime.Serialization.SafeSerializationEventArgs>? SerializeObjectState { add { } remove { } }
         public virtual System.Exception GetBaseException() { throw null; }
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public new System.Type GetType() { throw null; }
@@ -5363,7 +5363,7 @@ namespace System.Reflection
         public virtual System.Collections.Generic.IEnumerable<System.Reflection.Module> Modules { get { throw null; } }
         public virtual bool ReflectionOnly { get { throw null; } }
         public virtual System.Security.SecurityRuleSet SecurityRuleSet { get { throw null; } }
-        public virtual event System.Reflection.ModuleResolveEventHandler ModuleResolve { add { } remove { } }
+        public virtual event System.Reflection.ModuleResolveEventHandler? ModuleResolve { add { } remove { } }
         public object? CreateInstance(string typeName) { throw null; }
         public object? CreateInstance(string typeName, bool ignoreCase) { throw null; }
         public virtual object? CreateInstance(string typeName, bool ignoreCase, System.Reflection.BindingFlags bindingAttr, System.Reflection.Binder? binder, object[]? args, System.Globalization.CultureInfo? culture, object[]? activationAttributes) { throw null; }
@@ -8277,7 +8277,7 @@ namespace System.Threading.Tasks
         public static System.Threading.Tasks.TaskScheduler Default { get { throw null; } }
         public int Id { get { throw null; } }
         public virtual int MaximumConcurrencyLevel { get { throw null; } }
-        public static event System.EventHandler<System.Threading.Tasks.UnobservedTaskExceptionEventArgs> UnobservedTaskException { add { } remove { } }
+        public static event System.EventHandler<System.Threading.Tasks.UnobservedTaskExceptionEventArgs>? UnobservedTaskException { add { } remove { } }
         public static System.Threading.Tasks.TaskScheduler FromCurrentSynchronizationContext() { throw null; }
         protected abstract System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task>? GetScheduledTasks();
         protected internal abstract void QueueTask(System.Threading.Tasks.Task task);


### PR DESCRIPTION
This is the corefx part of: https://github.com/dotnet/coreclr/pull/25752

The events in AppContext are baselined and not exposed in corefx: https://github.com/dotnet/corefx/blob/53dc908890102d3a888ba603a06266b85d3f4a9b/src/System.Runtime/src/MatchingRefApiCompatBaseline.txt#L2-L7

This will need to be ported to 3.0.

cc: @danmosemsft @terrajobst @stephentoub 