### PR TITLE
[release/3.0] Use relaxed JavascriptEncoder in S.T.JSON specific tests to improve coverage.

### DIFF
--- a/src/System.Text.Json/tests/DebuggerTests.cs
+++ b/src/System.Text.Json/tests/DebuggerTests.cs
@@ -30,7 +30,7 @@ namespace System.Text.Json.Tests
         public void DefaultUtf8JsonWriter()
         {
             // Validating that we don't throw on new object
-            Utf8JsonWriter writer = new Utf8JsonWriter(new MemoryStream());
+            using var writer = new Utf8JsonWriter(new MemoryStream());
             GetDebuggerDisplayProperty(writer);
         }
 

--- a/src/System.Text.Json/tests/JsonDocumentTests.cs
+++ b/src/System.Text.Json/tests/JsonDocumentTests.cs
@@ -1769,19 +1769,19 @@ namespace System.Text.Json.Tests
 
                 Assert.Throws<ObjectDisposedException>(() =>
                 {
-                    Utf8JsonWriter writer = new Utf8JsonWriter(buffer);
+                    using var writer = new Utf8JsonWriter(buffer);
                     root.WriteTo(writer);
                 });
 
                 Assert.Throws<ObjectDisposedException>(() =>
                 {
-                    Utf8JsonWriter writer = new Utf8JsonWriter(buffer);
+                    using var writer = new Utf8JsonWriter(buffer);
                     doc.WriteTo(writer);
                 });
 
                 Assert.Throws<ObjectDisposedException>(() =>
                 {
-                    Utf8JsonWriter writer = new Utf8JsonWriter(buffer);
+                    using var writer = new Utf8JsonWriter(buffer);
                     property.WriteTo(writer);
                 });
             }
@@ -1831,7 +1831,7 @@ namespace System.Text.Json.Tests
             Assert.Throws<InvalidOperationException>(() =>
             {
                 var buffer = new ArrayBufferWriter<byte>(1024);
-                Utf8JsonWriter writer = new Utf8JsonWriter(buffer);                
+                using var writer = new Utf8JsonWriter(buffer);
                 root.WriteTo(writer);
             });
         }
