### PR TITLE
 Fix validation check within Utf8JsonWriter for writing a primitive value after another complete value has been written.

### DIFF
--- a/src/System.Text.Json/src/Resources/Strings.resx
+++ b/src/System.Text.Json/src/Resources/Strings.resx
@@ -156,8 +156,8 @@
   <data name="CannotWritePropertyAfterProperty" xml:space="preserve">
     <value>Cannot write a JSON property name following another property name. A JSON value is missing.</value>
   </data>
-  <data name="CannotWriteValueAfterPrimitive" xml:space="preserve">
-    <value>Cannot write a JSON value after a single JSON value. Current token type is '{0}'.</value>
+  <data name="CannotWriteValueAfterPrimitiveOrClose" xml:space="preserve">
+    <value>Cannot write a JSON value after a single JSON value or outside of an existing closed object/array. Current token type is '{0}'.</value>
   </data>
   <data name="CannotWriteValueWithinObject" xml:space="preserve">
     <value>Cannot write a JSON value within an object without a property name. Current token type is '{0}'.</value>

--- a/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
+++ b/src/System.Text.Json/src/System/Text/Json/ThrowHelper.cs
@@ -496,8 +496,8 @@ namespace System.Text.Json
                         SR.Format(SR.CannotWritePropertyAfterProperty) :
                         SR.Format(SR.CannotWritePropertyWithinArray, tokenType);
                     break;
-                case ExceptionResource.CannotWriteValueAfterPrimitive:
-                    message = SR.Format(SR.CannotWriteValueAfterPrimitive, tokenType);
+                case ExceptionResource.CannotWriteValueAfterPrimitiveOrClose:
+                    message = SR.Format(SR.CannotWriteValueAfterPrimitiveOrClose, tokenType);
                     break;
                 default:
                     Debug.Fail($"The ExceptionResource enum value: {resource} is not part of the switch. Add the appropriate case and exception message.");
@@ -623,7 +623,7 @@ namespace System.Text.Json
         CannotStartObjectArrayWithoutProperty,
         CannotStartObjectArrayAfterPrimitiveOrClose,
         CannotWriteValueWithinObject,
