### PR TITLE
throw for unknown or unsupported AddressFamily on Windows

### DIFF
--- a/src/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -18,6 +18,14 @@ namespace System.Net
 
         public static unsafe void SetAddressFamily(byte[] buffer, AddressFamily family)
         {
+            if ((int)(family) > (int)AddressFamily.Max)
+            {
+                // For legacy values up to AddressFamily.Max, family maps directly to Winsock value.
+                // Other values will need mapping if/when supported.
+                // Currently, that is Netlink, Packat and ControllerAreaNetwork, neither of them supported on Windows.
+                throw new PlatformNotSupportedException();
+            }
+
 #if BIGENDIAN
             buffer[0] = unchecked((byte)((int)family >> 8));
             buffer[1] = unchecked((byte)((int)family));

--- a/src/Common/src/System/Net/SocketAddressPal.Windows.cs
+++ b/src/Common/src/System/Net/SocketAddressPal.Windows.cs
@@ -22,7 +22,7 @@ namespace System.Net
             {
                 // For legacy values up to AddressFamily.Max, family maps directly to Winsock value.
                 // Other values will need mapping if/when supported.
-                // Currently, that is Netlink, Packat and ControllerAreaNetwork, neither of them supported on Windows.
+                // Currently, that is Netlink, Packet and ControllerAreaNetwork, neither of them supported on Windows.
                 throw new PlatformNotSupportedException();
             }
 

--- a/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -107,7 +107,7 @@ namespace System.Net.Primitives.Functional.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public static void ToString_AllFamilies_Success()
         {
-            foreach (AddressFamily family in  Enum.GetValues(typeof(AddressFamily)))
+            foreach (AddressFamily family in Enum.GetValues(typeof(AddressFamily)))
             {
                 if ((int)family > (int)AddressFamily.Max)
                 {

--- a/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -75,10 +75,49 @@ namespace System.Net.Primitives.Functional.Tests
             Assert.Equal(expected, sa.ToString());
         }
 
-        [ActiveIssue(37997, TestPlatforms.AnyUnix)]
-        [Theory] // recombine into ToString_Expected_Success when #37997 is fixed
-        [InlineData((AddressFamily)12345, -1, false, "12345:32:{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}")]
-        public static void ToString_UnknownFamily_Success(AddressFamily family, int size, bool fillBytes, string expected) =>
-            ToString_Expected_Success(family, size, fillBytes, expected);
+        [Theory]
+        [InlineData((AddressFamily)12345, -1)]
+        [InlineData((AddressFamily)12345, 16)]
+        public static void ToString_UnknownFamily_Throws(AddressFamily family, int size)
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => size >= 0 ? new SocketAddress(family, size) : new SocketAddress(family));
+        }
+
+        [Theory]
+        [InlineData(AddressFamily.Packet)]
+        [InlineData(AddressFamily.Netlink)]
+        [InlineData(AddressFamily.ControllerAreaNetwork)]
+        [PlatformSpecific(~TestPlatforms.Linux)]
+        public static void ToString_UnsupportedFamily_Throws(AddressFamily family)
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => new SocketAddress(family));
+        }
+
+        [Theory]
+        [InlineData(AddressFamily.Packet)]
+        [InlineData(AddressFamily.ControllerAreaNetwork)]
+        [PlatformSpecific(TestPlatforms.Linux)]
+        public static void ToString_LinuxSpecificFamily_Success(AddressFamily family)
+        {
+            SocketAddress sa = new SocketAddress(family);
+            Assert.Equal(family, sa.Family);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public static void ToString_AllFamilies_Success()
+        {
+            foreach (AddressFamily family in  Enum.GetValues(typeof(AddressFamily)))
+            {
+                if ((int)family > (int)AddressFamily.Max)
+                {
+                    // Skip Linux specific protocols.
+                    continue;
+                }
+
+                var sa = new SocketAddress(family);
+                Assert.NotNull(sa.ToString());
+            }
+        }
     }
 }


### PR DESCRIPTION
This is possibly breaking change for anybody depending on unsupported values.  
General approach was discussed in #37997

In the past we would simply marshal given value as .net enum values would normally match winsock header. 
With 3.0 we added new values for protocols currently supported on Linux and that breaks that logic. For Unix we would check with PAL and throw PNSP for unknown values.  
This change basically makes Windows behave the same. I did not add any mapping function yet as there is no real need for that but this will throw now for all values beyond legacy values. 
Note, that many address families would be reject by OS later if used as Windows generally support only IP/IPv6 (and some versions UnixDomain)

fixes #37997
