### PR TITLE
Streamline SslStream state validation

### DIFF
--- a/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -176,13 +176,13 @@ namespace System.Net.Security
 
         private SecurityStatusPal EncryptData(ReadOnlyMemory<byte> buffer, ref byte[] outBuffer, out int outSize)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             return _context.Encrypt(buffer, ref outBuffer, out outSize);
         }
 
         private SecurityStatusPal DecryptData()
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             return PrivateDecryptData(_internalBuffer, ref _decryptedBytesOffset, ref _decryptedBytesCount);
         }
 
@@ -223,7 +223,7 @@ namespace System.Net.Security
         //
         private int CheckOldKeyDecryptedData(Memory<byte> buffer)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             if (_queuedReadData != null)
             {
                 // This is inefficient yet simple and should be a REALLY rare case.
@@ -1004,7 +1004,7 @@ namespace System.Net.Security
             {
                 if (_lockWriteState != LockHandshake)
                 {
-                    CheckThrowAndAuthState();
+                    ThrowIfExceptionalOrNotAuthenticated();
                     return Task.CompletedTask;
                 }
 
@@ -1032,7 +1032,7 @@ namespace System.Net.Security
                 if (_lockWriteState != LockHandshake)
                 {
                     // Handshake has completed before we grabbed the lock.
-                    CheckThrowAndAuthState();
+                    ThrowIfExceptionalOrNotAuthenticated();
                     return;
                 }
 
@@ -1044,7 +1044,7 @@ namespace System.Net.Security
 
             // Need to exit from lock before waiting.
             lazyResult.InternalWaitForCompletion();
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             return;
         }
 
@@ -1465,7 +1465,7 @@ namespace System.Net.Security
         private async Task WriteAsyncInternal<TWriteAdapter>(TWriteAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
             where TWriteAdapter : struct, ISslWriteAdapter
         {
-            CheckThrowAuthAndShutdownState();
+            ThrowIfExceptionalOrNotAuthenticatedOrShutdown();
 
             if (buffer.Length == 0 && !SslStreamPal.CanEncryptEmptyMessage)
             {

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.Implementation.cs
@@ -63,26 +63,6 @@ namespace System.Net.Security
         private int _lockReadState;
         private object _queuedReadStateRequest;
 
-        /// <summary>Set as the _exception when the instance is disposed.</summary>
-        private static readonly ExceptionDispatchInfo s_disposedSentinel = ExceptionDispatchInfo.Capture(new ObjectDisposedException(nameof(SslStream), (string)null));
-
-        private void ThrowIfExceptional()
-        {
-            ExceptionDispatchInfo e = _exception;
-            if (e != null)
-            {
-                // If the stored exception just indicates disposal, throw a new ODE rather than the stored one,
-                // so as to not continually build onto the shared exception's stack.
-                if (ReferenceEquals(e, s_disposedSentinel))
-                {
-                    throw new ObjectDisposedException(nameof(SslStream));
-                }
-
-                // Throw the stored exception.
-                e.Throw();
-            }
-        }
-
         private void ValidateCreateContext(SslClientAuthenticationOptions sslClientAuthenticationOptions, RemoteCertValidationCallback remoteCallback, LocalCertSelectionCallback localCallback)
         {
             ThrowIfExceptional();
@@ -163,21 +143,6 @@ namespace System.Net.Security
             _context?.Close();
         }
 
-        private void CheckThrow(bool authSuccessCheck, bool shutdownCheck = false)
-        {
-            ThrowIfExceptional();
-
-            if (authSuccessCheck && !IsAuthenticated)
-            {
-                throw new InvalidOperationException(SR.net_auth_noauth);
-            }
-
-            if (shutdownCheck && _shutdown)
-            {
-                throw new InvalidOperationException(SR.net_ssl_io_already_shutdown);
-            }
-        }
-
         //
         // This is to not depend on GC&SafeHandle class if the context is not needed anymore.
         //
@@ -211,13 +176,13 @@ namespace System.Net.Security
 
         private SecurityStatusPal EncryptData(ReadOnlyMemory<byte> buffer, ref byte[] outBuffer, out int outSize)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             return _context.Encrypt(buffer, ref outBuffer, out outSize);
         }
 
         private SecurityStatusPal DecryptData()
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             return PrivateDecryptData(_internalBuffer, ref _decryptedBytesOffset, ref _decryptedBytesCount);
         }
 
@@ -258,7 +223,7 @@ namespace System.Net.Security
         //
         private int CheckOldKeyDecryptedData(Memory<byte> buffer)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             if (_queuedReadData != null)
             {
                 // This is inefficient yet simple and should be a REALLY rare case.
@@ -292,7 +257,7 @@ namespace System.Net.Security
 
             try
             {
-                CheckThrow(false);
+                ThrowIfExceptional();
                 AsyncProtocolRequest asyncRequest = null;
                 if (lazyResult != null)
                 {
@@ -1039,7 +1004,7 @@ namespace System.Net.Security
             {
                 if (_lockWriteState != LockHandshake)
                 {
-                    CheckThrow(authSuccessCheck: true);
+                    CheckThrowAndAuthState();
                     return Task.CompletedTask;
                 }
 
@@ -1067,7 +1032,7 @@ namespace System.Net.Security
                 if (_lockWriteState != LockHandshake)
                 {
                     // Handshake has completed before we grabbed the lock.
-                    CheckThrow(authSuccessCheck: true);
+                    CheckThrowAndAuthState();
                     return;
                 }
 
@@ -1079,7 +1044,7 @@ namespace System.Net.Security
 
             // Need to exit from lock before waiting.
             lazyResult.InternalWaitForCompletion();
-            CheckThrow(authSuccessCheck: true);
+            CheckThrowAndAuthState();
             return;
         }
 
@@ -1500,7 +1465,7 @@ namespace System.Net.Security
         private async Task WriteAsyncInternal<TWriteAdapter>(TWriteAdapter writeAdapter, ReadOnlyMemory<byte> buffer)
             where TWriteAdapter : struct, ISslWriteAdapter
         {
-            CheckThrow(authSuccessCheck: true, shutdownCheck: true);
+            CheckThrowAuthAndShutdownState();
 
             if (buffer.Length == 0 && !SslStreamPal.CanEncryptEmptyMessage)
             {

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
@@ -40,6 +41,9 @@ namespace System.Net.Security
 
     public partial class SslStream : AuthenticatedStream
     {
+        /// <summary>Set as the _exception when the instance is disposed.</summary>
+        private static readonly ExceptionDispatchInfo s_disposedSentinel = ExceptionDispatchInfo.Capture(new ObjectDisposedException(nameof(SslStream), (string)null));
+
         private X509Certificate2 _remoteCertificate;
         private bool _remoteCertificateExposed;
 
@@ -285,7 +289,7 @@ namespace System.Net.Security
 
         internal IAsyncResult BeginShutdown(AsyncCallback asyncCallback, object asyncState)
         {
-            CheckThrow(authSuccessCheck: true, shutdownCheck: true);
+            CheckThrowAuthAndShutdownState();
 
             ProtocolToken message = _context.CreateShutdownToken();
             return TaskToApm.Begin(InnerStream.WriteAsync(message.Payload, 0, message.Payload.Length), asyncCallback, asyncState);
@@ -293,7 +297,7 @@ namespace System.Net.Security
 
         internal void EndShutdown(IAsyncResult asyncResult)
         {
-            CheckThrow(authSuccessCheck: true, shutdownCheck: true);
+            CheckThrowAuthAndShutdownState();
 
             TaskToApm.End(asyncResult);
             _shutdown = true;
@@ -471,7 +475,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrow(true);
+                CheckThrowAndAuthState();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -527,7 +531,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrow(true);
+                CheckThrowAndAuthState();
                 return _context.IsServer ? _context.LocalServerCertificate : _context.LocalClientCertificate;
             }
         }
@@ -536,7 +540,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrow(true);
+                CheckThrowAndAuthState();
                 _remoteCertificateExposed = true;
                 return _remoteCertificate;
             }
@@ -547,7 +551,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrow(true);
+                CheckThrowAndAuthState();
                 return _context.ConnectionInfo?.TlsCipherSuite ?? default(TlsCipherSuite);
             }
         }
@@ -556,7 +560,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrow(true);
+                CheckThrowAndAuthState();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -570,7 +574,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrow(true);
+                CheckThrowAndAuthState();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -585,7 +589,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrow(true);
+                CheckThrowAndAuthState();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -599,7 +603,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrow(true);
+                CheckThrowAndAuthState();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -614,7 +618,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrow(true);
+                CheckThrowAndAuthState();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -629,7 +633,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrow(true);
+                CheckThrowAndAuthState();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -711,7 +715,7 @@ namespace System.Net.Security
 
         public override int ReadByte()
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             if (Interlocked.Exchange(ref _nestedRead, 1) == 1)
             {
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "ReadByte", "read"));
@@ -747,7 +751,7 @@ namespace System.Net.Security
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             ValidateParameters(buffer, offset, count);
             SslReadSync reader = new SslReadSync(this);
             return ReadAsyncInternal(reader, new Memory<byte>(buffer, offset, count)).GetAwaiter().GetResult();
@@ -757,7 +761,7 @@ namespace System.Net.Security
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             ValidateParameters(buffer, offset, count);
 
             SslWriteSync writeAdapter = new SslWriteSync(this);
@@ -766,45 +770,45 @@ namespace System.Net.Security
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             return TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
         }
 
         public override int EndRead(IAsyncResult asyncResult)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             return TaskToApm.End<int>(asyncResult);
         }
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             return TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
         }
 
         public override void EndWrite(IAsyncResult asyncResult)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             TaskToApm.End(asyncResult);
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             ValidateParameters(buffer, offset, count);
             return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
         }
 
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             SslWriteAsync writeAdapter = new SslWriteAsync(this, cancellationToken);
             return new ValueTask(WriteAsyncInternal(writeAdapter, buffer));
         }
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             ValidateParameters(buffer, offset, count);
             SslReadAsync read = new SslReadAsync(this, cancellationToken);
             return ReadAsyncInternal(read, new Memory<byte>(buffer, offset, count)).AsTask();
