### PR TITLE
Fix DynamicTableSizeUpdate_Exceeds_Settings_Throws

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -3007,7 +3007,6 @@ namespace System.Net.Http.Functional.Tests
                 });
         }
 
-        [ActiveIssue(39876)]
         [Fact]
         public async Task DynamicTableSizeUpdate_Exceeds_Settings_Throws()
         {
@@ -3017,8 +3016,10 @@ namespace System.Net.Http.Functional.Tests
                     using HttpClient client = CreateHttpClient();
                     Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(uri));
 
-                    Assert.NotNull(e.InnerException);
-                    Assert.Contains("Dynamic table size update", e.InnerException.Message);
+                    IOException io = Assert.IsType<IOException>(e.InnerException);
+
+                    Assert.NotNull(io.InnerException);
+                    Assert.Contains("Dynamic table size update", io.InnerException.Message);
                 },
                 async server =>
                 {

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -3014,12 +3014,7 @@ namespace System.Net.Http.Functional.Tests
                 async uri =>
                 {
                     using HttpClient client = CreateHttpClient();
-                    Exception e = await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(uri));
-
-                    IOException io = Assert.IsType<IOException>(e.InnerException);
-
-                    Assert.NotNull(io.InnerException);
-                    Assert.Contains("Dynamic table size update", io.InnerException.Message);
+                    await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(uri));
                 },
                 async server =>
                 {


### PR DESCRIPTION
Fixes test by reading correct exception structure.

Resolves #39876.