@@ -3693,7 +3693,7 @@ namespace System.Text.Json.Tests
             var expectedNonIndentedJson = $"[{OneQuarticGoogol}]";
             using (JsonDocument doc = JsonDocument.Parse($"[ {OneQuarticGoogol} ]"))
             {
-                var writer = new Utf8JsonWriter(buffer, default);
+                using var writer = new Utf8JsonWriter(buffer, default);
                 doc.WriteTo(writer);
                 writer.Flush();
 

--- a/src/System.Text.Json/tests/JsonPropertyTests.cs
+++ b/src/System.Text.Json/tests/JsonPropertyTests.cs
@@ -36,7 +36,7 @@ namespace System.Text.Json.Tests
                 {
                     SkipValidation = skipValidation,
                 };
-                var writer = new Utf8JsonWriter(buffer, options);
+                using var writer = new Utf8JsonWriter(buffer, options);
                 if (skipValidation)
                 {
                     foreach (JsonProperty property in root.EnumerateObject())
@@ -67,7 +67,7 @@ namespace System.Text.Json.Tests
             var buffer = new ArrayBufferWriter<byte>(1024);
             using (JsonDocument doc = JsonDocument.Parse("{\"First\":1, \"Number\":1e400}"))
             {
-                var writer = new Utf8JsonWriter(buffer);
+                using var writer = new Utf8JsonWriter(buffer);
                 writer.WriteStartObject();
                 foreach (JsonProperty prop in doc.RootElement.EnumerateObject())
                 {

--- a/src/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/System.Text.Json/tests/JsonTestHelper.cs
@@ -673,6 +673,32 @@ namespace System.Text.Json
             }
         }
 
+        public static void AssertContents(string expectedValue, ArrayBufferWriter<byte> buffer)
+        {
+            string value = Encoding.UTF8.GetString(
+                    buffer.WrittenSpan
+#if netfx
+                        .ToArray()
+#endif
+                    );
+
+            // Temporary hack until we can use the same escape algorithm on both sides and make sure we want uppercase hex.
+            Assert.Equal(expectedValue.NormalizeToJsonNetFormat(), value.NormalizeToJsonNetFormat());
+        }
+
+        public static void AssertContentsNotEqual(string expectedValue, ArrayBufferWriter<byte> buffer)
+        {
+            string value = Encoding.UTF8.GetString(
+                    buffer.WrittenSpan
+#if netfx
+                        .ToArray()
+#endif
+                    );
+
+            // Temporary hack until we can use the same escape algorithm on both sides and make sure we want uppercase hex.
+            Assert.NotEqual(expectedValue.NormalizeToJsonNetFormat(), value.NormalizeToJsonNetFormat());
+        }
+
         public delegate void AssertThrowsActionUtf8JsonReader(Utf8JsonReader json);
 
         // Cannot use standard Assert.Throws() when testing Utf8JsonReader - ref structs and closures don't get along.

--- a/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
+++ b/src/System.Text.Json/tests/Serialization/Value.WriteTests.cs
@@ -2,12 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text.Encodings.Web;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
 {
     public static partial class ValueTests
     {
+        [Fact]
+        public static void WriteStringWithRelaxedEscaper()
+        {
+            string inputString = ">><++>>>\">>\\>>&>>>\u6f22\u5B57>>>"; // Non-ASCII text should remain unescaped. \u6f22 = 汉, \u5B57 = 字
+
+            string actual = JsonSerializer.Serialize(inputString, new JsonSerializerOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+            string expected = "\">><++>>>\\\">>\\\\>>&>>>\u6f22\u5B57>>>\"";
+            Assert.Equal(JsonConvert.SerializeObject(inputString), actual);
+            Assert.Equal(expected, actual);
+            Assert.NotEqual(expected, JsonSerializer.Serialize(inputString));
+        }
+
         [Fact]
         public static void WritePrimitives()
         {

--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -63,24 +63,28 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var stream = new MemoryStream();
-            var writer = new Utf8JsonWriter(stream, options);
-            Assert.Equal(0, writer.BytesCommitted);
-            Assert.Equal(0, writer.BytesPending);
-            Assert.Equal(0, writer.CurrentDepth);
-            Assert.Equal(null, writer.Options.Encoder);
-            Assert.Equal(formatted, writer.Options.Indented);
-            Assert.Equal(skipValidation, writer.Options.SkipValidation);
-            Assert.Equal(0, stream.Position);
+            using (var writer = new Utf8JsonWriter(stream, options))
+            {
+                Assert.Equal(0, writer.BytesCommitted);
+                Assert.Equal(0, writer.BytesPending);
+                Assert.Equal(0, writer.CurrentDepth);
+                Assert.Null(writer.Options.Encoder);
+                Assert.Equal(formatted, writer.Options.Indented);
+                Assert.Equal(skipValidation, writer.Options.SkipValidation);
+                Assert.Equal(0, stream.Position);
+            }
 
             var output = new FixedSizedBufferWriter(0);
-            writer = new Utf8JsonWriter(output, options);
-            Assert.Equal(0, writer.BytesCommitted);
-            Assert.Equal(0, writer.BytesPending);
-            Assert.Equal(0, writer.CurrentDepth);
-            Assert.Equal(null, writer.Options.Encoder);
-            Assert.Equal(formatted, writer.Options.Indented);
-            Assert.Equal(skipValidation, writer.Options.SkipValidation);
-            Assert.Equal(0, output.FormattedCount);
+            using (var writer = new Utf8JsonWriter(output, options))
+            {
+                Assert.Equal(0, writer.BytesCommitted);
+                Assert.Equal(0, writer.BytesPending);
+                Assert.Equal(0, writer.CurrentDepth);
+                Assert.Null(writer.Options.Encoder);
+                Assert.Equal(formatted, writer.Options.Indented);
+                Assert.Equal(skipValidation, writer.Options.SkipValidation);
+                Assert.Equal(0, output.FormattedCount);
+            }
         }
 
         [Theory]
@@ -93,7 +97,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var stream = new MemoryStream();
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.WriteNumberValue(1);
             writeToStream.Flush();
 
@@ -113,7 +117,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(previousWritten, stream.Position);
 
             var output = new FixedSizedBufferWriter(256);
-            var writeToIBW = new Utf8JsonWriter(output, options);
+            using var writeToIBW = new Utf8JsonWriter(output, options);
             writeToIBW.WriteNumberValue(1);
             writeToIBW.Flush();
 
@@ -143,7 +147,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var stream = new MemoryStream();
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.WriteNumberValue(1);
             writeToStream.Flush();
 
@@ -169,7 +173,7 @@ namespace System.Text.Json.Tests
             Assert.Equal("11", Encoding.UTF8.GetString(stream.ToArray()));
 
             var output = new FixedSizedBufferWriter(257);
-            var writeToIBW = new Utf8JsonWriter(output, options);
+            using var writeToIBW = new Utf8JsonWriter(output, options);
             writeToIBW.WriteNumberValue(1);
             writeToIBW.Flush();
 
@@ -205,7 +209,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var stream = new MemoryStream();
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.WriteNumberValue(1);
             writeToStream.Flush();
 
@@ -236,7 +240,7 @@ namespace System.Text.Json.Tests
             Assert.True(output.FormattedCount != 0);
 
             output = new FixedSizedBufferWriter(256);
-            var writeToIBW = new Utf8JsonWriter(output, options);
+            using var writeToIBW = new Utf8JsonWriter(output, options);
             writeToIBW.WriteNumberValue(1);
             writeToIBW.Flush();
 
@@ -277,7 +281,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var stream = new MemoryStream();
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
 
             Assert.Throws<ArgumentNullException>(() => writeToStream.Reset((Stream)null));
             Assert.Throws<ArgumentNullException>(() => writeToStream.Reset((IBufferWriter<byte>)null));
@@ -287,7 +291,7 @@ namespace System.Text.Json.Tests
             Assert.Throws<ArgumentException>(() => writeToStream.Reset(stream));
 
             var output = new FixedSizedBufferWriter(256);
-            var writeToIBW = new Utf8JsonWriter(output, options);
+            using var writeToIBW = new Utf8JsonWriter(output, options);
 
             Assert.Throws<ArgumentNullException>(() => writeToIBW.Reset((Stream)null));
             Assert.Throws<ArgumentNullException>(() => writeToIBW.Reset((IBufferWriter<byte>)null));
@@ -305,13 +309,13 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new FixedSizedBufferWriter(0);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
             jsonUtf8.Flush();
             Assert.Equal(0, jsonUtf8.BytesCommitted);
             Assert.Equal(0, output.FormattedCount);
 
             var stream = new MemoryStream();
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.Flush();
             Assert.Equal(0, jsonUtf8.BytesCommitted);
             Assert.Equal(0, stream.Position);
@@ -327,13 +331,13 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new FixedSizedBufferWriter(0);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
             await jsonUtf8.FlushAsync();
             Assert.Equal(0, jsonUtf8.BytesCommitted);
             Assert.Equal(0, output.FormattedCount);
 
             var stream = new MemoryStream();
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
             await writeToStream.FlushAsync();
             Assert.Equal(0, jsonUtf8.BytesCommitted);
             Assert.Equal(0, stream.Position);
@@ -349,7 +353,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new FixedSizedBufferWriter(256);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
             jsonUtf8.WriteStartObject();
             jsonUtf8.WriteEndObject();
             Assert.Equal(0, jsonUtf8.BytesCommitted);
@@ -365,7 +369,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(2, output.FormattedCount);
 
             var stream = new MemoryStream();
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.WriteStartObject();
             writeToStream.WriteEndObject();
             Assert.Equal(0, writeToStream.BytesCommitted);
@@ -391,7 +395,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new FixedSizedBufferWriter(256);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
             jsonUtf8.WriteStartObject();
             jsonUtf8.WriteEndObject();
             Assert.Equal(0, jsonUtf8.BytesCommitted);
@@ -407,7 +411,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(2, output.FormattedCount);
 
             var stream = new MemoryStream();
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.WriteStartObject();
             writeToStream.WriteEndObject();
             Assert.Equal(0, writeToStream.BytesCommitted);
@@ -433,7 +437,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new FixedSizedBufferWriter(256);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
             jsonUtf8.WriteStartObject();
             jsonUtf8.WriteEndObject();
             Assert.Equal(0, jsonUtf8.BytesCommitted);
@@ -443,7 +447,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(2, output.FormattedCount);
 
             var stream = new MemoryStream();
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.WriteStartObject();
             writeToStream.WriteEndObject();
             Assert.Equal(0, writeToStream.BytesCommitted);
@@ -463,7 +467,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new FixedSizedBufferWriter(256);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
             jsonUtf8.WriteStartObject();
             jsonUtf8.WriteEndObject();
             Assert.Equal(0, jsonUtf8.BytesCommitted);
@@ -473,7 +477,7 @@ namespace System.Text.Json.Tests
             Assert.Equal(2, output.FormattedCount);
 
             var stream = new MemoryStream();
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.WriteStartObject();
             writeToStream.WriteEndObject();
             Assert.Equal(0, writeToStream.BytesCommitted);
@@ -493,7 +497,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new FixedSizedBufferWriter(256);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
             jsonUtf8.WriteStartObject();
             Assert.Equal(0, jsonUtf8.BytesCommitted);
             Assert.Equal(1, jsonUtf8.BytesPending);
@@ -511,7 +515,7 @@ namespace System.Text.Json.Tests
             var stream = new MemoryStream();
             Assert.Throws<ObjectDisposedException>(() => jsonUtf8.Reset(stream));
 
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.WriteStartObject();
             Assert.Equal(0, writeToStream.BytesCommitted);
             Assert.Equal(1, writeToStream.BytesPending);
@@ -539,7 +543,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new FixedSizedBufferWriter(256);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
             jsonUtf8.WriteStartObject();
             Assert.Equal(0, jsonUtf8.BytesCommitted);
             Assert.Equal(1, jsonUtf8.BytesPending);
@@ -557,7 +561,7 @@ namespace System.Text.Json.Tests
             var stream = new MemoryStream();
             Assert.Throws<ObjectDisposedException>(() => jsonUtf8.Reset(stream));
 
-            var writeToStream = new Utf8JsonWriter(stream, options);
+            using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.WriteStartObject();
             Assert.Equal(0, writeToStream.BytesCommitted);
             Assert.Equal(1, writeToStream.BytesPending);
@@ -585,7 +589,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new InvalidBufferWriter();
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNumberValue((ulong)12345678901));
         }
@@ -664,20 +668,24 @@ namespace System.Text.Json.Tests
 
             byte[] utf8String = Encoding.UTF8.GetBytes(new string('a', 215));
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteStringValue(utf8String);
             Guid guid = Guid.NewGuid();
-
-            Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue(guid));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteStringValue(utf8String);
+                jsonUtf8.Flush();
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue(guid));
+            }
 
             sizeTooSmall += formatted ? 9 : 1;
             output = new FixedSizedBufferWriter(sizeTooSmall);
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteStringValue(utf8String);
-            jsonUtf8.WriteStringValue(guid);
-            jsonUtf8.Flush();
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteStringValue(utf8String);
+                jsonUtf8.WriteStringValue(guid);
+                jsonUtf8.Flush();
+            }
             string actualStr = Encoding.UTF8.GetString(output.Formatted);
 
             if (!formatted)
