### PR TITLE
Upgrade Roslyn analyzers

### DIFF
--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -1,11 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisPackageVersion)" />
-    <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.2.0-beta4-final" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4-beta1.final" />
-    <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
-    <PackageReference Include="System.Runtime.InteropServices.Analyzers" Version="1.1.0" />
-    <PackageReference Include="System.Security.Cryptography.Hashing.Algorithms.Analyzers" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -2,8 +2,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisPackageVersion)" />
     <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.2.0-beta4-final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4-beta1.final" />
     <PackageReference Include="System.Runtime.Analyzers" Version="1.1.0" />
     <PackageReference Include="System.Runtime.InteropServices.Analyzers" Version="1.1.0" />
     <PackageReference Include="System.Security.Cryptography.Hashing.Algorithms.Analyzers" Version="1.1.0" />

--- a/src/CodeAnalysis.ruleset
+++ b/src/CodeAnalysis.ruleset
@@ -13,7 +13,6 @@
     <Rule Id="CA1000" Action="None" /> <!-- Do not declare static members on generic types -->
     <Rule Id="CA1001" Action="None" /> <!-- Non disposable class owns disposable fields -->
     <Rule Id="CA1010" Action="None" /> <!-- Collections should implement generic interface -->
-    <Rule Id="CA1018" Action="Error" /> <!-- Specify attribute usage on attribute -->
     <Rule Id="CA1028" Action="None" /> <!-- Enum storage should be Int32 -->
     <Rule Id="CA1030" Action="None" /> <!-- Use events where appropriate -->
     <Rule Id="CA1031" Action="None" /> <!-- Do not catch general exception types -->
@@ -84,20 +83,13 @@
     <Rule Id="CA2219" Action="None" /> <!-- Do not raise exceptions in finally clauses -->
     <Rule Id="CA2225" Action="None" /> <!-- Operator overloads have named alternates -->
     <Rule Id="CA2227" Action="None" /> <!-- Collection properties should be read only -->
-    <Rule Id="CA2229" Action="Error" /> <!-- Serializable type doesn't have a serialization constructor -->
     <Rule Id="CA2231" Action="None" /> <!-- Overload operator equals when overriding ValueType.Equals -->
     <Rule Id="CA2235" Action="None" /> <!-- Serializable type has non serializable field -->
     <Rule Id="CA2237" Action="None" /> <!-- Add [Serializable] to types that implement ISerializable -->
-    <Rule Id="CA5350" Action="Error" /> <!-- Do not use weak cryptographic algorithms -->
-    <Rule Id="CA5364" Action="None" /> <!-- Do Not Use Deprecated Security Protocols -->
     <Rule Id="CA5366" Action="None" /> <!-- Use XmlReader For DataSet Read Xml -->
     <Rule Id="CA5369" Action="None" /> <!-- Use XmlReader For Deserialize -->
     <Rule Id="CA5371" Action="None" /> <!-- Use XmlReader For Schema Read -->
     <Rule Id="CA5372" Action="None" /> <!-- Use XmlReader For XPathDocument -->
-    <Rule Id="CA5373" Action="None" /> <!-- Do not use obsolete key derivation function -->
-    <Rule Id="CA5379" Action="None" /> <!-- Do Not Use Weak Key Derivation Function Algorithm -->
-    <Rule Id="CA5384" Action="None" /> <!-- Do Not Use Digital Signature Algorithm (DSA) --> <!-- TODO -->
-    <Rule Id="CA5385" Action="None" /> <!-- Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size --> <!-- TODO -->
 
   </Rules>
   <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">

--- a/src/CodeAnalysis.ruleset
+++ b/src/CodeAnalysis.ruleset
@@ -1,42 +1,115 @@
 ﻿<RuleSet Name="Rules for Security Issues" Description="Code analysis rules for Security Issues." ToolsVersion="14.0">
   <Rules AnalyzerId="Desktop.Analyzers" RuleNamespace="Desktop.Analyzers">
-    <Rule Id="CA5350" Action="Error" /> <!-- Do not use Weak/Broken cryptographic algorithms -->
-    <Rule Id="CA5351" Action="Error" />
     <Rule Id="CA2153" Action="Error"/> <!-- Do not catch corrupted process state exceptions -->
