### PR TITLE
Fix FormatException if an invalid JsonConverter attribute is specified

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -89,12 +89,15 @@ namespace System.Text.Json
         public static void ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(Type classType, PropertyInfo propertyInfo)
         {
             string location = classType.ToString();
+            string type = location;
+
             if (propertyInfo != null)
             {
-                location += $".{propertyInfo.ToString()}";
+                type = propertyInfo.ToString();
+                location += $".{type}";
             }
 
-            throw new InvalidOperationException(SR.Format(SR.SerializationConverterOnAttributeNotCompatible, location));
+            throw new InvalidOperationException(SR.Format(SR.SerializationConverterOnAttributeNotCompatible, location, type));
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
@@ -350,7 +350,7 @@ namespace System.Text.Json.Serialization.Tests
             }
             catch (InvalidOperationException e)
             {
-                Assert.Equal("The converter specified on 'System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterClass.System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterEnum] MyEnumValues' is not compatible with the type 'System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterEnum]  MyEnumValues'.", e.Message);
+                Assert.Equal("The converter specified on 'System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterClass.System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterEnum] MyEnumValues' is not compatible with the type 'System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterEnum] MyEnumValues'.", e.Message);
             }
         }
 

--- a/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
@@ -350,7 +350,7 @@ namespace System.Text.Json.Serialization.Tests
             }
             catch (InvalidOperationException e)
             {
-                Assert.Equal("The converter specified on 'System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterClass.System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterEnum] MyEnumValues' is not compatible with the type 'System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterEnum]'.", e.Message);
+                Assert.Equal("The converter specified on 'System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterClass.System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterEnum] MyEnumValues' is not compatible with the type 'System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterEnum]  MyEnumValues'.", e.Message);
             }
         }
 

--- a/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
+++ b/src/System.Text.Json/tests/Serialization/ExceptionTests.cs
@@ -340,6 +340,20 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
+        [Fact]
+        public static void ThrowsExceptionIfTypeConverterAttributeIsIncompatible()
+        {
+            try
+            {
+                JsonSerializer.Serialize(new InvalidTypeConverterClass());
+                Assert.True(false, "Expected InvalidOperationException was not thrown.");
+            }
+            catch (InvalidOperationException e)
+            {
+                Assert.Equal("The converter specified on 'System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterClass.System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterEnum] MyEnumValues' is not compatible with the type 'System.Collections.Generic.ICollection`1[System.Text.Json.Serialization.Tests.ExceptionTests+InvalidTypeConverterEnum]'.", e.Message);
+            }
+        }
+
         public class RootClass
         {
             public ChildClass Child { get; set; }
@@ -351,6 +365,18 @@ namespace System.Text.Json.Serialization.Tests
             public int[] MyIntArray { get; set; }
             public Dictionary<string, ChildClass> MyDictionary { get; set; }
             public ChildClass[] Children { get; set; }
+        }
+
+        public class InvalidTypeConverterClass
+        {
+            [JsonConverter(typeof(JsonStringEnumConverter))]
+            public ICollection<InvalidTypeConverterEnum> MyEnumValues { get; set; }
+        }
+
+        public enum InvalidTypeConverterEnum
+        {
+            Value1,
+            Value2,
         }
     }
 }


### PR DESCRIPTION
Fixes a `FormatException` that was thrown if a `[JsonConverter(...)]` attribute on a property was incompatible with the type of the property.

I found this by accident while trying to get a collection of `Enum` to serialize as an array of strings instead of integers.

I wasn't entirely sure what the _intended_ exception message was, so I took a best guess and can fix it up as appropriate.

```
System.FormatException: Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
   at System.Text.StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
   at System.String.Format(String format, Object arg0)
   at System.SR.Format(String resourceFormat, Object p1)
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_SerializationConverterOnAttributeNotCompatible(Type classType, PropertyInfo propertyInfo)
   at System.Text.Json.JsonSerializerOptions.GetConverterFromAttribute(JsonConverterAttribute converterAttribute, Type typeToConvert, Type classType, PropertyInfo propertyInfo)
   at System.Text.Json.JsonSerializerOptions.DetermineConverterForProperty(Type parentClassType, Type runtimePropertyType, PropertyInfo propertyInfo)
   at System.Text.Json.JsonClassInfo.CreateProperty(Type declaredPropertyType, Type runtimePropertyType, PropertyInfo propertyInfo, Type parentClassType, JsonSerializerOptions options)
   at System.Text.Json.JsonClassInfo.AddProperty(Type propertyType, PropertyInfo propertyInfo, Type classType, JsonSerializerOptions options)
   at System.Text.Json.JsonClassInfo..ctor(Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializerOptions.GetOrAddClass(Type classType)
   at System.Text.Json.WriteStackFrame.Initialize(Type type, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.WriteAsyncCore(Stream utf8Json, Object value, Type type, JsonSerializerOptions options, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Mvc.Infrastructure.SystemTextJsonResultExecutor.ExecuteAsync(ActionContext context, JsonResult result)
```