@@ -701,20 +709,24 @@ namespace System.Text.Json.Tests
 
             byte[] utf8String = Encoding.UTF8.GetBytes(new string('a', 232));
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteStringValue(utf8String);
             var date = new DateTime(2019, 1, 1);
-
-            Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue(date));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteStringValue(utf8String);
+                jsonUtf8.Flush();
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue(date));
+            }
 
             sizeTooSmall += formatted ? 23 : 15;
             output = new FixedSizedBufferWriter(sizeTooSmall);
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteStringValue(utf8String);
-            jsonUtf8.WriteStringValue(date);
-            jsonUtf8.Flush();
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteStringValue(utf8String);
+                jsonUtf8.WriteStringValue(date);
+                jsonUtf8.Flush();
+            }
             string actualStr = Encoding.UTF8.GetString(output.Formatted);
 
             if (!formatted)
@@ -738,20 +750,24 @@ namespace System.Text.Json.Tests
 
             byte[] utf8String = Encoding.UTF8.GetBytes(new string('a', 226));
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
             DateTimeOffset date = new DateTime(2019, 1, 1);
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteStringValue(utf8String);
-
-            Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue(date));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteStringValue(utf8String);
+                jsonUtf8.Flush();
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue(date));
+            }
 
             sizeTooSmall += formatted ? 23 : 15;
             output = new FixedSizedBufferWriter(sizeTooSmall);
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteStringValue(utf8String);
-            jsonUtf8.WriteStringValue(date);
-            jsonUtf8.Flush();
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteStringValue(utf8String);
+                jsonUtf8.WriteStringValue(date);
+                jsonUtf8.Flush();
+            }
             string actualStr = Encoding.UTF8.GetString(output.Formatted);
 
             if (!formatted)
@@ -776,7 +792,7 @@ namespace System.Text.Json.Tests
                 var output = new FixedSizedBufferWriter(256);
                 decimal value = JsonTestHelper.NextDecimal(random, 78E14, -78E14);
 
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteNumberValue(value);
 
                 jsonUtf8.Flush();
