### PR TITLE
Upgrade Windows Nano Server to 1809

### DIFF
--- a/eng/pipelines/windows.yml
+++ b/eng/pipelines/windows.yml
@@ -34,7 +34,7 @@ stages:
                 _BuildConfig: Debug
                 _architecture: x64
                 _framework: netcoreapp
-                _helixQueues: $(netcoreappWindowsQueues) # Temporarily disable Nano for issue 38858: +$(nanoQueues)
+                _helixQueues: $(netcoreappWindowsQueues)+$(nanoQueues)
 
               x86_Release:
                 _BuildConfig: Release
@@ -110,7 +110,7 @@ stages:
         buildExtraArguments: /p:RuntimeOS=win10
 
         variables:
-          - nanoQueues: "`(Windows.Nano.1803.Amd64.Open`)windows.10.amd64.serverrs4.open@mcr.microsoft.com/dotnet-buildtools/prereqs:nanoserver-1803-helix-amd64-05227e1-20190509225944"
+          - nanoQueues: "`(Windows.Nano.1809.Amd64.Open`)windows.10.amd64.serverrs5.open@mcr.microsoft.com/dotnet-buildtools/prereqs:nanoserver-1809-helix-amd64-61052b7-20190723211353"
           - uapNetfxQueues: Windows.10.Amd64.ClientRS5.Open
           - windowsArmQueue: Windows.10.Arm64.Open
 

--- a/src/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/Common/tests/CoreFx.Private.TestUtilities/System/PlatformDetection.Windows.cs
@@ -222,6 +222,9 @@ namespace System
                     switch (result)
                     {
                         case 15703: // APPMODEL_ERROR_NO_APPLICATION
+                        case 120:   // ERROR_CALL_NOT_IMPLEMENTED
+                                    // This function is not supported on this system.
+                                    // In example on Windows Nano Server
                             s_isInAppContainer = 0;
                             break;
                         case 0:     // ERROR_SUCCESS

--- a/src/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/SpecialDirectoriesTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/SpecialDirectoriesTests.cs
@@ -83,7 +83,8 @@ namespace Microsoft.VisualBasic.FileIO.Tests
         [Fact]
         public static void TempFolderTest()
         {
-            Assert.Equal(TrimSeparators(System.IO.Path.GetTempPath()), TrimSeparators(SpecialDirectories.Temp));
+            // On Nano Server >=1809 the temp path's case is changed during the normalization.
+            Assert.Equal(TrimSeparators(System.IO.Path.GetTempPath()), TrimSeparators(SpecialDirectories.Temp), ignoreCase: PlatformDetection.IsWindowsNanoServer);
         }
 
         private static string TrimSeparators(string s)

--- a/src/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -28,12 +28,12 @@ namespace System.Globalization.Tests
             TextInfo ti = CultureInfo.GetCultureInfo(cultureName).TextInfo;
             Assert.Equal(lcid, ti.LCID);
             Assert.Equal(ansiCodePage, ti.ANSICodePage);
-            // On Nano Server >= 1809 the EBCDICCodePage always returns 65001.
+            Assert.Equal(ebcdiCCodePage, ti.EBCDICCodePage);
+            // On Nano Server >= 1809 the MacCodePage always returns 65001.
             if (!PlatformDetection.IsWindowsNanoServer)
             {
-                Assert.Equal(ebcdiCCodePage, ti.EBCDICCodePage);
+                Assert.Equal(macCodePage, ti.MacCodePage);
             }
-            Assert.Equal(macCodePage, ti.MacCodePage);
             Assert.Equal(oemCodePage, ti.OEMCodePage);
             Assert.Equal(isRightToLeft, ti.IsRightToLeft);
         }

--- a/src/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -21,7 +21,7 @@ namespace System.Globalization.Tests
             yield return new object[] { "he-IL", 0x40d, 0x4e7, 0x1f4, 0x2715, 0x35e, true };
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // OS changes
         [MemberData(nameof(TextInfo_TestData))]
         public void MiscTest(string cultureName, int lcid, int ansiCodePage, int ebcdiCCodePage, int macCodePage, int oemCodePage, bool isRightToLeft)
         {
@@ -29,11 +29,7 @@ namespace System.Globalization.Tests
             Assert.Equal(lcid, ti.LCID);
             Assert.Equal(ansiCodePage, ti.ANSICodePage);
             Assert.Equal(ebcdiCCodePage, ti.EBCDICCodePage);
-            // On Nano Server >= 1809 the MacCodePage always returns 65001.
-            if (!PlatformDetection.IsWindowsNanoServer)
-            {
-                Assert.Equal(macCodePage, ti.MacCodePage);
-            }
+            Assert.Equal(macCodePage, ti.MacCodePage);
             Assert.Equal(oemCodePage, ti.OEMCodePage);
             Assert.Equal(isRightToLeft, ti.IsRightToLeft);
         }

--- a/src/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -28,7 +28,11 @@ namespace System.Globalization.Tests
             TextInfo ti = CultureInfo.GetCultureInfo(cultureName).TextInfo;
             Assert.Equal(lcid, ti.LCID);
             Assert.Equal(ansiCodePage, ti.ANSICodePage);
-            Assert.Equal(ebcdiCCodePage, ti.EBCDICCodePage);
+            // On Nano Server >= 1809 the EBCDICCodePage always returns 65001.
+            if (!PlatformDetection.IsWindowsNanoServer)
+            {
+                Assert.Equal(ebcdiCCodePage, ti.EBCDICCodePage);
+            }
             Assert.Equal(macCodePage, ti.MacCodePage);
             Assert.Equal(oemCodePage, ti.OEMCodePage);
             Assert.Equal(isRightToLeft, ti.IsRightToLeft);

--- a/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.GetEnvironmentVariable.cs
@@ -220,6 +220,13 @@ namespace System.Tests
         public void EnumerateEnvironmentVariables(EnvironmentVariableTarget target)
         {
             bool lookForSetValue = (target == EnvironmentVariableTarget.Process) || PlatformDetection.IsWindowsAndElevated;
+            
+            // [ActiveIssue(40226)]
+            if (PlatformDetection.IsWindowsNanoServer && target == EnvironmentVariableTarget.User)
+            {
+                lookForSetValue = false;
+            }
+
             string key = $"EnumerateEnvironmentVariables ({target})";
             string value = Path.GetRandomFileName();
 

--- a/src/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.SetEnvironmentVariable.cs
@@ -17,6 +17,12 @@ namespace System.Tests
 
         internal static bool IsSupportedTarget(EnvironmentVariableTarget target)
         {
+            // [ActiveIssue(40226)]
+            if (target == EnvironmentVariableTarget.User && PlatformDetection.IsWindowsNanoServer)
+            {
+                return false;
+            }
+
             return target == EnvironmentVariableTarget.Process || (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !PlatformDetection.IsUap);
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/38858

cc @ericstj @safern checking if failures are still happening with the new image and on an updated server.