### PR TITLE
Fix Utf8JsonWriter.Dispose{Async} after failed Stream Write{Async}

### DIFF
--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -300,7 +300,7 @@ namespace System.Text.Json
                     _stream.Write(underlyingBuffer.Array, underlyingBuffer.Offset, underlyingBuffer.Count);
 #endif
 
-                    BytesCommitted += _arrayBufferWriter.WrittenSpan.Length;
+                    BytesCommitted += _arrayBufferWriter.WrittenCount;
                     _arrayBufferWriter.Clear();
                 }
                 _stream.Flush();
@@ -413,7 +413,7 @@ namespace System.Text.Json
                     await _stream.WriteAsync(underlyingBuffer.Array, underlyingBuffer.Offset, underlyingBuffer.Count, cancellationToken).ConfigureAwait(false);
 #endif
 
-                    BytesCommitted += _arrayBufferWriter.WrittenMemory.Length;
+                    BytesCommitted += _arrayBufferWriter.WrittenCount;
                     _arrayBufferWriter.Clear();
                 }
                 await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -1052,7 +1052,7 @@ namespace System.Text.Json
                 Debug.Assert(_arrayBufferWriter.WrittenCount == underlyingBuffer.Count);
                 _stream.Write(underlyingBuffer.Array, underlyingBuffer.Offset, underlyingBuffer.Count);
 #endif
-                BytesCommitted += _arrayBufferWriter.WrittenSpan.Length;
+                BytesCommitted += _arrayBufferWriter.WrittenCount;
                 _arrayBufferWriter.Clear();
 
                 _memory = _arrayBufferWriter.GetMemory(sizeHint);

--- a/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -280,13 +280,16 @@ namespace System.Text.Json
         {
             CheckNotDisposed();
 
+            _memory = default;
+
             if (_stream != null)
             {
                 Debug.Assert(_arrayBufferWriter != null);
                 if (BytesPending != 0)
                 {
                     _arrayBufferWriter.Advance(BytesPending);
-                    Debug.Assert(BytesPending == _arrayBufferWriter.WrittenCount);
+                    BytesPending = 0;
+
 #if BUILDING_INBOX_LIBRARY
                     _stream.Write(_arrayBufferWriter.WrittenSpan);
 #else
@@ -296,6 +299,8 @@ namespace System.Text.Json
                     Debug.Assert(_arrayBufferWriter.WrittenCount == underlyingBuffer.Count);
                     _stream.Write(underlyingBuffer.Array, underlyingBuffer.Offset, underlyingBuffer.Count);
 #endif
+
+                    BytesCommitted += _arrayBufferWriter.WrittenSpan.Length;
                     _arrayBufferWriter.Clear();
                 }
                 _stream.Flush();
@@ -306,12 +311,10 @@ namespace System.Text.Json
                 if (BytesPending != 0)
                 {
                     _output.Advance(BytesPending);
+                    BytesCommitted += BytesPending;
+                    BytesPending = 0;
                 }
             }
-
-            _memory = default;
-            BytesCommitted += BytesPending;
-            BytesPending = 0;
         }
 
         /// <summary>
@@ -390,13 +393,16 @@ namespace System.Text.Json
         {
             CheckNotDisposed();
 
+            _memory = default;
+
             if (_stream != null)
             {
                 Debug.Assert(_arrayBufferWriter != null);
                 if (BytesPending != 0)
                 {
                     _arrayBufferWriter.Advance(BytesPending);
-                    Debug.Assert(BytesPending == _arrayBufferWriter.WrittenCount);
+                    BytesPending = 0;
+
 #if BUILDING_INBOX_LIBRARY
                     await _stream.WriteAsync(_arrayBufferWriter.WrittenMemory, cancellationToken).ConfigureAwait(false);
 #else
@@ -406,6 +412,8 @@ namespace System.Text.Json
                     Debug.Assert(_arrayBufferWriter.WrittenCount == underlyingBuffer.Count);
                     await _stream.WriteAsync(underlyingBuffer.Array, underlyingBuffer.Offset, underlyingBuffer.Count, cancellationToken).ConfigureAwait(false);
 #endif
+
+                    BytesCommitted += _arrayBufferWriter.WrittenMemory.Length;
                     _arrayBufferWriter.Clear();
                 }
                 await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -416,12 +424,10 @@ namespace System.Text.Json
                 if (BytesPending != 0)
                 {
                     _output.Advance(BytesPending);
+                    BytesCommitted += BytesPending;
+                    BytesPending = 0;
                 }
             }
-
-            _memory = default;
-            BytesCommitted += BytesPending;
-            BytesPending = 0;
         }
 
         /// <summary>
