### PR TITLE
Re-enable unicode host name test

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -1631,7 +1631,6 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [ActiveIssue(37352)]
         [OuterLoop("Uses external server")]
         [Fact]
         public async Task GetAsync_UnicodeHostName_SuccessStatusCodeInResponse()


### PR DESCRIPTION
Site appears to be back up.
Fixes https://github.com/dotnet/corefx/issues/37352