### PR TITLE
Re-enable netfx testing for Microsoft.VisualBasic.Core

### DIFF
--- a/src/Microsoft.VisualBasic.Core/tests/Configurations.props
+++ b/src/Microsoft.VisualBasic.Core/tests/Configurations.props
@@ -3,6 +3,7 @@
     <BuildConfigurations>
       netcoreapp;
       uap;
+      netfx;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualBasic.Core/tests/FinancialTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/FinancialTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Microsoft.VisualBasic.Tests
 {
+    [ActiveIssue(39888, TargetFrameworkMonikers.NetFramework)]
     public class FinancialTests
     {
         private static bool IsNotArmOrAlpine() => !PlatformDetection.IsArmOrArm64Process && !PlatformDetection.IsAlpine;

--- a/src/Microsoft.VisualBasic.Core/tests/Microsoft.VisualBasic.Core.Tests.csproj
+++ b/src/Microsoft.VisualBasic.Core/tests/Microsoft.VisualBasic.Core.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{325260D6-D5DD-4E06-9DA2-9AF2AD9DE8C8}</ProjectGuid>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
-    <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release</Configurations>
+    <Configurations>netcoreapp-Debug;netcoreapp-Release;uap-Debug;uap-Release;netfx-Debug;netfx-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyAttributes.cs" />

--- a/src/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/ApplicationServices/ApplicationBaseTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/ApplicationServices/ApplicationBaseTests.cs
@@ -58,6 +58,7 @@ namespace Microsoft.VisualBasic.ApplicationServices.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Different entry assembly")]
         public void Info()
         {
             var app = new ApplicationBase();

--- a/src/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/SpecialDirectoriesTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/SpecialDirectoriesTests.cs
@@ -24,12 +24,14 @@ namespace Microsoft.VisualBasic.FileIO.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Supported on netfx")]
         public static void AllUsersApplicationDataFolderTest()
         {
             Assert.Throws<PlatformNotSupportedException>(() => SpecialDirectories.AllUsersApplicationData);
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Supported on netfx")]
         public static void CurrentUserApplicationDataFolderTest()
         {
             Assert.Throws<PlatformNotSupportedException>(() => SpecialDirectories.CurrentUserApplicationData);

--- a/src/Microsoft.VisualBasic.Core/tests/OperatorsTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/OperatorsTests.cs
@@ -3332,6 +3332,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         [Theory]
         [MemberData(nameof(ModObject_DivideByZeroObject_TestData))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Unfixed JIT bug in the .NET Framework")]
         public void ModObject_DivideByZeroObject_ThrowsDivideByZeroException(object left, object right)
         {
             Assert.Throws<DivideByZeroException>(() => Operators.ModObject(left, right));

--- a/src/Microsoft.VisualBasic.Core/tests/StringsTests.cs
+++ b/src/Microsoft.VisualBasic.Core/tests/StringsTests.cs
@@ -134,6 +134,7 @@ namespace Microsoft.VisualBasic.Tests
             }, charCode.ToString(), expected.ToString()).Dispose();
         }
 
+        [ActiveIssue(39888, TargetFrameworkMonikers.NetFramework)]
         [Theory]
         [InlineData(0, 0)]
         [InlineData(33, 33)]


### PR DESCRIPTION
@cston, this adds back the netfx test leg for Microsoft.VisualBasic.Core.  I will wait until your financial tests change goes in, as hopefully that'll address the financial failures here that I've ActiveIssue'd.  There are also some failing Asc_Chr_DoubleByte tests I've skipped, but I wasn't sure if that was expected.