+    <Rule Id="CA5350" Action="Error" /> <!-- Do not use weak cryptographic algorithms -->
+    <Rule Id="CA5351" Action="Error" /> <!-- Do not use broken cryptographic algorithms -->
   </Rules>
   <Rules AnalyzerId="Desktop.CSharp.Analyzers" RuleNamespace="Desktop.Analyzers">
-    <Rule Id="CA5350" Action="Error" /> <!-- Do not use Weak/Broken cryptographic algorithms -->
-    <Rule Id="CA5351" Action="Error" />
     <Rule Id="CA2153" Action="Error"/> <!-- Do not catch corrupted process state exceptions -->
+    <Rule Id="CA5350" Action="Error" /> <!-- Do not use weak cryptographic algorithms -->
+    <Rule Id="CA5351" Action="Error" /> <!-- Do not use broken cryptographic algorithms -->
   </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1000" Action="None" /> <!-- Do not declare static members on generic types -->
     <Rule Id="CA1001" Action="None" /> <!-- Non disposable class owns disposable fields -->
+    <Rule Id="CA1010" Action="None" /> <!-- Collections should implement generic interface -->
     <Rule Id="CA1018" Action="Error" /> <!-- Specify attribute usage on attribute -->
+    <Rule Id="CA1028" Action="None" /> <!-- Enum storage should be Int32 -->
+    <Rule Id="CA1030" Action="None" /> <!-- Use events where appropriate -->
+    <Rule Id="CA1031" Action="None" /> <!-- Do not catch general exception types -->
+    <Rule Id="CA1032" Action="None" /> <!-- Implement standard exception constructors  -->
+    <Rule Id="CA1034" Action="None" /> <!-- Nested types should not be visible -->
     <Rule Id="CA1036" Action="None" /> <!-- Overload comparison operators when implementing System.IComparable -->
-    <Rule Id="CA1715" Action="None" /> <!-- Type parameters names should be prefixed with T -->
-    <Rule Id="CA2213" Action="None" /> <!-- Disposable Fields should be disposed -->
-    <Rule Id="CA2229" Action="Error" /> <!-- Serializable type doesn't have a serialization constructor -->
-    <Rule Id="CA2235" Action="None" /> <!-- Serializable type has non serializable field -->
-    <Rule Id="CA2231" Action="None" /> <!-- Overload operator equals when overriding ValueType.Equals -->
-    <Rule Id="CA2237" Action="None" /> <!-- Add [Serializable] to types that implement ISerializable -->
-
-    <Rule Id="CA2200" Action="None"/> <!-- Rethrowing caught exception changes stack information -->
-
-    <Rule Id="CA2101" Action="None" /> <!-- Specify marshaling for P/Invoke string arguments -->
+    <Rule Id="CA1041" Action="None" /> <!-- Provide ObsoleteAttribute message -->
+    <Rule Id="CA1043" Action="None" /> <!-- Use integral or string argument for indexers -->
+    <Rule Id="CA1044" Action="None" /> <!-- Properties should not be write only -->
+    <Rule Id="CA1051" Action="None" /> <!-- Do not declare visible instance fields -->
+    <Rule Id="CA1052" Action="None" /> <!-- Static holder types should be sealed -->
+    <Rule Id="CA1054" Action="None" /> <!-- URI parameters should not be strings -->
+    <Rule Id="CA1055" Action="None" /> <!-- URI return values should not be strings -->
+    <Rule Id="CA1056" Action="None" /> <!-- URI properties should not be strings -->
+    <Rule Id="CA1058" Action="None" /> <!-- Types should not extend certain base types -->
+    <Rule Id="CA1061" Action="None" /> <!-- Do not hide base class methods -->
+    <Rule Id="CA1062" Action="None" /> <!-- Validate arguments of public methods -->
+    <Rule Id="CA1063" Action="None" /> <!-- Implement IDisposable correctly -->
+    <Rule Id="CA1064" Action="None" /> <!-- Exceptions should be public -->
+    <Rule Id="CA1065" Action="None" /> <!-- Do not raise exceptions in unexpected locations -->
+    <Rule Id="CA1066" Action="None" /> <!-- Type should implement IEquatable -->
+    <Rule Id="CA1067" Action="None" /> <!-- Override Object.Equals(object) when implementing IEquatable -->
+    <Rule Id="CA1068" Action="None" /> <!-- CancellationToken parameters must come last -->
+    <Rule Id="CA1200" Action="None" /> <!-- Avoid using cref tags with a prefix -->
+    <Rule Id="CA1303" Action="None" /> <!-- Do not pass literals as localized parameters -->
+    <Rule Id="CA1304" Action="None" /> <!-- Specify CultureInfo -->
+    <Rule Id="CA1305" Action="None" /> <!-- Specify IFormatProvider -->
+    <Rule Id="CA1307" Action="None" /> <!-- Specify StringComparison -->
+    <Rule Id="CA1308" Action="None" /> <!-- Normalize strings to upper case -->
     <Rule Id="CA1401" Action="None" /> <!-- P/Invoke method should not be visible -->
