### PR TITLE
Fix inotify support to work with FreeBSD libinotify

### DIFF
--- a/src/Native/Unix/System.Native/pal_io.c
+++ b/src/Native/Unix/System.Native/pal_io.c
@@ -33,7 +33,10 @@
 #elif HAVE_SENDFILE_4
 #include <sys/sendfile.h>
 #endif
-#if HAVE_INOTIFY
+#if defined(__FreeBSD__) & defined(HAVE_INOTIFY)
+// FreeBSD requires a fully explicit path when using libinotify shim
+#include </usr/local/include/sys/inotify.h>
+#elif HAVE_INOTIFY
 #include <sys/inotify.h>
 #endif
 


### PR DESCRIPTION
FreeBSD provides a kqueue-inotify shim in the form of devel/libinotify. However, because it is not in an expected system location, it requires the full path. Otherwise it will fail as though inotify were not present. With this modification, corefx now accepts the libinotify shim, correctly identifies supported functions, and Just Works (for generous values of Works.)