### PR TITLE
Add [Obsolete] to vbNewLine

### DIFF
--- a/src/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
+++ b/src/Microsoft.VisualBasic.Core/ref/Microsoft.VisualBasic.Core.cs
@@ -128,8 +128,8 @@ namespace Microsoft.VisualBasic
         public const MsgBoxStyle vbMsgBoxRight = MsgBoxStyle.MsgBoxRight;
         public const MsgBoxStyle vbMsgBoxRtlReading = MsgBoxStyle.MsgBoxRtlReading;
         public const MsgBoxStyle vbMsgBoxSetForeground = MsgBoxStyle.MsgBoxSetForeground;
-        [System.ObsoleteAttribute("For a carriage return and line feed, use vbCrLf.  For the current platform's newline, use System.Environment.NewLine.")]
         public const VbStrConv vbNarrow = VbStrConv.Narrow;
+        [System.ObsoleteAttribute("For a carriage return and line feed, use vbCrLf.  For the current platform's newline, use System.Environment.NewLine.")]
         public const string vbNewLine = "\r\n";
         public const MsgBoxResult vbNo = MsgBoxResult.No;
         public const FileAttribute vbNormal = FileAttribute.Normal;


### PR DESCRIPTION
Add `[Obsolete]` to `Microsoft.VisualBasic.Constants.vbNewLine` rather than `vbNarrow` in reference assembly.

(release/3.0 branch)