-        CannotWriteValueAfterPrimitive,
+        CannotWriteValueAfterPrimitiveOrClose,
         CannotWritePropertyWithinArray,
         ExpectedJsonTokens,
         TrailingCommaNotAllowedBeforeArrayEnd,

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
@@ -26,6 +26,8 @@ namespace System.Text.Json
                 else
                 {
                     Debug.Assert(_tokenType != JsonTokenType.PropertyName);
+
+                    // It is more likely for CurrentDepth to not equal 0 when writing valid JSON, so check that first to rely on short-circuiting and return quickly.
                     if (_tokenType != JsonTokenType.None && CurrentDepth == 0)
                     {
                         ThrowHelper.ThrowInvalidOperationException(ExceptionResource.CannotWriteValueAfterPrimitiveOrClose, currentDepth: default, token: default, _tokenType);

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
@@ -26,7 +26,7 @@ namespace System.Text.Json
                 else
                 {
                     Debug.Assert(_tokenType != JsonTokenType.PropertyName);
-                    if (_tokenType != JsonTokenType.None && (!_isNotPrimitive || CurrentDepth == 0))
+                    if (_tokenType != JsonTokenType.None && CurrentDepth == 0)
                     {
                         ThrowHelper.ThrowInvalidOperationException(ExceptionResource.CannotWriteValueAfterPrimitiveOrClose, currentDepth: default, token: default, _tokenType);
                     }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
@@ -26,9 +26,9 @@ namespace System.Text.Json
                 else
                 {
                     Debug.Assert(_tokenType != JsonTokenType.PropertyName);
-                    if (!_isNotPrimitive && _tokenType != JsonTokenType.None)
+                    if (_tokenType != JsonTokenType.None && (!_isNotPrimitive || CurrentDepth == 0))
                     {
-                        ThrowHelper.ThrowInvalidOperationException(ExceptionResource.CannotWriteValueAfterPrimitive, currentDepth: default, token: default, _tokenType);
+                        ThrowHelper.ThrowInvalidOperationException(ExceptionResource.CannotWriteValueAfterPrimitiveOrClose, currentDepth: default, token: default, _tokenType);
                     }
                 }
             }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
@@ -28,7 +28,7 @@ namespace System.Text.Json
                     Debug.Assert(_tokenType != JsonTokenType.PropertyName);
 
                     // It is more likely for CurrentDepth to not equal 0 when writing valid JSON, so check that first to rely on short-circuiting and return quickly.
-                    if (_tokenType != JsonTokenType.None && CurrentDepth == 0)
+                    if (CurrentDepth == 0 && _tokenType != JsonTokenType.None)
                     {
                         ThrowHelper.ThrowInvalidOperationException(ExceptionResource.CannotWriteValueAfterPrimitiveOrClose, currentDepth: default, token: default, _tokenType);
                     }

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -48,7 +48,6 @@ namespace System.Text.Json
         private Memory<byte> _memory;
 
         private bool _inObject;
-        private bool _isNotPrimitive;
         private JsonTokenType _tokenType;
         private BitStack _bitStack;
 
@@ -116,7 +115,6 @@ namespace System.Text.Json
             _memory = default;
 
             _inObject = default;
-            _isNotPrimitive = default;
             _tokenType = default;
             _currentDepth = default;
             _options = options;
@@ -152,7 +150,6 @@ namespace System.Text.Json
             _memory = default;
 
             _inObject = default;
-            _isNotPrimitive = default;
             _tokenType = default;
             _currentDepth = default;
             _options = options;
@@ -249,7 +246,6 @@ namespace System.Text.Json
             _memory = default;
 
             _inObject = default;
-            _isNotPrimitive = default;
             _tokenType = default;
             _currentDepth = default;
 
@@ -470,7 +466,6 @@ namespace System.Text.Json
 
             _currentDepth &= JsonConstants.RemoveFlagsBitMask;
             _currentDepth++;
-            _isNotPrimitive = true;
         }
 
         private void WriteStartMinimized(byte token)
@@ -524,7 +519,7 @@ namespace System.Text.Json
             {
                 Debug.Assert(_tokenType != JsonTokenType.PropertyName);
                 Debug.Assert(_tokenType != JsonTokenType.StartObject);
-                if (_tokenType != JsonTokenType.None && (!_isNotPrimitive || CurrentDepth == 0))
+                if (_tokenType != JsonTokenType.None && CurrentDepth == 0)
                 {
                     ThrowHelper.ThrowInvalidOperationException(ExceptionResource.CannotStartObjectArrayAfterPrimitiveOrClose, currentDepth: default, token: default, _tokenType);
                 }
@@ -602,7 +597,6 @@ namespace System.Text.Json
 
             _currentDepth &= JsonConstants.RemoveFlagsBitMask;
             _currentDepth++;
-            _isNotPrimitive = true;
         }
 
         /// <summary>
@@ -627,7 +621,6 @@ namespace System.Text.Json
 
             _currentDepth &= JsonConstants.RemoveFlagsBitMask;
             _currentDepth++;
-            _isNotPrimitive = true;
             _tokenType = JsonTokenType.StartArray;
         }
 
@@ -653,7 +646,6 @@ namespace System.Text.Json
 
             _currentDepth &= JsonConstants.RemoveFlagsBitMask;
             _currentDepth++;
-            _isNotPrimitive = true;
             _tokenType = JsonTokenType.StartObject;
         }
 
@@ -772,7 +764,6 @@ namespace System.Text.Json
 
             _currentDepth &= JsonConstants.RemoveFlagsBitMask;
             _currentDepth++;
-            _isNotPrimitive = true;
             _tokenType = JsonTokenType.StartArray;
         }
 
