### PR TITLE
Fix NRE when MatchEvaluator returns null

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -186,7 +186,7 @@ namespace System.Text.RegularExpressions
                             vsb.Append(input.AsSpan(prevat, match.Index - prevat));
 
                         prevat = match.Index + match.Length;
-                        vsb.Append(evaluator(match));
+                        vsb.Append(evaluator(match) ?? "");
 
                         if (--count == 0)
                             break;

--- a/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -229,21 +229,15 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(RegexOptions.RightToLeft)]
         public void Replace_MatchEvaluatorReturnsNullOrEmpty(RegexOptions options)
         {
-            string input = "abcde";
-            string result = Regex.Replace(input, @"[abcd]", (Match match) => {
-                switch(match.Value)
+            string result = Regex.Replace("abcde", @"[abcd]", (Match match) => {
+                return match.Value switch
                 {
-                    case "a":
-                        return "x";
-                    case "b":
-                        return null;
-                    case "c":
-                        return "";
-                    case "d":
-                        return "y";
-                    default:
-                        throw new InvalidOperationException();
-                }
+                    "a" => "x",
+                    "b" => null,
+                    "c" => "",
+                    "d" => "y",
+                    _ => throw new InvalidOperationException()
+                };
             }, options);
 
             Assert.Equal("xye", result);

--- a/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -224,6 +224,31 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Same(input, Regex.Replace(input, "no-match", new MatchEvaluator(MatchEvaluator1)));
         }
 
+        [Theory]
+        [InlineData(RegexOptions.None)]
+        [InlineData(RegexOptions.RightToLeft)]
+        public void Replace_MatchEvaluatorReturnsNullOrEmpty(RegexOptions options)
+        {
+            string input = "abcd123";
+            string result = Regex.Replace(input, @"[abcd]", (Match match) => {
+                switch(match.Value)
+                {
+                    case "a":
+                        return "x";
+                    case "b":
+                        return null;
+                    case "c":
+                        return "";
+                    case "d":
+                        return "y";
+                    default:
+                        throw new InvalidOperationException();
+                }
+            }, options);
+
+            Assert.Equal("xy123", result);
+        }
+
         [Fact]
         public void Replace_Invalid()
         {

--- a/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -229,7 +229,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(RegexOptions.RightToLeft)]
         public void Replace_MatchEvaluatorReturnsNullOrEmpty(RegexOptions options)
         {
-            string input = "abcd123";
+            string input = "abcde";
             string result = Regex.Replace(input, @"[abcd]", (Match match) => {
                 switch(match.Value)
                 {
@@ -246,7 +246,7 @@ namespace System.Text.RegularExpressions.Tests
                 }
             }, options);
 
-            Assert.Equal("xy123", result);
+            Assert.Equal("xye", result);
         }
 
         [Fact]


### PR DESCRIPTION
Fix https://github.com/dotnet/corefx/issues/39746

This regressed when moving from StringBuilder to ValueStringBuilder as the latter does not allow Append (or Insert) of null, whereas StringBuilder just ignores it.

No fix was needed for RightToLeft, as that uses ValueStringBuilder.AppendReversed, whose parameter is typed ROS<char>, and a cast from a null string to ROS<char> just results in a zero length span. ValueStringBuilder.Append has a string overload apparently for performance reasons which is why it needs null protection.

As far as I can tell all other use in Regex of VSB is passing in strings or chars that are not null, or passing in Spans.