-
+    <Rule Id="CA1507" Action="None" /> <!-- Use nameof to express symbol names -->
+    <Rule Id="CA1707" Action="None" /> <!-- Identifers should not contain underscores -->
+    <Rule Id="CA1710" Action="None" /> <!-- Identifers should have correct suffix -->
+    <Rule Id="CA1712" Action="None" /> <!-- Do not prefix enum values with type name -->
+    <Rule Id="CA1714" Action="None" /> <!-- Flags enums should have plural names -->
+    <Rule Id="CA1715" Action="None" /> <!-- Type parameters names should be prefixed with T -->
+    <Rule Id="CA1716" Action="None" /> <!-- Identifiers should not match keywords -->
+    <Rule Id="CA1717" Action="None" /> <!-- Only FlagsAttribute enums should have plural names -->
+    <Rule Id="CA1720" Action="None" /> <!-- Identifier contains type name -->
+    <Rule Id="CA1721" Action="None" /> <!-- Property names should not match get methods -->
+    <Rule Id="CA1724" Action="None" /> <!-- Type names should not match namespaces -->
+    <Rule Id="CA1801" Action="None" /> <!-- Review unused parameters -->
+    <Rule Id="CA1802" Action="None" /> <!-- Use literals where appropriate -->
+    <Rule Id="CA1806" Action="None" /> <!-- Do not ignore method results -->
+    <Rule Id="CA1810" Action="None" /> <!-- Initialize reference type static fields inline -->
+    <Rule Id="CA1812" Action="None" /> <!-- Avoid uninstantiated internal classes -->
+    <Rule Id="CA1814" Action="None" /> <!-- Prefer jagged arrays over multidimensional -->
+    <Rule Id="CA1815" Action="None" /> <!-- Override equals and operator equals on value types -->
+    <Rule Id="CA1816" Action="None" /> <!-- Dispose methods should call SuppressFinalize -->
+    <Rule Id="CA1819" Action="None" /> <!-- Properties should not return arrays -->
+    <Rule Id="CA1820" Action="None" /> <!-- Test for empty strings using string length -->
+    <Rule Id="CA1822" Action="None" /> <!-- Mark members as static -->
+    <Rule Id="CA1823" Action="None" /> <!-- Avoid unused private fields -->
+    <Rule Id="CA1825" Action="None" /> <!-- Avoid zero-length array allocations. -->
+    <Rule Id="CA2000" Action="None" /> <!-- Dispose objects before losing scope -->
+    <Rule Id="CA2007" Action="None" /> <!-- Consider calling ConfigureAwait on the awaited task -->
+    <Rule Id="CA2008" Action="None" /> <!-- Do not create tasks without passing a TaskScheduler -->
+    <Rule Id="CA2010" Action="None" /> <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->
+    <Rule Id="CA2100" Action="None" /> <!-- Review SQL queries for security vulnerabilities -->
+    <Rule Id="CA2101" Action="None" /> <!-- Specify marshaling for P/Invoke string arguments -->
+    <Rule Id="CA2119" Action="None" /> <!-- Seal methods that satisfy private interfaces -->
+    <Rule Id="CA2200" Action="None" /> <!-- Rethrowing caught exception changes stack information -->
+    <Rule Id="CA2207" Action="None" /> <!-- Initialize value type static fields inline -->
+    <Rule Id="CA2208" Action="None" /> <!-- Instantiate exception arguments correctly -->
+    <Rule Id="CA2211" Action="None" /> <!-- Non-constant fields should not be visible -->
+    <Rule Id="CA2213" Action="None" /> <!-- Disposable Fields should be disposed -->
     <Rule Id="CA2214" Action="None" /> <!-- Do not call overridable methods in constructors -->
