### PR TITLE
Add [Obsolete] to vbNewLine

### DIFF
--- a/src/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
+++ b/src/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
@@ -128,8 +128,8 @@ namespace Microsoft.VisualBasic
         public const Microsoft.VisualBasic.MsgBoxStyle vbMsgBoxRight = Microsoft.VisualBasic.MsgBoxStyle.MsgBoxRight;
         public const Microsoft.VisualBasic.MsgBoxStyle vbMsgBoxRtlReading = Microsoft.VisualBasic.MsgBoxStyle.MsgBoxRtlReading;
         public const Microsoft.VisualBasic.MsgBoxStyle vbMsgBoxSetForeground = Microsoft.VisualBasic.MsgBoxStyle.MsgBoxSetForeground;
-        [System.ObsoleteAttribute("For a carriage return and line feed, use vbCrLf.  For the current platform's newline, use System.Environment.NewLine.")]
         public const Microsoft.VisualBasic.VbStrConv vbNarrow = Microsoft.VisualBasic.VbStrConv.Narrow;
+        [System.ObsoleteAttribute("For a carriage return and line feed, use vbCrLf.  For the current platform's newline, use System.Environment.NewLine.")]
         public const string vbNewLine = "\r\n";
         public const Microsoft.VisualBasic.MsgBoxResult vbNo = Microsoft.VisualBasic.MsgBoxResult.No;
         public const Microsoft.VisualBasic.FileAttribute vbNormal = Microsoft.VisualBasic.FileAttribute.Normal;


### PR DESCRIPTION
Add `[Obsolete]` to `Microsoft.VisualBasic.Constants.vbNewLine` rather than `vbNarrow` in reference assembly.