@@ -1028,13 +1034,14 @@ namespace System.Text.Json
 
             Debug.Assert(BytesPending != 0);
 
+            _memory = default;
+
             if (_stream != null)
             {
                 Debug.Assert(_arrayBufferWriter != null);
 
                 _arrayBufferWriter.Advance(BytesPending);
-
-                Debug.Assert(BytesPending == _arrayBufferWriter.WrittenCount);
+                BytesPending = 0;
 
 #if BUILDING_INBOX_LIBRARY
                 _stream.Write(_arrayBufferWriter.WrittenSpan);
@@ -1045,6 +1052,7 @@ namespace System.Text.Json
                 Debug.Assert(_arrayBufferWriter.WrittenCount == underlyingBuffer.Count);
                 _stream.Write(underlyingBuffer.Array, underlyingBuffer.Offset, underlyingBuffer.Count);
 #endif
+                BytesCommitted += _arrayBufferWriter.WrittenSpan.Length;
                 _arrayBufferWriter.Clear();
 
                 _memory = _arrayBufferWriter.GetMemory(sizeHint);
@@ -1056,6 +1064,8 @@ namespace System.Text.Json
                 Debug.Assert(_output != null);
 
                 _output.Advance(BytesPending);
+                BytesCommitted += BytesPending;
+                BytesPending = 0;
 
                 _memory = _output.GetMemory(sizeHint);
 
@@ -1064,9 +1074,6 @@ namespace System.Text.Json
                     ThrowHelper.ThrowInvalidOperationException_NeedLargerSpan();
                 }
             }
-
-            BytesCommitted += BytesPending;
-            BytesPending = 0;
         }
 
         private void FirstCallToGetMemory(int requiredSize)
@@ -1079,7 +1086,6 @@ namespace System.Text.Json
             if (_stream != null)
             {
                 Debug.Assert(_arrayBufferWriter != null);
-                Debug.Assert(BytesPending == _arrayBufferWriter.WrittenCount);
                 _memory = _arrayBufferWriter.GetMemory(sizeHint);
                 Debug.Assert(_memory.Length >= sizeHint);
             }

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -631,7 +631,7 @@ namespace System.Text.Json.Tests
 
         private sealed class ThrowingFromWriteMemoryStream : MemoryStream
         {
-            public Exception ExceptionToThrow;
+            public Exception ExceptionToThrow { get; set; }
 
             public override void Write(byte[] buffer, int offset, int count)
             {


### PR DESCRIPTION
By the time the `Utf8JsonWriter` writes to the underlying `Stream` as part of `Flush{Async}` it has already `Advance`'d the `_arrayBufferWriter`, but it hasn't reset `BytesPending` to 0.  If the write to the stream throws an exception then, we end up in an inconsistent state where `BytesPending` != 0 but there's no corresponding pending bytes to `Advance` the `_arrayBufferWriter`.  When we then `Dispose` the `Utf8JsonWriter`, we attempt to `Advance` the `_arrayBufferWriter` and fail.  Since `Utf8JsonWriter` will often be used in a `using` block, an exception from a `Write`/`Flush{Async}` call inside the `using` will then be masked as the `using`'s call to `Dispose` ends up failing and throwing a secondary exception.

Fixes https://github.com/dotnet/corefx/issues/39648
cc: @ahsonkhan, @steveharter, @bartonjs 

@ericstj, I think this should be ported to release/3.0 once it's reviewed/approved.