+    <Rule Id="CA2216" Action="None" /> <!-- Disposable types should declare finalizer -->
+    <Rule Id="CA2219" Action="None" /> <!-- Do not raise exceptions in finally clauses -->
+    <Rule Id="CA2225" Action="None" /> <!-- Operator overloads have named alternates -->
+    <Rule Id="CA2227" Action="None" /> <!-- Collection properties should be read only -->
+    <Rule Id="CA2229" Action="Error" /> <!-- Serializable type doesn't have a serialization constructor -->
+    <Rule Id="CA2231" Action="None" /> <!-- Overload operator equals when overriding ValueType.Equals -->
+    <Rule Id="CA2235" Action="None" /> <!-- Serializable type has non serializable field -->
+    <Rule Id="CA2237" Action="None" /> <!-- Add [Serializable] to types that implement ISerializable -->
+    <Rule Id="CA5350" Action="Error" /> <!-- Do not use weak cryptographic algorithms -->
+    <Rule Id="CA5364" Action="None" /> <!-- Do Not Use Deprecated Security Protocols -->
+    <Rule Id="CA5366" Action="None" /> <!-- Use XmlReader For DataSet Read Xml -->
+    <Rule Id="CA5369" Action="None" /> <!-- Use XmlReader For Deserialize -->
+    <Rule Id="CA5371" Action="None" /> <!-- Use XmlReader For Schema Read -->
+    <Rule Id="CA5372" Action="None" /> <!-- Use XmlReader For XPathDocument -->
+    <Rule Id="CA5373" Action="None" /> <!-- Do not use obsolete key derivation function -->
+    <Rule Id="CA5379" Action="None" /> <!-- Do Not Use Weak Key Derivation Function Algorithm -->
+    <Rule Id="CA5384" Action="None" /> <!-- SHA1 cannot be used -->
+    <Rule Id="CA5385" Action="None" /> <!-- RSA key size too small -->
   </Rules>
   <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
     <Rule Id="CA2002" Action="Error" /> <!-- Do not lock on objects with weak identity -->
   </Rules>
   <Rules AnalyzerId="System.Security.Cryptography.Hashing.Algorithms.Analyzers" RuleNamespace="System.Security.Cryptography.Hashing.Algorithms.Analyzers">
-    <Rule Id="CA5350" Action="Error" /> <!-- Do not use Weak/Broken cryptographic algorithms -->
-    <Rule Id="CA5351" Action="Error" />
+    <Rule Id="CA5350" Action="Error" /> <!-- Do not use weak cryptographic algorithms -->
+    <Rule Id="CA5351" Action="Error" /> <!-- Do not use broken cryptographic algorithms -->
   </Rules>
   <Rules AnalyzerId="Microsoft.AnalyzerPowerPack.CSharp" RuleNamespace="Microsoft.AnalyzerPowerPack.CSharp">
     <!-- Disable analyzer warning 1821 until https://github.com/dotnet/roslyn-analyzers/issues/1804 is resolved -->
-    <Rule Id="CA1821" Action="None" />
+    <Rule Id="CA1821" Action="None" /> <!-- Remove empty finalizers -->
   </Rules>
   <Rules AnalyzerId="xunit.analyzers" RuleNamespace="xunit.analyzers">
     <Rule Id="xUnit1010" Action="None" />

--- a/src/CodeAnalysis.ruleset
+++ b/src/CodeAnalysis.ruleset
@@ -69,7 +69,6 @@
     <Rule Id="CA1823" Action="None" /> <!-- Avoid unused private fields -->
     <Rule Id="CA1825" Action="None" /> <!-- Avoid zero-length array allocations. -->
     <Rule Id="CA2000" Action="None" /> <!-- Dispose objects before losing scope -->
-    <Rule Id="CA2007" Action="None" /> <!-- Consider calling ConfigureAwait on the awaited task -->
     <Rule Id="CA2008" Action="None" /> <!-- Do not create tasks without passing a TaskScheduler -->
     <Rule Id="CA2010" Action="None" /> <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->
     <Rule Id="CA2100" Action="None" /> <!-- Review SQL queries for security vulnerabilities -->
