### PR TITLE
[3.0] Debian 10/Win8.1 fixes: Allow explicitly using SSLv3, TLS1.0/1.1

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -17,7 +17,7 @@ namespace System.Net.Security
             ApplicationProtocols = sslClientAuthenticationOptions.ApplicationProtocols;
             CertValidationDelegate = remoteCallback;
             CheckCertName = true;
-            EnabledSslProtocols = sslClientAuthenticationOptions.EnabledSslProtocols;
+            EnabledSslProtocols = FilterOutIncompatibleSslProtocols(sslClientAuthenticationOptions.EnabledSslProtocols);
             EncryptionPolicy = sslClientAuthenticationOptions.EncryptionPolicy;
             IsServer = false;
             RemoteCertRequired = true;
@@ -36,7 +36,7 @@ namespace System.Net.Security
             AllowRenegotiation = sslServerAuthenticationOptions.AllowRenegotiation;
             ApplicationProtocols = sslServerAuthenticationOptions.ApplicationProtocols;
             CheckCertName = false;
-            EnabledSslProtocols = sslServerAuthenticationOptions.EnabledSslProtocols;
+            EnabledSslProtocols = FilterOutIncompatibleSslProtocols(sslServerAuthenticationOptions.EnabledSslProtocols);
             EncryptionPolicy = sslServerAuthenticationOptions.EncryptionPolicy;
             IsServer = true;
             RemoteCertRequired = sslServerAuthenticationOptions.ClientCertificateRequired;
@@ -50,6 +50,21 @@ namespace System.Net.Security
             CertificateRevocationCheckMode = sslServerAuthenticationOptions.CertificateRevocationCheckMode;
             ServerCertificate = sslServerAuthenticationOptions.ServerCertificate;
             CipherSuitesPolicy = sslServerAuthenticationOptions.CipherSuitesPolicy;
+        }
+
+        private static SslProtocols FilterOutIncompatibleSslProtocols(SslProtocols protocols)
+        {
+            if (protocols.HasFlag(SslProtocols.Tls12) || protocols.HasFlag(SslProtocols.Tls13))
+            {
+#pragma warning disable 0618
+                // SSL2 is mutually exclusive with >= TLS1.2
+                // On Windows10 SSL2 flag has no effect but on earlier versions of the OS
+                // opting into both SSL2 and >= TLS1.2 causes negotiation to always fail.
+                protocols &= ~SslProtocols.Ssl2;
+#pragma warning restore 0618
+            }
+
+            return protocols;
         }
 
         internal bool AllowRenegotiation { get; set; }