@@ -798,7 +789,6 @@ namespace System.Text.Json
 
             _currentDepth &= JsonConstants.RemoveFlagsBitMask;
             _currentDepth++;
-            _isNotPrimitive = true;
             _tokenType = JsonTokenType.StartObject;
         }
 

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -519,7 +519,9 @@ namespace System.Text.Json
             {
                 Debug.Assert(_tokenType != JsonTokenType.PropertyName);
                 Debug.Assert(_tokenType != JsonTokenType.StartObject);
-                if (_tokenType != JsonTokenType.None && CurrentDepth == 0)
+
+                // It is more likely for CurrentDepth to not equal 0 when writing valid JSON, so check that first to rely on short-circuiting and return quickly.
+                if (CurrentDepth == 0 && _tokenType != JsonTokenType.None)
                 {
                     ThrowHelper.ThrowInvalidOperationException(ExceptionResource.CannotStartObjectArrayAfterPrimitiveOrClose, currentDepth: default, token: default, _tokenType);
                 }

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -883,141 +883,105 @@ namespace System.Text.Json.Tests
         [InlineData(JsonValueKind.Null, true, false)]
         [InlineData(JsonValueKind.Null, false, true)]
         [InlineData(JsonValueKind.Null, false, false)]
-        public void InvalidJsonDueToWritingTooMuch(JsonValueKind kind, bool formatted, bool skipValidation)
+        public void InvalidJsonDueToWritingMultipleValues(JsonValueKind kind, bool formatted, bool skipValidation)
         {
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WriteStartObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject());
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteStartObject(), skipValidation);
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WriteStartObject("foo");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject("foo"));
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteStartObject("foo"), skipValidation);
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WriteStartArray();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray());
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteStartArray(), skipValidation);
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WriteStartArray("foo");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("foo"));
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteEndObject(), skipValidation);
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WriteEndObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteEndArray(), skipValidation);
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WriteEndArray();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WritePropertyName("foo"), skipValidation);
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WritePropertyName("foo");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("foo"));
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteString("key", "foo"), skipValidation);
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WriteStringValue("foo");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue("foo"));
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteStringValue("foo"), skipValidation);
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WriteNumberValue(1);
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNumberValue(1));
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteNumber("key", 123), skipValidation);
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WriteBooleanValue(true);
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteBooleanValue(true));
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteNumberValue(123), skipValidation);
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WriteBooleanValue(false);
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteBooleanValue(false));
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteBoolean("key", true), skipValidation);
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            WritePreamble(jsonUtf8, kind);
-            if (skipValidation)
             {
-                jsonUtf8.WriteNullValue();
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteBooleanValue(true), skipValidation);
             }
-            else
+
             {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNullValue());
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteBoolean("key", false), skipValidation);
+            }
+
+            {
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteBooleanValue(false), skipValidation);
+            }
+
+            {
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteNull("key"), skipValidation);
+            }
+
+            {
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+                WritePreamble(jsonUtf8, kind);
+                ValidateAction(() => jsonUtf8.WriteNullValue(), skipValidation);
             }
         }
 
@@ -1053,6 +1017,18 @@ namespace System.Text.Json.Tests
                 default:
                     Debug.Fail($"Invalid JsonValueKind passed in '{kind}'.");
                     break;
+            }
+        }
+
+        private void ValidateAction(Action action, bool skipValidation)
+        {
+            if (skipValidation)
+            {
+                action.Invoke();
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(action);
             }
         }
 

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -888,106 +888,256 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteStartObject(), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteStartObject("foo"), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteStartArray(), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteEndObject(), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteEndArray(), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WritePropertyName("foo"), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteString("key", "foo"), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteStringValue("foo"), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteNumber("key", 123), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteNumberValue(123), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteBoolean("key", true), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteBooleanValue(true), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteBoolean("key", false), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteBooleanValue(false), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteNull("key"), skipValidation);
             }
 
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
                 ValidateAction(jsonUtf8, () => jsonUtf8.WriteNullValue(), skipValidation);
             }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind);