@@ -97,8 +96,9 @@
     <Rule Id="CA5372" Action="None" /> <!-- Use XmlReader For XPathDocument -->
     <Rule Id="CA5373" Action="None" /> <!-- Do not use obsolete key derivation function -->
     <Rule Id="CA5379" Action="None" /> <!-- Do Not Use Weak Key Derivation Function Algorithm -->
-    <Rule Id="CA5384" Action="None" /> <!-- SHA1 cannot be used -->
-    <Rule Id="CA5385" Action="None" /> <!-- RSA key size too small -->
+    <Rule Id="CA5384" Action="None" /> <!-- Do Not Use Digital Signature Algorithm (DSA) --> <!-- TODO -->
+    <Rule Id="CA5385" Action="None" /> <!-- Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size --> <!-- TODO -->
+
   </Rules>
   <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
     <Rule Id="CA2002" Action="Error" /> <!-- Do not lock on objects with weak identity -->

--- a/src/CodeAnalysis.ruleset
+++ b/src/CodeAnalysis.ruleset
@@ -59,7 +59,6 @@
     <Rule Id="CA1823" Action="None" /> <!-- Avoid unused private fields -->
     <Rule Id="CA1825" Action="None" /> <!-- Avoid zero-length array allocations. -->
     <Rule Id="CA2000" Action="None" /> <!-- Dispose objects before losing scope -->
-    <Rule Id="CA2002" Action="Error" /> <!-- Do not lock on objects with weak identity -->
     <Rule Id="CA2008" Action="None" /> <!-- Do not create tasks without passing a TaskScheduler -->
     <Rule Id="CA2010" Action="None" /> <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->
     <Rule Id="CA2100" Action="None" /> <!-- Review SQL queries for security vulnerabilities -->

--- a/src/CodeAnalysis.ruleset
+++ b/src/CodeAnalysis.ruleset
@@ -1,14 +1,4 @@
-﻿<RuleSet Name="Rules for Security Issues" Description="Code analysis rules for Security Issues." ToolsVersion="14.0">
-  <Rules AnalyzerId="Desktop.Analyzers" RuleNamespace="Desktop.Analyzers">
-    <Rule Id="CA2153" Action="Error"/> <!-- Do not catch corrupted process state exceptions -->
-    <Rule Id="CA5350" Action="Error" /> <!-- Do not use weak cryptographic algorithms -->
-    <Rule Id="CA5351" Action="Error" /> <!-- Do not use broken cryptographic algorithms -->
-  </Rules>
-  <Rules AnalyzerId="Desktop.CSharp.Analyzers" RuleNamespace="Desktop.Analyzers">
-    <Rule Id="CA2153" Action="Error"/> <!-- Do not catch corrupted process state exceptions -->
-    <Rule Id="CA5350" Action="Error" /> <!-- Do not use weak cryptographic algorithms -->
-    <Rule Id="CA5351" Action="Error" /> <!-- Do not use broken cryptographic algorithms -->
-  </Rules>
+﻿<RuleSet Name="Microsoft.Analyzers.ManagedCodeAnalysis" Description="Microsoft.Analyzers.ManagedCodeAnalysis" ToolsVersion="14.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1000" Action="None" /> <!-- Do not declare static members on generic types -->
     <Rule Id="CA1001" Action="None" /> <!-- Non disposable class owns disposable fields -->
@@ -64,10 +54,12 @@
     <Rule Id="CA1816" Action="None" /> <!-- Dispose methods should call SuppressFinalize -->
     <Rule Id="CA1819" Action="None" /> <!-- Properties should not return arrays -->
     <Rule Id="CA1820" Action="None" /> <!-- Test for empty strings using string length -->
+    <Rule Id="CA1821" Action="None" /> <!-- Remove empty finalizers --> <!-- Disable analyzer warning 1821 until https://github.com/dotnet/roslyn-analyzers/issues/1804 is resolved -->
     <Rule Id="CA1822" Action="None" /> <!-- Mark members as static -->
     <Rule Id="CA1823" Action="None" /> <!-- Avoid unused private fields -->
     <Rule Id="CA1825" Action="None" /> <!-- Avoid zero-length array allocations. -->
     <Rule Id="CA2000" Action="None" /> <!-- Dispose objects before losing scope -->