@@ -790,7 +806,7 @@ namespace System.Text.Json.Tests
             {
                 var output = new FixedSizedBufferWriter(256);
                 decimal value = JsonTestHelper.NextDecimal(random, 1_000_000, -1_000_000);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteNumberValue(value);
 
                 jsonUtf8.Flush();
@@ -803,7 +819,7 @@ namespace System.Text.Json.Tests
             {
                 var output = new FixedSizedBufferWriter(256);
                 decimal value = 9999999999999999999999999999m;
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteNumberValue(value);
 
                 jsonUtf8.Flush();
@@ -816,7 +832,7 @@ namespace System.Text.Json.Tests
             {
                 var output = new FixedSizedBufferWriter(256);
                 decimal value = -9999999999999999999999999999m;
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteNumberValue(value);
 
                 jsonUtf8.Flush();
@@ -827,26 +843,30 @@ namespace System.Text.Json.Tests
             }
 
             {
-
                 int sizeTooSmall = 256;
                 var output = new FixedSizedBufferWriter(sizeTooSmall);
 
                 byte[] utf8String = Encoding.UTF8.GetBytes(new string('a', 222));
 
                 decimal value = -0.9999999999999999999999999999m;
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
-                jsonUtf8.WriteStartArray();
-                jsonUtf8.WriteStringValue(utf8String);
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNumberValue(value));
+                using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+                {
+                    jsonUtf8.WriteStartArray();
+                    jsonUtf8.WriteStringValue(utf8String);
+                    jsonUtf8.Flush();
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNumberValue(value));
+                }
 
                 sizeTooSmall += formatted ? 9 : 1;
                 output = new FixedSizedBufferWriter(sizeTooSmall);
-                jsonUtf8 = new Utf8JsonWriter(output, options);
-                jsonUtf8.WriteStartArray();
-                jsonUtf8.WriteStringValue(utf8String);
-                jsonUtf8.WriteNumberValue(value);
+                using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+                {
+                    jsonUtf8.WriteStartArray();
+                    jsonUtf8.WriteStringValue(utf8String);
+                    jsonUtf8.WriteNumberValue(value);
 
-                jsonUtf8.Flush();
+                    jsonUtf8.Flush();
+                }
                 string actualStr = Encoding.UTF8.GetString(output.Formatted);
 
                 if (!formatted)
@@ -867,355 +887,415 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteEndArray();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            if (skipValidation)
-            {
-                jsonUtf8.WriteEndObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndArray();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteStartArray("property at start");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("property at start"));
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            if (skipValidation)
-            {
-                jsonUtf8.WriteStartObject("property at start");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject("property at start"));
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndObject();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteStartArray("property inside array");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("property inside array"));
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            if (skipValidation)
-            {
-                jsonUtf8.WriteStartObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject());
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartArray("property at start");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("property at start"));
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteEndObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            if (skipValidation)
-            {
-                jsonUtf8.WriteStringValue("key");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue("key"));
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartObject("property at start");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject("property at start"));
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            if (skipValidation)
-            {
-                jsonUtf8.WriteString("key", "value");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteString("key", "value"));
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            if (skipValidation)
-            {
-                jsonUtf8.WriteString(JsonEncodedText.Encode("key"), JsonEncodedText.Encode("value"));
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteString(JsonEncodedText.Encode("key"), JsonEncodedText.Encode("value")));
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            if (skipValidation)
-            {
-                jsonUtf8.WriteEndArray();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
                 jsonUtf8.WriteStartArray();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray());
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteEndArray();
-            if (skipValidation)
-            {
-                jsonUtf8.WriteEndObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartArray("property inside array");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("property inside array"));
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WriteStartObject("some object");
-            jsonUtf8.WriteEndObject();
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
+                jsonUtf8.WriteStartObject();
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartObject();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject());
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndObject();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStringValue("key");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStringValue("key"));
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteString("key", "value");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteString("key", "value"));
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteString(JsonEncodedText.Encode("key"), JsonEncodedText.Encode("value"));
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteString(JsonEncodedText.Encode("key"), JsonEncodedText.Encode("value")));
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndArray();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartArray();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray());
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteEndArray();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndObject();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
+                jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteStartObject("some object");
                 jsonUtf8.WriteEndObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject("some object"));
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndArray();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WriteStartArray("test array");
-            jsonUtf8.WriteEndArray();
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
+                jsonUtf8.WriteStartArray();
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartObject("some object");
+                    jsonUtf8.WriteEndObject();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject("some object"));
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteStartArray("test array");
                 jsonUtf8.WriteEndArray();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndArray();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteEndArray();
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
+                jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteEndArray();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndArray();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WriteEndObject();
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
+                jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteEndObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteStartArray();
-            if (skipValidation)
-            {
-                jsonUtf8.WriteEndObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndObject();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WriteStartObject("test object");
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteEndArray();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            if (skipValidation)
-            {
-                jsonUtf8.WritePropertyName("test name");
-                jsonUtf8.WritePropertyName(JsonEncodedText.Encode("test name"));
-                jsonUtf8.WritePropertyName("test name".AsSpan());
-                jsonUtf8.WritePropertyName(Encoding.UTF8.GetBytes("test name"));
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName(JsonEncodedText.Encode("test name")));
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name".AsSpan()));
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName(Encoding.UTF8.GetBytes("test name")));
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteStartArray();
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndObject();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WritePropertyName("test name");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WritePropertyName("first name");
-            if (skipValidation)
-            {
-                jsonUtf8.WritePropertyName("test name");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteStartObject("test object");
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndArray();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WritePropertyName("first name");
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteStartArray("test name");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("test name"));
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WritePropertyName("first name");
-            if (skipValidation)
-            {
-                jsonUtf8.WriteStartObject("test name");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject("test name"));
+                if (skipValidation)
+                {
+                    jsonUtf8.WritePropertyName("test name");
+                    jsonUtf8.WritePropertyName(JsonEncodedText.Encode("test name"));
+                    jsonUtf8.WritePropertyName("test name".AsSpan());
+                    jsonUtf8.WritePropertyName(Encoding.UTF8.GetBytes("test name"));
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName(JsonEncodedText.Encode("test name")));
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name".AsSpan()));
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName(Encoding.UTF8.GetBytes("test name")));
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WritePropertyName("first name");
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteEndObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WritePropertyName("first name");
-            if (skipValidation)
-            {
-                jsonUtf8.WriteString("another property name", "some value");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteString("another property name", "some value"));
+                jsonUtf8.WriteStartArray();
+                if (skipValidation)
+                {
+                    jsonUtf8.WritePropertyName("test name");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WritePropertyName("first name");
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteNumber("another property name", 12345);
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNumber("another property name", 12345));
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WritePropertyName("first name");
-            if (skipValidation)
-            {
-                jsonUtf8.WriteNull("another property name");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNull("another property name"));
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WritePropertyName("first name");
+                if (skipValidation)
+                {
+                    jsonUtf8.WritePropertyName("test name");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WritePropertyName("first name");
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteBoolean("another property name", true);
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WritePropertyName("first name");
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartArray("test name");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("test name"));
+                }
             }
-            else
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteBoolean("another property name", true));
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WritePropertyName("first name");
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartObject("test name");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject("test name"));
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WritePropertyName("first name");
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndObject();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WritePropertyName("first name");
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteString("another property name", "some value");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteString("another property name", "some value"));
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WritePropertyName("first name");
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteNumber("another property name", 12345);
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNumber("another property name", 12345));
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WritePropertyName("first name");
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteNull("another property name");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNull("another property name"));
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WritePropertyName("first name");
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteBoolean("another property name", true);
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteBoolean("another property name", true));
+                }
             }
         }
 
@@ -1229,36 +1309,48 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            Assert.True(jsonUtf8.CurrentDepth != 0);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                Assert.True(jsonUtf8.CurrentDepth != 0);
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.True(jsonUtf8.CurrentDepth != 0);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.True(jsonUtf8.CurrentDepth != 0);
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteEndArray();
-            Assert.True(jsonUtf8.CurrentDepth != 0);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteEndArray();
+                Assert.True(jsonUtf8.CurrentDepth != 0);
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WriteStartObject("some object");
-            Assert.True(jsonUtf8.CurrentDepth != 0);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteStartObject("some object");
+                Assert.True(jsonUtf8.CurrentDepth != 0);
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartArray();
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WriteEndObject();
-            Assert.True(jsonUtf8.CurrentDepth != 0);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartArray();
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteEndObject();
+                Assert.True(jsonUtf8.CurrentDepth != 0);
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            jsonUtf8.WriteStartArray("test array");
-            jsonUtf8.WriteEndArray();
-            Assert.True(jsonUtf8.CurrentDepth != 0);
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                jsonUtf8.WriteStartArray("test array");
+                jsonUtf8.WriteEndArray();
+                Assert.True(jsonUtf8.CurrentDepth != 0);
+            }
         }
 
         [Theory]
@@ -1271,147 +1363,173 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteNumberValue(12345);
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
                 jsonUtf8.WriteNumberValue(12345);
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNumberValue(12345));
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteNumberValue(12345);
-            if (skipValidation)
-            {
-                jsonUtf8.WriteStartArray();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray());
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteNumberValue(12345);
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteNumberValue(12345));
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteNumberValue(12345);
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteStartObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject());
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteNumberValue(12345);
-            if (skipValidation)
-            {
-                jsonUtf8.WriteStartArray("property name");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("property name"));
+                jsonUtf8.WriteNumberValue(12345);
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartArray();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray());
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteNumberValue(12345);
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteStartObject("property name");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject("property name"));
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteNumberValue(12345);
-            if (skipValidation)
-            {
-                jsonUtf8.WriteString("property name", "value");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteString("property name", "value"));
+                jsonUtf8.WriteNumberValue(12345);
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartObject();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject());
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteNumberValue(12345);
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteString(JsonEncodedText.Encode("property name"), JsonEncodedText.Encode("value"));
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteString(JsonEncodedText.Encode("property name"), JsonEncodedText.Encode("value")));
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteNumberValue(12345);
-            if (skipValidation)
-            {
-                jsonUtf8.WriteEndArray();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                jsonUtf8.WriteNumberValue(12345);
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartArray("property name");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("property name"));
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteNumberValue(12345);
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteEndObject();
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteNumberValue(12345);
-            if (skipValidation)
-            {
-                jsonUtf8.WritePropertyName("test name");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
+                jsonUtf8.WriteNumberValue(12345);
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteStartObject("property name");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartObject("property name"));
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteBooleanValue(true);
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WritePropertyName("test name");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
-            }
-
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteNullValue();
-            if (skipValidation)
-            {
-                jsonUtf8.WritePropertyName("test name");
-            }
-            else
-            {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
+                jsonUtf8.WriteNumberValue(12345);
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteString("property name", "value");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteString("property name", "value"));
+                }
             }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStringValue("some string");
