### PR TITLE
Enable target framework attribute on test assemblies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -246,7 +246,8 @@
     <NoStdLib>true</NoStdLib>
     <NoExplicitReferenceToStdLib>true</NoExplicitReferenceToStdLib>
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <!-- Enable the target framework attribute on test assemblies as vstest relies on that property. -->
+    <GenerateTargetFrameworkAttribute Condition="'$(IsTestProject)' != 'true'">false</GenerateTargetFrameworkAttribute>
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
     <!-- Don't reference implicit framework packages, all projects in this repo must be explicit -->
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>


### PR DESCRIPTION
Related https://github.com/dotnet/corefx/issues/26457

Fixes VS Test Explorer not working on 16.2 and upwards because vstest relies on the TargetFrameworkAttribute being set: https://github.com/microsoft/vstest/blob/7b6248203164f8ea821f6795632bd22e0b69afb0/src/vstest.console/CommandLine/AssemblyMetadataProvider.cs#L97

Thanks to @mayankbansal018 for helping me to debug this.