### PR TITLE
Update coverlet version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "coverlet.console": {
-      "version": "1.5.49-ge3d1a6c9df",
+      "version": "1.5.51-ged9195d73b",
       "commands": [
         "coverlet"
       ]


### PR DESCRIPTION
The new package fixes CoreLib code coverage crashes that were introduced with https://github.com/tonerdo/coverlet/commit/33fad1ee38849aa3df2b8754f919c5d23815cde5

This should be the last coverlet required update for a while.