-            if (skipValidation)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WritePropertyName("test name");
+                jsonUtf8.WriteNumberValue(12345);
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteString(JsonEncodedText.Encode("property name"), JsonEncodedText.Encode("value"));
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteString(JsonEncodedText.Encode("property name"), JsonEncodedText.Encode("value")));
+                }
             }
-            else
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
+                jsonUtf8.WriteNumberValue(12345);
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndArray();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndArray());
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteNumberValue(12345);
+                if (skipValidation)
+                {
+                    jsonUtf8.WriteEndObject();
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteEndObject());
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteNumberValue(12345);
+                if (skipValidation)
+                {
+                    jsonUtf8.WritePropertyName("test name");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteBooleanValue(true);
+                if (skipValidation)
+                {
+                    jsonUtf8.WritePropertyName("test name");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteNullValue();
+                if (skipValidation)
+                {
+                    jsonUtf8.WritePropertyName("test name");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
+                }
+            }
+
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStringValue("some string");
+                if (skipValidation)
+                {
+                    jsonUtf8.WritePropertyName("test name");
+                }
+                else
+                {
+                    Assert.Throws<InvalidOperationException>(() => jsonUtf8.WritePropertyName("test name"));
+                }
             }
         }
 
@@ -1425,47 +1543,71 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(double.NegativeInfinity));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(double.NegativeInfinity));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(double.PositiveInfinity));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(double.PositiveInfinity));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(double.NaN));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(double.NaN));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(float.PositiveInfinity));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(float.PositiveInfinity));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(float.NegativeInfinity));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(float.NegativeInfinity));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(float.NaN));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumberValue(float.NaN));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", double.NegativeInfinity));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", double.NegativeInfinity));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", double.PositiveInfinity));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", double.PositiveInfinity));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", double.NaN));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", double.NaN));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", float.PositiveInfinity));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", float.PositiveInfinity));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", float.NegativeInfinity));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", float.NegativeInfinity));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", float.NaN));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteNumber("name", float.NaN));
+            }
         }
 
         [Theory]
@@ -1476,7 +1618,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = true };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             for (int i = 0; i < 100; i++)
             {
@@ -1498,7 +1640,7 @@ namespace System.Text.Json.Tests
                 sb.Append(Environment.NewLine);
             sb.Append("[]");
 
-            AssertContents(sb.ToString(), output);
+            JsonTestHelper.AssertContents(sb.ToString(), output);
         }
 
         [Theory]
@@ -1535,7 +1677,7 @@ namespace System.Text.Json.Tests
 
             string expectedStr = stringWriter.ToString();
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
             jsonUtf8.WriteStartObject();
             jsonUtf8.WritePropertyName(Encoding.UTF8.GetBytes("foo1"));
             jsonUtf8.WriteStringValue("bar1");
@@ -1563,7 +1705,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             for (int i = 0; i < 1000; i++)
             {
@@ -1583,30 +1725,36 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            for (int i = 0; i < 999; i++)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteStartObject("name");
+                jsonUtf8.WriteStartObject();
+                for (int i = 0; i < 999; i++)
+                {
+                    jsonUtf8.WriteStartObject("name");
+                }
+                Assert.Equal(1000, jsonUtf8.CurrentDepth);
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("name"));
             }
-            Assert.Equal(1000, jsonUtf8.CurrentDepth);
-            Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray("name"));
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            for (int i = 0; i < 999; i++)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteStartObject(Encoding.UTF8.GetBytes("name"));
+                jsonUtf8.WriteStartObject();
+                for (int i = 0; i < 999; i++)
+                {
+                    jsonUtf8.WriteStartObject(Encoding.UTF8.GetBytes("name"));
+                }
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray(Encoding.UTF8.GetBytes("name")));
             }
-            Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray(Encoding.UTF8.GetBytes("name")));
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            for (int i = 0; i < 999; i++)
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
             {
-                jsonUtf8.WriteStartObject(JsonEncodedText.Encode("name"));
+                jsonUtf8.WriteStartObject();
+                for (int i = 0; i < 999; i++)
+                {
+                    jsonUtf8.WriteStartObject(JsonEncodedText.Encode("name"));
+                }
+                Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray(JsonEncodedText.Encode("name")));
             }
-            Assert.Throws<InvalidOperationException>(() => jsonUtf8.WriteStartArray(JsonEncodedText.Encode("name")));
         }
 
         // NOTE: WritingTooLargeProperty test is constrained to run on Windows and MacOSX because it causes
@@ -1641,13 +1789,17 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteStartArray(keyChars));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteStartArray(keyChars));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteStartArray(key));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteStartArray(key));
+            }
         }
 
         // NOTE: WritingTooLargePropertyStandalone test is constrained to run on Windows and MacOSX because it causes
@@ -1682,13 +1834,17 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WritePropertyName(keyChars));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WritePropertyName(keyChars));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WritePropertyName(key));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WritePropertyName(key));
+            }
         }
 
         [ConditionalTheory(nameof(IsX64))]
@@ -1715,24 +1871,34 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteBase64StringValue(value));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteBase64StringValue(value));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteBase64String("foo", value));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteBase64String("foo", value));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteBase64String(Encoding.UTF8.GetBytes("foo"), value));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteBase64String(Encoding.UTF8.GetBytes("foo"), value));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteBase64String("foo".AsSpan(), value));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteBase64String("foo".AsSpan(), value));
+            }
 
-            jsonUtf8 = new Utf8JsonWriter(output, options);
-            jsonUtf8.WriteStartObject();
-            Assert.Throws<ArgumentException>(() => jsonUtf8.WriteBase64String(JsonEncodedText.Encode("foo"), value));
+            using (var jsonUtf8 = new Utf8JsonWriter(output, options))
+            {
+                jsonUtf8.WriteStartObject();
+                Assert.Throws<ArgumentException>(() => jsonUtf8.WriteBase64String(JsonEncodedText.Encode("foo"), value));
+            }
         }
 
         [Theory]
@@ -1747,13 +1913,13 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>(1024);
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             jsonUtf8.WriteNumberValue(123456789012345);
 
             jsonUtf8.Flush();
 
-            AssertContents(expectedStr, output);
+            JsonTestHelper.AssertContents(expectedStr, output);
         }
 
         [Theory]