+    <Rule Id="CA2002" Action="Error" /> <!-- Do not lock on objects with weak identity -->
     <Rule Id="CA2008" Action="None" /> <!-- Do not create tasks without passing a TaskScheduler -->
     <Rule Id="CA2010" Action="None" /> <!-- Always consume the value returned by methods marked with PreserveSigAttribute -->
     <Rule Id="CA2100" Action="None" /> <!-- Review SQL queries for security vulnerabilities -->
@@ -90,18 +82,6 @@
     <Rule Id="CA5369" Action="None" /> <!-- Use XmlReader For Deserialize -->
     <Rule Id="CA5371" Action="None" /> <!-- Use XmlReader For Schema Read -->
     <Rule Id="CA5372" Action="None" /> <!-- Use XmlReader For XPathDocument -->
-
-  </Rules>
-  <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
-    <Rule Id="CA2002" Action="Error" /> <!-- Do not lock on objects with weak identity -->
-  </Rules>
-  <Rules AnalyzerId="System.Security.Cryptography.Hashing.Algorithms.Analyzers" RuleNamespace="System.Security.Cryptography.Hashing.Algorithms.Analyzers">
-    <Rule Id="CA5350" Action="Error" /> <!-- Do not use weak cryptographic algorithms -->
-    <Rule Id="CA5351" Action="Error" /> <!-- Do not use broken cryptographic algorithms -->
-  </Rules>
-  <Rules AnalyzerId="Microsoft.AnalyzerPowerPack.CSharp" RuleNamespace="Microsoft.AnalyzerPowerPack.CSharp">
-    <!-- Disable analyzer warning 1821 until https://github.com/dotnet/roslyn-analyzers/issues/1804 is resolved -->
-    <Rule Id="CA1821" Action="None" /> <!-- Remove empty finalizers -->
   </Rules>
   <Rules AnalyzerId="xunit.analyzers" RuleNamespace="xunit.analyzers">
     <Rule Id="xUnit1010" Action="None" />

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayAttribute.cs
@@ -18,11 +18,11 @@ namespace System.ComponentModel.DataAnnotations
     {
         #region Member Fields
 
-        private readonly LocalizableString _description = new LocalizableString("Description");
-        private readonly LocalizableString _groupName = new LocalizableString("GroupName");
-        private readonly LocalizableString _name = new LocalizableString("Name");
-        private readonly LocalizableString _prompt = new LocalizableString("Prompt");
-        private readonly LocalizableString _shortName = new LocalizableString("ShortName");
+        private readonly LocalizableString _description = new LocalizableString(nameof(Description));
+        private readonly LocalizableString _groupName = new LocalizableString(nameof(GroupName));
+        private readonly LocalizableString _name = new LocalizableString(nameof(Name));
+        private readonly LocalizableString _prompt = new LocalizableString(nameof(Prompt));
+        private readonly LocalizableString _shortName = new LocalizableString(nameof(ShortName));
         private bool? _autoGenerateField;
         private bool? _autoGenerateFilter;
         private int? _order;

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/DisplayFormatAttribute.cs
@@ -11,7 +11,7 @@ namespace System.ComponentModel.DataAnnotations
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
     public class DisplayFormatAttribute : Attribute
     {
-        private readonly LocalizableString _nullDisplayText = new LocalizableString("NullDisplayText");
+        private readonly LocalizableString _nullDisplayText = new LocalizableString(nameof(NullDisplayText));
 
         /// <summary>
         ///     Default constructor

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SslOverTdsStream.cs
@@ -91,11 +91,11 @@ namespace System.Data.SqlClient.SNI
         {
             if (_encapsulate)
             {
-                return await ReadInternalEncapsulate(buffer, offset, count, token, async);
+                return await ReadInternalEncapsulate(buffer, offset, count, token, async).ConfigureAwait(false);
             }
             else if (async)
             {
-                return await ReadInternalAsync(buffer, offset, count, token);
+                return await ReadInternalAsync(buffer, offset, count, token).ConfigureAwait(false);
             }
             else
             {
@@ -114,7 +114,7 @@ namespace System.Data.SqlClient.SNI
                 while (readBytes < TdsEnums.HEADER_LEN)
                 {
                     readBytes += (async ?
-                        await ReadInternalAsync(packetData, readBytes, TdsEnums.HEADER_LEN - readBytes, token) :
+                        await ReadInternalAsync(packetData, readBytes, TdsEnums.HEADER_LEN - readBytes, token).ConfigureAwait(false) :
                         ReadInternalSync(packetData, readBytes, TdsEnums.HEADER_LEN - readBytes)
                    );
                 }
@@ -129,7 +129,7 @@ namespace System.Data.SqlClient.SNI
             }
             
             readBytes = (async ?
-                await ReadInternalAsync(packetData, 0, count, token) :
+                await ReadInternalAsync(packetData, 0, count, token).ConfigureAwait(false) :
                 ReadInternalSync(packetData, 0, count)
             );
 

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessWaitState.Unix.cs
@@ -531,7 +531,7 @@ namespace System.Diagnostics
                         // Wait
                         try
                         {
-                            await Task.Delay(pollingIntervalMs, cancellationToken); // no need for ConfigureAwait(false) as we're in a Task.Run
+                            await Task.Delay(pollingIntervalMs, cancellationToken).ConfigureAwait(false);
                             pollingIntervalMs = Math.Min(pollingIntervalMs * 2, MaxPollingIntervalMs);
                         }
                         catch (OperationCanceledException) { }

--- a/src/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
+++ b/src/System.Net.HttpListener/src/System/Net/Managed/HttpConnection.cs
@@ -81,6 +81,7 @@ namespace System.Net
             }
             else
             {
+#pragma warning disable CA5359
                 _sslStream = epl.Listener.CreateSslStream(new NetworkStream(sock, false), false, (t, c, ch, e) =>
                 {
                     if (c == null)
@@ -98,6 +99,7 @@ namespace System.Net
                     _clientCertErrors = new int[] { (int)e };
                     return true;
                 });
+#pragma warning restore CA5359
 
                 _stream = _sslStream;
             }

--- a/src/System.Net.ServicePoint/src/System.Net.ServicePoint.csproj
+++ b/src/System.Net.ServicePoint/src/System.Net.ServicePoint.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{AD68DD5E-DEBF-48A0-B619-FBF65F502BC3}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);CA5364</NoWarn>
     <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);INTERNAL_ASYMMETRIC_IMPLEMENTATIONS</DefineConstants>
