### PR TITLE
Re-enable CA1200 (avoid cref tag prefixes)

### DIFF
--- a/src/CodeAnalysis.ruleset
+++ b/src/CodeAnalysis.ruleset
@@ -26,7 +26,6 @@
     <Rule Id="CA1066" Action="None" /> <!-- Type should implement IEquatable -->
     <Rule Id="CA1067" Action="None" /> <!-- Override Object.Equals(object) when implementing IEquatable -->
     <Rule Id="CA1068" Action="None" /> <!-- CancellationToken parameters must come last -->
-    <Rule Id="CA1200" Action="None" /> <!-- Avoid using cref tags with a prefix -->
     <Rule Id="CA1303" Action="None" /> <!-- Do not pass literals as localized parameters -->
     <Rule Id="CA1304" Action="None" /> <!-- Specify CultureInfo -->
     <Rule Id="CA1305" Action="None" /> <!-- Specify IFormatProvider -->

--- a/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
+++ b/src/Common/src/System/Collections/Generic/LargeArrayBuilder.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 namespace System.Collections.Generic
 {
     /// <summary>
-    /// Represents a position within a <see cref="T:System.Collections.Generic.LargeArrayBuilder`1"/>.
+    /// Represents a position within a <see cref="System.Collections.Generic.LargeArrayBuilder{T}"/>.
     /// </summary>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal readonly struct CopyPosition
@@ -27,7 +27,7 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
-        /// Represents a position at the start of a <see cref="T:System.Collections.Generic.LargeArrayBuilder`1"/>.
+        /// Represents a position at the start of a <see cref="System.Collections.Generic.LargeArrayBuilder{T}"/>.
         /// </summary>
         public static CopyPosition Start => default(CopyPosition);
 

--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -614,7 +614,7 @@ namespace System.Net.WebSockets
         /// </summary>
         /// <param name="payloadBuffer">The buffer into which payload data should be written.</param>
         /// <param name="cancellationToken">The CancellationToken used to cancel the websocket.</param>
-        /// <param name="resultGetter">Used to get the result.  Allows the same method to be used with both <see cref="WebSocketReceiveResult"/> and <see cref="T:System.Net.WebSockets.ValueWebSocketReceiveResult"/>.</param>
+        /// <param name="resultGetter">Used to get the result.  Allows the same method to be used with both <see cref="WebSocketReceiveResult"/> and <see cref="System.Net.WebSockets.ValueWebSocketReceiveResult"/>.</param>
         /// <returns>Information about the received message.</returns>
         private async ValueTask<TWebSocketReceiveResult> ReceiveAsyncPrivate<TWebSocketReceiveResultGetter, TWebSocketReceiveResult>(
             Memory<byte> payloadBuffer,

--- a/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -614,7 +614,7 @@ namespace System.Net.WebSockets
         /// </summary>
         /// <param name="payloadBuffer">The buffer into which payload data should be written.</param>
         /// <param name="cancellationToken">The CancellationToken used to cancel the websocket.</param>
-        /// <param name="resultGetter">Used to get the result.  Allows the same method to be used with both <see cref="WebSocketReceiveResult"/> and <see cref="System.Net.WebSockets.ValueWebSocketReceiveResult"/>.</param>
+        /// <param name="resultGetter">Used to get the result.  Allows the same method to be used with both WebSocketReceiveResult and ValueWebSocketReceiveResult.</param>
         /// <returns>Information about the received message.</returns>
         private async ValueTask<TWebSocketReceiveResult> ReceiveAsyncPrivate<TWebSocketReceiveResultGetter, TWebSocketReceiveResult>(
             Memory<byte> payloadBuffer,

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/BlockingCollection.cs
@@ -22,21 +22,21 @@ namespace System.Collections.Concurrent
 {
     /// <summary> 
     /// Provides blocking and bounding capabilities for thread-safe collections that 
-    /// implement <see cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. 
+    /// implement <see cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. 
     /// </summary>
     /// <remarks>
-    /// <see cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/> represents a collection
+    /// <see cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/> represents a collection
     /// that allows for thread-safe adding and removing of data. 
-    /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> is used as a wrapper
-    /// for an <see cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/> instance, allowing
+    /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> is used as a wrapper
+    /// for an <see cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/> instance, allowing
     /// removal attempts from the collection to block until data is available to be removed.  Similarly,
-    /// a <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> can be created to enforce
+    /// a <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> can be created to enforce
     /// an upper-bound on the number of data elements allowed in the 
-    /// <see cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>; addition attempts to the
+    /// <see cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>; addition attempts to the
     /// collection may then block until space is available to store the added items.  In this manner,
-    /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> is similar to a traditional
+    /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> is similar to a traditional
     /// blocking queue data structure, except that the underlying data storage mechanism is abstracted
-    /// away as an <see cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. 
+    /// away as an <see cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. 
     /// </remarks>
     /// <typeparam name="T">Specifies the type of elements in the collection.</typeparam>
     [DebuggerTypeProxy(typeof(BlockingCollectionDebugView<>))]
@@ -56,10 +56,10 @@ namespace System.Collections.Concurrent
         private const int COMPLETE_ADDING_ON_MASK = unchecked((int)0x80000000);
 
         #region Properties
-        /// <summary>Gets the bounded capacity of this <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</summary>
+        /// <summary>Gets the bounded capacity of this <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</summary>
         /// <value>The bounded capacity of this collection, or -1 if no bound was supplied.</value>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         public int BoundedCapacity
         {
             get
@@ -69,10 +69,10 @@ namespace System.Collections.Concurrent
             }
         }
 
-        /// <summary>Gets whether this <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been marked as complete for adding.</summary>
+        /// <summary>Gets whether this <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been marked as complete for adding.</summary>
         /// <value>Whether this collection has been marked as complete for adding.</value>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         public bool IsAddingCompleted
         {
             get
@@ -82,10 +82,10 @@ namespace System.Collections.Concurrent
             }
         }
 
-        /// <summary>Gets whether this <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been marked as complete for adding and is empty.</summary>
+        /// <summary>Gets whether this <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been marked as complete for adding and is empty.</summary>
         /// <value>Whether this collection has been marked as complete for adding and is empty.</value>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         public bool IsCompleted
         {
             get
@@ -95,10 +95,10 @@ namespace System.Collections.Concurrent
             }
         }
 
-        /// <summary>Gets the number of items contained in the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.</summary>
-        /// <value>The number of items contained in the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.</value>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <summary>Gets the number of items contained in the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.</summary>
+        /// <value>The number of items contained in the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.</value>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         public int Count
         {
             get
@@ -108,9 +108,9 @@ namespace System.Collections.Concurrent
             }
         }
 
-        /// <summary>Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection"/> is synchronized.</summary>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <summary>Gets a value indicating whether access to the <see cref="System.Collections.ICollection"/> is synchronized.</summary>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         bool ICollection.IsSynchronized
         {
             get
@@ -122,9 +122,9 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Gets an object that can be used to synchronize access to the <see
-        /// cref="T:System.Collections.ICollection"/>. This property is not supported.
+        /// cref="System.Collections.ICollection"/>. This property is not supported.
         /// </summary>
-        /// <exception cref="T:System.NotSupportedException">The SyncRoot property is not supported.</exception>
+        /// <exception cref="System.NotSupportedException">The SyncRoot property is not supported.</exception>
         object ICollection.SyncRoot
         {
             get
@@ -136,7 +136,7 @@ namespace System.Collections.Concurrent
 
 
         /// <summary>Initializes a new instance of the 
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>
         /// class without an upper-bound.
         /// </summary>
         /// <remarks>
@@ -148,11 +148,11 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>Initializes a new instance of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/>
         /// class with the specified upper-bound.
         /// </summary>
         /// <param name="boundedCapacity">The bounded size of the collection.</param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="boundedCapacity"/> is
+        /// <exception cref="System.ArgumentOutOfRangeException">The <paramref name="boundedCapacity"/> is
         /// not a positive value.</exception>
         /// <remarks>
         /// The default underlying collection is a <see cref="System.Collections.Concurrent.ConcurrentQueue{T}">ConcurrentQueue&lt;T&gt;</see>.
@@ -162,14 +162,14 @@ namespace System.Collections.Concurrent
         {
         }
 
-        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>
+        /// <summary>Initializes a new instance of the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>
         /// class with the specified upper-bound and using the provided 
-        /// <see cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/> as its underlying data store.</summary>
+        /// <see cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/> as its underlying data store.</summary>
         /// <param name="collection">The collection to use as the underlying data store.</param>
         /// <param name="boundedCapacity">The bounded size of the collection.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collection"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collection"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="boundedCapacity"/> is not a positive value.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The <paramref name="boundedCapacity"/> is not a positive value.</exception>
         /// <exception cref="System.ArgumentException">The supplied <paramref name="collection"/> contains more values 
         /// than is permitted by <paramref name="boundedCapacity"/>.</exception>
         public BlockingCollection(IProducerConsumerCollection<T> collection, int boundedCapacity)
@@ -192,11 +192,11 @@ nameof(boundedCapacity), boundedCapacity,
             Initialize(collection, boundedCapacity, count);
         }
 
-        /// <summary>Initializes a new instance of the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>
+        /// <summary>Initializes a new instance of the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>
         /// class without an upper-bound and using the provided 
-        /// <see cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/> as its underlying data store.</summary>
+        /// <see cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/> as its underlying data store.</summary>
         /// <param name="collection">The collection to use as the underlying data store.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collection"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collection"/> argument is
         /// null.</exception>
         public BlockingCollection(IProducerConsumerCollection<T> collection)
         {
@@ -237,18 +237,18 @@ nameof(boundedCapacity), boundedCapacity,
 
 
         /// <summary>
-        /// Adds the item to the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.
+        /// Adds the item to the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.
         /// </summary>
         /// <param name="item">The item to be added to the collection. The value can be a null reference.</param>
-        /// <exception cref="T:System.InvalidOperationException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
+        /// <exception cref="System.InvalidOperationException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
         /// as complete with regards to additions.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
         /// <remarks>
         /// If a bounded capacity was specified when this instance of 
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> was initialized, 
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> was initialized, 
         /// a call to Add may block until space is available to store the provided item.
         /// </remarks>
         public void Add(T item)
@@ -263,22 +263,22 @@ nameof(boundedCapacity), boundedCapacity,
         }
 
         /// <summary>
-        /// Adds the item to the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.
+        /// Adds the item to the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.
         /// A <see cref="System.OperationCanceledException"/> is thrown if the <see cref="CancellationToken"/> is
         /// canceled.
         /// </summary>
         /// <param name="item">The item to be added to the collection. The value can be a null reference.</param>
         /// <param name="cancellationToken">A cancellation token to observe.</param>
         /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken"/> is canceled.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
+        /// <exception cref="System.InvalidOperationException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
         /// as complete with regards to additions.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
         /// <remarks>
         /// If a bounded capacity was specified when this instance of 
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> was initialized, 
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> was initialized, 
         /// a call to <see cref="Add(T,System.Threading.CancellationToken)"/> may block until space is available to store the provided item.
         /// </remarks>
         public void Add(T item, CancellationToken cancellationToken)
@@ -293,23 +293,23 @@ nameof(boundedCapacity), boundedCapacity,
         }
 
         /// <summary>
-        /// Attempts to add the specified item to the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.
+        /// Attempts to add the specified item to the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.
         /// </summary>
         /// <param name="item">The item to be added to the collection.</param>
         /// <returns>true if the <paramref name="item"/> could be added; otherwise, false.</returns>
-        /// <exception cref="T:System.InvalidOperationException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
+        /// <exception cref="System.InvalidOperationException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
         /// as complete with regards to additions.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
         public bool TryAdd(T item)
         {
             return TryAddWithNoTimeValidation(item, 0, new CancellationToken());
         }
 
         /// <summary>
-        /// Attempts to add the specified item to the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.
+        /// Attempts to add the specified item to the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.
         /// </summary>
         /// <param name="item">The item to be added to the collection.</param>
         /// <param name="timeout">A <see cref="System.TimeSpan"/> that represents the number of milliseconds
@@ -317,15 +317,15 @@ nameof(boundedCapacity), boundedCapacity,
         /// </param>
         /// <returns>true if the <paramref name="item"/> could be added to the collection within 
         /// the alloted time; otherwise, false.</returns>
-        /// <exception cref="T:System.InvalidOperationException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
+        /// <exception cref="System.InvalidOperationException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
         /// as complete with regards to additions.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative number
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative number
         /// other than -1 milliseconds, which represents an infinite time-out -or- timeout is greater than
         /// <see cref="System.Int32.MaxValue"/>.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
         public bool TryAdd(T item, TimeSpan timeout)
         {
             ValidateTimeout(timeout);
@@ -333,21 +333,21 @@ nameof(boundedCapacity), boundedCapacity,
         }
 
         /// <summary>
-        /// Attempts to add the specified item to the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.
+        /// Attempts to add the specified item to the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.
         /// </summary>
         /// <param name="item">The item to be added to the collection.</param>
         /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see
         /// cref="System.Threading.Timeout.Infinite"/> (-1) to wait indefinitely.</param>
         /// <returns>true if the <paramref name="item"/> could be added to the collection within 
         /// the alloted time; otherwise, false.</returns>
-        /// <exception cref="T:System.InvalidOperationException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
+        /// <exception cref="System.InvalidOperationException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
         /// as complete with regards to additions.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
         public bool TryAdd(T item, int millisecondsTimeout)
         {
             ValidateMillisecondsTimeout(millisecondsTimeout);
@@ -355,7 +355,7 @@ nameof(boundedCapacity), boundedCapacity,
         }
 
         /// <summary>
-        /// Attempts to add the specified item to the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.
+        /// Attempts to add the specified item to the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.
         /// A <see cref="System.OperationCanceledException"/> is thrown if the <see cref="CancellationToken"/> is
         /// canceled.
         /// </summary>
@@ -366,14 +366,14 @@ nameof(boundedCapacity), boundedCapacity,
         /// <returns>true if the <paramref name="item"/> could be added to the collection within 
         /// the alloted time; otherwise, false.</returns>
         /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken"/> is canceled.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
+        /// <exception cref="System.InvalidOperationException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been marked
         /// as complete with regards to additions.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
         public bool TryAdd(T item, int millisecondsTimeout, CancellationToken cancellationToken)
         {
             ValidateMillisecondsTimeout(millisecondsTimeout);
@@ -394,7 +394,7 @@ nameof(boundedCapacity), boundedCapacity,
         /// <exception cref="System.InvalidOperationException">the collection has already been marked
         /// as complete with regards to additions.</exception>
         /// <exception cref="System.ObjectDisposedException">If the collection has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.InvalidOperationException">The underlying collection didn't accept the item.</exception>
         private bool TryAddWithNoTimeValidation(T item, int millisecondsTimeout, CancellationToken cancellationToken)
         {
             CheckDisposed();
@@ -522,16 +522,16 @@ nameof(boundedCapacity), boundedCapacity,
             return waitForSemaphoreWasSuccessful;
         }
 
-        /// <summary>Takes an item from the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.</summary>
+        /// <summary>Takes an item from the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.</summary>
         /// <returns>The item removed from the collection.</returns>
-        /// <exception cref="T:System.OperationCanceledException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> is empty and has been marked
+        /// <exception cref="System.OperationCanceledException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> is empty and has been marked
         /// as complete with regards to additions.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection was modified
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">The underlying collection was modified
         /// outside of this <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
         /// <remarks>A call to <see cref="Take()"/> may block until an item is available to be removed.</remarks>
         public T Take()
         {
@@ -545,17 +545,17 @@ nameof(boundedCapacity), boundedCapacity,
             return item;
         }
 
-        /// <summary>Takes an item from the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.</summary>
+        /// <summary>Takes an item from the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.</summary>
         /// <returns>The item removed from the collection.</returns>
-        /// <exception cref="T:System.OperationCanceledException">If the <see cref="CancellationToken"/> is
+        /// <exception cref="System.OperationCanceledException">If the <see cref="CancellationToken"/> is
         /// canceled or the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> is empty and has been marked
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> is empty and has been marked
         /// as complete with regards to additions.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection was modified
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">The underlying collection was modified
         /// outside of this <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
         /// <remarks>A call to <see cref="Take(CancellationToken)"/> may block until an item is available to be removed.</remarks>
         public T Take(CancellationToken cancellationToken)
         {
@@ -570,22 +570,22 @@ nameof(boundedCapacity), boundedCapacity,
         }
 
         /// <summary>
-        /// Attempts to remove an item from the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.
+        /// Attempts to remove an item from the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.
         /// </summary>
         /// <param name="item">The item removed from the collection.</param>
         /// <returns>true if an item could be removed; otherwise, false.</returns>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection was modified
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">The underlying collection was modified
         /// outside of this <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
         public bool TryTake([MaybeNullWhen(false)] out T item)
         {
             return TryTake(out item, 0, CancellationToken.None);
         }
 
         /// <summary>
-        /// Attempts to remove an item from the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.
+        /// Attempts to remove an item from the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.
         /// </summary>
         /// <param name="item">The item removed from the collection.</param>
         /// <param name="timeout">A <see cref="System.TimeSpan"/> that represents the number of milliseconds
@@ -593,14 +593,14 @@ nameof(boundedCapacity), boundedCapacity,
         /// </param>
         /// <returns>true if an item could be removed from the collection within 
         /// the alloted time; otherwise, false.</returns>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative number
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative number
         /// other than -1 milliseconds, which represents an infinite time-out -or- timeout is greater than
         /// <see cref="System.Int32.MaxValue"/>.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection was modified
+        /// <exception cref="System.InvalidOperationException">The underlying collection was modified
         /// outside of this <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
         public bool TryTake([MaybeNullWhen(false)] out T item, TimeSpan timeout)
         {
             ValidateTimeout(timeout);
@@ -608,20 +608,20 @@ nameof(boundedCapacity), boundedCapacity,
         }
 
         /// <summary>
-        /// Attempts to remove an item from the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.
+        /// Attempts to remove an item from the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.
         /// </summary>
         /// <param name="item">The item removed from the collection.</param>
         /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see
         /// cref="System.Threading.Timeout.Infinite"/> (-1) to wait indefinitely.</param>
         /// <returns>true if an item could be removed from the collection within 
         /// the alloted time; otherwise, false.</returns>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection was modified
+        /// <exception cref="System.InvalidOperationException">The underlying collection was modified
         /// outside of this <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
         public bool TryTake([MaybeNullWhen(false)] out T item, int millisecondsTimeout)
         {
             ValidateMillisecondsTimeout(millisecondsTimeout);
@@ -629,7 +629,7 @@ nameof(boundedCapacity), boundedCapacity,
         }
 
         /// <summary>
-        /// Attempts to remove an item from the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/>.
+        /// Attempts to remove an item from the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/>.
         /// A <see cref="System.OperationCanceledException"/> is thrown if the <see cref="CancellationToken"/> is
         /// canceled.
         /// </summary>
@@ -640,13 +640,13 @@ nameof(boundedCapacity), boundedCapacity,
         /// <returns>true if an item could be removed from the collection within 
         /// the alloted time; otherwise, false.</returns>
         /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken"/> is canceled.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The underlying collection was modified
+        /// <exception cref="System.InvalidOperationException">The underlying collection was modified
         /// outside of this <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
         public bool TryTake([MaybeNullWhen(false)] out T item, int millisecondsTimeout, CancellationToken cancellationToken)
         {
             ValidateMillisecondsTimeout(millisecondsTimeout);
@@ -767,24 +767,24 @@ nameof(boundedCapacity), boundedCapacity,
 
         /// <summary>
         /// Adds the specified item to any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// </summary>
         /// <param name="collections">The array of collections.</param>
         /// <param name="item">The item to be added to one of the collections.</param>
         /// <returns>The index of the collection in the <paramref name="collections"/> array to which the item was added.</returns>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element, or at least one of collections has been
         /// marked as complete for adding.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
         /// 62 for STA and 63 for MTA.</exception>
         /// <remarks>
         /// If a bounded capacity was specified when all of the
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances were initialized, 
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances were initialized, 
         /// a call to AddToAny may block until space is available in one of the collections
         /// to store the provided item.
         /// </remarks>
@@ -805,7 +805,7 @@ nameof(boundedCapacity), boundedCapacity,
 
         /// <summary>
         /// Adds the specified item to any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// A <see cref="System.OperationCanceledException"/> is thrown if the <see cref="CancellationToken"/> is
         /// canceled. 
         /// </summary>
@@ -814,19 +814,19 @@ nameof(boundedCapacity), boundedCapacity,
         /// <param name="cancellationToken">A cancellation token to observe.</param>
         /// <returns>The index of the collection in the <paramref name="collections"/> array to which the item was added.</returns>
         /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken"/> is canceled.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element, or at least one of collections has been
         /// marked as complete for adding.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
         /// 62 for STA and 63 for MTA.</exception>
         /// <remarks>
         /// If a bounded capacity was specified when all of the
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances were initialized, 
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances were initialized, 
         /// a call to AddToAny may block until space is available in one of the collections
         /// to store the provided item.
         /// </remarks>
@@ -847,21 +847,21 @@ nameof(boundedCapacity), boundedCapacity,
 
         /// <summary>
         /// Attempts to add the specified item to any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// </summary>
         /// <param name="collections">The array of collections.</param>
         /// <param name="item">The item to be added to one of the collections.</param>
         /// <returns>The index of the collection in the <paramref name="collections"/> 
         /// array to which the item was added, or -1 if the item could not be added.</returns>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element, or at least one of collections has been
         /// marked as complete for adding.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
         /// 62 for STA and 63 for MTA.</exception>
         public static int TryAddToAny(BlockingCollection<T>[] collections, T item)
         {
@@ -870,7 +870,7 @@ nameof(boundedCapacity), boundedCapacity,
 
         /// <summary>
         /// Attempts to add the specified item to any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// </summary>
         /// <param name="collections">The array of collections.</param>
         /// <param name="item">The item to be added to one of the collections.</param>
@@ -879,18 +879,18 @@ nameof(boundedCapacity), boundedCapacity,
         /// </param>
         /// <returns>The index of the collection in the <paramref name="collections"/> 
         /// array to which the item was added, or -1 if the item could not be added.</returns>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element, or at least one of collections has been
         /// marked as complete for adding.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative number
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative number
         /// other than -1 milliseconds, which represents an infinite time-out -or- timeout is greater than
         /// <see cref="System.Int32.MaxValue"/>.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
+        /// <exception cref="System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
         /// 62 for STA and 63 for MTA.</exception>
         public static int TryAddToAny(BlockingCollection<T>[] collections, T item, TimeSpan timeout)
         {
@@ -900,24 +900,24 @@ nameof(boundedCapacity), boundedCapacity,
 
         /// <summary>
         /// Attempts to add the specified item to any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// </summary>
         /// <param name="collections">The array of collections.</param>
         /// <param name="item">The item to be added to one of the collections.</param>
         /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see
         /// cref="System.Threading.Timeout.Infinite"/> (-1) to wait indefinitely.</param>        /// <returns>The index of the collection in the <paramref name="collections"/> 
         /// array to which the item was added, or -1 if the item could not be added.</returns>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element, or at least one of collections has been
         /// marked as complete for adding.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
+        /// <exception cref="System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
         /// 62 for STA and 63 for MTA.</exception>
         public static int TryAddToAny(BlockingCollection<T>[] collections, T item, int millisecondsTimeout)
         {
@@ -927,7 +927,7 @@ nameof(boundedCapacity), boundedCapacity,
 
         /// <summary>
         /// Attempts to add the specified item to any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// A <see cref="System.OperationCanceledException"/> is thrown if the <see cref="CancellationToken"/> is
         /// canceled.
         /// </summary>
@@ -939,17 +939,17 @@ nameof(boundedCapacity), boundedCapacity,
         /// array to which the item was added, or -1 if the item could not be added.</returns>
         /// <param name="cancellationToken">A cancellation token to observe.</param>
         /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken"/> is canceled.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element, or at least one of collections has been
         /// marked as complete for adding.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
+        /// <exception cref="System.InvalidOperationException">At least one underlying collection didn't accept the item.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
         /// 62 for STA and 63 for MTA.</exception>
         public static int TryAddToAny(BlockingCollection<T>[] collections, T item, int millisecondsTimeout, CancellationToken cancellationToken)
         {
@@ -1149,22 +1149,22 @@ nameof(boundedCapacity), boundedCapacity,
         }
         /// <summary>
         /// Takes an item from any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// </summary>
         /// <param name="collections">The array of collections.</param>
         /// <param name="item">The item removed from one of the collections.</param>
         /// <returns>The index of the collection in the <paramref name="collections"/> array from which 
         /// the item was removed, or -1 if an item could not be removed.</returns>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one of the underlying collections was modified
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">At least one of the underlying collections was modified
         /// outside of its <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
         /// 62 for STA and 63 for MTA.</exception>
         /// <remarks>A call to TakeFromAny may block until an item is available to be removed.</remarks>
         public static int TakeFromAny(BlockingCollection<T>[] collections, [MaybeNull] out T item)
@@ -1174,7 +1174,7 @@ nameof(boundedCapacity), boundedCapacity,
 
         /// <summary>
         /// Takes an item from any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// A <see cref="System.OperationCanceledException"/> is thrown if the <see cref="CancellationToken"/> is
         /// canceled.
         /// </summary>
@@ -1183,17 +1183,17 @@ nameof(boundedCapacity), boundedCapacity,
         /// <param name="cancellationToken">A cancellation token to observe.</param>
         /// <returns>The index of the collection in the <paramref name="collections"/> array from which 
         /// the item was removed, or -1 if an item could not be removed.</returns>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
         /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken"/> is canceled.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one of the underlying collections was modified
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">At least one of the underlying collections was modified
         /// outside of its <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of 
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of 
         /// 62 for STA and 63 for MTA.</exception>
         /// <remarks>A call to TakeFromAny may block until an item is available to be removed.</remarks>
         public static int TakeFromAny(BlockingCollection<T>[] collections, [MaybeNull] out T item, CancellationToken cancellationToken)
@@ -1206,22 +1206,22 @@ nameof(boundedCapacity), boundedCapacity,
 
         /// <summary>
         /// Attempts to remove an item from any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// </summary>
         /// <param name="collections">The array of collections.</param>
         /// <param name="item">The item removed from one of the collections.</param>
         /// <returns>The index of the collection in the <paramref name="collections"/> array from which 
         /// the item was removed, or -1 if an item could not be removed.</returns>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one of the underlying collections was modified
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.InvalidOperationException">At least one of the underlying collections was modified
         /// outside of its <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
         /// 62 for STA and 63 for MTA.</exception>
         /// <remarks>A call to TryTakeFromAny may block until an item is available to be removed.</remarks>
         public static int TryTakeFromAny(BlockingCollection<T>[] collections, [MaybeNull] out T item)
@@ -1231,7 +1231,7 @@ nameof(boundedCapacity), boundedCapacity,
 
         /// <summary>
         /// Attempts to remove an item from any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// </summary>
         /// <param name="collections">The array of collections.</param>
         /// <param name="item">The item removed from one of the collections.</param>
@@ -1240,19 +1240,19 @@ nameof(boundedCapacity), boundedCapacity,
         /// </param>
         /// <returns>The index of the collection in the <paramref name="collections"/> array from which 
         /// the item was removed, or -1 if an item could not be removed.</returns>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative number
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative number
         /// other than -1 milliseconds, which represents an infinite time-out -or- timeout is greater than
         /// <see cref="System.Int32.MaxValue"/>.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one of the underlying collections was modified
+        /// <exception cref="System.InvalidOperationException">At least one of the underlying collections was modified
         /// outside of its <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
         /// 62 for STA and 63 for MTA.</exception>
         /// <remarks>A call to TryTakeFromAny may block until an item is available to be removed.</remarks>
         public static int TryTakeFromAny(BlockingCollection<T>[] collections, [MaybeNull] out T item, TimeSpan timeout)
@@ -1263,7 +1263,7 @@ nameof(boundedCapacity), boundedCapacity,
 
         /// <summary>
         /// Attempts to remove an item from any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// </summary>
         /// <param name="collections">The array of collections.</param>
         /// <param name="item">The item removed from one of the collections.</param>
@@ -1271,18 +1271,18 @@ nameof(boundedCapacity), boundedCapacity,
         /// cref="System.Threading.Timeout.Infinite"/> (-1) to wait indefinitely.</param>
         /// <returns>The index of the collection in the <paramref name="collections"/> array from which 
         /// the item was removed, or -1 if an item could not be removed.</returns>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one of the underlying collections was modified
+        /// <exception cref="System.InvalidOperationException">At least one of the underlying collections was modified
         /// outside of its <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
         /// 62 for STA and 63 for MTA.</exception>
         /// <remarks>A call to TryTakeFromAny may block until an item is available to be removed.</remarks>
         public static int TryTakeFromAny(BlockingCollection<T>[] collections, [MaybeNull] out T item, int millisecondsTimeout)
@@ -1293,7 +1293,7 @@ nameof(boundedCapacity), boundedCapacity,
 
         /// <summary>
         /// Attempts to remove an item from any one of the specified
-        /// <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances.
+        /// <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances.
         /// A <see cref="System.OperationCanceledException"/> is thrown if the <see cref="CancellationToken"/> is
         /// canceled. 
         /// </summary>
@@ -1305,18 +1305,18 @@ nameof(boundedCapacity), boundedCapacity,
         /// <returns>The index of the collection in the <paramref name="collections"/> array from which 
         /// the item was removed, or -1 if an item could not be removed.</returns>
         /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken"/> is canceled.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collections"/> argument is
         /// null.</exception>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="collections"/> argument is
+        /// <exception cref="System.ArgumentException">The <paramref name="collections"/> argument is
         /// a 0-length array or contains a null element.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">At least one of the <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// <exception cref="System.ObjectDisposedException">At least one of the <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances has been disposed.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.InvalidOperationException">At least one of the underlying collections was modified
+        /// <exception cref="System.InvalidOperationException">At least one of the underlying collections was modified
         /// outside of its <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">The count of <paramref name="collections"/> is greater than the maximum size of
         /// 62 for STA and 63 for MTA.</exception>
         /// <remarks>A call to TryTakeFromAny may block until an item is available to be removed.</remarks>
         public static int TryTakeFromAny(BlockingCollection<T>[] collections, [MaybeNull] out T item, int millisecondsTimeout, CancellationToken cancellationToken)
@@ -1459,15 +1459,15 @@ nameof(boundedCapacity), boundedCapacity,
         }
 
         /// <summary>
-        /// Marks the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instances
+        /// Marks the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instances
         /// as not accepting any more additions.  
         /// </summary>
         /// <remarks>
         /// After a collection has been marked as complete for adding, adding to the collection is not permitted 
         /// and attempts to remove from the collection will not wait when the collection is empty.
         /// </remarks>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         public void CompleteAdding()
         {
             CheckDisposed();
@@ -1519,7 +1519,7 @@ nameof(boundedCapacity), boundedCapacity,
 
 
         /// <summary>
-        /// Releases resources used by the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.
+        /// Releases resources used by the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.
         /// </summary>
         public void Dispose()
         {
@@ -1528,7 +1528,7 @@ nameof(boundedCapacity), boundedCapacity,
         }
 
         /// <summary>
-        /// Releases resources used by the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance.
+        /// Releases resources used by the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance.
         /// </summary>
         /// <param name="disposing">Whether being disposed explicitly (true) or due to a finalizer (false).</param>
         protected virtual void Dispose(bool disposing)
@@ -1546,10 +1546,10 @@ nameof(boundedCapacity), boundedCapacity,
             }
         }
 
-        /// <summary>Copies the items from the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance into a new array.</summary>
+        /// <summary>Copies the items from the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance into a new array.</summary>
         /// <returns>An array containing copies of the elements of the collection.</returns>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         /// <remarks>
         /// The copied elements are not removed from the collection.
         /// </remarks>
@@ -1559,38 +1559,38 @@ nameof(boundedCapacity), boundedCapacity,
             return _collection.ToArray();
         }
 
-        /// <summary>Copies all of the items in the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance 
+        /// <summary>Copies all of the items in the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance 
         /// to a compatible one-dimensional array, starting at the specified index of the target array.
         /// </summary>
         /// <param name="array">The one-dimensional array that is the destination of the elements copied from 
-        /// the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance. The array must have zero-based indexing.</param>
+        /// the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance. The array must have zero-based indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying begins.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="array"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="array"/> argument is
         /// null.</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">The <paramref name="index"/> argument is less than zero.</exception>
         /// <exception cref="System.ArgumentException">The <paramref name="index"/> argument is equal to or greater 
         /// than the length of the <paramref name="array"/>.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         public void CopyTo(T[] array, int index)
         {
             ((ICollection)this).CopyTo(array, index);
         }
 
-        /// <summary>Copies all of the items in the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance 
+        /// <summary>Copies all of the items in the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance 
         /// to a compatible one-dimensional array, starting at the specified index of the target array.
         /// </summary>
         /// <param name="array">The one-dimensional array that is the destination of the elements copied from 
-        /// the <see cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> instance. The array must have zero-based indexing.</param>
+        /// the <see cref="System.Collections.Concurrent.BlockingCollection{T}"/> instance. The array must have zero-based indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying begins.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="array"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="array"/> argument is
         /// null.</exception>
         /// <exception cref="System.ArgumentOutOfRangeException">The <paramref name="index"/> argument is less than zero.</exception>
         /// <exception cref="System.ArgumentException">The <paramref name="index"/> argument is equal to or greater 
         /// than the length of the <paramref name="array"/>, the array is multidimensional, or the type parameter for the collection 
         /// cannot be cast automatically to the type of the destination array.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         void ICollection.CopyTo(Array array, int index)
         {
             CheckDisposed();
@@ -1629,23 +1629,23 @@ nameof(boundedCapacity), boundedCapacity,
             }
         }
 
-        /// <summary>Provides a consuming <see cref="T:System.Collections.Generics.IEnumerable{T}"/> for items in the collection.</summary>
-        /// <returns>An <see cref="T:System.Collections.Generics.IEnumerable{T}"/> that removes and returns items from the collection.</returns>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <summary>Provides a consuming <see cref="System.Collections.Generic.IEnumerable{T}"/> for items in the collection.</summary>
+        /// <returns>An <see cref="System.Collections.Generic.IEnumerable{T}"/> that removes and returns items from the collection.</returns>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         public IEnumerable<T> GetConsumingEnumerable()
         {
             return GetConsumingEnumerable(CancellationToken.None);
         }
 
-        /// <summary>Provides a consuming <see cref="T:System.Collections.Generics.IEnumerable{T}"/> for items in the collection.
+        /// <summary>Provides a consuming <see cref="System.Collections.Generic.IEnumerable{T}"/> for items in the collection.
         /// Calling MoveNext on the returned enumerable will block if there is no data available, or will
         /// throw an <see cref="System.OperationCanceledException"/> if the <see cref="CancellationToken"/> is canceled.
         /// </summary>
         /// <param name="cancellationToken">A cancellation token to observe.</param>
-        /// <returns>An <see cref="T:System.Collections.Generics.IEnumerable{T}"/> that removes and returns items from the collection.</returns>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <returns>An <see cref="System.Collections.Generic.IEnumerable{T}"/> that removes and returns items from the collection.</returns>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken"/> is canceled.</exception>
         public IEnumerable<T> GetConsumingEnumerable(CancellationToken cancellationToken)
         {
@@ -1671,20 +1671,20 @@ nameof(boundedCapacity), boundedCapacity,
             }
         }
 
