### PR TITLE
HTTP2: Rework shutdown handling

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -214,6 +214,27 @@ namespace System.Net.Test.Common
             _ignoreWindowUpdates = true;
         }
 
+        public async Task ReadRstStreamAsync(int streamId)
+        {
+            Frame frame = await ReadFrameAsync(Timeout);
+            if (frame.Type != FrameType.RstStream)
+            {
+                throw new Exception($"Expected RST_STREAM, saw {frame.Type}");
+            }
+
+            if (frame.StreamId != streamId)
+            {
+                throw new Exception($"Expected RST_STREAM on stream {streamId}, actual streamId={frame.StreamId}");
+            }
+        }
+
+        // Wait for the client to close the connection, e.g. after the HttpClient is disposed.
+        public async Task WaitForClientDisconnectAsync()
+        {
+            Frame frame = await ReadFrameAsync(Timeout);
+            Assert.Null(frame);
+        }
+
         public void ShutdownSend()
         {
             _connectionSocket.Shutdown(SocketShutdown.Send);

--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -217,6 +217,12 @@ namespace System.Net.Test.Common
         public async Task ReadRstStreamAsync(int streamId)
         {
             Frame frame = await ReadFrameAsync(Timeout);
+            
+            if (frame == null)
+            {
+                throw new Exception($"Expected RST_STREAM, saw EOF");
+            }
+
             if (frame.Type != FrameType.RstStream)
             {
                 throw new Exception($"Expected RST_STREAM, saw {frame.Type}");

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CreditManager.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CreditManager.cs
@@ -106,7 +106,7 @@ namespace System.Net.Http
             }
         }
 
-        public void Dispose(Exception abortException)
+        public void Dispose()
         {
             lock (SyncObject)
             {
@@ -121,9 +121,7 @@ namespace System.Net.Http
                 {
                     while (_waiters.TryDequeue(out Waiter waiter))
                     {
-                        waiter.TrySetException(abortException != null ? (Exception)
-                            new IOException(SR.net_http_request_aborted, abortException) :
-                            CreateObjectDisposedException(forActiveWaiter: true));
+                        waiter.TrySetException(CreateObjectDisposedException(forActiveWaiter: true));
                     }
                 }
             }

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -758,7 +758,7 @@ namespace System.Net.Http
             // We can't validate that we hold the semaphore, but we can at least validate that someone is holding it.
             Debug.Assert(_writerLock.CurrentCount == 0);
 
-            EndWrite(false);
+            EndWrite(forceFlush: false);
         }
 
         private void EndWrite(bool forceFlush)

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1263,9 +1263,9 @@ namespace System.Net.Http
             }
         }
 
