### PR TITLE
Avoid "async void" tests

### DIFF
--- a/src/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -437,7 +437,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
-        public async void TestLeaveOpenAfterValidDecompress()
+        public async Task TestLeaveOpenAfterValidDecompress()
         {
             //Create the Stream
             int _bufferSize = 1024;

--- a/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -66,7 +66,7 @@ namespace System.IO.Compression
         [InlineData(1000, true, false, 1, 1)]
         [InlineData(1000, false, false, 1001 * 24, 1)]
         [InlineData(1000, true, false, 1001 * 24, 1)]
-        public async void ManyConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream)
+        public async Task ManyConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream)
         {
             await TestConcatenatedGzipStreams(streamCount, useAsync, useReadByte, bufferSize, bytesPerStream);
         }
@@ -82,7 +82,7 @@ namespace System.IO.Compression
         [InlineData(1000, true, false, 1, 9000)]
         [InlineData(1000, false, false, 1001 * 24, 9000)]
         [InlineData(1000, true, false, 1001 * 24, 9000)]
-        public async void ManyManyConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream)
+        public async Task ManyManyConcatenatedGzipStreams(int streamCount, bool useAsync, bool useReadByte, int bufferSize, int bytesPerStream)
         {
             await TestConcatenatedGzipStreams(streamCount, useAsync, useReadByte, bufferSize, bytesPerStream);
         }

--- a/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -606,7 +606,7 @@ namespace System.IO.Pipes.Tests
 
         [Theory]
         [MemberData(nameof(GetCancellationTokens))]