-        /// <summary>Provides an <see cref="T:System.Collections.Generics.IEnumerator{T}"/> for items in the collection.</summary>
-        /// <returns>An <see cref="T:System.Collections.Generics.IEnumerator{T}"/> for the items in the collection.</returns>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <summary>Provides an <see cref="System.Collections.Generic.IEnumerator{T}"/> for items in the collection.</summary>
+        /// <returns>An <see cref="System.Collections.Generic.IEnumerator{T}"/> for the items in the collection.</returns>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         IEnumerator<T> IEnumerable<T>.GetEnumerator()
         {
             CheckDisposed();
             return _collection.GetEnumerator();
         }
 
-        /// <summary>Provides an <see cref="T:System.Collections.IEnumerator"/> for items in the collection.</summary>
-        /// <returns>An <see cref="T:System.Collections.IEnumerator"/> for the items in the collection.</returns>
-        /// <exception cref="T:System.ObjectDisposedException">The <see
-        /// cref="T:System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
+        /// <summary>Provides an <see cref="System.Collections.IEnumerator"/> for items in the collection.</summary>
+        /// <returns>An <see cref="System.Collections.IEnumerator"/> for the items in the collection.</returns>
+        /// <exception cref="System.ObjectDisposedException">The <see
+        /// cref="System.Collections.Concurrent.BlockingCollection{T}"/> has been disposed.</exception>
         IEnumerator IEnumerable.GetEnumerator()
         {
             return ((IEnumerable<T>)this).GetEnumerator();

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -251,13 +251,13 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Copies the <see cref="ConcurrentBag{T}"/> elements to an existing
-        /// one-dimensional <see cref="T:System.Array">Array</see>, starting at the specified array
+        /// one-dimensional <see cref="System.Array">Array</see>, starting at the specified array
         /// index.
         /// </summary>
-        /// <param name="array">The one-dimensional <see cref="T:System.Array">Array</see> that is the
+        /// <param name="array">The one-dimensional <see cref="System.Array">Array</see> that is the
         /// destination of the elements copied from the
         /// <see cref="ConcurrentBag{T}"/>. The <see
-        /// cref="T:System.Array">Array</see> must have zero-based indexing.</param>
+        /// cref="System.Array">Array</see> must have zero-based indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
         /// begins.</param>
         /// <exception cref="ArgumentNullException"><paramref name="array"/> is a null reference (Nothing in
@@ -330,14 +330,14 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Copies the elements of the <see cref="T:System.Collections.ICollection"/> to an <see
-        /// cref="T:System.Array"/>, starting at a particular
-        /// <see cref="T:System.Array"/> index.
+        /// Copies the elements of the <see cref="System.Collections.ICollection"/> to an <see
+        /// cref="System.Array"/>, starting at a particular
+        /// <see cref="System.Array"/> index.
         /// </summary>
-        /// <param name="array">The one-dimensional <see cref="T:System.Array">Array</see> that is the
+        /// <param name="array">The one-dimensional <see cref="System.Array">Array</see> that is the
         /// destination of the elements copied from the
         /// <see cref="ConcurrentBag{T}"/>. The <see
-        /// cref="T:System.Array">Array</see> must have zero-based indexing.</param>
+        /// cref="System.Array">Array</see> must have zero-based indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
         /// begins.</param>
         /// <exception cref="ArgumentNullException"><paramref name="array"/> is a null reference (Nothing in
@@ -348,10 +348,10 @@ namespace System.Collections.Concurrent
         /// <paramref name="array"/> is multidimensional. -or-
         /// <paramref name="array"/> does not have zero-based indexing. -or-
         /// <paramref name="index"/> is equal to or greater than the length of the <paramref name="array"/>
-        /// -or- The number of elements in the source <see cref="T:System.Collections.ICollection"/> is
+        /// -or- The number of elements in the source <see cref="System.Collections.ICollection"/> is
         /// greater than the available space from <paramref name="index"/> to the end of the destination
         /// <paramref name="array"/>. -or- The type of the source <see
-        /// cref="T:System.Collections.ICollection"/> cannot be cast automatically to the type of the
+        /// cref="System.Collections.ICollection"/> cannot be cast automatically to the type of the
         /// destination <paramref name="array"/>.
         /// </exception>
         void ICollection.CopyTo(Array array, int index)
@@ -583,19 +583,19 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection"/> is
+        /// Gets a value indicating whether access to the <see cref="System.Collections.ICollection"/> is
         /// synchronized with the SyncRoot.
         /// </summary>
-        /// <value>true if access to the <see cref="T:System.Collections.ICollection"/> is synchronized
+        /// <value>true if access to the <see cref="System.Collections.ICollection"/> is synchronized
         /// with the SyncRoot; otherwise, false. For <see cref="ConcurrentBag{T}"/>, this property always
         /// returns false.</value>
         bool ICollection.IsSynchronized => false;
 
         /// <summary>
         /// Gets an object that can be used to synchronize access to the <see
-        /// cref="T:System.Collections.ICollection"/>. This property is not supported.
+        /// cref="System.Collections.ICollection"/>. This property is not supported.
         /// </summary>
-        /// <exception cref="T:System.NotSupportedException">The SyncRoot property is not supported.</exception>
+        /// <exception cref="System.NotSupportedException">The SyncRoot property is not supported.</exception>
         object ICollection.SyncRoot
         {
             get { throw new NotSupportedException(SR.ConcurrentCollection_SyncRoot_NotSupported); }

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -129,51 +129,51 @@ namespace System.Collections.Concurrent
         /// <param name="capacity">The initial number of elements that the <see
         /// cref="ConcurrentDictionary{TKey,TValue}"/>
         /// can contain.</param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="concurrencyLevel"/> is
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="concurrencyLevel"/> is
         /// less than 1.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"> <paramref name="capacity"/> is less than
+        /// <exception cref="System.ArgumentOutOfRangeException"> <paramref name="capacity"/> is less than
         /// 0.</exception>
         public ConcurrentDictionary(int concurrencyLevel, int capacity) : this(concurrencyLevel, capacity, false, null) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentDictionary{TKey,TValue}"/>
         /// class that contains elements copied from the specified <see
-        /// cref="T:System.Collections.IEnumerable{KeyValuePair{TKey,TValue}}"/>, has the default concurrency
+        /// cref="System.Collections.Generic.IEnumerable{T}"/>, has the default concurrency
         /// level, has the default initial capacity, and uses the default comparer for the key type.
         /// </summary>
         /// <param name="collection">The <see
-        /// cref="T:System.Collections.IEnumerable{KeyValuePair{TKey,TValue}}"/> whose elements are copied to
+        /// cref="System.Collections.Generic.IEnumerable{T}"/> whose elements are copied to
         /// the new
         /// <see cref="ConcurrentDictionary{TKey,TValue}"/>.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="collection"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="collection"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.ArgumentException"><paramref name="collection"/> contains one or more
+        /// <exception cref="System.ArgumentException"><paramref name="collection"/> contains one or more
         /// duplicate keys.</exception>
         public ConcurrentDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection) : this(collection, null) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentDictionary{TKey,TValue}"/>
         /// class that is empty, has the specified concurrency level and capacity, and uses the specified
-        /// <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/>.
+        /// <see cref="System.Collections.Generic.IEqualityComparer{TKey}"/>.
         /// </summary>
-        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/>
+        /// <param name="comparer">The <see cref="System.Collections.Generic.IEqualityComparer{TKey}"/>
         /// implementation to use when comparing keys.</param>
         public ConcurrentDictionary(IEqualityComparer<TKey>? comparer) : this(DefaultConcurrencyLevel, DefaultCapacity, true, comparer) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentDictionary{TKey,TValue}"/>
         /// class that contains elements copied from the specified <see
-        /// cref="T:System.Collections.IEnumerable"/>, has the default concurrency level, has the default
+        /// cref="System.Collections.IEnumerable"/>, has the default concurrency level, has the default
         /// initial capacity, and uses the specified
-        /// <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/>.
+        /// <see cref="System.Collections.Generic.IEqualityComparer{TKey}"/>.
         /// </summary>
         /// <param name="collection">The <see
-        /// cref="T:System.Collections.IEnumerable{KeyValuePair{TKey,TValue}}"/> whose elements are copied to
+        /// cref="System.Collections.Generic.IEnumerable{T}"/> whose elements are copied to
         /// the new
         /// <see cref="ConcurrentDictionary{TKey,TValue}"/>.</param>
-        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/>
+        /// <param name="comparer">The <see cref="System.Collections.Generic.IEqualityComparer{TKey}"/>
         /// implementation to use when comparing keys.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="collection"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="collection"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
         public ConcurrentDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer)
             : this(comparer)
@@ -185,23 +185,23 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentDictionary{TKey,TValue}"/>
-        /// class that contains elements copied from the specified <see cref="T:System.Collections.IEnumerable"/>,
+        /// class that contains elements copied from the specified <see cref="System.Collections.IEnumerable"/>,
         /// has the specified concurrency level, has the specified initial capacity, and uses the specified
-        /// <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/>.
+        /// <see cref="System.Collections.Generic.IEqualityComparer{TKey}"/>.
         /// </summary>
         /// <param name="concurrencyLevel">The estimated number of threads that will update the
         /// <see cref="ConcurrentDictionary{TKey,TValue}"/> concurrently.</param>
-        /// <param name="collection">The <see cref="T:System.Collections.IEnumerable{KeyValuePair{TKey,TValue}}"/> whose elements are copied to the new
+        /// <param name="collection">The <see cref="System.Collections.Generic.IEnumerable{T}"/> whose elements are copied to the new
         /// <see cref="ConcurrentDictionary{TKey,TValue}"/>.</param>
-        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/> implementation to use
+        /// <param name="comparer">The <see cref="System.Collections.Generic.IEqualityComparer{TKey}"/> implementation to use
         /// when comparing keys.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="collection"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <exception cref="System.ArgumentOutOfRangeException">
         /// <paramref name="concurrencyLevel"/> is less than 1.
         /// </exception>
-        /// <exception cref="T:System.ArgumentException"><paramref name="collection"/> contains one or more duplicate keys.</exception>
+        /// <exception cref="System.ArgumentException"><paramref name="collection"/> contains one or more duplicate keys.</exception>
         public ConcurrentDictionary(
             int concurrencyLevel, IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer)
             : this(concurrencyLevel, DefaultCapacity, false, comparer)
@@ -233,16 +233,16 @@ namespace System.Collections.Concurrent
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurrentDictionary{TKey,TValue}"/>
         /// class that is empty, has the specified concurrency level, has the specified initial capacity, and
-        /// uses the specified <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/>.
+        /// uses the specified <see cref="System.Collections.Generic.IEqualityComparer{TKey}"/>.
         /// </summary>
         /// <param name="concurrencyLevel">The estimated number of threads that will update the
         /// <see cref="ConcurrentDictionary{TKey,TValue}"/> concurrently.</param>
         /// <param name="capacity">The initial number of elements that the <see
         /// cref="ConcurrentDictionary{TKey,TValue}"/>
         /// can contain.</param>
-        /// <param name="comparer">The <see cref="T:System.Collections.Generic.IEqualityComparer{TKey}"/>
+        /// <param name="comparer">The <see cref="System.Collections.Generic.IEqualityComparer{TKey}"/>
         /// implementation to use when comparing keys.</param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <exception cref="System.ArgumentOutOfRangeException">
         /// <paramref name="concurrencyLevel"/> is less than 1. -or-
         /// <paramref name="capacity"/> is less than 0.
         /// </exception>
@@ -294,9 +294,9 @@ namespace System.Collections.Concurrent
         /// <returns>true if the key/value pair was added to the <see cref="ConcurrentDictionary{TKey,
         /// TValue}"/>
         /// successfully; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.OverflowException">The <see cref="ConcurrentDictionary{TKey, TValue}"/>
