### PR TITLE
HTTP2: Validate dynamic table size updates

### DIFF
--- a/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -519,6 +519,11 @@ namespace System.Net.Test.Common
             return bytesGenerated;
         }
 
+        public static int EncodeDynamicTableSizeUpdate(int newMaximumSize, Span<byte> headerBlock)
+        {
+            return EncodeInteger(newMaximumSize, 0b00100000, 0b11100000, headerBlock);
+        }
+
         public async Task<byte[]> ReadBodyAsync()
         {
             byte[] body = null;

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -522,4 +522,7 @@
   <data name="net_http_disposed_while_in_use" xml:space="preserve">
     <value>The object was disposed while operations were in progress.</value>
   </data>
+  <data name="net_http_hpack_large_table_size_update" xml:space="preserve">
+    <value>Dynamic table size update to {0} bytes exceeds limit of {1} bytes.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -214,7 +214,12 @@ namespace System.Net.Http.HPack
 
                             if (_integerDecoder.StartDecode((byte)(b & ~DynamicTableSizeUpdateMask), DynamicTableSizeUpdatePrefix))
                             {
-                                // TODO: validate that it's less than what's defined via SETTINGS
+                                if (_integerDecoder.Value > _maxDynamicTableSize)
+                                {
+                                    // Dynamic table size update is too large.
+                                    throw new HPackDecodingException();
+                                }
+
                                 _dynamicTable.Resize(_integerDecoder.Value);
                             }
                             else

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HPack/HPackDecoder.cs
@@ -217,7 +217,7 @@ namespace System.Net.Http.HPack
                                 if (_integerDecoder.Value > _maxDynamicTableSize)
                                 {
                                     // Dynamic table size update is too large.
-                                    throw new HPackDecodingException();
+                                    throw new HPackDecodingException(SR.Format(SR.net_http_hpack_large_table_size_update, _integerDecoder.Value, _maxDynamicTableSize));
                                 }
 
                                 _dynamicTable.Resize(_integerDecoder.Value);
@@ -326,7 +326,7 @@ namespace System.Net.Http.HPack
                             if (_integerDecoder.Value > _maxDynamicTableSize)
                             {
                                 // Dynamic table size update is too large.
-                                throw new HPackDecodingException();
+                                throw new HPackDecodingException(SR.Format(SR.net_http_hpack_large_table_size_update, _integerDecoder.Value, _maxDynamicTableSize));
                             }
 
                             _dynamicTable.Resize(_integerDecoder.Value);

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -96,7 +96,7 @@ namespace System.Net.Http
             _outgoingBuffer = new ArrayBuffer(InitialConnectionBufferSize);
             _headerBuffer = new ArrayBuffer(InitialConnectionBufferSize);
 
-            _hpackDecoder = new HPackDecoder(maxResponseHeadersLength: pool.Settings._maxResponseHeadersLength * 1024);
+            _hpackDecoder = new HPackDecoder(maxDynamicTableSize: 0, maxResponseHeadersLength: pool.Settings._maxResponseHeadersLength * 1024);
 
             _httpStreams = new Dictionary<int, Http2Stream>();
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -2419,5 +2419,41 @@ namespace System.Net.Http.Functional.Tests
                     await con.ShutdownIgnoringErrorsAsync(streamId);
                 });
         }
+
+        [Fact]
+        public async Task DynamicTableSizeUpdate_Exceeds_Settings_Throws()
+        {
+            await Http2LoopbackServer.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpClient client = CreateHttpClient();
+                    Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(uri));
+
+                    Assert.NotNull(e.InnerException);
+                    Assert.Contains("Dynamic table size update", e.InnerException.Message);
+                },
+                async server =>
+                {
+                    (Http2LoopbackConnection con, SettingsFrame settings) = await server.EstablishConnectionGetSettingsAsync();
+                    int streamId = await con.ReadRequestHeaderAsync();
+
+                    int headerTableSize = 4096; // Default per HTTP2 spec.
+
+                    foreach (SettingsEntry setting in settings.Entries)
+                    {
+                        if (setting.SettingId == SettingId.HeaderTableSize)
+                        {
+                            headerTableSize = (int)setting.Value;
+                        }
+                    }
+
+                    byte[] headerData = new byte[16];
+                    int headersLen = Http2LoopbackConnection.EncodeDynamicTableSizeUpdate(headerTableSize + 1, headerData);
+                    HeadersFrame frame = new HeadersFrame(headerData.AsMemory(0, headersLen), FrameFlags.EndHeaders | FrameFlags.EndStream, 0, 0, 0, streamId);
+
+                    await con.WriteFrameAsync(frame);
+                    await con.ShutdownIgnoringErrorsAsync(streamId);
+                });
+        }
     }
 }


### PR DESCRIPTION
Fixes a bug where a misbehaving server could enable a dynamic table size larger than our configured maximum (which is currently 0).

Also sets the maximum size to the Dynamic Table, so that a server which does not respect our maximum of 0 will cause an error.

Resolves #39666