+                // Writing a comment after any preamable is valid (even when skipValidation is false)
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteCommentValue("some comment"), skipValidation: true);
+            }
         }
 
-        private void WritePreamble(Utf8JsonWriter writer, JsonValueKind kind)
+        [Theory]
+        [InlineData(JsonValueKind.Array, true, true)]
+        [InlineData(JsonValueKind.Array, true, false)]
+        [InlineData(JsonValueKind.Array, false, true)]
+        [InlineData(JsonValueKind.Array, false, false)]
+        [InlineData(JsonValueKind.Object, true, true)]
+        [InlineData(JsonValueKind.Object, true, false)]
+        [InlineData(JsonValueKind.Object, false, true)]
+        [InlineData(JsonValueKind.Object, false, false)]
+        [InlineData(JsonValueKind.String, true, true)]
+        [InlineData(JsonValueKind.String, true, false)]
+        [InlineData(JsonValueKind.String, false, true)]
+        [InlineData(JsonValueKind.String, false, false)]
+        [InlineData(JsonValueKind.Number, true, true)]
+        [InlineData(JsonValueKind.Number, true, false)]
+        [InlineData(JsonValueKind.Number, false, true)]
+        [InlineData(JsonValueKind.Number, false, false)]
+        [InlineData(JsonValueKind.True, true, true)]
+        [InlineData(JsonValueKind.True, true, false)]
+        [InlineData(JsonValueKind.True, false, true)]
+        [InlineData(JsonValueKind.True, false, false)]
+        [InlineData(JsonValueKind.False, true, true)]
+        [InlineData(JsonValueKind.False, true, false)]
+        [InlineData(JsonValueKind.False, false, true)]
+        [InlineData(JsonValueKind.False, false, false)]
+        [InlineData(JsonValueKind.Null, true, true)]
+        [InlineData(JsonValueKind.Null, true, false)]
+        [InlineData(JsonValueKind.Null, false, true)]
+        [InlineData(JsonValueKind.Null, false, false)]
+        public void InvalidJsonDueToWritingMultipleValuesWithComments(JsonValueKind kind, bool formatted, bool skipValidation)
+        {
+            var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
+            var output = new ArrayBufferWriter<byte>(1024);
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteStartObject(), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteStartObject("foo"), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteStartArray(), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteEndObject(), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteEndArray(), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WritePropertyName("foo"), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteString("key", "foo"), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteStringValue("foo"), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteNumber("key", 123), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteNumberValue(123), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteBoolean("key", true), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteBooleanValue(true), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteBoolean("key", false), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteBooleanValue(false), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteNull("key"), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteNullValue(), skipValidation);
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                WritePreamble(jsonUtf8, kind, addComments: true);
+                // Writing a comment after any preamable is valid (even when skipValidation is false)
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteCommentValue("some comment"), skipValidation: true);
+            }
+        }
+
+        private void WritePreamble(Utf8JsonWriter writer, JsonValueKind kind, bool addComments = false)
         {
             Debug.Assert(writer.BytesCommitted == 0 && writer.BytesPending == 0 && writer.CurrentDepth == 0 && kind != JsonValueKind.Undefined);
+
+            if (addComments)
+            {
+                writer.WriteCommentValue(" comment value before ");
+            }
 
             switch (kind)
             {
@@ -1017,6 +1167,11 @@ namespace System.Text.Json.Tests
                 default:
                     Debug.Fail($"Invalid JsonValueKind passed in '{kind}'.");
                     break;
+            }
+
+            if (addComments)
+            {
+                writer.WriteCommentValue(" comment value after ");
             }
         }
 

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -855,153 +855,169 @@ namespace System.Text.Json.Tests
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void InvalidJsonDueToWritingTooMuch(bool formatted, bool skipValidation)
+        [InlineData(JsonValueKind.Array, true, true)]
+        [InlineData(JsonValueKind.Array, true, false)]
+        [InlineData(JsonValueKind.Array, false, true)]
+        [InlineData(JsonValueKind.Array, false, false)]
+        [InlineData(JsonValueKind.Object, true, true)]
+        [InlineData(JsonValueKind.Object, true, false)]
+        [InlineData(JsonValueKind.Object, false, true)]
+        [InlineData(JsonValueKind.Object, false, false)]
+        [InlineData(JsonValueKind.String, true, true)]
+        [InlineData(JsonValueKind.String, true, false)]
+        [InlineData(JsonValueKind.String, false, true)]
+        [InlineData(JsonValueKind.String, false, false)]
+        [InlineData(JsonValueKind.Number, true, true)]
+        [InlineData(JsonValueKind.Number, true, false)]
+        [InlineData(JsonValueKind.Number, false, true)]
+        [InlineData(JsonValueKind.Number, false, false)]
+        [InlineData(JsonValueKind.True, true, true)]
+        [InlineData(JsonValueKind.True, true, false)]
+        [InlineData(JsonValueKind.True, false, true)]
+        [InlineData(JsonValueKind.True, false, false)]
+        [InlineData(JsonValueKind.False, true, true)]
+        [InlineData(JsonValueKind.False, true, false)]
+        [InlineData(JsonValueKind.False, false, true)]
+        [InlineData(JsonValueKind.False, false, false)]
+        [InlineData(JsonValueKind.Null, true, true)]
+        [InlineData(JsonValueKind.Null, true, false)]
+        [InlineData(JsonValueKind.Null, false, true)]
+        [InlineData(JsonValueKind.Null, false, false)]
+        public void InvalidJsonDueToWritingTooMuch(JsonValueKind kind, bool formatted, bool skipValidation)
         {
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            foreach (JsonValueKind kind in Enum.GetValues(typeof(JsonValueKind)))
+            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
             {
-                if (kind == JsonValueKind.Undefined)
-                {
-                    continue;
-                }
+                jsonUtf8.WriteStartObject();
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject());
+            }
 
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WriteStartObject();
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject());
-                }
+            jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
+            {
+                jsonUtf8.WriteStartObject("foo");
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject("foo"));
+            }
 
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WriteStartObject("foo");
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject("foo"));
-                }
+            jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
+            {
+                jsonUtf8.WriteStartArray();
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray());
+            }
 
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WriteStartArray();
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray());
-                }
+            jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
+            {
+                jsonUtf8.WriteStartArray("foo");
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("foo"));
+            }
 
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WriteStartArray("foo");
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("foo"));
-                }
+            jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
+            {
+                jsonUtf8.WriteEndObject();
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+            }
 
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WriteEndObject();
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
-                }
+            jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
+            {
+                jsonUtf8.WriteEndArray();
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+            }
 
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WriteEndArray();
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
-                }
+            jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
+            {
+                jsonUtf8.WritePropertyName("foo");
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("foo"));
+            }
 
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WritePropertyName("foo");
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("foo"));
-                }
+            jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
+            {
+                jsonUtf8.WriteStringValue("foo");
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue("foo"));
+            }
 
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WriteStringValue("foo");
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue("foo"));
-                }
+            jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
+            {
+                jsonUtf8.WriteNumberValue(1);
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNumberValue(1));
+            }
 
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WriteNumberValue(1);
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue("foo"));
-                }
+            jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
+            {
+                jsonUtf8.WriteBooleanValue(true);
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteBooleanValue(true));
+            }
 
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WriteBooleanValue(true);
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue("foo"));
-                }
+            jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
+            {
+                jsonUtf8.WriteBooleanValue(false);
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteBooleanValue(false));
+            }
 
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WriteBooleanValue(false);
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue("foo"));
-                }
-
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                WritePreamble(jsonUtf8, kind);
-                if (skipValidation)
-                {
-                    jsonUtf8.WriteNullValue();
-                }
-                else
-                {
-                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue("foo"));
-                }
+            jsonUtf8 = new Utf8JsonWriter(output, options);
+            WritePreamble(jsonUtf8, kind);
+            if (skipValidation)
+            {
+                jsonUtf8.WriteNullValue();
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNullValue());
             }
         }
 
