### PR TITLE
Mark System.Numerics.Tensors package as nonshipping

### DIFF
--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -23,11 +23,13 @@
     <SymbolsPublishExperimentalPattern>$(SymbolsOutputRoot)*Experimental*.nupkg</SymbolsPublishExperimentalPattern>
   </PropertyGroup>
 
-  <!-- List of packages to exclude from nuget.org publishing -->
+  <!-- List of packages/symbol packages to exclude from nuget.org publishing -->
   <!-- We can't use the `IsShippingPackage` metadata since CoreFx doesn't output packages
   to shipping/nonshipping directories -->
   <ItemGroup>
     <NonShippingPackages Include="$(PackageOutputRoot)*System.Numerics.Tensors*.nupkg" />
+
+    <NonShippingSymbolPackages Include="$(SymbolsOutputRoot)*System.Numerics.Tensors*.nupkg" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackagesGlob)' != ''">
@@ -42,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SymbolPackagesToPublish  Include="$(SymbolsPublishPrivatePattern);$(SymbolsPublishExperimentalPattern)">
+    <SymbolPackagesToPublish  Include="$(SymbolsPublishPrivatePattern);$(SymbolsPublishExperimentalPattern);@(NonShippingSymbolPackages)">
       <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
     </SymbolPackagesToPublish>
     <SymbolPackagesToPublish Include="$(SymbolsPublishPattern)" Exclude="@(SymbolPackagesToPublish)" />

--- a/eng/publish.proj
+++ b/eng/publish.proj
@@ -23,13 +23,19 @@
     <SymbolsPublishExperimentalPattern>$(SymbolsOutputRoot)*Experimental*.nupkg</SymbolsPublishExperimentalPattern>
   </PropertyGroup>
 
+  <!-- List of packages to exclude from nuget.org publishing -->
+  <!-- We can't use the `IsShippingPackage` metadata since CoreFx doesn't output packages
+  to shipping/nonshipping directories -->
+  <ItemGroup>
+    <NonShippingPackages Include="$(PackageOutputRoot)*System.Numerics.Tensors*.nupkg" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(PackagesGlob)' != ''">
     <PackagesToPublish Include="$(PackagesGlob)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(PackagesGlob)' == ''">
-    <PackagesToPublish Include="$(FinalPublishPrivatePattern);$(FinalPublishExperimentalPattern)">
+    <PackagesToPublish Include="$(FinalPublishPrivatePattern);$(FinalPublishExperimentalPattern);@(NonShippingPackages)">
       <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
     </PackagesToPublish>
     <PackagesToPublish Include="$(FinalPublishPattern)" Exclude="@(PackagesToPublish)" />

--- a/src/System.Numerics.Tensors/Directory.Build.props
+++ b/src/System.Numerics.Tensors/Directory.Build.props
@@ -4,5 +4,7 @@
     <AssemblyVersion>0.2.0.0</AssemblyVersion>
     <PackageVersion>0.2.0</PackageVersion>
     <StrongNameKeyId>Open</StrongNameKeyId>
+    <!-- This is a preview package. Do not mark as stable. -->
+    <BlockStable>true</BlockStable>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Ports https://github.com/dotnet/corefx/pull/39772 and https://github.com/dotnet/corefx/pull/39743 to rel/3.0 for `preview8.`

Marks `System.Numerics.Tensors` as nonshipping so that we don't push it to nuget.org. This is an experimental package that we don't intend to ship with our previews (there are already preview versions of this on nuget.org that were shipped w/ previews 1-7 - we don't need to take those down, but we also shouldn't use their existence as motivation to continue publishing preview versions of an unchanging experimental package that we didn't intend to ship yet).

CC @tannergooding 

@ericstj @danmosemsft - please consider this for preview8