### PR TITLE
HttpStress: Add randomized request headers

### DIFF
--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -48,6 +48,7 @@ namespace HttpStress
         public int MaxRequestParameters { get; }
         public int MaxRequestUriSize { get; }
         public int MaxContentLength => ContentSource.Length;
+        public Uri BaseAddress => _client.BaseAddress;
 
         // HttpClient.SendAsync() wrapper that wires randomized cancellation
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption httpCompletion = HttpCompletionOption.ResponseContentRead, CancellationToken? token = null)
@@ -417,7 +418,7 @@ namespace HttpStress
 
             var expectedString = new StringBuilder();
             var uriSb = new StringBuilder(uri);
-            maxRequestUriSize -= uri.Length;
+            maxRequestUriSize -= clientContext.BaseAddress.OriginalString.Length + uri.Length + 1;
 
             int appxMaxValueLength = Math.Max(maxRequestUriSize / numParameters, 1);
 

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -176,21 +176,8 @@ namespace HttpStress
                 async ctx =>
                 {
                     Version httpVersion = ctx.GetRandomHttpVersion();
+
                     using (var req = new HttpRequestMessage(HttpMethod.Get, "/headers") { Version = httpVersion })
-                    using (HttpResponseMessage m = await ctx.SendAsync(req))
-                    {
-                        ValidateHttpVersion(m, httpVersion);
-                        ValidateStatusCode(m);
-                        ValidateContent(ctx.ContentSource, await m.Content.ReadAsStringAsync());
-                    }
-                }),
-
-                ("GET Echo Headers",
-                async ctx =>
-                {
-                    Version httpVersion = ctx.GetRandomHttpVersion();
-
-                    using (var req = new HttpRequestMessage(HttpMethod.Get, "/echoHeaders") { Version = httpVersion })
                     {
                         ctx.PopulateWithRandomHeaders(req.Headers);
 
@@ -208,7 +195,7 @@ namespace HttpStress
                                 }
                                 else if (!reqHeader.Value.SequenceEqual(values))
                                 {
-                                    string FmtValues(IEnumerable<string> values) => $"{string.Join(", ", values.Select(x => $"\"{x}\""))}";
+                                    string FmtValues(IEnumerable<string> values) => string.Join(", ", values.Select(x => $"\"{x}\""));
                                     throw new Exception($"Unexpected values for header {reqHeader.Key}. Expected {FmtValues(reqHeader.Value)} but got {FmtValues(values)}");
                                 }
                             }

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -199,8 +199,8 @@ namespace HttpStress
                             ValidateHttpVersion(res, httpVersion);
                             ValidateStatusCode(res);
 
