### PR TITLE
Fix invalid IL generated in Xml serializers

### DIFF
--- a/src/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
+++ b/src/System.Private.Xml/src/System/Xml/Serialization/CodeGenerator.cs
@@ -1418,7 +1418,15 @@ namespace System.Xml.Serialization
         internal void WhileBegin()
         {
             WhileState whileState = new WhileState(this);
-            Br(whileState.CondLabel);
+            // ECMA-335 III.1.7.5 states that code blocks after unconditional
+            // branch which could only be reached by backward branch are assumed
+            // to have empty stack on the entrance.
+            //
+            // Since we don't have control over the current stack contents here
+            // we have to generate conditional branch here instead of
+            // Br(whileState.CondLabel) to make the IL verifiable.
+            Ldc(true);
+            Brtrue(whileState.CondLabel);
             MarkLabel(whileState.StartLabel);
             _whileStack.Push(whileState);
         }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/15174, https://github.com/mono/mono/issues/15175, https://github.com/mono/mono/issues/15176, https://github.com/mono/mono/issues/15177, https://github.com/mono/mono/issues/15178, https://github.com/mono/mono/issues/15179.

The detailed analysis of the problem is described in https://github.com/mono/mono/issues/15179.

ECMA 335, section 1.7.5 states

> III.1.7.5 Backward branch constraints
>
> It shall be possible, with a single forward-pass through the CIL instruction stream for any
method, to infer the exact state of the evaluation stack at every instruction (where by “state” we
mean the number and type of each item on the evaluation stack).
>
> In particular, if that single-pass analysis arrives at an instruction, call it location X, that
immediately follows an unconditional branch, and where X is not the target of an earlier branch
instruction, then the state of the evaluation stack at X, clearly, cannot be derived from existing
information. In this case, the CLI demands that the evaluation stack at X be empty.
>
> Following on from this rule, it would clearly be invalid CIL if a later branch instruction to X
were to have a non-empty evaluation stack
>
> [Rationale: This constraint ensures that CIL code can be processed by a simple CIL-to-native code compiler. It ensures that the state of the evaluation stack at the beginning of each CIL can
be inferred from a single, forward-pass analysis of the instruction stream. end rationale]
> [Note: the stack state at location X in the above can be inferred by various means: from a
previous forward branch to X; because X marks the start of an exception handler, etc. end note]

This particular condition was violated in code generated in `ILGenForCreateInstance` method [1] in the XML serialization. The method itself is correctly stack balanced as long as the initial stack has depth 0 at the time it starts the code generation. However, that assumption is violated on several call sites (eg. [2], [3]).

Two possible fixes are possible. First, we can ensure that the call sites of `ILGenForCreateInstance` always have stack depth of zero. Due to the number of call sites that are affected by this it would be hard to verify that all of them are correct. Second, we can modify `ILGenForCreateInstance` to work with non-empty stack. That could be done by modifying the `while` loop generation.

I opted for the smallest possible fix that makes the code valid by modifying the code `while` loop generation. Alternatively I can modify it to move the `while` condition block to the beginning of the `while` loop. It will require a few more code changes and it will differ more significantly from what C# compiler produces. Let me know if that is preferable. 

/cc @marek-safar @jkotas 

[1] https://github.com/dotnet/corefx/blob/8c2be7893fa585cba9c094c27b69d7c8e0822ef3/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationWriterILGen.cs#L2386
[2] https://github.com/dotnet/corefx/blob/8c2be7893fa585cba9c094c27b69d7c8e0822ef3/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs#L626-L628
[3]
https://github.com/dotnet/corefx/blob/8c2be7893fa585cba9c094c27b69d7c8e0822ef3/src/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs#L3251-L3252