-    <NoWarn>CS1573;CS3016;CA5350;CA5351;$(NoWarn)</NoWarn>
+    <NoWarn>CS1573;CS3016;CA5350;CA5351;CA5379;CA5384;CA5385;$(NoWarn)</NoWarn>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1\AsnXml.targets"/>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -3,7 +3,7 @@
     <ProjectGuid>{81A05E2E-E3AE-4246-B4E6-DD5F31FB71F9}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);INTERNAL_ASYMMETRIC_IMPLEMENTATIONS</DefineConstants>
-    <NoWarn>CS1573;CS3016;CA5351;$(NoWarn)</NoWarn>
+    <NoWarn>CS1573;CS3016;CA5350;CA5351;$(NoWarn)</NoWarn>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1\AsnXml.targets"/>

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>System.Security.Cryptography.Cng</AssemblyName>
     <ProjectGuid>{4C1BD451-6A99-45E7-9339-79C77C42EE9E}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>CS1573;CS3016;$(NoWarn)</NoWarn>
+    <NoWarn>$(NoWarn);CS1573;CS3016;CA5379</NoWarn>
     <IsPartialFacadeAssembly Condition="'$(TargetsNetFx)' == 'true'">true</IsPartialFacadeAssembly>
     <OmitResources Condition="'$(IsPartialFacadeAssembly)' == 'true'">true</OmitResources>
     <GenFacadesIgnoreMissingTypes Condition="'$(TargetGroup)' == 'net461'">true</GenFacadesIgnoreMissingTypes>

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -3,6 +3,7 @@
     <ProjectGuid>{3B7F91D7-0677-40CA-B4E7-D4E09D89A74E}</ProjectGuid>
     <AssemblyName>System.Security.Cryptography.Csp</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);CA5373</NoWarn>
     <NoWarn Condition="'$(TargetsUnix)' == 'true'">$(NoWarn);CS0809</NoWarn>
     <Configurations>netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>

