### PR TITLE
Allow JsonConverterAttribute to be applied to an Enum

### DIFF
--- a/src/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/System.Text.Json/ref/System.Text.Json.cs
@@ -459,7 +459,7 @@ namespace System.Text.Json.Serialization
         internal JsonConverter() { }
         public abstract bool CanConvert(System.Type typeToConvert);
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple=false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Enum | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple=false)]
     public partial class JsonConverterAttribute : System.Text.Json.Serialization.JsonAttribute
     {
         protected JsonConverterAttribute() { }

--- a/src/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterAttribute.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterAttribute.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Serialization
     /// <see cref="JsonSerializerOptions.Converters"/> or there is another <see cref="JsonConverterAttribute"/> on a property
     /// of the same type.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Struct, AllowMultiple = false)]
     public class JsonConverterAttribute : JsonAttribute
     {
         /// <summary>

--- a/src/System.Text.Json/tests/Serialization/EnumConverterTests.cs
+++ b/src/System.Text.Json/tests/Serialization/EnumConverterTests.cs
@@ -165,5 +165,25 @@ namespace System.Text.Json.Serialization.Tests
             public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
                 => s_stringEnumConverter.CreateConverter(typeToConvert, options);
         }
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        private enum MyCustomEnum
+        {
+            First = 1,
+            Second =2
+        }
+
+        [Fact]
+        public void EnumWithConverterAttribute()
+        {
+            string json = JsonSerializer.Serialize(MyCustomEnum.Second);
+            Assert.Equal(@"""Second""", json);
+
+            MyCustomEnum obj = JsonSerializer.Deserialize<MyCustomEnum>("\"Second\"");
+            Assert.Equal(MyCustomEnum.Second, obj);
+
+            obj = JsonSerializer.Deserialize<MyCustomEnum>("2");
+            Assert.Equal(MyCustomEnum.Second, obj);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/39741

Add capability to specify custom converter for an Enum by using [JsonConverter] just like we support for properties, etc.

This does affect the ref/System.Text.Json.cs but only to change the attribute targets (not really an API change).

@ericstj assuming approved for master, requesting approval for release/3.0.
