### PR TITLE
[release/3.0] Don't dispose StreamPipeWriter CancellationToken until after Flush

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -214,9 +214,9 @@ namespace System.IO.Pipelines
 
             _isCompleted = true;
 
-            _internalTokenSource?.Dispose();
-
             FlushInternal();
+
+            _internalTokenSource?.Dispose();
 
             if (!_leaveOpen)
             {
@@ -233,9 +233,9 @@ namespace System.IO.Pipelines
 
             _isCompleted = true;
 
-            _internalTokenSource?.Dispose();
-
             await FlushAsyncInternal().ConfigureAwait(false);
+
+            _internalTokenSource?.Dispose();
 
             if (!_leaveOpen)
             {

--- a/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
+++ b/src/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
@@ -62,6 +62,25 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        public async Task CompleteAsyncDoesNotThrowObjectDisposedException()
+        {
+            byte[] bytes = Encoding.ASCII.GetBytes("Hello World");
+            var stream = new MemoryStream();
+            PipeWriter writer = PipeWriter.Create(stream, new StreamPipeWriterOptions(leaveOpen: true));
+
+            await writer.FlushAsync();
+            bytes.AsSpan().CopyTo(writer.GetSpan(bytes.Length));
+            writer.Advance(bytes.Length);
+
+            Assert.Equal(0, stream.Length);
+
+            await writer.CompleteAsync();
+
+            Assert.Equal(bytes.Length, stream.Length);
+            Assert.Equal("Hello World", Encoding.ASCII.GetString(stream.ToArray()));
+        }
+
+        [Fact]
         public async Task DataWrittenOnFlushAsync()
         {
             byte[] bytes = Encoding.ASCII.GetBytes("Hello World");


### PR DESCRIPTION
Hit this in ASP.NET Core. If you call FlushAsync and then CompleteAsync, you'll hit an ODE in CompleteAsync. Previous tests didn't call FlushAsync and then CompleteAsync.