@@ -812,9 +816,71 @@ namespace System.Net.Security
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            CheckThrow(true);
+            CheckThrowAndAuthState();
             SslReadAsync read = new SslReadAsync(this, cancellationToken);
             return ReadAsyncInternal(read, buffer);
+        }
+
+        private void ThrowIfExceptional()
+        {
+            ExceptionDispatchInfo e = _exception;
+            if (e != null)
+            {
+                ThrowExceptional(e);
+            }
+
+            // Local function to make the check method more inline friendly.
+            static void ThrowExceptional(ExceptionDispatchInfo e)
+            {
+                // If the stored exception just indicates disposal, throw a new ODE rather than the stored one,
+                // so as to not continually build onto the shared exception's stack.
+                if (ReferenceEquals(e, s_disposedSentinel))
+                {
+                    throw new ObjectDisposedException(nameof(SslStream));
+                }
+
+                // Throw the stored exception.
+                e.Throw();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void CheckThrowAndAuthState()
+        {
+            ThrowIfExceptional();
+
+            if (!IsAuthenticated)
+            {
+                ThrowNotAuthenticated();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void CheckThrowAuthAndShutdownState()
+        {
+            ThrowIfExceptional();
+
+            if (!IsAuthenticated)
+            {
+                ThrowNotAuthenticated();
+            }
+
+            if (_shutdown)
+            {
+                ThrowAlreadyShutdown();
+            }
+
+            // Local function to make the check method more inline friendly.
+            static void ThrowAlreadyShutdown()
+            {
+                throw new InvalidOperationException(SR.net_ssl_io_already_shutdown);
+            }
+        }
+
+        // Static non-returning throw method to make the check methods more inline friendly.
+        private static void ThrowNotAuthenticated()
+        {
+            throw new InvalidOperationException(SR.net_auth_noauth);
         }
     }
 }

--- a/src/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -289,7 +289,7 @@ namespace System.Net.Security
 
         internal IAsyncResult BeginShutdown(AsyncCallback asyncCallback, object asyncState)
         {
-            CheckThrowAuthAndShutdownState();
+            ThrowIfExceptionalOrNotAuthenticatedOrShutdown();
 
             ProtocolToken message = _context.CreateShutdownToken();
             return TaskToApm.Begin(InnerStream.WriteAsync(message.Payload, 0, message.Payload.Length), asyncCallback, asyncState);
@@ -297,7 +297,7 @@ namespace System.Net.Security
 
         internal void EndShutdown(IAsyncResult asyncResult)
         {
-            CheckThrowAuthAndShutdownState();
+            ThrowIfExceptionalOrNotAuthenticatedOrShutdown();
 
             TaskToApm.End(asyncResult);
             _shutdown = true;
@@ -475,7 +475,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrowAndAuthState();
+                ThrowIfExceptionalOrNotAuthenticated();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -531,7 +531,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrowAndAuthState();
+                ThrowIfExceptionalOrNotAuthenticated();
                 return _context.IsServer ? _context.LocalServerCertificate : _context.LocalClientCertificate;
             }
         }
@@ -540,7 +540,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrowAndAuthState();
+                ThrowIfExceptionalOrNotAuthenticated();
                 _remoteCertificateExposed = true;
                 return _remoteCertificate;
             }
@@ -551,7 +551,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrowAndAuthState();
+                ThrowIfExceptionalOrNotAuthenticated();
                 return _context.ConnectionInfo?.TlsCipherSuite ?? default(TlsCipherSuite);
             }
         }
