### PR TITLE
[release/3.0] Fix WriteLargeKeyOrValue System.Text.Json test

### DIFF
--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -4980,9 +4980,9 @@ namespace System.Text.Json.Tests
             value.AsSpan().Fill((byte)'b');
 
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
-            var output = new ArrayBufferWriter<byte>(1024);
 
             {
+                var output = new ArrayBufferWriter<byte>(1024);
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartObject();
                 Assert.Throws<ArgumentException>(() => jsonUtf8.WriteString(key, DateTime.Now));
@@ -4990,6 +4990,7 @@ namespace System.Text.Json.Tests
             }
 
             {
+                var output = new ArrayBufferWriter<byte>(1024);
                 using var jsonUtf8 = new Utf8JsonWriter(output, options);
                 jsonUtf8.WriteStartArray();
                 Assert.Throws<ArgumentException>(() => jsonUtf8.WriteStringValue(value));


### PR DESCRIPTION
Port to release/3.0 of test-only change #39857

When the Utf8JsonWriter is disposed in the first part of the test, it flushes the WriteStartObject token to the ArrayBufferWriter, such that the output.WrittenCount is already 1 when the second part of the test starts, and then the Assert.Equal(0, output.WrittenCount) is doomed to fail.

Fixes #39856

This was just broken by #39560 in master and #39850 in release/3.0.

cc: @ahsonkhan 