### PR TITLE
Minor performance improvement in CaseInsensitiveAscii

### DIFF
--- a/src/Common/src/System/Net/CaseInsensitiveAscii.cs
+++ b/src/Common/src/System/Net/CaseInsensitiveAscii.cs
@@ -10,7 +10,7 @@ namespace System.Net
     {
         // ASCII char ToLower table
         internal static readonly CaseInsensitiveAscii StaticInstance = new CaseInsensitiveAscii();
-        internal static readonly byte[] AsciiToLower = new byte[] {
+        internal static ReadOnlySpan<byte> AsciiToLower => new byte[] {
               0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
              10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
              20, 21, 22, 23, 24, 25, 26, 27, 28, 29,


### PR DESCRIPTION
Improves performance for all `CaseInsensitiveAscii` members, e.g.:
```csharp
private int FastGetHashCode(string myString)
{
    int myHashCode = myString.Length;
    if (myHashCode != 0)
    {
        myHashCode ^= AsciiToLower[(byte)myString[0]] << 24 ^ 
          AsciiToLower[(byte)myString[myHashCode - 1]] << 16;
    }
    return myHashCode;
}
```
Asm diff: https://www.diffchecker.com/lhjjaHnt