-        private async Task SendEndStreamAsync(int streamId, CancellationToken cancellationToken)
+        private async Task SendEndStreamAsync(int streamId)
         {
-            Memory<byte> writeBuffer = await StartWriteAsync(FrameHeader.Size, cancellationToken).ConfigureAwait(false);
+            Memory<byte> writeBuffer = await StartWriteAsync(FrameHeader.Size).ConfigureAwait(false);
             if (NetEventSource.IsEnabled) Trace(streamId, "Started writing.");
 
             FrameHeader frameHeader = new FrameHeader(0, FrameType.Data, FrameFlags.EndStream, streamId);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +16,7 @@ namespace System.Net.Http
 {
     internal sealed partial class Http2Connection
     {
-        private sealed class Http2Stream : IValueTaskSource, IDisposable, IHttpTrace
+        private sealed class Http2Stream : IValueTaskSource, IHttpTrace
         {
             private const int InitialStreamBufferSize =
 #if DEBUG
@@ -39,10 +38,14 @@ namespace System.Net.Http
             private ArrayBuffer _responseBuffer; // mutable struct, do not make this readonly
             private int _pendingWindowUpdate;
 
-            private StreamState _state;
-            private bool _disposed;
-            private Exception _abortException;
-            private bool _canRetry;             // if _state == Aborted, this indicates the stream was refused and so the request is retryable
+            private StreamCompletionState _requestCompletionState;
+            private StreamCompletionState _responseCompletionState;
+            private ResponseProtocolState _responseProtocolState;
+
+            // If this is not null, then we have received a reset from the server
+            // (i.e. RST_STREAM or general IO error processing the connection)
+            private Exception _resetException;
+            private bool _canRetry;             // if _resetException != null, this indicates the stream was refused and so the request is retryable
 
             /// <summary>
             /// The core logic for the IValueTaskSource implementation.
@@ -67,8 +70,8 @@ namespace System.Net.Http
             /// </summary>
             private bool _hasWaiter;
 
-            private TaskCompletionSource<bool> _shouldSendRequestBodyWaiter;
-            private bool _shouldSendRequestBody;
+            private CancellationTokenSource _requestBodyCancellationSource;
+            private TaskCompletionSource<bool> _expect100ContinueWaiter;
 
             private int _headerBudgetRemaining;
 
@@ -82,12 +85,12 @@ namespace System.Net.Http
                 _connection = connection;
                 _streamId = streamId;
 
-                _state = StreamState.ExpectingStatus;
+                _requestCompletionState = StreamCompletionState.InProgress;
+                _responseCompletionState = StreamCompletionState.InProgress;
+
+                _responseProtocolState = ResponseProtocolState.ExpectingStatus;
 
                 _request = request;
-                _shouldSendRequestBody = true;
-
-                _disposed = false;
 
                 _responseBuffer = new ArrayBuffer(InitialStreamBufferSize, usePool: true);
 
@@ -117,60 +120,68 @@ namespace System.Net.Http
 
             public async Task SendRequestBodyAsync(CancellationToken cancellationToken)
             {
-                Debug.Assert(_request.Content != null);
-                if (NetEventSource.IsEnabled) Trace($"{_request.Content}");
-
-                try
+                if (_request.Content != null)
                 {
-                    using (Http2WriteStream writeStream = new Http2WriteStream(this))
+                    if (NetEventSource.IsEnabled)
+                        Trace($"{_request.Content}");
+
+                    // Create a linked cancellation token source so that we can cancel the request in the event of receiving RST_STREAM
+                    // and similiar situations where we need to cancel the request body (see CancelRequestBody).
+                    _requestBodyCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, CancellationToken.None);
+                    cancellationToken = _requestBodyCancellationSource.Token;
+
+                    try
                     {
-                        // TODO: until #9071 is fixed, cancellation on content.CopyToAsync does not apply for most content types,
-                        // because most content types aren't passed the token given to this internal overload of CopyToAsync.
-                        // To work around it, we register to set _abortException as needed; this won't preempt reads issued to
-                        // the source content, but it will at least enable the writes then performed on our write stream to see
-                        // that cancellation was requested and abort, rather than waiting for the whole copy to complete.
-                        using (cancellationToken.UnsafeRegister(stream =>
+                        bool sendRequestContent = true;
+                        if (_request.HasHeaders && _request.Headers.ExpectContinue == true)
                         {
-                            var thisRef = (Http2Stream)stream;
-                            if (thisRef._abortException == null)
-                            {
-                                if (NetEventSource.IsEnabled) thisRef.Trace($"Canceling sending request body.");
-                                Interlocked.CompareExchange(ref thisRef._abortException, new OperationCanceledException(), null);
-                            }
-                        }, this))
-                        {
-                            await _request.Content.CopyToAsync(writeStream, null, cancellationToken).ConfigureAwait(false);
-                            if (NetEventSource.IsEnabled) Trace($"Finished sending request body.");
+                            sendRequestContent = await WaitFor100ContinueAsync(cancellationToken).ConfigureAwait(false);
                         }
+
+                        if (sendRequestContent)
+                        {
+                            using (Http2WriteStream writeStream = new Http2WriteStream(this))
+                            {
+                                await _request.Content.CopyToAsync(writeStream, null, cancellationToken).ConfigureAwait(false);
+                            }
+                        }
+
+                        await _connection.SendEndStreamAsync(_streamId);
+
+                        if (NetEventSource.IsEnabled) Trace($"Finished sending request body.");
                     }
-
-                    // Don't wait for completion, which could happen asynchronously.
-                    _connection.LogExceptions(_connection.SendEndStreamAsync(_streamId));
-                }
-                catch (Exception e)
-                {
-                    if (NetEventSource.IsEnabled) Trace($"Failed to send request body: {e}");
-
-                    // if we decided abandon sending request and we get ObjectDisposed as result of it, just eat exception.
-                    if (!_shouldSendRequestBody && (e is ObjectDisposedException || e.InnerException is ObjectDisposedException))
+                    catch (Exception e)
                     {
-                        // Try to notify server if we did not finish sending request body.
-                        IgnoreExceptions(_connection.SendRstStreamAsync(_streamId, Http2ProtocolErrorCode.Cancel));
-                        return;
+                        if (NetEventSource.IsEnabled) Trace($"Failed to send request body: {e}");
+
+                        lock (SyncObject)
+                        {
+                            Debug.Assert(_requestCompletionState == StreamCompletionState.InProgress, $"Request already completed with state={_requestCompletionState}");
+
+                            _requestCompletionState = StreamCompletionState.Failed;
+                            CheckForCompletion();
+                        }
+
+                        CancelResponseBody();
+
+                        throw;
                     }
+                }
 
-                    // If we are still processing the response after receiving response headers,
-                    // this will give us a chance to propagate exception up.
-                    Interlocked.CompareExchange(ref _abortException, e, null);
+                lock (SyncObject)
+                {
+                    Debug.Assert(_requestCompletionState == StreamCompletionState.InProgress, $"Request already completed with state={_requestCompletionState}");
 
-                    throw;
+                    _requestCompletionState = StreamCompletionState.Completed;
+                    CheckForCompletion();
                 }
             }
 
-            // Process request body if we sent 100Continue. We can either get 100 response from server and send body
+            // Delay sending request body if we sent Expect: 100-continue.
+            // We can either get 100 response from server and send body
             // or we may exceed timeout and send request body anyway.
-            // If we get response > 300, we will try to stop sending and we will send RST_STREAM.
-            public async Task SendRequestBodyWithExpect100ContinueAsync(CancellationToken cancellationToken)
+            // If we get response status >= 300, we will not send the request body.
+            public async Task<bool> WaitFor100ContinueAsync(CancellationToken cancellationToken)
             {
                 Debug.Assert(_request.Content != null);
                 if (NetEventSource.IsEnabled) Trace($"Waiting to send request body content for 100-Continue.");
@@ -182,32 +193,99 @@ namespace System.Net.Http
                 // as we could end up starting the body copy operation on the main event loop thread, which could
                 // then starve the processing of other requests.  So, we make the TCS RunContinuationsAsynchronously.
                 bool sendRequestContent;
-                var waiter = _shouldSendRequestBodyWaiter = new TaskCompletionSource<bool>(TaskContinuationOptions.RunContinuationsAsynchronously);
+                var waiter = _expect100ContinueWaiter = new TaskCompletionSource<bool>(TaskContinuationOptions.RunContinuationsAsynchronously);
                 using (var expect100Timer = new Timer(s =>
-                    {
-                        var thisRef = (Http2Stream)s;
-                        if (NetEventSource.IsEnabled) thisRef.Trace($"100-Continue timer expired.");
-                        thisRef._shouldSendRequestBodyWaiter?.TrySetResult(true);
-                    }, this, _connection._pool.Settings._expect100ContinueTimeout, Timeout.InfiniteTimeSpan))
+                {
+                    var thisRef = (Http2Stream)s;
+                    if (NetEventSource.IsEnabled)
+                        thisRef.Trace($"100-Continue timer expired.");
+                    thisRef._expect100ContinueWaiter?.TrySetResult(true);
+                }, this, _connection._pool.Settings._expect100ContinueTimeout, Timeout.InfiniteTimeSpan))
                 {
                     sendRequestContent = await waiter.Task.ConfigureAwait(false);
                     // By now, either we got a response from the server or the timer expired.
                 }
 
-                if (sendRequestContent)
+                _expect100ContinueWaiter = null;
+                return sendRequestContent;
+            }
+
+            private void CheckForCompletion()
+            {
+                Debug.Assert(Monitor.IsEntered(SyncObject));
+                Debug.Assert(_requestCompletionState != StreamCompletionState.InProgress || _responseCompletionState != StreamCompletionState.InProgress,
+                    $"CheckForCompletion called but neither request nor response is completed");
+
+                if (_requestCompletionState == StreamCompletionState.InProgress || _responseCompletionState == StreamCompletionState.InProgress)
                 {
-                    // We received a positive response from the server, or we didn't receive a response but our timer expired.
-                    // In either case, start sending the request body.
-                    await SendRequestBodyAsync(cancellationToken).ConfigureAwait(false);
+                    return;
                 }
-                else
+
+                if (NetEventSource.IsEnabled) Trace($"Stream complete.");
+
+                if (_resetException == null &&
+                    (_requestCompletionState == StreamCompletionState.Failed || _responseCompletionState == StreamCompletionState.Failed))
                 {
-                    // We received a negative response from server, so we will not send the request body, and instead we will reset the stream.
-                    if (NetEventSource.IsEnabled) Trace("Avoiding sending 100-Continue request body content.");
-                    _shouldSendRequestBody = false;
-                    _shouldSendRequestBodyWaiter = null;
                     IgnoreExceptions(_connection.SendRstStreamAsync(_streamId, Http2ProtocolErrorCode.Cancel));
                 }
+
+                _connection.RemoveStream(this);
+
+                // Do cleanup.
+                _streamWindow.Dispose();
+
+                if (_requestBodyCancellationSource != null)
+                {
+                    _requestBodyCancellationSource.Dispose();
+                }
+            }
+
+            private void CancelRequestBody()
+            {
+                CancellationTokenSource requestBodyCancellationSource;
+
+                lock (SyncObject)
+                {
+                    if (_requestCompletionState != StreamCompletionState.InProgress)
+                    {
+                        return;
+                    }
+
+                    requestBodyCancellationSource = _requestBodyCancellationSource;
+                }
+
+                if (NetEventSource.IsEnabled) Trace($"Canceling sending request body.");
+                requestBodyCancellationSource.Cancel();
+
+                // When cancellation propagates, SendRequestBodyAsync will set _responseCompletionState to Failed
+            }
+
+            public void CancelResponseBody()
+            {
+                bool signalWaiter;
+
+                lock (SyncObject)
+                {
+                    if (_responseCompletionState != StreamCompletionState.InProgress)
+                    {
+                        return;
+                    }
+
+                    _responseCompletionState = StreamCompletionState.Failed;
+                    CheckForCompletion();
+
+                    _responseProtocolState = ResponseProtocolState.Aborted;
+
+                    signalWaiter = _hasWaiter;
+                    _hasWaiter = false;
+                }
+
+                if (signalWaiter)
+                {
+                    _waitSource.SetResult(true);
+                }
+
+                CancelRequestBody();
             }
 
             public void OnWindowUpdate(int amount) => _streamWindow.AdjustCredit(amount);
@@ -227,7 +305,7 @@ namespace System.Net.Http
 
                 lock (SyncObject)
                 {
-                    if (_state == StreamState.Aborted)
+                    if (_responseProtocolState == ResponseProtocolState.Aborted)
                     {
                         // We could have aborted while processing the header block.
                         return;
@@ -235,16 +313,16 @@ namespace System.Net.Http
 
                     if (name[0] == (byte)':')
                     {
-                        if (_state != StreamState.ExpectingHeaders && _state != StreamState.ExpectingStatus)
+                        if (_responseProtocolState != ResponseProtocolState.ExpectingHeaders && _responseProtocolState != ResponseProtocolState.ExpectingStatus)
                         {
                             // Pseudo-headers are allowed only in header block
-                            if (NetEventSource.IsEnabled) Trace($"Pseudo-header received in {_state} state.");
+                            if (NetEventSource.IsEnabled) Trace($"Pseudo-header received in {_responseProtocolState} state.");
                             throw new HttpRequestException(SR.net_http_invalid_response_pseudo_header_in_trailer);
                         }
 
                         if (name.SequenceEqual(s_statusHeaderName))
                         {
-                            if (_state != StreamState.ExpectingStatus)
+                            if (_responseProtocolState != ResponseProtocolState.ExpectingStatus)
                             {
                                 if (NetEventSource.IsEnabled) Trace("Received extra status header.");
                                 throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, "duplicate status"));
@@ -268,24 +346,33 @@ namespace System.Net.Http
                                 StatusCode = (HttpStatusCode)statusValue
                             };
 
-                            TaskCompletionSource<bool> shouldSendRequestBodyWaiter = _shouldSendRequestBodyWaiter;
+                            TaskCompletionSource<bool> expect100ContinueWaiter = _expect100ContinueWaiter;
                             if (statusValue < 200)
                             {
-                                if (_response.StatusCode == HttpStatusCode.Continue && shouldSendRequestBodyWaiter != null)
+                                // We do not process headers from 1xx responses.
+                                _responseProtocolState = ResponseProtocolState.ExpectingIgnoredHeaders;
+
+                                if (_response.StatusCode == HttpStatusCode.Continue && expect100ContinueWaiter != null)
                                 {
                                     if (NetEventSource.IsEnabled) Trace("Received 100-Continue status.");
-                                    shouldSendRequestBodyWaiter.TrySetResult(true);
-                                    _shouldSendRequestBodyWaiter = null;
+                                    expect100ContinueWaiter.TrySetResult(true);
+                                    _expect100ContinueWaiter = null;
                                 }
-                                // We do not process headers from 1xx responses.
-                                _state = StreamState.ExpectingIgnoredHeaders;
                             }
                             else
                             {
-                                _state = StreamState.ExpectingHeaders;
-                                // If we tried 100-Continue and got rejected signal that we should not send request body.
-                                _shouldSendRequestBody = (int)_response.StatusCode < 300;
-                                shouldSendRequestBodyWaiter?.TrySetResult(_shouldSendRequestBody);
+                                _responseProtocolState = ResponseProtocolState.ExpectingHeaders;
+
+                                // If we are waiting for a 100-continue response, signal the waiter now.
+                                if (expect100ContinueWaiter != null)
+                                {
+                                    // If the final status code is >= 300, skip sending the body.
+                                    bool shouldSendBody = (statusValue < 300);
+
+                                    if (NetEventSource.IsEnabled) Trace($"Expecting 100 Continue but received final status {statusValue}.");
+                                    expect100ContinueWaiter.TrySetResult(shouldSendBody);
+                                    _expect100ContinueWaiter = null;
+                                }
                             }
                         }
                         else
@@ -296,13 +383,13 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        if (_state == StreamState.ExpectingIgnoredHeaders)
+                        if (_responseProtocolState == ResponseProtocolState.ExpectingIgnoredHeaders)
                         {
                             // for 1xx response we ignore all headers.
                             return;
                         }
 
-                        if (_state != StreamState.ExpectingHeaders && _state != StreamState.ExpectingTrailingHeaders)
+                        if (_responseProtocolState != ResponseProtocolState.ExpectingHeaders && _responseProtocolState != ResponseProtocolState.ExpectingTrailingHeaders)
                         {
                             if (NetEventSource.IsEnabled) Trace("Received header before status.");
                             throw new HttpRequestException(SR.net_http_invalid_response);
@@ -318,7 +405,7 @@ namespace System.Net.Http
 
                         // Note we ignore the return value from TryAddWithoutValidation;
                         // if the header can't be added, we silently drop it.
-                        if (_state == StreamState.ExpectingTrailingHeaders)
+                        if (_responseProtocolState == ResponseProtocolState.ExpectingTrailingHeaders)
                         {
                             Debug.Assert(_trailers != null);
                             _trailers.Add(KeyValuePair.Create(descriptor.HeaderType == HttpHeaderType.Request ? descriptor.AsCustomHeader() : descriptor, headerValue));
@@ -341,19 +428,19 @@ namespace System.Net.Http
             {
                 lock (SyncObject)
                 {
-                    if (_state == StreamState.Aborted)
+                    if (_responseProtocolState == ResponseProtocolState.Aborted)
                     {
                         return;
                     }
 
-                    if (_state != StreamState.ExpectingStatus && _state != StreamState.ExpectingData)
+                    if (_responseProtocolState != ResponseProtocolState.ExpectingStatus && _responseProtocolState != ResponseProtocolState.ExpectingData)
                     {
                         throw new Http2ConnectionException(Http2ProtocolErrorCode.ProtocolError);
                     }
 
-                    if (_state == StreamState.ExpectingData)
+                    if (_responseProtocolState == ResponseProtocolState.ExpectingData)
                     {
-                        _state = StreamState.ExpectingTrailingHeaders;
+                        _responseProtocolState = ResponseProtocolState.ExpectingTrailingHeaders;
                         _trailers ??= new List<KeyValuePair<HeaderDescriptor, string>>();
                     }
                 }
@@ -364,21 +451,21 @@ namespace System.Net.Http
                 bool signalWaiter;
                 lock (SyncObject)
                 {
-                    if (_state == StreamState.Aborted)
+                    if (_responseProtocolState == ResponseProtocolState.Aborted)
                     {
                         return;
                     }
 
-                    if (_state != StreamState.ExpectingHeaders && _state != StreamState.ExpectingTrailingHeaders && _state != StreamState.ExpectingIgnoredHeaders)
+                    if (_responseProtocolState != ResponseProtocolState.ExpectingHeaders && _responseProtocolState != ResponseProtocolState.ExpectingTrailingHeaders && _responseProtocolState != ResponseProtocolState.ExpectingIgnoredHeaders)
                     {
                         throw new Http2ConnectionException(Http2ProtocolErrorCode.ProtocolError);
                     }
 
-                    if (_state == StreamState.ExpectingHeaders)
+                    if (_responseProtocolState == ResponseProtocolState.ExpectingHeaders)
                     {
-                        _state = endStream ? StreamState.Complete : StreamState.ExpectingData;
+                        _responseProtocolState = endStream ? ResponseProtocolState.Complete : ResponseProtocolState.ExpectingData;
                     }
-                    else if (_state == StreamState.ExpectingTrailingHeaders)
+                    else if (_responseProtocolState == ResponseProtocolState.ExpectingTrailingHeaders)
                     {
                         if (!endStream)
                         {
@@ -386,9 +473,9 @@ namespace System.Net.Http
                             throw new Http2ConnectionException(Http2ProtocolErrorCode.ProtocolError);
                         }
 
-                        _state = StreamState.Complete;
+                        _responseProtocolState = ResponseProtocolState.Complete;
                     }
-                    else if (_state == StreamState.ExpectingIgnoredHeaders)
+                    else if (_responseProtocolState == ResponseProtocolState.ExpectingIgnoredHeaders)
                     {
                         if (endStream)
                         {
@@ -396,13 +483,21 @@ namespace System.Net.Http
                             throw new Http2ConnectionException(Http2ProtocolErrorCode.ProtocolError);
                         }
 
-                        _state = StreamState.ExpectingStatus;
+                        _responseProtocolState = ResponseProtocolState.ExpectingStatus;
                         // We should wait for final response before signaling to waiter.
                         return;
                     }
                     else
                     {
-                        _state = StreamState.ExpectingData;
+                        _responseProtocolState = ResponseProtocolState.ExpectingData;
+                    }
+
+                    if (endStream)
+                    {
+                        Debug.Assert(_responseCompletionState == StreamCompletionState.InProgress, $"Response already completed with state={_responseCompletionState}");
+
+                        _responseCompletionState = StreamCompletionState.Completed;
+                        CheckForCompletion();
                     }
 
                     signalWaiter = _hasWaiter;
@@ -420,17 +515,12 @@ namespace System.Net.Http
                 bool signalWaiter;
                 lock (SyncObject)
                 {
-                    if (_disposed)
+                    if (_responseProtocolState == ResponseProtocolState.Aborted)
                     {
                         return;
                     }
 
-                    if (_state == StreamState.Aborted)
-                    {
-                        return;
-                    }
-
-                    if (_state != StreamState.ExpectingData)
+                    if (_responseProtocolState != ResponseProtocolState.ExpectingData)
                     {
                         // Flow control messages are not valid in this state.
                         throw new Http2ConnectionException(Http2ProtocolErrorCode.ProtocolError);
@@ -448,7 +538,12 @@ namespace System.Net.Http
 
                     if (endStream)
                     {
-                        _state = StreamState.Complete;
+                        _responseProtocolState = ResponseProtocolState.Complete;
+
+                        Debug.Assert(_responseCompletionState == StreamCompletionState.InProgress, $"Response already completed with state={_responseCompletionState}");
+
+                        _responseCompletionState = StreamCompletionState.Completed;
+                        CheckForCompletion();
                     }
 
                     signalWaiter = _hasWaiter;
@@ -461,54 +556,55 @@ namespace System.Net.Http
                 }
             }
 
-            public void OnAbort(Exception abortException, bool canRetry = false)
+            public void OnReset(Exception resetException, bool canRetry = false)
             {
-                bool signalWaiter;
+                if (NetEventSource.IsEnabled) Trace($"{nameof(resetException)}={resetException}");
+
                 lock (SyncObject)
                 {
-                    if (NetEventSource.IsEnabled) Trace($"{nameof(abortException)}={abortException}");
-
-                    if (_disposed || _state == StreamState.Aborted)
+                    // It's possible we could be called twice, e.g. we receive a RST_STREAM and then the whole connection dies
+                    // before we have a chance to process cancellation and tear everything down. Just ignore this.
+                    if (_resetException != null)
                     {
                         return;
                     }
 
-                    // We should not retry request which have started being processed since the behavior might be unpredictable
-                    // I.e. some action might have been taken based on the received data.
-                    // We will bubble the exception and let user decide what to do.
-                    bool isRetriable = _state == StreamState.ExpectingStatus || _state == StreamState.ExpectingHeaders;
-                    Interlocked.CompareExchange(ref _abortException, abortException, null);
-                    _state = StreamState.Aborted;
-                    _canRetry = canRetry && isRetriable;
+                    // If the server told us the request has not been processed (via Last-Stream-ID on GOAWAY),
+                    // but we've already received some response data from the server, then the server lied to us.
+                    // In this case, don't allow the request to be retried.
+                    if (canRetry && _responseProtocolState != ResponseProtocolState.ExpectingStatus)
+                    {
+                        canRetry = false;
+                    }
 
-                    signalWaiter = _hasWaiter;
-                    _hasWaiter = false;
+                    _resetException = resetException;
+                    _canRetry = canRetry;
                 }
 
-                if (signalWaiter)
-                {
-                    _waitSource.SetResult(true);
-                }
+                CancelRequestBody();
+                CancelResponseBody();
             }
 
-            private void CheckIfDisposedOrAborted()
+            private void CheckResponseBodyState()
             {
                 Debug.Assert(Monitor.IsEntered(SyncObject));
 
-                if (_disposed)
-                {
-                    throw new ObjectDisposedException(nameof(Http2Stream));
-                }
-
-                if (_state == StreamState.Aborted)
+                if (_resetException != null)
                 {
                     if (_canRetry)
                     {
-                        throw new HttpRequestException(SR.net_http_request_aborted, _abortException, allowRetry: true);
+                        throw new HttpRequestException(SR.net_http_request_aborted, _resetException, allowRetry: true);
                     }
 
-                    throw new IOException(SR.net_http_request_aborted, _abortException);
+                    throw new IOException(SR.net_http_request_aborted, _resetException);
                 }
+
+                if (_responseCompletionState == StreamCompletionState.Failed)
+                {
+                    throw new IOException(SR.net_http_request_aborted);
+                }
+
+                Debug.Assert(_responseProtocolState != ResponseProtocolState.Aborted);
             }
 
             // Determine if we have enough data to process up to complete final response headers.
@@ -516,22 +612,22 @@ namespace System.Net.Http
             {
                 lock (SyncObject)
                 {
-                    CheckIfDisposedOrAborted();
+                    CheckResponseBodyState();
 
-                    if (_state == StreamState.ExpectingHeaders || _state == StreamState.ExpectingIgnoredHeaders || _state == StreamState.ExpectingStatus)
+                    if (_responseProtocolState == ResponseProtocolState.ExpectingHeaders || _responseProtocolState == ResponseProtocolState.ExpectingIgnoredHeaders || _responseProtocolState == ResponseProtocolState.ExpectingStatus)
                     {
                         Debug.Assert(!_hasWaiter);
                         _hasWaiter = true;
                         _waitSource.Reset();
                         return (true, false);
                     }
-                    else if (_state == StreamState.ExpectingData || _state == StreamState.ExpectingTrailingHeaders)
+                    else if (_responseProtocolState == ResponseProtocolState.ExpectingData || _responseProtocolState == ResponseProtocolState.ExpectingTrailingHeaders)
                     {
                         return (false, false);
                     }
                     else
                     {
-                        Debug.Assert(_state == StreamState.Complete);
+                        Debug.Assert(_responseProtocolState == ResponseProtocolState.Complete);
                         return (false, _responseBuffer.ActiveLength == 0);
                     }
                 }
@@ -539,18 +635,27 @@ namespace System.Net.Http
 
             public async Task ReadResponseHeadersAsync(CancellationToken cancellationToken)
             {
-                // Wait for response headers to be read.
                 bool emptyResponse;
-                bool wait;
-
-                // Process all informational responses if any and wait for final status.
-                (wait, emptyResponse) = TryEnsureHeaders();
-                if (wait)
+                try
                 {
-                    await GetWaiterTask(cancellationToken).ConfigureAwait(false);
+                    // Wait for response headers to be read.
+                    bool wait;
 
+                    // Process all informational responses if any and wait for final status.
                     (wait, emptyResponse) = TryEnsureHeaders();
-                    Debug.Assert(!wait);
+                    if (wait)
+                    {
+                        await GetWaiterTask(cancellationToken).ConfigureAwait(false);
+
+                        (wait, emptyResponse) = TryEnsureHeaders();
+                        Debug.Assert(!wait);
+                    }
+                }
+                catch
+                {
+                    CancelRequestBody();
+                    CancelResponseBody();
+                    throw;
                 }
 
                 // Start to process the response body.
@@ -579,7 +684,7 @@ namespace System.Net.Http
                 Debug.Assert(amount > 0);
                 Debug.Assert(_pendingWindowUpdate < StreamWindowThreshold);
 
-                if (_state != StreamState.ExpectingData)
+                if (_responseProtocolState != ResponseProtocolState.ExpectingData)
                 {
                     // We are not expecting any more data (because we've either completed or aborted).
                     // So no need to send any more WINDOW_UPDATEs.
@@ -604,7 +709,7 @@ namespace System.Net.Http
 
                 lock (SyncObject)
                 {
-                    CheckIfDisposedOrAborted();
+                    CheckResponseBodyState();
 
                     if (_responseBuffer.ActiveLength > 0)
                     {
@@ -614,12 +719,12 @@ namespace System.Net.Http
 
                         return (false, bytesRead);
                     }
-                    else if (_state == StreamState.Complete)
+                    else if (_responseProtocolState == ResponseProtocolState.Complete)
                     {
                         return (false, 0);
                     }
 
-                    Debug.Assert(_state == StreamState.ExpectingData || _state == StreamState.ExpectingTrailingHeaders);
+                    Debug.Assert(_responseProtocolState == ResponseProtocolState.ExpectingData || _responseProtocolState == ResponseProtocolState.ExpectingTrailingHeaders);
 
                     Debug.Assert(!_hasWaiter);
                     _hasWaiter = true;
@@ -703,51 +808,42 @@ namespace System.Net.Http
             {
                 ReadOnlyMemory<byte> remaining = buffer;
 
-                while (remaining.Length > 0)
+                // Deal with ActiveIssue #9071:
+                // Custom HttpContent classes do not get passed the cancellationToken.
+                // So, inject the expected CancellationToken here, to ensure we can cancel the request body send if needed.
+                CancellationTokenSource customCancellationSource = null;
+                if (!cancellationToken.CanBeCanceled)
                 {
-                    int sendSize = await _streamWindow.RequestCreditAsync(remaining.Length, cancellationToken).ConfigureAwait(false);
-
-                    ReadOnlyMemory<byte> current;
-                    (current, remaining) = SplitBuffer(remaining, sendSize);
-
-                    await _connection.SendStreamDataAsync(_streamId, current, cancellationToken).ConfigureAwait(false);
+                    cancellationToken = _requestBodyCancellationSource.Token;
                 }
-            }
-
-            public void Dispose()
-            {
-                lock (SyncObject)
+                else if (cancellationToken != _requestBodyCancellationSource.Token)
                 {
-                    if (!_disposed)
+                    // User passed a custom CancellationToken.
+                    // We can't tell if it includes our Token or not, so assume it doesn't.
+                    customCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _requestBodyCancellationSource.Token);
+                    cancellationToken = customCancellationSource.Token;
+                }
+
+                using (customCancellationSource)
+                {
+                    while (remaining.Length > 0)
                     {
-                        _disposed = true;
+                        int sendSize = await _streamWindow.RequestCreditAsync(remaining.Length, cancellationToken).ConfigureAwait(false);
 
-                        _streamWindow.Dispose(_abortException);
-                        _responseBuffer.Dispose();
+                        ReadOnlyMemory<byte> current;
+                        (current, remaining) = SplitBuffer(remaining, sendSize);
 
-                        // TODO: ISSUE 31310: If the stream is not complete, we should send RST_STREAM
+                        await _connection.SendStreamDataAsync(_streamId, current, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }
 
-            public void Cancel()
+            private void CloseResponseBody()
             {
-                bool signalWaiter;
-                lock (SyncObject)
-                {
-                    IgnoreExceptions(_connection.SendRstStreamAsync(_streamId, Http2ProtocolErrorCode.Cancel));
-                    Interlocked.CompareExchange(ref _abortException, new OperationCanceledException(), null);
-                    _state = StreamState.Aborted;
+                // If the response body isn't completed, cancel it now.
+                CancelResponseBody();
 
-                    signalWaiter = _hasWaiter;
-                    _hasWaiter = false;
-                }
-                if (signalWaiter)
-                {
-                    _waitSource.SetResult(true);
-                }
-
-                _connection.RemoveStream(this);
+                _responseBuffer.Dispose();
             }
 
             // This object is itself usable as a backing source for ValueTask.  Since there's only ever one awaiter
@@ -805,7 +901,7 @@ namespace System.Net.Http
             public void Trace(string message, [CallerMemberName] string memberName = null) =>
                 _connection.Trace(_streamId, message, memberName);
 
-            private enum StreamState : byte
+            private enum ResponseProtocolState : byte
             {
                 ExpectingStatus,
                 ExpectingIgnoredHeaders,
@@ -814,6 +910,13 @@ namespace System.Net.Http
                 ExpectingTrailingHeaders,
                 Complete,
                 Aborted
+            }
+
+            private enum StreamCompletionState : byte
+            {
+                InProgress,
+                Completed,
+                Failed
             }
 
             private sealed class Http2ReadStream : HttpBaseStream
@@ -856,13 +959,7 @@ namespace System.Net.Http
                     // disposing of it, we need to a) signal to the server that the stream is being
                     // canceled, and b) clean up the associated state in the Http2Connection.
 
-                    if (http2Stream._state != StreamState.Aborted && http2Stream._state != StreamState.Complete)
-                    {
-                        // If we abort response stream before endOfStream, let server know.
-                        IgnoreExceptions(http2Stream._connection.SendRstStreamAsync(http2Stream._streamId, Http2ProtocolErrorCode.Cancel));
-                    }
-
-                    http2Stream.Dispose();
+                    http2Stream.CloseResponseBody();
 
                     base.Dispose(disposing);
                 }
@@ -873,10 +970,6 @@ namespace System.Net.Http
                 public override int Read(Span<byte> destination)
                 {
                     Http2Stream http2Stream = _http2Stream ?? throw new ObjectDisposedException(nameof(Http2ReadStream));
-                    if (http2Stream._abortException != null)
-                    {
-                        throw new IOException(SR.net_http_client_execution_error, http2Stream._abortException);
-                    }
 
                     return http2Stream.ReadData(destination, _responseMessage);
                 }
@@ -884,14 +977,10 @@ namespace System.Net.Http
                 public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
                 {
                     Http2Stream http2Stream = _http2Stream;
+
                     if (http2Stream == null)
                     {
                         return new ValueTask<int>(Task.FromException<int>(new ObjectDisposedException(nameof(Http2ReadStream))));
-                    }
-
-                    if (http2Stream._abortException != null)
-                    {
-                        return new ValueTask<int>(Task.FromException<int>(new IOException(SR.net_http_client_execution_error, http2Stream._abortException)));
                     }
 
                     if (cancellationToken.IsCancellationRequested)
@@ -939,15 +1028,9 @@ namespace System.Net.Http
                 {
                     Http2Stream http2Stream = _http2Stream;
 
-                    if (http2Stream == null || !http2Stream._shouldSendRequestBody)
+                    if (http2Stream == null)
                     {
                         return new ValueTask(Task.FromException(new ObjectDisposedException(nameof(Http2WriteStream))));
-                    }
-
-                    // TODO: until #9071 is fixed
-                    if (http2Stream._abortException is OperationCanceledException oce)
-                    {
-                        throw new OperationCanceledException(oce.Message, oce, oce.CancellationToken);
                     }
 
                     return new ValueTask(http2Stream.SendDataAsync(buffer, cancellationToken));

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -2687,8 +2687,6 @@ namespace System.Net.Http.Functional.Tests
                 // We should not reach retry limit without failing.
                 Assert.NotEqual(0, maxCount);
 
-                var headers = new HttpHeaderData[] { new HttpHeaderData("x-last", "done") };
-                await connection.SendResponseHeadersAsync(streamId, endStream: true, isTrailingHeader : true, headers: headers);
                 try
                 {
                     await connection.SendGoAway(streamId);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -2,18 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.IO;
-using System.Net.Security;
 using System.Linq;
+using System.Net.Security;
 using System.Net.Test.Common;
 using System.Text;
-using System.Text.Unicode;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Xunit;
 using Xunit.Abstractions;
 
@@ -26,11 +24,14 @@ namespace System.Net.Http.Functional.Tests
 
         public static bool SupportsAlpn => PlatformDetection.SupportsAlpn;
 
-        public HttpClientHandlerTest_Http2(ITestOutputHelper output) : base(output) { }
-
-        private async Task AssertProtocolErrorAsync(Task task, ProtocolErrors errorCode)
+        public HttpClientHandlerTest_Http2(ITestOutputHelper output) : base(output)
         {
-            Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => task);
+        }
+
+        private async Task AssertProtocolErrorAsync<T>(Task task, ProtocolErrors errorCode)
+            where T : Exception
+        {
+            Exception e = await Assert.ThrowsAsync<T>(() => task);
             if (UseSocketsHttpHandler)
             {
                 string text = e.ToString();
@@ -39,6 +40,16 @@ namespace System.Net.Http.Functional.Tests
                     Enum.IsDefined(typeof(ProtocolErrors), errorCode) ? errorCode.ToString() : "(unknown error)",
                     text);
             }
+        }
+
+        private Task AssertProtocolErrorAsync(Task task, ProtocolErrors errorCode)
+        {
+            return AssertProtocolErrorAsync<HttpRequestException>(task, errorCode);
+        }
+
+        private Task AssertProtocolErrorForIOExceptionAsync(Task task, ProtocolErrors errorCode)
+        {
+            return AssertProtocolErrorAsync<IOException>(task, errorCode);
         }
 
         private async Task<(bool, T)> IgnoreSpecificException<ExpectedException, T>(Task<T> task, string expectedExceptionContent = null) where ExpectedException : Exception
@@ -1667,6 +1678,9 @@ namespace System.Net.Http.Functional.Tests
 
                     await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await client.SendAsync(request, cts.Token));
 
+                    // Delay for a bit to ensure that the RST_STREAM for the previous request is sent before the next request starts.
+                    await Task.Delay(2000);
+
                     // Send another request to verify that connection is still functional.
                     request = new HttpRequestMessage(HttpMethod.Get, url);
                     request.Version = new Version(2,0);
@@ -1783,69 +1797,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalFact(nameof(SupportsAlpn))]
-        [OuterLoop("Uses Task.Delay")]
-        public async Task Dispose_ProcessingRequest_Throws()
-        {
-            HttpClient client =  CreateHttpClient();
-            bool stopSending = false;
-
-            await Http2LoopbackServer.CreateClientAndServerAsync(async url =>
-            {
-                string content = new string('*', 300);
-                var request = new HttpRequestMessage(HttpMethod.Post, url);
-                request.Version = new Version(2,0);
-                request.Content = new CustomContent(new CustomContent.SlowTestStream(Encoding.UTF8.GetBytes(content), null, count : 20));
-                HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-                Exception innerException = null;
-
-                using (Stream stream = await response.Content.ReadAsStreamAsync())
-                {
-                    // Dispose client after receiving response headers.
-                    client.Dispose();
-
-                    byte[] buffer = new byte[100];
-                    try
-                    {
-                        do
-                        {
-                            int readLength = await stream.ReadAsync(buffer);
-                            Assert.NotEqual(0, readLength);
-                        } while (true);
-                    }
-                    catch (System.IO.IOException e)
-                    {
-                        Assert.NotNull(e.InnerException);
-                        innerException = e.InnerException;
-                    }
-                    finally
-                    {
-                        stopSending = true;
-                    }
-                    Assert.True(innerException is HttpRequestException);
-                }
-            },
-            async server =>
-            {
-                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
-
-                (int streamId, HttpRequestData requestData) = await connection.ReadAndParseRequestHeaderAsync(readBody : false);
-                await connection.SendResponseHeadersAsync(streamId, endStream: false, HttpStatusCode.OK);
-
-                // Start streaming response and wait for client to be disposed.
-                byte[] responseBody = new byte[100];
-                while (!stopSending)
-                {
-                    await connection.SendResponseDataAsync(streamId, responseBody, endStream: false);
-                    await Task.Delay(100);
-                }
-
-                await connection.SendGoAway(streamId);
-            });
-        }
-
-        [ConditionalFact(nameof(SupportsAlpn))]
         public async Task Http2Connection_Should_Wrap_HttpContent_InvalidOperationException()
         {
             // test for #39295
@@ -1940,13 +1891,9 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        [OuterLoop("Uses Task.Delay")]
-        public async Task PostAsyncExpect100Continue_LateForbiddenResponse_Ok()
+        public async Task PostAsyncExpect100Continue_NonSuccessResponse_RequestBodyNotSent()
         {
-            TaskCompletionSource<bool> tsc = new TaskCompletionSource<bool>();
-            string content = new string('*', 300);
-
-            var stream = new CustomContent.SlowTestStream(Encoding.UTF8.GetBytes(content), tsc, trigger : 3, count : 30);
+            string responseContent = "no no!";
 
             await Http2LoopbackServer.CreateClientAndServerAsync(async url =>
             {
@@ -1954,12 +1901,13 @@ namespace System.Net.Http.Functional.Tests
                 {
                     var request = new HttpRequestMessage(HttpMethod.Post, url);
                     request.Version = new Version(2,0);
-                    request.Content = new CustomContent(stream);
+                    request.Content = new StringContent(new string('*', 3000));
                     request.Headers.ExpectContinue = true;
-                    request.Headers.Add("x-test", "PostAsyncExpect100Continue_LateForbiddenResponse_Ok");
+                    request.Headers.Add("x-test", "PostAsyncExpect100Continue_NonSuccessResponse_RequestBodyNotSent");
 
                     HttpResponseMessage response = await client.SendAsync(request);
                     Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+                    Assert.Equal(responseContent, await response.Content.ReadAsStringAsync());
                 }
             },
             async server =>
@@ -1969,21 +1917,465 @@ namespace System.Net.Http.Functional.Tests
                 (int streamId, HttpRequestData requestData) = await connection.ReadAndParseRequestHeaderAsync(readBody : false);
                 Assert.Equal("100-continue", requestData.GetSingleHeaderValue("Expect"));
 
-                // Wait for client so start sending body.
-                await tsc.Task.ConfigureAwait(false);
-                // And reject content with 403.
+                // Reject content with 403.
                 await connection.SendResponseHeadersAsync(streamId, endStream: false, HttpStatusCode.Forbidden);
-                await connection.SendResponseBodyAsync(streamId, Encoding.ASCII.GetBytes("no no!"));
-                try
-                {
-                    // Client should send reset.
-                    await connection.ReadBodyAsync();
-                    Assert.True(false, "Should not be here");
-                }
-                catch (IOException) { };
+                await connection.SendResponseBodyAsync(streamId, Encoding.ASCII.GetBytes(responseContent));
+
+                // Client should send empty request body
+                byte[] requestBody = await connection.ReadBodyAsync();
+                Assert.Null(requestBody);
 
                 await connection.ShutdownIgnoringErrorsAsync(streamId);
             });
+        }
+
+        class DuplexContent : HttpContent
+        {
+            private TaskCompletionSource<Stream> _waitForStream;
+            private TaskCompletionSource<bool> _waitForCompletion;
+
+            public DuplexContent()
+            {
+                _waitForStream = new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = 0;
+                return false;
+            }
+
+            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                _waitForCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _waitForStream.SetResult(stream);
+                await _waitForCompletion.Task;
+            }
+
+            public Task<Stream> WaitForStreamAsync()
+            {
+                return _waitForStream.Task;
+            }
+
+            public void Complete()
+            {
+                _waitForCompletion.SetResult(true);
+                _waitForCompletion = null;
+            }
+
+            public void Fail(Exception e)
+            {
+                _waitForCompletion.SetException(e);
+                _waitForCompletion = null;
+            }
+        }
+
+        private async Task SendAndReceiveResponseDataAsync(Memory<byte> data, Stream responseStream, Http2LoopbackConnection connection, int streamId)
+        {
+            byte[] readBuffer = new byte[data.Length];
+
+            await connection.SendResponseDataAsync(streamId, data, endStream: false);
+            int bytesRead = await responseStream.ReadAsync(readBuffer);
+            Assert.True(data.Span.SequenceEqual(readBuffer));
+        }
+
+        private async Task SendAndReceiveResponseEOFAsync(Stream responseStream, Http2LoopbackConnection connection, int streamId)
+        {
+            byte[] readBuffer = new byte[1];
+
+            await connection.SendResponseDataAsync(streamId, new byte[] { }, endStream: true);
+            int bytesRead = await responseStream.ReadAsync(readBuffer);
+            Assert.Equal(0, bytesRead);
+
+            // Another read should still give EOF
+            bytesRead = await responseStream.ReadAsync(readBuffer);
+            Assert.Equal(0, bytesRead);
+
+            // Dispose the response stream, to ensure that this doesn't affect the request stream
+            responseStream.Dispose();
+
+            // Attempting to read now should throw ObjectDisposedException
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => { await responseStream.ReadAsync(readBuffer); });
+        }
+
+        private async Task SendAndReceiveRequestDataAsync(Memory<byte> data, Stream requestStream, Http2LoopbackConnection connection, int streamId)
+        {
+            await requestStream.WriteAsync(data);
+            await requestStream.FlushAsync();
+            DataFrame dataFrame = (DataFrame)await connection.ReadFrameAsync(TimeSpan.FromSeconds(30));
+            Assert.True(data.Span.SequenceEqual(dataFrame.Data.Span));
+        }
+
+        private async Task SendAndReceiveRequestEOFAsync(DuplexContent duplexContent, Stream requestStream, Http2LoopbackConnection connection, int streamId)
+        {
+            duplexContent.Complete();
+            DataFrame dataFrame = (DataFrame)await connection.ReadFrameAsync(TimeSpan.FromSeconds(30));
+            Assert.True(dataFrame.EndStreamFlag);
+            Assert.Equal(0, dataFrame.Data.Length);
+
+            // Attempting to write now should throw ObjectDisposedException
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => { await requestStream.WriteAsync(new byte[1]); });
+        }
+
+        [Fact]
+        public async Task PostAsyncDuplex_ClientSendsEndStream_Success()
+        {
+            byte[] contentBytes = Encoding.UTF8.GetBytes("Hello world");
+
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                Http2LoopbackConnection connection;
+                using (HttpClient client = CreateHttpClient())
+                {
+                    var duplexContent = new DuplexContent();
+
+                    var request = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                    request.Version = new Version(2, 0);
+                    request.Content = duplexContent;
+                    Task<HttpResponseMessage> responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+                    connection = await server.EstablishConnectionAsync();
+
+                    // Client should have sent the request headers, and the request stream should now be available
+                    Stream requestStream = await duplexContent.WaitForStreamAsync();
+
+                    // Flush the content stream. Otherwise, the request headers are not guaranteed to be sent.
+                    await requestStream.FlushAsync();
+
+                    (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+
+                    // Send data to the server, even before we've received response headers.
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Send response headers
+                    await connection.SendResponseHeadersAsync(streamId, endStream: false);
+                    HttpResponseMessage response = await responseTask;
+                    Stream responseStream = await response.Content.ReadAsStreamAsync();
+
+                    // Send some data back and forth
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+
+                    // Complete sending the request body
+                    await SendAndReceiveRequestEOFAsync(duplexContent, requestStream, connection, streamId);
+
+                    // Send more data to the client
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+
+                    // Complete sending the response body
+                    await SendAndReceiveResponseEOFAsync(responseStream, connection, streamId);
+                }
+
+                // On handler dispose, client should shutdown the connection without sending additional frames.
+                await connection.WaitForClientDisconnectAsync();
+            }
+        }
+
+        [Fact]
+        public async Task PostAsyncDuplex_ServerSendsEndStream_Success()
+        {
+            byte[] contentBytes = Encoding.UTF8.GetBytes("Hello world");
+
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                Http2LoopbackConnection connection;
+                using (HttpClient client = CreateHttpClient())
+                {
+                    var duplexContent = new DuplexContent();
+
+                    var request = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                    request.Version = new Version(2, 0);
+                    request.Content = duplexContent;
+                    Task<HttpResponseMessage> responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+                    connection = await server.EstablishConnectionAsync();
+
+                    // Client should have sent the request headers, and the request stream should now be available
+                    Stream requestStream = await duplexContent.WaitForStreamAsync();
+
+                    // Flush the content stream. Otherwise, the request headers are not guaranteed to be sent.
+                    await requestStream.FlushAsync();
+
+                    (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+
+                    // Send data to the server, even before we've received response headers.
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Send response headers
+                    await connection.SendResponseHeadersAsync(streamId, endStream: false);
+                    HttpResponseMessage response = await responseTask;
+                    Stream responseStream = await response.Content.ReadAsStreamAsync();
+
+                    // Send some data back and forth
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+
+                    // Complete sending the response body
+                    await SendAndReceiveResponseEOFAsync(responseStream, connection, streamId);
+
+                    // Send more data to the server
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Complete sending the request body
+                    await SendAndReceiveRequestEOFAsync(duplexContent, requestStream, connection, streamId);
+                }
+
+                // On handler dispose, client should shutdown the connection without sending additional frames.
+                await connection.WaitForClientDisconnectAsync();
+            }
+        }
+
+        [Fact]
+        public async Task PostAsyncDuplex_RequestContentException_ResetsStream()
+        {
+            byte[] contentBytes = Encoding.UTF8.GetBytes("Hello world");
+
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                Http2LoopbackConnection connection;
+                using (HttpClient client = CreateHttpClient())
+                {
+                    var duplexContent = new DuplexContent();
+
+                    var request = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                    request.Version = new Version(2, 0);
+                    request.Content = duplexContent;
+                    Task<HttpResponseMessage> responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+                    connection = await server.EstablishConnectionAsync();
+
+                    // Client should have sent the request headers, and the request stream should now be available
+                    Stream requestStream = await duplexContent.WaitForStreamAsync();
+
+                    // Flush the content stream. Otherwise, the request headers are not guaranteed to be sent.
+                    await requestStream.FlushAsync();
+
+                    (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+
+                    // Send data to the server, even before we've received response headers.
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Send response headers
+                    await connection.SendResponseHeadersAsync(streamId, endStream: false);
+                    HttpResponseMessage response = await responseTask;
+                    Stream responseStream = await response.Content.ReadAsStreamAsync();
+
+                    // Send some data back and forth
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Throw an exception from the request content.
+                    Exception e = new ArithmeticException();
+                    duplexContent.Fail(e);
+
+                    // Client should set RST_STREAM.
+                    await connection.ReadRstStreamAsync(streamId);
+
+                    // Trying to read on the response stream should fail now, and client should ignore any data received
+                    await Assert.ThrowsAsync<IOException>(async () => await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId));
+                }
+
+                // On handler dispose, client should shutdown the connection without sending additional frames.
+                await connection.WaitForClientDisconnectAsync();
+            }
+        }
+
+        [OuterLoop("Uses Task.Delay")]
+        [Fact]
+        public async Task PostAsyncDuplex_CancelledBeforeResponseHeadersReceived_ResetsStream()
+        {
+            byte[] contentBytes = Encoding.UTF8.GetBytes("Hello world");
+
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                Http2LoopbackConnection connection;
+                using (HttpClient client = CreateHttpClient())
+                {
+                    var duplexContent = new DuplexContent();
+
+                    var request = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                    request.Version = new Version(2, 0);
+                    request.Content = duplexContent;
+                    var cancellationTokenSource = new CancellationTokenSource();
+                    Task<HttpResponseMessage> responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationTokenSource.Token);
+
+                    connection = await server.EstablishConnectionAsync();
+
+                    // Client should have sent the request headers, and the request stream should now be available
+                    Stream requestStream = await duplexContent.WaitForStreamAsync();
+
+                    // Flush the content stream. Otherwise, the request headers are not guaranteed to be sent.
+                    await requestStream.FlushAsync();
+
+                    (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+
+                    // Send data to the server, even before we've received response headers.
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Cancel the request
+                    cancellationTokenSource.Cancel();
+
+                    // Cancellation may not propagate immediately. So wait a brief time to try to ensure it propagates.
+                    await Task.Delay(500);
+
+                    // Attempting to write on the request body should now fail with OperationCanceledException.
+                    Exception e = await Assert.ThrowsAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
+
+                    // Propagate the exception to the request stream serialization task.
+                    // This allows the request processing to complete.
+                    duplexContent.Fail(e);
+
+                    // Client should set RST_STREAM.
+                    await connection.ReadRstStreamAsync(streamId);
+
+                    // Request should fail.
+                    await Assert.ThrowsAsync<TaskCanceledException>(() => responseTask);
+                }
+
+                // On handler dispose, client should shutdown the connection without sending additional frames.
+                await connection.WaitForClientDisconnectAsync();
+            }
+        }
+
+        [Fact]
+        public async Task PostAsyncDuplex_ServerResetsStream_Throws()
+        {
+            byte[] contentBytes = Encoding.UTF8.GetBytes("Hello world");
+
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                Http2LoopbackConnection connection;
+                using (HttpClient client = CreateHttpClient())
+                {
+                    var duplexContent = new DuplexContent();
+
+                    var request = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                    request.Version = new Version(2, 0);
+                    request.Content = duplexContent;
+                    Task<HttpResponseMessage> responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+                    connection = await server.EstablishConnectionAsync();
+
+                    // Client should have sent the request headers, and the request stream should now be available
+                    Stream requestStream = await duplexContent.WaitForStreamAsync();
+
+                    // Flush the content stream. Otherwise, the request headers are not guaranteed to be sent.
+                    await requestStream.FlushAsync();
+
+                    (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+
+                    // Send data to the server, even before we've received response headers.
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Send response headers
+                    await connection.SendResponseHeadersAsync(streamId, endStream: false);
+                    HttpResponseMessage response = await responseTask;
+                    Stream responseStream = await response.Content.ReadAsStreamAsync();
+
+                    // Send some data back and forth
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Send RST_STREAM to client.
+                    await connection.WriteFrameAsync(new RstStreamFrame(FrameFlags.None, (int)ProtocolErrors.ENHANCE_YOUR_CALM, streamId));
+
+                    // Trying to read on the response stream should fail now, and client should ignore any data received
+                    await AssertProtocolErrorForIOExceptionAsync(SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId), ProtocolErrors.ENHANCE_YOUR_CALM);
+
+                    // Attempting to write on the request body should now fail with OperationCanceledException.
+                    Exception e = await Assert.ThrowsAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
+
+                    // Propagate the exception to the request stream serialization task.
+                    // This allows the request processing to complete.
+                    duplexContent.Fail(e);
+                }
+
+                // On handler dispose, client should shutdown the connection without sending additional frames.
+                await connection.WaitForClientDisconnectAsync();
+            }
+        }
+
+        [OuterLoop("Uses Task.Delay")]
+        [Fact]
+        public async Task PostAsyncDuplex_DisposeResponseBodyBeforeEnd_ResetsStreamAndThrowsOnRequestStreamRead()
+        {
+            byte[] contentBytes = Encoding.UTF8.GetBytes("Hello world");
+
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                Http2LoopbackConnection connection;
+                using (HttpClient client = CreateHttpClient())
+                {
+                    var duplexContent = new DuplexContent();
+
+                    var request = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                    request.Version = new Version(2, 0);
+                    request.Content = duplexContent;
+                    Task<HttpResponseMessage> responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+                    connection = await server.EstablishConnectionAsync();
+
+                    // Client should have sent the request headers, and the request stream should now be available
+                    Stream requestStream = await duplexContent.WaitForStreamAsync();
+
+                    // Flush the content stream. Otherwise, the request headers are not guaranteed to be sent.
+                    await requestStream.FlushAsync();
+
+                    (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+
+                    // Send data to the server, even before we've received response headers.
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Send response headers
+                    await connection.SendResponseHeadersAsync(streamId, endStream: false);
+                    HttpResponseMessage response = await responseTask;
+                    Stream responseStream = await response.Content.ReadAsStreamAsync();
+
+                    // Send some data back and forth
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Dispose the response stream.
+                    responseStream.Dispose();
+
+                    // Trying to read on the response stream should fail now, and client should ignore any data received
+                    await Assert.ThrowsAsync<ObjectDisposedException>(async () => await SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId));
+
+                    // Cancellation on the request body may not propagate immediately. So wait a brief time to try to ensure it propagates.
+                    await Task.Delay(500);
+
+                    // Attempting to write on the request body should now fail with OperationCanceledException.
+                    Exception e = await Assert.ThrowsAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
+
+                    // Propagate the exception to the request stream serialization task.
+                    // This allows the request processing to complete.
+                    duplexContent.Fail(e);
+
+                    // Client should set RST_STREAM.
+                    await connection.ReadRstStreamAsync(streamId);
+                }
+
+                // On handler dispose, client should shutdown the connection without sending additional frames.
+                await connection.WaitForClientDisconnectAsync();
+            }
         }
 
         [Theory]
@@ -2033,13 +2425,8 @@ namespace System.Net.Http.Functional.Tests
                 await connection.SendResponseDataAsync(streamId, Encoding.ASCII.GetBytes(responseContent), endStream: false);
                 if (!shouldWait)
                 {
-                    try
-                    {
-                        // Client should send reset.
-                        await connection.ReadBodyAsync();
-                        if (responseCode != HttpStatusCode.OK) Assert.True(false, "Should not be here");
-                    }
-                    catch (IOException) when (responseCode != HttpStatusCode.OK) { };
+                    // Client should send request body.
+                    await connection.ReadBodyAsync();
                 }
                 var headers = new HttpHeaderData[] { new HttpHeaderData("x-last", "done") };
                 await connection.SendResponseHeadersAsync(streamId, endStream: true, isTrailingHeader : true, headers: headers);
@@ -2072,9 +2459,9 @@ namespace System.Net.Http.Functional.Tests
                     // and inject distinct exception on request stream.
                     stream.SetException(new ArithmeticException("Injected test exception"));
 
-                    Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => response.Content.ReadAsStringAsync());
-                    Assert.True(e.InnerException is IOException);
-                    Assert.True(e.InnerException.InnerException is ArithmeticException);
+                    HttpRequestException e = await Assert.ThrowsAsync<HttpRequestException>(() => response.Content.ReadAsStringAsync());
+                    Assert.IsType<IOException>(e.InnerException);
+
                     stopSending = true;
                 }
             },

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -2296,7 +2296,7 @@ namespace System.Net.Http.Functional.Tests
                     await Task.Delay(500);
 
                     // Attempting to write on the request body should now fail with OperationCanceledException.
