### PR TITLE
Catch InvalidCastException properly in Collection

### DIFF
--- a/src/System.Runtime/tests/System/Collections/ObjectModel/CollectionTests.cs
+++ b/src/System.Runtime/tests/System/Collections/ObjectModel/CollectionTests.cs
@@ -325,6 +325,33 @@ namespace System.Collections.ObjectModel.Tests
             Assert.Throws<NotSupportedException>(() => collection.RemoveAt(0));
         }
 
+        [Fact]
+        public void IList_Add_ValidItemButThrowsInvalidCastExceptionFromOverride_ThrowsInvalidCastException()
+        {
+            var collection = new ObservableCollection<int>();
+            collection.CollectionChanged += delegate { throw new InvalidCastException(); };
+
+            Assert.Throws<InvalidCastException>(() => ((IList)collection).Add(1));
+        }
+
+        [Fact]
+        public void IList_Insert_ValidItemButThrowsInvalidCastExceptionFromOverride_ThrowsInvalidCastException()
+        {
+            var collection = new ObservableCollection<int>();
+            collection.CollectionChanged += delegate { throw new InvalidCastException(); };
+
+            Assert.Throws<InvalidCastException>(() => ((IList)collection).Insert(0, 1));
+        }
+
+        [Fact]
+        public void IList_Item_Set_ValidItemButThrowsInvalidCastExceptionFromOverride_ThrowsInvalidCastException()
+        {
+            var collection = new ObservableCollection<int>() { 1 };
+            collection.CollectionChanged += delegate { throw new InvalidCastException(); };
+
+            Assert.Throws<InvalidCastException>(() => ((IList)collection)[0] = 2);
+        }
+
         private class TestCollection<T> : Collection<T>
         {
             public TestCollection()


### PR DESCRIPTION
The explicit implementations of IList.Add/Insert/Set methods catch
InvalidCastException for casting input argument to type T to throw
an ArgumentException. The issue here is they put the core collection
modification operation in the try block, and it could be overridden
by sub-classes and produce an InvalidCastException from user logic,
even the argument passed to IList.Add/Insert/Set is valid.

This commit contains the test cases for those three method. In those
test cases, we create an ObservableCollection (which is the sub-class
of Collection) and throw an InvalidCastException from the handler of
CollectionChanged event. This exception should be observed from the
outside when we pass a valid input, instead of an ArgumentException
as if we've passed an argument with invalid type.

Fix #39919