### PR TITLE
Add TrailingHeaders to HttpResponseMessage.ToString output

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
@@ -198,6 +198,12 @@ namespace System.Net.Http
             sb.Append(", Headers:\r\n");
             HeaderUtilities.DumpHeaders(sb, _headers, _content?.Headers);
 
+            if (_trailingHeaders != null)
+            {
+                sb.Append(", Trailing Headers:\r\n");
+                HeaderUtilities.DumpHeaders(sb, _trailingHeaders);
+            }
+
             return sb.ToString();
         }
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
@@ -281,6 +281,21 @@ namespace System.Net.Http.Functional.Tests
                     "  Content-Type: text/plain; charset=utf-8\r\n" +
                     "  Custom-Content-Header: value2\r\n" +
                     "}", rm.ToString());
+
+                rm.TrailingHeaders.Add("Custom-Trailing-Header", "value3");
+
+                Assert.Equal(
+                    "StatusCode: 400, ReasonPhrase: 'Bad Request', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:\r\n" +
+                    "{\r\n" +
+                    "  Accept-Ranges: bytes\r\n" +
+                    "  Accept-Ranges: pages\r\n" +
+                    "  Custom-Response-Header: value1\r\n" +
+                    "  Content-Type: text/plain; charset=utf-8\r\n" +
+                    "  Custom-Content-Header: value2\r\n" +
+                    "}, Trailing Headers:\r\n" +
+                    "{\r\n" +
+                    "  Custom-Trailing-Header: value3\r\n" +
+                    "}", rm.ToString());
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/39891
cc: @dotnet/ncl 

Seemed better to not include the trailing headers in the same grouping as the other headers, since they're fundamentally different.  If folks prefer a different representation, just let me know; this seemed reasonable.