### PR TITLE
HTTP2: Fix handling of RST_STREAM with error = NO_ERROR after response EndStream

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -655,11 +655,11 @@ namespace System.Net.Http
 
             if (protocolError == Http2ProtocolErrorCode.RefusedStream)
             {
-                http2Stream.OnReset(new Http2StreamException(protocolError), canRetry: true);
+                http2Stream.OnReset(new Http2StreamException(protocolError), resetStreamErrorCode: protocolError, canRetry: true);
             }
             else
             {
-                http2Stream.OnReset(new Http2StreamException(protocolError));
+                http2Stream.OnReset(new Http2StreamException(protocolError), resetStreamErrorCode: protocolError);
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -120,7 +120,7 @@ namespace System.Net.Http
                     {
                         // Create a TCS for handling Expect: 100-continue semantics. See WaitFor100ContinueAsync.
                         // Note we need to create this in the constructor, because we can receive a 100 Continue response at any time after the constructor finishes.
-                        _expect100ContinueWaiter = new TaskCompletionSource<bool>(TaskContinuationOptions.RunContinuationsAsynchronously);
+                        _expect100ContinueWaiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     }
                 }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -2634,23 +2634,70 @@ namespace System.Net.Http.Functional.Tests
                     // Ensure client has processed the RST_STREAM.
                     await connection.PingPong();
 
-                    // We should receive the response body and EOF.
-                    byte[] readBuffer = new byte[contentBytes.Length];
-                    int bytesRead = await responseStream.ReadAsync(readBuffer);
-                    Assert.True(contentBytes.SequenceEqual(readBuffer));
-                    bytesRead = await responseStream.ReadAsync(readBuffer);
-                    Assert.Equal(0, bytesRead);
-
                     // Attempting to write on the request body should now fail with OperationCanceledException.
                     Exception e = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
 
                     // Propagate the exception to the request stream serialization task.
                     // This allows the request processing to complete.
                     duplexContent.Fail(e);
+
+                    // We should receive the response body and EOF.
+                    byte[] readBuffer = new byte[contentBytes.Length];
+                    int bytesRead = await responseStream.ReadAsync(readBuffer);
+                    Assert.True(contentBytes.SequenceEqual(readBuffer));
+                    bytesRead = await responseStream.ReadAsync(readBuffer);
+                    Assert.Equal(0, bytesRead);
                 }
 
                 // On handler dispose, client should shutdown the connection without sending additional frames.
                 await connection.WaitForClientDisconnectAsync();
