### PR TITLE
[release/3.0] Fix Utf8JsonWriter.Dispose{Async} after failed Stream Write{Async}

### DIFF
--- a/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -2,17 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Xunit;
 using System.Buffers;
-using System.IO;
-using Newtonsoft.Json;
-using System.Globalization;
-using System.Threading.Tasks;
-using System.IO.Pipelines;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.IO.Pipelines;
 using System.Text.Encodings.Web;
 using System.Text.Unicode;
-using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Xunit;
 
 namespace System.Text.Json.Tests
 {
@@ -578,6 +579,63 @@ namespace System.Text.Json.Tests
             Assert.Throws<ObjectDisposedException>(() => writeToStream.Reset());
 
             Assert.Throws<ObjectDisposedException>(() => jsonUtf8.Reset(output));
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public async Task FlushToStreamThrows_WriterRemainsInConsistentState(bool useAsync, bool throwFromDispose)
+        {
+            var stream = new ThrowingFromWriteMemoryStream();
+            var jsonUtf8 = new Utf8JsonWriter(stream);
+
+            // Write and flush some of an object.
+            jsonUtf8.WriteStartObject();
+            jsonUtf8.WriteString("someProp1", "someValue1");
+            await jsonUtf8.FlushAsync(useAsync);
+
+            // Write some more, but fail while flushing to write to the underlying stream.
+            stream.ExceptionToThrow = new FormatException("uh oh");
+            jsonUtf8.WriteString("someProp2", "someValue2");
+            Assert.Same(stream.ExceptionToThrow, await Assert.ThrowsAsync<FormatException>(() => jsonUtf8.FlushAsync(useAsync)));
+
+            // Write some more.
+            jsonUtf8.WriteEndObject();
+
+            // Dispose, potentially throwing from the subsequent attempt to flush.
+            if (throwFromDispose)
+            {
+                // Disposing should propagate the new exception
+                stream.ExceptionToThrow = new FormatException("uh oh again");
+                Assert.Same(stream.ExceptionToThrow, await Assert.ThrowsAsync<FormatException>(() => jsonUtf8.DisposeAsync(useAsync)));
+                Assert.Equal("{\"someProp1\":\"someValue1\"", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+            else
+            {
+                // Disposing should not fail.
+                stream.ExceptionToThrow = null;
+                await jsonUtf8.DisposeAsync(useAsync);
+                Assert.Equal("{\"someProp1\":\"someValue1\",\"someProp2\":\"someValue2\"}", Encoding.UTF8.GetString(stream.ToArray()));
+            }
+        }
+
+        private sealed class ThrowingFromWriteMemoryStream : MemoryStream
+        {
+            public Exception ExceptionToThrow { get; set; }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                if (ExceptionToThrow != null) throw ExceptionToThrow;
+                base.Write(buffer, offset, count);
+            }
+
+            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                if (ExceptionToThrow != null) throw ExceptionToThrow;
+                await base.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         [Theory]
@@ -6587,6 +6645,30 @@ namespace System.Text.Json.Tests
             }
 
             return sb.ToString();
+        }
+
+        public static async Task FlushAsync(this Utf8JsonWriter writer, bool useAsync)
+        {
+            if (useAsync)
+            {
+                await writer.FlushAsync();
+            }
+            else
+            {
+                writer.Flush();
+            }
+        }
+
+        public static async Task DisposeAsync(this Utf8JsonWriter writer, bool useAsync)
+        {
+            if (useAsync)
+            {
+                await writer.DisposeAsync();
+            }
+            else
+            {
+                writer.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/39836 to release/3.0.

#### Description
If Flush{Async} is called on a Utf8JsonWriter (or if a Write call ends up needing to Grow and flushes as part of it) and the underlying Stream's Write (or Flush) throws an exception, the Utf8JsonWriter is likely to be left in an inconsistent state where its internal count of bytes pending doesn't align with its buffer writer's similar state.  As such, when the Utf8JsonWriter is then disposed, the disposal will likely end up throwing an exception from the underlying buffer writer about it being misused.
		
#### Customer Impact
If a developer writes code like:
```C#
using (var writer = new Utf8JsonWriter(stream))
{
    ... // operations on writer
}
```
and one of those operations on the writer throws, rather than that exception propagating and likely being diagnosable, instead an exception about the underlying buffer writer being misused is likely to propagate.  This is much less diagnosable.

As an example, the issue in https://github.com/dotnet/corefx/issues/39648 was due to the customer reporting a bug in System.Text.Json that was causing an exception "Cannot advance past the end of the buffer, which has a size of 256.", but in reality the issue was that the underlying ASP.NET stream being used was throwing an exception "Synchronous operations are disallowed" that was being masked.
		
#### Regression?
No
		
#### Risk
There is a little risk in that this is tweaking the core Flush{Async} and Grow routines in Utf8JsonWriter.  However, it's just moving around when the various operations in them are performed, i.e. clearing the memory ahead of time rather than after, resetting the pending bytes count to 0 before the stream call rather than after, etc.  All inner and outer loop tests passed, including new ones written to validate this case.

cc: @ahsonkhan, @danmosemsft 