### PR TITLE
Http2: Fix remote server tests occassionally timing out in CI

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -2268,7 +2268,7 @@ namespace System.Net.Http.Functional.Tests
                 // Compute MD5 of request body data. This will be verified by the server when it receives the request.
                 content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(contentBytes);
 
-                // Issue #39545: issue occassionally timing on CI using default timeout of 100 seconds.
+                // Issue #39545: test occassionally timing on CI using default timeout of 100 seconds.
                 var timeout = TimeSpan.FromSeconds(150);
 
                 using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer, timeout))

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.cs
@@ -115,12 +115,12 @@ namespace System.Net.Http.Functional.Tests
 
         public static readonly IEnumerable<object[]> RemoteServersMemberData = Configuration.Http.RemoteServersMemberData;
 
-        protected HttpClient CreateHttpClientForRemoteServer(Configuration.Http.RemoteServer remoteServer)
+        protected HttpClient CreateHttpClientForRemoteServer(Configuration.Http.RemoteServer remoteServer, TimeSpan? timeout = null)
         {
-            return CreateHttpClientForRemoteServer(remoteServer, CreateHttpClientHandler());
+            return CreateHttpClientForRemoteServer(remoteServer, CreateHttpClientHandler(), timeout);
         }
 
-        protected HttpClient CreateHttpClientForRemoteServer(Configuration.Http.RemoteServer remoteServer, HttpClientHandler httpClientHandler)
+        protected HttpClient CreateHttpClientForRemoteServer(Configuration.Http.RemoteServer remoteServer, HttpClientHandler httpClientHandler, TimeSpan? timeout = null)
         {
             HttpMessageHandler wrappedHandler = httpClientHandler;
 
@@ -133,6 +133,11 @@ namespace System.Net.Http.Functional.Tests
 
             var client = new HttpClient(wrappedHandler);
             SetDefaultRequestVersion(client, remoteServer.HttpVersion);
+            if (timeout.HasValue)
+            {
+                client.Timeout = timeout.Value;
+            }
+
             return client;
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -264,7 +264,7 @@ namespace System.Net.Http.Functional.Tests
             handler.PreAuthenticate = preAuthenticate;
             handler.Credentials = credential;
 
-            // Issue #39545: issue occassionally timing on CI using default timeout of 100 seconds.
+            // Issue #39545: test occassionally timing on CI using default timeout of 100 seconds.
             var timeout = TimeSpan.FromSeconds(150);
 
             using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer, handler, timeout))

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -167,14 +167,6 @@ namespace System.Net.Http.Functional.Tests
         [Theory, MemberData(nameof(RemoteServersMemberData))]
         public async Task PostRewindableContentUsingAuth_NoPreAuthenticate_Success(Configuration.Http.RemoteServer remoteServer)
         {
-            if (remoteServer.HttpVersion == new Version(2, 0))
-            {
-                // This is occasionally timing out in CI with SocketsHttpHandler and HTTP2, particularly on Linux
-                // Likely this is just a very slow test and not a product issue, so just increasing the timeout may be the right fix.
-                // Disable until we can investigate further.
-                return;
-            }
-
             HttpContent content = new StreamContent(new CustomContent.CustomStream(Encoding.UTF8.GetBytes(ExpectedContent), true));
             var credential = new NetworkCredential(UserName, Password);
             await PostUsingAuthHelper(remoteServer, ExpectedContent, content, credential, false);
@@ -271,7 +263,11 @@ namespace System.Net.Http.Functional.Tests
             HttpClientHandler handler = CreateHttpClientHandler();
             handler.PreAuthenticate = preAuthenticate;
             handler.Credentials = credential;
-            using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer, handler))
+
+            // Issue #39545: issue occassionally timing on CI using default timeout of 100 seconds.
+            var timeout = TimeSpan.FromSeconds(150);
+
+            using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer, handler, timeout))
             {
                 // Send HEAD request to help bypass the 401 auth challenge for the latter POST assuming
                 // that the authentication will be cached and re-used later when PreAuthenticate is true.


### PR DESCRIPTION
Increases HttpClient timeout from the default 100 seconds to 150, in order to address functional tests occasionally timing out in CI. Fixes #39545.