### PR TITLE
Update coverlet version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "coverlet.console": {
-      "version": "1.5.47-g016c3630ca",
+      "version": "1.5.49-ge3d1a6c9df",
       "commands": [
         "coverlet"
       ]


### PR DESCRIPTION
Fixes a NullReferenceException when instrumenting properties without a getter: https://github.com/tonerdo/coverlet/commit/e3d1a6c9df64b3ff95c7faeb5b7b90c7eebe30dd