-                            // Validate that response headers are being echoed
-                            foreach (var reqHeader in req.Headers)
+                            // Validate that request headers are being echoed
+                            foreach (KeyValuePair<string, IEnumerable<string>> reqHeader in req.Headers)
                             {
                                 if (!res.Headers.TryGetValues(reqHeader.Key, out var values))
                                 {
@@ -458,7 +458,7 @@ namespace HttpStress
 
         private static (string, MultipartContent) GetMultipartContent(RequestContext clientContext, int numFormFields)
         {
-            var multipartContent = new MultipartContent("prefix" + clientContext.GetRandomString(0, clientContext.MaxContentLength, alphaNumericOnly: true), "test_boundary");
+            var multipartContent = new MultipartContent("prefix" + clientContext.GetRandomString(0, clientContext.MaxContentLength), "test_boundary");
             StringBuilder sb = new StringBuilder();
 
             int num = clientContext.GetRandomInt32(1, numFormFields + 1);

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -118,7 +118,7 @@ namespace HttpStress
 
         public void PopulateWithRandomHeaders(HttpRequestHeaders headers)
         {
-            int numHeaders = _random.Next(maxValue: 100);
+            int numHeaders = _random.Next(100);
 
             for (int i = 0; i < numHeaders; i++)
             {

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -8,15 +8,19 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace HttpStress
 {
     /// <summary>Client context containing information pertaining to a single request.</summary>
     public sealed class RequestContext
     {
+        private const string alphaNumeric = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
         private readonly Random _random;
         private readonly HttpClient _client;
         private readonly double _cancellationProbability;
@@ -75,22 +79,33 @@ namespace HttpStress
             }
         }
 
-        public string GetRandomString(int maxLength)
+        /// Gets a random ASCII string within specified length range
+        public string GetRandomString(int minLength, int maxLength, bool alphaNumericOnly = true)
         {
-            int length = _random.Next(0, maxLength);
+            int length = _random.Next(minLength, maxLength);
             var sb = new StringBuilder(length);
             for (int i = 0; i < length; i++)
             {
-                sb.Append((char)(_random.Next(0, 26) + 'a'));
+                if (alphaNumericOnly)
+                {
+                    // alpha character
+                    sb.Append(alphaNumeric[_random.Next(alphaNumeric.Length)]);
+                }
+                else
+                {
+                    // use a random ascii character
+                    sb.Append((char)_random.Next(0, 128));
+                }
             }
+
             return sb.ToString();
         }
 
-        public string GetRandomSubstring(string input)
+        public byte[] GetRandomBytes(int minBytes, int maxBytes)
         {
-            int offset = _random.Next(0, input.Length);
-            int length = _random.Next(0, input.Length - offset + 1);
-            return input.Substring(offset, length);
+            byte[] bytes = new byte[_random.Next(minBytes, maxBytes)];
+            _random.NextBytes(bytes);
+            return bytes;
         }
 
         public bool GetRandomBoolean(double probability = 0.5)
@@ -99,6 +114,18 @@ namespace HttpStress
                 throw new ArgumentOutOfRangeException(nameof(probability));
 
             return _random.NextDouble() < probability;
+        }
+
+        public void PopulateWithRandomHeaders(HttpRequestHeaders headers)
+        {
+            int numHeaders = _random.Next(maxValue: 100);
+
+            for (int i = 0; i < numHeaders; i++)
+            {
+                string name = $"Header-{i}";
+                IEnumerable<string> values = Enumerable.Range(0, _random.Next(0, 5)).Select(_ => HttpUtility.UrlEncode(GetRandomString(0, 30, alphaNumericOnly: false)));
+                headers.Add(name, values);
+            }
         }
 
         public int GetRandomInt32(int minValueInclusive, int maxValueExclusive) => _random.Next(minValueInclusive, maxValueExclusive);
@@ -122,7 +149,8 @@ namespace HttpStress
                     using (var req = new HttpRequestMessage(HttpMethod.Get, "/") { Version = httpVersion })
                     using (HttpResponseMessage m = await ctx.SendAsync(req))
                     {
-                        ValidateResponse(m, httpVersion);
+                        ValidateHttpVersion(m, httpVersion);
+                        ValidateStatusCode(m);
                         ValidateContent(ctx.ContentSource, await m.Content.ReadAsStringAsync());
                     }
                 }),
@@ -134,7 +162,9 @@ namespace HttpStress
                     using (var req = new HttpRequestMessage(HttpMethod.Get, "/slow") { Version = httpVersion })
                     using (HttpResponseMessage m = await ctx.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
                     {
-                        ValidateResponse(m, httpVersion);
+                        ValidateHttpVersion(m, httpVersion);
+                        ValidateStatusCode(m);
+
                         using (Stream s = await m.Content.ReadAsStreamAsync())
                         {
                             s.ReadByte(); // read single byte from response and throw the rest away
@@ -149,8 +179,41 @@ namespace HttpStress
                     using (var req = new HttpRequestMessage(HttpMethod.Get, "/headers") { Version = httpVersion })
                     using (HttpResponseMessage m = await ctx.SendAsync(req))
                     {
-                        ValidateResponse(m, httpVersion);
+                        ValidateHttpVersion(m, httpVersion);
+                        ValidateStatusCode(m);
                         ValidateContent(ctx.ContentSource, await m.Content.ReadAsStringAsync());
+                    }
+                }),
+
+                ("GET Echo Headers",
+                async ctx =>
+                {
+                    Version httpVersion = ctx.GetRandomHttpVersion();
+
+                    using (var req = new HttpRequestMessage(HttpMethod.Get, "/echoHeaders") { Version = httpVersion })
+                    {
+                        ctx.PopulateWithRandomHeaders(req.Headers);
+
+                        using (HttpResponseMessage res = await ctx.SendAsync(req))
+                        {
+                            ValidateHttpVersion(res, httpVersion);
+                            ValidateStatusCode(res);
+
+                            // Validate that response headers are being echoed
+                            foreach (var reqHeader in req.Headers)
+                            {
+                                if (!res.Headers.TryGetValues(reqHeader.Key, out var values))
+                                {
+                                    throw new Exception($"Expected response header name {reqHeader.Key} missing.");
+                                }
+                                else if (!reqHeader.Value.SequenceEqual(values))
+                                {
+                                    string FmtValues(IEnumerable<string> values) => $"{string.Join(", ", values.Select(x => $"\"{x}\""))}";
+                                    throw new Exception($"Unexpected values for header {reqHeader.Key}. Expected {FmtValues(reqHeader.Value)} but got {FmtValues(values)}");
+                                }
+                            }
+                        }
+
                     }
                 }),
 