--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -16,7 +16,7 @@ namespace System.Net.Security.Tests
 
     public class CertificateValidationClientServer : IDisposable
     {
-        private readonly ITestOutputHelper _output;        
+        private readonly ITestOutputHelper _output;
         private readonly X509Certificate2 _clientCertificate;
         private readonly X509Certificate2Collection _clientCertificateCollection;
         private readonly X509Certificate2 _serverCertificate;
@@ -47,7 +47,7 @@ namespace System.Net.Security.Tests
         [InlineData(true)]
         public async Task CertificateValidationClientServer_EndToEnd_Ok(bool useClientSelectionCallback)
         {
-            IPEndPoint endPoint = new IPEndPoint(IPAddress.IPv6Loopback, 0);
+            IPEndPoint endPoint = new IPEndPoint(IPAddress.Loopback, 0);
             var server = new TcpListener(endPoint);
             server.Start();
 
@@ -67,7 +67,7 @@ namespace System.Net.Security.Tests
                 _clientCertificateRemovedByFilter = true;
             }
 
-            using (var clientConnection = new TcpClient(AddressFamily.InterNetworkV6))
+            using (var clientConnection = new TcpClient())
             {
                 IPEndPoint serverEndPoint = (IPEndPoint)server.LocalEndpoint;
 
@@ -204,7 +204,7 @@ namespace System.Net.Security.Tests
             // Verify that the certificate is in the trustedChain.
             _output.WriteLine($"cert: subject={cert.Subject}, issuer={cert.Issuer}, thumbprint={cert.Thumbprint}");
             Assert.Equal(cert.Thumbprint, trustedChain.ChainElements[0].Certificate.Thumbprint);
-            
+
             // Verify that the root certificate in the chain is the one that issued the received certificate.
             foreach (X509ChainElement element in trustedChain.ChainElements)
             {

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -139,10 +139,10 @@ namespace System.Net.Security.Tests
         {
             _log.WriteLine("Server: " + serverSslProtocols + "; Client: " + clientSslProtocols);
 
-            IPEndPoint endPoint = new IPEndPoint(IPAddress.IPv6Loopback, 0);
+            IPEndPoint endPoint = new IPEndPoint(IPAddress.Loopback, 0);
 
             using (var server = new DummyTcpServer(endPoint, encryptionPolicy))
-            using (var client = new TcpClient(AddressFamily.InterNetworkV6))
+            using (var client = new TcpClient())
             {
                 server.SslProtocols = serverSslProtocols;
                 await client.ConnectAsync(server.RemoteEndPoint.Address, server.RemoteEndPoint.Port);

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -99,11 +99,11 @@ namespace System.Net.Security.Tests
             int timeOut = expectedToFail ? TestConfiguration.FailingTestTimeoutMiliseconds
                 : TestConfiguration.PassingTestTimeoutMilliseconds;
 
-            IPEndPoint endPoint = new IPEndPoint(IPAddress.IPv6Loopback, 0);
+            IPEndPoint endPoint = new IPEndPoint(IPAddress.Loopback, 0);
             var server = new TcpListener(endPoint);
             server.Start();
 
-            using (var clientConnection = new TcpClient(AddressFamily.InterNetworkV6))
+            using (var clientConnection = new TcpClient())
             {
                 IPEndPoint serverEndPoint = (IPEndPoint)server.LocalEndpoint;
 

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamNegotiatedCipherSuiteTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamNegotiatedCipherSuiteTest.cs
@@ -21,12 +21,12 @@ namespace System.Net.Security.Tests
     public class NegotiatedCipherSuiteTest
     {
 #pragma warning disable CS0618 // Ssl2 and Ssl3 are obsolete
-        private const SslProtocols AllProtocols =
+        public const SslProtocols AllProtocols =
             SslProtocols.Ssl2 | SslProtocols.Ssl3 |
             SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.Tls13;
 #pragma warning restore CS0618
 
-        private const SslProtocols NonTls13Protocols = AllProtocols & (~SslProtocols.Tls13);
+        public const SslProtocols NonTls13Protocols = AllProtocols & (~SslProtocols.Tls13);
 
         private static bool IsKnownPlatformSupportingTls13 => PlatformDetection.SupportsTls13;
         private static bool CipherSuitesPolicySupported => s_cipherSuitePolicySupported.Value;
@@ -93,11 +93,17 @@ namespace System.Net.Security.Tests
             };
 
             NegotiatedParams ret = ConnectAndGetNegotiatedParams(p, p);
-            ret.Succeeded();
-
-            Assert.True(
-                s_protocolCipherSuiteLookup[protocol].Contains(ret.CipherSuite),
-                $"`{ret.CipherSuite}` is not recognized as {protocol} cipher suite");
+            if (ret.HasSucceeded)
+            {
+                Assert.True(
+                    s_protocolCipherSuiteLookup[protocol].Contains(ret.CipherSuite),
+                    $"`{ret.CipherSuite}` is not recognized as {protocol} cipher suite");
+            }
+            else
+            {
+                // currently TLS 1.2 should be enabled by all known implementations
+                Assert.NotEqual(SslProtocols.Tls12, protocol);
+            }
         }
 
         [Fact]

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSniTest.cs
@@ -67,7 +67,7 @@ namespace System.Net.Security.Tests
             var validationCallback = new RemoteCertificateValidationCallback((object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) =>
             {
                 Assert.Equal(serverCert, certificate);
-                return true; 
+                return true;
             });
 
             VirtualNetwork vn = new VirtualNetwork();
@@ -192,7 +192,7 @@ namespace System.Net.Security.Tests
             return new SslServerAuthenticationOptions()
             {
                 ClientCertificateRequired = false,
-                EnabledSslProtocols = SslProtocols.Tls,
+                EnabledSslProtocols = SslProtocols.None,
                 CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
             };
         }

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamSystemDefaultsTest.cs
@@ -39,15 +39,15 @@ namespace System.Net.Security.Tests
         [InlineData(SslProtocols.None, null)]
         [InlineData(null, SslProtocols.None)]
         [InlineData(SslProtocols.None, SslProtocols.None)]
-        [InlineData(null, SslProtocols.Tls11)]
-        [InlineData(SslProtocols.Tls11, null)]
+        [InlineData(NegotiatedCipherSuiteTest.NonTls13Protocols, SslProtocols.Tls11)]
+        [InlineData(SslProtocols.Tls11, NegotiatedCipherSuiteTest.NonTls13Protocols)]
         [InlineData(null, SslProtocols.Tls12)]
         [InlineData(SslProtocols.Tls12, null)]
         [InlineData(SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, null)]
         [InlineData(null, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12)]
 #pragma warning disable 0618
-        [InlineData(SslProtocols.Default, null)]
-        [InlineData(null, SslProtocols.Default)]
+        [InlineData(SslProtocols.Default, NegotiatedCipherSuiteTest.NonTls13Protocols)]
+        [InlineData(NegotiatedCipherSuiteTest.NonTls13Protocols, SslProtocols.Default)]
 #pragma warning restore 0618
         public async Task ClientAndServer_OneOrBothUseDefault_Ok(SslProtocols? clientProtocols, SslProtocols? serverProtocols)
         {


### PR DESCRIPTION
3.0 Port of https://github.com/dotnet/corefx/pull/39579

#### Description

Allow explicitly using SSL2, SSL3, TLS1.0/1.1 on all platforms

#### Customer Impact

- Customers can now use SSL2, SSL3, TLS1.0, TLS1.1 on all platforms which support it
  - previously some Linux distributions had OpenSSL setup that did not allow to use older protocols even when explicitly asked to only use selected protocol but OpenSSL tool allowed to use it explicitly
  - previously some combinations of protocols explicitly set are blocked by some SSL/TLS implementations and are causing authentication to always fail (SSL2 combined with TLS1.2/TLS1.3) - now behavior is consistent and as per spec opting into TLS1.2 or higher opts out of SSL2

#### Regression?

No

#### Risk

No known risk of breaking anything by merging this PR - this is enabling scenarios which already work on some platforms but not on others and modifies only scenario when SslProtocols are explicitly used (when using SslStream defaults this PR should not have any effect).

#### Test changes in this PR

- Convert System.Net.Security tests to not require IPv6 (they don't need it and it's disabled on docker by default)
- Harden some random tests against future changes to underlying implementations