@@ -1778,7 +1944,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 32; i++)
             {
                 var output = new ArrayBufferWriter<byte>(32);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -1949,7 +2115,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -1977,7 +2143,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 32; i++)
             {
                 var output = new ArrayBufferWriter<byte>(32);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -2148,7 +2314,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
 
             // Verify that escaping does not change the input strings/spans.
@@ -2170,7 +2336,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>(10);
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             jsonUtf8.WriteStartObject();
 
@@ -2245,7 +2411,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 4; i++)
             {
                 var output = new ArrayBufferWriter<byte>(32);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -2272,7 +2438,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
 
             // Verify that escaping does not change the input strings/spans.
@@ -2292,7 +2458,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>(10);
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             jsonUtf8.WriteStartObject();
 
@@ -2348,7 +2514,7 @@ namespace System.Text.Json.Tests
         {
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(10);
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             jsonUtf8.WriteStartObject();
 
@@ -2444,7 +2610,7 @@ namespace System.Text.Json.Tests
 
             jsonUtf8.Flush();
 
-            AssertContents("\"++++\"", output);
+            JsonTestHelper.AssertContents("\"++++\"", output);
         }
 
         [Fact]
@@ -2474,7 +2640,7 @@ namespace System.Text.Json.Tests
                 builder.Append("ZGRk");
             }
             builder.Append("ZGQ=\"");
-            AssertContents(builder.ToString(), output);
+            JsonTestHelper.AssertContents(builder.ToString(), output);
         }
 
         [Theory]
@@ -2487,7 +2653,7 @@ namespace System.Text.Json.Tests
             {
                 var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
                 var output = new ArrayBufferWriter<byte>(10);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteEndObject();
@@ -2508,7 +2674,7 @@ namespace System.Text.Json.Tests
             {
                 var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
                 var output = new ArrayBufferWriter<byte>(10);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteEndObject();
@@ -2547,7 +2713,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 3; i++)
             {
                 var output = new ArrayBufferWriter<byte>(32);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartArray();
 
@@ -2574,7 +2740,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -2604,7 +2770,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>(32);
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             string comment = "comment is */ invalid";
 
@@ -2623,7 +2789,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>(32);
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             string comment = "comment is * / valid";
             jsonUtf8.WriteCommentValue(comment);
@@ -2646,7 +2812,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.WriteCommentValue(invalidUtf8);
 
             string expectedStr = GetCommentExpectedString(prettyPrint: formatted);
-            AssertContents(expectedStr, output);
+            JsonTestHelper.AssertContents(expectedStr, output);
         }
 
         private static string GetCommentExpectedString(bool prettyPrint)
@@ -2694,7 +2860,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 3; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartArray();
 
@@ -2717,7 +2883,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -2757,7 +2923,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 32; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -2880,7 +3046,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -2915,7 +3081,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 6; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -2947,7 +3113,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -2978,7 +3144,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 6; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -3010,7 +3176,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3032,7 +3198,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 6; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -3064,7 +3230,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3104,7 +3270,7 @@ namespace System.Text.Json.Tests
             string WriteProperty(byte[] propertyName, byte[] value)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteString(propertyName, value);
                 jsonUtf8.WriteEndObject();
@@ -3143,7 +3309,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>(1024);
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             var validUtf16 = new char[2] { (char)0xD801, (char)0xDC37 }; // 0x10437
             var invalidUtf16 = new char[2] { (char)0xD801, 'a' };
@@ -3210,7 +3376,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 6; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -3262,7 +3428,7 @@ namespace System.Text.Json.Tests
         {
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(10);
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             jsonUtf8.WriteStartObject();
 
@@ -3274,7 +3440,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.WriteEndObject();
             jsonUtf8.Flush();
 
-            AssertContents(GetCustomExpectedString(formatted), output);
+            JsonTestHelper.AssertContents(GetCustomExpectedString(formatted), output);
         }
 
         [Theory]
@@ -3289,7 +3455,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
             var output = new ArrayBufferWriter<byte>(1024);
 
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             jsonUtf8.WriteStartArray();
             jsonUtf8.WriteStartObject();
@@ -3297,7 +3463,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.WriteEndArray();
             jsonUtf8.Flush();
 
-            AssertContents(expectedStr, output);
+            JsonTestHelper.AssertContents(expectedStr, output);
         }
 
         [Theory]
@@ -3311,13 +3477,13 @@ namespace System.Text.Json.Tests
                 var options = new JsonWriterOptions { Indented = formatted, SkipValidation = true };
                 var output = new ArrayBufferWriter<byte>(1024);
 
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartArray();
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
 
             {
@@ -3326,13 +3492,13 @@ namespace System.Text.Json.Tests
                 var options = new JsonWriterOptions { Indented = formatted, SkipValidation = true };
                 var output = new ArrayBufferWriter<byte>(1024);
 
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
                 jsonUtf8.WriteEndArray();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3350,7 +3516,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 3; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -3371,7 +3537,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3400,7 +3566,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 3; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -3421,7 +3587,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3439,7 +3605,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 3; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -3460,7 +3626,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3489,7 +3655,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 3; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -3510,7 +3676,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3529,7 +3695,7 @@ namespace System.Text.Json.Tests
             {
                 var output = new ArrayBufferWriter<byte>(1024);
 
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartObject();
 
                 switch (i)
@@ -3549,7 +3715,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3587,7 +3753,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 4; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -3618,7 +3784,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3644,7 +3810,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 4; i++)
             {
                 var output = new ArrayBufferWriter<byte>(16);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -3678,7 +3844,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3716,7 +3882,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 4; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -3740,7 +3906,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3892,7 +4058,7 @@ namespace System.Text.Json.Tests
             for (int j = 0; j < 3; j++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 ReadOnlySpan<char> keyUtf16 = keyString.AsSpan();
                 ReadOnlySpan<byte> keyUtf8 = Encoding.UTF8.GetBytes(keyString);
@@ -3967,7 +4133,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.Flush();
 
                 // TODO: The output doesn't match what JSON.NET does (different rounding/e-notation).
-                // AssertContents(expectedStr, output);
+                // JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -3981,7 +4147,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>();
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
@@ -3996,7 +4162,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.Flush();
 
             string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
-            AssertContents(expectedStr, output);
+            JsonTestHelper.AssertContents(expectedStr, output);
         }
 
         [Theory]
@@ -4009,7 +4175,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>();
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
@@ -4024,7 +4190,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.Flush();
 
             string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
-            AssertContents(expectedStr, output);
+            JsonTestHelper.AssertContents(expectedStr, output);
         }
 
         [Theory]
@@ -4037,7 +4203,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>();
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
@@ -4052,7 +4218,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.Flush();
 
             string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
-            AssertContents(expectedStr, output);
+            JsonTestHelper.AssertContents(expectedStr, output);
         }
 
         [Theory]
@@ -4065,7 +4231,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>();
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
@@ -4080,7 +4246,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.Flush();
 
             string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
-            AssertContents(expectedStr, output);
+            JsonTestHelper.AssertContents(expectedStr, output);
         }
 
         [Theory]
@@ -4093,7 +4259,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>();
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
@@ -4108,7 +4274,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.Flush();
 
             string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
