### PR TITLE
Fix to Build fails with 'error MSB3073' when run from folder containing space

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -9,7 +9,7 @@ powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0eng\build.ps1" %*
 goto end
 
 :help
-powershell -ExecutionPolicy ByPass -NoProfile -Command "& { . %~dp0eng\build.ps1; Get-Help }"
+powershell -ExecutionPolicy ByPass -NoProfile -Command "& { . '%~dp0eng\build.ps1'; Get-Help }"
 
 :end
 exit /b %ERRORLEVEL%

--- a/src/shims/ApiCompat.proj
+++ b/src/shims/ApiCompat.proj
@@ -80,9 +80,9 @@
     </PropertyGroup>
 
     <Exec Command="$(_ApiCompatCommand) &quot;$(_netStandard21OnlyRef)&quot; @&quot;$(ApiCompatResponseFile)&quot; $(_netStandard21BaselineModifer) &quot;$(ApiCompatNSOnlyBaselineFile)&quot;"
-      CustomErrorRegularExpression="^[a-zA-Z]+ :"
-      StandardOutputImportance="Low"
-      IgnoreExitCode="true"
+          CustomErrorRegularExpression="^[a-zA-Z]+ :"
+          StandardOutputImportance="Low"
+          IgnoreExitCode="true"
     >
       <Output TaskParameter="ExitCode" PropertyName="ApiCompatExitCode" />
     </Exec>

--- a/src/shims/ApiCompat.proj
+++ b/src/shims/ApiCompat.proj
@@ -79,10 +79,10 @@
     <PropertyGroup Condition="$(UpdateNETStandardBaseline)">
     </PropertyGroup>
 
-    <Exec Command="$(_ApiCompatCommand) &quot;$(_netStandard21OnlyRef)&quot; @&quot;$(ApiCompatResponseFile)&quot; $(_netStandard21BaselineModifer) $(ApiCompatNSOnlyBaselineFile)"
-          CustomErrorRegularExpression="^[a-zA-Z]+ :"
-          StandardOutputImportance="Low"
-          IgnoreExitCode="true"
+    <Exec Command="$(_ApiCompatCommand) &quot;$(_netStandard21OnlyRef)&quot; @&quot;$(ApiCompatResponseFile)&quot; $(_netStandard21BaselineModifer) &quot;$(ApiCompatNSOnlyBaselineFile)&quot;"
+      CustomErrorRegularExpression="^[a-zA-Z]+ :"
+      StandardOutputImportance="Low"
+      IgnoreExitCode="true"
     >
       <Output TaskParameter="ExitCode" PropertyName="ApiCompatExitCode" />
     </Exec>


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/39840

Also Requries fix to coreclr to fix Microsoft.NET.Sdk.IL.targets:

Source: "C:\Users\User.nuget\packages\microsoft.net.sdk.il\5.0.0-alpha1.19377.2\targets\Microsoft.NET.Sdk.IL.targets"

`<_IldasmCommand>"$(_IlasmDir)"ildasm</_IldasmCommand>`
`and`
`<_IlasmSwitches Condition="'$(IlasmResourceFile)' != ''">$(_IlasmSwitches) -RESOURCES="$(IlasmResourceFile)"</_IlasmSwitches>`
`and`
`<Exec Command="&quot;$(_IlasmDir)&quot;ilasm $(_IlasmSwitches) $(_OutputTypeArgument)` `$(IlasmFlags) -OUTPUT=&quot;@(IntermediateAssembly)&quot; $(_KeyFileArgument) `@(Compile)"> <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" /> </Exec>`