@@ -560,7 +560,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrowAndAuthState();
+                ThrowIfExceptionalOrNotAuthenticated();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -574,7 +574,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrowAndAuthState();
+                ThrowIfExceptionalOrNotAuthenticated();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -589,7 +589,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrowAndAuthState();
+                ThrowIfExceptionalOrNotAuthenticated();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -603,7 +603,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrowAndAuthState();
+                ThrowIfExceptionalOrNotAuthenticated();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -618,7 +618,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrowAndAuthState();
+                ThrowIfExceptionalOrNotAuthenticated();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -633,7 +633,7 @@ namespace System.Net.Security
         {
             get
             {
-                CheckThrowAndAuthState();
+                ThrowIfExceptionalOrNotAuthenticated();
                 SslConnectionInfo info = _context.ConnectionInfo;
                 if (info == null)
                 {
@@ -715,7 +715,7 @@ namespace System.Net.Security
 
         public override int ReadByte()
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             if (Interlocked.Exchange(ref _nestedRead, 1) == 1)
             {
                 throw new NotSupportedException(SR.Format(SR.net_io_invalidnestedcall, "ReadByte", "read"));
@@ -751,7 +751,7 @@ namespace System.Net.Security
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             ValidateParameters(buffer, offset, count);
             SslReadSync reader = new SslReadSync(this);
             return ReadAsyncInternal(reader, new Memory<byte>(buffer, offset, count)).GetAwaiter().GetResult();
@@ -761,7 +761,7 @@ namespace System.Net.Security
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             ValidateParameters(buffer, offset, count);
 
             SslWriteSync writeAdapter = new SslWriteSync(this);
@@ -770,45 +770,45 @@ namespace System.Net.Security
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             return TaskToApm.Begin(ReadAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
         }
 
         public override int EndRead(IAsyncResult asyncResult)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             return TaskToApm.End<int>(asyncResult);
         }
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             return TaskToApm.Begin(WriteAsync(buffer, offset, count, CancellationToken.None), asyncCallback, asyncState);
         }
 
         public override void EndWrite(IAsyncResult asyncResult)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             TaskToApm.End(asyncResult);
         }
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             ValidateParameters(buffer, offset, count);
             return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
         }
 
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             SslWriteAsync writeAdapter = new SslWriteAsync(this, cancellationToken);
             return new ValueTask(WriteAsyncInternal(writeAdapter, buffer));
         }
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             ValidateParameters(buffer, offset, count);
             SslReadAsync read = new SslReadAsync(this, cancellationToken);
             return ReadAsyncInternal(read, new Memory<byte>(buffer, offset, count)).AsTask();
@@ -816,7 +816,7 @@ namespace System.Net.Security
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            CheckThrowAndAuthState();
+            ThrowIfExceptionalOrNotAuthenticated();
             SslReadAsync read = new SslReadAsync(this, cancellationToken);
             return ReadAsyncInternal(read, buffer);
         }
@@ -845,7 +845,7 @@ namespace System.Net.Security
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void CheckThrowAndAuthState()
+        private void ThrowIfExceptionalOrNotAuthenticated()
         {
             ThrowIfExceptional();
 
@@ -856,7 +856,7 @@ namespace System.Net.Security
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void CheckThrowAuthAndShutdownState()
+        private void ThrowIfExceptionalOrNotAuthenticatedOrShutdown()
         {
             ThrowIfExceptional();
 


### PR DESCRIPTION
`CheckThrow` and `ThrowIfExceptional` are called on almost every op. Streamline the fast-path to and remove branches to mitigate the cost.

Pre

![image](https://user-images.githubusercontent.com/1142958/62300492-cff73e00-b46e-11e9-9904-513ba45bb66f.png)


Post

![image](https://user-images.githubusercontent.com/1142958/62300524-e30a0e00-b46e-11e9-8e8d-785420d8755d.png)


/cc @stephentoub 