--- a/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -7,7 +7,7 @@
     <OmitResources Condition="'$(IsPartialFacadeAssembly)' == 'true'">true</OmitResources>
     <UsePackageTargetRuntimeDefaults Condition="'$(IsPartialFacadeAssembly)' != 'true'">true</UsePackageTargetRuntimeDefaults>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
-    <NoWarn>$(NoWarn);CS1574;CS3016</NoWarn>
+    <NoWarn>$(NoWarn);CS1574;CS3016;CA5379;CA5384</NoWarn>
     <Configurations>net461-Windows_NT-Debug;net461-Windows_NT-Release;netcoreapp-Debug;netcoreapp-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;netfx-Windows_NT-Debug;netfx-Windows_NT-Release;netstandard-Debug;netstandard-Release;netstandard-Windows_NT-Debug;netstandard-Windows_NT-Release;netstandard2.1-Debug;netstandard2.1-Release;netstandard2.1-Windows_NT-Debug;netstandard2.1-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1\AsnXml.targets" Condition="'$(IsPartialFacadeAssembly)' != 'true'" />

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
@@ -206,7 +206,7 @@ namespace System.Security.Cryptography
             await semaphore.WaitAsync().ForceAsync();
             try
             {
-                return await ReadAsyncCore(buffer, offset, count, cancellationToken, useAsync: true); // ConfigureAwait not needed as ForceAsync was used
+                return await ReadAsyncCore(buffer, offset, count, cancellationToken, useAsync: true).ConfigureAwait(false);
             }
             finally
             {
@@ -326,7 +326,7 @@ namespace System.Security.Cryptography
                 try
                 {
                     amountRead = useAsync ?
-                        await _stream.ReadAsync(new Memory<byte>(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex), cancellationToken) : // ConfigureAwait not needed, as useAsync is only true if we're already on a TP thread
+                        await _stream.ReadAsync(new Memory<byte>(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex), cancellationToken).ConfigureAwait(false) :
                         _stream.Read(tempInputBuffer, _inputBufferIndex, numWholeBlocksInBytes - _inputBufferIndex);
 
                     int totalInput = _inputBufferIndex + amountRead;
@@ -485,7 +485,7 @@ namespace System.Security.Cryptography
             await semaphore.WaitAsync().ForceAsync();
             try
             {
-                await WriteAsyncCore(buffer, offset, count, cancellationToken, useAsync: true); // ConfigureAwait not needed due to earlier ForceAsync
+                await WriteAsyncCore(buffer, offset, count, cancellationToken, useAsync: true).ConfigureAwait(false);
             }
             finally
             {

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.X509Certificates</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>$(NoWarn);CS3016</NoWarn>
+    <NoWarn>$(NoWarn);CS3016;CA5379;CA5384;CA5385</NoWarn>
     <Configurations>netcoreapp-OSX-Debug;netcoreapp-OSX-Release;netcoreapp-Unix-Debug;netcoreapp-Unix-Release;netcoreapp-Windows_NT-Debug;netcoreapp-Windows_NT-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <Import Project="$(CommonPath)\System\Security\Cryptography\Asn1\AsnXml.targets" />

--- a/src/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
+++ b/src/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
@@ -4,6 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{0544EAE3-0CF2-4EA6-93BE-A9FF8B52724A}</ProjectGuid>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netstandard'">true</IsPartialFacadeAssembly>
+    <NoWarn>$(NoWarn);CA5384;CA5385</NoWarn>
     <Configurations>net461-Debug;net461-Release;netfx-Debug;netfx-Release;netstandard-Debug;netstandard-Release</Configurations>
   </PropertyGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">


### PR DESCRIPTION
We haven't upgraded the package(s) we use for our roslyn-analyzers in years, and in that time many more FxCop rules were ported, packages were consolidated, etc.  This updates us to the latest.

In the process, I suppressed most of the rules where we had violations, though I also fixed up some violations to be able to enable the rules (e.g. ConfigureAwait).  Most of these rules will remain disabled, but a few we'll probably want to fix-up over time and re-enable.

Fixes #39702 
cc: @safern, @bartonjs

(I've not built locally on all platforms; relying on CI to catch additional violations I may have missed.)