### PR TITLE
Port fix to NRE when regex MatchEvaluator returns null

### DIFF
--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -186,7 +186,9 @@ namespace System.Text.RegularExpressions
                             vsb.Append(input.AsSpan(prevat, match.Index - prevat));
 
                         prevat = match.Index + match.Length;
-                        vsb.Append(evaluator(match) ?? "");
+                        string result = evaluator(match);
+                        if (!string.IsNullOrEmpty(result))
+	                        vsb.Append(result);
 
                         if (--count == 0)
                             break;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -186,7 +186,7 @@ namespace System.Text.RegularExpressions
                             vsb.Append(input.AsSpan(prevat, match.Index - prevat));
 
                         prevat = match.Index + match.Length;
-                        vsb.Append(evaluator(match));
+                        vsb.Append(evaluator(match) ?? "");
 
                         if (--count == 0)
                             break;

--- a/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -224,6 +224,25 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Same(input, Regex.Replace(input, "no-match", new MatchEvaluator(MatchEvaluator1)));
         }
 
+        [Theory]
+        [InlineData(RegexOptions.None)]
+        [InlineData(RegexOptions.RightToLeft)]
+        public void Replace_MatchEvaluatorReturnsNullOrEmpty(RegexOptions options)
+        {
+            string result = Regex.Replace("abcde", @"[abcd]", (Match match) => {
+                return match.Value switch
+                {
+                    "a" => "x",
+                    "b" => null,
+                    "c" => "",
+                    "d" => "y",
+                    _ => throw new InvalidOperationException()
+                };
+            }, options);
+
+            Assert.Equal("xye", result);
+        }
+
         [Fact]
         public void Replace_Invalid()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/pull/39779

Porting to 3.0 because this is a regression from .NET Framework and from previous .NET Core releases, and it may be fairly common to return null from a MatchEvaluator.