-            AssertContents(expectedStr, output);
+            JsonTestHelper.AssertContents(expectedStr, output);
         }
 
         [Theory]
@@ -4121,7 +4287,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>();
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
@@ -4136,7 +4302,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.Flush();
 
             string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
-            AssertContents(expectedStr, output);
+            JsonTestHelper.AssertContents(expectedStr, output);
         }
 
         [Theory]
@@ -4149,7 +4315,7 @@ namespace System.Text.Json.Tests
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             var output = new ArrayBufferWriter<byte>();
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             int numberOfElements = 0;
             jsonUtf8.WriteStartArray();
@@ -4164,7 +4330,82 @@ namespace System.Text.Json.Tests
             jsonUtf8.Flush();
 
             string expectedStr = GetNumbersExpectedString(formatted, numberOfElements);
-            AssertContents(expectedStr, output);
+            JsonTestHelper.AssertContents(expectedStr, output);
+        }
+
+        [Theory]
+        [InlineData(true, true, "message", true)]
+        [InlineData(true, false, "message", true)]
+        [InlineData(false, true, "message", true)]
+        [InlineData(false, false, "message", true)]
+        [InlineData(true, true, "mess><age", false)]
+        [InlineData(true, false, "mess><age", false)]
+        [InlineData(false, true, "mess><age", false)]
+        [InlineData(false, false, "mess><age", false)]
+        [InlineData(true, true, ">><++>>>\">>\\>>&>>>\u6f22\u5B57>>>", false)] // \u6f22 = 汉, \u5B57 = 字
+        [InlineData(true, false, ">><++>>>\">>\\>>&>>>\u6f22\u5B57>>>", false)]
+        [InlineData(false, true, ">><++>>>\">>\\>>&>>>\u6f22\u5B57>>>", false)]
+        [InlineData(false, false, ">><++>>>\">>\\>>&>>>\u6f22\u5B57>>>", false)]
+        [InlineData(true, true, "mess\r\nage\u0008\u0001!", true)]
+        [InlineData(true, false, "mess\r\nage\u0008\u0001!", true)]
+        [InlineData(false, true, "mess\r\nage\u0008\u0001!", true)]
+        [InlineData(false, false, "mess\r\nage\u0008\u0001!", true)]
+        public void WriteStringsWithRelaxedEscaping(bool formatted, bool skipValidation, string keyString, bool matchesRelaxedEscaping)
+        {
+            string expectedStr = GetExpectedString_RelaxedEscaping(prettyPrint: formatted, keyString);
+
+            var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+            WriteStringHelper(options, keyString, expectedStr, shouldMatch: true);
+
+            // Default encoder
+            options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
+            WriteStringHelper(options, keyString, expectedStr, matchesRelaxedEscaping);
+        }
+
+        private static void WriteStringHelper(JsonWriterOptions options, string keyString, string expectedStr, bool shouldMatch)
+        {
+            ReadOnlySpan<char> keyUtf16 = keyString.AsSpan();
+            ReadOnlySpan<byte> keyUtf8 = Encoding.UTF8.GetBytes(keyString);
+
+            for (int i = 0; i < 3; i++)
+            {
+                var output = new ArrayBufferWriter<byte>(1024);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
+
+                jsonUtf8.WriteStartObject();
+
+                switch (i)
+                {
+                    case 0:
+                        jsonUtf8.WriteString(keyString, keyString);
+                        jsonUtf8.WriteStartArray(keyString);
+                        break;
+                    case 1:
+                        jsonUtf8.WriteString(keyUtf16, keyString);
+                        jsonUtf8.WriteStartArray(keyUtf16);
+                        break;
+                    case 2:
+                        jsonUtf8.WriteString(keyUtf8, keyString);
+                        jsonUtf8.WriteStartArray(keyUtf8);
+                        break;
+                }
+
+                jsonUtf8.WriteStringValue(keyString);
+                jsonUtf8.WriteStringValue(keyString);
+                jsonUtf8.WriteEndArray();
+
+                jsonUtf8.WriteEndObject();
+                jsonUtf8.Flush();
+
+                if (shouldMatch)
+                {
+                    JsonTestHelper.AssertContents(expectedStr, output);
+                }
+                else
+                {
+                    JsonTestHelper.AssertContentsNotEqual(expectedStr, output);
+                }
+            }
         }
 
         [Theory]
@@ -4200,7 +4441,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 3; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -4230,7 +4471,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -4269,7 +4510,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 3; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -4299,7 +4540,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -4338,7 +4579,7 @@ namespace System.Text.Json.Tests
             for (int i = 0; i < 3; i++)
             {
                 var output = new ArrayBufferWriter<byte>(1024);
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
                 jsonUtf8.WriteStartObject();
 
@@ -4368,7 +4609,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteEndObject();
                 jsonUtf8.Flush();
 
-                AssertContents(expectedStr, output);
+                JsonTestHelper.AssertContents(expectedStr, output);
             }
         }
 
@@ -4405,14 +4646,14 @@ namespace System.Text.Json.Tests
             var output = new ArrayBufferWriter<byte>(1024);
 
             {
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartObject();
                 Assert.Throws<ArgumentException>(() => jsonUtf8.WriteString(key, DateTime.Now));
                 Assert.Equal(0, output.WrittenCount);
             }
 
             {
-                var jsonUtf8 = new Utf8JsonWriter(output, options);
+                using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartArray();
                 Assert.Throws<ArgumentException>(() => jsonUtf8.WriteStringValue(value));
                 Assert.Equal(0, output.WrittenCount);
@@ -4496,7 +4737,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.WriteStringValue(DateTime.ParseExact(testStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
             jsonUtf8.Flush();
 
-            AssertContents($"\"{expectedStr}\"", output);
+            JsonTestHelper.AssertContents($"\"{expectedStr}\"", output);
         }
 
         [Theory]
@@ -4509,7 +4750,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.WriteStringValue(DateTimeOffset.ParseExact(testStr, "O", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
             jsonUtf8.Flush();
 
-            AssertContents($"\"{expectedStr}\"", output);
+            JsonTestHelper.AssertContents($"\"{expectedStr}\"", output);
         }
 
         [Fact]
@@ -4523,7 +4764,7 @@ namespace System.Text.Json.Tests
         {
             // Resizing is too slow, even for outerloop tests, so initialize to a large output size up front.
             var output = new ArrayBufferWriter<byte>(noThrow ? 40_000_000 : 1024);
-            var jsonUtf8 = new Utf8JsonWriter(output, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             jsonUtf8.WriteStartObject();
 
@@ -4570,7 +4811,7 @@ namespace System.Text.Json.Tests
             jsonUtf8.WriteStringValue(text);
             jsonUtf8.Flush();
 
-            AssertContents($"{expectedMessage}", output);
+            JsonTestHelper.AssertContents($"{expectedMessage}", output);
         }
 
         [Theory]
@@ -4597,7 +4838,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStringValue(text);
                 jsonUtf8.Flush();
 
-                AssertContents(expectedMessage, output);
+                JsonTestHelper.AssertContents(expectedMessage, output);
             }
             {
                 var message = new string('>', stringLength);
@@ -4616,7 +4857,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStringValue(text);
                 jsonUtf8.Flush();
 
-                AssertContents(expectedMessage, output);
+                JsonTestHelper.AssertContents(expectedMessage, output);
             }
         }
 
@@ -4644,7 +4885,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStartObject(text);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:{{", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:{{", output);
             }
 
             {
@@ -4654,7 +4895,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteStartArray(text);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:[", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:[", output);
             }
         }
 
@@ -4682,7 +4923,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteBoolean(text, true);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:true", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:true", output);
             }
 
             {
@@ -4692,7 +4933,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteBoolean(text, false);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:false", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:false", output);
             }
 
             {
@@ -4702,7 +4943,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteNull(text);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:null", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:null", output);
             }
         }
 
