### PR TITLE
Fix NullReferenceExceptions in IndentedTextWriter without writer

### DIFF
--- a/src/System.IO/tests/IndentedTextWriter.cs
+++ b/src/System.IO/tests/IndentedTextWriter.cs
@@ -29,6 +29,13 @@ namespace System.CodeDom.Tests
             Assert.Equal(new string(' ', 4), IndentedTextWriter.DefaultTabString);
         }
 
+        [Fact]
+        public void Ctor_NullWriter_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("writer", () => new IndentedTextWriter(null));
+            Assert.Throws<ArgumentNullException>("writer", () => new IndentedTextWriter(null, "TabString"));
+        }
+
         [Theory]
         [InlineData(42)]
         [InlineData(4)]

--- a/src/System.Runtime.Extensions/src/System/CodeDom/Compiler/IndentedTextWriter.cs
+++ b/src/System.Runtime.Extensions/src/System/CodeDom/Compiler/IndentedTextWriter.cs
@@ -22,6 +22,11 @@ namespace System.CodeDom.Compiler
 
         public IndentedTextWriter(TextWriter writer, string tabString) : base(CultureInfo.InvariantCulture)
         {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
             _writer = writer;
             _tabString = tabString;
             _indentLevel = 0;


### PR DESCRIPTION
Wouldn't throw NREs in the constructor but whenever *any* method was called on `IndentedTextWriter`. Fix this to validate in the constructor