### PR TITLE
HttpStress: Add duplex operation that disposes response content

### DIFF
--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -324,6 +324,22 @@ namespace HttpStress
                         ValidateContent(content, await m.Content.ReadAsStringAsync());
                     }
                 }),
+                
+                ("POST Duplex Dispose",
+                async ctx =>
+                {
+                    // try to reproduce conditions described in https://github.com/dotnet/corefx/issues/39819
+                    string content = ctx.GetRandomString(0, ctx.MaxContentLength);
+                    Version httpVersion = ctx.GetRandomHttpVersion();
+
+                    using (var req = new HttpRequestMessage(HttpMethod.Post, "/duplex") { Version = httpVersion, Content = new StringDuplexContent(content) })
+                    using (HttpResponseMessage m = await ctx.SendAsync(req, HttpCompletionOption.ResponseHeadersRead))
+                    {
+                        ValidateHttpVersion(m, httpVersion);
+                        ValidateStatusCode(m);
+                        m.Content.Dispose();
+                    }
+                }),
 
                 ("POST ExpectContinue",
                 async ctx =>

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -337,7 +337,7 @@ namespace HttpStress
                     {
                         ValidateHttpVersion(m, httpVersion);
                         ValidateStatusCode(m);
-                        m.Content.Dispose();
+                        // Leave scope (and dispose of the response), potentially before the client has had the chance to read the entire response
                     }
                 }),
 

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -337,7 +337,7 @@ namespace HttpStress
                     {
                         ValidateHttpVersion(m, httpVersion);
                         ValidateStatusCode(m);
-                        // Leave scope (and dispose of the response), potentially before the client has had the chance to read the entire content
+                        // Cause the response to be disposed without reading the response body, which will cause the client to cancel the request
                     }
                 }),
 

--- a/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
+++ b/src/System.Net.Http/tests/StressTests/HttpStress/ClientOperations.cs
@@ -337,7 +337,7 @@ namespace HttpStress
                     {
                         ValidateHttpVersion(m, httpVersion);
                         ValidateStatusCode(m);
-                        // Leave scope (and dispose of the response), potentially before the client has had the chance to read the entire response
+                        // Leave scope (and dispose of the response), potentially before the client has had the chance to read the entire content
                     }
                 }),
 


### PR DESCRIPTION
Adds a client operation that attempts to reproduce the bug in #39819. I have confirmed this induces a small percentage of failures using the latest nightly, however using the latest master seems to make the issue go away (probably fixed via #39834).

cc @geoffkizer 