@@ -159,11 +222,12 @@ namespace HttpStress
                 {
                     Version httpVersion = ctx.GetRandomHttpVersion();
                     string uri = "/variables";
-                    string expectedResponse = GetGetQueryParameters(ref uri, ctx.MaxRequestLineSize, ctx.ContentSource, ctx, ctx.MaxRequestParameters);
+                    string expectedResponse = GetGetQueryParameters(ref uri, ctx.MaxRequestLineSize, ctx, ctx.MaxRequestParameters);
                     using (var req = new HttpRequestMessage(HttpMethod.Get, uri) { Version = httpVersion })
                     using (HttpResponseMessage m = await ctx.SendAsync(req))
                     {
-                        ValidateResponse(m, httpVersion);
+                        ValidateHttpVersion(m, httpVersion);
+                        ValidateStatusCode(m);
                         ValidateContent(expectedResponse, await m.Content.ReadAsStringAsync(), $"Uri: {uri}");
                     }
                 }),
@@ -216,13 +280,14 @@ namespace HttpStress
                 ("POST",
                 async ctx =>
                 {
-                    string content = ctx.GetRandomSubstring(ctx.ContentSource);
+                    string content = ctx.GetRandomString(0, ctx.MaxContentLength);
                     Version httpVersion = ctx.GetRandomHttpVersion();
 
                     using (var req = new HttpRequestMessage(HttpMethod.Post, "/") { Version = httpVersion, Content = new StringDuplexContent(content) })
                     using (HttpResponseMessage m = await ctx.SendAsync(req))
                     {
-                        ValidateResponse(m, httpVersion);
+                        ValidateHttpVersion(m, httpVersion);
+                        ValidateStatusCode(m);
                         ValidateContent(content, await m.Content.ReadAsStringAsync());;
                     }
                 }),
@@ -230,13 +295,14 @@ namespace HttpStress
                 ("POST Multipart Data",
                 async ctx =>
                 {
-                    (string expected, MultipartContent formDataContent) formData = GetMultipartContent(ctx.ContentSource, ctx, ctx.MaxRequestParameters);
+                    (string expected, MultipartContent formDataContent) formData = GetMultipartContent(ctx, ctx.MaxRequestParameters);
                     Version httpVersion = ctx.GetRandomHttpVersion();
 
                     using (var req = new HttpRequestMessage(HttpMethod.Post, "/") { Version = httpVersion, Content = formData.formDataContent })
                     using (HttpResponseMessage m = await ctx.SendAsync(req))
                     {
-                        ValidateResponse(m, httpVersion);
+                        ValidateHttpVersion(m, httpVersion);
+                        ValidateStatusCode(m);
                         ValidateContent($"{formData.expected}", await m.Content.ReadAsStringAsync());;
                     }
                 }),
