### PR TITLE
FromBase64Transform.InputBlockSize set to 4 instead of 1

### DIFF
--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -126,7 +126,7 @@ namespace System.Security.Cryptography
         // Converting from Base64 generates 3 bytes output from each 4 bytes input block
         public int InputBlockSize => 4;
         public int OutputBlockSize => 3;
-        public bool CanTransformMultipleBlocks => false;
+        public bool CanTransformMultipleBlocks => true;
         public virtual bool CanReuseTransform => true;
 
         public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)

--- a/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
+++ b/src/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/Base64Transforms.cs
@@ -120,11 +120,11 @@ namespace System.Security.Cryptography
             _whitespaces = whitespaces;
         }
 
-        // Converting from Base64 generates 3 bytes output from each 4 bytes input block
-        private const int Base64InputBlockSize = 4;
         // A buffer with size 32 is stack allocated, to cover common cases and benefit from JIT's optimizations.
         private const int StackAllocSize = 32;
-        public int InputBlockSize => 1;
+
+        // Converting from Base64 generates 3 bytes output from each 4 bytes input block
+        public int InputBlockSize => 4;
         public int OutputBlockSize => 3;
         public bool CanTransformMultipleBlocks => false;
         public virtual bool CanReuseTransform => true;
@@ -152,7 +152,7 @@ namespace System.Security.Cryptography
             int bytesToTransform = _inputIndex + tmpBuffer.Length;
 
             // Too little data to decode: save data to _inputBuffer, so it can be transformed later
-            if (bytesToTransform < Base64InputBlockSize)
+            if (bytesToTransform < InputBlockSize)
             {
                 tmpBuffer.CopyTo(_inputBuffer.AsSpan(_inputIndex));
 
@@ -197,7 +197,7 @@ namespace System.Security.Cryptography
             int bytesToTransform = _inputIndex + tmpBuffer.Length;
 
             // Too little data to decode
-            if (bytesToTransform < Base64InputBlockSize)
+            if (bytesToTransform < InputBlockSize)
             {
                 // reinitialize the transform
                 Reset();

--- a/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Base64TransformsTests.cs
@@ -253,5 +253,45 @@ namespace System.Security.Cryptography.Encoding.Tests
                 Assert.Throws<FormatException>(() => cs.Read(outputBytes, 0, outputBytes.Length));
             }
         }
+
+        [Fact]
+        public void Blocksizes_ToBase64Transform()
+        {
+            using (var transform = new ToBase64Transform())
+            {
+                Assert.Equal(3, transform.InputBlockSize);
+                Assert.Equal(4, transform.OutputBlockSize);
+            }
+        }
+
+        [Fact]
+        public void Blocksizes_FromBase64Transform()
+        {
+            using (var transform = new FromBase64Transform())
+            {
+                Assert.Equal(4, transform.InputBlockSize);
+                Assert.Equal(3, transform.OutputBlockSize);
+            }
+        }
+
+        [Fact]
+        public void TransformUsageFlags_ToBase64Transform()
+        {
+            using (var transform = new ToBase64Transform())
+            {
+                Assert.False(transform.CanTransformMultipleBlocks);
+                Assert.True(transform.CanReuseTransform);
+            }
+        }
+
+        [Fact]
+        public void TransformUsageFlags_FromBase64Transform()
+        {
+            using (var transform = new FromBase64Transform())
+            {
+                Assert.True(transform.CanTransformMultipleBlocks);
+                Assert.True(transform.CanReuseTransform);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/39583 and sets `FromBase64Transform.CanTransformMultipleBlocks = true` (cf. https://github.com/dotnet/corefx/issues/39583#issuecomment-512854180).