### PR TITLE
[release/3.0] Change the default symmetric encryption algorithm for EnvelopedCms

### DIFF
--- a/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/EnvelopedCms.cs
+++ b/src/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/EnvelopedCms.cs
@@ -22,7 +22,7 @@ namespace System.Security.Cryptography.Pkcs
         }
 
         public EnvelopedCms(ContentInfo contentInfo)
-            : this(contentInfo, new AlgorithmIdentifier(Oid.FromOidValue(Oids.TripleDesCbc, OidGroup.EncryptionAlgorithm)))
+            : this(contentInfo, new AlgorithmIdentifier(Oid.FromOidValue(Oids.Aes256Cbc, OidGroup.EncryptionAlgorithm)))
         {
         }
 

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
@@ -19,6 +19,29 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         public static bool SupportsRsaOaepCerts => PlatformDetection.IsWindows;
 
         [Fact]
+        public static void DefaultEncryptionAlgorithm()
+        {
+            EnvelopedCms cms1 = new EnvelopedCms();
+            EnvelopedCms cms2 = new EnvelopedCms(new ContentInfo(Array.Empty<byte>()));
+
+            string[] supportedAlgorithms;
+
+            // net48 changes the default to AES-256-CBC, older versions (and quirk) are
+            // DES3-EDE-CBC
+            if (PlatformDetection.IsFullFramework)
+            {
+                supportedAlgorithms = new[] { Oids.TripleDesCbc, Oids.Aes256 };
+            }
+            else
+            {
+                supportedAlgorithms = new[] { Oids.Aes256 };
+            }
+
+            Assert.Contains(cms1.ContentEncryptionAlgorithm.Oid.Value, supportedAlgorithms);
+            Assert.Contains(cms2.ContentEncryptionAlgorithm.Oid.Value, supportedAlgorithms);
+        }
+
+        [Fact]
         public static void DecodeVersion0_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -59,7 +82,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         public static void DecodeRecipients3_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
-            EnvelopedCms ecms = new EnvelopedCms(contentInfo);
+            EnvelopedCms ecms = new EnvelopedCms(contentInfo, KeyAgreeRecipientInfoTests.TripleDesAlgId);
             CmsRecipientCollection recipients = new CmsRecipientCollection();
             foreach (X509Certificate2 cert in s_certs)
             {

--- a/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
+++ b/src/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
@@ -13,6 +13,9 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 {
     public static partial class KeyAgreeRecipientInfoTests
     {
+        internal static readonly AlgorithmIdentifier TripleDesAlgId =
+            new AlgorithmIdentifier(new Oid(Oids.TripleDesCbc, null));
+
         public static bool SupportsDiffieHellman => PlatformDetection.IsWindows;
         public static bool DoesNotSupportDiffieHellman => !SupportsDiffieHellman;
 
@@ -354,7 +357,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         private static KeyAgreeRecipientInfo EncodeKeyAgreel(SubjectIdentifierType type = SubjectIdentifierType.IssuerAndSerialNumber)
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
-            EnvelopedCms ecms = new EnvelopedCms(contentInfo);
+            EnvelopedCms ecms = new EnvelopedCms(contentInfo, TripleDesAlgId);
             using (X509Certificate2 cert = Certificates.DHKeyAgree1.GetCertificate())
             {
                 CmsRecipient cmsRecipient = new CmsRecipient(type, cert);


### PR DESCRIPTION
.NET Framework upgraded this for 4.8, .NET Core should for 3.0

Port of #39748