@@ -244,13 +310,14 @@ namespace HttpStress
                 ("POST Duplex",
                 async ctx =>
                 {
-                    string content = ctx.GetRandomSubstring(ctx.ContentSource);
+                    string content = ctx.GetRandomString(0, ctx.MaxContentLength);
                     Version httpVersion = ctx.GetRandomHttpVersion();
 
                     using (var req = new HttpRequestMessage(HttpMethod.Post, "/duplex") { Version = httpVersion, Content = new StringDuplexContent(content) })
                     using (HttpResponseMessage m = await ctx.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
                     {
-                        ValidateResponse(m, httpVersion);
+                        ValidateHttpVersion(m, httpVersion);
+                        ValidateStatusCode(m);
                         ValidateContent(content, await m.Content.ReadAsStringAsync());
                     }
                 }),
@@ -258,13 +325,14 @@ namespace HttpStress
                 ("POST Duplex Slow",
                 async ctx =>
                 {
-                    string content = ctx.GetRandomSubstring(ctx.ContentSource);
+                    string content = ctx.GetRandomString(0, ctx.MaxContentLength);
                     Version httpVersion = ctx.GetRandomHttpVersion();
 
                     using (var req = new HttpRequestMessage(HttpMethod.Post, "/duplexSlow") { Version = httpVersion, Content = new ByteAtATimeNoLengthContent(Encoding.ASCII.GetBytes(content)) })
                     using (HttpResponseMessage m = await ctx.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
                     {
-                        ValidateResponse(m, httpVersion);
+                        ValidateHttpVersion(m, httpVersion);
+                        ValidateStatusCode(m);
                         ValidateContent(content, await m.Content.ReadAsStringAsync());
                     }
                 }),
@@ -272,7 +340,7 @@ namespace HttpStress
                 ("POST ExpectContinue",
                 async ctx =>
                 {
-                    string content = ctx.GetRandomSubstring(ctx.ContentSource);
+                    string content = ctx.GetRandomString(0, ctx.MaxContentLength);
                     Version httpVersion = ctx.GetRandomHttpVersion();
 
                     using (var req = new HttpRequestMessage(HttpMethod.Post, "/") { Version = httpVersion, Content = new StringContent(content) })
@@ -280,7 +348,8 @@ namespace HttpStress
                         req.Headers.ExpectContinue = true;
                         using (HttpResponseMessage m = await ctx.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
                         {
-                            ValidateResponse(m, httpVersion);
+                            ValidateHttpVersion(m, httpVersion);
+                            ValidateStatusCode(m);
                             ValidateContent(content, await m.Content.ReadAsStringAsync());
                         }
                     }
@@ -293,7 +362,9 @@ namespace HttpStress
                     using (var req = new HttpRequestMessage(HttpMethod.Head, "/") { Version = httpVersion })
                     using (HttpResponseMessage m = await ctx.SendAsync(req))
                     {
-                        ValidateResponse(m, httpVersion);
+                        ValidateHttpVersion(m, httpVersion);
+                        ValidateStatusCode(m);
+
                         if (m.Content.Headers.ContentLength != ctx.MaxContentLength)
                         {
                             throw new Exception($"Expected {ctx.MaxContentLength}, got {m.Content.Headers.ContentLength}");
@@ -306,13 +377,15 @@ namespace HttpStress
                 ("PUT",
                 async ctx =>
                 {
-                    string content = ctx.GetRandomSubstring(ctx.ContentSource);
+                    string content = ctx.GetRandomString(0, ctx.MaxContentLength);
                     Version httpVersion = ctx.GetRandomHttpVersion();
 
                     using (var req = new HttpRequestMessage(HttpMethod.Put, "/") { Version = httpVersion, Content = new StringContent(content) })
                     using (HttpResponseMessage m = await ctx.SendAsync(req))
                     {
-                        ValidateResponse(m, httpVersion);
+                        ValidateHttpVersion(m, httpVersion);
+                        ValidateStatusCode(m);
+
                         string r = await m.Content.ReadAsStringAsync();
                         if (r != "") throw new Exception($"Got unexpected response: {r}");
                     }
@@ -320,11 +393,19 @@ namespace HttpStress
             };
 
         // Validation of a response message
-        private static void ValidateResponse(HttpResponseMessage m, Version expectedVersion)
+        private static void ValidateHttpVersion(HttpResponseMessage m, Version expectedVersion)
         {
             if (m.Version != expectedVersion)
             {
                 throw new Exception($"Expected response version {expectedVersion}, got {m.Version}");
+            }
+        }
+
+        private static void ValidateStatusCode(HttpResponseMessage m, HttpStatusCode expectedStatus = HttpStatusCode.OK)
+        {
+            if (m.StatusCode != expectedStatus)
+            {
+                throw new Exception($"Expected status code {expectedStatus}, got {m.StatusCode}");
             }
         }
 
@@ -336,7 +417,7 @@ namespace HttpStress
             }
         }
 
-        private static string GetGetQueryParameters(ref string uri, int maxRequestLineSize, string contentSource, RequestContext clientContext, int numParameters)
+        private static string GetGetQueryParameters(ref string uri, int maxRequestLineSize, RequestContext clientContext, int numParameters)
         {
             if (maxRequestLineSize < uri.Length)
             {
@@ -366,7 +447,7 @@ namespace HttpStress
 
                 uriSb.Append(key);
 
-                string value = clientContext.GetRandomString(Math.Min(appxMaxValueLength, remainingLength));
+                string value = clientContext.GetRandomString(0, Math.Min(appxMaxValueLength, remainingLength));
                 expectedString.Append(value);
                 uriSb.Append(value);
             }
@@ -375,9 +456,9 @@ namespace HttpStress
             return expectedString.ToString();
         }
 
-        private static (string, MultipartContent) GetMultipartContent(string contentSource, RequestContext clientContext, int numFormFields)
+        private static (string, MultipartContent) GetMultipartContent(RequestContext clientContext, int numFormFields)
         {
-            var multipartContent = new MultipartContent("prefix" + clientContext.GetRandomSubstring(contentSource), "test_boundary");
+            var multipartContent = new MultipartContent("prefix" + clientContext.GetRandomString(0, clientContext.MaxContentLength, alphaNumericOnly: true), "test_boundary");
             StringBuilder sb = new StringBuilder();
 
             int num = clientContext.GetRandomInt32(1, numFormFields + 1);
@@ -385,7 +466,7 @@ namespace HttpStress
             for (int i = 0; i < num; i++)
             {
                 sb.Append("--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n");
-                string content = clientContext.GetRandomSubstring(contentSource);
+                string content = clientContext.GetRandomString(0, clientContext.MaxContentLength);
                 sb.Append(content);
                 sb.Append("\r\n");
                 multipartContent.Add(new StringContent(content));

--- a/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -52,8 +52,7 @@ public class Program
             return;
         }
 
-        await
-        Run(
+        await Run(
             runMode                 : cmdline.ValueForOption<RunMode>("-runMode"),
             serverUri               : cmdline.ValueForOption<Uri>("-serverUri"),
             httpSys                 : cmdline.ValueForOption<bool>("-httpSys"),

--- a/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/Program.cs
@@ -26,7 +26,7 @@ public class Program
         cmd.AddOption(new Option("-serverUri", "Stress suite server uri.") { Argument = new Argument<Uri>("serverUri", new Uri("https://localhost:5001")) });
         cmd.AddOption(new Option("-runMode", "Stress suite execution mode. Defaults to Both.") { Argument = new Argument<RunMode>("runMode", RunMode.both)});
         cmd.AddOption(new Option("-maxContentLength", "Max content length for request and response bodies.") { Argument = new Argument<int>("numBytes", 1000) });
-        cmd.AddOption(new Option("-maxRequestLineSize", "Max query string length support by the server.") { Argument = new Argument<int>("numChars", 8192) });
+        cmd.AddOption(new Option("-maxRequestUriSize", "Max query string length support by the server.") { Argument = new Argument<int>("numChars", 8000) });
         cmd.AddOption(new Option("-http", "HTTP version (1.1 or 2.0)") { Argument = new Argument<Version>("version", HttpVersion.Version20) });
         cmd.AddOption(new Option("-connectionLifetime", "Max connection lifetime length (milliseconds).") { Argument = new Argument<int?>("connectionLifetime", null)});
         cmd.AddOption(new Option("-ops", "Indices of the operations to use") { Argument = new Argument<int[]>("space-delimited indices", null) });
@@ -58,7 +58,7 @@ public class Program
             httpSys                 : cmdline.ValueForOption<bool>("-httpSys"),
             concurrentRequests      : cmdline.ValueForOption<int>("-n"),
             maxContentLength        : cmdline.ValueForOption<int>("-maxContentLength"),
-            maxRequestLineSize      : cmdline.ValueForOption<int>("-maxRequestLineSize"),
+            maxRequestUriSize      : cmdline.ValueForOption<int>("-maxRequestUriSize"),
             httpVersion             : cmdline.ValueForOption<Version>("-http"),
             connectionLifetime      : cmdline.ValueForOption<int?>("-connectionLifetime"),
             opIndices               : cmdline.ValueForOption<int[]>("-ops"),
@@ -72,7 +72,7 @@ public class Program
             displayIntervalSeconds  : cmdline.ValueForOption<int>("-displayInterval"));
     }
 
-    private static async Task Run(RunMode runMode, Uri serverUri, bool httpSys, int concurrentRequests, int maxContentLength, int maxRequestLineSize, Version httpVersion, int? connectionLifetime, int[] opIndices, int[] excludedOpIndices, string logPath, bool aspnetLog, bool listOps, int seed, int numParameters, double cancellationProbability, int displayIntervalSeconds)
+    private static async Task Run(RunMode runMode, Uri serverUri, bool httpSys, int concurrentRequests, int maxContentLength, int maxRequestUriSize, Version httpVersion, int? connectionLifetime, int[] opIndices, int[] excludedOpIndices, string logPath, bool aspnetLog, bool listOps, int seed, int numParameters, double cancellationProbability, int displayIntervalSeconds)
     {
 
         (string name, Func<RequestContext, Task> op)[] clientOperations = ClientOperations.Operations;
@@ -143,8 +143,7 @@ public class Program
         {
             // Start the Kestrel web server in-proc.
             Console.WriteLine($"Starting {(httpSys ? "http.sys" : "Kestrel")} server.");
-            var server = new StressServer(serverUri, httpSys, maxContentLength, logPath, aspnetLog);
-            maxRequestLineSize = server.MaxRequestLineSize;
+            var server = new StressServer(serverUri, httpSys, maxContentLength, maxRequestUriSize, logPath, aspnetLog);
             Console.WriteLine($"Server started at {server.ServerUri}");
         }
 
@@ -159,7 +158,7 @@ public class Program
                 concurrentRequests: concurrentRequests,
                 maxContentLength: maxContentLength,
                 maxRequestParameters: numParameters,
-                maxRequestLineSize: maxRequestLineSize,
+                maxRequestUriSize: maxRequestUriSize,
                 randomSeed: seed,
                 cancellationProbability: cancellationProbability,
                 http2Probability: (httpVersion == new Version(2, 0)) ? 1 : 0,

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -20,7 +20,7 @@ namespace HttpStress
 
         // TOCONSIDER: configuration class to avoid threading so many parameters
         public StressClient(Uri serverUri, (string name, Func<RequestContext, Task> operation)[] clientOperations, int concurrentRequests,
-                                int maxContentLength, int maxRequestParameters, int maxRequestLineSize,
+                                int maxContentLength, int maxRequestParameters, int maxRequestUriSize,
                                 int randomSeed, double cancellationProbability, double http2Probability,
                                 int? connectionLifetime, TimeSpan displayInterval)
         {
@@ -125,7 +125,7 @@ namespace HttpStress
                         // Random instance should be shared across all requests made by same worker
                         Random random = CreateRandomInstance();
 
-                        return () => new RequestContext(client, random, taskNum, contentSource, maxRequestParameters, maxRequestLineSize, cancellationProbability, http2Probability);
+                        return () => new RequestContext(client, random, taskNum, contentSource, maxRequestParameters, maxRequestUriSize, cancellationProbability, http2Probability);
                     }
 
                     async Task RunWorker(int taskNum)

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -174,7 +174,7 @@ namespace HttpStress
                     }
 
                     // Start N workers, each of which sits in a loop making requests.
-                    Task[] tasks = Enumerable.Range(0, concurrentRequests - 1).Select(RunWorker).ToArray();
+                    Task[] tasks = Enumerable.Range(0, concurrentRequests).Select(RunWorker).ToArray();
                     await Task.WhenAll(tasks);
                 }
             }

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -33,9 +33,8 @@ namespace HttpStress
         private readonly IWebHost _webHost;
 
         public Uri ServerUri { get; }
-        public int MaxRequestLineSize { get; private set; } = -1;
 
-        public StressServer(Uri serverUri, bool httpSys, int maxContentLength, string logPath, bool enableAspNetLogs)
+        public StressServer(Uri serverUri, bool httpSys, int maxContentLength, int maxRequestUriSize, string logPath, bool enableAspNetLogs)
         {
             ServerUri = serverUri;
             IWebHostBuilder host = WebHost.CreateDefaultBuilder();
@@ -50,7 +49,6 @@ namespace HttpStress
                 // 3. Register the cert, e.g. netsh http add sslcert ipport=[::1]:5001 certhash=THUMBPRINTFROMABOVE appid="{some-guid}"
                 host = host.UseHttpSys(hso =>
                 {
-                    MaxRequestLineSize = 8192;
                     hso.UrlPrefixes.Add(ServerUri.ToString());
                     hso.Authentication.Schemes = Microsoft.AspNetCore.Server.HttpSys.AuthenticationSchemes.None;
                     hso.Authentication.AllowAnonymous = true;
@@ -63,7 +61,9 @@ namespace HttpStress
                 // Use Kestrel, and configure it for HTTPS with a self-signed test certificate.
                 host = host.UseKestrel(ko =>
                 {
-                    MaxRequestLineSize = ko.Limits.MaxRequestLineSize - 10;
+                    // conservative estimation based on https://github.com/aspnet/AspNetCore/blob/caa910ceeba5f2b2c02c47a23ead0ca31caea6f0/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs#L204
+                    ko.Limits.MaxRequestLineSize = Math.Max(ko.Limits.MaxRequestLineSize, maxRequestUriSize + 100);
+
                     ko.ListenLocalhost(serverUri.Port, listenOptions =>
                     {
                         // Create self-signed cert for server.

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -63,7 +63,7 @@ namespace HttpStress
                 // Use Kestrel, and configure it for HTTPS with a self-signed test certificate.
                 host = host.UseKestrel(ko =>
                 {
-                    MaxRequestLineSize = ko.Limits.MaxRequestLineSize;
+                    MaxRequestLineSize = ko.Limits.MaxRequestLineSize - 10;
                     ko.ListenLocalhost(serverUri.Port, listenOptions =>
                     {
                         // Create self-signed cert for server.

--- a/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/StressServer.cs
@@ -145,6 +145,21 @@ namespace HttpStress
                     }
                 }
             });
+            endpoints.MapGet("/echoHeaders", async context =>
+            {
+                foreach(KeyValuePair<string, StringValues> header in context.Request.Headers)
+                {
+                    // skip pseudo-headers surfaced by kestrel
+                    if (header.Key.StartsWith(':')) continue;
+
+                    // kestrel seems to not be splitting comma separated header values, handle here
+                    string[] values = header.Value.SelectMany(v => v.Split(',')).Select(x => x.Trim()).ToArray();
+                    context.Response.Headers.Add(header.Key, new StringValues(values));
+                }
+
+                await context.Response.WriteAsync("ok");
+
+            });
             endpoints.MapGet("/variables", async context =>
             {
                 string queryString = context.Request.QueryString.Value;


### PR DESCRIPTION
Makes the following changes:
* Adds an "Echo Header" operation that sends and receives a randomized set of headers.
* Extends random string generation to full alphanumeric/ascii range.
* Adds an `-xops` argument for blacklisting operations from the cli.
* Fixes a bug where `n - 1` workers were being initialized instead of `n`.