### PR TITLE
Exclude System.Numerics.Tensors Symbol package from publishing

### DIFF
--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -23,11 +23,13 @@
     <SymbolsPublishExperimentalPattern>$(SymbolsOutputRoot)*Experimental*.nupkg</SymbolsPublishExperimentalPattern>
   </PropertyGroup>
 
-  <!-- List of packages to exclude from nuget.org publishing -->
+  <!-- List of packages/symbol packages to exclude from nuget.org publishing -->
   <!-- We can't use the `IsShippingPackage` metadata since CoreFx doesn't output packages
   to shipping/nonshipping directories -->
   <ItemGroup>
     <NonShippingPackages Include="$(PackageOutputRoot)*System.Numerics.Tensors*.nupkg" />
+
+    <NonShippingSymbolPackages Include="$(SymbolsOutputRoot)*System.Numerics.Tensors*.nupkg" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackagesGlob)' != ''">
@@ -42,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SymbolPackagesToPublish  Include="$(SymbolsPublishPrivatePattern);$(SymbolsPublishExperimentalPattern)">
+    <SymbolPackagesToPublish  Include="$(SymbolsPublishPrivatePattern);$(SymbolsPublishExperimentalPattern);@(NonShippingSymbolPackages)">
       <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
     </SymbolPackagesToPublish>
     <SymbolPackagesToPublish Include="$(SymbolsPublishPattern)" Exclude="@(SymbolPackagesToPublish)" />


### PR DESCRIPTION
I've confirmed that https://github.com/dotnet/corefx/pull/39743 does mark `System.Numerics.Tensors` as nonshipping, but I realized I missed doing the same for the symbol package.

CC @safern @ericstj @ViktorHofer @tannergooding 