-        public async void ClientConnectAsync_Throws_Timeout_When_Pipe_Not_Found(CancellationToken cancellationToken)
+        public async Task ClientConnectAsync_Throws_Timeout_When_Pipe_Not_Found(CancellationToken cancellationToken)
         {
             string pipeName = GetUniquePipeName();
             using (NamedPipeClientStream client = new NamedPipeClientStream(pipeName))
@@ -642,7 +642,7 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [MemberData(nameof(GetCancellationTokens))]
         [PlatformSpecific(TestPlatforms.Windows)] // Unix ignores MaxNumberOfServerInstances and second client also connects.
-        public async void ClientConnectAsync_With_Cancellation_Throws_Timeout_When_Pipe_Busy(CancellationToken cancellationToken)
+        public async Task ClientConnectAsync_With_Cancellation_Throws_Timeout_When_Pipe_Busy(CancellationToken cancellationToken)
         {
             string pipeName = GetUniquePipeName();
 

--- a/src/System.IO/tests/TextReader/TextReaderTests.cs
+++ b/src/System.IO/tests/TextReader/TextReaderTests.cs
@@ -164,7 +164,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public async void ReadBlockAsyncCharArr()
+        public async Task ReadBlockAsyncCharArr()
         {
             (char[] chArr, CharArrayTextReader textReader) baseInfo = GetCharArray();
             using (CharArrayTextReader tr = baseInfo.textReader)

--- a/src/System.IO/tests/TextWriter/TextWriterTests.cs
+++ b/src/System.IO/tests/TextWriter/TextWriterTests.cs
@@ -463,7 +463,7 @@ namespace System.IO.Tests
         #region Write Async Overloads
 
         [Fact]
-        public async void WriteAsyncCharTest()
+        public async Task WriteAsyncCharTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
             {
@@ -473,7 +473,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public async void WriteAsyncStringTest()
+        public async Task WriteAsyncStringTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
             {
@@ -484,7 +484,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public async void WriteAsyncCharArrayIndexCountTest()
+        public async Task WriteAsyncCharArrayIndexCountTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
             {
@@ -498,7 +498,7 @@ namespace System.IO.Tests
         #region WriteLineAsync Overloads
 
         [Fact]
-        public async void WriteLineAsyncTest()
+        public async Task WriteLineAsyncTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
             {
@@ -508,7 +508,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public async void WriteLineAsyncCharTest()
+        public async Task WriteLineAsyncCharTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
             {
@@ -518,7 +518,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public async void WriteLineAsyncStringTest()
+        public async Task WriteLineAsyncStringTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
             {
@@ -529,7 +529,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public async void WriteLineAsyncCharArrayIndexCount()
+        public async Task WriteLineAsyncCharArrayIndexCount()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
             {

--- a/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
+++ b/src/System.IO/tests/TextWriter/TextWriterTests.netcoreapp.cs
@@ -84,7 +84,7 @@ namespace System.IO.Tests
 
         [Theory]
         [MemberData(nameof(GetStringBuilderTestData))]
-        public async void WriteAsyncStringBuilderTest(bool isSynchronized, StringBuilder testData)
+        public async Task WriteAsyncStringBuilderTest(bool isSynchronized, StringBuilder testData)
         {
             using (CharArrayTextWriter ctw = NewTextWriter)
             {
@@ -97,7 +97,7 @@ namespace System.IO.Tests
 
         [Theory]
         [MemberData(nameof(GetStringBuilderTestData))]
-        public async void WriteLineAsyncStringBuilderTest(bool isSynchronized, StringBuilder testData)
+        public async Task WriteLineAsyncStringBuilderTest(bool isSynchronized, StringBuilder testData)
         {
             using (CharArrayTextWriter ctw = NewTextWriter)
             {

--- a/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DefaultCredentialsTest.cs
@@ -324,7 +324,7 @@ namespace System.Net.Http.Functional.Tests
 
             public string Uri => _uri;
 
-            private async void ProcessRequests()
+            private async Task ProcessRequests()
             {
                 while (true)
                 {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Authentication.cs
@@ -75,7 +75,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("WWW-Authenticate: Basic realm=\"hello\"\r\nWWW-Authenticate: Basic realm=\"hello\"\r\n")]
         [InlineData("WWW-Authenticate: Digest realm=\"hello\", nonce=\"hello\", algorithm=MD5\r\nWWW-Authenticate: Digest realm=\"hello\", nonce=\"hello\", algorithm=MD5\r\n")]
         [InlineData("WWW-Authenticate: Digest realm=\"hello1\", nonce=\"hello\", algorithm=MD5\r\nWWW-Authenticate: Digest realm=\"hello\", nonce=\"hello\", algorithm=MD5\r\n")]
-        public async void HttpClientHandler_MultipleAuthenticateHeaders_WithSameAuth_Succeeds(string authenticateHeader)
+        public async Task HttpClientHandler_MultipleAuthenticateHeaders_WithSameAuth_Succeeds(string authenticateHeader)
         {
             if (IsWinHttpHandler)
             {
@@ -135,7 +135,7 @@ namespace System.Net.Http.Functional.Tests
         [Theory]
         [InlineData("WWW-Authenticate: Basic realm=\"hello\"\r\n")]
         [InlineData("WWW-Authenticate: Digest realm=\"hello\", nonce=\"testnonce\"\r\n")]
-        public async void HttpClientHandler_IncorrectCredentials_Fails(string authenticateHeader)
+        public async Task HttpClientHandler_IncorrectCredentials_Fails(string authenticateHeader)
         {
             var options = new LoopbackServer.Options { Domain = Domain, Username = Username, Password = Password };
             await LoopbackServer.CreateServerAsync(async (server, url) =>

--- a/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1183,7 +1183,7 @@ namespace System.Net.Http.Functional.Tests
 
         [Theory]
         [MemberData(nameof(Authentication_SocketsHttpHandler_TestData))]
-        public async void SocketsHttpHandler_Authentication_Succeeds(string authenticateHeader, bool result)
+        public async Task SocketsHttpHandler_Authentication_Succeeds(string authenticateHeader, bool result)
         {
             await HttpClientHandler_Authentication_Succeeds(authenticateHeader, result);
         }
@@ -2204,7 +2204,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData("http://a/\u00C3\u0028", new byte[] { (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/', (byte)'a', (byte)'/', 0xC3, 0x28 })]
         // Incomplete utf-8 sequence
         [InlineData("http://a/\u00C2", new byte[] { (byte)'h', (byte)'t', (byte)'t', (byte)'p', (byte)':', (byte)'/', (byte)'/', (byte)'a', (byte)'/', 0xC2 })]
-        public async void LocationHeader_DecodesUtf8_Success(string expected, byte[] location)
+        public async Task LocationHeader_DecodesUtf8_Success(string expected, byte[] location)
         {
             await LoopbackServer.CreateClientAndServerAsync(async url =>
             {

--- a/src/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
+++ b/src/System.Net.Http/tests/UnitTests/DigestAuthenticationTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Net.Http.Tests
@@ -47,7 +48,7 @@ namespace System.Net.Http.Tests
         [InlineData("realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\"", true)]
         [InlineData("nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\", qop=\"auth\", stale=false", false)]
         [InlineData("realm=\"NetCore\", qop=\"auth\", stale=false", false)]
-        public async void DigestResponse_AuthToken_Handling(string response, bool expectedResult)
+        public async Task DigestResponse_AuthToken_Handling(string response, bool expectedResult)
         {
             NetworkCredential credential = new NetworkCredential("foo", "bar");
             AuthenticationHelper.DigestResponse digestResponse = new AuthenticationHelper.DigestResponse(response);
@@ -63,7 +64,7 @@ namespace System.Net.Http.Tests
         [InlineData("test\"example.org", "username=\"test\\\"example.org\"")]
         [InlineData("t\u00E6st", "username*=utf-8''t%C3%A6st")]
         [InlineData("\uD834\uDD1E", "username*=utf-8''%F0%9D%84%9E")]
-        public async void DigestResponse_UserName_Encoding(string username, string encodedUserName)
+        public async Task DigestResponse_UserName_Encoding(string username, string encodedUserName)
         {
             NetworkCredential credential = new NetworkCredential(username, "bar");
             AuthenticationHelper.DigestResponse digestResponse = new AuthenticationHelper.DigestResponse("realm=\"NetCore\", nonce=\"qMRqWgAAAAAQMjIABgAAAFwEiEwAAAAA\"");
@@ -84,7 +85,7 @@ namespace System.Net.Http.Tests
 
         [Theory]
         [MemberData(nameof(DigestResponse_ShouldSendQop_TestData))]
-        public async void DigestResponse_ShouldSendQop(string response, string match, string doesNotMatch, int fieldCount)
+        public async Task DigestResponse_ShouldSendQop(string response, string match, string doesNotMatch, int fieldCount)
         {
             NetworkCredential credential = new NetworkCredential("foo", "bar");
             AuthenticationHelper.DigestResponse digestResponse = new AuthenticationHelper.DigestResponse(response);

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -18,11 +18,11 @@ namespace System.Net.Security.Tests
     {
         [Theory]
         [MemberData(nameof(HostNameData))]
-        public void SslStream_ClientSendsSNIServerReceives_Ok(string hostName)
+        public async Task SslStream_ClientSendsSNIServerReceives_Ok(string hostName)
         {
             X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
 
-            WithVirtualConnection(async (server, client) =>
+            await WithVirtualConnection(async (server, client) =>
                 {
                     Task clientJob = Task.Run(() => {
                         client.AuthenticateAsClient(hostName);
@@ -52,7 +52,7 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [MemberData(nameof(HostNameData))]
-        public async void SslStream_ServerCallbackAndLocalCertificateSelectionSet_Throws(string hostName)
+        public async Task SslStream_ServerCallbackAndLocalCertificateSelectionSet_Throws(string hostName)
         {
             X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
 
@@ -97,7 +97,7 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [MemberData(nameof(HostNameData))]
-        public async void SslStream_ServerCallbackNotSet_UsesLocalCertificateSelection(string hostName)
+        public async Task SslStream_ServerCallbackNotSet_UsesLocalCertificateSelection(string hostName)
         {
             X509Certificate serverCert = Configuration.Certificates.GetSelfSignedServerCertificate();
 
@@ -137,9 +137,9 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        public void SslStream_NoSniFromClient_CallbackReturnsNull()
+        public async Task SslStream_NoSniFromClient_CallbackReturnsNull()
         {
-            WithVirtualConnection(async (server, client) =>
+            await WithVirtualConnection(async (server, client) =>
             {
                 Task clientJob = Task.Run(() => {
                     Assert.Throws<VirtualNetwork.VirtualNetworkConnectionBroken>(() =>
@@ -197,7 +197,7 @@ namespace System.Net.Security.Tests
             };
         }
 
-        private async void WithVirtualConnection(Func<SslStream, SslStream, Task> serverClientConnection, RemoteCertificateValidationCallback clientCertValidate)
+        private async Task WithVirtualConnection(Func<SslStream, SslStream, Task> serverClientConnection, RemoteCertificateValidationCallback clientCertValidate)
         {
             VirtualNetwork vn = new VirtualNetwork();
             using (VirtualNetworkStream serverStream = new VirtualNetworkStream(vn, isServer: true),

--- a/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -191,7 +191,7 @@ namespace System.Net.Sockets.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // Skip on Nano: dotnet/corefx #29929
         [PlatformSpecific(TestPlatforms.Windows)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Uap)] // UWP Apps are normally blocked to send network traffic on loopback.
-        public async void MulticastInterface_Set_IPv6_Loopback_Succeeds()
+        public async Task MulticastInterface_Set_IPv6_Loopback_Succeeds()
         {
             // On Windows, we can apparently assume interface 1 is "loopback." On other platforms, this is not a
             // valid assumption. We could maybe use NetworkInterface.LoopbackInterfaceIndex to get the index, but

--- a/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Stream.ReadTests.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class StreamTests
     {
         [Fact]
-        public static async void NullArgumentFail()
+        public static async Task NullArgumentFail()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.DeserializeAsync<string>((Stream)null));
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await JsonSerializer.DeserializeAsync(new MemoryStream(), (Type)null));

--- a/src/System.Threading.Channels/tests/ChannelTests.cs
+++ b/src/System.Threading.Channels/tests/ChannelTests.cs
@@ -132,7 +132,7 @@ namespace System.Threading.Channels.Tests
         }
 
         [Fact]
-        public async void TestBaseClassReadAsync()
+        public async Task TestBaseClassReadAsync()
         {
             WrapperChannel<int> channel = new WrapperChannel<int>(10);
             ChannelReader<int> reader = channel.Reader;


### PR DESCRIPTION
Most of these are just because "async void" tests are rare and require special handling in xunit we needn't use.  But a few of these are plain wrong and were resulting in our not actually testing what we hoped to test.