### PR TITLE
Mark System.Numerics.Tensors package as nonshipping

### DIFF
--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -23,6 +23,12 @@
     <SymbolsPublishExperimentalPattern>$(SymbolsOutputRoot)*Experimental*.nupkg</SymbolsPublishExperimentalPattern>
   </PropertyGroup>
 
+  <!-- List of packages to exclude from nuget.org publishing -->
+  <!-- We can't use the `IsShippingPackage` metadata since CoreFx doesn't output packages
+  to shipping/nonshipping directories -->
+  <ItemGroup>
+    <NonShippingPackages Include="$(PackageOutputRoot)*System.Numerics.Tensors*.nupkg" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(PackagesGlob)' != ''">
     <PackagesToPublish Include="$(PackagesGlob)" />
@@ -30,6 +36,9 @@
 
   <ItemGroup Condition="'$(PackagesGlob)' == ''">
     <PackagesToPublish Include="$(FinalPublishPrivatePattern);$(FinalPublishExperimentalPattern)">
+      <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
+    </PackagesToPublish>
+    <PackagesToPublish Include="@(NonShippingPackages)">
       <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
     </PackagesToPublish>
     <PackagesToPublish Include="$(FinalPublishPattern)" Exclude="@(PackagesToPublish)" />

--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -35,10 +35,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackagesGlob)' == ''">
-    <PackagesToPublish Include="$(FinalPublishPrivatePattern);$(FinalPublishExperimentalPattern)">
-      <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
-    </PackagesToPublish>
-    <PackagesToPublish Include="@(NonShippingPackages)">
+    <PackagesToPublish Include="$(FinalPublishPrivatePattern);$(FinalPublishExperimentalPattern);@(NonShippingPackages)">
       <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
     </PackagesToPublish>
     <PackagesToPublish Include="$(FinalPublishPattern)" Exclude="@(PackagesToPublish)" />

--- a/src/System.Numerics.Tensors/Directory.Build.props
+++ b/src/System.Numerics.Tensors/Directory.Build.props
@@ -4,5 +4,7 @@
     <PackageVersion>0.3.0</PackageVersion>
     <AssemblyVersion>0.2.0.0</AssemblyVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <!-- This is a preview package. Do not mark as stable. -->
+    <BlockStable>true</BlockStable>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Marks `System.Numerics.Tensors` as nonshipping so we stop publishing it to nuget.org, as well as giving it the `BlockStable` property so we don't generate a stable version of it.

Since CoreFx defines its own package output directory scheme, and doesn't follow Arcade's `ArtifactsShippingPackagesDir`/`ArtifactsNonShippingPackagesDir` structure, we can't just wire into their calculation of `ManifestArtifactData` by setting `IsShippingPackage=false` in the .pkgproj. Instead, I define an explicit list of NonShippingPackages which currently contains only `System.Numerics.Tensors`. @mmitche, do you know if there's a way I can generate the manifest for this build to confirm that the package winds up in `nonshipping`, without first merging this commit?

@safern @ericstj @ViktorHofer PTAL

CC @tannergooding 