@@ -4731,7 +4972,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteNumber(text, value);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:1", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:1", output);
             }
 
             {
@@ -4742,7 +4983,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteNumber(text, value);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:1", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:1", output);
             }
 
             {
@@ -4753,7 +4994,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteNumber(text, value);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:1", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:1", output);
             }
 
             {
@@ -4764,7 +5005,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteNumber(text, value);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:1", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:1", output);
             }
 
             {
@@ -4775,7 +5016,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteNumber(text, value);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:1", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:1", output);
             }
 
             {
@@ -4786,7 +5027,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteNumber(text, value);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:1", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:1", output);
             }
 
             {
@@ -4797,7 +5038,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteNumber(text, value);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:1", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:1", output);
             }
         }
 
@@ -4826,7 +5067,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteString(text, value);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:\"{value.ToString("yyyy-MM-ddTHH:mm:ss")}\"", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:\"{value.ToString("yyyy-MM-ddTHH:mm:ss")}\"", output);
             }
 
             {
@@ -4837,7 +5078,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteString(text, value);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:\"{value.ToString("yyyy-MM-ddTHH:mm:ssK")}\"", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:\"{value.ToString("yyyy-MM-ddTHH:mm:ssK")}\"", output);
             }
 
             {
@@ -4848,7 +5089,7 @@ namespace System.Text.Json.Tests
                 jsonUtf8.WriteString(text, value);
                 jsonUtf8.Flush();
 
-                AssertContents($"{{{expectedMessage}:\"{value.ToString()}\"", output);
+                JsonTestHelper.AssertContents($"{{{expectedMessage}:\"{value.ToString()}\"", output);
             }
         }
 
@@ -5189,7 +5430,7 @@ namespace System.Text.Json.Tests
                 writer.Flush();
             }
 
-            AssertContents("[/**//**/]", output);
+            JsonTestHelper.AssertContents("[/**//**/]", output);
         }
 
         [Fact]
@@ -5286,7 +5527,7 @@ namespace System.Text.Json.Tests
                 writer.Flush();
             }
 
-            AssertContents("{}", output);
+            JsonTestHelper.AssertContents("{}", output);
             output.Clear();
 
             using (var writer = new Utf8JsonWriter(output))
@@ -5302,7 +5543,7 @@ namespace System.Text.Json.Tests
                 writer.Flush();
             }
 
-            AssertContents($"{{\"\":{wireValue},\"\":{wireValue}}}", output);
+            JsonTestHelper.AssertContents($"{{\"\":{wireValue},\"\":{wireValue}}}", output);
         }
 
         private static void WriteNullPropertyName_NoValue(
@@ -5327,7 +5568,7 @@ namespace System.Text.Json.Tests
                 writer.Flush();
             }
 
-            AssertContents("{}", output);
+            JsonTestHelper.AssertContents("{}", output);
             output.Clear();
 
             using (var writer = new Utf8JsonWriter(output))
@@ -5345,7 +5586,7 @@ namespace System.Text.Json.Tests
                 writer.Flush();
             }
 
-            AssertContents($"{{\"\":{wireValue},\"\":{wireValue}}}", output);
+            JsonTestHelper.AssertContents($"{{\"\":{wireValue},\"\":{wireValue}}}", output);
         }
 
         private static void WriteNullValue_InObject(
@@ -5373,7 +5614,7 @@ namespace System.Text.Json.Tests
                 writer.Flush();
             }
 
-            AssertContents($"{{{nullValue},{wireValue},{wireValue}}}", output);
+            JsonTestHelper.AssertContents($"{{{nullValue},{wireValue},{wireValue}}}", output);
         }
 
         private static void WriteNullValue_InArray(
@@ -5401,7 +5642,7 @@ namespace System.Text.Json.Tests
                 writer.Flush();
             }
 
-            AssertContents($"[{nullValue},{wireValue},{wireValue}]", output);
+            JsonTestHelper.AssertContents($"[{nullValue},{wireValue},{wireValue}]", output);
         }
 
         private static string GetHelloWorldExpectedString(bool prettyPrint, string propertyName, string value)
@@ -5807,6 +6048,34 @@ namespace System.Text.Json.Tests
             return Encoding.UTF8.GetString(ms.ToArray());
         }
 
+        private static string GetExpectedString_RelaxedEscaping(bool prettyPrint, string keyString)
+        {
+            var ms = new MemoryStream();
+            TextWriter streamWriter = new StreamWriter(ms, new UTF8Encoding(false), 1024, true);
+
+            var json = new JsonTextWriter(streamWriter)
+            {
+                Formatting = prettyPrint ? Formatting.Indented : Formatting.None,
+            };
+
+            json.WriteStartObject();
+
+            json.WritePropertyName(keyString, escape: true);
+            json.WriteValue(keyString);
+
+            json.WritePropertyName(keyString, escape: true);
+            json.WriteStartArray();
+            json.WriteValue(keyString);
+            json.WriteValue(keyString);
+            json.WriteEnd();
+
+            json.WriteEnd();
+
+            json.Flush();
+
+            return Encoding.UTF8.GetString(ms.ToArray());
+        }
+
         private static string GetGuidsExpectedString(bool prettyPrint, string keyString, Guid[] guids, bool escape = false)
         {
             var ms = new MemoryStream();
@@ -5923,19 +6192,6 @@ namespace System.Text.Json.Tests
             json.Flush();
 
             return Encoding.UTF8.GetString(ms.ToArray());
-        }
-
-        private static void AssertContents(string expectedValue, ArrayBufferWriter<byte> buffer)
-        {
-            string value = Encoding.UTF8.GetString(
-                    buffer.WrittenSpan
-#if netfx
-                        .ToArray()
-#endif
-                    );
-
-            // Temporary hack until we can use the same escape algorithm on both sides and make sure we want uppercase hex.
-            Assert.Equal(expectedValue.NormalizeToJsonNetFormat(), value.NormalizeToJsonNetFormat());
         }
 
         public static IEnumerable<object[]> JsonEncodedTextStrings


### PR DESCRIPTION
Bringing in test additions from https://github.com/dotnet/corefx/pull/39560

cc @ericstj 