### PR TITLE
improve handling of 100continue for H2

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -113,6 +113,17 @@ namespace System.Net.Http
                     _requestBodyCancellationSource = new CancellationTokenSource();
                 }
 
+                if (_request.HasHeaders && _request.Headers.ExpectContinue == true)
+                {
+                    // Create a TCS that will complete when one of two things occurs:
+                    // 1. if a timer fires before we receive the relevant response from the server.
+                    // 2. if we receive the relevant response from the server before a timer fires.
+                    // In the first case, we could run this continuation synchronously, but in the latter, we shouldn't,
+                    // as we could end up starting the body copy operation on the main event loop thread, which could
+                    // then starve the processing of other requests.  So, we make the TCS RunContinuationsAsynchronously.
+                    _expect100ContinueWaiter = new TaskCompletionSource<bool>(TaskContinuationOptions.RunContinuationsAsynchronously);
+                }
+
                 if (NetEventSource.IsEnabled) Trace($"{request}, {nameof(initialWindowSize)}={initialWindowSize}");
             }
 
@@ -150,7 +161,7 @@ namespace System.Net.Http
                 try
                 {
                     bool sendRequestContent = true;
-                    if (_request.HasHeaders && _request.Headers.ExpectContinue == true)
+                    if (_expect100ContinueWaiter != null)
                     {
                         sendRequestContent = await WaitFor100ContinueAsync(_requestBodyCancellationToken).ConfigureAwait(false);
                     }
@@ -228,7 +239,7 @@ namespace System.Net.Http
                 // as we could end up starting the body copy operation on the main event loop thread, which could
                 // then starve the processing of other requests.  So, we make the TCS RunContinuationsAsynchronously.
                 bool sendRequestContent;
-                var waiter = _expect100ContinueWaiter = new TaskCompletionSource<bool>(TaskContinuationOptions.RunContinuationsAsynchronously);
+                TaskCompletionSource<bool> waiter = _expect100ContinueWaiter;
                 using (var expect100Timer = new Timer(s =>
                 {
                     var thisRef = (Http2Stream)s;
@@ -240,7 +251,6 @@ namespace System.Net.Http
                     // By now, either we got a response from the server or the timer expired.
                 }
 
-                _expect100ContinueWaiter = null;
                 return sendRequestContent;
             }
 
@@ -382,17 +392,15 @@ namespace System.Net.Http
                                 StatusCode = (HttpStatusCode)statusValue
                             };
 
-                            TaskCompletionSource<bool> expect100ContinueWaiter = _expect100ContinueWaiter;
                             if (statusValue < 200)
                             {
                                 // We do not process headers from 1xx responses.
                                 _responseProtocolState = ResponseProtocolState.ExpectingIgnoredHeaders;
 
-                                if (_response.StatusCode == HttpStatusCode.Continue && expect100ContinueWaiter != null)
+                                if (_response.StatusCode == HttpStatusCode.Continue && _expect100ContinueWaiter != null)
                                 {
                                     if (NetEventSource.IsEnabled) Trace("Received 100-Continue status.");
-                                    expect100ContinueWaiter.TrySetResult(true);
-                                    _expect100ContinueWaiter = null;
+                                    _expect100ContinueWaiter.TrySetResult(true);
                                 }
                             }
                             else
@@ -400,14 +408,13 @@ namespace System.Net.Http
                                 _responseProtocolState = ResponseProtocolState.ExpectingHeaders;
 
                                 // If we are waiting for a 100-continue response, signal the waiter now.
-                                if (expect100ContinueWaiter != null)
+                                if (_expect100ContinueWaiter != null)
                                 {
                                     // If the final status code is >= 300, skip sending the body.
                                     bool shouldSendBody = (statusValue < 300);
 
                                     if (NetEventSource.IsEnabled) Trace($"Expecting 100 Continue but received final status {statusValue}.");
-                                    expect100ContinueWaiter.TrySetResult(shouldSendBody);
-                                    _expect100ContinueWaiter = null;
+                                    _expect100ContinueWaiter.TrySetResult(shouldSendBody);
                                 }
                             }
                         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1897,8 +1897,13 @@ namespace System.Net.Http.Functional.Tests
 
             await Http2LoopbackServer.CreateClientAndServerAsync(async url =>
             {
+                using (var handler = new SocketsHttpHandler())
                 using (HttpClient client = CreateHttpClient())
                 {
+                    handler.SslOptions.RemoteCertificateValidationCallback = delegate { return true; };
+                    // Increase default Expect: 100-continue timeout to ensure that we don't accidentally fire the timer and send the request body.
+                    handler.Expect100ContinueTimeout = TimeSpan.FromSeconds(300);
+
                     var request = new HttpRequestMessage(HttpMethod.Post, url);
                     request.Version = new Version(2,0);
                     request.Content = new StringContent(new string('*', 3000));


### PR DESCRIPTION
This change has three parts:
- it increases timeout for PostAsyncExpect100Continue_NonSuccessResponse_RequestBodyNotSent to avoid CI failures. 
- changes product to create _expect100ContinueWaiter in constructor as needed to avoid race with early responses
- port one more 100Continue test @davidsh wrote from 2.1

fixes #39780
