### PR TITLE
Fix test scope when sending to helix resulting in double //

### DIFF
--- a/eng/pipelines/corefx-base.yml
+++ b/eng/pipelines/corefx-base.yml
@@ -199,7 +199,7 @@ jobs:
                 helixQueues: $(_helixQueues)
                 msbuildScript: $(_msbuildCommand)
                 framework: $(_framework)
-                testScope: ${{ parameters.testScope }}
+                testScope: ${{ coalesce(parameters.testScope, 'innerloop') }} # if parameters.testScope is empty use 'innerloop'
 
                 ${{ if eq(parameters.isOfficialBuild, 'true') }}:
                   officialBuildId: $(Build.BuildNumber)

--- a/eng/pipelines/helix.yml
+++ b/eng/pipelines/helix.yml
@@ -8,7 +8,7 @@ parameters:
   msbuildScript: ''
   targetOS: ''
   officialBuildId: ''
-  testScope: '' # empty | innerloop | outerloop | all
+  testScope: 'innerloop' # innerloop | outerloop | all
   condition: always()
 
 steps:
@@ -18,7 +18,7 @@ steps:
             /p:ArchGroup=${{ parameters.archGroup }}
             /p:ConfigurationGroup=${{ parameters.configuration }}
             /p:OSGroup=${{ parameters.targetOS }}
-            /p:testScope=${{ parameters.testScope }}
+            /p:TestScope=${{ parameters.testScope }}
             /p:TargetGroup=${{ parameters.framework }}
             /p:HelixTargetQueues=${{ parameters.helixQueues }}
             /p:HelixBuild=$(Build.BuildNumber)


### PR DESCRIPTION
Currently since TestScope is passed as a global empty property we can't override it, therefore in the results data the `HelixSource` is set as `test/functional/cli//` instead of `test/functional/cli/innerloop/`

cc: @wfurt 