-                    Exception e = await Assert.ThrowsAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
+                    Exception e = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
 
                     // Propagate the exception to the request stream serialization task.
                     // This allows the request processing to complete.
@@ -2362,7 +2362,7 @@ namespace System.Net.Http.Functional.Tests
                     await AssertProtocolErrorForIOExceptionAsync(SendAndReceiveResponseDataAsync(contentBytes, responseStream, connection, streamId), ProtocolErrors.ENHANCE_YOUR_CALM);
 
                     // Attempting to write on the request body should now fail with OperationCanceledException.
-                    Exception e = await Assert.ThrowsAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
+                    Exception e = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
 
                     // Propagate the exception to the request stream serialization task.
                     // This allows the request processing to complete.
@@ -2426,7 +2426,7 @@ namespace System.Net.Http.Functional.Tests
                     await Task.Delay(500);
 
                     // Attempting to write on the request body should now fail with OperationCanceledException.
-                    Exception e = await Assert.ThrowsAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
+                    Exception e = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
 
                     // Propagate the exception to the request stream serialization task.
                     // This allows the request processing to complete.
@@ -2499,7 +2499,7 @@ namespace System.Net.Http.Functional.Tests
                     await Task.Delay(500);
 
                     // Attempting to write on the request body should now fail with OperationCanceledException.
-                    Exception e = await Assert.ThrowsAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
+                    Exception e = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
 
                     // Propagate the exception to the request stream serialization task.
                     // This allows the request processing to complete.


### PR DESCRIPTION
Fixes #39630
Fixes #39624
Fixes #39586
Fixes #39461
Fixes #39460
Fixes #39459
Fixes #39548
Fixes #39404

Rework shutdown handling to be reliable and consistent, for both streams and connections.

Each Http2Stream has to complete both request and response before shutting down, at which time it will remove itself from the stream dictionary and clean up associated state.

The request body and response body can each be cancelled, and these are now cancelled at appropriate times (e.g. Dispose on response stream before reading to end).

The behavior of early non-success status codes is changed to not cancel the request body. This matches HTTP/1.1 behavior.

The connection is now shut down only when all streams are removed from the dictionary. Receiving EndStream or RST_STREAM does not automatically remove the stream; instead we let the stream manage its own shutdown and then remove it from the dictionary.

Add relevant tests, fix up some existing tests, and remove one bogus test.

I haven't run stress tests on this yet -- I wanted to get the review out first. Will report when I have stress results.

cc @stephentoub @dotnet/ncl