+        /// <exception cref="System.OverflowException">The <see cref="ConcurrentDictionary{TKey, TValue}"/>
         /// contains too many elements.</exception>
         public bool TryAdd(TKey key, TValue value)
         {
@@ -313,7 +313,7 @@ namespace System.Collections.Concurrent
         /// TValue}"/>.</param>
         /// <returns>true if the <see cref="ConcurrentDictionary{TKey, TValue}"/> contains an element with
         /// the specified key; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
         public bool ContainsKey(TKey key)
         {
@@ -333,7 +333,7 @@ namespace System.Collections.Concurrent
         /// name="TValue"/>
         /// if the operation failed.</param>
         /// <returns>true if an object was removed successfully; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
         public bool TryRemove(TKey key, [MaybeNullWhen(false)] out TValue value)
         {
@@ -421,7 +421,7 @@ namespace System.Collections.Concurrent
         /// <typeparamref name="TValue"/>, if the operation failed.</param>
         /// <returns>true if the key was found in the <see cref="ConcurrentDictionary{TKey,TValue}"/>;
         /// otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
         {
@@ -470,7 +470,7 @@ namespace System.Collections.Concurrent
         /// <returns>true if the value with <paramref name="key"/> was equal to <paramref
         /// name="comparisonValue"/> and replaced with <paramref name="newValue"/>; otherwise,
         /// false.</returns>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null
         /// reference.</exception>
         public bool TryUpdate(TKey key, TValue newValue, TValue comparisonValue)
         {
@@ -492,7 +492,7 @@ namespace System.Collections.Concurrent
         /// <returns>true if the value with <paramref name="key"/> was equal to <paramref
         /// name="comparisonValue"/> and replaced with <paramref name="newValue"/>; otherwise,
         /// false.</returns>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null
         /// reference.</exception>
         private bool TryUpdateInternal(TKey key, int hashcode, TValue newValue, TValue comparisonValue)
         {
@@ -580,24 +580,24 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Copies the elements of the <see cref="T:System.Collections.Generic.ICollection"/> to an array of
-        /// type <see cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/>, starting at the
+        /// Copies the elements of the <see cref="System.Collections.Generic.ICollection{T}"/> to an array of
+        /// type <see cref="System.Collections.Generic.KeyValuePair{TKey,TValue}"/>, starting at the
         /// specified array index.
         /// </summary>
         /// <param name="array">The one-dimensional array of type <see
-        /// cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
+        /// cref="System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
         /// that is the destination of the <see
-        /// cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/> elements copied from the <see
-        /// cref="T:System.Collections.ICollection"/>. The array must have zero-based indexing.</param>
+        /// cref="System.Collections.Generic.KeyValuePair{TKey,TValue}"/> elements copied from the <see
+        /// cref="System.Collections.ICollection"/>. The array must have zero-based indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
         /// begins.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="array"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="array"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index"/> is less than
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="index"/> is less than
         /// 0.</exception>
-        /// <exception cref="T:System.ArgumentException"><paramref name="index"/> is equal to or greater than
+        /// <exception cref="System.ArgumentException"><paramref name="index"/> is equal to or greater than
         /// the length of the <paramref name="array"/>. -or- The number of elements in the source <see
-        /// cref="T:System.Collections.ICollection"/>
+        /// cref="System.Collections.ICollection"/>
         /// is greater than the available space from <paramref name="index"/> to the end of the destination
         /// <paramref name="array"/>.</exception>
         void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
@@ -863,11 +863,11 @@ namespace System.Collections.Concurrent
         /// <param name="key">The key of the value to get or set.</param>
         /// <value>The value associated with the specified key. If the specified key is not found, a get
         /// operation throws a
-        /// <see cref="T:System.Collections.Generic.KeyNotFoundException"/>, and a set operation creates a new
+        /// <see cref="System.Collections.Generic.KeyNotFoundException"/>, and a set operation creates a new
         /// element with the specified key.</value>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.Collections.Generic.KeyNotFoundException">The property is retrieved and
+        /// <exception cref="System.Collections.Generic.KeyNotFoundException">The property is retrieved and
         /// <paramref name="key"/>
         /// does not exist in the collection.</exception>
         public TValue this[TKey key]
@@ -929,7 +929,7 @@ namespace System.Collections.Concurrent
         /// Gets the number of key/value pairs contained in the <see
         /// cref="ConcurrentDictionary{TKey,TValue}"/>.
         /// </summary>
-        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// <exception cref="System.OverflowException">The dictionary contains too many
         /// elements.</exception>
         /// <value>The number of key/value pairs contained in the <see
         /// cref="ConcurrentDictionary{TKey,TValue}"/>.</value>
@@ -961,7 +961,7 @@ namespace System.Collections.Concurrent
         /// cref="ConcurrentDictionary{TKey,TValue}"/>. Should only be used after all locks
         /// have been acquired.
         /// </summary>
-        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// <exception cref="System.OverflowException">The dictionary contains too many
         /// elements.</exception>
         /// <value>The number of key/value pairs contained in the <see
         /// cref="ConcurrentDictionary{TKey,TValue}"/>.</value>
@@ -987,11 +987,11 @@ namespace System.Collections.Concurrent
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
         /// <param name="valueFactory">The function used to generate a value for the key</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="valueFactory"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="valueFactory"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// <exception cref="System.OverflowException">The dictionary contains too many
         /// elements.</exception>
         /// <returns>The value for the key.  This will be either the existing value for the key if the
         /// key is already in the dictionary, or the new value for the key as returned by valueFactory
@@ -1018,11 +1018,11 @@ namespace System.Collections.Concurrent
         /// <param name="key">The key of the element to add.</param>
         /// <param name="valueFactory">The function used to generate a value for the key</param>
         /// <param name="factoryArgument">An argument value to pass into <paramref name="valueFactory"/>.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="valueFactory"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="valueFactory"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// <exception cref="System.OverflowException">The dictionary contains too many
         /// elements.</exception>
         /// <returns>The value for the key.  This will be either the existing value for the key if the
         /// key is already in the dictionary, or the new value for the key as returned by valueFactory
@@ -1048,9 +1048,9 @@ namespace System.Collections.Concurrent
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
         /// <param name="value">the value to be added, if the key does not already exist</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// <exception cref="System.OverflowException">The dictionary contains too many
         /// elements.</exception>
         /// <returns>The value for the key.  This will be either the existing value for the key if the
         /// key is already in the dictionary, or the new value if the key was not in the dictionary.</returns>
@@ -1078,13 +1078,13 @@ namespace System.Collections.Concurrent
         /// <param name="updateValueFactory">The function used to generate a new value for an existing key
         /// based on the key's existing value</param>
         /// <param name="factoryArgument">An argument to pass into <paramref name="addValueFactory"/> and <paramref name="updateValueFactory"/>.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="addValueFactory"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="addValueFactory"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="updateValueFactory"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="updateValueFactory"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// <exception cref="System.OverflowException">The dictionary contains too many
         /// elements.</exception>
         /// <returns>The new value for the key.  This will be either be the result of addValueFactory (if the key was
         /// absent) or the result of updateValueFactory (if the key was present).</returns>
@@ -1130,13 +1130,13 @@ namespace System.Collections.Concurrent
         /// <param name="addValueFactory">The function used to generate a value for an absent key</param>
         /// <param name="updateValueFactory">The function used to generate a new value for an existing key
         /// based on the key's existing value</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="addValueFactory"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="addValueFactory"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="updateValueFactory"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="updateValueFactory"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// <exception cref="System.OverflowException">The dictionary contains too many
         /// elements.</exception>
         /// <returns>The new value for the key.  This will be either the result of addValueFactory (if the key was
         /// absent) or the result of updateValueFactory (if the key was present).</returns>
@@ -1181,11 +1181,11 @@ namespace System.Collections.Concurrent
         /// <param name="addValue">The value to be added for an absent key</param>
         /// <param name="updateValueFactory">The function used to generate a new value for an existing key based on
         /// the key's existing value</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="updateValueFactory"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="updateValueFactory"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// <exception cref="System.OverflowException">The dictionary contains too many
         /// elements.</exception>
         /// <returns>The new value for the key.  This will be either the value of addValue (if the key was
         /// absent) or the result of updateValueFactory (if the key was present).</returns>
@@ -1275,15 +1275,15 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Adds the specified key and value to the <see
-        /// cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/>.
+        /// cref="System.Collections.Generic.IDictionary{TKey,TValue}"/>.
         /// </summary>
         /// <param name="key">The object to use as the key of the element to add.</param>
         /// <param name="value">The object to use as the value of the element to add.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// <exception cref="System.OverflowException">The dictionary contains too many
         /// elements.</exception>
-        /// <exception cref="T:System.ArgumentException">
+        /// <exception cref="System.ArgumentException">
         /// An element with the same key already exists in the <see
         /// cref="ConcurrentDictionary{TKey,TValue}"/>.</exception>
         void IDictionary<TKey, TValue>.Add(TKey key, TValue value)
@@ -1296,15 +1296,15 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Removes the element with the specified key from the <see
-        /// cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/>.
+        /// cref="System.Collections.Generic.IDictionary{TKey,TValue}"/>.
         /// </summary>
         /// <param name="key">The key of the element to remove.</param>
         /// <returns>true if the element is successfully remove; otherwise false. This method also returns
         /// false if
         /// <paramref name="key"/> was not found in the original <see
-        /// cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/>.
+        /// cref="System.Collections.Generic.IDictionary{TKey,TValue}"/>.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
         bool IDictionary<TKey, TValue>.Remove(TKey key)
         {
@@ -1314,21 +1314,21 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Gets a collection containing the keys in the <see
-        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.
+        /// cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>.
         /// </summary>
-        /// <value>An <see cref="T:System.Collections.Generic.ICollection{TKey}"/> containing the keys in the
-        /// <see cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.</value>
+        /// <value>An <see cref="System.Collections.Generic.ICollection{TKey}"/> containing the keys in the
+        /// <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>.</value>
         public ICollection<TKey> Keys
         {
             get { return GetKeys(); }
         }
 
         /// <summary>
-        /// Gets an <see cref="T:System.Collections.Generic.IEnumerable{TKey}"/> containing the keys of
-        /// the <see cref="T:System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.
+        /// Gets an <see cref="System.Collections.Generic.IEnumerable{TKey}"/> containing the keys of
+        /// the <see cref="System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.
         /// </summary>
-        /// <value>An <see cref="T:System.Collections.Generic.IEnumerable{TKey}"/> containing the keys of
-        /// the <see cref="T:System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.</value>
+        /// <value>An <see cref="System.Collections.Generic.IEnumerable{TKey}"/> containing the keys of
+        /// the <see cref="System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.</value>
         IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys
         {
             get { return GetKeys(); }
@@ -1336,22 +1336,22 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Gets a collection containing the values in the <see
-        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.
+        /// cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>.
         /// </summary>
-        /// <value>An <see cref="T:System.Collections.Generic.ICollection{TValue}"/> containing the values in
+        /// <value>An <see cref="System.Collections.Generic.ICollection{TValue}"/> containing the values in
         /// the
-        /// <see cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.</value>
+        /// <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>.</value>
         public ICollection<TValue> Values
         {
             get { return GetValues(); }
         }
 
         /// <summary>
-        /// Gets an <see cref="T:System.Collections.Generic.IEnumerable{TValue}"/> containing the values
-        /// in the <see cref="T:System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.
+        /// Gets an <see cref="System.Collections.Generic.IEnumerable{TValue}"/> containing the values
+        /// in the <see cref="System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.
         /// </summary>
-        /// <value>An <see cref="T:System.Collections.Generic.IEnumerable{TValue}"/> containing the
-        /// values in the <see cref="T:System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.</value>
+        /// <value>An <see cref="System.Collections.Generic.IEnumerable{TValue}"/> containing the
+        /// values in the <see cref="System.Collections.Generic.IReadOnlyDictionary{TKey,TValue}"/>.</value>
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values
         {
             get { return GetValues(); }
@@ -1361,33 +1361,33 @@ namespace System.Collections.Concurrent
         #region ICollection<KeyValuePair<TKey,TValue>> Members
 
         /// <summary>
-        /// Adds the specified value to the <see cref="T:System.Collections.Generic.ICollection{TValue}"/>
+        /// Adds the specified value to the <see cref="System.Collections.Generic.ICollection{TValue}"/>
         /// with the specified key.
         /// </summary>
-        /// <param name="keyValuePair">The <see cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
+        /// <param name="keyValuePair">The <see cref="System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
         /// structure representing the key and value to add to the <see
-        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="keyValuePair"/> of <paramref
+        /// cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>.</param>
+        /// <exception cref="System.ArgumentNullException">The <paramref name="keyValuePair"/> of <paramref
         /// name="keyValuePair"/> is null.</exception>
-        /// <exception cref="T:System.OverflowException">The <see
-        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>
+        /// <exception cref="System.OverflowException">The <see
+        /// cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>
         /// contains too many elements.</exception>
-        /// <exception cref="T:System.ArgumentException">An element with the same key already exists in the
-        /// <see cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/></exception>
+        /// <exception cref="System.ArgumentException">An element with the same key already exists in the
+        /// <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/></exception>
         void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair)
         {
             ((IDictionary<TKey, TValue>)this).Add(keyValuePair.Key, keyValuePair.Value);
         }
 
         /// <summary>
-        /// Determines whether the <see cref="T:System.Collections.Generic.ICollection{TKey,TValue}"/>
+        /// Determines whether the <see cref="System.Collections.Generic.ICollection{T}"/>
         /// contains a specific key and value.
         /// </summary>
-        /// <param name="keyValuePair">The <see cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
+        /// <param name="keyValuePair">The <see cref="System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
         /// structure to locate in the <see
-        /// cref="T:System.Collections.Generic.ICollection{TValue}"/>.</param>
+        /// cref="System.Collections.Generic.ICollection{TValue}"/>.</param>
         /// <returns>true if the <paramref name="keyValuePair"/> is found in the <see
-        /// cref="T:System.Collections.Generic.ICollection{TKey,TValue}"/>; otherwise, false.</returns>
+        /// cref="System.Collections.Generic.ICollection{T}"/>; otherwise, false.</returns>
         bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair)
         {
             TValue value;
@@ -1401,9 +1401,9 @@ namespace System.Collections.Concurrent
         /// <summary>
         /// Gets a value indicating whether the dictionary is read-only.
         /// </summary>
-        /// <value>true if the <see cref="T:System.Collections.Generic.ICollection{TKey,TValue}"/> is
+        /// <value>true if the <see cref="System.Collections.Generic.ICollection{T}"/> is
         /// read-only; otherwise, false. For <see
-        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>, this property always returns
+        /// cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>, this property always returns
         /// false.</value>
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly
         {
@@ -1414,12 +1414,12 @@ namespace System.Collections.Concurrent
         /// Removes a key and value from the dictionary.
         /// </summary>
         /// <param name="keyValuePair">The <see
-        /// cref="T:System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
+        /// cref="System.Collections.Generic.KeyValuePair{TKey,TValue}"/>
         /// structure representing the key and value to remove from the <see
-        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.</param>
+        /// cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>.</param>
         /// <returns>true if the key and value represented by <paramref name="keyValuePair"/> is successfully
         /// found and removed; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentNullException">The Key property of <paramref
+        /// <exception cref="System.ArgumentNullException">The Key property of <paramref
         /// name="keyValuePair"/> is a null reference (Nothing in Visual Basic).</exception>
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)
         {
@@ -1456,17 +1456,17 @@ namespace System.Collections.Concurrent
         /// </summary>
         /// <param name="key">The object to use as the key.</param>
         /// <param name="value">The object to use as the value.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// <exception cref="System.OverflowException">The dictionary contains too many
         /// elements.</exception>
-        /// <exception cref="T:System.ArgumentException">
+        /// <exception cref="System.ArgumentException">
         /// <paramref name="key"/> is of a type that is not assignable to the key type <typeparamref
-        /// name="TKey"/> of the <see cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>. -or-
+        /// name="TKey"/> of the <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>. -or-
         /// <paramref name="value"/> is of a type that is not assignable to <typeparamref name="TValue"/>,
-        /// the type of values in the <see cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.
+        /// the type of values in the <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>.
         /// -or- A value with the same key already exists in the <see
-        /// cref="T:System.Collections.Generic.Dictionary{TKey,TValue}"/>.
+        /// cref="System.Collections.Generic.Dictionary{TKey,TValue}"/>.
         /// </exception>
         void IDictionary.Add(object key, object? value)
         {
@@ -1478,14 +1478,14 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Gets whether the <see cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/> contains an
+        /// Gets whether the <see cref="System.Collections.IDictionary"/> contains an
         /// element with the specified key.
         /// </summary>
         /// <param name="key">The key to locate in the <see
-        /// cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/>.</param>
-        /// <returns>true if the <see cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/> contains
+        /// cref="System.Collections.IDictionary"/>.</param>
+        /// <returns>true if the <see cref="System.Collections.IDictionary"/> contains
         /// an element with the specified key; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentNullException"> <paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"> <paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
         bool IDictionary.Contains(object key)
         {
@@ -1494,10 +1494,10 @@ namespace System.Collections.Concurrent
             return (key is TKey) && this.ContainsKey((TKey)key);
         }
 
-        /// <summary>Provides an <see cref="T:System.Collections.Generics.IDictionaryEnumerator"/> for the
-        /// <see cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/>.</summary>
-        /// <returns>An <see cref="T:System.Collections.Generics.IDictionaryEnumerator"/> for the <see
-        /// cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/>.</returns>
+        /// <summary>Provides an <see cref="System.Collections.IDictionaryEnumerator"/> for the
+        /// <see cref="System.Collections.IDictionary"/>.</summary>
+        /// <returns>An <see cref="System.Collections.IDictionaryEnumerator"/> for the <see
+        /// cref="System.Collections.IDictionary"/>.</returns>
         IDictionaryEnumerator IDictionary.GetEnumerator()
         {
             return new DictionaryEnumerator(this);
@@ -1505,11 +1505,11 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Gets a value indicating whether the <see
-        /// cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/> has a fixed size.
+        /// cref="System.Collections.IDictionary"/> has a fixed size.
         /// </summary>
-        /// <value>true if the <see cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/> has a
+        /// <value>true if the <see cref="System.Collections.IDictionary"/> has a
         /// fixed size; otherwise, false. For <see
-        /// cref="T:System.Collections.Generic.ConcurrentDictionary{TKey,TValue}"/>, this property always
+        /// cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>, this property always
         /// returns false.</value>
         bool IDictionary.IsFixedSize
         {
@@ -1518,11 +1518,11 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Gets a value indicating whether the <see
-        /// cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/> is read-only.
+        /// cref="System.Collections.IDictionary"/> is read-only.
         /// </summary>
-        /// <value>true if the <see cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/> is
+        /// <value>true if the <see cref="System.Collections.IDictionary"/> is
         /// read-only; otherwise, false. For <see
-        /// cref="T:System.Collections.Generic.ConcurrentDictionary{TKey,TValue}"/>, this property always
+        /// cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>, this property always
         /// returns false.</value>
         bool IDictionary.IsReadOnly
         {
@@ -1530,11 +1530,11 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Gets an <see cref="T:System.Collections.ICollection"/> containing the keys of the <see
-        /// cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/>.
+        /// Gets an <see cref="System.Collections.ICollection"/> containing the keys of the <see
+        /// cref="System.Collections.IDictionary"/>.
         /// </summary>
-        /// <value>An <see cref="T:System.Collections.ICollection"/> containing the keys of the <see
-        /// cref="T:System.Collections.Generic.IDictionary{TKey,TValue}"/>.</value>
+        /// <value>An <see cref="System.Collections.ICollection"/> containing the keys of the <see
+        /// cref="System.Collections.IDictionary"/>.</value>
         ICollection IDictionary.Keys
         {
             get { return GetKeys(); }
@@ -1542,10 +1542,10 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Removes the element with the specified key from the <see
-        /// cref="T:System.Collections.IDictionary"/>.
+        /// cref="System.Collections.IDictionary"/>.
         /// </summary>
         /// <param name="key">The key of the element to remove.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
         void IDictionary.Remove(object key)
         {
@@ -1559,11 +1559,11 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Gets an <see cref="T:System.Collections.ICollection"/> containing the values in the <see
-        /// cref="T:System.Collections.IDictionary"/>.
+        /// Gets an <see cref="System.Collections.ICollection"/> containing the values in the <see
+        /// cref="System.Collections.IDictionary"/>.
         /// </summary>
-        /// <value>An <see cref="T:System.Collections.ICollection"/> containing the values in the <see
-        /// cref="T:System.Collections.IDictionary"/>.</value>
+        /// <value>An <see cref="System.Collections.ICollection"/> containing the values in the <see
+        /// cref="System.Collections.IDictionary"/>.</value>
         ICollection IDictionary.Values
         {
             get { return GetValues(); }
@@ -1576,16 +1576,16 @@ namespace System.Collections.Concurrent
         /// <value>The value associated with the specified key, or a null reference (Nothing in Visual Basic)
         /// if <paramref name="key"/> is not in the dictionary or <paramref name="key"/> is of a type that is
         /// not assignable to the key type <typeparamref name="TKey"/> of the <see
-        /// cref="T:System.Collections.Generic.ConcurrentDictionary{TKey,TValue}"/>.</value>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>.</value>
+        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.ArgumentException">
+        /// <exception cref="System.ArgumentException">
         /// A value is being assigned, and <paramref name="key"/> is of a type that is not assignable to the
         /// key type <typeparamref name="TKey"/> of the <see
-        /// cref="T:System.Collections.Generic.ConcurrentDictionary{TKey,TValue}"/>. -or- A value is being
+        /// cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>. -or- A value is being
         /// assigned, and <paramref name="key"/> is of a type that is not assignable to the value type
         /// <typeparamref name="TValue"/> of the <see
-        /// cref="T:System.Collections.Generic.ConcurrentDictionary{TKey,TValue}"/>
+        /// cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>
         /// </exception>
         object? IDictionary.this[object key]
         {
@@ -1617,21 +1617,21 @@ namespace System.Collections.Concurrent
         #region ICollection Members
 
         /// <summary>
-        /// Copies the elements of the <see cref="T:System.Collections.ICollection"/> to an array, starting
+        /// Copies the elements of the <see cref="System.Collections.ICollection"/> to an array, starting
         /// at the specified array index.
         /// </summary>
         /// <param name="array">The one-dimensional array that is the destination of the elements copied from
-        /// the <see cref="T:System.Collections.ICollection"/>. The array must have zero-based
+        /// the <see cref="System.Collections.ICollection"/>. The array must have zero-based
         /// indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
         /// begins.</param>
-        /// <exception cref="T:System.ArgumentNullException"><paramref name="array"/> is a null reference
+        /// <exception cref="System.ArgumentNullException"><paramref name="array"/> is a null reference
         /// (Nothing in Visual Basic).</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="index"/> is less than
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="index"/> is less than
         /// 0.</exception>
-        /// <exception cref="T:System.ArgumentException"><paramref name="index"/> is equal to or greater than
+        /// <exception cref="System.ArgumentException"><paramref name="index"/> is equal to or greater than
         /// the length of the <paramref name="array"/>. -or- The number of elements in the source <see
-        /// cref="T:System.Collections.ICollection"/>
+        /// cref="System.Collections.ICollection"/>
         /// is greater than the available space from <paramref name="index"/> to the end of the destination
         /// <paramref name="array"/>.</exception>
         void ICollection.CopyTo(Array array, int index)
@@ -1693,12 +1693,12 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection"/> is
+        /// Gets a value indicating whether access to the <see cref="System.Collections.ICollection"/> is
         /// synchronized with the SyncRoot.
         /// </summary>
-        /// <value>true if access to the <see cref="T:System.Collections.ICollection"/> is synchronized
+        /// <value>true if access to the <see cref="System.Collections.ICollection"/> is synchronized
         /// (thread safe); otherwise, false. For <see
-        /// cref="T:System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>, this property always
+        /// cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>, this property always
         /// returns false.</value>
         bool ICollection.IsSynchronized
         {
@@ -1707,9 +1707,9 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Gets an object that can be used to synchronize access to the <see
-        /// cref="T:System.Collections.ICollection"/>. This property is not supported.
+        /// cref="System.Collections.ICollection"/>. This property is not supported.
         /// </summary>
-        /// <exception cref="T:System.NotSupportedException">The SyncRoot property is not supported.</exception>
+        /// <exception cref="System.NotSupportedException">The SyncRoot property is not supported.</exception>
         object ICollection.SyncRoot
         {
             get

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -75,7 +75,7 @@ namespace System.Collections.Concurrent
         /// </summary>
         /// <param name="collection">The collection whose elements are copied to the new <see
         /// cref="ConcurrentStack{T}"/>.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collection"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collection"/> argument is
         /// null.</exception>
         public ConcurrentStack(IEnumerable<T> collection)
         {
@@ -160,10 +160,10 @@ namespace System.Collections.Concurrent
 
 
         /// <summary>
-        /// Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection"/> is
+        /// Gets a value indicating whether access to the <see cref="System.Collections.ICollection"/> is
         /// synchronized with the SyncRoot.
         /// </summary>
-        /// <value>true if access to the <see cref="T:System.Collections.ICollection"/> is synchronized
+        /// <value>true if access to the <see cref="System.Collections.ICollection"/> is synchronized
         /// with the SyncRoot; otherwise, false. For <see cref="ConcurrentStack{T}"/>, this property always
         /// returns false.</value>
         bool ICollection.IsSynchronized
@@ -177,9 +177,9 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Gets an object that can be used to synchronize access to the <see
-        /// cref="T:System.Collections.ICollection"/>. This property is not supported.
+        /// cref="System.Collections.ICollection"/>. This property is not supported.
         /// </summary>
-        /// <exception cref="T:System.NotSupportedException">The SyncRoot property is not supported</exception>
+        /// <exception cref="System.NotSupportedException">The SyncRoot property is not supported</exception>
         object ICollection.SyncRoot
         {
             get
@@ -201,13 +201,13 @@ namespace System.Collections.Concurrent
         }
 
         /// <summary>
-        /// Copies the elements of the <see cref="T:System.Collections.ICollection"/> to an <see
-        /// cref="T:System.Array"/>, starting at a particular
-        /// <see cref="T:System.Array"/> index.
+        /// Copies the elements of the <see cref="System.Collections.ICollection"/> to an <see
+        /// cref="System.Array"/>, starting at a particular
+        /// <see cref="System.Array"/> index.
         /// </summary>
-        /// <param name="array">The one-dimensional <see cref="T:System.Array"/> that is the destination of
+        /// <param name="array">The one-dimensional <see cref="System.Array"/> that is the destination of
         /// the elements copied from the
-        /// <see cref="ConcurrentStack{T}"/>. The <see cref="T:System.Array"/> must
+        /// <see cref="ConcurrentStack{T}"/>. The <see cref="System.Array"/> must
         /// have zero-based indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
         /// begins.</param>
@@ -219,10 +219,10 @@ namespace System.Collections.Concurrent
         /// <paramref name="array"/> is multidimensional. -or-
         /// <paramref name="array"/> does not have zero-based indexing. -or-
         /// <paramref name="index"/> is equal to or greater than the length of the <paramref name="array"/>
-        /// -or- The number of elements in the source <see cref="T:System.Collections.ICollection"/> is
+        /// -or- The number of elements in the source <see cref="System.Collections.ICollection"/> is
         /// greater than the available space from <paramref name="index"/> to the end of the destination
         /// <paramref name="array"/>. -or- The type of the source <see
-        /// cref="T:System.Collections.ICollection"/> cannot be cast automatically to the type of the
+        /// cref="System.Collections.ICollection"/> cannot be cast automatically to the type of the
         /// destination <paramref name="array"/>.
         /// </exception>
         void ICollection.CopyTo(Array array, int index)
@@ -242,11 +242,11 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Copies the <see cref="ConcurrentStack{T}"/> elements to an existing one-dimensional <see
-        /// cref="T:System.Array"/>, starting at the specified array index.
+        /// cref="System.Array"/>, starting at the specified array index.
         /// </summary>
-        /// <param name="array">The one-dimensional <see cref="T:System.Array"/> that is the destination of
+        /// <param name="array">The one-dimensional <see cref="System.Array"/> that is the destination of
         /// the elements copied from the
-        /// <see cref="ConcurrentStack{T}"/>. The <see cref="T:System.Array"/> must have zero-based
+        /// <see cref="ConcurrentStack{T}"/>. The <see cref="System.Array"/> must have zero-based
         /// indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
         /// begins.</param>
@@ -423,10 +423,10 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Attempts to add an object to the <see
-        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
+        /// cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
         /// </summary>
         /// <param name="item">The object to add to the <see
-        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. The value can be a null
+        /// cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. The value can be a null
         /// reference (Nothing in Visual Basic) for reference types.
         /// </param>
         /// <returns>true if the object was added successfully; otherwise, false.</returns>
@@ -444,7 +444,7 @@ namespace System.Collections.Concurrent
         /// without removing it.
         /// </summary>
         /// <param name="result">When this method returns, <paramref name="result"/> contains an object from
-        /// the top of the <see cref="T:System.Collections.Concurrent.ConcurrentStack{T}"/> or an
+        /// the top of the <see cref="System.Collections.Concurrent.ConcurrentStack{T}"/> or an
         /// unspecified value if the operation failed.</param>
         /// <returns>true if and object was returned successfully; otherwise, false.</returns>
         public bool TryPeek([MaybeNullWhen(false)] out T result)
@@ -498,7 +498,7 @@ namespace System.Collections.Concurrent
         /// atomically.
         /// </summary>
         /// <param name="items">
-        /// The <see cref="T:System.Array"/> to which objects popped from the top of the <see
+        /// The <see cref="System.Array"/> to which objects popped from the top of the <see
         /// cref="ConcurrentStack{T}"/> will be added.
         /// </param>
         /// <returns>The number of objects successfully popped from the top of the <see
@@ -528,7 +528,7 @@ namespace System.Collections.Concurrent
         /// atomically.
         /// </summary>
         /// <param name="items">
-        /// The <see cref="T:System.Array"/> to which objects popped from the top of the <see
+        /// The <see cref="System.Array"/> to which objects popped from the top of the <see
         /// cref="ConcurrentStack{T}"/> will be added.
         /// </param>
         /// <param name="startIndex">The zero-based offset in <paramref name="items"/> at which to begin
@@ -682,7 +682,7 @@ namespace System.Collections.Concurrent
 
         /// <summary>
         /// Attempts to remove and return an object from the <see
-        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
+        /// cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
         /// </summary>
         /// <param name="item">
         /// When this method returns, if the operation was successful, <paramref name="item"/> contains the
@@ -773,7 +773,7 @@ namespace System.Collections.Concurrent
         /// <summary>
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
-        /// <returns>An <see cref="T:System.Collections.IEnumerator"/> that can be used to iterate through
+        /// <returns>An <see cref="System.Collections.IEnumerator"/> that can be used to iterate through
         /// the collection.</returns>
         /// <remarks>
         /// The enumeration represents a moment-in-time snapshot of the contents of the stack. It does not

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/OrderablePartitioner.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/OrderablePartitioner.cs
@@ -33,17 +33,17 @@ namespace System.Collections.Concurrent
     /// <li>All indices must be non-negative. If any indices are negative, consumers of the implementation
     /// may throw exceptions.</li>
     /// <li><see cref="GetPartitions"/> and <see cref="GetOrderablePartitions"/> should throw a
-    /// <see cref="T:System.ArgumentOutOfRangeException"/> if the requested partition count is less than or
+    /// <see cref="System.ArgumentOutOfRangeException"/> if the requested partition count is less than or
     /// equal to zero.</li>
     /// <li><see cref="GetPartitions"/> and <see cref="GetOrderablePartitions"/> should always return a number
     /// of enumerables equal to the requested partition count. If the partitioner runs out of data and cannot
     /// create as many partitions as requested, an empty enumerator should be returned for each of the
     /// remaining partitions. If this rule is not followed, consumers of the implementation may throw a <see
-    /// cref="T:System.InvalidOperationException"/>.</li>
+    /// cref="System.InvalidOperationException"/>.</li>
     /// <li><see cref="GetPartitions"/>, <see cref="GetOrderablePartitions"/>,
     /// <see cref="GetDynamicPartitions"/>, and <see cref="GetOrderableDynamicPartitions"/>
     /// should never return null. If null is returned, a consumer of the implementation may throw a
-    /// <see cref="T:System.InvalidOperationException"/>.</li>
+    /// <see cref="System.InvalidOperationException"/>.</li>
     /// <li><see cref="GetPartitions"/>, <see cref="GetOrderablePartitions"/>,
     /// <see cref="GetDynamicPartitions"/>, and <see cref="GetOrderableDynamicPartitions"/>
     /// should always return partitions that can fully and uniquely enumerate the input data source. All of
@@ -106,7 +106,7 @@ namespace System.Collections.Concurrent
         /// <remarks>
         /// <para>
         /// The returned object implements the <see
-        /// cref="T:System.Collections.Generic.IEnumerable{TSource}"/> interface. Calling <see
+        /// cref="System.Collections.Generic.IEnumerable{TSource}"/> interface. Calling <see
         /// cref="System.Collections.Generic.IEnumerable{TSource}.GetEnumerator">GetEnumerator</see> on the
         /// object creates another partition over the sequence.
         /// </para>
@@ -187,7 +187,7 @@ namespace System.Collections.Concurrent
         /// <remarks>
         /// <para>
         /// The returned object implements the <see
-        /// cref="T:System.Collections.Generic.IEnumerable{TSource}"/> interface. Calling <see
+        /// cref="System.Collections.Generic.IEnumerable{TSource}"/> interface. Calling <see
         /// cref="System.Collections.Generic.IEnumerable{TSource}.GetEnumerator">GetEnumerator</see> on the
         /// object creates another partition over the sequence.
         /// </para>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/Partitioner.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/Partitioner.cs
@@ -25,16 +25,16 @@ namespace System.Collections.Concurrent
     /// Inheritors of <see cref="Partitioner{TSource}"/> must adhere to the following rules:
     /// <ol>
     /// <li><see cref="GetPartitions"/> should throw a
-    /// <see cref="T:System.ArgumentOutOfRangeException"/> if the requested partition count is less than or
+    /// <see cref="System.ArgumentOutOfRangeException"/> if the requested partition count is less than or
     /// equal to zero.</li>
     /// <li><see cref="GetPartitions"/> should always return a number of enumerables equal to the requested
     /// partition count. If the partitioner runs out of data and cannot create as many partitions as 
     /// requested, an empty enumerator should be returned for each of the remaining partitions. If this rule
     /// is not followed, consumers of the implementation may throw a <see
-    /// cref="T:System.InvalidOperationException"/>.</li>
+    /// cref="System.InvalidOperationException"/>.</li>
     /// <li><see cref="GetPartitions"/> and <see cref="GetDynamicPartitions"/>
     /// should never return null. If null is returned, a consumer of the implementation may throw a
-    /// <see cref="T:System.InvalidOperationException"/>.</li>
+    /// <see cref="System.InvalidOperationException"/>.</li>
     /// <li><see cref="GetPartitions"/> and <see cref="GetDynamicPartitions"/> should always return
     /// partitions that can fully and uniquely enumerate the input data source. All of the data and only the
     /// data contained in the input source should be enumerated, with no duplication that was not already in
@@ -79,7 +79,7 @@ namespace System.Collections.Concurrent
         /// <remarks>
         /// <para>
         /// The returned object implements the <see
-        /// cref="T:System.Collections.Generic.IEnumerable{TSource}"/> interface. Calling <see
+        /// cref="System.Collections.Generic.IEnumerable{TSource}"/> interface. Calling <see
         /// cref="System.Collections.Generic.IEnumerable{TSource}.GetEnumerator">GetEnumerator</see> on the
         /// object creates another partition over the sequence.
         /// </para>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/PartitionerStatic.cs
@@ -151,9 +151,9 @@ namespace System.Collections.Concurrent
         /// <typeparam name="TSource">Type of the elements in source enumerable.</typeparam>
         /// <param name="source">The enumerable to be partitioned.</param>
         /// <param name="partitionerOptions">Options to control the buffering behavior of the partitioner.</param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <exception cref="System.ArgumentOutOfRangeException">
         /// The <paramref name="partitionerOptions"/> argument specifies an invalid value for <see
-        /// cref="T:System.Collections.Concurrent.EnumerablePartitionerOptions"/>.
+        /// cref="System.Collections.Concurrent.EnumerablePartitionerOptions"/>.
         /// </exception>
         /// <returns>
         /// An orderable partitioner based on the input array.
@@ -179,7 +179,7 @@ namespace System.Collections.Concurrent
         /// <param name="fromInclusive">The lower, inclusive bound of the range.</param>
         /// <param name="toExclusive">The upper, exclusive bound of the range.</param>
         /// <returns>A partitioner.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"> The <paramref name="toExclusive"/> argument is 
+        /// <exception cref="System.ArgumentOutOfRangeException"> The <paramref name="toExclusive"/> argument is 
         /// less than or equal to the <paramref name="fromInclusive"/> argument.</exception>
         public static OrderablePartitioner<Tuple<long, long>> Create(long fromInclusive, long toExclusive)
         {
@@ -200,9 +200,9 @@ namespace System.Collections.Concurrent
         /// <param name="toExclusive">The upper, exclusive bound of the range.</param>
         /// <param name="rangeSize">The size of each subrange.</param>
         /// <returns>A partitioner.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"> The <paramref name="toExclusive"/> argument is 
+        /// <exception cref="System.ArgumentOutOfRangeException"> The <paramref name="toExclusive"/> argument is 
         /// less than or equal to the <paramref name="fromInclusive"/> argument.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"> The <paramref name="rangeSize"/> argument is 
+        /// <exception cref="System.ArgumentOutOfRangeException"> The <paramref name="rangeSize"/> argument is 
         /// less than or equal to 0.</exception>
         public static OrderablePartitioner<Tuple<long, long>> Create(long fromInclusive, long toExclusive, long rangeSize)
         {
@@ -236,7 +236,7 @@ namespace System.Collections.Concurrent
         /// <param name="fromInclusive">The lower, inclusive bound of the range.</param>
         /// <param name="toExclusive">The upper, exclusive bound of the range.</param>
         /// <returns>A partitioner.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"> The <paramref name="toExclusive"/> argument is 
+        /// <exception cref="System.ArgumentOutOfRangeException"> The <paramref name="toExclusive"/> argument is 
         /// less than or equal to the <paramref name="fromInclusive"/> argument.</exception>
         public static OrderablePartitioner<Tuple<int, int>> Create(int fromInclusive, int toExclusive)
         {
@@ -257,9 +257,9 @@ namespace System.Collections.Concurrent
         /// <param name="toExclusive">The upper, exclusive bound of the range.</param>
         /// <param name="rangeSize">The size of each subrange.</param>
         /// <returns>A partitioner.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"> The <paramref name="toExclusive"/> argument is 
+        /// <exception cref="System.ArgumentOutOfRangeException"> The <paramref name="toExclusive"/> argument is 
         /// less than or equal to the <paramref name="fromInclusive"/> argument.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"> The <paramref name="rangeSize"/> argument is 
+        /// <exception cref="System.ArgumentOutOfRangeException"> The <paramref name="rangeSize"/> argument is 
         /// less than or equal to 0.</exception>
         public static OrderablePartitioner<Tuple<int, int>> Create(int fromInclusive, int toExclusive, int rangeSize)
         {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -18,7 +18,7 @@ namespace System.Collections.Immutable
     /// <typeparam name="T">The type of element stored by the array.</typeparam>
     /// <devremarks>
     /// This type has a documented contract of being exactly one reference-type field in size.
-    /// Our own <see cref="T:System.Collections.Immutable.ImmutableInterlocked"/> class depends on it, as well as others externally.
+    /// Our own <see cref="System.Collections.Immutable.ImmutableInterlocked"/> class depends on it, as well as others externally.
     /// IMPORTANT NOTICE FOR MAINTAINERS AND REVIEWERS:
     /// This type should be thread-safe. As a struct, it cannot protect its own fields
     /// from being changed from one thread while its members are executing on other threads

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
@@ -1079,7 +1079,7 @@ namespace System.Collections.Immutable
         /// Bulk adds entries to the map.
         /// </summary>
         /// <param name="pairs">The entries to add.</param>
-        /// <param name="avoidToHashMap"><c>true</c> when being called from <see cref="WithComparers(IEqualityComparer{TKey}, IEqualityComparer{TValue})"/> to avoid <see cref="System.StackOverflowException"/>.</param>
+        /// <param name="avoidToHashMap"><c>true</c> when being called from <see cref="WithComparers(IEqualityComparer{TKey}, IEqualityComparer{TValue})"/> to avoid a stack overflow.</param>
         [Pure]
         private ImmutableDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs, bool avoidToHashMap)
         {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
@@ -1079,7 +1079,7 @@ namespace System.Collections.Immutable
         /// Bulk adds entries to the map.
         /// </summary>
         /// <param name="pairs">The entries to add.</param>
-        /// <param name="avoidToHashMap"><c>true</c> when being called from <see cref="WithComparers(IEqualityComparer{TKey}, IEqualityComparer{TValue})"/> to avoid <see cref="T:System.StackOverflowException"/>.</param>
+        /// <param name="avoidToHashMap"><c>true</c> when being called from <see cref="WithComparers(IEqualityComparer{TKey}, IEqualityComparer{TValue})"/> to avoid <see cref="System.StackOverflowException"/>.</param>
         [Pure]
         private ImmutableDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs, bool avoidToHashMap)
         {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.Minimal.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.Minimal.cs
@@ -146,7 +146,7 @@ namespace System.Collections.Immutable
         /// <param name="count">The number of elements in the sequence.</param>
         /// <returns>The array.</returns>
         /// <remarks>
-        /// This is more efficient than the <see cref="M:System.Linq.Enumerable.ToArray``1(System.Collections.Generic.IEnumerable{``0})"/> extension method
+        /// This is more efficient than the <see cref="System.Linq.Enumerable.ToArray{TSource}(IEnumerable{TSource})"/> extension method
         /// because that only tries to cast the sequence to <see cref="ICollection{T}"/> to determine
         /// the count before it falls back to reallocating arrays as it enumerates.
         /// </remarks>

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
@@ -1023,7 +1023,7 @@ namespace System.Collections.Immutable
         /// Bulk adds entries to the set.
         /// </summary>
         /// <param name="items">The entries to add.</param>
-        /// <param name="avoidWithComparer"><c>true</c> when being called from <see cref="WithComparer"/> to avoid <see cref="System.StackOverflowException"/>.</param>
+        /// <param name="avoidWithComparer"><c>true</c> when being called from <see cref="WithComparer"/> to avoid a stack overflow.</param>
         [Pure]
         private ImmutableHashSet<T> Union(IEnumerable<T> items, bool avoidWithComparer)
         {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
@@ -1023,7 +1023,7 @@ namespace System.Collections.Immutable
         /// Bulk adds entries to the set.
         /// </summary>
         /// <param name="items">The entries to add.</param>
-        /// <param name="avoidWithComparer"><c>true</c> when being called from <see cref="WithComparer"/> to avoid <see cref="T:System.StackOverflowException"/>.</param>
+        /// <param name="avoidWithComparer"><c>true</c> when being called from <see cref="WithComparer"/> to avoid <see cref="System.StackOverflowException"/>.</param>
         [Pure]
         private ImmutableHashSet<T> Union(IEnumerable<T> items, bool avoidWithComparer)
         {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
@@ -815,7 +815,7 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="items">The entries to add.</param>
         /// <param name="overwriteOnCollision"><c>true</c> to allow the <paramref name="items"/> sequence to include duplicate keys and let the last one win; <c>false</c> to throw on collisions.</param>
-        /// <param name="avoidToSortedMap"><c>true</c> when being called from <see cref="WithComparers(IComparer{TKey}, IEqualityComparer{TValue})"/> to avoid <see cref="System.StackOverflowException"/>.</param>
+        /// <param name="avoidToSortedMap"><c>true</c> when being called from <see cref="WithComparers(IComparer{TKey}, IEqualityComparer{TValue})"/> to avoid a stack overflow.</param>
         [Pure]
         private ImmutableSortedDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> items, bool overwriteOnCollision, bool avoidToSortedMap)
         {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
@@ -815,7 +815,7 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="items">The entries to add.</param>
         /// <param name="overwriteOnCollision"><c>true</c> to allow the <paramref name="items"/> sequence to include duplicate keys and let the last one win; <c>false</c> to throw on collisions.</param>
-        /// <param name="avoidToSortedMap"><c>true</c> when being called from <see cref="WithComparers(IComparer{TKey}, IEqualityComparer{TValue})"/> to avoid <see cref="T:System.StackOverflowException"/>.</param>
+        /// <param name="avoidToSortedMap"><c>true</c> when being called from <see cref="WithComparers(IComparer{TKey}, IEqualityComparer{TValue})"/> to avoid <see cref="System.StackOverflowException"/>.</param>
         [Pure]
         private ImmutableSortedDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> items, bool overwriteOnCollision, bool avoidToSortedMap)
         {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
@@ -17,7 +17,7 @@ namespace System.Collections.Immutable
     /// with <c>TKey</c> fixed to be <see cref="int"/>.  This avoids multiple interface-based dispatches while examining
     /// each node in the tree during a lookup: an interface call to the comparer's <see cref="IComparer{T}.Compare"/> method,
     /// and then an interface call to <see cref="int"/>'s <see cref="IComparable{T}.CompareTo"/> method as part of
-    /// the <see cref="T:System.Collections.Generic.GenericComparer`1"/>'s <see cref="IComparer{T}.Compare"/> implementation.
+    /// the comparer's <see cref="IComparer{T}.Compare"/> implementation.
     /// </remarks>
     [DebuggerDisplay("{_key} = {_value}")]
     internal sealed partial class SortedInt32KeyNode<TValue> : IBinaryTree

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionScopeDefinition.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/CompositionScopeDefinition.cs
@@ -221,7 +221,7 @@ namespace System.ComponentModel.Composition.Hosting
         public event EventHandler<ComposablePartCatalogChangeEventArgs> Changing;
 
         /// <summary>
-        /// Raises the <see cref="E:Changed"/> event.
+        /// Raises the <see cref="Changed"/> event.
         /// </summary>
         /// <param name="e">The <see cref="System.ComponentModel.Composition.Hosting.ComposablePartCatalogChangeEventArgs"/> instance containing the event data.</param>
         protected virtual void OnChanged(ComposablePartCatalogChangeEventArgs e)
@@ -234,7 +234,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         /// <summary>
-        /// Raises the <see cref="E:Changing"/> event.
+        /// Raises the <see cref="Changing"/> event.
         /// </summary>
         /// <param name="e">The <see cref="System.ComponentModel.Composition.Hosting.ComposablePartCatalogChangeEventArgs"/> instance containing the event data.</param>
         protected virtual void OnChanging(ComposablePartCatalogChangeEventArgs e)

--- a/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/FilteredCatalog.cs
+++ b/src/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/FilteredCatalog.cs
@@ -179,7 +179,7 @@ namespace System.ComponentModel.Composition.Hosting
         public event EventHandler<ComposablePartCatalogChangeEventArgs> Changing;
 
 /// <summary>
-        /// Raises the <see cref="E:Changed"/> event.
+        /// Raises the <see cref="Changed"/> event.
         /// </summary>
         /// <param name="e">The <see cref="System.ComponentModel.Composition.Hosting.ComposablePartCatalogChangeEventArgs"/> instance containing the event data.</param>
         protected virtual void OnChanged(ComposablePartCatalogChangeEventArgs e)
@@ -192,7 +192,7 @@ namespace System.ComponentModel.Composition.Hosting
         }
 
         /// <summary>
-        /// Raises the <see cref="E:Changing"/> event.
+        /// Raises the <see cref="Changing"/> event.
         /// </summary>
         /// <param name="e">The <see cref="System.ComponentModel.Composition.Hosting.ComposablePartCatalogChangeEventArgs"/> instance containing the event data.</param>
         protected virtual void OnChanging(ComposablePartCatalogChangeEventArgs e)

--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeDescriptor.cs
@@ -249,11 +249,6 @@ namespace System.ComponentModel
         /// components, you would pass typeof(IComponent). Passing typeof(object) 
         /// will cause the provider to be called to provide type information for 
         /// all types.
-        /// 
-        /// This method can be called from partially trusted code. If 
-        /// <see cref="E:System.Security.Permissions.TypeDescriptorPermissionFlags.RestrictedRegistrationAccess"/>
-        /// is defined, the caller can register a provider for the specified type 
-        /// if it's also partially trusted.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static void AddProviderTransparent(TypeDescriptionProvider provider, Type type)
@@ -277,11 +272,6 @@ namespace System.ComponentModel
         /// using this method will never have its CreateInstance method called 
         /// because the instance already exists. This method does not prevent 
         /// the object from finalizing.
-        /// 
-        /// This method can be called from partially trusted code. If 
-        /// <see cref="E:System.Security.Permissions.TypeDescriptorPermissionFlags.RestrictedRegistrationAccess"/>
-        /// is defined, the caller can register a provider for the specified instance 
-        /// if its type is also partially trusted.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static void AddProviderTransparent(TypeDescriptionProvider provider, object instance)
@@ -2501,11 +2491,6 @@ namespace System.ComponentModel
         /// description provider. Removing a provider causes a Refresh 
         /// event to be raised for the object or type the provider is 
         /// associated with.
-        /// 
-        /// This method can be called from partially trusted code. If 
-        /// <see cref="E:System.Security.Permissions.TypeDescriptorPermissionFlags.RestrictedRegistrationAccess"/>
-        /// is defined, the caller can unregister a provider for the specified type
-        /// if it's also partially trusted.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static void RemoveProviderTransparent(TypeDescriptionProvider provider, Type type)
@@ -2528,11 +2513,6 @@ namespace System.ComponentModel
         /// description provider. Removing a provider causes a Refresh 
         /// event to be raised for the object or type the provider is 
         /// associated with.
-        /// 
-        /// This method can be called from partially trusted code. If 
-        /// <see cref="E:System.Security.Permissions.TypeDescriptorPermissionFlags.RestrictedRegistrationAccess"/>
-        /// is defined, the caller can register a provider for the specified instance 
-        /// if its type is also partially trusted.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public static void RemoveProviderTransparent(TypeDescriptionProvider provider, object instance)

--- a/src/System.Data.Common/src/System/Data/DataSet.cs
+++ b/src/System.Data.Common/src/System/Data/DataSet.cs
@@ -1592,7 +1592,7 @@ namespace System.Data
         }
 
         /// <summary>
-        /// Reads the XML schema from the specified <see cref='T:System.Xml.XMLReader'/> into the <see cref='System.Data.DataSet'/>
+        /// Reads the XML schema from the specified <see cref="System.Xml.XmlReader" /> into the <see cref="System.Data.DataSet" />
         /// </summary>
         public void ReadXmlSchema(XmlReader reader) => ReadXmlSchema(reader, false);
 

--- a/src/System.Data.Common/src/System/Data/DataView.cs
+++ b/src/System.Data.Common/src/System/Data/DataView.cs
@@ -1359,7 +1359,7 @@ namespace System.Data
         }
 
         /// <summary>
-        /// Raises the <see cref='E:System.Data.DataView.ListChanged'/> event.
+        /// Raises the <see cref="System.Data.DataView.ListChanged" /> event.
         /// </summary>
         protected virtual void OnListChanged(ListChangedEventArgs e)
         {

--- a/src/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/TextWriterTraceListener.cs
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/System/Diagnostics/TextWriterTraceListener.cs
@@ -11,8 +11,8 @@ namespace System.Diagnostics
 {
     /// <devdoc>
     ///    <para>Directs tracing or debugging output to
-    ///       a <see cref='T:System.IO.TextWriter'/> or to a <see cref='T:System.IO.Stream'/>,
-    ///       such as <see cref='F:System.Console.Out'/> or <see cref='T:System.IO.FileStream'/>.</para>
+    ///       a <see cref='System.IO.TextWriter'/> or to a <see cref='System.IO.Stream'/>,
+    ///       such as <see cref='System.Console.Out'/> or <see cref='System.IO.FileStream'/>.</para>
     /// </devdoc>
     public class TextWriterTraceListener : TraceListener
     {

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/ErrorEventArgs.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/ErrorEventArgs.cs
@@ -5,7 +5,7 @@
 namespace System.IO
 {
     /// <devdoc>
-    ///    Provides data for the <see cref='E:System.IO.FileSystemWatcher.Error'/> event.
+    ///    Provides data for the <see cref='System.IO.FileSystemWatcher.Error'/> event.
     /// </devdoc>
     public class ErrorEventArgs : EventArgs
     {

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/ErrorEventHandler.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/ErrorEventHandler.cs
@@ -6,8 +6,8 @@ namespace System.IO
 {
     /// <devdoc>
     ///    Represents the method that will
-    ///    handle the <see cref='E:System.IO.FileSystemWatcher.Error'/>
-    ///    event of a <see cref='T:System.IO.FileSystemWatcher'/>.
+    ///    handle the <see cref='System.IO.FileSystemWatcher.Error'/>
+    ///    event of a <see cref='System.IO.FileSystemWatcher'/>.
     /// </devdoc>
     public delegate void ErrorEventHandler(object sender, ErrorEventArgs e);
 }

--- a/src/System.Linq.Parallel/src/System/Linq/ParallelEnumerable.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/ParallelEnumerable.cs
@@ -85,7 +85,7 @@ namespace System.Linq
         /// to convert to a <see cref="System.Linq.ParallelQuery{T}"/>.</param>
         /// <returns>The source as a <see cref="System.Linq.ParallelQuery{T}"/> to bind to
         /// ParallelEnumerable extension methods.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> AsParallel<TSource>(this IEnumerable<TSource> source)
@@ -110,7 +110,7 @@ namespace System.Linq
         /// whereas the partitioner's GetPartitions is used if ordering is not enabled (the default).
         /// The source partitioner's GetDynamicPartitions and GetDynamicOrderedPartitions are not used.
         /// </remarks>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> AsParallel<TSource>(this Partitioner<TSource> source)
@@ -131,10 +131,10 @@ namespace System.Linq
         /// </summary>
         /// <typeparam name="TSource">The type of elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The input sequence.</param>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// Thrown if <paramref name="source"/> is not one of AsParallel, ParallelEnumerable.Range, or ParallelEnumerable.Repeat.
         /// </exception>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         /// <remarks>
@@ -178,7 +178,7 @@ namespace System.Linq
         /// <exception cref="InvalidOperationException">
         /// Thrown if the <paramref name="source"/> is not one of AsParallel, ParallelEnumerable.Range, or ParallelEnumerable.Repeat.
         /// </exception>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         /// <remarks>
@@ -213,7 +213,7 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The input sequence.</param>
         /// <returns>The source sequence with arbitrary order.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> AsUnordered<TSource>(this ParallelQuery<TSource> source)
@@ -235,7 +235,7 @@ namespace System.Linq
         /// The source as a ParallelQuery to bind to
         /// ParallelEnumerable extension methods.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery AsParallel(this IEnumerable source)
@@ -262,7 +262,7 @@ namespace System.Linq
         /// <param name="source">A <see cref="ParallelQuery{T}"/> to convert to an <see cref="System.Collections.Generic.IEnumerable{T}"/>.</param>
         /// <returns>The source as an <see cref="System.Collections.Generic.IEnumerable{T}"/>
         /// to bind to sequential extension methods.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static IEnumerable<TSource> AsSequential<TSource>(this ParallelQuery<TSource> source)
@@ -289,13 +289,13 @@ namespace System.Linq
         /// <param name="source">A ParallelQuery on which to set the limit on the degrees of parallelism.</param>
         /// <param name="degreeOfParallelism">The degree of parallelism for the query.</param>
         /// <returns>ParallelQuery representing the same query as source, with the limit on the degrees of parallelism set.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// WithDegreeOfParallelism is used multiple times in the query.
         /// </exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <exception cref="System.ArgumentOutOfRangeException">
         /// <paramref name="degreeOfParallelism"/> is less than 1 or greater than 512.
         /// </exception>
         public static ParallelQuery<TSource> WithDegreeOfParallelism<TSource>(this ParallelQuery<TSource> source, int degreeOfParallelism)
@@ -321,10 +321,10 @@ namespace System.Linq
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>ParallelQuery representing the same query as source, but with the <seealso cref="System.Threading.CancellationToken"/>
         /// registered.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// WithCancellation is used multiple times in the query.
         /// </exception>
         public static ParallelQuery<TSource> WithCancellation<TSource>(this ParallelQuery<TSource> source, CancellationToken cancellationToken)
@@ -346,13 +346,13 @@ namespace System.Linq
         /// <param name="executionMode">The mode in which to execute the query.</param>
         /// <returns>ParallelQuery representing the same query as source, but with the 
         /// <seealso cref="System.Linq.ParallelExecutionMode"/> registered.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.ArgumentException">
-        /// <paramref name="executionMode"/> is not a valid <see cref="T:System.Linq.ParallelExecutionMode"/> value.
+        /// <exception cref="System.ArgumentException">
+        /// <paramref name="executionMode"/> is not a valid <see cref="System.Linq.ParallelExecutionMode"/> value.
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// WithExecutionMode is used multiple times in the query.
         /// </exception>
         public static ParallelQuery<TSource> WithExecutionMode<TSource>(this ParallelQuery<TSource> source, ParallelExecutionMode executionMode)
@@ -378,13 +378,13 @@ namespace System.Linq
         /// <param name="mergeOptions">The merge options to set for this query.</param>
         /// <returns>ParallelQuery representing the same query as source, but with the 
         /// <seealso cref="ParallelMergeOptions"/> registered.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.ArgumentException">
-        /// <paramref name="mergeOptions"/> is not a valid <see cref="T:System.Linq.ParallelMergeOptions"/> value.
+        /// <exception cref="System.ArgumentException">
+        /// <paramref name="mergeOptions"/> is not a valid <see cref="System.Linq.ParallelMergeOptions"/> value.
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// WithMergeOptions is used multiple times in the query.
         /// </exception>
         public static ParallelQuery<TSource> WithMergeOptions<TSource>(this ParallelQuery<TSource> source, ParallelMergeOptions mergeOptions)
@@ -416,10 +416,10 @@ namespace System.Linq
         /// <param name="count">The number of sequential integers to generate.</param>
         /// <returns>An <b>IEnumerable&lt;Int32&gt;</b> in C# or <B>IEnumerable(Of Int32)</B> in 
         /// Visual Basic that contains a range of sequential integral numbers.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <exception cref="System.ArgumentOutOfRangeException">
         /// <paramref name="count"/> is less than 0
         /// -or-
-        /// <paramref name="start"/> + <paramref name="count"/> - 1 is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <paramref name="start"/> + <paramref name="count"/> - 1 is larger than <see cref="System.Int32.MaxValue"/>.
         /// </exception>
         public static ParallelQuery<int> Range(int start, int count)
         {
@@ -438,7 +438,7 @@ namespace System.Linq
         /// <param name="element">The value to be repeated.</param>
         /// <param name="count">The number of times to repeat the value in the generated sequence.</param>
         /// <returns>A sequence that contains a repeated value.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <exception cref="System.ArgumentOutOfRangeException">
         /// <paramref name="count"/> is less than 0.
         /// </exception>
         public static ParallelQuery<TResult> Repeat<TResult>(TResult element, int count)
@@ -490,13 +490,13 @@ namespace System.Linq
         /// <param name="source">The <see cref="ParallelQuery{T}"/> whose elements will be processed by 
         /// <paramref name="action"/>.</param>
         /// <param name="action">An Action to invoke on each element.</param>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="action"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static void ForAll<TSource>(this ParallelQuery<TSource> source, Action<TSource> action)
@@ -528,7 +528,7 @@ namespace System.Linq
         /// <param name="predicate">A function to test each element for a condition.</param>
         /// <returns>A sequence that contains elements from the input sequence that satisfy 
         /// the condition.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Where<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -546,7 +546,7 @@ namespace System.Linq
         /// <param name="source">A sequence to filter.</param>
         /// <param name="predicate">A function to test each element for a condition.</param>
         /// <returns>A sequence that contains elements from the input sequence that satisfy the condition.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Where<TSource>(this ParallelQuery<TSource> source, Func<TSource, int, bool> predicate)
@@ -571,7 +571,7 @@ namespace System.Linq
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>A sequence whose elements are the result of invoking the transform function on each 
         /// element of <paramref name="source"/>.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TResult> Select<TSource, TResult>(
@@ -592,7 +592,7 @@ namespace System.Linq
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>A sequence whose elements are the result of invoking the transform function on each 
         /// element of <paramref name="source"/>.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TResult> Select<TSource, TResult>(
@@ -622,7 +622,7 @@ namespace System.Linq
         /// resultSelector pairwise on two sequences. If the sequence lengths are unequal, this truncates
         /// to the length of the shorter sequence.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="first"/> or <paramref name="second"/> or <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TResult> Zip<TFirst, TSecond, TResult>(
@@ -647,7 +647,7 @@ namespace System.Linq
         /// <param name="second">This parameter is not used.</param>
         /// <param name="resultSelector">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of Zip with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TFirst}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TSecond}"/>.
@@ -682,7 +682,7 @@ namespace System.Linq
         /// <param name="resultSelector">A function to create a result element from two matching elements.</param>
         /// <returns>A sequence that has elements of type <typeparamref name="TResult"/> that are obtained by performing 
         /// an inner join on two sequences.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="outer"/> or <paramref name="inner"/> or <paramref name="outerKeySelector"/> or
         /// <paramref name="innerKeySelector"/> or <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -709,7 +709,7 @@ namespace System.Linq
         /// <param name="innerKeySelector">This parameter is not used.</param>
         /// <param name="resultSelector">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage Join with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TOuter}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TInner}"/>.
@@ -742,7 +742,7 @@ namespace System.Linq
         /// <param name="comparer">An IEqualityComparer&lt;(Of &lt;(T&gt;)&gt;) to hash and compare keys.</param>
         /// <returns>A sequence that has elements of type <typeparamref name="TResult"/> that are obtained by performing 
         /// an inner join on two sequences.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="outer"/> or <paramref name="inner"/> or <paramref name="outerKeySelector"/> or
         /// <paramref name="innerKeySelector"/> or <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -776,7 +776,7 @@ namespace System.Linq
         /// <param name="resultSelector">This parameter is not used.</param>
         /// <param name="comparer">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of Join with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TOuter}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TInner}"/>.
@@ -814,7 +814,7 @@ namespace System.Linq
         /// the first sequence and a collection of matching elements from the second sequence.</param>
         /// <returns>A sequence that has elements of type <typeparamref name="TResult"/> that are obtained by performing 
         /// a grouped join on two sequences.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="outer"/> or <paramref name="inner"/> or <paramref name="outerKeySelector"/> or
         /// <paramref name="innerKeySelector"/> or <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -841,7 +841,7 @@ namespace System.Linq
         /// <param name="innerKeySelector">This parameter is not used.</param>
         /// <param name="resultSelector">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of GroupJoin with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TOuter}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TInner}"/>.
@@ -876,7 +876,7 @@ namespace System.Linq
         /// <param name="comparer">An IEqualityComparer&lt;(Of &lt;(T&gt;)&gt;) to hash and compare keys.</param>
         /// <returns>A sequence that has elements of type <typeparamref name="TResult"/> that are obtained by performing 
         /// a grouped join on two sequences.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="outer"/> or <paramref name="inner"/> or <paramref name="outerKeySelector"/> or
         /// <paramref name="innerKeySelector"/> or <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -910,7 +910,7 @@ namespace System.Linq
         /// <param name="resultSelector">This parameter is not used.</param>
         /// <param name="comparer">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of GroupJoin with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TOuter}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TInner}"/>.
@@ -942,7 +942,7 @@ namespace System.Linq
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>A sequence whose elements are the result of invoking the one-to-many transform 
         /// function on each element of the input sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TResult> SelectMany<TSource, TResult>(
@@ -965,7 +965,7 @@ namespace System.Linq
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>A sequence whose elements are the result of invoking the one-to-many transform 
         /// function on each element of the input sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TResult> SelectMany<TSource, TResult>(
@@ -993,7 +993,7 @@ namespace System.Linq
         /// <returns>A sequence whose elements are the result of invoking the one-to-many transform 
         /// function <paramref name="collectionSelector"/> on each element of <paramref name="source"/> and then mapping 
         /// each of those sequence elements and their corresponding source element to a result element.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="collectionSelector"/> or
         /// <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -1029,7 +1029,7 @@ namespace System.Linq
         /// each of those sequence elements and their corresponding source element to a 
         /// result element.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="collectionSelector"/> or
         /// <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -1065,7 +1065,7 @@ namespace System.Linq
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <returns>An OrderedParallelQuery{TSource} whose elements are sorted 
         /// according to a key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static OrderedParallelQuery<TSource> OrderBy<TSource, TKey>(
@@ -1093,7 +1093,7 @@ namespace System.Linq
         /// <param name="comparer">An IComparer{TKey} to compare keys.</param>
         /// <returns>An OrderedParallelQuery{TSource} whose elements are sorted according 
         /// to a key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static OrderedParallelQuery<TSource> OrderBy<TSource, TKey>(
@@ -1120,7 +1120,7 @@ namespace System.Linq
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <returns>An OrderedParallelQuery{TSource} whose elements are sorted 
         /// descending according to a key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static OrderedParallelQuery<TSource> OrderByDescending<TSource, TKey>(
@@ -1147,7 +1147,7 @@ namespace System.Linq
         /// <param name="comparer">An IComparer{TKey} to compare keys.</param>
         /// <returns>An OrderedParallelQuery{TSource} whose elements are sorted descending 
         /// according to a key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static OrderedParallelQuery<TSource> OrderByDescending<TSource, TKey>(
@@ -1176,7 +1176,7 @@ namespace System.Linq
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <returns>An OrderedParallelQuery{TSource} whose elements are 
         /// sorted according to a key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
 
@@ -1206,7 +1206,7 @@ namespace System.Linq
         /// <param name="comparer">An IComparer{TKey} to compare keys.</param>
         /// <returns>An OrderedParallelQuery{TSource} whose elements are sorted 
         /// according to a key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         /// 
@@ -1236,7 +1236,7 @@ namespace System.Linq
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <returns>An OrderedParallelQuery{TSource} whose elements are sorted 
         /// descending according to a key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         /// 
@@ -1267,7 +1267,7 @@ namespace System.Linq
         /// <param name="comparer">An IComparer{TKey} to compare keys.</param>
         /// <returns>An OrderedParallelQuery{TSource} whose elements are sorted 
         /// descending according to a key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         ///         
@@ -1295,7 +1295,7 @@ namespace System.Linq
         /// <param name="keySelector">A function to extract a key from an element.</param>
         /// <returns>A collection of elements of type IGrouping{TKey, TElement}, where each element represents a 
         /// group and its key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/>
         /// is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -1315,7 +1315,7 @@ namespace System.Linq
         /// <param name="comparer">An equality comparer to compare keys.</param>
         /// <returns>A collection of elements of type IGrouping{TKey, TElement}, where each element represents a 
         /// group and its key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(
@@ -1341,7 +1341,7 @@ namespace System.Linq
         /// IGrouping{Key, TElement}.</param>
         /// <returns>A collection of elements of type IGrouping{TKey, TElement}, where each element represents a 
         /// group and its key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> or
         /// <paramref name="elementSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -1367,7 +1367,7 @@ namespace System.Linq
         /// <param name="comparer">An equality comparer to compare keys.</param>
         /// <returns>A collection of elements of type IGrouping{TKey, TElement}, where each element represents a 
         /// group and its key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> or
         /// <paramref name="elementSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -1406,7 +1406,7 @@ namespace System.Linq
         /// <param name="resultSelector">A function to create a result value from each group.</param>
         /// <returns>A collection of elements of type <typeparamref name="TResult"/> where each element represents a 
         /// projection over a group and its key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> or
         /// <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -1434,7 +1434,7 @@ namespace System.Linq
         /// <param name="comparer">An equality comparer to compare keys.</param>
         /// <returns>A collection of elements of type <typeparamref name="TResult"/> where each element represents a 
         /// projection over a group and its key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> or
         /// <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -1464,7 +1464,7 @@ namespace System.Linq
         /// <param name="resultSelector">A function to create a result value from each group.</param>
         /// <returns>A collection of elements of type <typeparamref name="TResult"/> where each element represents a 
         /// projection over a group and its key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> or
         /// <paramref name="elementSelector"/> or <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -1495,7 +1495,7 @@ namespace System.Linq
         /// <param name="comparer">An equality comparer to compare keys.</param>
         /// <returns>A collection of elements of type <typeparamref name="TResult"/> where each element represents a 
         /// projection over a group and its key.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> or
         /// <paramref name="elementSelector"/> or <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
@@ -1611,16 +1611,16 @@ namespace System.Linq
         /// <param name="source">A sequence to aggregate over.</param>
         /// <param name="func">An accumulator function to be invoked on each element.</param>
         /// <returns>The final accumulator value.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="func"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource Aggregate<TSource>(
@@ -1661,13 +1661,13 @@ namespace System.Linq
         /// <param name="seed">The initial accumulator value.</param>
         /// <param name="func">An accumulator function to be invoked on each element.</param>
         /// <returns>The final accumulator value.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="func"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TAccumulate Aggregate<TSource, TAccumulate>(
@@ -1700,13 +1700,13 @@ namespace System.Linq
         /// <param name="resultSelector">A function to transform the final accumulator value 
         /// into the result value.</param>
         /// <returns>The transformed final accumulator value.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="func"/> or <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TResult Aggregate<TSource, TAccumulate, TResult>(
@@ -1762,14 +1762,14 @@ namespace System.Linq
         /// A function to transform the final accumulator value into the result value.
         /// </param>
         /// <returns>The transformed final accumulator value.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="updateAccumulatorFunc"/> 
         /// or <paramref name="combineAccumulatorsFunc"/> or <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TResult Aggregate<TSource, TAccumulate, TResult>(
@@ -1815,14 +1815,14 @@ namespace System.Linq
         /// A function to transform the final accumulator value into the result value.
         /// </param>
         /// <returns>The transformed final accumulator value.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="seedFactory"/> or <paramref name="updateAccumulatorFunc"/> 
         /// or <paramref name="combineAccumulatorsFunc"/> or <paramref name="resultSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TResult Aggregate<TSource, TAccumulate, TResult>(
@@ -1854,15 +1854,15 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">A sequence that contains elements to be counted.</param>
         /// <returns>The number of elements in the input sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The number of elements in source is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The number of elements in source is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int Count<TSource>(this ParallelQuery<TSource> source)
@@ -1898,15 +1898,15 @@ namespace System.Linq
         /// A number that represents how many elements in the sequence satisfy the condition 
         /// in the predicate function.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The number of elements in source is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The number of elements in source is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int Count<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -1927,15 +1927,15 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">A sequence that contains elements to be counted.</param>
         /// <returns>The number of elements in the input sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The number of elements in source is larger than <see cref="M:System.Int64.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The number of elements in source is larger than <see cref="System.Int64.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long LongCount<TSource>(this ParallelQuery<TSource> source)
@@ -1967,15 +1967,15 @@ namespace System.Linq
         /// A number that represents how many elements in the sequence satisfy the condition 
         /// in the predicate function.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The number of elements in source is larger than <see cref="M:System.Int64.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The number of elements in source is larger than <see cref="System.Int64.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long LongCount<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -1996,15 +1996,15 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int Sum(this ParallelQuery<int> source)
@@ -2018,15 +2018,15 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int? Sum(this ParallelQuery<int?> source)
@@ -2040,15 +2040,15 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Int64.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Int64.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long Sum(this ParallelQuery<long> source)
@@ -2062,15 +2062,15 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Int64.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Int64.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long? Sum(this ParallelQuery<long?> source)
@@ -2084,13 +2084,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float Sum(this ParallelQuery<float> source)
@@ -2104,13 +2104,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float? Sum(this ParallelQuery<float?> source)
@@ -2124,13 +2124,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Sum(this ParallelQuery<double> source)
@@ -2144,13 +2144,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Sum(this ParallelQuery<double?> source)
@@ -2164,15 +2164,15 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Decimal.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Decimal.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal Sum(this ParallelQuery<decimal> source)
@@ -2186,15 +2186,15 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Decimal.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Decimal.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal? Sum(this ParallelQuery<decimal?> source)
@@ -2210,15 +2210,15 @@ namespace System.Linq
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int Sum<TSource>(this ParallelQuery<TSource> source, Func<TSource, int> selector)
@@ -2234,15 +2234,15 @@ namespace System.Linq
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int? Sum<TSource>(this ParallelQuery<TSource> source, Func<TSource, int?> selector)
@@ -2258,15 +2258,15 @@ namespace System.Linq
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Int64.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Int64.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long Sum<TSource>(this ParallelQuery<TSource> source, Func<TSource, long> selector)
@@ -2282,15 +2282,15 @@ namespace System.Linq
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Int64.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Int64.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long? Sum<TSource>(this ParallelQuery<TSource> source, Func<TSource, long?> selector)
@@ -2306,13 +2306,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float Sum<TSource>(this ParallelQuery<TSource> source, Func<TSource, float> selector)
@@ -2328,13 +2328,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float? Sum<TSource>(this ParallelQuery<TSource> source, Func<TSource, float?> selector)
@@ -2350,13 +2350,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Sum<TSource>(this ParallelQuery<TSource> source, Func<TSource, double> selector)
@@ -2372,13 +2372,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Sum<TSource>(this ParallelQuery<TSource> source, Func<TSource, double?> selector)
@@ -2394,15 +2394,15 @@ namespace System.Linq
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Decimal.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Decimal.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal Sum<TSource>(this ParallelQuery<TSource> source, Func<TSource, decimal> selector)
@@ -2418,15 +2418,15 @@ namespace System.Linq
         /// <param name="source">A sequence of values to calculate the sum of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The sum of the values in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum is larger than <see cref="M:System.Decimal.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum is larger than <see cref="System.Decimal.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal? Sum<TSource>(this ParallelQuery<TSource> source, Func<TSource, decimal?> selector)
@@ -2453,16 +2453,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int Min(this ParallelQuery<int> source)
@@ -2476,13 +2476,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int? Min(this ParallelQuery<int?> source)
@@ -2496,16 +2496,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long Min(this ParallelQuery<long> source)
@@ -2519,13 +2519,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long? Min(this ParallelQuery<long?> source)
@@ -2539,16 +2539,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float Min(this ParallelQuery<float> source)
@@ -2562,13 +2562,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float? Min(this ParallelQuery<float?> source)
@@ -2582,16 +2582,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Min(this ParallelQuery<double> source)
@@ -2605,13 +2605,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Min(this ParallelQuery<double?> source)
@@ -2625,16 +2625,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal Min(this ParallelQuery<decimal> source)
@@ -2648,13 +2648,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal? Min(this ParallelQuery<decimal?> source)
@@ -2669,16 +2669,16 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements and <typeparamref name="TSource"/> is a non-nullable value type.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource Min<TSource>(this ParallelQuery<TSource> source)
@@ -2695,16 +2695,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int Min<TSource>(this ParallelQuery<TSource> source, Func<TSource, int> selector)
@@ -2720,13 +2720,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int? Min<TSource>(this ParallelQuery<TSource> source, Func<TSource, int?> selector)
@@ -2742,16 +2742,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long Min<TSource>(this ParallelQuery<TSource> source, Func<TSource, long> selector)
@@ -2767,13 +2767,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long? Min<TSource>(this ParallelQuery<TSource> source, Func<TSource, long?> selector)
@@ -2789,16 +2789,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float Min<TSource>(this ParallelQuery<TSource> source, Func<TSource, float> selector)
@@ -2814,13 +2814,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float? Min<TSource>(this ParallelQuery<TSource> source, Func<TSource, float?> selector)
@@ -2836,16 +2836,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Min<TSource>(this ParallelQuery<TSource> source, Func<TSource, double> selector)
@@ -2861,13 +2861,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Min<TSource>(this ParallelQuery<TSource> source, Func<TSource, double?> selector)
@@ -2883,16 +2883,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal Min<TSource>(this ParallelQuery<TSource> source, Func<TSource, decimal> selector)
@@ -2908,13 +2908,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal? Min<TSource>(this ParallelQuery<TSource> source, Func<TSource, decimal?> selector)
@@ -2931,16 +2931,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the minimum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements and <typeparamref name="TResult"/> is a non-nullable value type.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TResult Min<TSource, TResult>(this ParallelQuery<TSource> source, Func<TSource, TResult> selector)
@@ -2957,16 +2957,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int Max(this ParallelQuery<int> source)
@@ -2980,13 +2980,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int? Max(this ParallelQuery<int?> source)
@@ -3000,16 +3000,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long Max(this ParallelQuery<long> source)
@@ -3023,13 +3023,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long? Max(this ParallelQuery<long?> source)
@@ -3043,16 +3043,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float Max(this ParallelQuery<float> source)
@@ -3066,13 +3066,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float? Max(this ParallelQuery<float?> source)
@@ -3086,16 +3086,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Max(this ParallelQuery<double> source)
@@ -3109,13 +3109,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Max(this ParallelQuery<double?> source)
@@ -3129,16 +3129,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal Max(this ParallelQuery<decimal> source)
@@ -3152,13 +3152,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal? Max(this ParallelQuery<decimal?> source)
@@ -3172,16 +3172,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements and <typeparam name="TSource"/> is a non-nullable value type.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource Max<TSource>(this ParallelQuery<TSource> source)
@@ -3198,16 +3198,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int Max<TSource>(this ParallelQuery<TSource> source, Func<TSource, int> selector)
@@ -3223,13 +3223,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static int? Max<TSource>(this ParallelQuery<TSource> source, Func<TSource, int?> selector)
@@ -3245,16 +3245,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long Max<TSource>(this ParallelQuery<TSource> source, Func<TSource, long> selector)
@@ -3270,13 +3270,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static long? Max<TSource>(this ParallelQuery<TSource> source, Func<TSource, long?> selector)
@@ -3292,16 +3292,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float Max<TSource>(this ParallelQuery<TSource> source, Func<TSource, float> selector)
@@ -3317,13 +3317,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float? Max<TSource>(this ParallelQuery<TSource> source, Func<TSource, float?> selector)
@@ -3339,16 +3339,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Max<TSource>(this ParallelQuery<TSource> source, Func<TSource, double> selector)
@@ -3364,13 +3364,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Max<TSource>(this ParallelQuery<TSource> source, Func<TSource, double?> selector)
@@ -3386,16 +3386,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal Max<TSource>(this ParallelQuery<TSource> source, Func<TSource, decimal> selector)
@@ -3411,13 +3411,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal? Max<TSource>(this ParallelQuery<TSource> source, Func<TSource, decimal?> selector)
@@ -3434,16 +3434,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values to determine the maximum value of.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements and <typeparamref name="TResult"/> is a non-nullable value type.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TResult Max<TSource, TResult>(this ParallelQuery<TSource> source, Func<TSource, TResult> selector)
@@ -3460,18 +3460,18 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum or count of the elements in the sequence is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum or count of the elements in the sequence is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Average(this ParallelQuery<int> source)
@@ -3485,15 +3485,15 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum or count of the elements in the sequence is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum or count of the elements in the sequence is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Average(this ParallelQuery<int?> source)
@@ -3507,18 +3507,18 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum or count of the elements in the sequence is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum or count of the elements in the sequence is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Average(this ParallelQuery<long> source)
@@ -3532,15 +3532,15 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum or count of the elements in the sequence is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum or count of the elements in the sequence is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Average(this ParallelQuery<long?> source)
@@ -3554,16 +3554,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float Average(this ParallelQuery<float> source)
@@ -3577,13 +3577,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float? Average(this ParallelQuery<float?> source)
@@ -3597,16 +3597,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Average(this ParallelQuery<double> source)
@@ -3618,15 +3618,15 @@ namespace System.Linq
         /// <summary>
         /// Computes in parallel the average of a sequence of values.
         /// </summary>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <returns>The average of the sequence of values.</returns>
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Average(this ParallelQuery<double?> source)
@@ -3640,16 +3640,16 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal Average(this ParallelQuery<decimal> source)
@@ -3663,13 +3663,13 @@ namespace System.Linq
         /// </summary>
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal? Average(this ParallelQuery<decimal?> source)
@@ -3686,18 +3686,18 @@ namespace System.Linq
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum or count of the elements in the sequence is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum or count of the elements in the sequence is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Average<TSource>(this ParallelQuery<TSource> source, Func<TSource, int> selector)
@@ -3713,15 +3713,15 @@ namespace System.Linq
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum or count of the elements in the sequence is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum or count of the elements in the sequence is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Average<TSource>(this ParallelQuery<TSource> source, Func<TSource, int?> selector)
@@ -3737,18 +3737,18 @@ namespace System.Linq
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum or count of the elements in the sequence is larger than <see cref="M:System.Int32.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum or count of the elements in the sequence is larger than <see cref="System.Int32.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Average<TSource>(this ParallelQuery<TSource> source, Func<TSource, long> selector)
@@ -3764,15 +3764,15 @@ namespace System.Linq
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
-        /// The sum or count of the elements in the sequence is larger than <see cref="M:System.Int64.MaxValue"/>.
+        /// <exception cref="System.AggregateException">
+        /// The sum or count of the elements in the sequence is larger than <see cref="System.Int64.MaxValue"/>.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Average<TSource>(this ParallelQuery<TSource> source, Func<TSource, long?> selector)
@@ -3788,16 +3788,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float Average<TSource>(this ParallelQuery<TSource> source, Func<TSource, float> selector)
@@ -3813,13 +3813,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static float? Average<TSource>(this ParallelQuery<TSource> source, Func<TSource, float?> selector)
@@ -3835,16 +3835,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double Average<TSource>(this ParallelQuery<TSource> source, Func<TSource, double> selector)
@@ -3860,13 +3860,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static double? Average<TSource>(this ParallelQuery<TSource> source, Func<TSource, double?> selector)
@@ -3882,16 +3882,16 @@ namespace System.Linq
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal Average<TSource>(this ParallelQuery<TSource> source, Func<TSource, decimal> selector)
@@ -3907,13 +3907,13 @@ namespace System.Linq
         /// <param name="source">A sequence of values that are used to calculate an average.</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>The average of the sequence of values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="selector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static decimal? Average<TSource>(this ParallelQuery<TSource> source, Func<TSource, decimal?> selector)
@@ -3934,13 +3934,13 @@ namespace System.Linq
         /// <returns>
         /// true if any elements in the source sequence pass the test in the specified predicate; otherwise, false.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static bool Any<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -3957,13 +3957,13 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The IEnumerable to check for emptiness.</param>
         /// <returns>true if the source sequence contains any elements; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static bool Any<TSource>(this ParallelQuery<TSource> source)
@@ -3986,13 +3986,13 @@ namespace System.Linq
         /// <returns>
         /// true if all elements in the source sequence pass the test in the specified predicate; otherwise, false.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static bool All<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -4017,13 +4017,13 @@ namespace System.Linq
         /// <returns>
         /// true if the source sequence contains an element that has the specified value; otherwise, false.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static bool Contains<TSource>(this ParallelQuery<TSource> source, TSource value)
@@ -4042,13 +4042,13 @@ namespace System.Linq
         /// <returns>
         /// true if the source sequence contains an element that has the specified value; otherwise, false.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static bool Contains<TSource>(this ParallelQuery<TSource> source, TSource value, IEqualityComparer<TSource> comparer)
@@ -4077,7 +4077,7 @@ namespace System.Linq
         /// <returns>
         /// A sequence that contains the specified number of elements from the start of the input sequence.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Take<TSource>(this ParallelQuery<TSource> source, int count)
@@ -4109,7 +4109,7 @@ namespace System.Linq
         /// A sequence that contains the elements from the input sequence that occur before 
         /// the element at which the test no longer passes.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> TakeWhile<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -4134,7 +4134,7 @@ namespace System.Linq
         /// A sequence that contains elements from the input sequence that occur before 
         /// the element at which the test no longer passes.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> TakeWhile<TSource>(this ParallelQuery<TSource> source, Func<TSource, int, bool> predicate)
@@ -4159,7 +4159,7 @@ namespace System.Linq
         /// <returns>
         /// A sequence that contains the elements that occur after the specified index in the input sequence.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Skip<TSource>(this ParallelQuery<TSource> source, int count)
@@ -4191,7 +4191,7 @@ namespace System.Linq
         /// <returns>A sequence that contains the elements from the input sequence starting at 
         /// the first element in the linear series that does not pass the test specified by 
         /// <B>predicate</B>.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> SkipWhile<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -4218,7 +4218,7 @@ namespace System.Linq
         /// first element in the linear series that does not pass the test specified by 
         /// <B>predicate</B>.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> SkipWhile<TSource>(this ParallelQuery<TSource> source, Func<TSource, int, bool> predicate)
@@ -4244,7 +4244,7 @@ namespace System.Linq
         /// <param name="first">The first sequence to concatenate.</param>
         /// <param name="second">The sequence to concatenate to the first sequence.</param>
         /// <returns>A sequence that contains the concatenated elements of the two input sequences.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="first"/> or <paramref name="second"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Concat<TSource>(this ParallelQuery<TSource> first, ParallelQuery<TSource> second)
@@ -4262,7 +4262,7 @@ namespace System.Linq
         /// <param name="first">This parameter is not used.</param>
         /// <param name="second">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of Concat with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TSource}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TSource}"/>.
@@ -4290,13 +4290,13 @@ namespace System.Linq
         /// true if the two source sequences are of equal length and their corresponding elements 
         /// are equal according to the default equality comparer for their type; otherwise, false.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="first"/> or <paramref name="second"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static bool SequenceEqual<TSource>(this ParallelQuery<TSource> first, ParallelQuery<TSource> second)
@@ -4314,7 +4314,7 @@ namespace System.Linq
         /// <param name="first">This parameter is not used.</param>
         /// <param name="second">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">Thrown every time this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">Thrown every time this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of SequenceEqual with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TSource}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TSource}"/>.
@@ -4339,13 +4339,13 @@ namespace System.Linq
         /// true if the two source sequences are of equal length and their corresponding 
         /// elements are equal according to the default equality comparer for their type; otherwise, false.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="first"/> or <paramref name="second"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static bool SequenceEqual<TSource>(this ParallelQuery<TSource> first, ParallelQuery<TSource> second, IEqualityComparer<TSource> comparer)
@@ -4435,7 +4435,7 @@ namespace System.Linq
         /// <param name="second">This parameter is not used.</param>
         /// <param name="comparer">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">Thrown every time this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">Thrown every time this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of SequenceEqual with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TSource}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TSource}"/>.
@@ -4459,7 +4459,7 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The sequence to remove duplicate elements from.</param>
         /// <returns>A sequence that contains distinct elements from the source sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Distinct<TSource>(
@@ -4476,7 +4476,7 @@ namespace System.Linq
         /// <param name="source">The sequence to remove duplicate elements from.</param>
         /// <param name="comparer">An IEqualityComparer&lt;(Of &lt;(T&gt;)&gt;) to compare values.</param>
         /// <returns>A sequence that contains distinct elements from the source sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Distinct<TSource>(
@@ -4498,7 +4498,7 @@ namespace System.Linq
         /// <param name="first">A sequence whose distinct elements form the first set for the union.</param>
         /// <param name="second">A sequence whose distinct elements form the second set for the union.</param>
         /// <returns>A sequence that contains the elements from both input sequences, excluding duplicates.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="first"/> or <paramref name="second"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Union<TSource>(
@@ -4515,7 +4515,7 @@ namespace System.Linq
         /// <param name="first">This parameter is not used.</param>
         /// <param name="second">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of Union with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TSource}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TSource}"/>.
@@ -4537,7 +4537,7 @@ namespace System.Linq
         /// <param name="second">A sequence whose distinct elements form the second set for the union.</param>
         /// <param name="comparer">An IEqualityComparer&lt;(Of &lt;(T&gt;)&gt;) to compare values.</param>
         /// <returns>A sequence that contains the elements from both input sequences, excluding duplicates.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="first"/> or <paramref name="second"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Union<TSource>(
@@ -4558,7 +4558,7 @@ namespace System.Linq
         /// <param name="second">This parameter is not used.</param>
         /// <param name="comparer">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of Union with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TSource}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TSource}"/>.
@@ -4588,7 +4588,7 @@ namespace System.Linq
         /// A sequence whose distinct elements that also appear in the first sequence will be returned.
         /// </param>
         /// <returns>A sequence that contains the elements that form the set intersection of two sequences.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="first"/> or <paramref name="second"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Intersect<TSource>(
@@ -4605,7 +4605,7 @@ namespace System.Linq
         /// <param name="first">This parameter is not used.</param>
         /// <param name="second">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of Intersect with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TSource}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TSource}"/>.
@@ -4632,7 +4632,7 @@ namespace System.Linq
         /// </param>
         /// <param name="comparer">An IEqualityComparer&lt;(Of &lt;(T&gt;)&gt;) to compare values.</param>
         /// <returns>A sequence that contains the elements that form the set intersection of two sequences.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="first"/> or <paramref name="second"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Intersect<TSource>(
@@ -4653,7 +4653,7 @@ namespace System.Linq
         /// <param name="second">This parameter is not used.</param>
         /// <param name="comparer">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of Intersect with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TSource}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TSource}"/>.
@@ -4685,7 +4685,7 @@ namespace System.Linq
         /// elements to be removed from the returned sequence.
         /// </param>
         /// <returns>A sequence that contains the set difference of the elements of two sequences.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="first"/> or <paramref name="second"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Except<TSource>(
@@ -4702,7 +4702,7 @@ namespace System.Linq
         /// <param name="first">This parameter is not used.</param>
         /// <param name="second">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of Except with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TSource}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TSource}"/>.
@@ -4728,7 +4728,7 @@ namespace System.Linq
         /// </param>
         /// <param name="comparer">An IEqualityComparer&lt;(Of &lt;(T&gt;)&gt;) to compare values.</param>
         /// <returns>A sequence that contains the set difference of the elements of two sequences.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="first"/> or <paramref name="second"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Except<TSource>(
@@ -4749,7 +4749,7 @@ namespace System.Linq
         /// <param name="second">This parameter is not used.</param>
         /// <param name="comparer">This parameter is not used.</param>
         /// <returns>This overload always throws a <see cref="System.NotSupportedException"/>.</returns>
-        /// <exception cref="T:System.NotSupportedException">The exception that occurs when this method is called.</exception>
+        /// <exception cref="System.NotSupportedException">The exception that occurs when this method is called.</exception>
         /// <remarks>
         /// This overload exists to disallow usage of Except with a left data source of type
         /// <see cref="System.Linq.ParallelQuery{TSource}"/> and a right data source of type <see cref="System.Collections.Generic.IEnumerable{TSource}"/>.
@@ -4779,7 +4779,7 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The sequence to type as <see cref="System.Collections.Generic.IEnumerable{T}"/>.</param>
         /// <returns>The input sequence types as <see cref="System.Collections.Generic.IEnumerable{T}"/>.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static IEnumerable<TSource> AsEnumerable<TSource>(this ParallelQuery<TSource> source)
@@ -4798,13 +4798,13 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">A sequence to create an array from.</param>
         /// <returns>An array that contains the elements from the input sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource[] ToArray<TSource>(this ParallelQuery<TSource> source)
@@ -4832,13 +4832,13 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">A sequence to create a List&lt;(Of &lt;(T&gt;)&gt;) from.</param>
         /// <returns>A List&lt;(Of &lt;(T&gt;)&gt;) that contains elements from the input sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static List<TSource> ToList<TSource>(this ParallelQuery<TSource> source)
@@ -4910,17 +4910,17 @@ namespace System.Linq
         /// <param name="source">A sequence to create a Dictionary&lt;(Of &lt;(TKey, TValue&gt;)&gt;) from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <returns>A Dictionary&lt;(Of &lt;(TKey, TValue&gt;)&gt;) that contains keys and values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// <paramref name="keySelector"/> produces a key that is a null reference (Nothing in Visual Basic).
         /// -or-
         /// <paramref name="keySelector"/> produces duplicate keys for two elements.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(
@@ -4939,17 +4939,17 @@ namespace System.Linq
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="comparer">An IEqualityComparer&lt;(Of &lt;(T&gt;)&gt;) to compare keys.</param>
         /// <returns>A Dictionary&lt;(Of &lt;(TKey, TValue&gt;)&gt;) that contains keys and values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// <paramref name="keySelector"/> produces a key that is a null reference (Nothing in Visual Basic).
         /// -or-
         /// <paramref name="keySelector"/> produces duplicate keys for two elements.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(
@@ -5008,17 +5008,17 @@ namespace System.Linq
         /// A Dictionary&lt;(Of &lt;(TKey, TValue&gt;)&gt;) that contains values of type <typeparamref name="TElement"/> 
         /// selected from the input sequence
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> or <paramref name="elementSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// <paramref name="keySelector"/> produces a key that is a null reference (Nothing in Visual Basic).
         /// -or-
         /// <paramref name="keySelector"/> produces duplicate keys for two elements.
         /// -or- 
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(
@@ -5043,17 +5043,17 @@ namespace System.Linq
         /// A Dictionary&lt;(Of &lt;(TKey, TValue&gt;)&gt;) that contains values of type <typeparamref name="TElement"/> 
         /// selected from the input sequence
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> or <paramref name="elementSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// <paramref name="keySelector"/> produces a key that is a null reference (Nothing in Visual Basic).
         /// -or-
         /// <paramref name="keySelector"/> produces duplicate keys for two elements.
         /// -or-
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(
@@ -5111,13 +5111,13 @@ namespace System.Linq
         /// <param name="source">The sequence to create a Lookup&lt;(Of &lt;(TKey, TElement&gt;)&gt;) from.</param>
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <returns>A Lookup&lt;(Of &lt;(TKey, TElement&gt;)&gt;) that contains keys and values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static ILookup<TKey, TSource> ToLookup<TSource, TKey>(
@@ -5136,13 +5136,13 @@ namespace System.Linq
         /// <param name="keySelector">A function to extract a key from each element.</param>
         /// <param name="comparer">An IEqualityComparer&lt;(Of &lt;(T&gt;)&gt;) to compare keys.</param>
         /// <returns>A Lookup&lt;(Of &lt;(TKey, TElement&gt;)&gt;) that contains keys and values.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> or is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static ILookup<TKey, TSource> ToLookup<TSource, TKey>(
@@ -5190,13 +5190,13 @@ namespace System.Linq
         /// A Lookup&lt;(Of &lt;(TKey, TElement&gt;)&gt;) that contains values of type TElement 
         /// selected from the input sequence.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> or <paramref name="elementSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static ILookup<TKey, TElement> ToLookup<TSource, TKey, TElement>(
@@ -5222,13 +5222,13 @@ namespace System.Linq
         /// A Lookup&lt;(Of &lt;(TKey, TElement&gt;)&gt;) that contains values of type TElement selected 
         /// from the input sequence.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="keySelector"/> or <paramref name="elementSelector"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static ILookup<TKey, TElement> ToLookup<TSource, TKey, TElement>(
@@ -5275,7 +5275,7 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">A sequence of values to reverse.</param>
         /// <returns>A sequence whose elements correspond to those of the input sequence in reverse order.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> Reverse<TSource>(this ParallelQuery<TSource> source)
@@ -5296,7 +5296,7 @@ namespace System.Linq
         /// <typeparam name="TResult">The type to filter the elements of the sequence on.</typeparam>
         /// <param name="source">The sequence whose elements to filter.</param>
         /// <returns>A sequence that contains elements from the input sequence of type <typeparamref name="TResult"/>.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TResult> OfType<TResult>(this ParallelQuery source)
@@ -5314,7 +5314,7 @@ namespace System.Linq
         /// <returns>
         /// A sequence that contains each weakly-type element of the source sequence converted to the specified stronger type.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TResult> Cast<TResult>(this ParallelQuery source)
@@ -5391,16 +5391,16 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The sequence to return the first element of.</param>
         /// <returns>The first element in the specified sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource First<TSource>(this ParallelQuery<TSource> source)
@@ -5434,16 +5434,16 @@ namespace System.Linq
         /// <param name="source">The sequence to return an element from.</param>
         /// <param name="predicate">A function to test each element for a condition.</param>
         /// <returns>The first element in the sequence that passes the test in the specified predicate function.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// No element in <paramref name="source"/> satisfies the condition in <paramref name="predicate"/>.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource First<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -5476,13 +5476,13 @@ namespace System.Linq
         /// <returns>
         /// default(<B>TSource</B>) if <paramref name="source"/> is empty; otherwise, the first element in <paramref name="source"/>.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource FirstOrDefault<TSource>(this ParallelQuery<TSource> source)
@@ -5522,13 +5522,13 @@ namespace System.Linq
         /// specified by <B>predicate</B>; otherwise, the first element in <paramref name="source"/> that 
         /// passes the test specified by <B>predicate</B>.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource FirstOrDefault<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -5567,16 +5567,16 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The sequence to return the last element from.</param>
         /// <returns>The value at the last position in the source sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// <paramref name="source"/> contains no elements.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource Last<TSource>(this ParallelQuery<TSource> source)
@@ -5610,16 +5610,16 @@ namespace System.Linq
         /// <returns>
         /// The last element in the sequence that passes the test in the specified predicate function.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// No element in <paramref name="source"/> satisfies the condition in <paramref name="predicate"/>.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource Last<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -5654,13 +5654,13 @@ namespace System.Linq
         /// <returns>
         /// default(<typeparamref name="TSource"/>) if the source sequence is empty; otherwise, the last element in the sequence.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource LastOrDefault<TSource>(this ParallelQuery<TSource> source)
@@ -5696,13 +5696,13 @@ namespace System.Linq
         /// default(<typeparamref name="TSource"/>) if the sequence is empty or if no elements pass the test in the 
         /// predicate function; otherwise, the last element that passes the test in the predicate function.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource LastOrDefault<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -5741,16 +5741,16 @@ namespace System.Linq
         /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">The sequence to return the single element of.</param>
         /// <returns>The single element of the input sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The input sequence contains more than one element. -or- The input sequence is empty.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource Single<TSource>(this ParallelQuery<TSource> source)
@@ -5770,16 +5770,16 @@ namespace System.Linq
         /// <param name="source">The sequence to return the single element of.</param>
         /// <param name="predicate">A function to test an element for a condition.</param>
         /// <returns>The single element of the input sequence that satisfies a condition.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// No element satisfies the condition in <paramref name="predicate"/>. -or- More than one element satisfies the condition in <paramref name="predicate"/>.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource Single<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -5800,13 +5800,13 @@ namespace System.Linq
         /// The single element of the input sequence, or default(<typeparamref name="TSource"/>) if the 
         /// sequence contains no elements.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource SingleOrDefault<TSource>(this ParallelQuery<TSource> source)
@@ -5830,13 +5830,13 @@ namespace System.Linq
         /// The single element of the input sequence that satisfies the condition, or 
         /// default(<typeparamref name="TSource"/>) if no such element is found.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> or <paramref name="predicate"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource SingleOrDefault<TSource>(this ParallelQuery<TSource> source, Func<TSource, bool> predicate)
@@ -5861,7 +5861,7 @@ namespace System.Linq
         /// <returns>
         /// A sequence that contains default(<B>TSource</B>) if <paramref name="source"/> is empty; otherwise, <paramref name="source"/>.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> DefaultIfEmpty<TSource>(this ParallelQuery<TSource> source)
@@ -5879,7 +5879,7 @@ namespace System.Linq
         /// <returns>
         /// A sequence that contains <B>defaultValue</B> if <paramref name="source"/> is empty; otherwise, <paramref name="source"/>.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
         public static ParallelQuery<TSource> DefaultIfEmpty<TSource>(this ParallelQuery<TSource> source, TSource defaultValue)
@@ -5901,16 +5901,16 @@ namespace System.Linq
         /// <param name="source">A sequence to return an element from.</param>
         /// <param name="index">The zero-based index of the element to retrieve.</param>
         /// <returns>The element at the specified position in the source sequence.</returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <exception cref="System.ArgumentOutOfRangeException">
         /// <paramref name="index"/> is less than 0 or greater than or equal to the number of elements in <paramref name="source"/>.
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource ElementAt<TSource>(this ParallelQuery<TSource> source, int index)
@@ -5943,13 +5943,13 @@ namespace System.Linq
         /// default(<B>TSource</B>) if the index is outside the bounds of the source sequence; 
         /// otherwise, the element at the specified position in the source sequence.
         /// </returns>
-        /// <exception cref="T:System.ArgumentNullException">
+        /// <exception cref="System.ArgumentNullException">
         /// <paramref name="source"/> is a null reference (Nothing in Visual Basic).
         /// </exception>
-        /// <exception cref="T:System.AggregateException">
+        /// <exception cref="System.AggregateException">
         /// One or more exceptions occurred during the evaluation of the query.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException">
+        /// <exception cref="System.OperationCanceledException">
         /// The query was canceled.
         /// </exception>
         public static TSource ElementAtOrDefault<TSource>(this ParallelQuery<TSource> source, int index)

--- a/src/System.Linq/src/System/Linq/Concat.cs
+++ b/src/System.Linq/src/System/Linq/Concat.cs
@@ -114,7 +114,7 @@ namespace System.Linq
             /// </summary>
             /// <remarks>
             /// This flag allows us to determine in O(1) time whether we can preallocate for <see cref="ToArray"/>
-            /// and <see cref="M:System.Linq.Enumerable.ConcatIterator`1.ToList"/>, and whether we can get the count of the iterator cheaply.
+            /// and <see cref="System.Linq.Enumerable.ConcatIterator{T}.ToList"/>, and whether we can get the count of the iterator cheaply.
             /// </remarks>
             private readonly bool _hasOnlyCollections;
 

--- a/src/System.Linq/src/System/Linq/Concat.cs
+++ b/src/System.Linq/src/System/Linq/Concat.cs
@@ -113,8 +113,8 @@ namespace System.Linq
             /// otherwise, <c>false</c>.
             /// </summary>
             /// <remarks>
-            /// This flag allows us to determine in O(1) time whether we can preallocate for <see cref="ToArray"/>
-            /// and <see cref="System.Linq.Enumerable.ConcatIterator{T}.ToList"/>, and whether we can get the count of the iterator cheaply.
+            /// This flag allows us to determine in O(1) time whether we can preallocate for ToArray/ToList,
+            /// and whether we can get the count of the iterator cheaply.
             /// </remarks>
             private readonly bool _hasOnlyCollections;
 

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -150,7 +150,7 @@ namespace System.Linq
         }
 
         /// <summary>
-        /// An iterator that maps each item of a <see cref="T:TSource[]"/>.
+        /// An iterator that maps each item of a array.
         /// </summary>
         /// <typeparam name="TSource">The type of the source array.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>

--- a/src/System.Linq/src/System/Linq/SingleLinkedNode.cs
+++ b/src/System.Linq/src/System/Linq/SingleLinkedNode.cs
@@ -86,7 +86,7 @@ namespace System.Linq
         }
 
         /// <summary>
-        /// Returns an <see cref="T:TSource[]"/> that contains the items of this node's singly-linked list in reverse.
+        /// Returns an array that contains the items of this node's singly-linked list in reverse.
         /// </summary>
         /// <param name="count">The number of items in this node.</param>
         public TSource[] ToArray(int count)

--- a/src/System.Linq/src/System/Linq/Where.cs
+++ b/src/System.Linq/src/System/Linq/Where.cs
@@ -139,7 +139,7 @@ namespace System.Linq
         }
 
         /// <summary>
-        /// An iterator that filters each item of a <see cref="T:TSource[]"/>.
+        /// An iterator that filters each item of an array.
         /// </summary>
         /// <typeparam name="TSource">The type of the source array.</typeparam>
         internal sealed partial class WhereArrayIterator<TSource> : Iterator<TSource>
@@ -240,7 +240,7 @@ namespace System.Linq
         }
 
         /// <summary>
-        /// An iterator that filters, then maps, each item of a <see cref="T:TSource[]"/>.
+        /// An iterator that filters, then maps, each item of an array.
         /// </summary>
         /// <typeparam name="TSource">The type of the source array.</typeparam>
         /// <typeparam name="TResult">The type of the mapped items.</typeparam>

--- a/src/System.Management/src/System/Management/ManagementEventWatcher.cs
+++ b/src/System.Management/src/System/Management/ManagementEventWatcher.cs
@@ -9,12 +9,12 @@ using System.Threading;
 namespace System.Management
 {
     /// <summary>
-    /// <para>Represents the method that will handle the <see cref='E:System.Management.ManagementEventWatcher.EventArrived'/> event.</para>
+    /// <para>Represents the method that will handle the <see cref='System.Management.ManagementEventWatcher.EventArrived'/> event.</para>
     /// </summary>
     public delegate void EventArrivedEventHandler(object sender, EventArrivedEventArgs e);
 
     /// <summary>
-    /// <para>Represents the method that will handle the <see cref='E:System.Management.ManagementEventWatcher.Stopped'/> event.</para>
+    /// <para>Represents the method that will handle the <see cref='System.Management.ManagementEventWatcher.Stopped'/> event.</para>
     /// </summary>
     public delegate void StoppedEventHandler (object sender, StoppedEventArgs e);
 

--- a/src/System.Management/src/System/Management/ManagementOperationWatcher.cs
+++ b/src/System.Management/src/System/Management/ManagementOperationWatcher.cs
@@ -9,22 +9,22 @@ namespace System.Management
 {
 
     /// <summary>
-    /// <para>Represents the method that will handle the <see cref='E:System.Management.ManagementOperationObserver.ObjectReady'/> event.</para>
+    /// <para>Represents the method that will handle the <see cref='System.Management.ManagementOperationObserver.ObjectReady'/> event.</para>
     /// </summary>
     public delegate void ObjectReadyEventHandler(object sender, ObjectReadyEventArgs e);
 
     /// <summary>
-    /// <para>Represents the method that will handle the <see cref='E:System.Management.ManagementOperationObserver.Completed'/> event.</para>
+    /// <para>Represents the method that will handle the <see cref='System.Management.ManagementOperationObserver.Completed'/> event.</para>
     /// </summary>
     public delegate void CompletedEventHandler (object sender, CompletedEventArgs e);
 
     /// <summary>
-    /// <para>Represents the method that will handle the <see cref='E:System.Management.ManagementOperationObserver.Progress'/> event.</para>
+    /// <para>Represents the method that will handle the <see cref='System.Management.ManagementOperationObserver.Progress'/> event.</para>
     /// </summary>
     public delegate void ProgressEventHandler (object sender, ProgressEventArgs e);
 
     /// <summary>
-    /// <para>Represents the method that will handle the <see cref='E:System.Management.ManagementOperationObserver.ObjectPut'/> event.</para>
+    /// <para>Represents the method that will handle the <see cref='System.Management.ManagementOperationObserver.ObjectPut'/> event.</para>
     /// </summary>
     public delegate void ObjectPutEventHandler(object sender, ObjectPutEventArgs e);
 

--- a/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
+++ b/src/System.Memory/src/System/Buffers/ReadOnlySequence.cs
@@ -111,7 +111,7 @@ namespace System.Buffers
         }
 
         /// <summary>
-        /// Creates an instance of <see cref="ReadOnlySequence{T}"/> from the <see cref="T:T[]"/>.
+        /// Creates an instance of <see cref="ReadOnlySequence{T}"/> from the array.
         /// </summary>
         public ReadOnlySequence(T[] array)
         {
@@ -125,7 +125,7 @@ namespace System.Buffers
         }
 
         /// <summary>
-        /// Creates an instance of <see cref="ReadOnlySequence{T}"/> from the <see cref="T:T[]"/>, start and index.
+        /// Creates an instance of <see cref="ReadOnlySequence{T}"/> from the array, start, and index.
         /// </summary>
         public ReadOnlySequence(T[] array, int start, int length)
         {

--- a/src/System.Net.Primitives/src/System/Net/Sockets/AddressFamily.cs
+++ b/src/System.Net.Primitives/src/System/Net/Sockets/AddressFamily.cs
@@ -4,12 +4,7 @@
 
 namespace System.Net.Sockets
 {
-    /// <devdoc>
-    ///    <para>
-    ///       Specifies the address families that an instance of the <see cref='T:System.Net.Sockets.Socket'/>
-    ///       class can use.
-    ///    </para>
-    /// </devdoc>
+    /// <summary>Specifies the addressing scheme that an instance of the Socket class can use.</summary>
     public enum AddressFamily
     {
         Unknown = -1,           // Unknown

--- a/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ImmutableByteArrayInterop.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/ImmutableByteArrayInterop.cs
@@ -24,7 +24,7 @@ namespace System.Reflection.Internal
     /// This implementation is scoped to byte arrays as that is all that the metadata reader needs.
     /// 
     /// Also, since we don't have access to immutable collection internals, we use a trick involving
-    /// overlapping a <see cref="ImmutableArray{Byte}"/> with a <see cref="T:Byte[]"/> refer. While
+    /// overlapping a <see cref="ImmutableArray{Byte}"/> with an array reference. While
     /// unverifiable, it is valid. See ECMA-335, section II.10.7 Controlling instance layout:
     /// 
     /// "It is possible to overlap fields in this way, though offsets occupied by an object reference 
@@ -32,7 +32,7 @@ namespace System.Reflection.Internal
     /// another object reference. While one object reference can completely overlap another, this is
     /// unverifiable."
     /// 
-    /// Furthermore, the fact that <see cref="ImmutableArray{Byte}"/> backed by a single <see cref="T:Byte[]"/> 
+    /// Furthermore, the fact that <see cref="ImmutableArray{Byte}"/> backed by a single byte array
     /// field is something inherent to the design of ImmutableArray in order to get its performance
     /// characteristics and therefore something we (Microsoft) are comfortable defining as a contract that 
     /// can be depended upon as below.

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/AsyncInfo.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/AsyncInfo.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Foundation;
@@ -22,7 +21,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         #region Factory methods for creating "normal" IAsyncInfo instances backed by a Task created by a pastProvider delegate
 
         /// <summary>
-        /// Creates and starts an <see cref="T:Windows.Foundation.IAsyncAction"/> instance from a function that generates
+        /// Creates and starts an <see cref="IAsyncAction"/> instance from a function that generates
         /// a <see cref="System.Threading.Tasks.Task"/>.
         /// Use this overload if your task supports cancellation in order to hook-up the <code>Cancel</code>
         /// mechanism exposed by the created asynchronous action and the cancellation of your task.</summary>
@@ -30,7 +29,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         /// The function is passed a <see cref="System.Threading.CancellationToken"/> that the task may monitor
         /// to be notified of a cancellation request;
         /// you may ignore the <code>CancellationToken</code> if your task does not support cancellation.</param>
-        /// <returns>An unstarted <see cref="T:Windows.Foundation.IAsyncAction"/> instance. </returns>
+        /// <returns>An unstarted <see cref="IAsyncAction"/> instance. </returns>
         public static IAsyncAction Run(Func<CancellationToken, Task> taskProvider)
         {
             if (taskProvider == null)
@@ -41,7 +40,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
 
         /// <summary>
-        /// Creates and starts an <see cref="T:Windows.Foundation.IAsyncActionWithProgress`1"/> instance from a function
+        /// Creates and starts an <see cref="IAsyncActionWithProgress{TProgress}"/> instance from a function
         /// that generates a <see cref="System.Threading.Tasks.Task"/>.
         /// Use this overload if your task supports cancellation and progress monitoring is order to:
         /// (1) hook-up the <code>Cancel</code> mechanism of the created asynchronous action and the cancellation of your task,
@@ -53,7 +52,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         /// you may ignore the <code>CancellationToken</code> if your task does not support cancellation.
         /// It is also passed a <see cref="System.IProgress{TProgress}"/> instance to which progress updates may be published;
         /// you may ignore the <code>IProgress</code> if your task does not support progress reporting.</param>
-        /// <returns>An unstarted <see cref="T:Windows.Foundation.IAsyncActionWithProgress`1"/> instance.</returns>
+        /// <returns>An unstarted <see cref="IAsyncActionWithProgress{TProgress}"/> instance.</returns>
         public static IAsyncActionWithProgress<TProgress> Run<TProgress>(Func<CancellationToken, IProgress<TProgress>, Task> taskProvider)
         {
             if (taskProvider == null)
@@ -64,7 +63,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
 
         /// <summary>
-        /// Creates and starts  an <see cref="T:Windows.Foundation.IAsyncOperation`1"/> instance from a function
+        /// Creates and starts  an <see cref="IAsyncOperation{TResult}"/> instance from a function
         /// that generates a <see cref="System.Threading.Tasks.Task{TResult}"/>.
         /// Use this overload if your task supports cancellation in order to hook-up the <code>Cancel</code>
         /// mechanism exposed by the created asynchronous operation and the cancellation of your task.</summary>
@@ -72,7 +71,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         /// The function is passed a <see cref="System.Threading.CancellationToken"/> that the task may monitor
         /// to be notified of a cancellation request;
         /// you may ignore the <code>CancellationToken</code> if your task does not support cancellation.</param>
-        /// <returns>An unstarted <see cref="T:Windows.Foundation.IAsyncOperation`1"/> instance.</returns>
+        /// <returns>An unstarted <see cref="IAsyncOperation{TResult}"/> instance.</returns>
         public static IAsyncOperation<TResult> Run<TResult>(Func<CancellationToken, Task<TResult>> taskProvider)
         {
             // This is only internal to reduce the number of public overloads.
@@ -86,7 +85,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
 
 
         /// <summary>
-        /// Creates and starts  an <see cref="T:Windows.Foundation.IAsyncOperationWithProgress`2"/> instance
+        /// Creates and starts  an <see cref="IAsyncOperationWithProgress{TResult, TProgress}"/> instance
         /// from a function that generates a <see cref="System.Threading.Tasks.Task{TResult}"/>.<br />
         /// Use this overload if your task supports cancellation and progress monitoring is order to:
         /// (1) hook-up the <code>Cancel</code> mechanism of the created asynchronous operation and the cancellation of your task,
@@ -100,7 +99,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
         /// you may ignore the <code>CancellationToken</code> if your task does not support cancellation.
         /// It is also passed a <see cref="System.IProgress{TProgress}"/> instance to which progress updates may be published;
         /// you may ignore the <code>IProgress</code> if your task does not support progress reporting.</param>
-        /// <returns>An unstarted <see cref="T:Windows.Foundation.IAsyncOperationWithProgress`2"/> instance.</returns>
+        /// <returns>An unstarted <see cref="IAsyncOperationWithProgress{TResult, TProgress}"/> instance.</returns>
         public static IAsyncOperationWithProgress<TResult, TProgress> Run<TResult, TProgress>(
                                                                             Func<CancellationToken, IProgress<TProgress>, Task<TResult>> taskProvider)
         {

--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
@@ -227,7 +227,7 @@ namespace System.Threading.Tasks.Dataflow
         #endregion
 
         #region Post and SendAsync
-        /// <summary>Posts an item to the <see cref="T:System.Threading.Tasks.Dataflow.ITargetBlock`1"/>.</summary>
+        /// <summary>Posts an item to the <see cref="System.Threading.Tasks.Dataflow.ITargetBlock{T}"/>.</summary>
         /// <typeparam name="TInput">Specifies the type of data accepted by the target block.</typeparam>
         /// <param name="target">The target block.</param>
         /// <param name="item">The item being offered to the target.</param>
@@ -235,11 +235,11 @@ namespace System.Threading.Tasks.Dataflow
         /// <remarks>
         /// This method will return once the target block has decided to accept or decline the item,
         /// but unless otherwise dictated by special semantics of the target block, it does not wait
-        /// for the item to actually be processed (for example, <see cref="T:System.Threading.Tasks.Dataflow.ActionBlock`1"/>
+        /// for the item to actually be processed (for example, <see cref="System.Threading.Tasks.Dataflow.ActionBlock{T}"/>
         /// will return from Post as soon as it has stored the posted item into its input queue).  From the perspective
         /// of the block's processing, Post is asynchronous. For target blocks that support postponing offered messages, 
         /// or for blocks that may do more processing in their Post implementation, consider using
-        ///  <see cref="T:System.Threading.Tasks.Dataflow.DataflowBlock.SendAsync">SendAsync</see>, 
+        /// <see cref="System.Threading.Tasks.Dataflow.DataflowBlock.SendAsync{TInput}(ITargetBlock{TInput}, TInput)">SendAsync</see>, 
         /// which will return immediately and will enable the target to postpone the posted message and later consume it 
         /// after SendAsync returns.
         /// </remarks>
@@ -766,7 +766,7 @@ namespace System.Threading.Tasks.Dataflow
         #region TryReceive, ReceiveAsync, and Receive
         #region TryReceive
         /// <summary>
-        /// Attempts to synchronously receive an item from the <see cref="T:System.Threading.Tasks.Dataflow.ISourceBlock`1"/>.
+        /// Attempts to synchronously receive an item from the <see cref="System.Threading.Tasks.Dataflow.ISourceBlock{T}"/>.
         /// </summary>
         /// <param name="source">The source from which to receive.</param>
         /// <param name="item">The item received from the source.</param>
@@ -2716,7 +2716,7 @@ namespace System.Threading.Tasks.Dataflow
         /// Gets a target block that synchronously accepts all messages offered to it and drops them.
         /// </summary>
         /// <typeparam name="TInput">The type of the messages this block can accept.</typeparam>
-        /// <returns>A <see cref="T:System.Threading.Tasks.Dataflow.ITargetBlock`1"/> that accepts and subsequently drops all offered messages.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Dataflow.ITargetBlock{T}"/> that accepts and subsequently drops all offered messages.</returns>
         public static ITargetBlock<TInput> NullTarget<TInput>()
         {
             return new NullTargetBlock<TInput>();

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/ActionBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/ActionBlock.cs
@@ -250,17 +250,17 @@ namespace System.Threading.Tasks.Dataflow
             get { return _defaultTarget != null ? _defaultTarget.Completion : _spscTarget.Completion; }
         }
 
-        /// <summary>Posts an item to the <see cref="T:System.Threading.Tasks.Dataflow.ITargetBlock`1"/>.</summary>
+        /// <summary>Posts an item to the <see cref="System.Threading.Tasks.Dataflow.ITargetBlock{T}"/>.</summary>
         /// <param name="item">The item being offered to the target.</param>
         /// <returns>true if the item was accepted by the target block; otherwise, false.</returns>
         /// <remarks>
         /// This method will return once the target block has decided to accept or decline the item,
         /// but unless otherwise dictated by special semantics of the target block, it does not wait
-        /// for the item to actually be processed (for example, <see cref="T:System.Threading.Tasks.Dataflow.ActionBlock`1"/>
+        /// for the item to actually be processed (for example, <see cref="System.Threading.Tasks.Dataflow.ActionBlock{T}"/>
         /// will return from Post as soon as it has stored the posted item into its input queue).  From the perspective
         /// of the block's processing, Post is asynchronous. For target blocks that support postponing offered messages, 
         /// or for blocks that may do more processing in their Post implementation, consider using
-        ///  <see cref="T:System.Threading.Tasks.Dataflow.DataflowBlock.SendAsync">SendAsync</see>, 
+        /// <see cref="System.Threading.Tasks.Dataflow.DataflowBlock.SendAsync{TInput}(ITargetBlock{TInput}, TInput)">SendAsync</see>, 
         /// which will return immediately and will enable the target to postpone the posted message and later consume it 
         /// after SendAsync returns.
         /// </remarks>

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/ConcurrentQueue.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/ConcurrentQueue.cs
@@ -79,7 +79,7 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
         /// </summary>
         /// <param name="collection">The collection whose elements are copied to the new <see
         /// cref="ConcurrentQueue{T}"/>.</param>
-        /// <exception cref="T:System.ArgumentNullException">The <paramref name="collection"/> argument is
+        /// <exception cref="System.ArgumentNullException">The <paramref name="collection"/> argument is
         /// null.</exception>
         public ConcurrentQueue(IEnumerable<T> collection)
         {
@@ -92,14 +92,14 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
         }
 
         /// <summary>
-        /// Copies the elements of the <see cref="T:System.Collections.ICollection"/> to an <see
-        /// cref="T:System.Array"/>, starting at a particular
-        /// <see cref="T:System.Array"/> index.
+        /// Copies the elements of the <see cref="System.Collections.ICollection"/> to an <see
+        /// cref="System.Array"/>, starting at a particular
+        /// <see cref="System.Array"/> index.
         /// </summary>
-        /// <param name="array">The one-dimensional <see cref="T:System.Array">Array</see> that is the
+        /// <param name="array">The one-dimensional <see cref="System.Array">Array</see> that is the
         /// destination of the elements copied from the
-        /// <see cref="T:System.Collections.Concurrent.ConcurrentBag"/>. The <see
-        /// cref="T:System.Array">Array</see> must have zero-based indexing.</param>
+        /// <see cref="System.Collections.Concurrent.ConcurrentBag"/>. The <see
+        /// cref="System.Array">Array</see> must have zero-based indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
         /// begins.</param>
         /// <exception cref="ArgumentNullException"><paramref name="array"/> is a null reference (Nothing in
@@ -110,10 +110,10 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
         /// <paramref name="array"/> is multidimensional. -or-
         /// <paramref name="array"/> does not have zero-based indexing. -or-
         /// <paramref name="index"/> is equal to or greater than the length of the <paramref name="array"/>
-        /// -or- The number of elements in the source <see cref="T:System.Collections.ICollection"/> is
+        /// -or- The number of elements in the source <see cref="System.Collections.ICollection"/> is
         /// greater than the available space from <paramref name="index"/> to the end of the destination
         /// <paramref name="array"/>. -or- The type of the source <see
-        /// cref="T:System.Collections.ICollection"/> cannot be cast automatically to the type of the
+        /// cref="System.Collections.ICollection"/> cannot be cast automatically to the type of the
         /// destination <paramref name="array"/>.
         /// </exception>
         void ICollection.CopyTo(Array array, int index)
@@ -132,10 +132,10 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
         }
 
         /// <summary>
-        /// Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection"/> is
+        /// Gets a value indicating whether access to the <see cref="System.Collections.ICollection"/> is
         /// synchronized with the SyncRoot.
         /// </summary>
-        /// <value>true if access to the <see cref="T:System.Collections.ICollection"/> is synchronized
+        /// <value>true if access to the <see cref="System.Collections.ICollection"/> is synchronized
         /// with the SyncRoot; otherwise, false. For <see cref="ConcurrentQueue{T}"/>, this property always
         /// returns false.</value>
         bool ICollection.IsSynchronized
@@ -150,9 +150,9 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
 
         /// <summary>
         /// Gets an object that can be used to synchronize access to the <see
-        /// cref="T:System.Collections.ICollection"/>. This property is not supported.
+        /// cref="System.Collections.ICollection"/>. This property is not supported.
         /// </summary>
-        /// <exception cref="T:System.NotSupportedException">The SyncRoot property is not supported.</exception>
+        /// <exception cref="System.NotSupportedException">The SyncRoot property is not supported.</exception>
         object ICollection.SyncRoot
         {
             get
@@ -164,7 +164,7 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
         /// <summary>
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
-        /// <returns>An <see cref="T:System.Collections.IEnumerator"/> that can be used to iterate through the collection.</returns>
+        /// <returns>An <see cref="System.Collections.IEnumerator"/> that can be used to iterate through the collection.</returns>
         IEnumerator IEnumerable.GetEnumerator()
         {
             return ((IEnumerable<T>)this).GetEnumerator();
@@ -172,10 +172,10 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
 
         /// <summary>
         /// Attempts to add an object to the <see
-        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
+        /// cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
         /// </summary>
         /// <param name="item">The object to add to the <see
-        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. The value can be a null
+        /// cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. The value can be a null
         /// reference (Nothing in Visual Basic) for reference types.
         /// </param>
         /// <returns>true if the object was added successfully; otherwise, false.</returns>
@@ -190,7 +190,7 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
 
         /// <summary>
         /// Attempts to remove and return an object from the <see
-        /// cref="T:System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
+        /// cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
         /// </summary>
         /// <param name="item">
         /// When this method returns, if the operation was successful, <paramref name="item"/> contains the
@@ -261,9 +261,9 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
 
         /// <summary>
         /// Copies the <see cref="ConcurrentQueue{T}"/> elements to a new <see
-        /// cref="T:System.Collections.Generic.List{T}"/>.
+        /// cref="System.Collections.Generic.List{T}"/>.
         /// </summary>
-        /// <returns>A new <see cref="T:System.Collections.Generic.List{T}"/> containing a snapshot of
+        /// <returns>A new <see cref="System.Collections.Generic.List{T}"/> containing a snapshot of
         /// elements copied from the <see cref="ConcurrentQueue{T}"/>.</returns>
         private List<T> ToList()
         {
@@ -380,11 +380,11 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
 
         /// <summary>
         /// Copies the <see cref="ConcurrentQueue{T}"/> elements to an existing one-dimensional <see
-        /// cref="T:System.Array">Array</see>, starting at the specified array index.
+        /// cref="System.Array">Array</see>, starting at the specified array index.
         /// </summary>
-        /// <param name="array">The one-dimensional <see cref="T:System.Array">Array</see> that is the
+        /// <param name="array">The one-dimensional <see cref="System.Array">Array</see> that is the
         /// destination of the elements copied from the
-        /// <see cref="ConcurrentQueue{T}"/>. The <see cref="T:System.Array">Array</see> must have zero-based
+        /// <see cref="ConcurrentQueue{T}"/>. The <see cref="System.Array">Array</see> must have zero-based
         /// indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
         /// begins.</param>
@@ -574,7 +574,7 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
         /// without removing it.
         /// </summary>
         /// <param name="result">When this method returns, <paramref name="result"/> contains an object from
-        /// the beginning of the <see cref="T:System.Collections.Concurrent.ConcurrentQueue{T}"/> or an
+        /// the beginning of the <see cref="System.Collections.Concurrent.ConcurrentQueue{T}"/> or an
         /// unspecified value if the operation failed.</param>
         /// <returns>true if and object was returned successfully; otherwise, false.</returns>
         public bool TryPeek(out T result)

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/ConcurrentQueue.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/ConcurrentQueue.cs
@@ -98,7 +98,7 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
         /// </summary>
         /// <param name="array">The one-dimensional <see cref="System.Array">Array</see> that is the
         /// destination of the elements copied from the
-        /// <see cref="System.Collections.Concurrent.ConcurrentBag"/>. The <see
+        /// <see cref="ConcurrentQueue{T}"/>. The <see
         /// cref="System.Array">Array</see> must have zero-based indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
         /// begins.</param>
@@ -172,10 +172,10 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
 
         /// <summary>
         /// Attempts to add an object to the <see
-        /// cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
+        /// cref="IProducerConsumerCollection{T}"/>.
         /// </summary>
         /// <param name="item">The object to add to the <see
-        /// cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>. The value can be a null
+        /// cref="IProducerConsumerCollection{T}"/>. The value can be a null
         /// reference (Nothing in Visual Basic) for reference types.
         /// </param>
         /// <returns>true if the object was added successfully; otherwise, false.</returns>
@@ -190,7 +190,7 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
 
         /// <summary>
         /// Attempts to remove and return an object from the <see
-        /// cref="System.Collections.Concurrent.IProducerConsumerCollection{T}"/>.
+        /// cref="IProducerConsumerCollection{T}"/>.
         /// </summary>
         /// <param name="item">
         /// When this method returns, if the operation was successful, <paramref name="item"/> contains the
@@ -574,7 +574,7 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
         /// without removing it.
         /// </summary>
         /// <param name="result">When this method returns, <paramref name="result"/> contains an object from
-        /// the beginning of the <see cref="System.Collections.Concurrent.ConcurrentQueue{T}"/> or an
+        /// the beginning of the <see cref="ConcurrentQueue{T}"/> or an
         /// unspecified value if the operation failed.</param>
         /// <returns>true if and object was returned successfully; otherwise, false.</returns>
         public bool TryPeek(out T result)

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/IProducerConsumerCollection.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/IProducerConsumerCollection.cs
@@ -30,9 +30,9 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
         /// <summary>
         /// Copies the elements of the <see cref="IProducerConsumerCollection{T}"/> to
         /// an
-        /// <see cref="T:System.Array"/>, starting at a specified index.
+        /// <see cref="System.Array"/>, starting at a specified index.
         /// </summary>
-        /// <param name="array">The one-dimensional <see cref="T:System.Array"/> that is the destination of
+        /// <param name="array">The one-dimensional <see cref="System.Array"/> that is the destination of
         /// the elements copied from the <see cref="IProducerConsumerCollection{T}"/>.
         /// The array must have zero-based indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying
@@ -56,7 +56,7 @@ namespace System.Threading.Tasks.Dataflow.Internal.Collections
         /// <param name="item">The object to add to the <see
         /// cref="IProducerConsumerCollection{T}"/>.</param>
         /// <returns>true if the object was added successfully; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentException">The <paramref name="item"/> was invalid for this collection.</exception>
+        /// <exception cref="System.ArgumentException">The <paramref name="item"/> was invalid for this collection.</exception>
         bool TryAdd(T item);
 
         /// <summary>

--- a/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
+++ b/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
@@ -20,7 +20,7 @@ namespace System.Threading.Tasks
 {
     /// <summary>
     /// Stores options that configure the operation of methods on the 
-    /// <see cref="T:System.Threading.Tasks.Parallel">Parallel</see> class.
+    /// <see cref="System.Threading.Tasks.Parallel">Parallel</see> class.
     /// </summary>
     /// <remarks>
     /// By default, methods on the Parallel class attempt to utilize all available processors, are non-cancelable, and target
@@ -51,7 +51,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="T:System.Threading.Tasks.TaskScheduler">TaskScheduler</see> 
+        /// Gets or sets the <see cref="System.Threading.Tasks.TaskScheduler">TaskScheduler</see> 
         /// associated with this <see cref="ParallelOptions"/> instance. Setting this property to null
         /// indicates that the current scheduler should be used.
         /// </summary>
@@ -76,12 +76,12 @@ namespace System.Threading.Tasks
         /// </summary>
         /// <remarks>
         /// The <see cref="MaxDegreeOfParallelism"/> limits the number of concurrent operations run by <see
-        /// cref="T:System.Threading.Tasks.Parallel">Parallel</see> method calls that are passed this
+        /// cref="System.Threading.Tasks.Parallel">Parallel</see> method calls that are passed this
         /// ParallelOptions instance to the set value, if it is positive. If <see
         /// cref="MaxDegreeOfParallelism"/> is -1, then there is no limit placed on the number of concurrently
         /// running operations.
         /// </remarks>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">
+        /// <exception cref="System.ArgumentOutOfRangeException">
         /// The exception that is thrown when this <see cref="MaxDegreeOfParallelism"/> is set to 0 or some
         /// value less than -1.
         /// </exception>
@@ -97,15 +97,15 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="T:System.Threading.CancellationToken">CancellationToken</see>
+        /// Gets or sets the <see cref="System.Threading.CancellationToken">CancellationToken</see>
         /// associated with this <see cref="ParallelOptions"/> instance.
         /// </summary>
         /// <remarks>
-        /// Providing a <see cref="T:System.Threading.CancellationToken">CancellationToken</see>
-        /// to a <see cref="T:System.Threading.Tasks.Parallel">Parallel</see> method enables the operation to be
+        /// Providing a <see cref="System.Threading.CancellationToken">CancellationToken</see>
+        /// to a <see cref="System.Threading.Tasks.Parallel">Parallel</see> method enables the operation to be
         /// exited early. Code external to the operation may cancel the token, and if the operation observes the
         /// token being set, it may exit early by throwing an
-        /// <see cref="T:System.OperationCanceledException"/>.
+        /// <see cref="System.OperationCanceledException"/>.
         /// </remarks>
         public CancellationToken CancellationToken
         {
@@ -132,7 +132,7 @@ namespace System.Threading.Tasks
     /// Provides support for parallel loops and regions.
     /// </summary>
     /// <remarks>
-    /// The <see cref="T:System.Threading.Tasks.Parallel"/> class provides library-based data parallel replacements
+    /// The <see cref="System.Threading.Tasks.Parallel"/> class provides library-based data parallel replacements
     /// for common operations such as for loops, for each loops, and execution of a set of statements.
     /// </remarks>
     public static class Parallel
@@ -149,12 +149,12 @@ namespace System.Threading.Tasks
         /// <summary>
         /// Executes each of the provided actions, possibly in parallel.
         /// </summary>
-        /// <param name="actions">An array of <see cref="T:System.Action">Actions</see> to execute.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <param name="actions">An array of <see cref="System.Action">Actions</see> to execute.</param>
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="actions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentException">The exception that is thrown when the 
         /// <paramref name="actions"/> array contains a null element.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown when any
+        /// <exception cref="System.AggregateException">The exception that is thrown when any
         /// action in the <paramref name="actions"/> array throws an exception.</exception>
         /// <remarks>
         /// This method can be used to execute a set of operations, potentially in parallel.   
@@ -171,23 +171,23 @@ namespace System.Threading.Tasks
         /// <summary>
         /// Executes each of the provided actions, possibly in parallel.
         /// </summary>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
-        /// <param name="actions">An array of <see cref="T:System.Action">Actions</see> to execute.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <param name="actions">An array of <see cref="System.Action">Actions</see> to execute.</param>
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="actions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentException">The exception that is thrown when the 
         /// <paramref name="actions"/> array contains a null element.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> is set.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown when any 
+        /// <exception cref="System.AggregateException">The exception that is thrown when any 
         /// action in the <paramref name="actions"/> array throws an exception.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
         /// <remarks>
         /// This method can be used to execute a set of operations, potentially in parallel.   
@@ -382,11 +382,11 @@ namespace System.Threading.Tasks
         /// <param name="fromInclusive">The start index, inclusive.</param>
         /// <param name="toExclusive">The end index, exclusive.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each value in the iteration range: 
@@ -411,11 +411,11 @@ namespace System.Threading.Tasks
         /// <param name="fromInclusive">The start index, inclusive.</param>
         /// <param name="toExclusive">The end index, exclusive.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each value in the iteration range: 
@@ -438,23 +438,23 @@ namespace System.Threading.Tasks
         /// </summary>
         /// <param name="fromInclusive">The start index, inclusive.</param>
         /// <param name="toExclusive">The end index, exclusive.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each value in the iteration range: 
@@ -481,23 +481,23 @@ namespace System.Threading.Tasks
         /// </summary>
         /// <param name="fromInclusive">The start index, inclusive.</param>
         /// <param name="toExclusive">The end index, exclusive.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each value in the iteration range: 
@@ -525,11 +525,11 @@ namespace System.Threading.Tasks
         /// <param name="fromInclusive">The start index, inclusive.</param>
         /// <param name="toExclusive">The end index, exclusive.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
@@ -555,7 +555,7 @@ namespace System.Threading.Tasks
         /// which other iterations will not execute.
         /// </para>
         /// <para>
-        /// When a loop is ended prematurely, the <see cref="T:ParallelLoopState"/> that's returned will contain
+        /// When a loop is ended prematurely, the <see cref="ParallelLoopState"/> that's returned will contain
         /// relevant information about the loop's completion.
         /// </para>
         /// </remarks>
@@ -577,11 +577,11 @@ namespace System.Threading.Tasks
         /// <param name="fromInclusive">The start index, inclusive.</param>
         /// <param name="toExclusive">The end index, exclusive.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each value in the iteration range: 
@@ -606,23 +606,23 @@ namespace System.Threading.Tasks
         /// </summary>
         /// <param name="fromInclusive">The start index, inclusive.</param>
         /// <param name="toExclusive">The end index, exclusive.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each value in the iteration range: 
@@ -651,23 +651,23 @@ namespace System.Threading.Tasks
         /// </summary>
         /// <param name="fromInclusive">The start index, inclusive.</param>
         /// <param name="toExclusive">The end index, exclusive.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each value in the iteration range: 
@@ -703,15 +703,15 @@ namespace System.Threading.Tasks
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
@@ -765,15 +765,15 @@ namespace System.Threading.Tasks
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
@@ -822,31 +822,31 @@ namespace System.Threading.Tasks
         /// <typeparam name="TLocal">The type of the thread-local data.</typeparam>
         /// <param name="fromInclusive">The start index, inclusive.</param>
         /// <param name="toExclusive">The end index, exclusive.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="localInit">The function delegate that returns the initial state of the local data 
         /// for each thread.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
@@ -899,31 +899,31 @@ namespace System.Threading.Tasks
         /// <typeparam name="TLocal">The type of the thread-local data.</typeparam>
         /// <param name="fromInclusive">The start index, inclusive.</param>
         /// <param name="toExclusive">The end index, exclusive.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="localInit">The function delegate that returns the initial state of the local data 
         /// for each thread.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
@@ -1016,7 +1016,7 @@ namespace System.Threading.Tasks
         /// <param name="localInit">A selector function that returns new thread local state.</param>
         /// <param name="localFinally">A cleanup function to destroy thread local state.</param>
         /// <remarks>Only one of the body arguments may be supplied (i.e. they are exclusive).</remarks>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult"/> structure.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult"/> structure.</returns>
         private static ParallelLoopResult ForWorker<TLocal>(
             int fromInclusive, int toExclusive,
             ParallelOptions parallelOptions,
@@ -1277,7 +1277,7 @@ namespace System.Threading.Tasks
         /// <param name="localInit">A selector function that returns new thread local state.</param>
         /// <param name="localFinally">A cleanup function to destroy thread local state.</param>
         /// <remarks>Only one of the body arguments may be supplied (i.e. they are exclusive).</remarks>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult"/> structure.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult"/> structure.</returns>
         private static ParallelLoopResult ForWorker64<TLocal>(
             long fromInclusive, long toExclusive,
             ParallelOptions parallelOptions,
@@ -1526,19 +1526,19 @@ namespace System.Threading.Tasks
 
 
         /// <summary>
-        /// Executes a for each operation on an <see cref="T:System.Collections.IEnumerable{TSource}"/> 
+        /// Executes a for each operation on an <see cref="System.Collections.Generic.IEnumerable{TSource}"/> 
         /// in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the data in the source.</typeparam>
         /// <param name="source">An enumerable data source.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each element in the <paramref name="source"/> 
@@ -1560,30 +1560,30 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on an <see cref="T:System.Collections.IEnumerable{TSource}"/> 
+        /// Executes a for each operation on an <see cref="System.Collections.Generic.IEnumerable{TSource}"/> 
         /// in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the data in the source.</typeparam>
         /// <param name="source">An enumerable data source.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each element in the <paramref name="source"/> 
@@ -1609,19 +1609,19 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on an <see cref="T:System.Collections.IEnumerable{TSource}"/> 
+        /// Executes a for each operation on an <see cref="System.Collections.Generic.IEnumerable{TSource}"/> 
         /// in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the data in the source.</typeparam>
         /// <param name="source">An enumerable data source.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each element in the <paramref name="source"/> 
@@ -1645,30 +1645,30 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on an <see cref="T:System.Collections.IEnumerable{TSource}"/> 
+        /// Executes a for each operation on an <see cref="System.Collections.Generic.IEnumerable{TSource}"/> 
         /// in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the data in the source.</typeparam>
         /// <param name="source">An enumerable data source.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each element in the <paramref name="source"/> 
@@ -1696,19 +1696,19 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on an <see cref="T:System.Collections.IEnumerable{TSource}"/> 
+        /// Executes a for each operation on an <see cref="System.Collections.Generic.IEnumerable{TSource}"/> 
         /// in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the data in the source.</typeparam>
         /// <param name="source">An enumerable data source.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each element in the <paramref name="source"/> 
@@ -1732,30 +1732,30 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on an <see cref="T:System.Collections.IEnumerable{TSource}"/> 
+        /// Executes a for each operation on an <see cref="System.Collections.Generic.IEnumerable{TSource}"/> 
         /// in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the data in the source.</typeparam>
         /// <param name="source">An enumerable data source.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// The <paramref name="body"/> delegate is invoked once for each element in the <paramref name="source"/> 
@@ -1783,7 +1783,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on an <see cref="T:System.Collections.IEnumerable{TSource}"/> 
+        /// Executes a for each operation on an <see cref="System.Collections.Generic.IEnumerable{TSource}"/> 
         /// in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the data in the source.</typeparam>
@@ -1794,17 +1794,17 @@ namespace System.Threading.Tasks
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
@@ -1848,39 +1848,39 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on an <see cref="T:System.Collections.IEnumerable{TSource}"/> 
+        /// Executes a for each operation on an <see cref="System.Collections.Generic.IEnumerable{TSource}"/> 
         /// in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the data in the source.</typeparam>
         /// <typeparam name="TLocal">The type of the thread-local data.</typeparam>
         /// <param name="source">An enumerable data source.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="localInit">The function delegate that returns the initial state of the local data 
         /// for each thread.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
@@ -1929,7 +1929,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on an <see cref="T:System.Collections.IEnumerable{TSource}"/> 
+        /// Executes a for each operation on an <see cref="System.Collections.Generic.IEnumerable{TSource}"/> 
         /// in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the data in the source.</typeparam>
@@ -1940,17 +1940,17 @@ namespace System.Threading.Tasks
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
@@ -1994,39 +1994,39 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on an <see cref="T:System.Collections.IEnumerable{TSource}"/> 
+        /// Executes a for each operation on an <see cref="System.Collections.Generic.IEnumerable{TSource}"/> 
         /// in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the data in the source.</typeparam>
         /// <typeparam name="TLocal">The type of the thread-local data.</typeparam>
         /// <param name="source">An enumerable data source.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="localInit">The function delegate that returns the initial state of the local data 
         /// for each thread.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
@@ -2095,7 +2095,7 @@ namespace System.Threading.Tasks
         /// <param name="localInit">A selector function that returns new thread local state.</param>
         /// <param name="localFinally">A cleanup function to destroy thread local state.</param>
         /// <remarks>Only one of the bodyXX arguments may be supplied (i.e. they are exclusive).</remarks>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult"/> structure.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult"/> structure.</returns>
         private static ParallelLoopResult ForEachWorker<TSource, TLocal>(
             IEnumerable<TSource> source,
             ParallelOptions parallelOptions,
@@ -2155,7 +2155,7 @@ namespace System.Threading.Tasks
         /// <param name="bodyWithEverything">The loop body for the most generic overload.</param>
         /// <param name="localInit">A selector function that returns new thread local state.</param>
         /// <param name="localFinally">A cleanup function to destroy thread local state.</param>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult"/> structure.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult"/> structure.</returns>
         private static ParallelLoopResult ForEachWorker<TSource, TLocal>(
             TSource[] array,
             ParallelOptions parallelOptions,
@@ -2214,7 +2214,7 @@ namespace System.Threading.Tasks
         /// <param name="bodyWithEverything">The loop body for the most generic overload.</param>
         /// <param name="localInit">A selector function that returns new thread local state.</param>
         /// <param name="localFinally">A cleanup function to destroy thread local state.</param>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult"/> structure.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult"/> structure.</returns>
         private static ParallelLoopResult ForEachWorker<TSource, TLocal>(
             IList<TSource> list,
             ParallelOptions parallelOptions,
@@ -2258,39 +2258,39 @@ namespace System.Threading.Tasks
 
 
         /// <summary>
-        /// Executes a for each operation on a <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">
+        /// Executes a for each operation on a <see cref="System.Collections.Concurrent.Partitioner{TSource}">
         /// Partitioner</see> in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in <paramref name="source"/>.</typeparam>
         /// <param name="source">The Partitioner that contains the original data source.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// SupportsDynamicPartitions property in the <paramref name="source"/> Partitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when any 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when any 
         /// methods in the <paramref name="source"/> Partitioner return null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner does not return 
         /// the correct number of partitions.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner returns an IList 
         /// with at least one null value.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetDynamicPartitions() method in the <paramref name="source"/> Partitioner returns an 
         /// IEnumerable whose GetEnumerator() method returns null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
+        /// The <see cref="System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
         /// the elements to be processed, in place of the original data source.  If the current element's 
-        /// index is desired, the source must be an <see cref="T:System.Collections.Concurrent.OrderablePartitioner">
+        /// index is desired, the source must be an <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see>.
         /// </para>
         /// <para>
@@ -2315,39 +2315,39 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on a <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">
+        /// Executes a for each operation on a <see cref="System.Collections.Concurrent.Partitioner{TSource}">
         /// Partitioner</see> in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in <paramref name="source"/>.</typeparam>
         /// <param name="source">The Partitioner that contains the original data source.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// SupportsDynamicPartitions property in the <paramref name="source"/> Partitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when any 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when any 
         /// methods in the <paramref name="source"/> Partitioner return null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner does not return 
         /// the correct number of partitions.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner returns an IList 
         /// with at least one null value.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetDynamicPartitions() method in the <paramref name="source"/> Partitioner returns an 
         /// IEnumerable whose GetEnumerator() method returns null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
+        /// The <see cref="System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
         /// the elements to be processed, in place of the original data source.  If the current element's 
-        /// index is desired, the source must be an <see cref="T:System.Collections.Concurrent.OrderablePartitioner">
+        /// index is desired, the source must be an <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see>.
         /// </para>
         /// <para>
@@ -2374,42 +2374,42 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on a <see cref="T:System.Collections.Concurrent.OrderablePartitioner{TSource}">
+        /// Executes a for each operation on a <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see> in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in <paramref name="source"/>.</typeparam>
         /// <param name="source">The OrderablePartitioner that contains the original data source.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// SupportsDynamicPartitions property in the <paramref name="source"/> OrderablePartitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// KeysNormalized property in the <paramref name="source"/> OrderablePartitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when any 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when any 
         /// methods in the <paramref name="source"/> OrderablePartitioner return null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() or GetOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner do not return the correct number of partitions.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() or GetOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner return an IList with at least one null value.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetDynamicPartitions() or GetDynamicOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner return an IEnumerable whose GetEnumerator() method returns null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
+        /// The <see cref="System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
         /// the elements to be processed, in place of the original data source.  If the current element's 
-        /// index is desired, the source must be an <see cref="T:System.Collections.Concurrent.OrderablePartitioner">
+        /// index is desired, the source must be an <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see>.
         /// </para>
         /// <para>
@@ -2441,7 +2441,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on a <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">
+        /// Executes a for each operation on a <see cref="System.Collections.Concurrent.Partitioner{TSource}">
         /// Partitioner</see> in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in <paramref name="source"/>.</typeparam>
@@ -2452,37 +2452,37 @@ namespace System.Threading.Tasks
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// SupportsDynamicPartitions property in the <paramref name="source"/> Partitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when any 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when any 
         /// methods in the <paramref name="source"/> Partitioner return null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner does not return 
         /// the correct number of partitions.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner returns an IList 
         /// with at least one null value.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetDynamicPartitions() method in the <paramref name="source"/> Partitioner returns an 
         /// IEnumerable whose GetEnumerator() method returns null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
+        /// The <see cref="System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
         /// the elements to be processed, in place of the original data source.  If the current element's 
-        /// index is desired, the source must be an <see cref="T:System.Collections.Concurrent.OrderablePartitioner">
+        /// index is desired, the source must be an <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see>.
         /// </para>
         /// <para>
@@ -2528,7 +2528,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on a <see cref="T:System.Collections.Concurrent.OrderablePartitioner{TSource}">
+        /// Executes a for each operation on a <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see> in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in <paramref name="source"/>.</typeparam>
@@ -2539,40 +2539,40 @@ namespace System.Threading.Tasks
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// SupportsDynamicPartitions property in the <paramref name="source"/> OrderablePartitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// KeysNormalized property in the <paramref name="source"/> OrderablePartitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when any 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when any 
         /// methods in the <paramref name="source"/> OrderablePartitioner return null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() or GetOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner do not return the correct number of partitions.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() or GetOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner return an IList with at least one null value.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetDynamicPartitions() or GetDynamicOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner return an IEnumerable whose GetEnumerator() method returns null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
+        /// The <see cref="System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
         /// the elements to be processed, in place of the original data source.  If the current element's 
-        /// index is desired, the source must be an <see cref="T:System.Collections.Concurrent.OrderablePartitioner">
+        /// index is desired, the source must be an <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see>.
         /// </para>
         /// <para>
@@ -2623,50 +2623,50 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on a <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">
+        /// Executes a for each operation on a <see cref="System.Collections.Concurrent.Partitioner{TSource}">
         /// Partitioner</see> in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in <paramref name="source"/>.</typeparam>
         /// <param name="source">The Partitioner that contains the original data source.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// SupportsDynamicPartitions property in the <paramref name="source"/> Partitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when any 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when any 
         /// methods in the <paramref name="source"/> Partitioner return null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner does not return 
         /// the correct number of partitions.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner returns an IList 
         /// with at least one null value.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetDynamicPartitions() method in the <paramref name="source"/> Partitioner returns an 
         /// IEnumerable whose GetEnumerator() method returns null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
+        /// The <see cref="System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
         /// the elements to be processed, in place of the original data source.  If the current element's 
-        /// index is desired, the source must be an <see cref="T:System.Collections.Concurrent.OrderablePartitioner">
+        /// index is desired, the source must be an <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see>.
         /// </para>
         /// <para>
@@ -2696,50 +2696,50 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on a <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">
+        /// Executes a for each operation on a <see cref="System.Collections.Concurrent.Partitioner{TSource}">
         /// Partitioner</see> in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in <paramref name="source"/>.</typeparam>
         /// <param name="source">The Partitioner that contains the original data source.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// SupportsDynamicPartitions property in the <paramref name="source"/> Partitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when any 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when any 
         /// methods in the <paramref name="source"/> Partitioner return null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner does not return 
         /// the correct number of partitions.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner returns an IList 
         /// with at least one null value.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetDynamicPartitions() method in the <paramref name="source"/> Partitioner returns an 
         /// IEnumerable whose GetEnumerator() method returns null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
+        /// The <see cref="System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
         /// the elements to be processed, in place of the original data source.  If the current element's 
-        /// index is desired, the source must be an <see cref="T:System.Collections.Concurrent.OrderablePartitioner">
+        /// index is desired, the source must be an <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see>.
         /// </para>
         /// <para>
@@ -2771,53 +2771,53 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on a <see cref="T:System.Collections.Concurrent.OrderablePartitioner{TSource}">
+        /// Executes a for each operation on a <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see> in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in <paramref name="source"/>.</typeparam>
         /// <param name="source">The OrderablePartitioner that contains the original data source.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// SupportsDynamicPartitions property in the <paramref name="source"/> OrderablePartitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// KeysNormalized property in the <paramref name="source"/> OrderablePartitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when any 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when any 
         /// methods in the <paramref name="source"/> OrderablePartitioner return null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() or GetOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner do not return the correct number of partitions.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() or GetOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner return an IList with at least one null value.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetDynamicPartitions() or GetDynamicOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner return an IEnumerable whose GetEnumerator() method returns null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
+        /// The <see cref="System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
         /// the elements to be processed, in place of the original data source.  If the current element's 
-        /// index is desired, the source must be an <see cref="T:System.Collections.Concurrent.OrderablePartitioner">
+        /// index is desired, the source must be an <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see>.
         /// </para>
         /// <para>
@@ -2854,59 +2854,59 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on a <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">
+        /// Executes a for each operation on a <see cref="System.Collections.Concurrent.Partitioner{TSource}">
         /// Partitioner</see> in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in <paramref name="source"/>.</typeparam>
         /// <typeparam name="TLocal">The type of the thread-local data.</typeparam>
         /// <param name="source">The Partitioner that contains the original data source.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="localInit">The function delegate that returns the initial state of the local data 
         /// for each thread.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// SupportsDynamicPartitions property in the <paramref name="source"/> Partitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when any 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when any 
         /// methods in the <paramref name="source"/> Partitioner return null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner does not return 
         /// the correct number of partitions.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() method in the <paramref name="source"/> Partitioner returns an IList 
         /// with at least one null value.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetDynamicPartitions() method in the <paramref name="source"/> Partitioner returns an 
         /// IEnumerable whose GetEnumerator() method returns null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
+        /// The <see cref="System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
         /// the elements to be processed, in place of the original data source.  If the current element's 
-        /// index is desired, the source must be an <see cref="T:System.Collections.Concurrent.OrderablePartitioner">
+        /// index is desired, the source must be an <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see>.
         /// </para>
         /// <para>
@@ -2957,62 +2957,62 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Executes a for each operation on a <see cref="T:System.Collections.Concurrent.OrderablePartitioner{TSource}">
+        /// Executes a for each operation on a <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see> in which iterations may run in parallel.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in <paramref name="source"/>.</typeparam>
         /// <typeparam name="TLocal">The type of the thread-local data.</typeparam>
         /// <param name="source">The OrderablePartitioner that contains the original data source.</param>
-        /// <param name="parallelOptions">A <see cref="T:System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
+        /// <param name="parallelOptions">A <see cref="System.Threading.Tasks.ParallelOptions">ParallelOptions</see> 
         /// instance that configures the behavior of this operation.</param>
         /// <param name="localInit">The function delegate that returns the initial state of the local data 
         /// for each thread.</param>
         /// <param name="body">The delegate that is invoked once per iteration.</param>
         /// <param name="localFinally">The delegate that performs a final action on the local state of each
         /// thread.</param>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="source"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="parallelOptions"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the <paramref name="body"/> 
         /// argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localInit"/> argument is null.</exception>
-        /// <exception cref="T:System.ArgumentNullException">The exception that is thrown when the 
+        /// <exception cref="System.ArgumentNullException">The exception that is thrown when the 
         /// <paramref name="localFinally"/> argument is null.</exception>
-        /// <exception cref="T:System.OperationCanceledException">The exception that is thrown when the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
+        /// <exception cref="System.OperationCanceledException">The exception that is thrown when the 
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> in the <paramref name="parallelOptions"/> 
         /// argument is set</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// SupportsDynamicPartitions property in the <paramref name="source"/> OrderablePartitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// KeysNormalized property in the <paramref name="source"/> OrderablePartitioner returns 
         /// false.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when any 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when any 
         /// methods in the <paramref name="source"/> OrderablePartitioner return null.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() or GetOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner do not return the correct number of partitions.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetPartitions() or GetOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner return an IList with at least one null value.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The exception that is thrown when the 
+        /// <exception cref="System.InvalidOperationException">The exception that is thrown when the 
         /// GetDynamicPartitions() or GetDynamicOrderablePartitions() methods in the <paramref name="source"/> 
         /// OrderablePartitioner return an IEnumerable whose GetEnumerator() method returns null.</exception>
-        /// <exception cref="T:System.AggregateException">The exception that is thrown to contain an exception
+        /// <exception cref="System.AggregateException">The exception that is thrown to contain an exception
         /// thrown from one of the specified delegates.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The exception that is thrown when the 
-        /// the <see cref="T:System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
-        /// the <see cref="T:System.Threading.CancellationToken">CancellationToken</see> in the 
+        /// <exception cref="System.ObjectDisposedException">The exception that is thrown when the 
+        /// the <see cref="System.Threading.CancellationTokenSource">CancellationTokenSource</see> associated with the 
+        /// the <see cref="System.Threading.CancellationToken">CancellationToken</see> in the 
         /// <paramref name="parallelOptions"/> has been disposed.</exception>
-        /// <returns>A <see cref="T:System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
+        /// <returns>A <see cref="System.Threading.Tasks.ParallelLoopResult">ParallelLoopResult</see> structure
         /// that contains information on what portion of the loop completed.</returns>
         /// <remarks>
         /// <para>
-        /// The <see cref="T:System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
+        /// The <see cref="System.Collections.Concurrent.Partitioner{TSource}">Partitioner</see> is used to retrieve 
         /// the elements to be processed, in place of the original data source.  If the current element's 
-        /// index is desired, the source must be an <see cref="T:System.Collections.Concurrent.OrderablePartitioner">
+        /// index is desired, the source must be an <see cref="System.Collections.Concurrent.OrderablePartitioner{TSource}">
         /// OrderablePartitioner</see>.
         /// </para>
         /// <para>

--- a/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelLoopState.cs
+++ b/src/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/ParallelLoopState.cs
@@ -16,7 +16,7 @@ using System.Diagnostics;
 namespace System.Threading.Tasks
 {
     /// <summary>
-    /// Enables iterations of <see cref="T:System.Threading.Tasks.Parallel"/> loops to interact with
+    /// Enables iterations of <see cref="System.Threading.Tasks.Parallel"/> loops to interact with
     /// other iterations.
     /// </summary>
     [DebuggerDisplay("ShouldExitCurrentIteration = {ShouldExitCurrentIteration}")]
@@ -120,7 +120,7 @@ namespace System.Threading.Tasks
         /// Communicates that the <see cref="Parallel"/> loop should cease execution at the system's earliest
         /// convenience.
         /// </summary>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The <see cref="Break()"/> method was previously called.  <see cref="Break()"/> and <see
         /// cref="Stop()"/> may not be used in combination by iterations of the same loop.
         /// </exception>
@@ -153,7 +153,7 @@ namespace System.Threading.Tasks
         /// Communicates that the <see cref="Parallel"/> loop should cease execution at the system's earliest
         /// convenience of iterations beyond the current iteration.
         /// </summary>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The <see cref="Stop()"/> method was previously called. <see cref="Break()"/> and <see cref="Stop()"/>
         /// may not be used in combination by iterations of the same loop.
         /// </exception>
@@ -312,7 +312,7 @@ namespace System.Threading.Tasks
         /// Communicates that parallel tasks should stop when they reach a specified iteration element.
         /// (which is CurrentIteration of the caller).
         /// </summary>
-        /// <exception cref="T:System.InvalidOperationException">Break() called after Stop().</exception>
+        /// <exception cref="System.InvalidOperationException">Break() called after Stop().</exception>
         /// <remarks>
         /// This is shared with all other concurrent threads in the system which are participating in the
         /// loop's execution. After calling Break(), no additional iterations will be executed on
@@ -380,7 +380,7 @@ namespace System.Threading.Tasks
         /// Communicates that parallel tasks should stop when they reach a specified iteration element.
         /// (which is CurrentIteration of the caller).
         /// </summary>
-        /// <exception cref="T:System.InvalidOperationException">Break() called after Stop().</exception>
+        /// <exception cref="System.InvalidOperationException">Break() called after Stop().</exception>
         /// <remarks>
         /// Atomically sets shared StoppedBroken flag to BROKEN, then atomically sets shared 
         /// LowestBreakIteration to CurrentIteration, but only if CurrentIteration is less than 

--- a/src/System.Threading/src/System/Threading/Barrier.cs
+++ b/src/System.Threading/src/System/Threading/Barrier.cs
@@ -193,7 +193,7 @@ namespace System.Threading
         /// </summary>
         /// <param name="participantCount">The number of participating threads.</param>
         /// <exception cref="ArgumentOutOfRangeException"> <paramref name="participantCount"/> is less than 0
-        /// or greater than <see cref="T:System.Int16.MaxValue"/>.</exception>
+        /// or greater than <see cref="System.Int16.MaxValue"/>.</exception>
         public Barrier(int participantCount)
             : this(participantCount, null)
         {
@@ -203,10 +203,10 @@ namespace System.Threading
         /// Initializes a new instance of the <see cref="Barrier"/> class.
         /// </summary>
         /// <param name="participantCount">The number of participating threads.</param>
-        /// <param name="postPhaseAction">The <see cref="T:System.Action`1"/> to be executed after each
+        /// <param name="postPhaseAction">The <see cref="System.Action{Barrier}"/> to be executed after each
         /// phase.</param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"> <paramref name="participantCount"/> is less than 0
-        /// or greater than <see cref="T:System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException"> <paramref name="participantCount"/> is less than 0
+        /// or greater than <see cref="System.Int32.MaxValue"/>.</exception>
         /// <remarks>
         /// The <paramref name="postPhaseAction"/> delegate will be executed after
         /// all participants have arrived at the barrier in one phase.  The participants
@@ -275,14 +275,14 @@ namespace System.Threading
         /// </summary>
         /// <returns>The phase number of the barrier in which the new participants will first
         /// participate.</returns>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// Adding a participant would cause the barrier's participant count to 
-        /// exceed <see cref="T:System.Int16.MaxValue"/>.
+        /// exceed <see cref="System.Int16.MaxValue"/>.
         /// </exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The method was invoked from within a post-phase action.
         /// </exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public long AddParticipant()
         {
@@ -303,14 +303,14 @@ namespace System.Threading
         /// barrier.</param>
         /// <returns>The phase number of the barrier in which the new participants will first
         /// participate.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="participantCount"/> is less than
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="participantCount"/> is less than
         /// 0.</exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException">Adding <paramref name="participantCount"/> participants would cause the
-        /// barrier's participant count to exceed <see cref="T:System.Int16.MaxValue"/>.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.ArgumentOutOfRangeException">Adding <paramref name="participantCount"/> participants would cause the
+        /// barrier's participant count to exceed <see cref="System.Int16.MaxValue"/>.</exception>
+        /// <exception cref="System.InvalidOperationException">
         /// The method was invoked from within a post-phase action.
         /// </exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public long AddParticipants(int participantCount)
         {
@@ -393,12 +393,12 @@ namespace System.Threading
         /// <summary>
         /// Notifies the <see cref="Barrier"/> that there will be one less participant.
         /// </summary>
-        /// <exception cref="T:System.InvalidOperationException">The barrier already has 0
+        /// <exception cref="System.InvalidOperationException">The barrier already has 0
         /// participants.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The method was invoked from within a post-phase action.
         /// </exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public void RemoveParticipant()
         {
@@ -409,13 +409,13 @@ namespace System.Threading
         /// Notifies the <see cref="Barrier"/> that there will be fewer participants.
         /// </summary>
         /// <param name="participantCount">The number of additional participants to remove from the barrier.</param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="participantCount"/> is less than
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="participantCount"/> is less than
         /// 0.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The barrier already has 0 participants.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">The barrier already has 0 participants.</exception>
+        /// <exception cref="System.InvalidOperationException">
         /// The method was invoked from within a post-phase action.
         /// </exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public void RemoveParticipants(int participantCount)
         {
@@ -478,11 +478,11 @@ namespace System.Threading
         /// Signals that a participant has reached the <see cref="Barrier"/> and waits for all other
         /// participants to reach the barrier as well.
         /// </summary>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The method was invoked from within a post-phase action, the barrier currently has 0 participants,
         /// or the barrier is being used by more threads than are registered as participants.
         /// </exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public void SignalAndWait()
         {
@@ -492,17 +492,17 @@ namespace System.Threading
         /// <summary>
         /// Signals that a participant has reached the <see cref="Barrier"/> and waits for all other
         /// participants to reach the barrier, while observing a <see
-        /// cref="T:System.Threading.CancellationToken"/>.
+        /// cref="System.Threading.CancellationToken"/>.
         /// </summary>
-        /// <param name="cancellationToken">The <see cref="T:System.Threading.CancellationToken"/> to
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> to
         /// observe.</param>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The method was invoked from within a post-phase action, the barrier currently has 0 participants,
         /// or the barrier is being used by more threads than are registered as participants.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException"><paramref name="cancellationToken"/> has been
+        /// <exception cref="System.OperationCanceledException"><paramref name="cancellationToken"/> has been
         /// canceled.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public void SignalAndWait(CancellationToken cancellationToken)
         {
@@ -518,20 +518,20 @@ namespace System.Threading
         /// <summary>
         /// Signals that a participant has reached the <see cref="Barrier"/> and waits for all other
         /// participants to reach the barrier as well, using a
-        /// <see cref="T:System.TimeSpan"/> to measure the time interval.
+        /// <see cref="System.TimeSpan"/> to measure the time interval.
         /// </summary>
-        /// <param name="timeout">A <see cref="T:System.TimeSpan"/> that represents the number of
-        /// milliseconds to wait, or a <see cref="T:System.TimeSpan"/> that represents -1 milliseconds to
+        /// <param name="timeout">A <see cref="System.TimeSpan"/> that represents the number of
+        /// milliseconds to wait, or a <see cref="System.TimeSpan"/> that represents -1 milliseconds to
         /// wait indefinitely.</param>
         /// <returns>true if all other participants reached the barrier; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="timeout"/>is a negative number
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="timeout"/>is a negative number
         /// other than -1 milliseconds, which represents an infinite time-out, or it is greater than
-        /// <see cref="T:System.Int32.MaxValue"/>.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <see cref="System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="System.InvalidOperationException">
         /// The method was invoked from within a post-phase action, the barrier currently has 0 participants,
         /// or the barrier is being used by more threads than are registered as participants.
         /// </exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public bool SignalAndWait(TimeSpan timeout)
         {
@@ -541,24 +541,24 @@ namespace System.Threading
         /// <summary>
         /// Signals that a participant has reached the <see cref="Barrier"/> and waits for all other
         /// participants to reach the barrier as well, using a
-        /// <see cref="T:System.TimeSpan"/> to measure the time interval, while observing a <see
-        /// cref="T:System.Threading.CancellationToken"/>.
+        /// <see cref="System.TimeSpan"/> to measure the time interval, while observing a <see
+        /// cref="System.Threading.CancellationToken"/>.
         /// </summary>
-        /// <param name="timeout">A <see cref="T:System.TimeSpan"/> that represents the number of
-        /// milliseconds to wait, or a <see cref="T:System.TimeSpan"/> that represents -1 milliseconds to
+        /// <param name="timeout">A <see cref="System.TimeSpan"/> that represents the number of
+        /// milliseconds to wait, or a <see cref="System.TimeSpan"/> that represents -1 milliseconds to
         /// wait indefinitely.</param>
-        /// <param name="cancellationToken">The <see cref="T:System.Threading.CancellationToken"/> to
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> to
         /// observe.</param>
         /// <returns>true if all other participants reached the barrier; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="timeout"/>is a negative number
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="timeout"/>is a negative number
         /// other than -1 milliseconds, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The method was invoked from within a post-phase action, the barrier currently has 0 participants,
         /// or the barrier is being used by more threads than are registered as participants.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException"><paramref name="cancellationToken"/> has been
+        /// <exception cref="System.OperationCanceledException"><paramref name="cancellationToken"/> has been
         /// canceled.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public bool SignalAndWait(TimeSpan timeout, CancellationToken cancellationToken)
         {
@@ -579,13 +579,13 @@ namespace System.Threading
         /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see
         /// cref="Timeout.Infinite"/>(-1) to wait indefinitely.</param>
         /// <returns>true if all other participants reached the barrier; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The method was invoked from within a post-phase action, the barrier currently has 0 participants,
         /// or the barrier is being used by more threads than are registered as participants.
         /// </exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public bool SignalAndWait(int millisecondsTimeout)
         {
@@ -596,22 +596,22 @@ namespace System.Threading
         /// Signals that a participant has reached the barrier and waits for all other participants to reach
         /// the barrier as well, using a
         /// 32-bit signed integer to measure the time interval, while observing a <see
-        /// cref="T:System.Threading.CancellationToken"/>.
+        /// cref="System.Threading.CancellationToken"/>.
         /// </summary>
         /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see
         /// cref="Timeout.Infinite"/>(-1) to wait indefinitely.</param>
-        /// <param name="cancellationToken">The <see cref="T:System.Threading.CancellationToken"/> to
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> to
         /// observe.</param>
         /// <returns>true if all other participants reached the barrier; otherwise, false.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The method was invoked from within a post-phase action, the barrier currently has 0 participants,
         /// or the barrier is being used by more threads than are registered as participants.
         /// </exception>
-        /// <exception cref="T:System.OperationCanceledException"><paramref name="cancellationToken"/> has been
+        /// <exception cref="System.OperationCanceledException"><paramref name="cancellationToken"/> has been
         /// canceled.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public bool SignalAndWait(int millisecondsTimeout, CancellationToken cancellationToken)
         {
@@ -892,7 +892,7 @@ namespace System.Threading
         /// <summary>
         /// Releases all resources used by the current instance of <see cref="Barrier"/>.
         /// </summary>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The method was invoked from within a post-phase action.
         /// </exception>
         /// <remarks>

--- a/src/System.Threading/src/System/Threading/CountdownEvent.cs
+++ b/src/System.Threading/src/System/Threading/CountdownEvent.cs
@@ -38,12 +38,12 @@ namespace System.Threading
         private volatile bool _disposed; // Whether the latch has been disposed.
 
         /// <summary>
-        /// Initializes a new instance of <see cref="T:System.Threading.CountdownEvent"/> class with the
+        /// Initializes a new instance of <see cref="System.Threading.CountdownEvent"/> class with the
         /// specified count.
         /// </summary>
         /// <param name="initialCount">The number of signals required to set the <see
-        /// cref="T:System.Threading.CountdownEvent"/>.</param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="initialCount"/> is less
+        /// cref="System.Threading.CountdownEvent"/>.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="initialCount"/> is less
         /// than 0.</exception>
         public CountdownEvent(int initialCount)
         {
@@ -108,10 +108,10 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Gets a <see cref="T:System.Threading.WaitHandle"/> that is used to wait for the event to be set. 
+        /// Gets a <see cref="System.Threading.WaitHandle"/> that is used to wait for the event to be set. 
         /// </summary>
-        /// <value>A <see cref="T:System.Threading.WaitHandle"/> that is used to wait for the event to be set.</value>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been disposed.</exception>
+        /// <value>A <see cref="System.Threading.WaitHandle"/> that is used to wait for the event to be set.</value>
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been disposed.</exception>
         /// <remarks>
         /// <see cref="WaitHandle"/> should only be used if it's needed for integration with code bases
         /// that rely on having a WaitHandle.  If all that's needed is to wait for the <see cref="CountdownEvent"/>
@@ -127,7 +127,7 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Releases all resources used by the current instance of <see cref="T:System.Threading.CountdownEvent"/>.
+        /// Releases all resources used by the current instance of <see cref="System.Threading.CountdownEvent"/>.
         /// </summary>
         /// <remarks>
         /// Unlike most of the members of <see cref="CountdownEvent"/>, <see cref="Dispose()"/> is not
@@ -146,7 +146,7 @@ namespace System.Threading
 
         /// <summary>
         /// When overridden in a derived class, releases the unmanaged resources used by the
-        /// <see cref="T:System.Threading.CountdownEvent"/>, and optionally releases the managed resources.
+        /// <see cref="System.Threading.CountdownEvent"/>, and optionally releases the managed resources.
         /// </summary>
         /// <param name="disposing">true to release both managed and unmanaged resources; false to release
         /// only unmanaged resources.</param>
@@ -164,14 +164,14 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Registers a signal with the <see cref="T:System.Threading.CountdownEvent"/>, decrementing its
+        /// Registers a signal with the <see cref="System.Threading.CountdownEvent"/>, decrementing its
         /// count.
         /// </summary>
         /// <returns>true if the signal caused the count to reach zero and the event was set; otherwise,
         /// false.</returns>
-        /// <exception cref="T:System.InvalidOperationException">The current instance is already set.
+        /// <exception cref="System.InvalidOperationException">The current instance is already set.
         /// </exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public bool Signal()
         {
@@ -200,19 +200,19 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Registers multiple signals with the <see cref="T:System.Threading.CountdownEvent"/>,
+        /// Registers multiple signals with the <see cref="System.Threading.CountdownEvent"/>,
         /// decrementing its count by the specified amount.
         /// </summary>
         /// <param name="signalCount">The number of signals to register.</param>
         /// <returns>true if the signals caused the count to reach zero and the event was set; otherwise,
         /// false.</returns>
-        /// <exception cref="T:System.InvalidOperationException">
+        /// <exception cref="System.InvalidOperationException">
         /// The current instance is already set. -or- Or <paramref name="signalCount"/> is greater than <see
         /// cref="CurrentCount"/>.
         /// </exception>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="signalCount"/> is less
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="signalCount"/> is less
         /// than 1.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public bool Signal(int signalCount)
         {
@@ -257,13 +257,13 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Increments the <see cref="T:System.Threading.CountdownEvent"/>'s current count by one.
+        /// Increments the <see cref="System.Threading.CountdownEvent"/>'s current count by one.
         /// </summary>
-        /// <exception cref="T:System.InvalidOperationException">The current instance is already
+        /// <exception cref="System.InvalidOperationException">The current instance is already
         /// set.</exception>
-        /// <exception cref="T:System.InvalidOperationException"><see cref="CurrentCount"/> is equal to <see
-        /// cref="T:System.Int32.MaxValue"/>.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">
+        /// <exception cref="System.InvalidOperationException"><see cref="CurrentCount"/> is equal to <see
+        /// cref="System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="System.ObjectDisposedException">
         /// The current instance has already been disposed.
         /// </exception>
         public void AddCount()
@@ -272,13 +272,13 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Attempts to increment the <see cref="T:System.Threading.CountdownEvent"/>'s current count by one.
+        /// Attempts to increment the <see cref="System.Threading.CountdownEvent"/>'s current count by one.
         /// </summary>
         /// <returns>true if the increment succeeded; otherwise, false. If <see cref="CurrentCount"/> is
         /// already at zero. this will return false.</returns>
-        /// <exception cref="T:System.InvalidOperationException"><see cref="CurrentCount"/> is equal to <see
-        /// cref="T:System.Int32.MaxValue"/>.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.InvalidOperationException"><see cref="CurrentCount"/> is equal to <see
+        /// cref="System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public bool TryAddCount()
         {
@@ -286,17 +286,17 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Increments the <see cref="T:System.Threading.CountdownEvent"/>'s current count by a specified
+        /// Increments the <see cref="System.Threading.CountdownEvent"/>'s current count by a specified
         /// value.
         /// </summary>
         /// <param name="signalCount">The value by which to increase <see cref="CurrentCount"/>.</param>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="signalCount"/> is less than
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="signalCount"/> is less than
         /// 0.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The current instance is already
+        /// <exception cref="System.InvalidOperationException">The current instance is already
         /// set.</exception>
-        /// <exception cref="T:System.InvalidOperationException"><see cref="CurrentCount"/> is equal to <see
-        /// cref="T:System.Int32.MaxValue"/>.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.InvalidOperationException"><see cref="CurrentCount"/> is equal to <see
+        /// cref="System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public void AddCount(int signalCount)
         {
@@ -307,19 +307,19 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Attempts to increment the <see cref="T:System.Threading.CountdownEvent"/>'s current count by a
+        /// Attempts to increment the <see cref="System.Threading.CountdownEvent"/>'s current count by a
         /// specified value.
         /// </summary>
         /// <param name="signalCount">The value by which to increase <see cref="CurrentCount"/>.</param>
         /// <returns>true if the increment succeeded; otherwise, false. If <see cref="CurrentCount"/> is
         /// already at zero this will return false.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="signalCount"/> is less
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="signalCount"/> is less
         /// than 0.</exception>
-        /// <exception cref="T:System.InvalidOperationException">The current instance is already
+        /// <exception cref="System.InvalidOperationException">The current instance is already
         /// set.</exception>
-        /// <exception cref="T:System.InvalidOperationException"><see cref="CurrentCount"/> is equal to <see
-        /// cref="T:System.Int32.MaxValue"/>.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.InvalidOperationException"><see cref="CurrentCount"/> is equal to <see
+        /// cref="System.Int32.MaxValue"/>.</exception>
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public bool TryAddCount(int signalCount)
         {
@@ -365,7 +365,7 @@ namespace System.Threading
         /// Unlike most of the members of <see cref="CountdownEvent"/>, Reset is not
         /// thread-safe and may not be used concurrently with other members of this instance.
         /// </remarks>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public void Reset()
         {
@@ -376,14 +376,14 @@ namespace System.Threading
         /// Resets the <see cref="CurrentCount"/> to a specified value.
         /// </summary>
         /// <param name="count">The number of signals required to set the <see
-        /// cref="T:System.Threading.CountdownEvent"/>.</param>
+        /// cref="System.Threading.CountdownEvent"/>.</param>
         /// <remarks>
         /// Unlike most of the members of <see cref="CountdownEvent"/>, Reset is not
         /// thread-safe and may not be used concurrently with other members of this instance.
         /// </remarks>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="count"/> is
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="count"/> is
         /// less than 0.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been disposed.</exception>
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been disposed.</exception>
         public void Reset(int count)
         {
             ThrowIfDisposed();
@@ -407,13 +407,13 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Blocks the current thread until the <see cref="T:System.Threading.CountdownEvent"/> is set.
+        /// Blocks the current thread until the <see cref="System.Threading.CountdownEvent"/> is set.
         /// </summary>
         /// <remarks>
         /// The caller of this method blocks indefinitely until the current instance is set. The caller will
         /// return immediately if the event is currently in a set state.
         /// </remarks>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public void Wait()
         {
@@ -422,21 +422,21 @@ namespace System.Threading
 
 
         /// <summary>
-        /// Blocks the current thread until the <see cref="T:System.Threading.CountdownEvent"/> is set, while
-        /// observing a <see cref="T:System.Threading.CancellationToken"/>.
+        /// Blocks the current thread until the <see cref="System.Threading.CountdownEvent"/> is set, while
+        /// observing a <see cref="System.Threading.CancellationToken"/>.
         /// </summary>
-        /// <param name="cancellationToken">The <see cref="T:System.Threading.CancellationToken"/> to
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> to
         /// observe.</param>
         /// <remarks>
         /// The caller of this method blocks indefinitely until the current instance is set. The caller will
         /// return immediately if the event is currently in a set state.  If the 
-        /// <see cref="T:System.Threading.CancellationToken">CancellationToken</see> being observed
-        /// is canceled during the wait operation, an <see cref="T:System.OperationCanceledException"/>
+        /// <see cref="System.Threading.CancellationToken">CancellationToken</see> being observed
+        /// is canceled during the wait operation, an <see cref="System.OperationCanceledException"/>
         /// will be thrown.
         /// </remarks>
-        /// <exception cref="T:System.OperationCanceledException"><paramref name="cancellationToken"/> has been
+        /// <exception cref="System.OperationCanceledException"><paramref name="cancellationToken"/> has been
         /// canceled.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public void Wait(CancellationToken cancellationToken)
         {
@@ -444,18 +444,18 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Blocks the current thread until the <see cref="T:System.Threading.CountdownEvent"/> is set, using a
-        /// <see cref="T:System.TimeSpan"/> to measure the time interval.
+        /// Blocks the current thread until the <see cref="System.Threading.CountdownEvent"/> is set, using a
+        /// <see cref="System.TimeSpan"/> to measure the time interval.
         /// </summary>
-        /// <param name="timeout">A <see cref="T:System.TimeSpan"/> that represents the number of
-        /// milliseconds to wait, or a <see cref="T:System.TimeSpan"/> that represents -1 milliseconds to
+        /// <param name="timeout">A <see cref="System.TimeSpan"/> that represents the number of
+        /// milliseconds to wait, or a <see cref="System.TimeSpan"/> that represents -1 milliseconds to
         /// wait indefinitely.</param>
         /// <returns>true if the <see cref="System.Threading.CountdownEvent"/> was set; otherwise,
         /// false.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative
         /// number other than -1 milliseconds, which represents an infinite time-out -or- timeout is greater
         /// than <see cref="System.Int32.MaxValue"/>.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public bool Wait(TimeSpan timeout)
         {
@@ -469,23 +469,23 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Blocks the current thread until the <see cref="T:System.Threading.CountdownEvent"/> is set, using
-        /// a <see cref="T:System.TimeSpan"/> to measure the time interval, while observing a
-        /// <see cref="T:System.Threading.CancellationToken"/>.
+        /// Blocks the current thread until the <see cref="System.Threading.CountdownEvent"/> is set, using
+        /// a <see cref="System.TimeSpan"/> to measure the time interval, while observing a
+        /// <see cref="System.Threading.CancellationToken"/>.
         /// </summary>
-        /// <param name="timeout">A <see cref="T:System.TimeSpan"/> that represents the number of
-        /// milliseconds to wait, or a <see cref="T:System.TimeSpan"/> that represents -1 milliseconds to
+        /// <param name="timeout">A <see cref="System.TimeSpan"/> that represents the number of
+        /// milliseconds to wait, or a <see cref="System.TimeSpan"/> that represents -1 milliseconds to
         /// wait indefinitely.</param>
-        /// <param name="cancellationToken">The <see cref="T:System.Threading.CancellationToken"/> to
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> to
         /// observe.</param>
         /// <returns>true if the <see cref="System.Threading.CountdownEvent"/> was set; otherwise,
         /// false.</returns>
-        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative
         /// number other than -1 milliseconds, which represents an infinite time-out -or- timeout is greater
         /// than <see cref="System.Int32.MaxValue"/>.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
-        /// <exception cref="T:System.OperationCanceledException"><paramref name="cancellationToken"/> has
+        /// <exception cref="System.OperationCanceledException"><paramref name="cancellationToken"/> has
         /// been canceled.</exception>
         public bool Wait(TimeSpan timeout, CancellationToken cancellationToken)
         {
@@ -499,7 +499,7 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Blocks the current thread until the <see cref="T:System.Threading.CountdownEvent"/> is set, using a
+        /// Blocks the current thread until the <see cref="System.Threading.CountdownEvent"/> is set, using a
         /// 32-bit signed integer to measure the time interval.
         /// </summary>
         /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see
@@ -508,7 +508,7 @@ namespace System.Threading
         /// false.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
         public bool Wait(int millisecondsTimeout)
         {
@@ -516,21 +516,21 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// Blocks the current thread until the <see cref="T:System.Threading.CountdownEvent"/> is set, using a
+        /// Blocks the current thread until the <see cref="System.Threading.CountdownEvent"/> is set, using a
         /// 32-bit signed integer to measure the time interval, while observing a
-        /// <see cref="T:System.Threading.CancellationToken"/>.
+        /// <see cref="System.Threading.CancellationToken"/>.
         /// </summary>
         /// <param name="millisecondsTimeout">The number of milliseconds to wait, or <see
         /// cref="Timeout.Infinite"/>(-1) to wait indefinitely.</param>
-        /// <param name="cancellationToken">The <see cref="T:System.Threading.CancellationToken"/> to
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> to
         /// observe.</param>
         /// <returns>true if the <see cref="System.Threading.CountdownEvent"/> was set; otherwise,
         /// false.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
         /// negative number other than -1, which represents an infinite time-out.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The current instance has already been
+        /// <exception cref="System.ObjectDisposedException">The current instance has already been
         /// disposed.</exception>
-        /// <exception cref="T:System.OperationCanceledException"><paramref name="cancellationToken"/> has
+        /// <exception cref="System.OperationCanceledException"><paramref name="cancellationToken"/> has
         /// been canceled.</exception>
         public bool Wait(int millisecondsTimeout, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Specifying the prefix prevents the compiler from validating what comes after it.