+            }
+        }
+
+        [Fact]
+        public async Task PostAsyncNonDuplex_ServerCompletesResponseBodyThenResetsStreamWithNoError_SuccessAndRequestBodyCancelled()
+        {
+            // Per section 8.1 of the RFC:
+            // Receiving RST_STREAM with NO_ERROR after receiving EndStream on the response body is a special case.
+            // We should stop sending the request body, but treat the request as successful and 
+            // return the completed response body to the user.
+
+            byte[] contentBytes = Encoding.UTF8.GetBytes("Hello world");
+
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                Http2LoopbackConnection connection;
+                using (HttpClient client = CreateHttpClient())
+                {
+                    // We want non-duplex content, so use ByteArrayContent,
+                    // but make it large enough to ensure that the content can't be fully sent because of flow control limitations.
+                    // This allows us to validate that the content is actually canceled, not just fully sent and completed.
+                    const int ContentSize = 100_000;
+                    var requestContent = new ByteArrayContent(TestHelper.GenerateRandomContent(ContentSize));
+
+                    var request = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                    request.Version = new Version(2, 0);
+                    request.Content = requestContent;
+                    Task<HttpResponseMessage> responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+                    connection = await server.EstablishConnectionAsync();
+
+                    (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+
+                    // Send full response
+                    await connection.SendResponseHeadersAsync(streamId, endStream: false);
+                    await connection.SendResponseDataAsync(streamId, contentBytes, endStream: true);
+
+                    // Send RST_STREAM to client with error = NO_ERROR.
+                    await connection.WriteFrameAsync(new RstStreamFrame(FrameFlags.None, (int)ProtocolErrors.NO_ERROR, streamId));
+
+                    // Response should now complete successfully
+                    HttpResponseMessage response = await responseTask;
+                    Assert.Equal("Hello world", await response.Content.ReadAsStringAsync());
+                }
+
+                // On handler dispose, client should shutdown the connection. Ignore any request stream frames already sent.
+                await connection.WaitForClientDisconnectAsync(ignoreUnexpectedFrames: true);
             }
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -2585,6 +2585,75 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Fact]
+        public async Task PostAsyncDuplex_ServerCompletesResponseBodyThenResetsStreamWithNoError_SuccessAndRequestBodyCancelled()
+        {
+            // Per section 8.1 of the RFC:
+            // Receiving RST_STREAM with NO_ERROR after receiving EndStream on the response body is a special case.
+            // We should stop sending the request body, but treat the request as successful and 
+            // return the completed response body to the user.
+
+            byte[] contentBytes = Encoding.UTF8.GetBytes("Hello world");
+
+            using (var server = Http2LoopbackServer.CreateServer())
+            {
+                Http2LoopbackConnection connection;
+                using (HttpClient client = CreateHttpClient())
+                {
+                    var duplexContent = new DuplexContent();
+
+                    var request = new HttpRequestMessage(HttpMethod.Post, server.Address);
+                    request.Version = new Version(2, 0);
+                    request.Content = duplexContent;
+                    Task<HttpResponseMessage> responseTask = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+                    connection = await server.EstablishConnectionAsync();
+
+                    // Client should have sent the request headers, and the request stream should now be available
+                    Stream requestStream = await duplexContent.WaitForStreamAsync();
+
+                    // Flush the content stream. Otherwise, the request headers are not guaranteed to be sent.
+                    await requestStream.FlushAsync();
+
+                    (int streamId, _) = await connection.ReadAndParseRequestHeaderAsync(readBody: false);
+
+                    // Send data to the server, even before we've received response headers.
+                    await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId);
+
+                    // Send response headers
+                    await connection.SendResponseHeadersAsync(streamId, endStream: false);
+                    HttpResponseMessage response = await responseTask;
+                    Stream responseStream = await response.Content.ReadAsStreamAsync();
+
+                    // Send response body and complete response
+                    await connection.SendResponseDataAsync(streamId, contentBytes, endStream: true);
+
+                    // Send RST_STREAM to client with error = NO_ERROR.
+                    await connection.WriteFrameAsync(new RstStreamFrame(FrameFlags.None, (int)ProtocolErrors.NO_ERROR, streamId));
+
+                    // Ensure client has processed the RST_STREAM.
+                    await connection.PingPong();
+
+                    // We should receive the response body and EOF.
+                    byte[] readBuffer = new byte[contentBytes.Length];
+                    int bytesRead = await responseStream.ReadAsync(readBuffer);
+                    Assert.True(contentBytes.SequenceEqual(readBuffer));
+                    bytesRead = await responseStream.ReadAsync(readBuffer);
+                    Assert.Equal(0, bytesRead);
+
+                    // Attempting to write on the request body should now fail with OperationCanceledException.
+                    Exception e = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });
+
+                    // Propagate the exception to the request stream serialization task.
+                    // This allows the request processing to complete.
+                    duplexContent.Fail(e);
+                }
+
+                // On handler dispose, client should shutdown the connection without sending additional frames.
+                await connection.WaitForClientDisconnectAsync();
+            }
+        }
+
         [Theory]
         [InlineData(true, HttpStatusCode.Forbidden)]
         [InlineData(false, HttpStatusCode.Forbidden)]


### PR DESCRIPTION
Fixes #39586 
Fixes #40030 

The RFC defines special behavior for receiving a RST_STREAM with error = NO_ERROR after the response body stream has been completed. When this happens, a client is supposed to cancel sending the request body but still consider the request successful. Previously, we did not do this.

@danmosemsft This impacts GRPC scenarios and will need to be ported to the 3.0 branch.
