### PR TITLE
Move ConnectAsync_AddCustomHeaders_Success ClientWebSocket test to loopback

### DIFF
--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.netcoreapp.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketOptionsTests.netcoreapp.cs
@@ -63,7 +63,7 @@ namespace System.Net.WebSockets.Client.Tests
                 }
             }, server => server.AcceptConnectionAsync(async connection =>
             {
-                Assert.True(await LoopbackHelper.WebSocketHandshakeAsync(connection));
+                Assert.NotNull(await LoopbackHelper.WebSocketHandshakeAsync(connection));
             }),
             new LoopbackServer.Options { UseSsl = secure, WebSocketEndpoint = true });
 
@@ -100,7 +100,7 @@ namespace System.Net.WebSockets.Client.Tests
 
                     // Complete the WebSocket upgrade over the secure channel. After this is done, the client-side
                     // ConnectAsync should complete.
-                    Assert.True(await LoopbackHelper.WebSocketHandshakeAsync(connection));
+                    Assert.NotNull(await LoopbackHelper.WebSocketHandshakeAsync(connection));
                 }), new LoopbackServer.Options { UseSsl = true, WebSocketEndpoint = true });
             }
         }

--- a/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -384,7 +384,7 @@ namespace System.Net.WebSockets.Client.Tests
                 Task acceptTask = server.AcceptConnectionAsync(async connection =>
                 {
                     // Complete the WebSocket upgrade. After this is done, the client-side ConnectAsync should complete.
-                    Assert.True(await LoopbackHelper.WebSocketHandshakeAsync(connection));
+                    Assert.NotNull(await LoopbackHelper.WebSocketHandshakeAsync(connection));
 
                     // Wait for client-side ConnectAsync to complete and for a pending ReceiveAsync to be posted.
                     await pendingReceiveAsyncPosted.Task.TimeoutAfter(TimeOutMilliseconds);


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/39271
cc: @davidsh