@@ -1033,6 +1049,9 @@ namespace System.Text.Json.Tests
                     break;
                 case JsonValueKind.Null:
                     writer.WriteNullValue();
+                    break;
+                default:
+                    Debug.Fail($"Invalid JsonValueKind passed in '{kind}'.");
                     break;
             }
         }

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -891,97 +891,97 @@ namespace System.Text.Json.Tests
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteStartObject(), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteStartObject(), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteStartObject("foo"), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteStartObject("foo"), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteStartArray(), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteStartArray(), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteEndObject(), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteEndObject(), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteEndArray(), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteEndArray(), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WritePropertyName("foo"), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WritePropertyName("foo"), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteString("key", "foo"), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteString("key", "foo"), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteStringValue("foo"), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteStringValue("foo"), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteNumber("key", 123), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteNumber("key", 123), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteNumberValue(123), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteNumberValue(123), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteBoolean("key", true), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteBoolean("key", true), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteBooleanValue(true), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteBooleanValue(true), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteBoolean("key", false), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteBoolean("key", false), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteBooleanValue(false), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteBooleanValue(false), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteNull("key"), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteNull("key"), skipValidation);
             }
 
             {
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 WritePreamble(jsonUtf8, kind);
-                ValidateAction(() => jsonUtf8.WriteNullValue(), skipValidation);
+                ValidateAction(jsonUtf8, () => jsonUtf8.WriteNullValue(), skipValidation);
             }
         }
 
