### PR TITLE
Obsolete old HTTP implementation

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 namespace System.Net
 {
     public delegate void HttpContinueDelegate(int StatusCode, WebHeaderCollection httpHeaders);
-
+    [Obsolete("HttpWebRequest is deprecated, please use HttpClient instead.", true)]
     public class HttpWebRequest : WebRequest, ISerializable
     {
         private const int DefaultContinueTimeout = 350; // Current default value from .NET Desktop.

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 namespace System.Net
 {
     public delegate void HttpContinueDelegate(int StatusCode, WebHeaderCollection httpHeaders);
-    [Obsolete("HttpWebRequest is deprecated, please use HttpClient instead.", true)]
+    [Obsolete("HttpWebRequest is deprecated, please use HttpClient instead.")]
     public class HttpWebRequest : WebRequest, ISerializable
     {
         private const int DefaultContinueTimeout = 350; // Current default value from .NET Desktop.

--- a/src/System.Net.WebClient/ref/System.Net.WebClient.cs
+++ b/src/System.Net.WebClient/ref/System.Net.WebClient.cs
@@ -71,7 +71,7 @@ namespace System.Net
         public byte[] Result { get { throw null; } }
     }
     public delegate void UploadValuesCompletedEventHandler(object sender, System.Net.UploadValuesCompletedEventArgs e);
-    [System.ObsoleteAttribute("WebClient is deprecated, please use HttpClient instead.", true)]
+    [System.ObsoleteAttribute("WebClient is deprecated, please use HttpClient instead.")]
     public partial class WebClient : System.ComponentModel.Component
     {
         public WebClient() { }

--- a/src/System.Net.WebClient/ref/System.Net.WebClient.cs
+++ b/src/System.Net.WebClient/ref/System.Net.WebClient.cs
@@ -71,6 +71,7 @@ namespace System.Net
         public byte[] Result { get { throw null; } }
     }
     public delegate void UploadValuesCompletedEventHandler(object sender, System.Net.UploadValuesCompletedEventArgs e);
+    [System.ObsoleteAttribute("WebClient is deprecated, please use HttpClient instead.", true)]
     public partial class WebClient : System.ComponentModel.Component
     {
         public WebClient() { }


### PR DESCRIPTION
As @jskeet noted in his book:
> HttpClient is in some senses the new and improved WebClient; it’s
the preferred HTTP API for .NET 4.5 onward, and it contains only asynchronous
operations.

If HttpClient is a newer and improved version of WebClient why we don't suggest to developers to use the HttpClient in summary or make them obsolete.

- [x] Codes
- [ ] Documents

## Codes
Currently, I've made HttpWebRequest and WebClient obsolete.

## Documents
In the [dotnet/docs][1] repo, we have a lot of sections that use WebClient and HttpWebRequest.
Shall I replace all of them with HttpClient? If it needs, I want to submit a PR to the docs.

cc. @karelz

[1]:https://github.com/dotnet/docs/search?p=3&q=WebClient&unscoped_q=WebClient