### PR TITLE
Re-enable ~20 xunit analyzers

### DIFF
--- a/src/CodeAnalysis.ruleset
+++ b/src/CodeAnalysis.ruleset
@@ -39,25 +39,10 @@
     <Rule Id="CA1821" Action="None" />
   </Rules>
   <Rules AnalyzerId="xunit.analyzers" RuleNamespace="xunit.analyzers">
-    <Rule Id="xUnit1004" Action="Hidden" />
-    <Rule Id="xUnit1005" Action="None" />
     <Rule Id="xUnit1006" Action="None" />
-    <Rule Id="xUnit1007" Action="None" />
-    <Rule Id="xUnit1008" Action="None" />
-    <Rule Id="xUnit1009" Action="None" />
     <Rule Id="xUnit1010" Action="None" />
-    <Rule Id="xUnit1011" Action="None" />
-    <Rule Id="xUnit1012" Action="None" />
-    <Rule Id="xUnit1014" Action="None" />
-    <Rule Id="xUnit1015" Action="None" />
     <Rule Id="xUnit1016" Action="None" />
-    <Rule Id="xUnit1017" Action="None" />
-    <Rule Id="xUnit1018" Action="None" />
     <Rule Id="xUnit1019" Action="None" />
-    <Rule Id="xUnit1020" Action="None" />
-    <Rule Id="xUnit1021" Action="None" />
-    <Rule Id="xUnit1022" Action="None" />
-    <Rule Id="xUnit1023" Action="None" />
     <Rule Id="xUnit1024" Action="None" />
     <Rule Id="xUnit1025" Action="None" />
     <Rule Id="xUnit1026" Action="None" />
@@ -70,13 +55,9 @@
     <Rule Id="xUnit2007" Action="None" />
     <Rule Id="xUnit2008" Action="None" />
     <Rule Id="xUnit2009" Action="None" />
-    <Rule Id="xUnit2010" Action="None" />
-    <Rule Id="xUnit2011" Action="None" />
     <Rule Id="xUnit2012" Action="None" />
     <Rule Id="xUnit2013" Action="None" />
-    <Rule Id="xUnit2014" Action="None" />
     <Rule Id="xUnit2015" Action="None" />
-    <Rule Id="xUnit2016" Action="None" />
     <Rule Id="xUnit2017" Action="None" />
     <Rule Id="xUnit2018" Action="None" />
   </Rules>

--- a/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ActiveDirectoryTests.cs
+++ b/src/System.DirectoryServices/tests/System/DirectoryServices/ActiveDirectory/ActiveDirectoryTests.cs
@@ -30,7 +30,7 @@ namespace System.DirectoryServices.Tests
 
                 using (DirectoryEntry de = schema.GetDirectoryEntry())
                 {
-                    Assert.True("CN=Schema".Equals(de.Name, StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal("CN=Schema", de.Name, StringComparer.OrdinalIgnoreCase);
                 }
             }
         }
@@ -63,7 +63,7 @@ namespace System.DirectoryServices.Tests
 
                 using (DirectoryEntry de = orgClass.GetDirectoryEntry())
                 {
-                    Assert.True("CN=Organization".Equals(de.Name, StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal("CN=Organization", de.Name, StringComparer.OrdinalIgnoreCase);
                 }
             }
         }
@@ -86,7 +86,7 @@ namespace System.DirectoryServices.Tests
 
                 using (DirectoryEntry de = adsp.GetDirectoryEntry())
                 {
-                    Assert.True("CN=Object-Class".Equals(de.Name, StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal("CN=Object-Class", de.Name, StringComparer.OrdinalIgnoreCase);
                 }
 
                 Assert.Equal(ActiveDirectorySyntax.Oid, adsp.Syntax);
@@ -123,7 +123,7 @@ namespace System.DirectoryServices.Tests
                 {
                     // we expect to get top only entries
                     string s  = (string) child.Properties["objectClass"][0];
-                    Assert.True(s.Equals("top", StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal(s, "top", StringComparer.OrdinalIgnoreCase);
                     newTopClassCount += 1;
                 }
 
@@ -222,7 +222,7 @@ namespace System.DirectoryServices.Tests
                 using (ActiveDirectorySchema schema = forest.Schema)
                 using (ActiveDirectorySchemaClass  adsc = schema.FindClass("top"))
                 {
-                    Assert.True("top".Equals(adsc.CommonName, StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal("top", adsc.CommonName, StringComparer.OrdinalIgnoreCase);
                 }
             }
         }

--- a/src/System.Memory/tests/Span/GcReporting.cs
+++ b/src/System.Memory/tests/Span/GcReporting.cs
@@ -12,6 +12,7 @@ namespace System.SpanTests
         /// This is a simple sanity test to check that GC reporting for Span is not completely broken, it is not meant to be
         /// comprehensive.
         /// </summary>
+        [Theory]
         [InlineData(100_000, 10_000)]
         [InlineData(100, 100)]
         [OuterLoop]

--- a/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/DiagnosticsTests.cs
@@ -1091,6 +1091,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [OuterLoop("Uses external server")]
+        [Theory]
         [InlineData(true, false)]
         [InlineData(false, true)]
         public void SendAsync_SuppressedGlobalStaticPropagationNoListenerAppCtx(bool switchValue, bool isInstrumentationEnabled)


### PR DESCRIPTION
All but one of these had no associated warnings firing.  I fixed one warning to be able to re-enable another analyzer.

cc: @ViktorHofer 