### PR TITLE
Update coverlet.console to fix coverage measurement

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "coverlet.console": {
-      "version": "1.5.1",
+      "version": "1.5.47-g016c3630ca",
       "commands": [
         "coverlet"
       ]

--- a/NuGet.config
+++ b/NuGet.config
@@ -8,6 +8,8 @@
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-coreclr" value="https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json" />
+    <!-- TODO: Remove when an updated coverlet.console package is pushed to nuget.org. Issue: #39595 -->
+    <add key="coverlet-dev" value="https://www.myget.org/F/coverlet-dev/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>


### PR DESCRIPTION
The updated coverlet.console version allows major version roll-forwards which fixes locally failing coverage runs.

Tracking issue to remove the dev feed: https://github.com/dotnet/corefx/issues/39595