### PR TITLE
Improve Utf8JsonWriter code coverage

### DIFF
--- a/src/System.Text.Json/tests/JsonElementWriteTests.cs
+++ b/src/System.Text.Json/tests/JsonElementWriteTests.cs
@@ -343,6 +343,24 @@ namespace System.Text.Json.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        public static void WriteSimpleObjectNeedsEscaping(bool indented)
+        {
+            WriteComplexValue(
+                indented,
+                @"{ ""prop><erty""   : 3,
+            ""> This is one long & unusual property name. <"":
+4
+}",
+                @"{
+  ""prop\u003E\u003Certy"": 3,
+  ""\u003E This is one long \u0026 unusual property name. \u003C"": 4
+}",
+                "{\"prop\\u003E\\u003Certy\":3,\"\\u003E This is one long \\u0026 unusual property name. \\u003C\":4}");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public static void WriteEverythingArray(bool indented)
         {
             WriteComplexValue(

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -2791,6 +2791,10 @@ namespace System.Text.Json.Tests
         [InlineData(true, false, "<write base64 string when escape length bigger than given string")]
         [InlineData(false, true, "<write base64 string when escape length bigger than given string")]
         [InlineData(false, false, "<write base64 string when escape length bigger than given string")]
+        [InlineData(true, true, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")]
+        [InlineData(true, false, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")]
+        [InlineData(false, true, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")]
+        [InlineData(false, false, ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")]
         public void WriteBase64String(bool formatted, bool skipValidation, string inputValue)
         {
             string propertyName = inputValue;
@@ -2829,6 +2833,11 @@ namespace System.Text.Json.Tests
                         jsonUtf8.WriteBase64String(encodedPropertyName, value);
                         break;
                 }
+
+                jsonUtf8.WriteStartArray("array");
+                jsonUtf8.WriteBase64StringValue(new byte[] { 1, 2 });
+                jsonUtf8.WriteBase64StringValue(new byte[] { 3, 4 });
+                jsonUtf8.WriteEndArray();
 
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
@@ -6080,6 +6089,11 @@ namespace System.Text.Json.Tests
             json.WriteValue(value);
             json.WritePropertyName(propertyName);
             json.WriteValue(value);
+            json.WritePropertyName("array");
+            json.WriteStartArray();
+            json.WriteValue(new byte[] { 1, 2 });
+            json.WriteValue(new byte[] { 3, 4 });
+            json.WriteEndArray();
             json.WriteEnd();
 
             json.Flush();


### PR DESCRIPTION
Targeted following methods for the coverage improvement: 

```
private void WriteBase64Indented(ReadOnlySpan<byte> escapedPropertyName, ReadOnlySpan<byte> bytes)
private void WriteBase64Minimized(ReadOnlySpan<byte> escapedPropertyName, ReadOnlySpan<byte> bytes)

private void WriteNumberEscape(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> value)
private void WriteNumberEscapeProperty(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> value, int firstEscapeIndexProp)

private void WriteBase64Indented(ReadOnlySpan<byte> bytes)
```

[code_coverage_39699.zip](https://github.com/dotnet/corefx/files/3423161/code_coverage_39699.zip)

Contributes to #34570.
cc: @ahsonkhan