### PR TITLE
[release/3.0] Pass CancellationToken from Http2Connection.SendHeadersAsync to StartWriteAsync

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1121,7 +1121,7 @@ namespace System.Net.Http
                     (request.Content == null ? FrameFlags.EndStream : FrameFlags.None);
 
                 // Note, HEADERS and CONTINUATION frames must be together, so hold the writer lock across sending all of them.
-                Memory<byte> writeBuffer = await StartWriteAsync(totalSize).ConfigureAwait(false);
+                Memory<byte> writeBuffer = await StartWriteAsync(totalSize, cancellationToken).ConfigureAwait(false);
                 if (NetEventSource.IsEnabled) Trace(streamId, $"Started writing. {nameof(flags)}={flags}, {nameof(totalSize)}={totalSize}");
 
                 FrameHeader frameHeader = new FrameHeader(current.Length, FrameType.Headers, flags, streamId);


### PR DESCRIPTION
Port #39635 to release/3.0
Approved at https://github.com/dotnet/corefx/pull/39635#issuecomment-513426866