### PR TITLE
Fix CompilerResults.CompiledAssembly in .NET Core

### DIFF
--- a/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.cs
@@ -9,6 +9,8 @@ namespace System.CodeDom.Compiler
 {
     public partial class CompilerResults
     {
+        private Assembly _compiledAssembly;
+
         public CompilerResults(TempFileCollection tempFiles)
         {
             TempFiles = tempFiles;
@@ -16,8 +18,18 @@ namespace System.CodeDom.Compiler
 
         public TempFileCollection TempFiles { get; set; }
 
-        public Assembly CompiledAssembly { get; set; }
-
+        public Assembly CompiledAssembly
+        {
+            get
+            {
+                if (_compiledAssembly == null && PathToAssembly != null)
+                {
+                    _compiledAssembly = Assembly.LoadFile(PathToAssembly);
+                }
+                return _compiledAssembly;
+            }
+            set => _compiledAssembly = value;
+        }
         public CompilerErrorCollection Errors { get; } = new CompilerErrorCollection();
 
         public StringCollection Output { get; } = new StringCollection();

--- a/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.cs
+++ b/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.cs
@@ -9,8 +9,6 @@ namespace System.CodeDom.Compiler
 {
     public partial class CompilerResults
     {
-        private Assembly _compiledAssembly;
-
         public CompilerResults(TempFileCollection tempFiles)
         {
             TempFiles = tempFiles;
@@ -18,22 +16,12 @@ namespace System.CodeDom.Compiler
 
         public TempFileCollection TempFiles { get; set; }
 
-        public Assembly CompiledAssembly
-        {
-            get
-            {
-                if (_compiledAssembly == null && PathToAssembly != null)
-                {
-                    _compiledAssembly = Assembly.Load(new AssemblyName() { CodeBase = PathToAssembly });
-                }
-                return _compiledAssembly;
-            }
-            set => _compiledAssembly = value;
-        }
+        public Assembly CompiledAssembly { get; set; }
 
         public CompilerErrorCollection Errors { get; } = new CompilerErrorCollection();
 
         public StringCollection Output { get; } = new StringCollection();
+
         public string PathToAssembly { get; set; }
 
         public int NativeCompilerReturnValue { get; set; }

--- a/src/System.CodeDom/tests/System/CodeDom/Compiler/CompilerResultsTests.cs
+++ b/src/System.CodeDom/tests/System/CodeDom/Compiler/CompilerResultsTests.cs
@@ -30,11 +30,13 @@ namespace System.CodeDom.Compiler.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Loading from PathToAssembly is only supported in .NET Framework")]
         public void CompiledAssembly_GetWithPathToAssembly_ReturnsExpected()
         {
-            var results = new CompilerResults(null) { PathToAssembly = typeof(int).Assembly.CodeBase };
-            Assert.Null(results.CompiledAssembly);
+            var results = new CompilerResults(null) { PathToAssembly = typeof(CompilerResultsTests).Assembly.Location };
+
+            Assert.NotNull(results.CompiledAssembly);
+//            Assert.Equal(typeof(CompilerResultsTests).Assembly, results.CompiledAssembly);
+            Assert.Same(results.CompiledAssembly, results.CompiledAssembly);
         }
 
         public static IEnumerable<object[]> CompiledAssembly_Set_TestData()

--- a/src/System.CodeDom/tests/System/CodeDom/Compiler/CompilerResultsTests.cs
+++ b/src/System.CodeDom/tests/System/CodeDom/Compiler/CompilerResultsTests.cs
@@ -30,20 +30,59 @@ namespace System.CodeDom.Compiler.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework, "Assembly.Load ignores CodeBase by design, except on netfx. See https://github.com/dotnet/coreclr/issues/10561")]
-        public void CompiledAssembly_ValidPathToAssembly_ReturnsExpected()
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core ignores AssemblyName.CodeBase")]
+        public void CompiledAssembly_GetWithPathToAssembly_ReturnsExpected()
         {
-            var results = new CompilerResults(null) { PathToAssembly = typeof(int).Assembly.EscapedCodeBase };
-            Assert.Equal(typeof(int).Assembly, results.CompiledAssembly);
-            Assert.Same(results.CompiledAssembly, results.CompiledAssembly);
+            var results = new CompilerResults(null) { PathToAssembly = typeof(int).Assembly.CodeBase };
+            Assert.Null(results.CompiledAssembly);
         }
 
-        [Fact]
-        public void CompiledAssembly_Set_GetReturnsExpecte()
+        public static IEnumerable<object[]> CompiledAssembly_Set_TestData()
         {
-            Assembly assembly = typeof(CompilerResultsTests).Assembly;
-            var results = new CompilerResults(null) { CompiledAssembly = assembly };
-            Assert.Same(assembly, results.CompiledAssembly);
+            yield return new object[] { null };
+            yield return new object[] { typeof(CompilerResultsTests).Assembly };
+        }
+
+        [Theory]
+        [MemberData(nameof(CompiledAssembly_Set_TestData))]
+        public void CompiledAssembly_Set_GetReturnsExpected(Assembly value)
+        {
+            var results = new CompilerResults(null) { CompiledAssembly = value };
+            Assert.Same(value, results.CompiledAssembly);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("name")]
+        public void PathToAssembly_Set_GetReturnsExpected(string value)
+        {
+            var results = new CompilerResults(null) { PathToAssembly = value };
+            Assert.Same(value, results.PathToAssembly);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void NativeCompilerReturnValue_Set_GetReturnsExpected(int value)
+        {
+            var results = new CompilerResults(null) { NativeCompilerReturnValue = value };
+            Assert.Equal(value, results.NativeCompilerReturnValue);
+        }
+
+        public static IEnumerable<object[]> TempFiles_Set_TestData()
+        {
+            yield return new object[] { null };
+            yield return new object[] { new TempFileCollection() };
+        }
+
+        [Theory]
+        [MemberData(nameof(TempFiles_Set_TestData))]
+        public void TempFiles_Set_GetReturnsExpected(TempFileCollection value)
+        {
+            var results = new CompilerResults(null) { TempFiles = value };
+            Assert.Same(value, results.TempFiles);
         }
     }
 }

--- a/src/System.CodeDom/tests/System/CodeDom/Compiler/CompilerResultsTests.cs
+++ b/src/System.CodeDom/tests/System/CodeDom/Compiler/CompilerResultsTests.cs
@@ -35,7 +35,7 @@ namespace System.CodeDom.Compiler.Tests
             var results = new CompilerResults(null) { PathToAssembly = typeof(CompilerResultsTests).Assembly.Location };
 
             Assert.NotNull(results.CompiledAssembly);
-//            Assert.Equal(typeof(CompilerResultsTests).Assembly, results.CompiledAssembly);
+            Assert.Equal(typeof(CompilerResultsTests).Assembly.FullName, results.CompiledAssembly.FullName);
             Assert.Same(results.CompiledAssembly, results.CompiledAssembly);
         }
 

--- a/src/System.CodeDom/tests/System/CodeDom/Compiler/CompilerResultsTests.cs
+++ b/src/System.CodeDom/tests/System/CodeDom/Compiler/CompilerResultsTests.cs
@@ -30,13 +30,21 @@ namespace System.CodeDom.Compiler.Tests
         }
 
         [Fact]
-        public void CompiledAssembly_GetWithPathToAssembly_ReturnsExpected()
+        public void CompiledAssembly_GetWithPathToAssemblySet_ReturnsExpectedAssembly()
         {
             var results = new CompilerResults(null) { PathToAssembly = typeof(CompilerResultsTests).Assembly.Location };
 
             Assert.NotNull(results.CompiledAssembly);
             Assert.Equal(typeof(CompilerResultsTests).Assembly.FullName, results.CompiledAssembly.FullName);
             Assert.Same(results.CompiledAssembly, results.CompiledAssembly);
+        }
+
+        [Fact]
+        public void CompiledAssembly_GetWithPathToAssemblyNotSet_ReturnsNull()
+        {
+            var results = new CompilerResults(null);
+
+            Assert.Null(results.CompiledAssembly);
         }
 
         public static IEnumerable<object[]> CompiledAssembly_Set_TestData()

--- a/src/System.CodeDom/tests/System/CodeDom/Compiler/CompilerResultsTests.cs
+++ b/src/System.CodeDom/tests/System/CodeDom/Compiler/CompilerResultsTests.cs
@@ -30,7 +30,7 @@ namespace System.CodeDom.Compiler.Tests
         }
 
         [Fact]
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Core ignores AssemblyName.CodeBase")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Loading from PathToAssembly is only supported in .NET Framework")]
         public void CompiledAssembly_GetWithPathToAssembly_ReturnsExpected()
         {
             var results = new CompilerResults(null) { PathToAssembly = typeof(int).Assembly.CodeBase };


### PR DESCRIPTION
Because Assembly.Load ignore `CodeBase` unconditionally in .NET Core (https://github.com/dotnet/coreclr/issues/10561), the following exception would always be thrown:

> System.CodeDom.Compiler.Tests.CompilerResultsTests.CompiledAssembly_GetWithPathToAssembly_ReturnsExpected [FAIL]
System.ArgumentException : String cannot have zero length.
Stack Trace:
        at System.Reflection.RuntimeAssembly.nLoad(AssemblyName fileName, String codeBase, RuntimeAssembly assemblyContext, StackCrawlMark& stackMark, Boolean throwOnFileNotFound, AssemblyLoadContext assemblyLoadContext)
    /_/src/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs(345,0): at System.Reflection.RuntimeAssembly.InternalLoadAssemblyName(AssemblyName assemblyRef, StackCrawlMark& stackMark, AssemblyLoadContext assemblyLoadContext)
    /_/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs(73,0): at System.Reflection.Assembly.Load(AssemblyName assemblyRef, StackCrawlMark& stackMark, AssemblyLoadContext assemblyLoadContext)
    /_/src/System.Private.CoreLib/src/System/Reflection/Assembly.CoreCLR.cs(55,0): at System.Reflection.Assembly.Load(AssemblyName assemblyRef)
    /Users/hugh/Documents/GitHub/corefx/src/System.CodeDom/src/System/CodeDom/Compiler/CompilerResults.cs(27,0): at System.CodeDom.Compiler.CompilerResults.get_CompiledAssembly()
    /Users/hugh/Documents/GitHub/corefx/src/System.CodeDom/tests/System/CodeDom/Compiler/CompilerResultsTests.cs(36,0): at System.CodeDom.Compiler.Tests.CompilerResultsTests.CompiledAssembly_GetWithPathToAssembly_ReturnsExpected()


This leaves us with the following options to fix this in .NET Core
- Throw PlatformNotSupportedException
- Don't attempt to load anything
- Read PathToAssembly as Assembly.Location, not Assembly.CodeBase

I opted with the second option because it is the least breaking. The first is a bit obnoxious and the third changes the documented behaviour between .NET Framework and .NET Core: CodeBase and Location have subtly different meanings.

I'm flexible, so let me know what you all think.