@@ -1020,11 +1020,13 @@ namespace System.Text.Json.Tests
             }
         }
 
-        private void ValidateAction(Action action, bool skipValidation)
+        private void ValidateAction(Utf8JsonWriter writer, Action action, bool skipValidation)
         {
             if (skipValidation)
             {
+                int originalBytesPending = writer.BytesPending;
                 action.Invoke();
+                Assert.NotEqual(originalBytesPending, writer.BytesPending);
             }
             else
             {

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -1022,15 +1022,16 @@ namespace System.Text.Json.Tests
 
         private void ValidateAction(Utf8JsonWriter writer, Action action, bool skipValidation)
         {
+            int originalBytesPending = writer.BytesPending;
             if (skipValidation)
             {
-                int originalBytesPending = writer.BytesPending;
                 action.Invoke();
                 Assert.NotEqual(originalBytesPending, writer.BytesPending);
             }
             else
             {
                 Assert.Throws<InvalidOperationException>(action);
+                Assert.Equal(originalBytesPending, writer.BytesPending);
             }
         }
 
@@ -5420,9 +5421,9 @@ namespace System.Text.Json.Tests
 
                 ReadOnlySpan<char> nullStringSpan = nullString.AsSpan();
                 charSpanAction(writer, nullStringSpan, value);
-            
+
                 byteSpanAction(writer, ReadOnlySpan<byte>.Empty, value);
-                
+
                 writer.WriteEndObject();
                 writer.Flush();
             }
@@ -5510,7 +5511,7 @@ namespace System.Text.Json.Tests
         {
             var output = new ArrayBufferWriter<byte>(1024);
             string nullString = null;
-            
+
             using (var writer = new Utf8JsonWriter(output))
             {
                 writer.WriteStartArray();


### PR DESCRIPTION
Also removed use of `_isNotPrimitive` as that is redundant and unnecessary (turns out using `CurrentDepth == 0` for validation is sufficient).

cc @bartonjs, @JamesNK 

cc @ericstj for 3.0