### PR TITLE
Only Removing logName which are not actual logs from the geteventlogs  api output

### DIFF
--- a/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
+++ b/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs
@@ -667,6 +667,12 @@ namespace System.Diagnostics
                     handle.Close();
                     logs.Add(log);
                 }
+                else if (Marshal.GetLastWin32Error() != Interop.Errors.ERROR_INVALID_PARAMETER)
+                {
+                    // This api should return the list of all event logs present on the system even if the current user can't open the log.
+                    // Windows returns ERROR_INVALID_PARAMETER for special keys which were added in RS5+ but do not represent actual event logs.
+                    logs.Add(log);
+                }
             }
 
             return logs.ToArray();

--- a/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
+++ b/src/System.Diagnostics.EventLog/tests/EventLogTests/EventLogTests.cs
@@ -4,6 +4,7 @@
 
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -349,7 +350,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void GetEventLogEntriesTest()
         {
@@ -358,6 +359,14 @@ namespace System.Diagnostics.Tests
                 // Accessing eventlog properties should not throw.
                 Assert.True(Helpers.RetryOnWin7(() => eventLog.Entries.Count) >= 0);
             }
+        }
+
+        [ConditionalFact(typeof(Helpers), nameof(Helpers.SupportsEventLogs))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void GetEventLogContainsSecurityLogTest()
+        {
+            EventLog[] eventlogs = EventLog.GetEventLogs();
+            Assert.True(eventlogs.Select(t => t.Log).Contains("Security", StringComparer.OrdinalIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
The handle returned on the https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.EventLog/src/System/Diagnostics/EventLog.cs#L663 is invalid if the user doesnot have access to this log eg non admin trying to access security log.
The code added in this #38430 ended up removing such logs as well.
This Pr fixes that problem for release 3.0 branch